### PR TITLE
refactor: 02-templateページのsetTimeout自動保存を即座保存に変更 (#22)

### DIFF
--- a/app/projects/[projectId]/02-template/page.tsx
+++ b/app/projects/[projectId]/02-template/page.tsx
@@ -29,9 +29,6 @@ export default function TemplateStepPage() {
   const projectId =
     typeof paramsProjectId === "string" ? paramsProjectId : paramsProjectId?.[0]
 
-  const [saveTimeoutId, setSaveTimeoutId] = useState<NodeJS.Timeout | null>(
-    null,
-  )
   const isSavingRef = useRef(false)
   const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
   const [project, setProject] = useState<Project | null>(null)
@@ -274,28 +271,19 @@ export default function TemplateStepPage() {
   )
 
   const handleRegionsChange = useCallback(
-    (newRegions: any[] | ((prev: any[]) => any[])) => {
-      setLayoutRegions((prevRegions) => {
-        const finalRegions =
-          typeof newRegions === "function"
-            ? newRegions(prevRegions)
-            : newRegions
+    async (newRegions: any[] | ((prev: any[]) => any[])) => {
+      const finalRegions =
+        typeof newRegions === "function"
+          ? newRegions(layoutRegions)
+          : newRegions
 
-        // Auto-save logic with timeout
-        setSaveTimeoutId((currentTimeoutId) => {
-          if (currentTimeoutId) {
-            clearTimeout(currentTimeoutId)
-          }
+      // Update React state immediately
+      setLayoutRegions(finalRegions)
 
-          return setTimeout(() => {
-            autoSaveRegions(finalRegions)
-          }, 1000)
-        })
-
-        return finalRegions
-      })
+      // Save to database immediately without timeout
+      await autoSaveRegions(finalRegions)
     },
-    [autoSaveRegions],
+    [layoutRegions, autoSaveRegions],
   )
 
   const handleSaveTemplate = async () => {


### PR DESCRIPTION
## 概要

issue #22 で報告された、02-templateページの不要なsetTimeout自動保存処理を即座保存に変更しました。

## 🔧 修正内容

### 1. 不要なsetTimeout削除

**修正前（複雑）:**
```typescript
// Auto-save logic with timeout
setSaveTimeoutId((currentTimeoutId) => {
  if (currentTimeoutId) {
    clearTimeout(currentTimeoutId)
  }

  return setTimeout(() => {
    autoSaveRegions(finalRegions)
  }, 1000)
})
```

**修正後（シンプル）:**
```typescript
// Save to database immediately without timeout
await autoSaveRegions(finalRegions)
```

### 2. 状態管理の簡素化

**削除したもの:**
- ❌ `saveTimeoutId` state変数
- ❌ `setSaveTimeoutId` 関数
- ❌ タイマー管理ロジック（15行 → 0行）

**追加したもの:**
- ✅ シンプルな即座保存処理（5行）
- ✅ async/awaitによる確実な保存

### 3. 処理フローの改善

**修正前:**
```
mouseup → 領域作成 → React state更新 → 1秒待機 → DB保存
```

**修正後:**
```
mouseup → 領域作成 → React state更新 → 即座にDB保存
```

## 📊 修正の根拠

### mouseupイベントの特性
- **mouseupは単発イベント**：連続発生しない
- **1秒遅延が不要**：パフォーマンス向上の効果なし
- **リスクの方が大きい**：ページ切り替え時の保存漏れ

### setTimeout使用が適切なケース
- ✅ mousemove（連続イベント）
- ✅ input（高速入力）
- ✅ resize（連続リサイズ）

### mouseupでの使用が不適切な理由
- ❌ 単発イベントなのでデバウンシング不要
- ❌ 保存タイミングの競合を生む
- ❌ コードの複雑化

## 🎯 期待効果

### 1. 信頼性向上
- ✅ 保存タイミングが確実
- ✅ ページ切り替え時の保存漏れ防止
- ✅ 競合状態の発生要因削減

### 2. コード品質向上
- ✅ 15行 → 5行への簡素化
- ✅ 状態変数の削減
- ✅ 処理フローの直線化

### 3. 今後の問題解決基盤
- ✅ 領域大量生成問題の解決に向けた基盤整備
- ✅ より確実な保存処理
- ✅ デバッグしやすいコード

## 🧪 テスト

- [x] 領域作成時の即座保存動作確認
- [x] React state更新の正常動作確認
- [x] TypeScriptコンパイルエラーの解消
- [x] 既存機能の動作確認

## 🔗 関連

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)