### PR TITLE
fix: 領域情報ページのテーブルスクロール問題を修正

### DIFF
--- a/app/projects/[projectId]/03-region-info/page.tsx
+++ b/app/projects/[projectId]/03-region-info/page.tsx
@@ -318,8 +318,8 @@ export default function RegionInfoPage() {
         </div>
 
         {/* Right: Region Details Table */}
-        <div className="flex-1 overflow-y-auto">
-          <div className="p-4">
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex-shrink-0 p-4 pb-0">
             <div className="mb-4">
               <h3 className="text-lg font-medium">
                 領域情報テーブル（全ページ統一順序）
@@ -332,7 +332,12 @@ export default function RegionInfoPage() {
                   </span>
                 )}
               </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                各行をクリックして選択し、種類・ラベル・配点などを設定してください。ドラッグ&ドロップで順序を変更できます。
+              </p>
             </div>
+          </div>
+          <div className="flex-1 overflow-hidden">
             <RegionDetailsTable
               regions={cropRegions}
               setRegions={handleRegionsChange}

--- a/components/projects/03-region-info/components/RegionDetailsTable.tsx
+++ b/components/projects/03-region-info/components/RegionDetailsTable.tsx
@@ -153,17 +153,7 @@ const RegionDetailsTable = ({
   }
 
   return (
-    <div className="p-6">
-      <div className="mb-6">
-        <h3 className="mb-2 text-lg font-semibold">
-          作成した領域の詳細設定（全ページ統一順序）
-        </h3>
-        <p className="text-muted-foreground text-sm">
-          各行をクリックして選択し、種類・ラベル・配点などを設定してください。ドラッグ&ドロップで順序を変更できます。
-        </p>
-      </div>
-
-      <div className="overflow-x-auto">
+    <div className="h-full overflow-auto p-6">
         <table className="border-border w-full border-collapse border">
           <thead>
             <tr className="bg-muted/50">
@@ -219,13 +209,12 @@ const RegionDetailsTable = ({
             })}
           </tbody>
         </table>
-      </div>
 
-      <DeleteConfirmModal
-        isOpen={deleteModalOpen}
-        onClose={() => setDeleteModalOpen(false)}
-        onConfirm={confirmDeleteRegion}
-      />
+        <DeleteConfirmModal
+          isOpen={deleteModalOpen}
+          onClose={() => setDeleteModalOpen(false)}
+          onConfirm={confirmDeleteRegion}
+        />
     </div>
   )
 }


### PR DESCRIPTION
## 概要

領域情報ページのテーブルスクロール表示問題を修正しました。

Closes #74

## 変更内容

### 主な修正点

1. **RegionDetailsTableコンポーネントの最適化**
   - 重複するヘッダー部分を削除
   - テーブルコンテナの高さ制約を適切に設定
   - スクロール動作を単純化

2. **ページレイアウト構造の改善**  
   - ヘッダー部分を固定表示に変更
   - テーブル領域の高さ制御を最適化
   - 操作説明をヘッダー部分に統合

### 修正ファイル

- `app/projects/[projectId]/03-region-info/page.tsx`: ページレイアウト構造の改善
- `components/projects/03-region-info/components/RegionDetailsTable.tsx`: テーブルコンテナの最適化

## 修正前の問題

- テーブル下部が画面外に切れる
- ヘッダー部分も一緒にスクロールしてしまう  
- 複数のスクロールコンテナによる動作の複雑化

## 修正後の改善

- ✅ ヘッダー部分が固定され、常に表示される
- ✅ テーブル内容のみが適切にスクロール
- ✅ 全30個の領域データが適切に表示・操作可能
- ✅ 一貫したユーザーエクスペリエンス

## テスト計画

- [x] ヘッダー固定表示の確認
- [x] テーブル内容のスクロール動作確認  
- [x] 全領域データの表示・操作可能性確認
- [x] レスポンシブ表示の確認

🤖 Generated with [Claude Code](https://claude.ai/code)