### PR TITLE
日本語IME入力時のキーボードナビゲーション改善

### DIFF
--- a/components/projects/03-region-info/RegionDetailsTable.tsx
+++ b/components/projects/03-region-info/RegionDetailsTable.tsx
@@ -31,7 +31,7 @@ const RegionDetailsTable = ({
   const filteredRegions = regions
 
   // カスタムフック
-  const { handleKeyDown } = useKeyboardNavigation({ filteredRegions })
+  const { handleKeyDown, handleCompositionStart, handleCompositionEnd } = useKeyboardNavigation({ filteredRegions })
   const {
     dragState,
     handleDragStart,
@@ -196,6 +196,8 @@ const RegionDetailsTable = ({
                   disabled={disabled}
                   onRegionChange={handleRegionChange}
                   onKeyDown={handleKeyDown}
+                  onCompositionStart={handleCompositionStart}
+                  onCompositionEnd={handleCompositionEnd}
                   onDelete={handleDeleteRegion}
                   onSelect={setSelectedRowIndex}
                   onDragStart={handleDragStart}

--- a/components/projects/03-region-info/components/RegionTableRow.tsx
+++ b/components/projects/03-region-info/components/RegionTableRow.tsx
@@ -48,6 +48,8 @@ type RegionTableRowProps = {
   disabled: boolean
   onRegionChange: (globalIndex: number, field: string, value: any) => void
   onKeyDown: (e: React.KeyboardEvent, rowIndex: number, fieldName: string) => void
+  onCompositionStart: () => void
+  onCompositionEnd: () => void
   onDelete: (globalIndex: number) => void
   onSelect: (globalIndex: number | null) => void
   onDragStart: (index: number) => void
@@ -66,6 +68,8 @@ export const RegionTableRow = ({
   disabled,
   onRegionChange,
   onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
   onDelete,
   onSelect,
   onDragStart,
@@ -154,6 +158,8 @@ export const RegionTableRow = ({
           onKeyDown={(e) =>
             onKeyDown(e, globalIndex, "label")
           }
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           disabled={disabled}
           placeholder="領域名を入力"
           className="h-8 w-full min-w-20"
@@ -176,6 +182,8 @@ export const RegionTableRow = ({
             onKeyDown={(e) =>
               onKeyDown(e, globalIndex, "points")
             }
+            onCompositionStart={onCompositionStart}
+            onCompositionEnd={onCompositionEnd}
             disabled={disabled}
             placeholder="10"
             className="h-8 w-full min-w-20"

--- a/components/projects/03-region-info/hooks/useKeyboardNavigation.ts
+++ b/components/projects/03-region-info/hooks/useKeyboardNavigation.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import type { LayoutRegionWithDetails } from "@/types/electron"
 
 type UseKeyboardNavigationProps = {
@@ -5,11 +6,26 @@ type UseKeyboardNavigationProps = {
 }
 
 export const useKeyboardNavigation = ({ filteredRegions }: UseKeyboardNavigationProps) => {
+  const isComposingRef = useRef(false)
+
+  const handleCompositionStart = () => {
+    isComposingRef.current = true
+  }
+
+  const handleCompositionEnd = () => {
+    isComposingRef.current = false
+  }
+
   const handleKeyDown = (
     e: React.KeyboardEvent,
     rowIndex: number,
     fieldName: string,
   ) => {
+    // IME入力中はEnterキーとTabキーでの移動をスキップ
+    if ((e.key === "Enter" || e.key === "Tab") && isComposingRef.current) {
+      return
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
       // Move to next row, same field
@@ -102,5 +118,9 @@ export const useKeyboardNavigation = ({ filteredRegions }: UseKeyboardNavigation
     }
   }
 
-  return { handleKeyDown }
+  return { 
+    handleKeyDown,
+    handleCompositionStart,
+    handleCompositionEnd
+  }
 }


### PR DESCRIPTION
## 概要

領域詳細設定画面において、日本語IME入力時に発生していたキーボードナビゲーションの問題を解決しました。

## 問題

日本語入力時のIME確定（Enter）で意図しない行移動が発生し、入力体験が阻害されていました。

## 解決内容

### 🔧 技術実装

- **IME状態追跡**: `onCompositionStart`/`onCompositionEnd`イベントでIME入力状態を管理
- **条件分岐処理**: IME入力中は`Enter`と`Tab`キーでのフィールド移動を無効化  
- **通常操作維持**: IME非使用時の既存キーボードナビゲーションは完全保持

### 📝 変更ファイル

- `components/projects/03-region-info/hooks/useKeyboardNavigation.ts`
- `components/projects/03-region-info/components/RegionTableRow.tsx`  
- `components/projects/03-region-info/RegionDetailsTable.tsx`

## テスト計画

- [x] 日本語入力でのIME確定時に行移動しないことを確認
- [x] 通常のEnter/Tabキーでの移動は正常に動作することを確認
- [x] 既存のキーボードショートカット機能に影響がないことを確認

## 影響範囲

ユーザー体験の改善のみで、既存機能への影響はありません。

Closes #46

🤖 Generated with [Claude Code](https://claude.ai/code)