### PR TITLE
Excel出力機能の改善：学年・学級・出席番号と受験状態の追加

### DIFF
--- a/electron-src/lib/export/excel/data-fetcher.ts
+++ b/electron-src/lib/export/excel/data-fetcher.ts
@@ -64,6 +64,28 @@ export async function fetchExportData(
     // 選択された生徒のフィルタリングとソート
     const selectedStudents = (studentsResult.students || [])
       .filter((student) => selectedStudentIds.includes(student.id))
+      .map((student) => {
+        // 最新の学級情報を取得（memberships配列の最初の要素）
+        const studentWithMemberships = student as typeof student & {
+          memberships?: Array<{
+            attendanceNumber?: number | null
+            class: {
+              id: string
+              name: string
+              grade?: number | null
+            }
+          }>
+        }
+        const latestMembership = studentWithMemberships.memberships?.[0]
+        const classInfo = latestMembership?.class
+        
+        return {
+          ...student,
+          grade: classInfo?.grade?.toString(),
+          className: classInfo?.name,
+          attendanceNumber: latestMembership?.attendanceNumber,
+        }
+      })
       .sort((a, b) => {
         const aOrder =
           (a as Student & { customOrder?: number }).customOrder ?? 999999
@@ -136,6 +158,7 @@ async function buildScoringData(
     grade?: string
     className?: string
     attendanceNumber?: number | null
+    status?: "participating" | "expected" | "absent"
   })[],
   questionRegions: CropRegion[],
   subtotalRegions: CropRegion[],
@@ -173,6 +196,7 @@ async function buildScoringData(
         grade: student.grade,
         className: student.className,
         attendanceNumber: student.attendanceNumber,
+        status: student.status,
         scores,
         totalScore,
         totalMaxScore,

--- a/electron-src/lib/export/excel/header-creators.ts
+++ b/electron-src/lib/export/excel/header-creators.ts
@@ -15,6 +15,7 @@ export async function createSheetHeaders(
   subtotalRegions: CropRegion[],
 ) {
   const row = worksheet.addRow([
+    "受験状態",
     "順位",
     "学年",
     "学級",

--- a/electron-src/lib/export/excel/row-creators.ts
+++ b/electron-src/lib/export/excel/row-creators.ts
@@ -17,6 +17,14 @@ import {
  * @param subtotalTargetMap - 小計対象設問マップ
  * @param isScoreSheet - 点数一覧シートかどうか（true: 点数一覧、false: 正誤一覧）
  */
+/**
+ * 順位付きの採点データ型
+ */
+type ScoringDataWithRank = ScoringData & {
+  originalIndex: number
+  rank: number
+}
+
 export async function createDataRows(
   worksheet: ExcelJS.Worksheet,
   scoringData: ScoringData[],
@@ -24,12 +32,31 @@ export async function createDataRows(
   subtotalTargetMap: SubtotalTargetMap,
   isScoreSheet: boolean,
 ) {
-  for (let i = 0; i < scoringData.length; i++) {
-    const student = scoringData[i]
+  // 事前に順位を計算（総合点の降順でソート）
+  const scoringDataWithRank: ScoringDataWithRank[] = scoringData
+    .map((student, index): ScoringDataWithRank => ({
+      ...student,
+      originalIndex: index,
+      rank: 0, // 仮の値、後で正しい順位に更新
+    }))
+    .sort((a, b) => b.totalScore - a.totalScore)
+    .map((student, rank): ScoringDataWithRank => ({
+      ...student,
+      rank: rank + 1,
+    }))
+    // 元の順序に戻す
+    .sort((a, b) => a.originalIndex - b.originalIndex)
+
+  for (let i = 0; i < scoringDataWithRank.length; i++) {
+    const student = scoringDataWithRank[i]
     const rowIndex = i + 2 // ヘッダー行を考慮
 
+    // 受験状態を最左列（A列）に設定
+    const statusText = getStatusText(student.status)
+    
     const row = worksheet.addRow([
-      `=RANK(G${rowIndex},G:G,0)`, // 順位計算
+      statusText, // 受験状態（A列）
+      student.rank, // 順位（B列）- 事前に計算済みの順位を使用
       student.grade || "",
       student.className || "",
       student.attendanceNumber || "",
@@ -38,12 +65,12 @@ export async function createDataRows(
     ])
 
     // 合計点の計算（Excel関数使用）
-    const questionStartColIndex = 8 + subtotalRegions.length
+    const questionStartColIndex = 9 + subtotalRegions.length // 1つ右にシフト
     const questionEndColIndex =
       questionStartColIndex + student.scores.length - 1
     const questionStartCol = getExcelColumnLetter(questionStartColIndex)
     const questionEndCol = getExcelColumnLetter(questionEndColIndex)
-    const totalCell = row.getCell("G")
+    const totalCell = row.getCell("H") // G列からH列に変更
     totalCell.value = {
       formula: `SUM(${questionStartCol}${rowIndex}:${questionEndCol}${rowIndex})`,
     }
@@ -88,8 +115,8 @@ async function setSubtotalCells(
   rowIndex: number,
   isScoreSheet: boolean,
 ) {
-  let subtotalColIndex = 8
-  const questionStartColIndex = 8 + subtotalRegions.length
+  let subtotalColIndex = 9 // 1つ右にシフト
+  const questionStartColIndex = 9 + subtotalRegions.length // 1つ右にシフト
 
   for (let i = 0; i < subtotalRegions.length; i++) {
     const col = getExcelColumnLetter(subtotalColIndex)
@@ -144,7 +171,7 @@ function setQuestionCells(
   subtotalCount: number,
   isScoreSheet: boolean,
 ) {
-  let scoreColIndex = 8 + subtotalCount
+  let scoreColIndex = 9 + subtotalCount // 1つ右にシフト
 
   for (const score of student.scores) {
     const col = getExcelColumnLetter(scoreColIndex)
@@ -166,5 +193,24 @@ function setQuestionCells(
       }
     }
     scoreColIndex++
+  }
+}
+
+/**
+ * 受験状態を日本語に変換する
+ *
+ * @param status - 受験状態
+ * @returns 日本語の受験状態
+ */
+function getStatusText(status?: "participating" | "expected" | "absent"): string {
+  switch (status) {
+    case "participating":
+      return "受験"
+    case "expected":
+      return "見込"
+    case "absent":
+      return "欠席"
+    default:
+      return "受験"
   }
 }

--- a/electron-src/lib/shared/types/export-types.ts
+++ b/electron-src/lib/shared/types/export-types.ts
@@ -14,6 +14,7 @@ export interface ScoringData {
   grade?: string
   className?: string
   attendanceNumber?: number | null
+  status?: "participating" | "expected" | "absent"
   scores: ScoreDetail[]
   totalScore: number
   totalMaxScore: number


### PR DESCRIPTION
## 概要
Excel出力機能において、学年・学級・出席番号情報と受験状態を含めるよう改善しました。

Closes #94

## 変更内容

### ✨ 新機能
- **学年・学級・出席番号**をデータベースから取得してExcelに出力
- **受験状態**（受験/見込/欠席）を最左列に追加表示

### 🐛 バグ修正
- RANK関数の表示問題を解決（`=RANK(...)`表示 → 実際の順位数値）

### 🔧 技術的改善
- 事前計算による順位表示で表示問題を根本解決
- 型安全性の向上（`ScoringDataWithRank`型の新規追加）
- 全ての列インデックス計算を正しく調整

## 新しい列順序
1. **受験状態** (A列) - 受験/見込/欠席
2. **順位** (B列) - 実際の順位数値
3. **学年** (C列)  
4. **学級** (D列)
5. **出席番号** (E列)
6. **学籍番号** (F列)
7. **氏名** (G列)
8. **合計点** (H列)
9. **小計** (I列以降)
10. **設問** (最後の列群)

## 修正対象ファイル
- ✅ `electron-src/lib/export/excel/data-fetcher.ts` - データ取得・構造化
- ✅ `electron-src/lib/export/excel/header-creators.ts` - ヘッダー列の追加
- ✅ `electron-src/lib/export/excel/row-creators.ts` - データ行の生成・順位計算
- ✅ `electron-src/lib/shared/types/export-types.ts` - 型定義の拡張

## テスト結果
- ✅ TypeScriptコンパイル: PASS
- ✅ ESLint: PASS  
- ✅ 型チェック: PASS

## 使用技術
- ExcelJS（Excelファイル生成）
- Prisma ORM（データベースアクセス）
- TypeScript（型安全性確保）

🤖 Generated with [Claude Code](https://claude.ai/code)