### PR TITLE
fix: マスター解答と採点画面の型整備

### DIFF
--- a/app/projects/[projectId]/01-upload/page.tsx
+++ b/app/projects/[projectId]/01-upload/page.tsx
@@ -3,6 +3,7 @@
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 import { MasterAnswerManager } from "@/components/projects/01-upload/components/MasterAnswerManager"
+import { convertProjectPagesToMasterAnswers } from "@/components/projects/01-upload/utils/image-utils"
 import { Button } from "@/components/ui/button"
 import type { MasterAnswerData } from "@/types/common.types"
 import { useParams, useRouter } from "next/navigation"
@@ -47,24 +48,9 @@ export default function MasterAnswerStepPage() {
         await window.electronAPI.fetchProjectById(projectId) // ProjectWithDetails 型
       if (fetchedProject && fetchedProject.projectPages) {
         // projectPages から master answers を抽出してソート
-        const masterAnswers = fetchedProject.projectPages
-          .filter((page) =>
-            page.pageImages?.some((img) => img.imageType === "MODEL_ANSWER"),
-          )
-          .map((page) => {
-            const masterAnswer = page.pageImages?.find(
-              (img) => img.imageType === "MODEL_ANSWER",
-            )
-            return {
-              id: page.id,
-              projectId: page.projectId,
-              imagePath: masterAnswer?.imagePath || "",
-              pageNumber: page.pageNumber,
-              createdAt: page.createdAt,
-              updatedAt: page.updatedAt,
-            }
-          })
-          .sort((a, b) => a.pageNumber - b.pageNumber)
+        const masterAnswers = convertProjectPagesToMasterAnswers(
+          fetchedProject.projectPages,
+        ).sort((a, b) => a.pageNumber - b.pageNumber)
         setMasterAnswers(masterAnswers)
       } else {
         setMasterAnswers([])

--- a/app/projects/[projectId]/03-region-info/page.tsx
+++ b/app/projects/[projectId]/03-region-info/page.tsx
@@ -139,7 +139,9 @@ export default function RegionInfoPage() {
               regionData,
             )
           } else {
-            return await window.electronAPI.createCropRegion(regionData)
+            const { orderIndex: _ignoredOrderIndex, ...createData } =
+              regionData
+            return await window.electronAPI.createCropRegion(createData)
           }
         })
 
@@ -221,40 +223,15 @@ export default function RegionInfoPage() {
         >
           <h3 className="mb-3 font-medium">模範解答 (全ページ)</h3>
           <div className="space-y-4">
-            {projectPages.map((_, pageIndex) => {
-              // 順序は固定（1, 2, 3...）だが、対応する画像は実際のpageNumber順
-              const displayPageNumber = pageIndex + 1
-              const correspondingPage = projectPages.find(
-                (img) => img.pageNumber === displayPageNumber,
-              )
-
-              if (!correspondingPage) {
-                return (
-                  <div key={`page-${displayPageNumber}`} className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <h4 className="text-sm font-medium">
-                        ページ {displayPageNumber}
-                      </h4>
-                      <div className="text-muted-foreground text-xs">
-                        (画像なし)
-                      </div>
-                    </div>
-                    <div className="relative flex aspect-[3/4] items-center justify-center overflow-hidden rounded-lg border bg-gray-100">
-                      <div className="text-muted-foreground text-sm">
-                        画像が見つかりません
-                      </div>
-                    </div>
-                  </div>
-                )
-              }
-
-              const imageUrl = backgroundImageUrls[correspondingPage.id]
+            {projectPages.map((page) => {
+              const displayPageNumber = page.pageNumber
+              const imageUrl = backgroundImageUrls[page.id]
               const pageRegions = cropRegions.filter(
-                (region) => region.projectPage?.id === correspondingPage.id,
+                (region) => region.projectPage?.id === page.id,
               )
 
               return (
-                <div key={`page-${displayPageNumber}`} className="space-y-2">
+                <div key={page.id} className="space-y-2">
                   <div className="flex items-center gap-2">
                     <h4 className="text-sm font-medium">
                       ページ {displayPageNumber}
@@ -263,7 +240,8 @@ export default function RegionInfoPage() {
                       ({pageRegions.length}個の領域)
                     </div>
                   </div>
-                  {imageUrl && (
+
+                  {imageUrl ? (
                     <div className="relative overflow-hidden rounded-lg border">
                       <Image
                         src={imageUrl}
@@ -273,10 +251,9 @@ export default function RegionInfoPage() {
                         height={600}
                         unoptimized
                         onClick={() => {
-                          setSelectedProjectPage(correspondingPage)
+                          setSelectedProjectPage(page)
                         }}
                       />
-                      {/* Overlay regions for this page */}
                       {pageRegions.map((area, index) => {
                         const globalIndex = cropRegions.findIndex(
                           (r) => r.id === area.id,
@@ -284,7 +261,7 @@ export default function RegionInfoPage() {
                         const isSelected = selectedRowIndex === globalIndex
                         return (
                           <div
-                            key={area.id || `area-${pageIndex}-${index}`}
+                            key={area.id ?? `area-${page.id}-${index}`}
                             className={`absolute border-2 ${
                               isSelected
                                 ? "border-orange-500 bg-orange-500/30"
@@ -303,12 +280,17 @@ export default function RegionInfoPage() {
                           />
                         )
                       })}
-                      {/* Page indicator if this is selected */}
-                      {selectedProjectPage?.id === correspondingPage.id && (
+                      {selectedProjectPage?.id === page.id && (
                         <div className="absolute top-2 left-2 rounded bg-blue-500 px-2 py-1 text-xs font-medium text-white">
                           編集中
                         </div>
                       )}
+                    </div>
+                  ) : (
+                    <div className="relative flex aspect-[3/4] items-center justify-center overflow-hidden rounded-lg border bg-gray-100">
+                      <div className="text-muted-foreground text-sm">
+                        画像が見つかりません
+                      </div>
                     </div>
                   )}
                 </div>

--- a/components/projects/01-upload/hooks/useMasterAnswers.ts
+++ b/components/projects/01-upload/hooks/useMasterAnswers.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 import { MasterAnswer, MasterAnswersState } from "@/components/projects/01-upload/types"
 import {
+  convertProjectPagesToMasterAnswers,
   createUploadData,
   generateImageUrls,
   generatePageNumberUpdateRequests,
@@ -182,25 +183,11 @@ export function useMasterAnswers(
           const updatedProject =
             await window.electronAPI.fetchProjectById(projectId)
           if (updatedProject && updatedProject.projectPages) {
-            // Convert projectPages to master answers format for compatibility
-            const masterAnswers = updatedProject.projectPages
-              .filter((page) =>
-                page.pageImages?.some((img) => img.imageType === "MODEL_ANSWER"),
-              )
-              .map((page) => {
-                const masterAnswer = page.pageImages?.find(
-                  (img) => img.imageType === "MODEL_ANSWER",
-                )
-                return {
-                  id: page.id,
-                  projectId: page.projectId,
-                  imagePath: masterAnswer?.imagePath || "",
-                  pageNumber: page.pageNumber,
-                  createdAt: page.createdAt,
-                  updatedAt: page.updatedAt,
-                }
-              })
-            const sortedUpdatedAnswers = sortImagesByPageNumber(masterAnswers)
+            const masterAnswers = convertProjectPagesToMasterAnswers(
+              updatedProject.projectPages,
+            )
+            const sortedUpdatedAnswers =
+              sortImagesByPageNumber(masterAnswers)
 
             setState((prev) => ({ ...prev, answers: sortedUpdatedAnswers }))
             onAnswersChange(sortedUpdatedAnswers)
@@ -299,16 +286,17 @@ export function useMasterAnswers(
       }))
 
       try {
-        await window.electronAPI.deleteMasterAnswer(answerId)
-        const updatedAnswers = state.answers.filter((answer) => answer.id !== answerId)
+        const result = await window.electronAPI.deleteMasterAnswer(answerId)
+        const updatedAnswers = sortImagesByPageNumber(
+          convertProjectPagesToMasterAnswers(result.projectPages),
+        )
+        const newUrls = await generateImageUrls(updatedAnswers)
 
         setState((prev) => ({
           ...prev,
           answers: updatedAnswers,
           isDeleting: { ...prev.isDeleting, [answerId]: false },
-          imageUrls: Object.fromEntries(
-            Object.entries(prev.imageUrls).filter(([id]) => id !== answerId),
-          ),
+          imageUrls: newUrls,
         }))
 
         onAnswersChange(updatedAnswers)
@@ -322,7 +310,7 @@ export function useMasterAnswers(
         }))
       }
     },
-    [state.answers, onAnswersChange],
+    [onAnswersChange],
   )
 
   /**

--- a/components/projects/01-upload/utils/image-utils.ts
+++ b/components/projects/01-upload/utils/image-utils.ts
@@ -126,3 +126,53 @@ export const generatePageNumberUpdateRequests = (
     pageNumber: index + 1,
   }))
 }
+
+/**
+ * ProjectPage配列からMasterAnswer配列を生成する
+ * @param {ProjectPageWithDetails[]} projectPages - プロジェクトページ一覧
+ * @returns {MasterAnswer[]} MasterAnswer形式の配列
+ */
+type MinimalPageImage = {
+  id: string
+  imagePath: string
+  imageType: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+type MinimalProjectPage = {
+  id: string
+  projectId: string
+  pageNumber: number
+  pageImages?: MinimalPageImage[]
+}
+
+export const convertProjectPagesToMasterAnswers = <
+  T extends MinimalProjectPage
+>(
+  projectPages: T[],
+): MasterAnswer[] => {
+  return projectPages.flatMap((page) => {
+    const masterAnswer = page.pageImages?.find(
+      (img) => img.imageType === "MODEL_ANSWER",
+    )
+
+    if (!masterAnswer) {
+      console.warn(
+        `Project page ${page.id} is flagged as having a master answer but no MODEL_ANSWER image exists.`,
+      )
+      return []
+    }
+
+    return [
+      {
+        id: masterAnswer.id,
+        projectId: page.projectId,
+        imagePath: masterAnswer.imagePath,
+        pageNumber: page.pageNumber,
+        createdAt: masterAnswer.createdAt,
+        updatedAt: masterAnswer.updatedAt,
+      },
+    ]
+  })
+}

--- a/components/projects/02-template/hooks/useCropRegionSave.ts
+++ b/components/projects/02-template/hooks/useCropRegionSave.ts
@@ -66,7 +66,8 @@ export function useCropRegionSave(
           )
         } else if (operation === "create") {
           // 新規領域の作成
-          return await window.electronAPI.createCropRegion(regionData)
+          const { orderIndex: _ignoredOrderIndex, ...createData } = regionData
+          return await window.electronAPI.createCropRegion(createData)
         } else {
           throw new Error(
             `Invalid operation: ${operation} for region with ID: ${region.id}`,
@@ -112,7 +113,6 @@ export function useCropRegionSave(
           }
 
           const regionData = {
-            projectId,
             projectPageId: area.projectPageId,
             type: area.type,
             x: area.x,
@@ -136,7 +136,8 @@ export function useCropRegionSave(
             saveResults.push({ originalIndex: i, result, wasUpdate: true })
           } else {
             // 新規領域の作成
-            const result = await window.electronAPI.createCropRegion(regionData)
+            const { orderIndex: _ignoredOrderIndex, ...createData } = regionData
+            const result = await window.electronAPI.createCropRegion(createData)
             saveResults.push({ originalIndex: i, result, wasUpdate: false })
           }
         }
@@ -198,7 +199,6 @@ export function useCropRegionSave(
       }
 
       // 新規領域オブジェクトを作成（orderIndexを設定）
-      const nextOrderIndex = existingRegions.length
       const newRegion: CropRegionArea = {
         type,
         x: coords.x,
@@ -208,7 +208,6 @@ export function useCropRegionSave(
         label,
         points,
         projectPageId,
-        orderIndex: nextOrderIndex,
       }
 
       try {
@@ -220,6 +219,12 @@ export function useCropRegionSave(
           return {
             ...newRegion,
             id: savedRegion.id,
+            orderIndex: savedRegion.orderIndex ?? null,
+            points:
+              typeof savedRegion.points === "number"
+                ? String(savedRegion.points)
+                : newRegion.points,
+            label: savedRegion.label ?? newRegion.label,
           }
         }
         return null

--- a/components/projects/02-template/utils/template-actions.ts
+++ b/components/projects/02-template/utils/template-actions.ts
@@ -33,7 +33,6 @@ export async function saveTemplate(
       }
 
       const regionData = {
-        projectId,
         projectPageId: area.projectPageId,
         type: area.type,
         x: area.x,

--- a/components/projects/03-region-info/components/RegionTableRow.tsx
+++ b/components/projects/03-region-info/components/RegionTableRow.tsx
@@ -91,6 +91,12 @@ export const RegionTableRow = ({
     ? typeIcons[regionType]
     : typeIcons["OTHER"]
 
+  const ensureSelected = () => {
+    if (!isSelected) {
+      onSelect(globalIndex)
+    }
+  }
+
   return (
     <tr
       key={region.id || `region-${globalIndex}`}
@@ -129,7 +135,10 @@ export const RegionTableRow = ({
           onValueChange={(value) => onRegionChange(globalIndex, "type", value)}
           disabled={disabled}
         >
-          <SelectTrigger className="w-full">
+          <SelectTrigger
+            className="w-full"
+            onFocus={ensureSelected}
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -150,6 +159,7 @@ export const RegionTableRow = ({
           onKeyDown={(e) => onKeyDown(e, globalIndex, "label")}
           onCompositionStart={onCompositionStart}
           onCompositionEnd={onCompositionEnd}
+          onFocus={ensureSelected}
           disabled={disabled}
           placeholder="領域名を入力"
           className="h-8 w-full min-w-20"
@@ -168,6 +178,7 @@ export const RegionTableRow = ({
             onKeyDown={(e) => onKeyDown(e, globalIndex, "points")}
             onCompositionStart={onCompositionStart}
             onCompositionEnd={onCompositionEnd}
+            onFocus={ensureSelected}
             disabled={disabled}
             placeholder="10"
             className="h-8 w-full min-w-20"

--- a/components/projects/03-region-info/hooks/useDragAndDrop.ts
+++ b/components/projects/03-region-info/hooks/useDragAndDrop.ts
@@ -44,19 +44,27 @@ export const useDragAndDrop = ({
     const { draggedIndex } = dragState
 
     if (draggedIndex !== null && draggedIndex !== dropIndex) {
-      const newRegions = [...regions]
-      const draggedItem = newRegions[draggedIndex]
+      const reordered = [...regions]
+      const draggedItem = reordered[draggedIndex]
 
-      newRegions.splice(draggedIndex, 1)
-      newRegions.splice(dropIndex, 0, draggedItem)
-      setRegions(newRegions)
+      reordered.splice(draggedIndex, 1)
+      reordered.splice(dropIndex, 0, draggedItem)
+
+      const reorderedWithOrder = reordered.map((region, index) => ({
+        ...region,
+        orderIndex: index,
+      }))
+
+      setRegions(reorderedWithOrder)
 
       // orderIndexを更新（データベースに反映）
       try {
-        const updates = newRegions.map((region, index) => ({
-          id: region.id,
-          orderIndex: index, // 0から始まる連番
-        }))
+        const updates = reorderedWithOrder
+          .map((region) => ({
+            id: region.id,
+            orderIndex: region.orderIndex ?? 0,
+          }))
+          .filter((update) => update.id)
 
         if ((window as any).electronAPI?.updateLayoutRegionOrders) {
           await (window as any).electronAPI.updateLayoutRegionOrders(updates)

--- a/components/projects/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/components/projects/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -56,12 +56,17 @@ export function useBatchScoring({
         status = statusOrAnswerIds as ScoringStatus
         answerIds = Array.from(selectedAnswers)
         inputPartialScore =
-          typeof statusOrPartialScore === "number" ? statusOrPartialScore : null
+          typeof statusOrPartialScore === "number"
+            ? statusOrPartialScore
+            : null
       } else {
         // 旧形式: handleBatchScore(answerIds, status)
         answerIds = statusOrAnswerIds as string | string[]
         status = statusOrPartialScore as ScoringStatus
-        inputPartialScore = partialScore || null
+        inputPartialScore =
+          partialScore !== undefined && partialScore !== null
+            ? partialScore
+            : null
       }
 
       let effectiveUserId: string
@@ -118,9 +123,11 @@ export function useBatchScoring({
               newScore = inputPartialScore
             } else {
               // nullの場合は現在のpartialScoreを維持（ステータスのみ変更）
-              newScore = currentScore?.partialScore
-                ? Number(currentScore.partialScore)
-                : null
+              newScore =
+                currentScore?.partialScore !== undefined &&
+                currentScore?.partialScore !== null
+                  ? Number(currentScore.partialScore)
+                  : null
             }
             break
           case "pending":
@@ -129,9 +136,11 @@ export function useBatchScoring({
               newScore = inputPartialScore
             } else {
               // nullの場合は現在のpartialScoreを維持（ステータスのみ変更）
-              newScore = currentScore?.partialScore
-                ? Number(currentScore.partialScore)
-                : null
+              newScore =
+                currentScore?.partialScore !== undefined &&
+                currentScore?.partialScore !== null
+                  ? Number(currentScore.partialScore)
+                  : null
             }
             break
         }

--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -14,7 +14,7 @@ import type {
   ScoringData,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
-import { useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 export interface AnswerGridViewProps {
   // 統一されたデータ引数
@@ -87,6 +87,7 @@ export default function AnswerGridView({
     isFiltered: filteredScoringDataIds.includes(answer.id)
   })))
   
+  const containerRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
 
   // Custom hooks
@@ -124,7 +125,7 @@ export default function AnswerGridView({
     selectedAnswers: selectedScoringDataIds,
     layoutDirection,
     autoScroll,
-    gridRef,
+    containerRef,
   })
 
   // Mouse event handlers
@@ -168,7 +169,7 @@ export default function AnswerGridView({
   }
 
   return (
-    <div className={`h-full overflow-y-auto ${className}`}>
+    <div ref={containerRef} className={`h-full overflow-y-auto ${className}`}>
       {/* 答案グリッド */}
       <div
         ref={gridRef}

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -4,6 +4,18 @@ import CroppedAnswerImage from "@/components/projects/07-score-at-once/ScoringMa
 import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
 import { Badge } from "@/components/ui/badge"
 
+const SCORE_STATUS_KEYS = Object.keys(SCORE_STATUS_CONFIG) as Array<
+  keyof typeof SCORE_STATUS_CONFIG
+>
+
+type ScoreStatusConfig =
+  (typeof SCORE_STATUS_CONFIG)[keyof typeof SCORE_STATUS_CONFIG]
+
+const isScoreStatusKey = (
+  status: keyof typeof SCORE_STATUS_CONFIG,
+): status is keyof typeof SCORE_STATUS_CONFIG =>
+  SCORE_STATUS_KEYS.includes(status)
+
 interface GridCellProps {
   answer: GridAnswerItem
   isSelected: boolean
@@ -25,12 +37,32 @@ export function GridCell({
   selectionBorderSettings,
   onMouseDown,
 }: GridCellProps) {
-  const config =
-    SCORE_STATUS_CONFIG[answer.status as keyof typeof SCORE_STATUS_CONFIG] ||
-    SCORE_STATUS_CONFIG.unscored
+  const statusKey: keyof typeof SCORE_STATUS_CONFIG = isScoreStatusKey(
+    answer.status,
+  )
+    ? answer.status
+    : "unscored"
+  const config: ScoreStatusConfig =
+    SCORE_STATUS_CONFIG[statusKey] ?? SCORE_STATUS_CONFIG.unscored
   const Icon = config.icon
   const isMaster =
     answer.studentId === "MASTER" || answer.studentName === "模範解答"
+
+  const cellClasses = ["flex flex-shrink-0 flex-col gap-1 p-2"]
+
+  if (isMaster) {
+    cellClasses.push("border-2 border-black bg-white")
+  } else {
+    cellClasses.push("border-2")
+    if (isSelected) {
+      cellClasses.push(
+        selectionBorderSettings.tailwindClass,
+        config.selectedBgColor,
+      )
+    } else {
+      cellClasses.push(config.borderColor, config.bgColor ?? "bg-white")
+    }
+  }
 
   const getScoreDisplay = () => {
     if (answer.status === "correct") {
@@ -50,17 +82,7 @@ export function GridCell({
   return (
     <div
       data-answer-id={answer.id}
-      className={`flex flex-shrink-0 flex-col gap-1 p-2 ${
-        isMaster
-          ? "border-2 border-black bg-white"
-          : `${config.bgColor || "bg-white"}`
-      } ${!isMaster ? config.borderColor : ""} ${
-        !isMaster
-          ? isSelected
-            ? `border-2 ${selectionBorderSettings.tailwindClass}`
-            : "border-2 border-transparent"
-          : ""
-      }`}
+      className={cellClasses.join(" ")}
       onMouseDown={(e) => onMouseDown(e, answer.id)}
     >
       {/* 答案画像 */}

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
@@ -1,55 +1,181 @@
 import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
-import { RefObject, useEffect } from "react"
+import { RefObject, useEffect, useRef, useCallback, useMemo } from "react"
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3)
 
 interface UseAutoScrollProps {
   selectedAnswers: Set<string>
   layoutDirection: LayoutDirection
   autoScroll: boolean
-  gridRef: RefObject<HTMLDivElement | null>
+  containerRef: RefObject<HTMLDivElement | null>
 }
 
 export function useAutoScroll({
   selectedAnswers,
   layoutDirection,
   autoScroll,
-  gridRef,
+  containerRef,
 }: UseAutoScrollProps) {
+
+  const selectedAnswerId = useMemo(() => {
+    if (!autoScroll || selectedAnswers.size !== 1) {
+      return null
+    }
+    return Array.from(selectedAnswers)[0]
+  }, [autoScroll, selectedAnswers])
+  const animationRef = useRef<number | null>(null)
+  const animationStateRef = useRef<{
+    startTime: number
+    duration: number
+    startX: number
+    startY: number
+    targetX: number
+    targetY: number
+  } | null>(null)
+  const previousTargetRef = useRef<{ x: number; y: number } | null>(null)
+
+  const cancelAnimation = useCallback(() => {
+    if (animationRef.current !== null) {
+      cancelAnimationFrame(animationRef.current)
+      animationRef.current = null
+    }
+    animationStateRef.current = null
+  }, [])
+
+  const startAnimation = useCallback(
+    (container: HTMLElement, targetX: number, targetY: number) => {
+      const now = performance.now()
+      const duration = 350 // ms
+
+      const startX = container.scrollLeft
+      const startY = container.scrollTop
+
+    animationStateRef.current = {
+      startTime: now,
+      duration,
+      startX,
+      startY,
+      targetX,
+      targetY,
+    }
+
+    const step = () => {
+      const state = animationStateRef.current
+      if (!state) return
+
+      const elapsed = performance.now() - state.startTime
+      const progress = Math.min(elapsed / state.duration, 1)
+      const eased = easeOutCubic(progress)
+
+      const nextX = state.startX + (state.targetX - state.startX) * eased
+      const nextY = state.startY + (state.targetY - state.startY) * eased
+
+      container.scrollTo(nextX, nextY)
+
+      if (progress < 1) {
+        animationRef.current = requestAnimationFrame(step)
+      } else {
+        cancelAnimation()
+      }
+      }
+
+      cancelAnimation()
+      animationRef.current = requestAnimationFrame(step)
+    },
+    [cancelAnimation],
+  )
+
+  useEffect(() => {
+    return () => {
+      cancelAnimation()
+    }
+  }, [cancelAnimation])
+
+  const scrollElementIntoView = useCallback(
+    (element: HTMLElement, force: boolean = false) => {
+      if (!autoScroll || !containerRef.current) return
+
+      const container = containerRef.current
+
+      const containerRect = container.getBoundingClientRect()
+      const elementRect = element.getBoundingClientRect()
+
+      const targetX =
+        elementRect.left -
+        containerRect.left +
+        container.scrollLeft -
+        container.clientWidth / 2 +
+        elementRect.width / 2
+
+      const targetY =
+        elementRect.top -
+        containerRect.top +
+        container.scrollTop -
+        container.clientHeight / 2 +
+        elementRect.height / 2
+
+      const target = {
+        x: Math.max(0, targetX),
+        y: Math.max(0, targetY),
+      }
+
+      const prevTarget = previousTargetRef.current
+      if (
+        !force &&
+        prevTarget &&
+        Math.abs(prevTarget.x - target.x) < 1 &&
+        Math.abs(prevTarget.y - target.y) < 1
+      ) {
+        return
+      }
+
+      previousTargetRef.current = target
+      startAnimation(container, target.x, target.y)
+    },
+    [autoScroll, containerRef, startAnimation],
+  )
+
   // 選択された答案を画面中央にスクロール（自動スクロール設定に基づく）
   useEffect(() => {
-    if (autoScroll && selectedAnswers.size === 1 && gridRef.current) {
-      const selectedId = Array.from(selectedAnswers)[0]
-      const selectedElement = gridRef.current.querySelector(
-        `[data-answer-id="${selectedId}"]`,
-      ) as HTMLElement
-
-      if (selectedElement) {
-        // gridRef.current自体がスクロールコンテナ（overflow-auto）
-        const container = gridRef.current
-        const containerRect = container.getBoundingClientRect()
-        const elementRect = selectedElement.getBoundingClientRect()
-
-        // 縦・横両方向のスクロール計算（すべてのレイアウトに対応）
-        const scrollLeft =
-          elementRect.left -
-          containerRect.left +
-          container.scrollLeft -
-          container.clientWidth / 2 +
-          elementRect.width / 2
-
-        const scrollTop =
-          elementRect.top -
-          containerRect.top +
-          container.scrollTop -
-          container.clientHeight / 2 +
-          elementRect.height / 2
-
-        // 両方向に同時にスクロール
-        container.scrollTo({
-          left: Math.max(0, scrollLeft),
-          top: Math.max(0, scrollTop),
-          behavior: "smooth",
-        })
-      }
+    if (!autoScroll || !selectedAnswerId || !containerRef.current) {
+      return
     }
-  }, [selectedAnswers, layoutDirection, autoScroll, gridRef])
+
+    const container = containerRef.current
+    const selectedElement = container.querySelector(
+      `[data-answer-id="${selectedAnswerId}"]`,
+    ) as HTMLElement | null
+
+    if (!selectedElement) {
+      return
+    }
+
+    scrollElementIntoView(selectedElement, false)
+  }, [autoScroll, containerRef, selectedAnswerId, scrollElementIntoView])
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      if (!autoScroll || !containerRef.current) {
+        return
+      }
+
+      const customEvent = event as CustomEvent<{ answerId?: string }>
+      const answerId = customEvent.detail?.answerId
+      if (!answerId) return
+
+      const container = containerRef.current
+      const element = container.querySelector(
+        `[data-answer-id="${answerId}"]`,
+      ) as HTMLElement | null
+
+      if (!element) return
+
+      scrollElementIntoView(element, true)
+    }
+
+    window.addEventListener("score-view:scroll-to-answer", handler)
+    return () => {
+      window.removeEventListener("score-view:scroll-to-answer", handler)
+    }
+  }, [autoScroll, containerRef, scrollElementIntoView])
 }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -86,21 +86,22 @@ export function usePartialScore({
       }
 
       let finalInput = partialScoreInput
-      if (finalInput.endsWith(".")) {
-        finalInput = finalInput + "0"
-      }
 
-      const finalValue = parseFloat(finalInput)
-      const maxPoints = currentCropRegion?.points || 10
-
-      // 値の妥当性チェック
-      if (!isNaN(finalValue) && finalValue >= 0 && finalValue <= maxPoints) {
-        const roundedValue = Math.round(finalValue * 100) / 100
-        onBatchScore(confirmType, roundedValue, null, selectedAnswers)
-      } else if (finalInput === "" || finalInput === "0.") {
-        // 空の場合は0点として処理
-        onBatchScore(confirmType, 0, null, selectedAnswers)
+      if (finalInput.trim() === "") {
+        onBatchScore(confirmType, null, null, selectedAnswers)
       } else {
+        if (finalInput.endsWith(".")) {
+          finalInput = finalInput + "0"
+        }
+
+        const finalValue = parseFloat(finalInput)
+        const maxPoints = currentCropRegion?.points || 10
+
+        // 値の妥当性チェック
+        if (!isNaN(finalValue) && finalValue >= 0 && finalValue <= maxPoints) {
+          const roundedValue = Math.round(finalValue * 100) / 100
+          onBatchScore(confirmType, roundedValue, null, selectedAnswers)
+        }
       }
 
       // モーダルを閉じる

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -156,9 +156,10 @@ export function useScoringFilter({
           imageUrl: pageImage.imagePath
             ? `appimg://${pageImage.imagePath}`
             : "",
-          currentScore: score?.partialScore
-            ? Number(score.partialScore)
-            : undefined,
+          currentScore:
+            score?.partialScore !== undefined && score?.partialScore !== null
+              ? Number(score.partialScore)
+              : undefined,
           maxScore: currentCropRegion.points ?? 0,
           status: (score?.status as ScoringStatus) ?? "unscored",
           questionRegion: currentCropRegion, // 採点領域情報を追加
@@ -255,6 +256,20 @@ export function useScoringFilter({
     selectedPageImageIdsRef.current = selectedPageImageIds
   }, [selectedPageImageIds])
 
+  useEffect(() => {
+    if (selectedPageImageIds.size !== 1) {
+      return
+    }
+    const selectedId = Array.from(selectedPageImageIds)[0]
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("score-view:scroll-to-answer", {
+          detail: { answerId: selectedId },
+        }),
+      )
+    }
+  }, [selectedPageImageIds])
+
   // visibleAnswersが更新されたら適切な答案選択を行う（最適化版）
   useEffect(() => {
     console.log("🔍 Selection debug - visibleAnswers changed:", {
@@ -287,6 +302,9 @@ export function useScoringFilter({
     // 早期リターンで不要な処理をスキップ
     if (visibleAnswers.length === 0) {
       console.log("🔍 Selection debug - No visible answers, returning")
+      if (selectedPageImageIdsRef.current.size > 0) {
+        setSelectedPageImageIds(new Set())
+      }
       return
     }
 
@@ -300,6 +318,13 @@ export function useScoringFilter({
             "🔍 Selection debug - Current selection is still valid:",
             selectedId,
           )
+          if (typeof window !== "undefined") {
+            window.dispatchEvent(
+              new CustomEvent("score-view:scroll-to-answer", {
+                detail: { answerId: selectedId },
+              }),
+            )
+          }
           return // 有効な選択があるので処理終了
         }
       }
@@ -320,6 +345,13 @@ export function useScoringFilter({
           answerId,
         )
         setSelectedPageImageIds(new Set([answerId]))
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(
+            new CustomEvent("score-view:scroll-to-answer", {
+              detail: { answerId },
+            }),
+          )
+        }
         return // 見つかったらすぐ終了
       }
     }

--- a/electron-src/lib/export/excel/data-fetcher.ts
+++ b/electron-src/lib/export/excel/data-fetcher.ts
@@ -99,23 +99,25 @@ export async function fetchExportData(
     }
 
     // 設問領域と小計領域の分離・ソート
+    const sortByOrderIndex = (a: CropRegion, b: CropRegion) => {
+      const orderA = a.orderIndex ?? Number.MAX_SAFE_INTEGER
+      const orderB = b.orderIndex ?? Number.MAX_SAFE_INTEGER
+      if (orderA !== orderB) {
+        return orderA - orderB
+      }
+      if (Math.abs(a.y - b.y) < 0.01) {
+        return a.x - b.x
+      }
+      return a.y - b.y
+    }
+
     const questionRegions = cropRegions
       .filter((region: CropRegion) => region.type === "QUESTION_ANSWER")
-      .sort((a: CropRegion, b: CropRegion) => {
-        if (Math.abs(a.y - b.y) < 0.01) {
-          return a.x - b.x
-        }
-        return a.y - b.y
-      })
+      .sort(sortByOrderIndex)
 
     const subtotalRegions = cropRegions
       .filter((region: CropRegion) => region.type === "SUBTOTAL_SCORE")
-      .sort((a: CropRegion, b: CropRegion) => {
-        if (Math.abs(a.y - b.y) < 0.01) {
-          return a.x - b.x
-        }
-        return a.y - b.y
-      })
+      .sort(sortByOrderIndex)
 
     // 採点データの構造化
     const scoringData = await buildScoringData(
@@ -237,7 +239,7 @@ function buildScoreDetails(
 
     return {
       questionId: region.id,
-      questionLabel: region.label || `問${region.orderIndex || 1}`,
+      questionLabel: region.label || `問${(region.orderIndex ?? 0) + 1}`,
       score: actualScore,
       maxScore: region.points || 0,
       status:
@@ -311,7 +313,7 @@ async function buildSubtotalScores(
       const result = {
         subtotalRegionId: subtotalRegion.id,
         subtotalLabel:
-          subtotalRegion.label || `小計${subtotalRegion.orderIndex || 1}`,
+        subtotalRegion.label || `小計${(subtotalRegion.orderIndex ?? 0) + 1}`,
         score,
         maxScore,
       }

--- a/electron-src/lib/export/excel/header-creators.ts
+++ b/electron-src/lib/export/excel/header-creators.ts
@@ -24,10 +24,10 @@ export async function createSheetHeaders(
     "氏名",
     "合計点",
     ...subtotalRegions.map(
-      (region: CropRegion) => region.label || `小計${region.orderIndex || 1}`,
+      (region: CropRegion) => region.label || `小計${(region.orderIndex ?? 0) + 1}`,
     ),
     ...questionRegions.map(
-      (region: CropRegion) => region.label || `問${region.orderIndex || 1}`,
+      (region: CropRegion) => region.label || `問${(region.orderIndex ?? 0) + 1}`,
     ),
   ])
 

--- a/electron-src/lib/prisma/cropRegion.ts
+++ b/electron-src/lib/prisma/cropRegion.ts
@@ -5,8 +5,42 @@ import prisma from "./client"
 export const createCropRegion = async (
   data: Prisma.CropRegionUncheckedCreateInput,
 ) => {
+  if (!data.projectPageId) {
+    throw new Error("projectPageId is required to create a crop region.")
+  }
+
+  const projectPage = await prisma.projectPage.findUnique({
+    where: { id: data.projectPageId },
+    select: { projectId: true },
+  })
+
+  if (!projectPage) {
+    throw new Error(
+      `Project page not found for crop region creation (id: ${data.projectPageId}).`,
+    )
+  }
+
+  let orderIndex = data.orderIndex ?? null
+
+  if (orderIndex === null || orderIndex === undefined) {
+    const maxOrder = await prisma.cropRegion.aggregate({
+      _max: { orderIndex: true },
+      where: {
+        projectPage: {
+          projectId: projectPage.projectId,
+        },
+      },
+    })
+
+    const currentMax = maxOrder._max.orderIndex ?? -1
+    orderIndex = currentMax + 1
+  }
+
   return prisma.cropRegion.create({
-    data,
+    data: {
+      ...data,
+      orderIndex,
+    },
     include: {
       projectPage: true,
       cropSubtotals: {

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -92,45 +92,128 @@ export const uploadMasterAnswers = async (
   return uploadedAnswers
 }
 
+type ProjectPageWithMasterImages = Prisma.ProjectPageGetPayload<{
+  include: {
+    project: true
+    pageImages: {
+      where: { imageType: "MODEL_ANSWER" }
+      orderBy: { createdAt: "asc" }
+      include: { student: true }
+    }
+    cropRegions: true
+  }
+}>
+
+export interface DeleteMasterAnswerResult {
+  deletedAnswer: PageImage | null
+  projectPages: ProjectPageWithMasterImages[]
+}
+
 export const deleteMasterAnswer = async (
   answerId: string,
-): Promise<PageImage | void> => {
+): Promise<DeleteMasterAnswerResult> => {
   try {
     const answer = await prisma.pageImage.findUnique({
       where: { id: answerId },
-      include: { projectPage: true }
+      include: { projectPage: true },
     })
-    
-    if (answer && answer.imageType === "MODEL_ANSWER") {
-      const filePath = getAbsolutePathFromData(answer.imagePath)
-      
-      try {
-        await fs.unlink(filePath)
-      } catch (fileError: unknown) {
-        if (fileError && typeof fileError === 'object' && 'code' in fileError && fileError.code !== "ENOENT") {
-          console.warn(`Failed to delete answer file ${filePath}:`, fileError)
-        }
-      }
 
-      // Delete the PageImage
-      const deletedAnswer = await prisma.pageImage.delete({ 
-        where: { id: answerId } 
+    if (!answer) {
+      console.warn(
+        `No PageImage found for master answer deletion (id: ${answerId}).`,
+      )
+      return { deletedAnswer: null, projectPages: [] }
+    }
+
+    if (answer.imageType !== "MODEL_ANSWER") {
+      console.warn(
+        `PageImage ${answerId} is not a MODEL_ANSWER (found ${answer.imageType}). Skipping deletion.`,
+      )
+      return { deletedAnswer: null, projectPages: [] }
+    }
+
+    const projectId = answer.projectPage.projectId
+    const filePath = getAbsolutePathFromData(answer.imagePath)
+    let updatedPages: ProjectPageWithMasterImages[] = []
+
+    await prisma.$transaction(async (tx) => {
+      await tx.pageImage.delete({
+        where: { id: answerId },
       })
 
-      // Check if this was the only answer for this ProjectPage
-      const remainingAnswers = await prisma.pageImage.count({
-        where: { projectPageId: answer.projectPageId }
+      const remainingAnswers = await tx.pageImage.count({
+        where: { projectPageId: answer.projectPageId },
       })
 
-      // If no answers remain, delete the ProjectPage
       if (remainingAnswers === 0) {
-        await prisma.projectPage.delete({
-          where: { id: answer.projectPageId }
+        await tx.projectPage.delete({
+          where: { id: answer.projectPageId },
         })
       }
 
-      return deletedAnswer
+      const pages = await tx.projectPage.findMany({
+        where: { projectId },
+        orderBy: { pageNumber: "asc" },
+        include: {
+          project: true,
+          cropRegions: true,
+          pageImages: {
+            where: { imageType: "MODEL_ANSWER" },
+            orderBy: { createdAt: "asc" },
+            include: {
+              student: true,
+            },
+          },
+        },
+      })
+
+      let resequenced = false
+      for (let index = 0; index < pages.length; index++) {
+        const targetPageNumber = index + 1
+        if (pages[index].pageNumber !== targetPageNumber) {
+          resequenced = true
+          await tx.projectPage.update({
+            where: { id: pages[index].id },
+            data: { pageNumber: targetPageNumber },
+          })
+        }
+      }
+
+      if (resequenced) {
+        updatedPages = await tx.projectPage.findMany({
+          where: { projectId },
+          orderBy: { pageNumber: "asc" },
+          include: {
+            project: true,
+            cropRegions: true,
+            pageImages: {
+              where: { imageType: "MODEL_ANSWER" },
+              orderBy: { createdAt: "asc" },
+              include: {
+                student: true,
+              },
+            },
+          },
+        })
+      } else {
+        updatedPages = pages
+      }
+    })
+
+    try {
+      await fs.unlink(filePath)
+    } catch (fileError: unknown) {
+      if (
+        fileError &&
+        typeof fileError === "object" &&
+        "code" in fileError &&
+        fileError.code !== "ENOENT"
+      ) {
+        console.warn(`Failed to delete answer file ${filePath}:`, fileError)
+      }
     }
+
+    return { deletedAnswer: answer, projectPages: updatedPages }
   } catch (error) {
     console.error(`Failed to delete master answer ${answerId}:`, error)
     throw error

--- a/electron-src/tsconfig.json
+++ b/electron-src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "allowJs": true,
     "alwaysStrict": true,
     "esModuleInterop": true,

--- a/hooks/useLayoutRegions.ts
+++ b/hooks/useLayoutRegions.ts
@@ -13,7 +13,7 @@ export interface CropRegion {
   height: number
   label: string
   points: string | null
-  orderIndex: number
+  orderIndex: number | null
   masterImageId: string
 }
 
@@ -47,7 +47,7 @@ export function useCropRegions(projectId?: string) {
         height: region.height,
         label: region.label || "",
         points: region.points ? String(region.points) : null,
-        orderIndex: region.orderIndex || 1,
+        orderIndex: region.orderIndex ?? 1,
         masterImageId: region.projectPage?.id || ""
       }))
 
@@ -85,7 +85,8 @@ export function useCropRegions(projectId?: string) {
         if (region.id) {
           return await window.electronAPI.updateCropRegion(region.id, regionData)
         } else {
-          return await window.electronAPI.createCropRegion(regionData)
+          const { orderIndex: _ignoredOrderIndex, ...createData } = regionData
+          return await window.electronAPI.createCropRegion(createData)
         }
       })
 
@@ -102,8 +103,11 @@ export function useCropRegions(projectId?: string) {
             width: region!.width,
             height: region!.height,
             label: region!.label || "",
-            points: region!.points ? String(region!.points) : null,
-            orderIndex: region!.orderIndex || 1,
+          points: region!.points ? String(region!.points) : null,
+          orderIndex:
+            region!.orderIndex !== undefined && region!.orderIndex !== null
+              ? region!.orderIndex
+              : null,
             masterImageId: region!.projectPage?.id || "",
           }))
 

--- a/hooks/useMasterAnswers.ts
+++ b/hooks/useMasterAnswers.ts
@@ -74,6 +74,40 @@ export function useMasterAnswers(
   const [_currentFileIndex, setCurrentFileIndex] = useState(0)
   const [_currentPassword, setCurrentPassword] = useState<string>("")
 
+  const convertPdfToImagesWithPassword = useCallback(async (file: File): Promise<ConvertedImage[]> => {
+    try {
+      // まずパスワードなしで試行
+      const pdfImages = await convertPdfToImages(file)
+      return pdfImages
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      if (errorMessage === 'password-required' || errorMessage === 'invalid-password') {
+        // パスワードが必要な場合、ダイアログを表示してPromiseを返す
+        return new Promise((resolve, reject) => {
+          const isInvalidPassword = errorMessage === 'invalid-password'
+          setState(prev => ({
+            ...prev,
+            passwordDialog: {
+              isOpen: true,
+              fileName: file.name,
+              attempts: isInvalidPassword ? prev.passwordDialog.attempts + 1 : 0,
+              hasError: isInvalidPassword,
+              isLoading: false
+            }
+          }))
+          
+          // グローバルスコープで解決関数を保存
+          ;(window as any).__masterAnswerPasswordResolve = resolve
+          ;(window as any).__masterAnswerPasswordReject = reject
+          ;(window as any).__masterAnswerPasswordFile = file
+        })
+      } else {
+        // その他のエラーはそのまま投げる
+        throw error
+      }
+    }
+  }, [])
+
   const uploadAnswers = useCallback(async (files: File[]) => {
     if (!projectId) {
       toast.error("プロジェクトIDが指定されていません。")
@@ -175,42 +209,7 @@ export function useMasterAnswers(
       setCurrentFileIndex(0)
       setCurrentPassword("")
     }
-  }, [projectId, onAnswersChange])
-
-  // パスワード付きPDF変換処理
-  const convertPdfToImagesWithPassword = useCallback(async (file: File): Promise<ConvertedImage[]> => {
-    try {
-      // まずパスワードなしで試行
-      const pdfImages = await convertPdfToImages(file)
-      return pdfImages
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      if (errorMessage === 'password-required' || errorMessage === 'invalid-password') {
-        // パスワードが必要な場合、ダイアログを表示してPromiseを返す
-        return new Promise((resolve, reject) => {
-          const isInvalidPassword = errorMessage === 'invalid-password'
-          setState(prev => ({
-            ...prev,
-            passwordDialog: {
-              isOpen: true,
-              fileName: file.name,
-              attempts: isInvalidPassword ? prev.passwordDialog.attempts + 1 : 0,
-              hasError: isInvalidPassword,
-              isLoading: false
-            }
-          }))
-          
-          // グローバルスコープで解決関数を保存
-          ;(window as any).__masterAnswerPasswordResolve = resolve
-          ;(window as any).__masterAnswerPasswordReject = reject
-          ;(window as any).__masterAnswerPasswordFile = file
-        })
-      } else {
-        // その他のエラーはそのまま投げる
-        throw error
-      }
-    }
-  }, [])
+  }, [projectId, onAnswersChange, convertPdfToImagesWithPassword])
 
   // パスワード送信処理
   const handlePasswordSubmit = useCallback(async (password: string) => {
@@ -324,16 +323,31 @@ export function useMasterAnswers(
     }))
 
     try {
-      await window.electronAPI.deleteMasterAnswer(answerId)
-      const updatedAnswers = state.answers.filter((answer) => answer.id !== answerId)
-      
+      const result = await window.electronAPI.deleteMasterAnswer(answerId)
+      const updatedAnswers = result.projectPages
+        .flatMap(page =>
+          page.pageImages
+            .filter(img => img.imageType === "MODEL_ANSWER")
+            .map(img => ({ ...img, projectPage: page })),
+        )
+        .sort((a, b) => a.projectPage.pageNumber - b.projectPage.pageNumber)
+
+      const newUrls: Record<string, string> = {}
+      for (const answer of updatedAnswers) {
+        try {
+          const resolvedUrl = await window.electronAPI.resolveFileProtocolPath(answer.imagePath)
+          newUrls[answer.id] = resolvedUrl
+        } catch (error) {
+          console.error(`Failed to resolve path for answer ${answer.id} (${answer.imagePath}):`, error)
+          newUrls[answer.id] = ""
+        }
+      }
+
       setState(prev => ({
         ...prev,
         answers: updatedAnswers,
         isDeleting: { ...prev.isDeleting, [answerId]: false },
-        imageUrls: Object.fromEntries(
-          Object.entries(prev.imageUrls).filter(([id]) => id !== answerId)
-        )
+        imageUrls: newUrls
       }))
       
       onAnswersChange(updatedAnswers)
@@ -346,7 +360,7 @@ export function useMasterAnswers(
         isDeleting: { ...prev.isDeleting, [answerId]: false }
       }))
     }
-  }, [state.answers, onAnswersChange])
+  }, [onAnswersChange])
 
   const moveAnswer = useCallback(async (fromIndex: number, direction: "left" | "right") => {
     const toIndex = direction === "left" ? fromIndex - 1 : fromIndex + 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "lib": [
       "dom",

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -261,6 +261,11 @@ export type PageImageWithDetails = Prisma.PageImageGetPayload<{
   }
 }>
 
+export interface MasterAnswerDeletionResult {
+  deletedAnswer: PageImage | null
+  projectPages: ProjectPageWithDetails[]
+}
+
 // Backward compatibility aliases
 export type MasterAnswerPayload = ProjectPageWithDetails
 
@@ -554,7 +559,9 @@ export interface MyAPI {
       path?: string
     }[],
   ) => Promise<ProjectPageWithDetails[]>
-  deleteMasterAnswer: (answerId: string) => Promise<ProjectPageWithDetails | void>
+  deleteMasterAnswer: (
+    answerId: string,
+  ) => Promise<MasterAnswerDeletionResult>
   updateMasterAnswersOrder: (
     answerOrders: { id: string; pageNumber: number }[],
   ) => Promise<Prisma.BatchPayload>


### PR DESCRIPTION
## 概要
- マスター解答関連のユーティリティとフロントロジックを整理し、型安全に再利用できるようにしました
- 領域管理やExcelエクスポート処理を最新スキーマに合わせて修正しました
- 採点グリッドの自動スクロールやUI依存関係を調整し、型エラーと挙動不良を解消しました

## 変更内容
- `convertProjectPagesToMasterAnswers` を汎用化し、各画面から利用
- マスター解答管理フロー（アップロード・削除・移動・PDFパスワード対応）の再整理
- 領域情報ページとテンプレート関連フックのページ番号・orderIndexの扱いを是正
- 採点グリッド/フィルター/部分点まわりのコールバック依存を修正
- Excel出力で使用するデータ取得・ヘッダー生成処理を更新
- 各種 Prisma 型定義を同期

Closes #124
