### PR TITLE
ショートカット安定化とUI微修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -106,7 +106,8 @@ export function GridCell({
       <div className="flex items-center justify-between">
         <div className="flex min-w-0 flex-1 items-center space-x-1">
           <span
-            className={`truncate text-xs ${
+            title={isMaster || showStudentNames ? answer.studentName : undefined}
+            className={`block max-w-full truncate text-xs ${
               isMaster ? "font-bold text-black" : "font-medium"
             }`}
           >

--- a/components/projects/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -191,6 +191,15 @@ export default function ScoringToolbar({
     },
   })
 
+  useCommand("scoring.partial", () => onScore("partial"), {
+    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    metadata: {
+      title: "部分点として採点",
+      category: "採点",
+      description: "選択中の答案を部分点として採点します",
+    },
+  })
+
   useCommand("scoring.pending", () => onScore("pending"), {
     when: "!inputFocus && !modalOpen && hasSelectedAnswers",
     metadata: {

--- a/components/projects/07-score-at-once/hooks/useCommand.ts
+++ b/components/projects/07-score-at-once/hooks/useCommand.ts
@@ -23,6 +23,18 @@ import type {
 import { useShortcutContext } from "../ScoringMain/contexts/ShortcutProvider"
 
 /**
+ * メタデータの同値性を判定するために安定したシグネチャを生成
+ */
+function createMetadataSignature(metadata?: CommandMetadata): string {
+  if (!metadata) return "null"
+  try {
+    return JSON.stringify(metadata)
+  } catch {
+    return "nonserializable"
+  }
+}
+
+/**
  * useCommandのオプション
  */
 export interface UseCommandOptions {
@@ -79,8 +91,13 @@ export function useCommand(
     handlerRef.current()
   }, [])
 
-  // メタデータを安定化（オブジェクトの内容で比較）
-  const stableMetadata = useMemo(() => options.metadata, [options.metadata])
+  // メタデータを安定化（内容が変わらない限り再登録しない）
+  const metadataSignature = useMemo(
+    () => createMetadataSignature(options.metadata),
+    [options.metadata],
+  )
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- metadataSignature already reflects changes to options.metadata
+  const stableMetadata = useMemo(() => options.metadata, [metadataSignature])
 
   // when句を安定化
   const when = options.when || "true"


### PR DESCRIPTION
## 目的
- useCommandフックの依存関係を整理して再登録ループを防ぐ
- Fキーで部分点採点が完了するようにショートカットを追加
- 生徒名表示が長い場合のレイアウト崩れを防止

## 変更点
- metadataシグネチャによるメモ化でuseCommand登録処理を安定化
- scoring.partialコマンドをサイドパネルで登録
- GridCellの生徒名を省略表示+title付与

## 動作確認
- 採点画面でF/Jキーを押して期待通り採点されること
- 生徒名が長い場合に省略記号になり、ホバーで全体が見えること

Closes #137