### PR TITLE
fix: 02-templateページで日本語ファイル名のPDFが表示されない問題を修正 (#20)

### DIFF
--- a/electron-src/app-initializer.ts
+++ b/electron-src/app-initializer.ts
@@ -52,16 +52,54 @@ export async function initializeApp(): Promise<void> {
   // カスタムプロトコルの設定
   protocol.handle("appimg", async (request) => {
     try {
+      console.log(`[appimg] Request URL: ${request.url}`)
+      
       const relativePathInData = request.url.substring("appimg://".length)
-      const decodedRelativePath = decodeURI(relativePathInData)
+      console.log(`[appimg] Relative path (raw): ${relativePathInData}`)
+      
+      // より確実なデコード処理
+      let decodedRelativePath
+      try {
+        // まずdecodeURIComponentを試す
+        decodedRelativePath = decodeURIComponent(relativePathInData)
+        console.log(`[appimg] Decoded with decodeURIComponent: ${decodedRelativePath}`)
+      } catch (err) {
+        try {
+          // 失敗したらdecodeURIを試す
+          decodedRelativePath = decodeURI(relativePathInData)
+          console.log(`[appimg] Decoded with decodeURI: ${decodedRelativePath}`)
+        } catch (err2) {
+          // 両方失敗したら生のパスを使用
+          decodedRelativePath = relativePathInData
+          console.log(`[appimg] Using raw path (decode failed): ${decodedRelativePath}`)
+        }
+      }
+      
       const absolutePath = getAbsolutePathFromData(decodedRelativePath)
+      console.log(`[appimg] Absolute path: ${absolutePath}`)
+
+      // ファイル存在確認
+      const fs = await import("fs/promises")
+      try {
+        await fs.access(absolutePath)
+        console.log(`[appimg] File exists: ✓`)
+      } catch (accessError) {
+        const errorMessage = accessError instanceof Error ? accessError.message : String(accessError)
+        console.log(`[appimg] File not accessible: ${errorMessage}`)
+        return new Response("File not found", { status: 404 })
+      }
 
       const fileURL = format({
         pathname: absolutePath,
         protocol: "file:",
         slashes: true,
       })
-      return net.fetch(fileURL)
+      console.log(`[appimg] File URL: ${fileURL}`)
+      
+      const response = await net.fetch(fileURL)
+      console.log(`[appimg] Response status: ${response.status}`)
+      
+      return response
     } catch (error) {
       console.error(
         `Failed to handle 'appimg' protocol request ${request.url}:`,

--- a/electron-src/ipc-handlers/misc-handlers.ts
+++ b/electron-src/ipc-handlers/misc-handlers.ts
@@ -454,7 +454,16 @@ export function setupMiscHandlers(): void {
     "resolve-file-protocol-path",
     async (_event, relativePath: string) => {
       try {
-        return `appimg://${relativePath}`
+        console.log(`[resolve-file-protocol-path] Input path: ${relativePath}`)
+        
+        // パスを適切にエンコード
+        const encodedPath = encodeURI(relativePath)
+        const result = `appimg://${encodedPath}`
+        
+        console.log(`[resolve-file-protocol-path] Encoded path: ${encodedPath}`)
+        console.log(`[resolve-file-protocol-path] Result URL: ${result}`)
+        
+        return result
       } catch (err) {
         console.error("Error in IPC resolve-file-protocol-path:", err)
         throw err


### PR DESCRIPTION
## 問題の概要

issue #20 で報告された、02-templateページ（採点領域作成画面）において日本語文字を含むファイル名のPDFファイルが表示されない問題を修正しました。

## 🔧 修正内容

### 1. appimgプロトコルハンドラーの強化 (`electron-src/app-initializer.ts`)

```typescript
// 3段階フォールバック処理を追加
try {
  decodedRelativePath = decodeURIComponent(relativePathInData)
} catch (err) {
  try {
    decodedRelativePath = decodeURI(relativePathInData)
  } catch (err2) {
    decodedRelativePath = relativePathInData // 生パス使用
  }
}
```

- より確実なURLデコード処理
- 詳細なデバッグログ出力
- ファイル存在確認の強化

### 2. URL生成時のエンコーディング改善 (`electron-src/ipc-handlers/misc-handlers.ts`)

```typescript
// パスを適切にエンコード
const encodedPath = encodeURI(relativePath)
const result = `appimg://${encodedPath}`
```

- `resolveFileProtocolPath` 関数での適切なエンコーディング
- デバッグログによる処理過程の可視化

## 🧪 テスト結果

### 修正前
```
❌ 日本語ファイル名: "単元テスト②_page_111.png" → 表示されない
❌ 日本語ファイル名: "冬休みの友 表紙_page_1.png" → 表示されない
```

### 修正後
```
✅ 日本語ファイル名: "パンデ ★2025 CAD演習Ⅰ 練習問題2_A4_1-1_尺度2倍-モデル_page_1.png" → 正常表示
✅ ログ出力: "[appimg] File exists: ✓" "[appimg] Response status: 200"
```

## 📋 検証ログ

```
[resolve-file-protocol-path] Input path: projects/.../1752907757133-0-07 パンデ ★2025 CAD演習Ⅰ 練習問題2_A4_1-1_尺度2倍-モデル_page_1.png
[resolve-file-protocol-path] Encoded path: projects/.../1752907757133-0-07%20%E3%83%8F%E3%82%9A%E3%83%B3%E3%83%86%E3%82%99%20%E2%98%852025%20CAD%E6%BC%94%E7%BF%92%E2%85%A0%20%E7%B7%B4%E7%BF%92%E5%95%8F%E9%A1%8C2_A4_1-1_%E5%B0%BA%E5%BA%A62%E5%80%8D-%E3%83%A2%E3%83%86%E3%82%99%E3%83%AB_page_1.png
[appimg] Decoded with decodeURIComponent: projects/.../1752907757133-0-07 パンデ ★2025 CAD演習Ⅰ 練習問題2_A4_1-1_尺度2倍-モデル_page_1.png
[appimg] File exists: ✓
[appimg] Response status: 200
```

## 🎯 影響範囲

- ✅ 02-templateページでの日本語ファイル名PDF表示問題の解決
- ✅ 既存の英数字ファイル名プロジェクトの動作維持
- ✅ Electronカスタムプロトコルの信頼性向上
- ✅ 今後の多言語ファイル名対応基盤の整備

## 🔗 関連

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)