### PR TITLE
機能追加: Excel・PDF出力ファイル名にプロジェクト名を含める

### DIFF
--- a/electron-src/lib/export/excel/excel-export-main.ts
+++ b/electron-src/lib/export/excel/excel-export-main.ts
@@ -68,7 +68,8 @@ export async function exportGradingDataExcel(
     )
 
     // ファイル保存
-    const saveResult = await saveWorkbook(workbook, options.outputPath)
+    const projectName = dataResult.project?.examName
+    const saveResult = await saveWorkbook(workbook, options.outputPath, projectName)
     if (!saveResult.success) {
       return { success: false, error: saveResult.error }
     }

--- a/electron-src/lib/export/excel/file-saver.ts
+++ b/electron-src/lib/export/excel/file-saver.ts
@@ -3,23 +3,40 @@ import * as ExcelJS from "exceljs"
 import { ExportResult } from "../../shared/types/export-types"
 
 /**
+ * ファイル名として安全でない文字を置換する
+ * @param name - 元の名前
+ * @returns サニタイズされた名前
+ */
+function sanitizeFileName(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, '_').trim()
+}
+
+/**
  * ワークブックを保存する
  *
  * @param workbook - 保存するワークブック
  * @param outputPath - 出力パス（省略可能）
+ * @param projectName - プロジェクト名（省略可能）
  * @returns 保存結果
  */
 export async function saveWorkbook(
   workbook: ExcelJS.Workbook,
   outputPath?: string,
+  projectName?: string,
 ): Promise<ExportResult> {
   try {
     let finalOutputPath = outputPath
 
     if (!finalOutputPath) {
+      const dateStr = new Date().toISOString().slice(0, 10)
+      const safeProjectName = projectName ? sanitizeFileName(projectName) : null
+      const fileName = safeProjectName 
+        ? `採点結果_${safeProjectName}_${dateStr}.xlsx`
+        : `採点結果_${dateStr}.xlsx`
+        
       const result = await dialog.showSaveDialog({
         title: "Excel出力先を選択",
-        defaultPath: `採点結果_${new Date().toISOString().slice(0, 10)}.xlsx`,
+        defaultPath: fileName,
         filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
       })
 

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -7,6 +7,7 @@ import { PageSizes, PDFDocument, rgb } from "pdf-lib"
 import { getAbsolutePathFromData, getAppRootPath } from "../dataManager"
 import { getCropRegionsByProjectId } from "./cropRegion"
 import { getDrawingAnnotationsByQuestionScore } from "./drawingAnnotation"
+import { getProjectById } from "./project"
 import { getStudentsForProject } from "./projectStudent"
 import {
   calculateActualScore,
@@ -25,6 +26,15 @@ try {
     "Sharp module not available, some image processing features may be limited:",
     error instanceof Error ? error.message : error,
   )
+}
+
+/**
+ * ファイル名として安全でない文字を置換する
+ * @param name - 元の名前
+ * @returns サニタイズされた名前
+ */
+function sanitizeFileName(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, '_').trim()
 }
 
 // 採点状態の型定義（フロントエンドと統一）
@@ -659,11 +669,19 @@ export async function exportScoredAnswersPDF(
       })
     }
 
+    // プロジェクト情報を取得
+    const project = await getProjectById(projectId)
+    const projectName = project?.examName
+    
     // 保存場所を最初に選択
     let outputPath = options.outputPath
     if (!outputPath) {
       reportProgress(0, 100, "保存場所を選択してください...", 0)
-      const defaultFileName = `採点済み答案_${new Date().toISOString().split("T")[0]}.pdf`
+      const dateStr = new Date().toISOString().split("T")[0]
+      const safeProjectName = projectName ? sanitizeFileName(projectName) : null
+      const defaultFileName = safeProjectName 
+        ? `採点済み答案_${safeProjectName}_${dateStr}.pdf`
+        : `採点済み答案_${dateStr}.pdf`
       const result = await dialog.showSaveDialog({
         title: "採点済み答案PDFの保存",
         defaultPath: defaultFileName,


### PR DESCRIPTION
## 概要

Excel・PDF出力時のファイル名にプロジェクト名を含めることで、複数プロジェクトを扱う際のファイル識別を容易にします。

Fixes #96

## 変更内容

### 📊 Excel出力の改善
- **file-saver.ts**: プロジェクト名パラメータ追加とファイル名生成ロジック修正
- **excel-export-main.ts**: プロジェクト名をfile-saverに渡すよう修正

### 📄 PDF出力の改善  
- **pdfExport.ts**: プロジェクト情報取得とファイル名生成ロジック修正

## 🔄 ファイル名形式の変更

**変更前:**
- Excel: `採点結果_2024-03-15.xlsx`
- PDF: `採点済み答案_2024-03-15.pdf`

**変更後:**
- Excel: `採点結果_数学テスト_2024-03-15.xlsx`
- PDF: `採点済み答案_数学テスト_2024-03-15.pdf`

## 🛡️ 安全性

- ファイル名として適さない文字（`\/:*?"<>|`）の自動サニタイズ機能を追加
- プロジェクト名が空の場合は従来通りの形式で出力
- 既存の機能に影響しない後方互換性を維持

## 🧪 テストプラン

- [ ] プロジェクト名を含むExcel出力のテスト
- [ ] プロジェクト名を含むPDF出力のテスト
- [ ] プロジェクト名が空の場合の出力テスト
- [ ] 特殊文字を含むプロジェクト名のサニタイズテスト

🤖 Generated with [Claude Code](https://claude.ai/code)