### PR TITLE
小計点グループUIの簡素化とワークフロー最適化 (#80)

### DIFF
--- a/app/projects/[projectId]/04-question-group/page.tsx
+++ b/app/projects/[projectId]/04-question-group/page.tsx
@@ -7,9 +7,7 @@ import { SubtotalGroupSelector } from "@/components/projects/04-question-group/c
 import { SubtotalAssignmentMatrix } from "@/components/projects/04-question-group/components/SubtotalAssignmentMatrix"
 import { QuestionAssignmentMatrix } from "@/components/projects/04-question-group/components/QuestionAssignmentMatrix"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Calculator, Settings, ExternalLink } from "lucide-react"
-import Link from "next/link"
+import { Calculator } from "lucide-react"
 import { useParams, useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 import { CropRegionWithDetails, SubtotalGroupWithItems } from "@/types/electron"
@@ -190,22 +188,6 @@ export default function SubtotalGroupPage() {
       />
 
       <div className="space-y-8">
-        {/* 小計点グループ管理への案内 */}
-        <div className="border border-blue-200 bg-blue-50 rounded-lg p-6">
-          <div className="flex items-center gap-2 text-blue-800 mb-4">
-            <Settings className="h-5 w-5" />
-            <h2 className="text-lg font-semibold">小計点グループの作成・管理</h2>
-          </div>
-          <p className="text-blue-700 text-sm mb-4">
-            新しい小計点グループの作成や既存グループの編集は、専用の管理ページで行います。
-          </p>
-          <Link href="/subtotal-groups">
-            <Button variant="outline" className="border-blue-300 text-blue-700 hover:bg-blue-100">
-              <ExternalLink className="mr-2 h-4 w-4" />
-              小計点グループ管理ページを開く
-            </Button>
-          </Link>
-        </div>
 
         {/* 小計点グループ選択 */}
         <SubtotalGroupSelector
@@ -214,29 +196,6 @@ export default function SubtotalGroupPage() {
           onRefresh={loadData}
         />
 
-        {/* 適用済み小計点グループの表示 */}
-        {activeSubtotalGroups.length > 0 && (
-          <div className="border rounded-lg p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <Calculator className="h-5 w-5" />
-              <h2 className="text-lg font-semibold">適用済み小計点グループ</h2>
-            </div>
-            <div className="space-y-4">
-              {activeSubtotalGroups.map((group) => (
-                <div key={group.id} className="p-4 border rounded-lg bg-gray-50">
-                  <h3 className="font-medium text-lg mb-2">{group.name}</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                    {group.subtotals?.map((subtotal) => (
-                      <div key={subtotal.id} className="text-sm bg-white px-3 py-1 rounded border">
-                        {subtotal.name}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
 
         {/* 設問と小計項目の関連付け */}
         {activeSubtotalGroups.length > 0 && cropRegions.length > 0 && (

--- a/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
+++ b/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
@@ -12,7 +12,8 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { Calculator, Plus, Search, Trash2 } from "lucide-react"
+import { Calculator, Plus, Search, Trash2, ExternalLink } from "lucide-react"
+import Link from "next/link"
 import type { SubtotalGroup } from "@/components/subtotal-groups/types/subtotal-group-types"
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 
@@ -126,7 +127,7 @@ export function SubtotalGroupSelector({
             <Calculator className="mx-auto mb-4 h-12 w-12 opacity-50" />
             <p>有効化された小計点グループがありません</p>
             <p className="mt-2 text-sm">
-              「グループを追加」ボタンで既存のグループを有効化できます
+              「グループを追加」ボタンで既存のグループを有効化するか、新しいグループを作成できます
             </p>
           </div>
         ) : (
@@ -170,6 +171,20 @@ export function SubtotalGroupSelector({
             <DialogTitle>小計点グループを選択</DialogTitle>
           </DialogHeader>
 
+          {/* 新規小計点グループ作成ボタン */}
+          <div className="border border-green-200 bg-green-50 rounded-lg p-3">
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-green-800">新しいグループを作成</span>
+              <Link href="/subtotal-groups" target="_blank">
+                <Button size="sm" className="bg-green-600 hover:bg-green-700 text-white">
+                  <Plus className="mr-1 h-4 w-4" />
+                  新規作成
+                  <ExternalLink className="ml-1 h-4 w-4" />
+                </Button>
+              </Link>
+            </div>
+          </div>
+
           <div className="space-y-4">
             {/* 検索 */}
             <div className="relative">
@@ -197,13 +212,7 @@ export function SubtotalGroupSelector({
                 </p>
                 {!searchTerm && (
                   <p className="mt-2 text-sm">
-                    <a
-                      href="/subtotal-groups"
-                      className="text-blue-600 hover:underline"
-                    >
-                      小計点管理ページ
-                    </a>
-                    で新しいグループを作成できます
+                    上部の「新規作成」ボタンから新しいグループを作成できます
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## 関連Issue
Closes #80

## 変更概要

このPRは、小計点設定ページのUIを大幅に簡素化し、より直感的で効率的なユーザーエクスペリエンスを提供します。

## 🗂️ 主な変更内容

### 冗長なUI要素の削除
- **適用済み小計点グループ**の表示カードを削除
- **小計点グループの作成・管理**の案内カードを削除
- ページ全体をシンプルで集中しやすいレイアウトに変更

### ワークフローの統合
- 小計点グループの「選択」と「作成」を一つのモーダルで完結
- モーダル内に目立つ新規作成ボタンを配置
- ユーザーが迷うことなく必要な操作を実行可能

### 新規作成ボタンの最適化
- 文章量を削減し、コンパクトなワンライン表示に改善
- 緑色のボタンで新規作成アクションを視覚的に強調
- `target="_blank"`で別タブ開きに対応

## 📊 変更統計
- **2ファイル**を修正
- **51行削除**、**19行追加**
- **純減32行**（コードの簡素化を実現）

## 🎯 改善効果

### Before（変更前）
```
┌─ 小計点設定 ────────────────┐
│ [小計点グループの作成・管理カード]  │
│ [小計点グループ選択カード]        │  
│ [適用済み小計点グループカード]     │
│ [設問と小計項目の関連付け]        │
│ [小計点領域との関連付け]         │
└─────────────────────────┘
```

### After（変更後）
```
┌─ 小計点設定 ────────────────┐
│ [小計点グループ選択カード]        │
│   └ モーダル内に新規作成ボタン     │  
│ [設問と小計項目の関連付け]        │
│ [小計点領域との関連付け]         │
└─────────────────────────┘
```

## 🔍 レビューポイント
- [ ] 冗長なカード要素が適切に削除されているか
- [ ] モーダル内の新規作成ボタンが目立つ位置に配置されているか
- [ ] 新規作成ボタンのレイアウトがコンパクトで見やすいか
- [ ] 小計点グループの選択と作成がワンストップで行えるか
- [ ] 不要なimport文が適切に整理されているか

## 💡 ユーザビリティの向上
- **操作の簡素化**: 5つのUI要素 → 3つのUI要素
- **ワンストップ操作**: 選択と作成を一つのモーダルで完結
- **視覚的な明確性**: 重要な機能に集中したレイアウト

🤖 Generated with [Claude Code](https://claude.ai/code)