### PR TITLE
fix: 採点領域の作成順序と表示順序が一致しない問題を修正

### DIFF
--- a/app/projects/[projectId]/03-region-info/page.tsx
+++ b/app/projects/[projectId]/03-region-info/page.tsx
@@ -162,6 +162,7 @@ export default function RegionInfoPage() {
             height: area.height,
             label: area.label,
             points: area.points,
+            orderIndex: area.orderIndex,
           }
 
           if (area.id) {

--- a/components/projects/02-template/hooks/use-region-save.ts
+++ b/components/projects/02-template/hooks/use-region-save.ts
@@ -50,6 +50,7 @@ export function useRegionSave(
           height: region.height,
           label: region.label,
           points: typeof region.points === 'string' ? parseInt(region.points) : region.points,
+          orderIndex: region.orderIndex,
         }
 
         if (operation === 'update' && region.id) {
@@ -106,6 +107,7 @@ export function useRegionSave(
             height: area.height,
             label: area.label,
             points: typeof area.points === 'string' ? parseInt(area.points) : area.points,
+            orderIndex: area.orderIndex,
           }
 
           if (area.id) {
@@ -174,7 +176,8 @@ export function useRegionSave(
           label = "新規エリア"
       }
 
-      // 新規領域オブジェクトを作成
+      // 新規領域オブジェクトを作成（orderIndexを設定）
+      const nextOrderIndex = existingRegions.length
       const newRegion: LayoutRegionArea = {
         type,
         x: coords.x,
@@ -184,6 +187,7 @@ export function useRegionSave(
         label,
         points,
         masterImageId,
+        orderIndex: nextOrderIndex,
       }
 
       try {

--- a/components/projects/03-region-info/RegionDetailsTable.tsx
+++ b/components/projects/03-region-info/RegionDetailsTable.tsx
@@ -82,7 +82,28 @@ const RegionDetailsTable = ({
 
         // UI状態を更新
         const newRegions = regions.filter((_, i) => i !== regionToDelete)
-        setRegions(newRegions)
+        
+        // orderIndexを再計算してデータベースに反映
+        const updatedRegions = newRegions.map((region, index) => ({
+          ...region,
+          orderIndex: index,
+        }))
+        
+        // データベースのorderIndexを更新
+        try {
+          const updates = updatedRegions.map((region, index) => ({
+            id: region.id,
+            orderIndex: index,
+          })).filter(update => update.id) // IDがあるもののみ
+          
+          if ((window as any).electronAPI?.updateLayoutRegionOrders && updates.length > 0) {
+            await (window as any).electronAPI.updateLayoutRegionOrders(updates)
+          }
+        } catch (orderError) {
+          console.error("Error updating region order after deletion:", orderError)
+        }
+        
+        setRegions(updatedRegions)
         setDeleteModalOpen(false)
         setRegionToDelete(null)
 

--- a/components/projects/03-region-info/hooks/useDragAndDrop.ts
+++ b/components/projects/03-region-info/hooks/useDragAndDrop.ts
@@ -55,7 +55,7 @@ export const useDragAndDrop = ({
       try {
         const updates = newRegions.map((region, index) => ({
           id: region.id,
-          orderIndex: index + 1, // 1から始まる連番
+          orderIndex: index, // 0から始まる連番
         }))
         
         if ((window as any).electronAPI?.updateLayoutRegionOrders) {

--- a/electron-src/lib/prisma/layoutRegion.ts
+++ b/electron-src/lib/prisma/layoutRegion.ts
@@ -69,7 +69,7 @@ export const deleteLayoutRegion = async (id: string) => {
 
 // プロジェクトIDで LayoutRegion を取得
 export const getLayoutRegionsByProjectId = async (projectId: string) => {
-  return prisma.layoutRegion.findMany({
+  const regions = await prisma.layoutRegion.findMany({
     where: { projectId },
     include: {
       masterImage: true, // masterImage情報を追加
@@ -92,6 +92,49 @@ export const getLayoutRegionsByProjectId = async (projectId: string) => {
       { x: "asc" }, // X座標（フォールバック）
     ],
   })
+
+  // orderIndexがnullの領域があった場合、自動で設定する
+  const regionsWithNullOrder = regions.filter(region => region.orderIndex === null)
+  if (regionsWithNullOrder.length > 0) {
+    console.log(`Found ${regionsWithNullOrder.length} regions with null orderIndex, fixing...`)
+    
+    // orderIndex順で並べ替え済みの結果を使用してorderIndexを設定
+    const updates = regions.map((region, index) => 
+      prisma.layoutRegion.update({
+        where: { id: region.id },
+        data: { orderIndex: index }
+      })
+    )
+    
+    await Promise.all(updates)
+    
+    // 更新後のデータを再取得
+    return await prisma.layoutRegion.findMany({
+      where: { projectId },
+      include: {
+        masterImage: true,
+        subtotalDefinitions: {
+          include: {
+            questionGroupItem: true,
+          },
+        },
+        questionSubtotalAssignments: {
+          include: {
+            questionGroupItem: true,
+          },
+        },
+        questionScores: true,
+      },
+      orderBy: [
+        { orderIndex: "asc" },
+        { masterImageId: "asc" },
+        { y: "asc" },
+        { x: "asc" },
+      ],
+    })
+  }
+
+  return regions
 }
 
 // IDで LayoutRegion を取得


### PR DESCRIPTION
## 解決する問題

採点領域作成ページ（02-template）で順番に枠を決めていき、次の領域情報ページ（03-region-info）に行くと、ラベルの番号と＃の番号が一致せず、ラベルの順番が順番通りに並ばない問題を修正します。

Closes #40

## 原因

1. データベースには`orderIndex`フィールドが存在し、データ取得時も`orderBy: [{ orderIndex: "asc" }]`で順序付けしている
2. しかし、領域作成時に`orderIndex`が設定されていない
3. 結果として、`orderIndex`が`null`のため、フォールバック順序（`masterImageId`, `y`, `x`）で並び替えられ、作成順と異なる順序で表示される

## 修正内容

### 1. 領域作成時の`orderIndex`設定
- `use-region-save.ts`: 新規領域作成時に`orderIndex: existingRegions.length`を設定
- `saveRegion`と`autoSaveRegions`でもorderIndexをデータベースに保存

### 2. 領域情報ページでの保存処理
- `03-region-info/page.tsx`: `autoSaveRegions`でもorderIndexを含めて保存

### 3. ドラッグ&ドロップでの順序変更
- `useDragAndDrop.ts`: DnD時の順序変更で0から始まる連番に修正

### 4. 領域削除時の順序再計算
- `RegionDetailsTable.tsx`: 削除後に残りの領域のorderIndexを再計算・更新

### 5. 既存データの自動修正
- `layoutRegion.ts`: 既存のorderIndexがnullの領域を自動で修正

## テスト計画

- [ ] 新規プロジェクトで採点領域を作成し、順序が正しく保持されることを確認
- [ ] 既存プロジェクトでorderIndexが自動修正されることを確認
- [ ] DnDによる順序変更が正しく動作することを確認
- [ ] 領域削除後も順序が正しく保持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)