### PR TITLE
修正: PDF出力で点数下の白い長方形を削除

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -1216,15 +1216,6 @@ async function addAnswerSheetToPDF(
           config.scoreAlignment,
         )
 
-        // スコアテキスト背景をクリア（重複描画防止）
-        const textPadding = 2 // テキスト周囲のパディング
-        page.drawRectangle({
-          x: scorePosition.x - textPadding,
-          y: scorePosition.y - textPadding,
-          width: textWidth + textPadding * 2,
-          height: textHeight + textPadding * 2,
-          color: rgb(1, 1, 1), // 白色背景
-        })
 
         // Draw score text
         page.drawText(scoreText, {
@@ -1245,15 +1236,6 @@ async function addAnswerSheetToPDF(
         // コメントテキスト背景をクリア（重複描画防止）
         const commentWidth = font.widthOfTextAtSize(score.comment, commentSize)
         const commentHeight = commentSize
-        const commentPadding = 1
-
-        page.drawRectangle({
-          x: commentX - commentPadding,
-          y: commentY - commentPadding,
-          width: commentWidth + commentPadding * 2,
-          height: commentHeight + commentPadding * 2,
-          color: rgb(1, 1, 1), // 白色背景
-        })
 
         page.drawText(score.comment, {
           x: commentX,
@@ -1371,15 +1353,6 @@ async function addAnswerSheetToPDF(
           config.scoreAlignment,
         )
 
-        // 小計点テキスト背景をクリア（重複描画防止）
-        const subtotalPadding = 2
-        page.drawRectangle({
-          x: subtotalPosition.x - subtotalPadding,
-          y: subtotalPosition.y - subtotalPadding,
-          width: textWidth + subtotalPadding * 2,
-          height: textHeight + subtotalPadding * 2,
-          color: rgb(1, 1, 1), // 白色背景
-        })
 
         // 小計点を描画
         console.log(
@@ -1497,15 +1470,6 @@ async function addAnswerSheetToPDF(
           config.scoreAlignment,
         )
 
-        // 合計点テキスト背景をクリア（重複描画防止）
-        const totalScorePadding = 2
-        page.drawRectangle({
-          x: totalScorePosition.x - totalScorePadding,
-          y: totalScorePosition.y - totalScorePadding,
-          width: textWidth + totalScorePadding * 2,
-          height: textHeight + totalScorePadding * 2,
-          color: rgb(1, 1, 1), // 白色背景
-        })
 
         // 合計点を描画
         console.log(


### PR DESCRIPTION
## 概要

PDF出力時に点数テキストの下に表示される白い長方形背景を削除しました。

Fixes #92

## 変更内容

- メインの点数表示の白い背景を削除
- コメントテキストの白い背景を削除
- 小計点の白い背景を削除  
- 合計点の白い背景を削除

## 改善効果

- 答案画像の内容が隠れなくなります
- PDF出力の視認性が向上します
- 点数は背景なしで直接答案に印字されます

## テスト方法

1. プロジェクトでPDF出力を実行
2. 点数テキストの背景が透明になっていることを確認
3. 答案画像の内容が隠れていないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)