### PR TITLE
feat: Excel出力の正誤一覧で部分点・保留の点数表示と赤色表示を追加

### DIFF
--- a/electron-src/lib/export/excel/row-creators.ts
+++ b/electron-src/lib/export/excel/row-creators.ts
@@ -42,9 +42,12 @@ export async function createDataRows(
       questionStartColIndex + student.scores.length - 1
     const questionStartCol = getExcelColumnLetter(questionStartColIndex)
     const questionEndCol = getExcelColumnLetter(questionEndColIndex)
-    row.getCell("G").value = {
+    const totalCell = row.getCell("G")
+    totalCell.value = {
       formula: `SUM(${questionStartCol}${rowIndex}:${questionEndCol}${rowIndex})`,
     }
+    // 合計点を赤色に設定
+    totalCell.font = { color: { argb: 'FFFF0000' } }
 
     // 小計点の設定
     await setSubtotalCells(
@@ -140,13 +143,22 @@ function setQuestionCells(
 
   for (const score of student.scores) {
     const col = getExcelColumnLetter(scoreColIndex)
+    const cell = row.getCell(col)
 
     if (isScoreSheet) {
       // 点数一覧
-      row.getCell(col).value = score.score || 0
+      cell.value = score.score || 0
+      // 部分点・保留の場合は赤色に設定
+      if (score.status === "partial" || score.status === "hold") {
+        cell.font = { color: { argb: 'FFFF0000' } }
+      }
     } else {
       // 正誤一覧
-      row.getCell(col).value = getStatusSymbol(score.status)
+      cell.value = getStatusSymbol(score.status, score.score ?? undefined)
+      // 部分点・保留の場合は赤色に設定
+      if (score.status === "partial" || score.status === "hold") {
+        cell.font = { color: { argb: 'FFFF0000' } }
+      }
     }
     scoreColIndex++
   }

--- a/electron-src/lib/shared/utilities/excel-utilities.ts
+++ b/electron-src/lib/shared/utilities/excel-utilities.ts
@@ -17,14 +17,14 @@ export function getExcelColumnLetter(colIndex: number): string {
 /**
  * 採点ステータスを正誤記号に変換する関数
  */
-export function getStatusSymbol(status: string): string {
+export function getStatusSymbol(status: string, score?: number): string {
   switch (status) {
     case "correct":
       return "○"
     case "partial":
-      return "△"
+      return score !== undefined && score !== null ? `△${score}` : "△"
     case "hold":
-      return "保"
+      return score !== undefined && score !== null ? `△${score}` : "保"
     case "incorrect":
       return "×"
     case "no_answer":


### PR DESCRIPTION
## 概要
Excel出力の正誤一覧において、部分点・保留について「△4」のように具体的な点数を表示し、さらに赤色で強調表示する機能を追加しました。

## 新機能

### 🎯 部分点・保留の点数表示
- **部分点**: 「△4」形式で実際の獲得点数を表示
- **保留**: 「△4」形式で実際の獲得点数を表示
- **フォールバック**: 点数情報がない場合は従来通り「△」「保」を表示

### 🎨 赤色フォント表示
- **部分点・保留**: 赤色で表示して注目を引く
- **合計点**: 赤色で表示して重要性を強調
- **正答・誤答**: 従来通り黒色で「○」「×」表示

## 主な変更

### excel-utilities.ts
- `getStatusSymbol()` 関数を拡張
- 第二引数として点数(`score?: number`)を受け取るように変更
- 部分点・保留のケースで点数情報を含む文字列を返す

```typescript
// 変更前
export function getStatusSymbol(status: string): string

// 変更後  
export function getStatusSymbol(status: string, score?: number): string
```

### row-creators.ts
- 正誤一覧で `getStatusSymbol()` に点数情報を渡すように修正
- 部分点・保留・合計点セルに赤色フォント(`FFFF0000`)を設定
- TypeScript型エラー修正(`score.score ?? undefined`)

## 表示例

### 点数一覧シート
| 設問 | 結果 | 色 |
|------|------|-----|
| 問1  | 10   | 黒  |
| 問2  | 4    | 赤（部分点）|
| 問3  | 3    | 赤（保留）|
| 合計 | 17   | 赤  |

### 正誤一覧シート
| 設問 | 結果 | 色 |
|------|------|-----|
| 問1  | ○   | 黒  |
| 問2  | △4  | 赤（部分点）|
| 問3  | △3  | 赤（保留）|

## 技術的改善

### 型安全性の向上
- `number | null` → `number | undefined` の適切な変換
- TypeScript型エラーの解決

### 可読性の向上
- 重要な情報（部分点・保留・合計点）が視覚的に区別される
- 具体的な点数情報により詳細な分析が可能

## テスト
- [ ] 部分点が「△4」形式で表示されることを確認
- [ ] 保留が「△4」形式で表示されることを確認
- [ ] 部分点・保留・合計点が赤色で表示されることを確認
- [ ] 正答・誤答が従来通り表示されることを確認
- [ ] 点数情報がない場合の表示が適切であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)