### PR TITLE
fix: ログインリンクのルーティングを修正

### DIFF
--- a/components/Auth/ProtectedRoute.tsx
+++ b/components/Auth/ProtectedRoute.tsx
@@ -14,7 +14,7 @@ export default function ProtectedRoute({
 
   useEffect(() => {
     if (!isLoading && !user) {
-      router.push("/login")
+      router.push("/")
     }
   }, [user, isLoading, router])
 

--- a/components/auth/ProtectedRoute.tsx
+++ b/components/auth/ProtectedRoute.tsx
@@ -14,7 +14,7 @@ export default function ProtectedRoute({
 
   useEffect(() => {
     if (!isLoading && !user) {
-      router.push("/login")
+      router.push("/")
     }
   }, [user, isLoading, router])
 

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -181,9 +181,9 @@ export default function Navigation({
             {isSidebarMinimized ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Link href="/login" passHref>
+                  <Link href="/" passHref>
                     <Button
-                      variant={pathname === "/login" ? "secondary" : "ghost"}
+                      variant={pathname === "/" ? "secondary" : "ghost"}
                       size="icon"
                       className="w-full justify-center"
                       aria-label="ログイン"
@@ -197,9 +197,9 @@ export default function Navigation({
                 </TooltipContent>
               </Tooltip>
             ) : (
-              <Link href="/login" passHref>
+              <Link href="/" passHref>
                 <Button
-                  variant={pathname === "/login" ? "secondary" : "ghost"}
+                  variant={pathname === "/" ? "secondary" : "ghost"}
                   className="w-full justify-start"
                 >
                   <LogIn className="mr-3 h-5 w-5" />


### PR DESCRIPTION
## Summary
- ナビゲーションのログインリンクが存在しない `/login` ページを指していた問題を修正
- 実際のログイン機能を提供するユーザー選択画面（`/`）に正しくリンクするよう変更

## 問題
- Navigation.tsx でログインリンクが `/login` を指していた
- ProtectedRoute.tsx で認証失敗時に `/login` にリダイレクトしていた
- しかし `app/login/page.tsx` が存在せず、404エラーが発生していた

## 解決策
- **Navigation.tsx**: ログインリンクを `/login` から `/` に変更
- **ProtectedRoute.tsx**: 認証失敗時のリダイレクト先を `/login` から `/` に変更
- 現在のアプリケーション設計では、ユーザー選択画面（`app/page.tsx`）がログイン機能を提供している

## 修正したファイル
- `components/layout/Navigation.tsx` - ログインボタンのリンク先変更
- `components/auth/ProtectedRoute.tsx` - 未認証時のリダイレクト先変更
- `components/Auth/ProtectedRoute.tsx` - 同上（重複ファイル）

## Test plan
- [x] ナビゲーションの「ログイン」ボタンをクリックしてユーザー選択画面に遷移
- [x] 未認証状態で保護されたページにアクセスして `/` にリダイレクト
- [x] 404エラーが発生しないことを確認
- [x] ユーザー選択→認証→ダッシュボードのフローが正常動作

🤖 Generated with [Claude Code](https://claude.ai/code)