### PR TITLE
fix: パッケージ版でのAPI関数名不整合を修正

### DIFF
--- a/electron-src/ipc-handlers/misc-handlers.ts
+++ b/electron-src/ipc-handlers/misc-handlers.ts
@@ -413,7 +413,7 @@ export function setupMiscHandlers(): void {
 
   // Master image handlers
   ipcMain.handle(
-    "upload-master-images",
+    "upload-master-answers",
     async (
       _event,
       projectId: string,
@@ -433,22 +433,22 @@ export function setupMiscHandlers(): void {
     },
   )
 
-  ipcMain.handle("delete-master-image", async (_event, imageId: string) => {
+  ipcMain.handle("delete-master-answer", async (_event, answerId: string) => {
     try {
-      return await deleteMasterAnswer(imageId)
+      return await deleteMasterAnswer(answerId)
     } catch (err) {
-      console.error("Error in IPC delete-master-image:", err)
+      console.error("Error in IPC delete-master-answer:", err)
       throw err
     }
   })
 
   ipcMain.handle(
-    "update-master-images-order",
-    async (_event, imageOrders: { id: string; pageNumber: number }[]) => {
+    "update-master-answers-order",
+    async (_event, answerOrders: { id: string; pageNumber: number }[]) => {
       try {
-        return await updateMasterAnswersOrder(imageOrders)
+        return await updateMasterAnswersOrder(answerOrders)
       } catch (err) {
-        console.error("Error in IPC update-master-images-order:", err)
+        console.error("Error in IPC update-master-answers-order:", err)
         throw err
       }
     },

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -200,16 +200,16 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getMembershipsByDateRange: (startDate: Date, endDate?: Date) =>
     ipcRenderer.invoke("get-memberships-by-date-range", startDate, endDate),
 
-  // MasterImage related
-  uploadMasterImages: (
+  // MasterAnswer related
+  uploadMasterAnswers: (
     projectId: string,
-    filesData: { name: string; type: string; buffer: ArrayBuffer }[], // Updated signature
-  ) => ipcRenderer.invoke("upload-master-images", projectId, filesData),
-  deleteMasterImage: (imageId: string) =>
-    ipcRenderer.invoke("delete-master-image", imageId),
-  updateMasterImagesOrder: (
-    imageOrders: { id: string; pageNumber: number }[],
-  ) => ipcRenderer.invoke("update-master-images-order", imageOrders),
+    filesData: { name: string; type: string; buffer: ArrayBuffer }[],
+  ) => ipcRenderer.invoke("upload-master-answers", projectId, filesData),
+  deleteMasterAnswer: (answerId: string) =>
+    ipcRenderer.invoke("delete-master-answer", answerId),
+  updateMasterAnswersOrder: (
+    answerOrders: { id: string; pageNumber: number }[],
+  ) => ipcRenderer.invoke("update-master-answers-order", answerOrders),
 
   // New API to resolve file path for display
   resolveFileProtocolPath: (relativePath: string) =>


### PR DESCRIPTION
## 概要
パッケージ版アプリで`window.electronAPI.uploadMasterAnswers is not a function`エラーが発生する問題を修正

## 問題
- preload.tsでの関数名定義とフロントエンドでの呼び出し名に不整合があった
- パッケージ版で模範解答画像のアップロードが失敗していた

## 修正内容
以下の関数名をフロントエンドの呼び出しに合わせて統一：

### preload.ts
- `uploadMasterImages` → `uploadMasterAnswers`
- `deleteMasterImage` → `deleteMasterAnswer`
- `updateMasterImagesOrder` → `updateMasterAnswersOrder`

### IPC handlers (misc-handlers.ts)
- `upload-master-images` → `upload-master-answers`
- `delete-master-image` → `delete-master-answer`
- `update-master-images-order` → `update-master-answers-order`

## テスト
- [x] 型定義ファイルとの整合性確認
- [x] import文での関数名整合性確認
- [x] フロントエンドでの関数呼び出し名との整合性確認

## 影響範囲
- パッケージ版アプリでの模範解答アップロード機能が正常動作するようになる
- 既存の開発環境での動作に影響なし

Closes #65