### PR TITLE
選択答案の表示方式を背景から枠線に変更し、カスタマイズ可能に

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -13,6 +13,11 @@ import { UserEditModal } from "@/components/auth/UserEditModal"
 import { UserPen, Edit3 } from "lucide-react"
 import { useState, useEffect } from "react"
 import { toast } from "sonner"
+import { 
+  getSelectionBorderSettings, 
+  saveSelectionBorderColor, 
+  SELECTION_BORDER_COLORS 
+} from "@/lib/utils"
 
 interface User {
   id: string
@@ -39,6 +44,7 @@ export default function SettingsPage() {
   const [isPasscodeEditOpen, setIsPasscodeEditOpen] = useState(false)
   const [isUserEditOpen, setIsUserEditOpen] = useState(false)
   const [selectedUser, setSelectedUser] = useState<User | null>(null)
+  const [selectionBorderColor, setSelectionBorderColor] = useState(getSelectionBorderSettings().color)
 
   useEffect(() => {
     loadUsers()
@@ -70,6 +76,14 @@ export default function SettingsPage() {
 
   const handlePasscodeUpdated = () => {
     loadUsers() // ユーザー一覧を再読み込み
+  }
+
+  const handleSelectionBorderColorChange = (color: string) => {
+    setSelectionBorderColor(color)
+    saveSelectionBorderColor(color)
+    // カスタムイベントを発火して他のコンポーネントに通知
+    window.dispatchEvent(new CustomEvent('selectionBorderColorChanged'))
+    toast.success("選択枠色が変更されました")
   }
 
   return (
@@ -122,6 +136,43 @@ export default function SettingsPage() {
                     </div>
                   </div>
                 ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Separator />
+
+          <Card>
+            <CardHeader>
+              <CardTitle>表示設定</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label className="text-base font-medium">選択枠の色</Label>
+                <p className="text-sm text-muted-foreground mb-3">
+                  答案選択時の枠色を変更できます
+                </p>
+                <div className="grid grid-cols-3 gap-3">
+                  {Object.entries(SELECTION_BORDER_COLORS).map(([colorValue, config]) => (
+                    <button
+                      key={colorValue}
+                      onClick={() => handleSelectionBorderColorChange(colorValue)}
+                      className={`relative flex items-center justify-center p-3 rounded-lg border-2 transition-all hover:scale-105 ${
+                        selectionBorderColor === colorValue 
+                          ? 'border-gray-800 shadow-md' 
+                          : 'border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <div 
+                        className="w-8 h-8 rounded border-2"
+                        style={{ borderColor: config.color }}
+                      />
+                      {selectionBorderColor === colorValue && (
+                        <div className="absolute -top-1 -right-1 w-3 h-3 bg-blue-500 rounded-full" />
+                      )}
+                    </button>
+                  ))}
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/components/projects/07-score-at-once/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/AnswerGridView.tsx
@@ -23,6 +23,7 @@ type ScoringStatus =
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import CroppedAnswerImage from "@/components/projects/07-score-at-once/components/CroppedAnswerImage"
+import { getSelectionBorderSettings } from "@/lib/utils"
 
 // 採点状態のアイコンと色を定義
 const SCORE_STATUS_CONFIG = {
@@ -169,6 +170,23 @@ export default function AnswerGridView({
   } | null>(null)
   const [itemsPerRow, setItemsPerRow] = useState([5]) // 1行あたりの表示件数 (0-10)
   const gridRef = useRef<HTMLDivElement>(null)
+  const [selectionBorderSettings, setSelectionBorderSettings] = useState(getSelectionBorderSettings())
+
+  // 選択枠色の設定変更を監視
+  useEffect(() => {
+    const handleStorageChange = () => {
+      setSelectionBorderSettings(getSelectionBorderSettings())
+    }
+    
+    window.addEventListener("storage", handleStorageChange)
+    // カスタムイベントでも監視（同じページ内での変更）
+    window.addEventListener("selectionBorderColorChanged", handleStorageChange)
+    
+    return () => {
+      window.removeEventListener("storage", handleStorageChange)
+      window.removeEventListener("selectionBorderColorChanged", handleStorageChange)
+    }
+  }, [])
 
   // 外部からのitemsPerRowを優先し、ない場合はlocalStorageから読み込み
   useEffect(() => {
@@ -605,7 +623,7 @@ export default function AnswerGridView({
             <div
               key={answer.id}
               data-answer-id={answer.id}
-              className={`flex flex-shrink-0 flex-col gap-1 p-2 ${isMaster ? "border-2 border-black bg-white" : `${config.bgColor || "bg-white"}`} ${!isMaster ? config.borderColor : ""} ${!isMaster && isSelected ? config.selectedBgColor : ""}`}
+              className={`flex flex-shrink-0 flex-col gap-1 p-2 ${isMaster ? "border-2 border-black bg-white" : `${config.bgColor || "bg-white"}`} ${!isMaster ? config.borderColor : ""} ${!isMaster ? (isSelected ? `border-2 ${selectionBorderSettings.tailwindClass}` : "border-2 border-transparent") : ""}`}
               onMouseDown={(e) => handleMouseDown(e, answer.id)}
             >
               {/* 答案画像 */}

--- a/components/projects/07-score-at-once/CroppedAnswerImage.tsx
+++ b/components/projects/07-score-at-once/CroppedAnswerImage.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { getSelectionBorderSettings } from "@/lib/utils"
 
 interface QuestionRegion {
   id: string
@@ -32,6 +33,22 @@ export function CroppedAnswerImage({
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
   const [imageLoaded, setImageLoaded] = useState(false)
+  const [selectionBorderSettings, setSelectionBorderSettings] = useState(getSelectionBorderSettings())
+
+  // 選択枠色の設定変更を監視
+  useEffect(() => {
+    const handleStorageChange = () => {
+      setSelectionBorderSettings(getSelectionBorderSettings())
+    }
+    
+    window.addEventListener("storage", handleStorageChange)
+    window.addEventListener("selectionBorderColorChanged", handleStorageChange)
+    
+    return () => {
+      window.removeEventListener("storage", handleStorageChange)
+      window.removeEventListener("selectionBorderColorChanged", handleStorageChange)
+    }
+  }, [])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -106,7 +123,8 @@ export function CroppedAnswerImage({
 
   return (
     <div
-      className={`relative ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""} ${className}`}
+      className={`relative ring-2 ring-inset ${isSelected ? "" : "ring-transparent"} ${className}`}
+      style={isSelected ? { "--tw-ring-color": selectionBorderSettings.color } as React.CSSProperties : undefined}
     >
       <Image
         ref={imageRef}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,36 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// 選択枠色の設定
+export interface SelectionBorderSettings {
+  color: string
+  tailwindClass: string
+}
+
+export const DEFAULT_SELECTION_BORDER_COLOR = "#f97316" // orange-500
+export const SELECTION_BORDER_COLORS = {
+  "#f97316": { color: "#f97316", tailwindClass: "border-orange-500" }, // オレンジ
+  "#3b82f6": { color: "#3b82f6", tailwindClass: "border-blue-500" }, // 青
+  "#ef4444": { color: "#ef4444", tailwindClass: "border-red-500" }, // 赤
+  "#10b981": { color: "#10b981", tailwindClass: "border-emerald-500" }, // エメラルド
+  "#8b5cf6": { color: "#8b5cf6", tailwindClass: "border-violet-500" }, // バイオレット
+  "#f59e0b": { color: "#f59e0b", tailwindClass: "border-amber-500" }, // アンバー
+}
+
+export function getSelectionBorderSettings(): SelectionBorderSettings {
+  if (typeof window === "undefined") {
+    return SELECTION_BORDER_COLORS[DEFAULT_SELECTION_BORDER_COLOR]
+  }
+  
+  const stored = localStorage.getItem("selectionBorderColor")
+  const color = stored || DEFAULT_SELECTION_BORDER_COLOR
+  
+  return SELECTION_BORDER_COLORS[color] || SELECTION_BORDER_COLORS[DEFAULT_SELECTION_BORDER_COLOR]
+}
+
+export function saveSelectionBorderColor(color: string): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem("selectionBorderColor", color)
+  }
+}


### PR DESCRIPTION
## Summary
- 選択答案の背景表示を削除し、オレンジ色の枠線表示に変更
- 6色のプリセット（オレンジ、青、赤、エメラルド、バイオレット、アンバー）から選択可能な設定機能を追加
- 設定画面に「表示設定」セクションを追加、視覚的な色選択UIを実装
- 非選択答案にも透明枠を追加してUIレイアウトの一貫性を保持

## Test plan
- [x] 07-score-at-once画面で選択答案が枠線で表示されることを確認
- [x] 設定画面で枠色を変更できることを確認
- [x] 枠色変更がリアルタイムで反映されることを確認
- [x] 非選択答案も透明枠でレイアウトが維持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)