### PR TITLE
fix: 答案入れ替え機能の根本的改善とモーダルUI修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ data/
 
 # ビルド出力・テスト
 temp-test/
+test-results/
 
 # Electron配布ファイル
 dist/

--- a/app/projects/[projectId]/06-answer-sheets/hooks/index.tsx
+++ b/app/projects/[projectId]/06-answer-sheets/hooks/index.tsx
@@ -5,7 +5,10 @@
 import { useCallback, useState } from "react"
 import { toast } from "sonner"
 import type { AnswerSheetWithDetails } from "@/types/electron"
-import type { PendingChange, ScoringDataOption } from "@/types/answer-sheet.types"
+import type {
+  PendingChange,
+  ScoringDataOption,
+} from "@/types/answer-sheet.types"
 import type { StudentData } from "../components"
 
 interface ProjectData {
@@ -15,7 +18,6 @@ interface ProjectData {
 }
 
 export function useAnswerSheetsData(projectId: string) {
-  const [project, setProject] = useState<ProjectData | null>(null)
   const [students, setStudents] = useState<StudentData[]>([])
   const [answerSheets, setAnswerSheets] = useState<AnswerSheetWithDetails[]>([])
   const [masterImageCount, setMasterImageCount] = useState<number>(0)
@@ -27,23 +29,18 @@ export function useAnswerSheetsData(projectId: string) {
     try {
       setIsLoading(true)
 
-      // Load project
-      const projectResult = await window.electronAPI.fetchProjectById(projectId)
-      if (projectResult) {
-        setProject({
-          id: projectResult.id,
-          name: projectResult.examName,
-          description: projectResult.description || undefined,
-        })
-      }
-
       // Load students
-      const projectStudentsResult = await window.electronAPI.getStudentsForProject(projectId)
+      const projectStudentsResult =
+        await window.electronAPI.getStudentsForProject(projectId)
       if (projectStudentsResult.success && projectStudentsResult.students) {
         const sortedStudents = projectStudentsResult.students
           .sort((a: any, b: any) => {
-            if (a.customOrder !== null && a.customOrder !== undefined && 
-                b.customOrder !== null && b.customOrder !== undefined) {
+            if (
+              a.customOrder !== null &&
+              a.customOrder !== undefined &&
+              b.customOrder !== null &&
+              b.customOrder !== undefined
+            ) {
               return a.customOrder - b.customOrder
             }
             if (a.customOrder !== null && a.customOrder !== undefined) return -1
@@ -66,7 +63,8 @@ export function useAnswerSheetsData(projectId: string) {
             lastNameKana: student.lastNameKana,
             firstNameKana: student.firstNameKana,
             studentId: student.studentId,
-            attendanceNumber: student.memberships?.[0]?.attendanceNumber || null,
+            attendanceNumber:
+              student.memberships?.[0]?.attendanceNumber || null,
             status: student.status,
             customOrder: student.customOrder ?? null,
           }))
@@ -75,17 +73,20 @@ export function useAnswerSheetsData(projectId: string) {
       }
 
       // Load answer sheets
-      const answerSheetsResult = await window.electronAPI.getAnswerSheetsByProjectId(projectId)
+      const answerSheetsResult =
+        await window.electronAPI.getAnswerSheetsByProjectId(projectId)
       if (answerSheetsResult.success && answerSheetsResult.answerSheets) {
         setAnswerSheets(answerSheetsResult.answerSheets)
       }
 
       // Load master image count
       try {
-        const masterImages = await window.electronAPI.getMasterImagesByProjectId(projectId)
-        const maxPages = masterImages && masterImages.length > 0 
-          ? Math.max(...masterImages.map((img: any) => img.pageNumber)) 
-          : 0
+        const masterImages =
+          await window.electronAPI.getMasterImagesByProjectId(projectId)
+        const maxPages =
+          masterImages && masterImages.length > 0
+            ? Math.max(...masterImages.map((img: any) => img.pageNumber))
+            : 0
         setMasterImageCount(maxPages)
       } catch (error) {
         console.error("Failed to load master image count:", error)
@@ -100,7 +101,6 @@ export function useAnswerSheetsData(projectId: string) {
   }, [projectId])
 
   return {
-    project,
     students,
     answerSheets,
     masterImageCount,
@@ -109,81 +109,157 @@ export function useAnswerSheetsData(projectId: string) {
   }
 }
 
-export function usePendingChanges(onDataReload: () => Promise<void>, students?: StudentData[]) {
+export function usePendingChanges(
+  onDataReload: () => Promise<void>,
+  students?: StudentData[],
+  answerSheets?: AnswerSheetWithDetails[],
+) {
   const [pendingChanges, setPendingChanges] = useState<PendingChange[]>([])
   const [affectedCells, setAffectedCells] = useState<Set<string>>(new Set())
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false)
 
-  const handleUpdatePendingChanges = useCallback((changedFiles: Array<{ fileId: string; fromState: any; toState: any }>) => {
-    // PendingChange配列を一括作成
-    const newPendingChanges = changedFiles.map(({ fileId, fromState, toState }) => {
-      // 生徒名を解決
-      const fromStudent = students?.find(s => s.id === fromState.studentId)
-      const toStudent = students?.find(s => s.id === toState.studentId)
+  const handleUpdatePendingChanges = useCallback(
+    (changedFiles: Array<{ fileId: string; fromState: any; toState: any }>) => {
+      console.log(
+        "🔄 Creating pending changes from changed files:",
+        changedFiles,
+      )
 
-      const change: PendingChange = {
-        id: `${fileId}-change-${Date.now()}-${fromState.studentId}-${fromState.pageNumber}-${toState.studentId}-${toState.pageNumber}`,
-        answerSheetId1: fileId,
-        answerSheetId2: fileId,
-        timestamp: new Date(),
-        position1: {
-          studentId: fromState.studentId,
-          pageNumber: fromState.pageNumber,
-          studentName: fromStudent ? `${fromStudent.lastName} ${fromStudent.firstName}` : undefined,
-        },
-        position2: {
-          studentId: toState.studentId,
-          pageNumber: toState.pageNumber,
-          studentName: toStudent ? `${toStudent.lastName} ${toStudent.firstName}` : undefined,
-        },
-      }
-      return change
-    })
-
-    // 一括更新
-    setPendingChanges(newPendingChanges)
-    setAffectedCells(new Set(changedFiles.map(({ fileId }) => fileId)))
-  }, [students])
-
-  const handleApplyChanges = useCallback(async (option: ScoringDataOption, resetDragDropFn?: () => void) => {
-    if (option === "cancel") {
-      setPendingChanges([])
-      setAffectedCells(new Set())
-      // DnD配列も初期状態に戻す
-      if (resetDragDropFn) {
-        resetDragDropFn()
-      }
-      toast.info("変更をキャンセルしました")
-      return
-    }
-
-    try {
-      for (const change of pendingChanges) {
-        if (option === "with-scoring") {
-          await window.electronAPI.swapAnswerSheetPlacementsWithScoring(
-            change.answerSheetId1,
-            change.answerSheetId2
+      // PendingChange配列を一括作成
+      const newPendingChanges = changedFiles.map(
+        ({ fileId, fromState, toState }) => {
+          // 生徒名を解決
+          const fromStudent = students?.find(
+            (s) => s.id === fromState.studentId,
           )
-        } else {
-          await window.electronAPI.swapAnswerSheetPlacements(
-            change.answerSheetId1,
-            change.answerSheetId2
+          const toStudent = students?.find((s) => s.id === toState.studentId)
+
+          // 移動先にある既存ファイルを特定
+          // answerSheetsから移動先位置(toState.studentId, toState.pageNumber)にあるファイルを検索
+          const targetFile = answerSheets?.find(
+            (sheet) =>
+              sheet.studentId === toState.studentId &&
+              sheet.pageNumber === toState.pageNumber &&
+              sheet.id !== fileId, // 移動されたファイル自体は除外
           )
+
+          console.log("🎯 Target file search:", {
+            fileId,
+            toState,
+            targetFile: targetFile
+              ? {
+                  id: targetFile.id,
+                  studentId: targetFile.studentId,
+                  pageNumber: targetFile.pageNumber,
+                }
+              : null,
+            totalAnswerSheets: answerSheets?.length || 0,
+          })
+
+          const change: PendingChange = {
+            id: `${fileId}-change-${Date.now()}-${fromState.studentId}-${fromState.pageNumber}-${toState.studentId}-${toState.pageNumber}`,
+            movedFileId: fileId,
+            targetFileId: targetFile?.id || null, // 移動先にファイルがない場合はnull
+            timestamp: new Date(),
+            fromPosition: {
+              studentId: fromState.studentId,
+              pageNumber: fromState.pageNumber,
+              studentName: fromStudent
+                ? `${fromStudent.lastName} ${fromStudent.firstName}`
+                : undefined,
+            },
+            toPosition: {
+              studentId: toState.studentId,
+              pageNumber: toState.pageNumber,
+              studentName: toStudent
+                ? `${toStudent.lastName} ${toStudent.firstName}`
+                : undefined,
+            },
+          }
+          return change
+        },
+      )
+
+      // 一括更新
+      setPendingChanges(newPendingChanges)
+      setAffectedCells(new Set(changedFiles.map(({ fileId }) => fileId)))
+    },
+    [students, answerSheets],
+  )
+
+  const handleApplyChanges = useCallback(
+    async (option: ScoringDataOption, resetDragDropFn?: () => void) => {
+      try {
+        // 全ての変更を一方向移動として収集
+        const allMoves: Array<{
+          fileId: string
+          finalStudentId: string | null
+          finalPageNumber: number
+        }> = []
+
+        for (const change of pendingChanges) {
+          // 移動されるファイルの最終位置
+          allMoves.push({
+            fileId: change.movedFileId,
+            finalStudentId: change.toPosition.studentId,
+            finalPageNumber: change.toPosition.pageNumber,
+          })
         }
+
+        console.log("🔄 Batch moves to apply:", {
+          totalMoves: allMoves.length,
+          moves: allMoves.map((m) => ({
+            fileId: m.fileId.substring(0, 8) + "...",
+            to: `${m.finalStudentId?.substring(0, 8) || "null"}...page${m.finalPageNumber}`,
+          })),
+        })
+
+        // 一括移動処理：トランザクション内で全ての移動を同時実行
+        console.log("📝 Calling batch placement update...")
+        const result =
+          await window.electronAPI.batchUpdateAnswerSheetPlacements(
+            allMoves,
+            option === "with-scoring",
+          )
+
+        console.log("✅ Batch placement update result:", result)
+
+        if (!result || !result.success) {
+          throw new Error(result?.error || "一括配置変更に失敗しました")
+        }
+
+        console.log("🔄 Clearing pending changes and reloading data...")
+        setPendingChanges([])
+        setAffectedCells(new Set())
+
+        console.log("🔄 Calling onDataReload...")
+        await onDataReload()
+        console.log("✅ Data reload completed")
+
+        const optionText =
+          option === "with-scoring" ? "採点情報込み" : "答案画像のみ"
+        toast.success(
+          `${pendingChanges.length}件の変更を適用しました（${optionText}）`,
+        )
+      } catch (error) {
+        console.error("変更の適用に失敗しました:", error)
+        toast.error("変更の適用に失敗しました")
+        throw error
       }
+    },
+    [pendingChanges, onDataReload],
+  )
 
-      setPendingChanges([])
-      setAffectedCells(new Set())
-      await onDataReload()
-
-      const optionText = option === "with-scoring" ? "採点情報込み" : "答案画像のみ"
-      toast.success(`${pendingChanges.length}件の変更を適用しました（${optionText}）`)
-    } catch (error) {
-      console.error("変更の適用に失敗しました:", error)
-      toast.error("変更の適用に失敗しました")
-      throw error
+  const handleResetChanges = useCallback((resetDragDropFn?: () => void) => {
+    setPendingChanges([])
+    setAffectedCells(new Set())
+    // DnD配列も初期状態に戻す
+    if (resetDragDropFn) {
+      resetDragDropFn()
     }
-  }, [pendingChanges, onDataReload])
+    setIsConfirmModalOpen(false)
+    toast.info("変更をリセットしました")
+  }, [])
 
   return {
     pendingChanges,
@@ -191,6 +267,7 @@ export function usePendingChanges(onDataReload: () => Promise<void>, students?: 
     isConfirmModalOpen,
     handleUpdatePendingChanges,
     handleApplyChanges,
+    handleResetChanges,
     openConfirmModal: () => setIsConfirmModalOpen(true),
     closeConfirmModal: () => setIsConfirmModalOpen(false),
   }

--- a/app/projects/[projectId]/06-answer-sheets/page.tsx
+++ b/app/projects/[projectId]/06-answer-sheets/page.tsx
@@ -17,13 +17,13 @@ import { toast } from "sonner"
 
 /**
  * AnswerSheetsPage - Main page component for answer sheet management
- * 
+ *
  * Features:
  * - Upload and manage answer sheets
  * - Associate answer sheets with students
  * - Optimistic updates for answer sheet placement changes
  * - Tabbed interface for new uploads and existing sheets
- * 
+ *
  * @returns JSX component for answer sheets page
  */
 
@@ -36,7 +36,6 @@ export default function AnswerSheetsPage() {
 
   // Data loading hook
   const {
-    project: _project,
     students,
     answerSheets,
     masterImageCount,
@@ -51,9 +50,10 @@ export default function AnswerSheetsPage() {
     isConfirmModalOpen,
     handleUpdatePendingChanges,
     handleApplyChanges,
+    handleResetChanges,
     openConfirmModal,
     closeConfirmModal,
-  } = usePendingChanges(loadData, students)
+  } = usePendingChanges(loadData, students, answerSheets)
 
   // DnD reset function ref
   const resetDragDropRef = useRef<(() => void) | null>(null)
@@ -119,6 +119,7 @@ export default function AnswerSheetsPage() {
             onClose={closeConfirmModal}
             pendingChanges={pendingChanges}
             onConfirm={handleApplyChanges}
+            onReset={handleResetChanges}
             resetDragDropFn={resetDragDropRef.current || undefined}
           />
         </div>

--- a/components/projects/06-answer-sheets/answer-sheet-table/components/confirm-changes-modal.tsx
+++ b/components/projects/06-answer-sheets/answer-sheet-table/components/confirm-changes-modal.tsx
@@ -20,6 +20,7 @@ interface ConfirmChangesModalProps {
   onClose: () => void
   pendingChanges: PendingChange[]
   onConfirm: (option: ScoringDataOption, resetDragDropFn?: () => void) => Promise<void>
+  onReset?: (resetDragDropFn?: () => void) => void
   resetDragDropFn?: (() => void) | undefined
 }
 
@@ -28,6 +29,7 @@ export function ConfirmChangesModal({
   onClose,
   pendingChanges,
   onConfirm,
+  onReset,
   resetDragDropFn,
 }: ConfirmChangesModalProps) {
   const [selectedOption, setSelectedOption] = useState<ScoringDataOption>("with-scoring")
@@ -46,8 +48,13 @@ export function ConfirmChangesModal({
   }
 
   const handleCancel = () => {
-    onConfirm("cancel", resetDragDropFn)
     onClose()
+  }
+
+  const handleReset = () => {
+    if (onReset) {
+      onReset(resetDragDropFn)
+    }
   }
 
   return (
@@ -79,14 +86,19 @@ export function ConfirmChangesModal({
                   <div className="flex-1 text-sm">
                     <div className="flex items-center gap-2">
                       <span className="font-medium">
-                        {change.position1.studentName || "未割当"} 
-                        <span className="text-gray-500 ml-1">P{change.position1.pageNumber}</span>
+                        {change.fromPosition.studentName || "未割当"} 
+                        <span className="text-gray-500 ml-1">P{change.fromPosition.pageNumber}</span>
                       </span>
                       <span className="text-gray-400">→</span>
                       <span className="font-medium">
-                        {change.position2.studentName || "未割当"}
-                        <span className="text-gray-500 ml-1">P{change.position2.pageNumber}</span>
+                        {change.toPosition.studentName || "未割当"}
+                        <span className="text-gray-500 ml-1">P{change.toPosition.pageNumber}</span>
                       </span>
+                      {change.targetFileId && (
+                        <span className="text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded">
+                          入れ替え
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -173,10 +185,15 @@ export function ConfirmChangesModal({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="flex gap-2">
           <Button variant="outline" onClick={handleCancel} disabled={isApplying}>
             キャンセル
           </Button>
+          {onReset && (
+            <Button variant="outline" onClick={handleReset} disabled={isApplying} className="text-red-600 border-red-300 hover:bg-red-50">
+              リセット
+            </Button>
+          )}
           <Button
             onClick={handleConfirm}
             disabled={isApplying}

--- a/electron-src/ipc-handlers/misc-handlers.ts
+++ b/electron-src/ipc-handlers/misc-handlers.ts
@@ -22,6 +22,7 @@ import {
   updateAnswerSheetPlacement,
   swapAnswerSheetPlacements,
   swapAnswerSheetPlacementsWithScoring,
+  batchUpdateAnswerSheetPlacements,
 } from "../lib/prisma/answerSheet"
 import { fetchUsers, getCurrentUser } from "../lib/prisma/user"
 import {
@@ -372,6 +373,31 @@ export function setupMiscHandlers(): void {
           "Error swapping answer sheet placements with scoring:",
           err,
         )
+        throw err
+      }
+    },
+  )
+
+  ipcMain.handle(
+    "batch-update-answer-sheet-placements",
+    async (
+      _event,
+      moves: Array<{
+        fileId: string
+        finalStudentId: string | null
+        finalPageNumber: number
+      }>,
+      withScoring: boolean = false
+    ) => {
+      try {
+        const result = await batchUpdateAnswerSheetPlacements(moves, withScoring)
+        if (!result.success) {
+          const errorMessage = "error" in result ? result.error : "Unknown error"
+          throw new Error(errorMessage)
+        }
+        return result
+      } catch (err) {
+        console.error("Error in batch update answer sheet placements:", err)
         throw err
       }
     },

--- a/electron-src/lib/prisma/answerSheet.ts
+++ b/electron-src/lib/prisma/answerSheet.ts
@@ -433,11 +433,132 @@ export async function swapAnswerSheetPlacements(
   }
 }
 
+// 複数の答案の配置を一括で変更（採点情報の移行も対応）
+export async function batchUpdateAnswerSheetPlacements(
+  moves: Array<{
+    fileId: string
+    finalStudentId: string | null
+    finalPageNumber: number
+  }>,
+  withScoring: boolean = false
+) {
+  console.log("🔄 [Electron] Starting batch placement update:", {
+    movesCount: moves.length,
+    withScoring,
+    moves: moves.map(m => ({ fileId: m.fileId.substring(0, 8) + "...", to: `${m.finalStudentId?.substring(0, 8) || 'null'}...p${m.finalPageNumber}` }))
+  })
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      // 移動対象の答案情報と採点データを取得
+      const answerSheets = await Promise.all(
+        moves.map(move => 
+          tx.answerSheet.findUnique({
+            where: { id: move.fileId },
+            select: { 
+              id: true,
+              projectId: true, 
+              studentId: true, 
+              pageNumber: true 
+            },
+          })
+        )
+      )
+
+      console.log("📄 [Electron] Found answer sheets:", answerSheets.filter(Boolean).length)
+
+      // 見つからない答案をチェック
+      const missingSheets = moves.filter((_, index) => !answerSheets[index])
+      if (missingSheets.length > 0) {
+        throw new Error(`答案が見つかりません: ${missingSheets.map(m => m.fileId).join(', ')}`)
+      }
+
+      let allQuestionScores: any[] = []
+
+      if (withScoring) {
+        // 全ての採点データを取得
+        allQuestionScores = await tx.questionScore.findMany({
+          where: { 
+            answerSheetId: { 
+              in: moves.map(m => m.fileId) 
+            } 
+          },
+        })
+
+        console.log("📊 [Electron] Found question scores:", allQuestionScores.length)
+
+        // 一時的に採点データを削除（制約回避）
+        await tx.questionScore.deleteMany({
+          where: { 
+            answerSheetId: { 
+              in: moves.map(m => m.fileId) 
+            } 
+          },
+        })
+      }
+
+      // 一時的に全ての答案をnull位置に移動（制約回避）
+      await Promise.all(
+        moves.map((_, index) => 
+          tx.answerSheet.update({
+            where: { id: moves[index].fileId },
+            data: {
+              studentId: null,
+              pageNumber: -(index + 1), // 一時的な一意の値
+            },
+          })
+        )
+      )
+
+      // 各答案を最終位置に移動
+      await Promise.all(
+        moves.map(move => 
+          tx.answerSheet.update({
+            where: { id: move.fileId },
+            data: {
+              studentId: move.finalStudentId,
+              pageNumber: move.finalPageNumber,
+            },
+          })
+        )
+      )
+
+      if (withScoring && allQuestionScores.length > 0) {
+        // 採点データを復元（答案IDは変更せず、位置情報が変わっただけ）
+        await tx.questionScore.createMany({
+          data: allQuestionScores.map((score) => ({
+            answerSheetId: score.answerSheetId,
+            layoutRegionId: score.layoutRegionId,
+            status: score.status,
+            comment: score.comment,
+            scoredByUserId: score.scoredByUserId,
+            scoreVersion: score.scoreVersion,
+          })),
+        })
+      }
+
+      console.log("✅ [Electron] Batch placement update transaction completed")
+      return { success: true }
+    })
+
+    console.log("✅ [Electron] Batch placement update completed successfully")
+    return result
+  } catch (error) {
+    console.error("❌ [Electron] Error in batch placement update:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "一括配置変更に失敗しました",
+    }
+  }
+}
+
 // 2つの答案の配置を交換（採点情報も一緒に入れ替え）
 export async function swapAnswerSheetPlacementsWithScoring(
   answerSheetId1: string,
   answerSheetId2: string,
 ) {
+  console.log("🔄 [Electron] Starting swap with scoring:", answerSheetId1, "↔", answerSheetId2)
+  console.log("🔄 [Electron] Transaction starting...")
   try {
     // トランザクション内で答案交換を実行
     const result = await prisma.$transaction(async (tx) => {
@@ -453,6 +574,11 @@ export async function swapAnswerSheetPlacementsWithScoring(
         }),
       ])
 
+      console.log("📄 [Electron] Found answer sheets:", {
+        answerSheet1: answerSheet1 ? { studentId: answerSheet1.studentId, pageNumber: answerSheet1.pageNumber } : null,
+        answerSheet2: answerSheet2 ? { studentId: answerSheet2.studentId, pageNumber: answerSheet2.pageNumber } : null
+      })
+
       if (!answerSheet1 || !answerSheet2) {
         throw new Error("答案が見つかりません")
       }
@@ -466,6 +592,11 @@ export async function swapAnswerSheetPlacementsWithScoring(
           where: { answerSheetId: answerSheetId2 },
         }),
       ])
+
+      console.log("📊 [Electron] Found question scores:", {
+        questionScores1Count: questionScores1.length,
+        questionScores2Count: questionScores2.length
+      })
 
       // 採点データを一時的に削除（制約回避のため）
       await Promise.all([
@@ -577,15 +708,21 @@ export async function swapAnswerSheetPlacementsWithScoring(
         }),
       ])
 
+      console.log("✅ [Electron] Transaction completed successfully")
+      console.log("📝 [Electron] Final answer sheet positions:", {
+        answerSheet1: { id: answerSheetId1, studentId: updatedAnswerSheet1?.studentId, pageNumber: updatedAnswerSheet1?.pageNumber },
+        answerSheet2: { id: answerSheetId2, studentId: updatedAnswerSheet2?.studentId, pageNumber: updatedAnswerSheet2?.pageNumber }
+      })
       return { updatedAnswerSheet1, updatedAnswerSheet2 }
     })
 
+    console.log("✅ [Electron] Swap with scoring completed successfully")
     return {
       success: true,
       answerSheets: [result.updatedAnswerSheet1, result.updatedAnswerSheet2],
     }
   } catch (error) {
-    console.error("Error swapping answer sheet placements with scoring:", error)
+    console.error("❌ [Electron] Error swapping answer sheet placements with scoring:", error)
     return {
       success: false,
       error:

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -110,6 +110,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
       answerSheetId1,
       answerSheetId2,
     ),
+  batchUpdateAnswerSheetPlacements: (
+    moves: Array<{
+      fileId: string
+      finalStudentId: string | null
+      finalPageNumber: number
+    }>,
+    withScoring: boolean
+  ) =>
+    ipcRenderer.invoke(
+      "batch-update-answer-sheet-placements",
+      moves,
+      withScoring
+    ),
   getImageData: (relativePath: string) =>
     ipcRenderer.invoke("get-image-data", relativePath),
 

--- a/types/answer-sheet.types.ts
+++ b/types/answer-sheet.types.ts
@@ -205,20 +205,21 @@ export interface PasswordDialogState {
 
 /**
  * 保留中の変更データ
+ * 2つのファイルの位置入れ替えを表現
  */
 export interface PendingChange {
   id: string // ユニークID
-  answerSheetId1: string // 交換対象1のID
-  answerSheetId2: string // 交換対象2のID
+  movedFileId: string // 移動されたファイルのID
+  targetFileId: string | null // 移動先にあったファイルのID（空の場合はnull）
   timestamp: Date // 変更時刻
-  position1: {
-    // 交換前の位置1
+  fromPosition: {
+    // 移動元の位置
     studentId: string | null
     pageNumber: number
     studentName?: string // 表示用
   }
-  position2: {
-    // 交換前の位置2
+  toPosition: {
+    // 移動先の位置
     studentId: string | null
     pageNumber: number
     studentName?: string // 表示用
@@ -231,4 +232,3 @@ export interface PendingChange {
 export type ScoringDataOption =
   | "image-only" // 答案画像のみ入れ替え
   | "with-scoring" // 採点情報も一緒に入れ替え
-  | "cancel" // キャンセル

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -293,6 +293,17 @@ export interface MyAPI {
     answerSheets?: AnswerSheetWithDetails[]
     error?: string
   }>
+  batchUpdateAnswerSheetPlacements: (
+    moves: Array<{
+      fileId: string
+      finalStudentId: string | null
+      finalPageNumber: number
+    }>,
+    withScoring: boolean
+  ) => Promise<{
+    success: boolean
+    error?: string
+  }>
   getImageData: (relativePath: string) => Promise<{
     success: boolean
     data?: string


### PR DESCRIPTION
## 概要

答案入れ替え機能の根本的な問題を解決し、ユーザビリティを向上させました。

## 修正内容

### 🔧 答案入れ替えロジックの改善
- **問題**: 複雑なスワップ操作で重複処理が発生し、変更が相殺される
- **解決**: 一方向移動の同時適用アプローチに変更
- **効果**: ABC→BCAなどのマルチエレメント操作にも対応

### 🎨 モーダルUI改善  
- **問題**: キャンセルボタンで意図しないリセットが発生
- **解決**: キャンセルとリセット機能を分離
- **UI**: `[キャンセル] [リセット] [適用]` の明確な配置

### ⚡ 技術的改善
- `batchUpdateAnswerSheetPlacements`関数の新規実装
- トランザクション内での一括処理により一時的重複を回避
- 採点データの適切な保持・復元機能

## テスト計画

- [x] 単純な2要素スワップ操作
- [x] 複雑なマルチエレメント移動（ABC→BCA）
- [x] キャンセル・リセット・適用の各ボタン動作
- [x] 採点情報込み/画像のみの両オプション
- [x] ページリロード後の変更永続化

## 関連Issue

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)