### PR TITLE
fix: resolve EBUSY error during Windows build process

### DIFF
--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -79,7 +79,18 @@ process.on("unhandledRejection", (reason, promise) => {
   console.error("Unhandled Rejection at:", promise, "reason:", reason)
 })
 
-// アプリが異常終了する前にログを出力
-app.on("before-quit", () => {
+// アプリが異常終了する前にログを出力とクリーンアップ
+app.on("before-quit", async (event) => {
   console.log("Application is about to quit")
+  
+  // Prismaクライアントのクリーンアップ
+  try {
+    const { getPrismaClient } = await import("./lib/prisma/prismaClient")
+    const prisma = getPrismaClient()
+    await prisma.$disconnect()
+    console.log("Prisma client disconnected successfully")
+  } catch (error) {
+    console.warn("Failed to disconnect Prisma client:", error)
+    // エラーがあってもアプリ終了は継続
+  }
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "windows-build-fix": "node scripts/windows-build-fix.js",
-    "windows-build": "npm run windows-build-fix && npm run build && npm run make"
+    "force-cleanup": "node scripts/force-cleanup.js",
+    "find-lock": "node scripts/find-lock.js",
+    "windows-build": "npm run windows-build-fix && npm run build && npm run make",
+    "windows-build-force": "npm run force-cleanup && npm run build && npm run make"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/find-lock.js
+++ b/scripts/find-lock.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+console.log('File Lock Detection Script');
+console.log('==========================');
+
+const lockedPath = 'C:\\Users\\taro_\\dev\\score-at-once-electron\\out\\Score at Once-win32-x64';
+
+function findLockingProcesses() {
+  console.log(`Checking what's locking: ${lockedPath}\n`);
+
+  try {
+    // Method 1: Use handle.exe if available (Sysinternals)
+    console.log('1. Trying handle.exe (if available)...');
+    try {
+      const handleOutput = execSync(`handle.exe "${lockedPath}"`, { encoding: 'utf8', timeout: 5000 });
+      console.log('Handle.exe output:');
+      console.log(handleOutput);
+    } catch (e) {
+      console.log('handle.exe not available or no handles found');
+    }
+  } catch (e) {
+    console.log('handle.exe method failed');
+  }
+
+  try {
+    // Method 2: Use PowerShell to find processes with open handles
+    console.log('\n2. Using PowerShell to find open handles...');
+    const psScript = `
+    Get-Process | Where-Object {
+      try {
+        $_.Modules | Where-Object { $_.FileName -like "*Score at Once*" -or $_.FileName -like "*${lockedPath.replace(/\\/g, '\\\\')}*" }
+      } catch {}
+    } | Select-Object ProcessName, Id, Path
+    `;
+    
+    const psOutput = execSync(`powershell -Command "${psScript}"`, { 
+      encoding: 'utf8', 
+      timeout: 10000 
+    });
+    console.log('PowerShell output:');
+    console.log(psOutput || 'No processes found');
+  } catch (e) {
+    console.log('PowerShell method failed:', e.message);
+  }
+
+  try {
+    // Method 3: Check for any Electron/Node processes
+    console.log('\n3. Checking for Electron/Node processes...');
+    const tasklist = execSync('tasklist /FI "IMAGENAME eq electron.exe" /FO CSV', { encoding: 'utf8' });
+    console.log('Electron processes:');
+    console.log(tasklist);
+  } catch (e) {
+    console.log('No Electron processes found');
+  }
+
+  try {
+    console.log('\n4. Checking for Score at Once processes...');
+    const scoreProcesses = execSync('tasklist /FI "IMAGENAME eq Score at Once.exe" /FO CSV', { encoding: 'utf8' });
+    console.log('Score at Once processes:');
+    console.log(scoreProcesses);
+  } catch (e) {
+    console.log('No Score at Once processes found');
+  }
+
+  try {
+    // Method 4: Check Windows Explorer
+    console.log('\n5. Checking if Windows Explorer has the folder open...');
+    const explorerProcesses = execSync('tasklist /FI "IMAGENAME eq explorer.exe" /FO CSV', { encoding: 'utf8' });
+    console.log('Explorer processes found:');
+    console.log(explorerProcesses);
+    
+    console.log('\nNote: If Explorer is running, check if any Explorer windows');
+    console.log('are open to the out directory or its subdirectories.');
+  } catch (e) {
+    console.log('Could not check Explorer processes');
+  }
+
+  try {
+    // Method 5: Use WMIC to get detailed process info
+    console.log('\n6. Detailed process check with WMIC...');
+    const wmicOutput = execSync('wmic process where "name=\'electron.exe\' or name=\'Score at Once.exe\' or name=\'node.exe\'" get ProcessId,Name,CommandLine /format:csv', { 
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    console.log('WMIC process details:');
+    console.log(wmicOutput);
+  } catch (e) {
+    console.log('WMIC method failed:', e.message);
+  }
+
+  try {
+    // Method 6: Check if any antivirus is scanning
+    console.log('\n7. Checking for potential antivirus interference...');
+    const antivirusProcesses = [
+      'MsMpEng.exe',      // Windows Defender
+      'avp.exe',          // Kaspersky
+      'avgnt.exe',        // Avira
+      'mcshield.exe',     // McAfee
+      'NortonSecurity.exe' // Norton
+    ];
+    
+    for (const av of antivirusProcesses) {
+      try {
+        const avCheck = execSync(`tasklist /FI "IMAGENAME eq ${av}"`, { encoding: 'utf8' });
+        if (avCheck.includes(av)) {
+          console.log(`Found antivirus process: ${av}`);
+        }
+      } catch (e) {
+        // Process not found, continue
+      }
+    }
+  } catch (e) {
+    console.log('Antivirus check failed');
+  }
+
+  console.log('\n=== RECOMMENDATIONS ===');
+  console.log('1. Close any Windows Explorer windows pointing to the /out directory');
+  console.log('2. Make sure no Electron app is running');
+  console.log('3. Check if antivirus is scanning the directory');
+  console.log('4. Try running as administrator');
+  console.log('5. Restart Windows Explorer: taskkill /f /im explorer.exe && start explorer.exe');
+}
+
+findLockingProcesses();

--- a/scripts/force-cleanup.js
+++ b/scripts/force-cleanup.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+console.log('Force Cleanup Script for EBUSY Errors');
+console.log('====================================');
+
+/**
+ * Force kill any processes that might be locking files
+ */
+function forceKillProcesses() {
+  console.log('Checking for running processes...');
+  
+  try {
+    // Kill any running Electron processes
+    execSync('taskkill /F /IM "Score at Once.exe" 2>nul', { stdio: 'ignore' });
+    console.log('✓ Killed Score at Once processes');
+  } catch (e) {
+    // Process not found, which is fine
+  }
+
+  try {
+    // Kill any running electron processes
+    execSync('taskkill /F /IM electron.exe 2>nul', { stdio: 'ignore' });
+    console.log('✓ Killed Electron processes');
+  } catch (e) {
+    // Process not found, which is fine
+  }
+
+  try {
+    // Kill Prisma processes that might be hanging
+    console.log('Checking for Prisma processes...');
+    const wmicOutput = execSync('wmic process where "CommandLine like \'%prisma%\'" get ProcessId,CommandLine /format:csv 2>nul', { 
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    
+    if (wmicOutput && wmicOutput.includes('prisma')) {
+      console.log('Found Prisma processes:');
+      const lines = wmicOutput.split('\n').filter(line => line.includes('prisma'));
+      lines.forEach(line => {
+        const match = line.match(/(\d+)$/);
+        if (match) {
+          const pid = match[1];
+          try {
+            execSync(`taskkill /F /PID ${pid} 2>nul`, { stdio: 'ignore' });
+            console.log(`✓ Killed Prisma process PID: ${pid}`);
+          } catch (e) {
+            console.log(`✗ Failed to kill Prisma process PID: ${pid}`);
+          }
+        }
+      });
+    } else {
+      console.log('✓ No Prisma processes found');
+    }
+  } catch (e) {
+    console.log('✓ No Prisma processes found');
+  }
+
+  try {
+    // Kill any Node.js processes that might be related to this project
+    const nodeProcesses = execSync('wmic process where "name=\'node.exe\'" get ProcessId,CommandLine /format:csv 2>nul', { 
+      encoding: 'utf8',
+      timeout: 5000
+    });
+    
+    if (nodeProcesses) {
+      const projectPath = process.cwd().replace(/\\/g, '\\\\');
+      const lines = nodeProcesses.split('\n').filter(line => line.includes(projectPath));
+      
+      if (lines.length > 0) {
+        console.log('Found project-related Node.js processes:');
+        lines.forEach(line => {
+          const match = line.match(/(\d+)$/);
+          if (match) {
+            const pid = match[1];
+            // Don't kill the current process
+            if (pid !== process.pid.toString()) {
+              try {
+                execSync(`taskkill /F /PID ${pid} 2>nul`, { stdio: 'ignore' });
+                console.log(`✓ Killed Node.js process PID: ${pid}`);
+              } catch (e) {
+                console.log(`✗ Failed to kill Node.js process PID: ${pid}`);
+              }
+            }
+          }
+        });
+      } else {
+        console.log('✓ No project-related Node.js processes found');
+      }
+    }
+  } catch (e) {
+    console.log('✓ No project-related Node.js processes found');
+  }
+}
+
+/**
+ * Force remove directory with retries
+ */
+function forceRemoveDirectory(dirPath, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      if (fs.existsSync(dirPath)) {
+        console.log(`Attempting to remove ${dirPath} (attempt ${i + 1}/${retries})...`);
+        
+        // First try to change permissions
+        try {
+          execSync(`attrib -R "${dirPath}\\*.*" /S /D`, { stdio: 'ignore' });
+        } catch (e) {
+          // Ignore permission errors
+        }
+        
+        // Try to remove
+        fs.rmSync(dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+        console.log(`✓ Successfully removed ${dirPath}`);
+        return true;
+      }
+      return true;
+    } catch (error) {
+      if (i === retries - 1) {
+        console.error(`✗ Failed to remove ${dirPath}: ${error.message}`);
+        return false;
+      }
+      console.log(`Retry ${i + 1} failed, waiting 2 seconds...`);
+      // Wait before retry
+      execSync('timeout /t 2 /nobreak >nul', { stdio: 'ignore' });
+    }
+  }
+  return false;
+}
+
+// Main execution
+async function main() {
+  // Step 1: Kill processes
+  forceKillProcesses();
+  
+  // Step 2: Wait a moment for processes to fully terminate
+  console.log('Waiting for processes to terminate...');
+  execSync('timeout /t 3 /nobreak >nul', { stdio: 'ignore' });
+  
+  // Step 3: Clear directories
+  const dirsToClean = [
+    path.join(process.cwd(), '.next'),
+    path.join(process.cwd(), 'main'), 
+    path.join(process.cwd(), 'out')
+  ];
+  
+  let allSuccess = true;
+  for (const dir of dirsToClean) {
+    if (!forceRemoveDirectory(dir)) {
+      allSuccess = false;
+    }
+  }
+  
+  if (allSuccess) {
+    console.log('\n✓ Force cleanup completed successfully');
+    console.log('Next steps:');
+    console.log('1. Run: npm run build');
+    console.log('2. Run: npm run make');
+  } else {
+    console.log('\n⚠ Some directories could not be removed');
+    console.log('You may need to:');
+    console.log('1. Restart your computer');
+    console.log('2. Check Windows Explorer is not open in the build directories');
+    console.log('3. Run this script as administrator');
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Fixes #5\r\n\r\n## Problem\r\nWindows build process fails with EBUSY error when trying to clean the out directory.\r\n\r\n## Solution Implemented\r\n1. **Enhanced force cleanup script** (scripts/force-cleanup.js)\r\n   - Detects and kills hanging Prisma processes\r\n   - Kills project-related Node.js processes\r\n   - Enhanced retry logic with permission changes\r\n\r\n2. **Lock detection script** (scripts/find-lock.js)\r\n   - Identifies processes locking files\r\n   - Provides detailed diagnostic information\r\n\r\n3. **Proper Prisma cleanup** (electron-src/index.ts)\r\n   - Added prisma.() in before-quit event\r\n   - Ensures clean shutdown of database connections\r\n\r\n## New Commands Added\r\n- npm run find-lock - Diagnose file locks\r\n- npm run force-cleanup - Force clean resources\r\n- npm run windows-build-force - Build with cleanup