### PR TITLE
fix: Build後のexeでscore-assetsが読み込めない問題を修正

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -2,7 +2,7 @@ import { dialog } from "electron"
 import fs from "fs"
 import path from "path"
 import { PageSizes, PDFDocument, rgb } from "pdf-lib"
-import { getAbsolutePathFromData } from "../dataManager"
+import { getAbsolutePathFromData, getAppRootPath } from "../dataManager"
 import { getAnswerSheetsByProjectId } from "./answerSheet"
 import { getLayoutRegionsByProjectId } from "./layoutRegion"
 import { getStudentsForProject } from "./projectStudent"
@@ -87,7 +87,7 @@ function getMarkImagePath(
   status: ScoringStatus,
   useTransparent: boolean,
 ): string {
-  const publicDir = path.join(process.cwd(), "public")
+  const publicDir = path.join(getAppRootPath(), "public")
   const prefix = useTransparent ? "tranceparent_" : ""
 
   switch (status) {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "files": [
       "main/**/*",
       ".next/**/*",
+      "public/**/*",
       "node_modules/**/*",
       "package.json"
     ],


### PR DESCRIPTION
## 概要

dev環境では正常に動作するが、build後のexeファイルでscore-assetsが読み込めない問題を修正。

Fixes #37

## 修正内容

### 1. パス解決の修正
- `electron-src/lib/prisma/pdfExport.ts`の`getMarkImagePath()`関数を修正
- `process.cwd()`を`getAppRootPath()`に変更
- build後のexeでも正しいパスを取得できるように修正

### 2. ビルド設定の修正
- `package.json`の`build.files`に`"public/**/*"`を追加  
- score-assetsがexeに正しく包含されるように修正

## 解決する問題

- ✅ 08-exportページで採点マークが表示されない
- ✅ PDF出力時に採点マークが印字されない
- ✅ build後のexeで`/public/score-assets`の画像が取得できない

## テスト計画

- [ ] 修正後にbuild実行
- [ ] 生成されたexeファイルでscore-assetsが正しく表示されることを確認
- [ ] PDF出力で採点マークが正しく印字されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)