### PR TITLE
fix: 関連付けマトリックスの横スクロール機能を修正

### DIFF
--- a/components/projects/04-question-group/QuestionAssignmentMatrix.tsx
+++ b/components/projects/04-question-group/QuestionAssignmentMatrix.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   Table,
   TableBody,
@@ -386,27 +385,36 @@ export function QuestionAssignmentMatrix({
         <CardHeader>
           <CardTitle className="text-base">関連付けマトリックス</CardTitle>
         </CardHeader>
-        <CardContent>
-          <ScrollArea className="h-96 w-full">
-            <div className="overflow-x-auto">
-              <Table 
-                ref={tableRef}
-                className="table-auto" 
-                style={{ minWidth: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 128}px` }}
-                onMouseMove={handleMouseMove}
-                onMouseUp={handleMouseUp}
-                onMouseLeave={handleMouseUp}
-              >
+        <CardContent className="p-0">
+          <div 
+            className="relative h-96 w-full overflow-x-auto overflow-y-auto"
+            style={{ 
+              scrollbarWidth: 'thin',
+              scrollbarColor: 'rgba(0, 0, 0, 0.2) transparent'
+            }}
+          >
+            <Table 
+              ref={tableRef}
+              className="table-fixed" 
+              style={{ 
+                minWidth: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 120}px`,
+                width: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 120}px`
+              }}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseLeave={handleMouseUp}
+            >
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-background sticky left-0 z-10 w-48">
+                  <TableHead className="bg-white sticky left-0 z-10 w-48 border-r-2 border-gray-200">
                     設問
                   </TableHead>
                   {questionGroups.map((group) => (
                     <TableHead 
                       key={group.id} 
-                      className="w-32 text-center bg-blue-50/50 border-l-2 border-blue-200" 
+                      className="text-center bg-blue-50/50 border-l-2 border-blue-200" 
                       colSpan={group.items.length}
+                      style={{ width: `${group.items.length * 120}px` }}
                     >
                       <div className="text-sm font-semibold text-blue-700">
                         {group.name}
@@ -415,12 +423,16 @@ export function QuestionAssignmentMatrix({
                   ))}
                 </TableRow>
                 <TableRow>
-                  <TableHead className="bg-background sticky left-0 z-10 w-48">
+                  <TableHead className="bg-white sticky left-0 z-10 w-48 border-r-2 border-gray-200">
                     {/* 空のセル */}
                   </TableHead>
                   {questionGroups.map((group) => (
                     group.items.map((item) => (
-                      <TableHead key={item.id} className="w-32 text-center bg-gray-50/50">
+                      <TableHead 
+                        key={item.id} 
+                        className="text-center bg-gray-50/50"
+                        style={{ width: '120px', minWidth: '120px' }}
+                      >
                         <div className="text-muted-foreground text-xs">
                           {item.name}
                         </div>
@@ -432,7 +444,7 @@ export function QuestionAssignmentMatrix({
               <TableBody>
                 {layoutRegions.map((region) => (
                   <TableRow key={region.id}>
-                    <TableCell className="bg-background sticky left-0 z-10">
+                    <TableCell className="bg-white sticky left-0 z-10 border-r-2 border-gray-200">
                       <div className="flex items-center gap-2">
                         <div className="font-medium">
                           {region.label || `問${region.orderIndex || 1}`}
@@ -447,6 +459,7 @@ export function QuestionAssignmentMatrix({
                         <TableCell 
                           key={item.id} 
                           className="text-center"
+                          style={{ width: '120px', minWidth: '120px' }}
                           data-checkbox-cell
                           data-question-id={region.id}
                           data-item-id={item.id}
@@ -474,8 +487,7 @@ export function QuestionAssignmentMatrix({
                 ))}
               </TableBody>
               </Table>
-            </div>
-          </ScrollArea>
+          </div>
         </CardContent>
       </Card>
 

--- a/components/projects/04-question-group/SubtotalAssignmentMatrix.tsx
+++ b/components/projects/04-question-group/SubtotalAssignmentMatrix.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   Table,
   TableBody,
@@ -235,20 +234,32 @@ export function SubtotalAssignmentMatrix({
         <CardHeader>
           <CardTitle className="text-base">小計点関連付けマトリックス</CardTitle>
         </CardHeader>
-        <CardContent>
-          <ScrollArea className="h-96 w-full">
-            <div className="overflow-x-auto">
-              <Table className="table-auto" style={{ minWidth: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 128}px` }}>
+        <CardContent className="p-0">
+          <div 
+            className="relative h-96 w-full overflow-x-auto overflow-y-auto"
+            style={{ 
+              scrollbarWidth: 'thin',
+              scrollbarColor: 'rgba(0, 0, 0, 0.2) transparent'
+            }}
+          >
+            <Table 
+              className="table-fixed" 
+              style={{ 
+                minWidth: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 120}px`,
+                width: `${192 + questionGroups.reduce((sum, group) => sum + group.items.length, 0) * 120}px`
+              }}
+            >
               <TableHeader>
                 <TableRow>
-                  <TableHead className="bg-background sticky left-0 z-10 w-48">
+                  <TableHead className="bg-white sticky left-0 z-10 w-48 border-r-2 border-gray-200">
                     小計点領域
                   </TableHead>
                   {questionGroups.map((group) => (
                     <TableHead 
                       key={group.id} 
-                      className="w-32 text-center bg-green-50/50 border-l-2 border-green-200" 
+                      className="text-center bg-green-50/50 border-l-2 border-green-200" 
                       colSpan={group.items.length}
+                      style={{ width: `${group.items.length * 120}px` }}
                     >
                       <div className="text-sm font-semibold text-green-700">
                         {group.name}
@@ -257,12 +268,16 @@ export function SubtotalAssignmentMatrix({
                   ))}
                 </TableRow>
                 <TableRow>
-                  <TableHead className="bg-background sticky left-0 z-10 w-48">
+                  <TableHead className="bg-white sticky left-0 z-10 w-48 border-r-2 border-gray-200">
                     {/* 空のセル */}
                   </TableHead>
                   {questionGroups.map((group) => (
                     group.items.map((item) => (
-                      <TableHead key={item.id} className="w-32 text-center bg-gray-50/50">
+                      <TableHead 
+                        key={item.id} 
+                        className="text-center bg-gray-50/50"
+                        style={{ width: '120px', minWidth: '120px' }}
+                      >
                         <div className="text-muted-foreground text-xs">
                           {item.name}
                         </div>
@@ -274,7 +289,7 @@ export function SubtotalAssignmentMatrix({
               <TableBody>
                 {subtotalRegions.map((region) => (
                   <TableRow key={region.id}>
-                    <TableCell className="bg-background sticky left-0 z-10">
+                    <TableCell className="bg-white sticky left-0 z-10 border-r-2 border-gray-200">
                       <div className="flex items-center gap-2">
                         <div className="font-medium">
                           {region.label || `小計${region.orderIndex || 1}`}
@@ -286,7 +301,11 @@ export function SubtotalAssignmentMatrix({
                     </TableCell>
                     {questionGroups.map((group) => (
                       group.items.map((item) => (
-                        <TableCell key={item.id} className="text-center">
+                        <TableCell 
+                          key={item.id} 
+                          className="text-center"
+                          style={{ width: '120px', minWidth: '120px' }}
+                        >
                           <div className="flex justify-center">
                             <Checkbox
                               checked={
@@ -309,8 +328,7 @@ export function SubtotalAssignmentMatrix({
                 ))}
               </TableBody>
               </Table>
-            </div>
-          </ScrollArea>
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## 概要
関連付けマトリックス（設問・小計点の両方）の横スクロール機能を修正しました。ScrollAreaコンポーネントが横スクロールを阻害していた問題を解決しました。

## 修正内容

### 🐛 問題の原因
- ScrollAreaコンポーネントが横スクロールを適切に処理できていない
- テーブルの幅計算が不正確
- スティッキーカラムの視覚的な区別が不十分

### 🔧 修正内容

#### ScrollAreaからネイティブoverflowへの変更
- `ScrollArea`コンポーネントを削除
- `overflow-x-auto overflow-y-auto`を使用したネイティブスクロール実装
- 薄いスクロールバーのカスタムスタイル適用

#### テーブル構造の改善
- `table-auto` → `table-fixed`に変更して列幅を固定
- 明示的な幅計算（`minWidth`と`width`の両方を指定）
- 列幅を統一（128px → 120px）

#### スティッキーカラムの視覚改善
- 背景色を`bg-background` → `bg-white`に変更
- `border-r-2 border-gray-200`で明確な境界線を追加
- 各セルに`width`と`minWidth`を明示的に指定

## 対象ファイル

### QuestionAssignmentMatrix.tsx
- 設問とグループ項目の関連付けマトリックス
- ドラッグトグル機能と横スクロール機能の両立

### SubtotalAssignmentMatrix.tsx
- 小計点とグループ項目の関連付けマトリックス
- 同様の横スクロール問題を解決

## 改善効果

### ✅ 機能改善
- 横スクロールが正常に動作
- 大量の項目がある場合でも快適な操作性
- スティッキーカラムが適切に固定される

### ✅ 視覚改善
- スティッキーカラムの境界がより明確
- 統一された列幅による整然とした表示
- 薄いスクロールバーによる洗練された外観

## テスト
- [ ] 横スクロールが正常に動作することを確認
- [ ] スティッキーカラムが適切に固定されることを確認
- [ ] 大量の項目でもパフォーマンスが良好であることを確認
- [ ] ドラッグトグル機能が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)