### PR TITLE
lucide-react アイコンへの差し替え

### DIFF
--- a/components/projects/02-template/components/CropRegionList.tsx
+++ b/components/projects/02-template/components/CropRegionList.tsx
@@ -1,6 +1,18 @@
 "use client"
 
+import type { ComponentType } from "react"
 import { CropRegionArea } from "@/types/common.types"
+import {
+  Ellipsis,
+  FileText,
+  Hash,
+  ListOrdered,
+  MessageSquare,
+  Palette,
+  Pencil,
+  Trophy,
+  User,
+} from "lucide-react"
 
 type CropRegionListProps = {
   areas: CropRegionArea[]
@@ -9,34 +21,36 @@ type CropRegionListProps = {
   disabled: boolean
 }
 
+type IconType = ComponentType<{ className?: string }>
+
+const typeIcons: Record<string, IconType> = {
+  QUESTION_ANSWER: FileText,
+  STUDENT_NAME: User,
+  STUDENT_ID: Hash,
+  TOTAL_SCORE: Trophy,
+  SUBTOTAL_SCORE: ListOrdered,
+  MARK: Pencil,
+  COMMENT: MessageSquare,
+  OTHER: Ellipsis,
+}
+
+const typeLabels = {
+  QUESTION_ANSWER: "設問",
+  STUDENT_NAME: "氏名",
+  STUDENT_ID: "番号",
+  TOTAL_SCORE: "合計",
+  SUBTOTAL_SCORE: "小計",
+  MARK: "マーク",
+  COMMENT: "コメント",
+  OTHER: "その他",
+}
+
 const CropRegionList = ({
   areas,
   selectedAreaIndex,
   onSelectArea,
   disabled,
 }: CropRegionListProps) => {
-  const typeIcons = {
-    QUESTION_ANSWER: "📋",
-    STUDENT_NAME: "📄",
-    STUDENT_ID: "🔢",
-    TOTAL_SCORE: "🏆",
-    SUBTOTAL_SCORE: "🔢",
-    MARK: "✏️",
-    COMMENT: "💬",
-    OTHER: "📎",
-  }
-
-  const typeLabels = {
-    QUESTION_ANSWER: "設問",
-    STUDENT_NAME: "氏名",
-    STUDENT_ID: "番号",
-    TOTAL_SCORE: "合計",
-    SUBTOTAL_SCORE: "小計",
-    MARK: "マーク",
-    COMMENT: "コメント",
-    OTHER: "その他",
-  }
-
   return (
     <div className="flex h-full flex-col">
       <div className="bg-background flex-shrink-0 border-b p-4">
@@ -51,7 +65,7 @@ const CropRegionList = ({
       <div className="scrollbar-overlay flex-1 overflow-auto p-4">
         {areas.length === 0 ? (
           <div className="text-muted-foreground border-muted-foreground/25 rounded-lg border-2 border-dashed py-8 text-center">
-            <div className="mb-3 text-3xl">🎨</div>
+            <Palette className="mx-auto mb-3 h-10 w-10 text-muted-foreground/70" />
             <p className="text-base font-medium">領域を作成してください</p>
             <p className="mt-2 text-sm">
               左の模範解答上でマウスをドラッグして領域を作成できます
@@ -61,7 +75,7 @@ const CropRegionList = ({
           <div className="space-y-3">
             {areas.map((area, index) => {
               const isSelected = selectedAreaIndex === index
-              const icon =
+              const IconComponent =
                 typeIcons[area.type as keyof typeof typeIcons] ||
                 typeIcons["OTHER"]
               const typeLabel =
@@ -81,7 +95,13 @@ const CropRegionList = ({
                   }`}
                 >
                   <div className="mb-1 flex items-center space-x-2">
-                    <span className="text-lg">{icon}</span>
+                    <IconComponent
+                      className={`h-4 w-4 flex-shrink-0 ${
+                        isSelected
+                          ? "text-primary-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                    />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-medium">
                         {area.label || `領域 ${index + 1}`}

--- a/components/projects/03-region-info/components/RegionDetailsTable.tsx
+++ b/components/projects/03-region-info/components/RegionDetailsTable.tsx
@@ -6,6 +6,7 @@ import { useDragAndDrop } from "@/components/projects/03-region-info/hooks/useDr
 import { useKeyboardNavigation } from "@/components/projects/03-region-info/hooks/useKeyboardNavigation"
 import type { CropRegionWithDetails } from "@/types/electron"
 import { useState } from "react"
+import { Palette } from "lucide-react"
 
 type RegionDetailsTableProps = {
   regions: CropRegionWithDetails[]
@@ -137,7 +138,7 @@ const RegionDetailsTable = ({
   if (filteredRegions.length === 0) {
     return (
       <div className="p-8 text-center">
-        <div className="mb-4 text-4xl">🎨</div>
+        <Palette className="mx-auto mb-4 h-12 w-12 text-muted-foreground/70" />
         <h3 className="mb-2 text-lg font-medium">
           {selectedMasterImageId
             ? "このページに領域がありません"

--- a/components/projects/03-region-info/components/RegionTableRow.tsx
+++ b/components/projects/03-region-info/components/RegionTableRow.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ComponentType } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -14,7 +15,18 @@ import {
   CropRegionAreaType,
 } from "@/types/common.types"
 import type { CropRegionWithDetails } from "@/types/electron"
-import { GripVertical, Trash2 } from "lucide-react"
+import {
+  Ellipsis,
+  FileText,
+  GripVertical,
+  Hash,
+  ListOrdered,
+  MessageSquare,
+  Pencil,
+  Trash2,
+  Trophy,
+  User,
+} from "lucide-react"
 
 // AreaTypeの日本語表示マッピング
 const areaTypeToJapanese: Record<string, string> = {
@@ -28,15 +40,17 @@ const areaTypeToJapanese: Record<string, string> = {
   OTHER: "その他",
 }
 
-const typeIcons: Record<CropRegionAreaType, string> = {
-  ["QUESTION_ANSWER"]: "📋",
-  ["STUDENT_NAME"]: "📄",
-  ["STUDENT_ID"]: "🔢",
-  ["TOTAL_SCORE"]: "🏆",
-  ["SUBTOTAL_SCORE"]: "🔢",
-  ["MARK"]: "✏️",
-  ["COMMENT"]: "💬",
-  ["OTHER"]: "📎",
+type IconType = ComponentType<{ className?: string }>
+
+const typeIcons: Record<CropRegionAreaType, IconType> = {
+  ["QUESTION_ANSWER"]: FileText,
+  ["STUDENT_NAME"]: User,
+  ["STUDENT_ID"]: Hash,
+  ["TOTAL_SCORE"]: Trophy,
+  ["SUBTOTAL_SCORE"]: ListOrdered,
+  ["MARK"]: Pencil,
+  ["COMMENT"]: MessageSquare,
+  ["OTHER"]: Ellipsis,
 }
 
 type RegionTableRowProps = {
@@ -87,7 +101,7 @@ export const RegionTableRow = ({
   const isValidType = (type: string): type is CropRegionAreaType =>
     CROP_REGION_AREA_TYPES.includes(type as CropRegionAreaType)
 
-  const icon = isValidType(regionType)
+  const IconComponent = isValidType(regionType)
     ? typeIcons[regionType]
     : typeIcons["OTHER"]
 
@@ -120,7 +134,11 @@ export const RegionTableRow = ({
       </td>
       <td className="border-border border px-2 py-1">
         <div className="flex items-center space-x-2">
-          <span className="text-lg">{icon}</span>
+          <IconComponent
+            className={`h-4 w-4 flex-shrink-0 ${
+              isSelected ? "text-primary" : "text-muted-foreground"
+            }`}
+          />
           <span className="text-sm font-medium">{globalIndex + 1}</span>
         </div>
       </td>


### PR DESCRIPTION
## 概要
- Issue #133 の対応です
- 採点領域ステップと領域情報ステップで使用していた絵文字を lucide-react のアイコンに置き換えました

## 変更内容
- CropRegionList で領域種別ごとに lucide-react アイコンを表示
- RegionDetailsTable の空状態に Palette アイコンを利用
- RegionTableRow で領域種別アイコンを lucide-react に置き換え

## チェックリスト
- [x] Issue をリンクしました
- [x] ビルドが通ることを確認済み

Closes #133