### PR TITLE
fix: PDF出力での部分点重複描画と領域順序リバートバグを修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
@@ -56,16 +56,13 @@ export function useScoringDataLoader(
 
         // 設問領域データの読み込み
         const regionsResult =
-          await window.electronAPI.getCropRegionsByProjectId(projectId)
+          await window.electronAPI.getQuestionAnswerRegionsByProjectId(projectId)
         if (!regionsResult || !Array.isArray(regionsResult)) {
           throw new Error("設問領域データの読み込みに失敗しました")
         }
 
-        const cropRegions = regionsResult.filter(
-          (region: any) => region.type === "QUESTION_ANSWER",
-        ) as CropRegionWithProjectPage[]
-
-        setCropRegions(cropRegions)
+        // DBレベルでフィルタリング済みなので、順序を保持したまま設定
+        setCropRegions(regionsResult as CropRegionWithProjectPage[])
 
         // ユーザーIDの取得
         const userData = await window.electronAPI.getCurrentUser()

--- a/electron-src/ipc-handlers/crop-region-handlers.ts
+++ b/electron-src/ipc-handlers/crop-region-handlers.ts
@@ -5,6 +5,7 @@ import {
   updateCropRegion as dbUpdateCropRegion,
   deleteCropRegion as dbDeleteCropRegion,
   getCropRegionsByProjectId as dbGetCropRegionsByProjectId,
+  getQuestionAnswerRegionsByProjectId as dbGetQuestionAnswerRegionsByProjectId,
   getCropRegionById as dbGetCropRegionById,
   createManyCropRegions as dbCreateManyCropRegions,
   updateCropRegionOrders as dbUpdateCropRegionOrders,
@@ -128,6 +129,30 @@ export function setupCropRegionHandlers(): void {
         return JSON.parse(JSON.stringify(result))
       } catch (error) {
         console.error("❌ IPC: get-crop-regions-by-project-id error:", error)
+        throw error
+      }
+    },
+  )
+
+  ipcMain.handle(
+    "get-question-answer-regions-by-project-id",
+    async (_event, projectId: string) => {
+      try {
+        console.log(
+          "🔄 IPC: get-question-answer-regions-by-project-id called with projectId:",
+          projectId,
+        )
+        const result = await dbGetQuestionAnswerRegionsByProjectId(projectId)
+        console.log(
+          "✅ IPC: get-question-answer-regions-by-project-id result:",
+          result?.length,
+          "regions",
+        )
+
+        // JSON.stringify/parseで循環参照を除去し、確実にシリアライズ可能にする
+        return JSON.parse(JSON.stringify(result))
+      } catch (error) {
+        console.error("❌ IPC: get-question-answer-regions-by-project-id error:", error)
         throw error
       }
     },

--- a/electron-src/lib/prisma/cropRegion.ts
+++ b/electron-src/lib/prisma/cropRegion.ts
@@ -121,6 +121,57 @@ export const getCropRegionsByProjectId = async (projectId: string) => {
   return regions
 }
 
+/**
+ * プロジェクトのQUESTION_ANSWER型領域のみを順序付きで取得（採点画面専用）
+ * フィルタリングを DB レベルで行うことで正しい順序を保持
+ */
+export const getQuestionAnswerRegionsByProjectId = async (projectId: string) => {
+  const regions = await prisma.cropRegion.findMany({
+    where: { 
+      projectPage: {
+        projectId: projectId
+      },
+      type: "QUESTION_ANSWER" // DB レベルでフィルタリング
+    },
+    include: {
+      projectPage: true,
+      cropSubtotals: {
+        include: {
+          subtotal: true,
+        },
+      },
+      questionScores: true,
+    },
+    orderBy: [
+      { orderIndex: "asc" }, // 手動順序（最優先）
+      { projectPage: { pageNumber: "asc" } }, // ページ順（フォールバック）
+      { y: "asc" }, // Y座標（フォールバック）
+      { x: "asc" }, // X座標（フォールバック）
+    ],
+  })
+
+  // orderIndexがnullの領域があった場合、自動で設定する
+  const regionsWithNullOrder = regions.filter(region => region.orderIndex === null)
+  if (regionsWithNullOrder.length > 0) {
+    console.log(`Found ${regionsWithNullOrder.length} question answer regions with null orderIndex, fixing...`)
+    
+    // 同じ修正ロジック
+    for (let i = 0; i < regionsWithNullOrder.length; i++) {
+      const region = regionsWithNullOrder[i]
+      const newOrderIndex = regions.length + i // 既存の最大値の後に追加
+      
+      await prisma.cropRegion.update({
+        where: { id: region.id },
+        data: { orderIndex: newOrderIndex }
+      })
+      
+      region.orderIndex = newOrderIndex
+    }
+  }
+
+  return regions
+}
+
 // IDで CropRegion を取得
 export const getCropRegionById = async (id: string) => {
   return prisma.cropRegion.findUnique({

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -1305,8 +1305,17 @@ async function addAnswerSheetToPDF(
           config.scoreAlignment,
         )
 
-        // Draw score text
+        // スコアテキスト背景をクリア（重複描画防止）
+        const textPadding = 2 // テキスト周囲のパディング
+        page.drawRectangle({
+          x: scorePosition.x - textPadding,
+          y: scorePosition.y - textPadding,
+          width: textWidth + (textPadding * 2),
+          height: textHeight + (textPadding * 2),
+          color: rgb(1, 1, 1), // 白色背景
+        })
 
+        // Draw score text
         page.drawText(scoreText, {
           x: scorePosition.x,
           y: scorePosition.y,
@@ -1320,11 +1329,25 @@ async function addAnswerSheetToPDF(
       if (score.comment) {
         const commentX = markPosition.x
         const commentY = markPosition.y - 20
+        const commentSize = Math.max(8, config.scoreSize - 4)
+        
+        // コメントテキスト背景をクリア（重複描画防止）
+        const commentWidth = font.widthOfTextAtSize(score.comment, commentSize)
+        const commentHeight = commentSize
+        const commentPadding = 1
+        
+        page.drawRectangle({
+          x: commentX - commentPadding,
+          y: commentY - commentPadding,
+          width: commentWidth + (commentPadding * 2),
+          height: commentHeight + (commentPadding * 2),
+          color: rgb(1, 1, 1), // 白色背景
+        })
 
         page.drawText(score.comment, {
           x: commentX,
           y: commentY,
-          size: Math.max(8, config.scoreSize - 4),
+          size: commentSize,
           font: font,
           color: rgb(0.5, 0, 0), // 暗い赤色
         })
@@ -1424,6 +1447,16 @@ async function addAnswerSheetToPDF(
           textHeight,
           config.scoreAlignment,
         )
+
+        // 小計点テキスト背景をクリア（重複描画防止）
+        const subtotalPadding = 2
+        page.drawRectangle({
+          x: subtotalPosition.x - subtotalPadding,
+          y: subtotalPosition.y - subtotalPadding,
+          width: textWidth + (subtotalPadding * 2),
+          height: textHeight + (subtotalPadding * 2),
+          color: rgb(1, 1, 1), // 白色背景
+        })
 
         // 小計点を描画
         console.log(
@@ -1540,6 +1573,16 @@ async function addAnswerSheetToPDF(
           textHeight,
           config.scoreAlignment,
         )
+
+        // 合計点テキスト背景をクリア（重複描画防止）
+        const totalScorePadding = 2
+        page.drawRectangle({
+          x: totalScorePosition.x - totalScorePadding,
+          y: totalScorePosition.y - totalScorePadding,
+          width: textWidth + (totalScorePadding * 2),
+          height: textHeight + (totalScorePadding * 2),
+          color: rgb(1, 1, 1), // 白色背景
+        })
 
         // 合計点を描画
         console.log(

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -233,6 +233,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("delete-crop-region", id),
   getCropRegionsByProjectId: (projectId: string) =>
     ipcRenderer.invoke("get-crop-regions-by-project-id", projectId),
+  getQuestionAnswerRegionsByProjectId: (projectId: string) =>
+    ipcRenderer.invoke("get-question-answer-regions-by-project-id", projectId),
   getCropRegionById: (id: string) =>
     ipcRenderer.invoke("get-crop-region-by-id", id),
   updateCropRegionOrders: (

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -588,6 +588,9 @@ export interface MyAPI {
   getCropRegionsByProjectId: (
     projectId: string,
   ) => Promise<CropRegionWithDetails[]>
+  getQuestionAnswerRegionsByProjectId: (
+    projectId: string,
+  ) => Promise<CropRegionWithDetails[]>
   getCropRegionById: (id: string) => Promise<CropRegionWithDetails | null>
   updateCropRegionOrders: (
     updates: Array<{ id: string; orderIndex: number }>,


### PR DESCRIPTION
## Summary

Fixes #72 - PDF出力での部分点重複描画と領域順序リバートバグの修正

## 修正内容

### 🔧 1. PDF出力での部分点重複描画バグ修正
- **問題**: 部分点変更時に新旧スコアテキストが重複表示される
- **原因**: pdf-libライブラリにテキスト消去機能がない
- **解決**: テキスト描画前に白背景矩形でクリア処理を追加

**修正対象**:
- ✅ スコアテキスト描画前の背景クリア
- ✅ コメントテキスト描画前の背景クリア  
- ✅ 小計点テキスト描画前の背景クリア
- ✅ 合計点テキスト描画前の背景クリア

### 🔧 2. 領域順序リバートバグ修正
- **問題**: 採点モードで設定した領域順序が元に戻る
- **原因**: フロントエンドでの`filter()`操作が順序を破綻
- **解決**: DBレベルでのフィルタリングにより順序保持

**実装内容**:
- ✅ 新API `getQuestionAnswerRegionsByProjectId` 追加
- ✅ IPCハンドラーとpreload API追加
- ✅ 型定義更新
- ✅ 採点データローダーを新API使用に変更

## 技術的詳細

### PDF背景クリア実装
```typescript
// テキスト描画前に白色矩形で背景をクリア
page.drawRectangle({
  x: position.x - padding,
  y: position.y - padding,
  width: textWidth + (padding * 2),
  height: textHeight + (padding * 2),
  color: rgb(1, 1, 1), // 白色背景
})
```

### DB レベルフィルタリング
```sql
-- 新関数では DB クエリにフィルター条件を追加
WHERE type = "QUESTION_ANSWER"
ORDER BY orderIndex ASC, pageNumber ASC, y ASC, x ASC
```

## Test plan

- ✅ TypeScript型チェック: Pass
- ✅ ESLintチェック: Pass
- ✅ ビルド: 正常
- ✅ 既存機能に影響なし

## 影響範囲

- PDF出力機能（スコア表示の重複防止）
- 採点画面での領域順序表示（正しい順序保持）
- 採点ワークフローの操作性向上

## リスク評価

**Low**: 
- 既存ロジックに影響しない追加実装
- 後方互換性を維持
- 型安全性確保済み

🤖 Generated with [Claude Code](https://claude.ai/code)