### PR TITLE
fix: PDF採点済み答案の書き出し順序を受験生徒順に修正

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -513,10 +513,19 @@ export async function exportScoredAnswersPDF(
     const questionScores = await getQuestionScoresForProject(projectId)
     const layoutRegions = await getLayoutRegionsByProjectId(projectId)
 
-    // 選択された生徒のデータをフィルタリング
-    const selectedStudents = studentsResult.students.filter((student) =>
-      selectedStudentIds.includes(student.id),
-    )
+    // 選択された生徒のデータをフィルタリングして順序を保持
+    const selectedStudents = studentsResult.students
+      .filter((student) => selectedStudentIds.includes(student.id))
+      .sort((a, b) => {
+        // customOrderが設定されている場合は優先
+        if (a.customOrder !== null && b.customOrder !== null) {
+          return a.customOrder - b.customOrder;
+        }
+        if (a.customOrder !== null) return -1;  // aが優先
+        if (b.customOrder !== null) return 1;   // bが優先
+        // 学籍番号でソート
+        return a.studentId.localeCompare(b.studentId);
+      })
 
     if (selectedStudents.length === 0) {
       throw new Error("選択された生徒が見つかりません")

--- a/electron-src/lib/prisma/projectStudent.ts
+++ b/electron-src/lib/prisma/projectStudent.ts
@@ -10,6 +10,10 @@ export async function getStudentsForProject(projectId: string) {
     // プロジェクトに参加している生徒を取得
     const projectStudents = await prisma.projectStudent.findMany({
       where: { projectId },
+      orderBy: [
+        { customOrder: 'asc' },  // カスタム順序を優先
+        { student: { studentId: 'asc' } }  // 学籍番号順をフォールバック
+      ],
       include: {
         student: {
           include: {


### PR DESCRIPTION
## Summary
- PDF採点済み答案の出力順序が不定だった問題を修正
- 受験生徒管理で設定したカスタム順序が正しく反映されるよう改善
- データベース取得時とPDF出力時の二重ソート実装

## Changes
- `getStudentsForProject()`: ORDER BY句追加（customOrder優先、学籍番号フォールバック）
- `exportScoredAnswersPDF()`: selectedStudentsの明示的ソート処理追加

## Test plan
- [x] TypeScriptビルドが正常に完了することを確認
- [x] 既存機能に影響がないことを確認
- [ ] PDF出力時の生徒順序が設定通りになることをテスト
- [ ] customOrder未設定時に学籍番号順になることをテスト

🤖 Generated with [Claude Code](https://claude.ai/code)