### PR TITLE
fix: 一覧採点の選択安定化とMasterデータ型の追加

### DIFF
--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -10,28 +10,33 @@ import { useGridSelection } from "@/components/projects/07-score-at-once/Scoring
 import { useSelectionBorder } from "@/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder"
 import type {
   LayoutDirection,
+  MasterAnswerData,
   ScoringData,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
 import { useRef } from "react"
 
 export interface AnswerGridViewProps {
-  // 統一されたデータ引数
+  /** 統一されたデータ引数 */
   allScoringData: ScoringData[]
-  masterAnswerData: any // 模範解答データ
+  /** Grid表示用の模範解答データ */
+  masterAnswerData: MasterAnswerData | null
   filteredScoringDataIds: string[]
   selectedScoringDataIds: Set<string>
-  // Grid表示では設問情報不要
 
-  // 操作関数
+  /** 操作関数 */
   onScoringDataSelect: (id: string, isSelected: boolean) => void
+  onScoringDataReplace?: (ids: string[]) => void
   onScoringDataScore: (id: string | string[], status: ScoringStatus) => void
 
-  // 表示設定
+  /** 表示設定 */
   layoutDirection: LayoutDirection
-  itemsPerRow?: number[] // 外部からの1行/列あたり表示件数
-  autoScroll?: boolean // 自動スクロール設定
-  showStudentNames?: boolean // 生徒名表示設定
+  /** 外部からの1行/列あたり表示件数 */
+  itemsPerRow?: number[]
+  /** 自動スクロール設定 */
+  autoScroll?: boolean
+  /** 生徒名表示設定 */
+  showStudentNames?: boolean
   className?: string
 }
 
@@ -41,6 +46,7 @@ export default function AnswerGridView({
   filteredScoringDataIds,
   selectedScoringDataIds,
   onScoringDataSelect,
+  onScoringDataReplace,
   onScoringDataScore,
   layoutDirection,
   itemsPerRow: externalItemsPerRow,
@@ -48,7 +54,7 @@ export default function AnswerGridView({
   showStudentNames = true,
   className = "",
 }: AnswerGridViewProps) {
-  // フィルタリングされた採点データを取得（模範解答 + 学生データ）
+  /** フィルタリングされた採点データ（模範解答 + 学生データ） */
   const masterAnswers = masterAnswerData
     ? [
         {
@@ -70,7 +76,7 @@ export default function AnswerGridView({
   const containerRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
 
-  // Custom hooks
+  /** 主要なカスタムフック */
   const { itemsPerRow } = useGridNavigation({
     externalItemsPerRow,
   })
@@ -90,11 +96,12 @@ export default function AnswerGridView({
     useGridDragSelection({
       gridRef,
       onAnswerSelect: onScoringDataSelect,
+      onReplaceSelection: onScoringDataReplace,
       selectedAnswers: selectedScoringDataIds,
       sortedAnswers,
     })
 
-  // Auto scroll
+  /** 自動スクロール制御 */
   useAutoScroll({
     selectedAnswers: selectedScoringDataIds,
     layoutDirection,
@@ -102,7 +109,7 @@ export default function AnswerGridView({
     containerRef,
   })
 
-  // Mouse event handlers
+  /** ドラッグ中のマウス移動ハンドラー */
   const handleMouseMove = (event: React.MouseEvent) => {
     if (dragStart && gridRef.current) {
       const gridRect = gridRef.current.getBoundingClientRect()
@@ -117,7 +124,6 @@ export default function AnswerGridView({
         updateDrag(currentX, currentY)
       }
 
-      // ドラッグ中の現在位置を更新（グリッドコンテナに対する相対座標）
       if (isDragging || distance > 5) {
         updateDrag(currentX, currentY)
       }
@@ -126,14 +132,12 @@ export default function AnswerGridView({
 
   const handleMouseUp = (event: React.MouseEvent) => {
     if (isDragging) {
-      // ドラッグ選択を終了
       handleDragSelection(event, dragStart)
     }
     endDrag()
   }
 
   const onCellMouseDown = (event: React.MouseEvent, answerId: string) => {
-    // グリッドコンテナに対する相対座標を保存
     if (gridRef.current) {
       const gridRect = gridRef.current.getBoundingClientRect()
       startDrag(event.clientX - gridRect.left, event.clientY - gridRect.top)
@@ -151,23 +155,23 @@ export default function AnswerGridView({
         style={{
           gridTemplateColumns:
             layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "none" // 列表示: 自動生成される列
+              ? "none"
               : `repeat(${effectiveGridSize.columns}, 1fr)`,
           gridTemplateRows:
             layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? `repeat(${effectiveGridSize.rows}, 1fr)` // 高さのみ指定
+              ? `repeat(${effectiveGridSize.rows}, 1fr)`
               : "none",
           gridAutoRows: "auto",
           gridAutoColumns:
             layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "minmax(200px, max-content)" // 列表示: 最小200px、内容に応じて拡張
+              ? "minmax(200px, max-content)"
               : undefined,
           gridAutoFlow:
             layoutDirection === "down-right" || layoutDirection === "down-left"
               ? "column"
               : "row",
           width: "100%",
-          height: "max-content", // 内容に応じた高さ
+          height: "max-content",
         }}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
@@ -4,6 +4,7 @@ import { RefObject } from "react"
 interface UseGridDragSelectionProps {
   gridRef: RefObject<HTMLDivElement | null>
   onAnswerSelect: (id: string, isSelected: boolean) => void
+  onReplaceSelection?: (ids: string[]) => void
   selectedAnswers: Set<string>
   sortedAnswers: () => GridAnswerItem[]
 }
@@ -11,44 +12,34 @@ interface UseGridDragSelectionProps {
 export function useGridDragSelection({
   gridRef,
   onAnswerSelect,
+  onReplaceSelection,
   selectedAnswers,
   sortedAnswers,
 }: UseGridDragSelectionProps) {
-  // マウスドラッグ選択
   const handleMouseDown = (event: React.MouseEvent, answerId: string) => {
-    // 模範解答の場合は選択処理をスキップ
     if (answerId.startsWith("master-")) {
       event.preventDefault()
       return
     }
 
-    // Ctrlキーが押されている場合は複数選択（追加・削除切り替え）
     if (event.ctrlKey) {
       event.preventDefault()
       onAnswerSelect(answerId, !selectedAnswers.has(answerId))
-    }
-    // Shiftキーが押されている場合は範囲選択
-    else if (event.shiftKey) {
+    } else if (event.shiftKey) {
       event.preventDefault()
       handleShiftSelect(answerId)
-    }
-    // 通常クリック（単一選択または新規選択開始）
-    else {
+    } else {
       if (!selectedAnswers.has(answerId)) {
-        // 現在の選択をクリア
         selectedAnswers.forEach((id) => onAnswerSelect(id, false))
-        // 新しい選択を追加
         onAnswerSelect(answerId, true)
       }
     }
   }
 
-  // Shift+クリックでの範囲選択処理
   const handleShiftSelect = (endAnswerId: string) => {
     const answers = sortedAnswers()
     if (answers.length === 0) return
 
-    // 既に選択されている最初の答案を取得
     let startIndex = -1
     for (let i = 0; i < answers.length; i++) {
       if (selectedAnswers.has(answers[i].id)) {
@@ -57,16 +48,13 @@ export function useGridDragSelection({
       }
     }
 
-    // 終了位置を取得
     const endIndex = answers.findIndex((answer) => answer.id === endAnswerId)
 
     if (startIndex === -1 || endIndex === -1) {
-      // 範囲選択できない場合は単一選択
       onAnswerSelect(endAnswerId, true)
       return
     }
 
-    // 範囲を選択
     const minIndex = Math.min(startIndex, endIndex)
     const maxIndex = Math.max(startIndex, endIndex)
 
@@ -77,19 +65,15 @@ export function useGridDragSelection({
     }
   }
 
-  // 選択範囲の描画を計算する関数
   const getDragSelectionRect = (
     dragStart: { x: number; y: number } | null,
     dragCurrent: { x: number; y: number } | null,
   ) => {
     if (!dragStart || !dragCurrent || !gridRef.current) return null
 
-    // スクロール位置を取得
     const scrollLeft = gridRef.current.scrollLeft
     const scrollTop = gridRef.current.scrollTop
 
-    // dragStartとdragCurrentは既にグリッドコンテナに対する相対座標だが、
-    // 表示用にはスクロール位置を加算する必要がある
     const startX = Math.min(dragStart.x, dragCurrent.x) + scrollLeft
     const endX = Math.max(dragStart.x, dragCurrent.x) + scrollLeft
     const startY = Math.min(dragStart.y, dragCurrent.y) + scrollTop
@@ -103,7 +87,6 @@ export function useGridDragSelection({
     }
   }
 
-  // ドラッグによる矩形選択処理
   const handleDragSelection = (
     event: React.MouseEvent,
     dragStart: { x: number; y: number } | null,
@@ -113,17 +96,14 @@ export function useGridDragSelection({
     const gridElement = gridRef.current
     const gridRect = gridElement.getBoundingClientRect()
 
-    // 現在のマウス位置をグリッドコンテナに対する相対座標に変換
     const currentX = event.clientX - gridRect.left
     const currentY = event.clientY - gridRect.top
 
-    // 矩形選択範囲を計算（dragStartは既にグリッドコンテナに対する相対座標）
     const startX = Math.min(dragStart.x, currentX)
     const endX = Math.max(dragStart.x, currentX)
     const startY = Math.min(dragStart.y, currentY)
     const endY = Math.max(dragStart.y, currentY)
 
-    // グリッド内の答案カードをチェック
     const cardElements = gridElement.querySelectorAll("[data-answer-id]")
     const selectedIds: string[] = []
 
@@ -136,7 +116,6 @@ export function useGridDragSelection({
         bottom: rect.bottom - gridRect.top,
       }
 
-      // 矩形と重なるかチェック
       if (
         relativeRect.left < endX &&
         relativeRect.right > startX &&
@@ -150,12 +129,19 @@ export function useGridDragSelection({
       }
     })
 
-    // 選択状態を更新
-    if (selectedIds.length > 0) {
-      // 現在の選択をクリア
-      selectedAnswers.forEach((id) => onAnswerSelect(id, false))
-      // 新しい選択を追加
-      selectedIds.forEach((id) => onAnswerSelect(id, true))
+    const uniqueSelectedIds = Array.from(new Set(selectedIds)).filter(
+      (id) => !id.startsWith("master-"),
+    )
+
+    if (uniqueSelectedIds.length > 0) {
+      if (onReplaceSelection) {
+        onReplaceSelection(uniqueSelectedIds)
+      } else {
+        selectedAnswers.forEach((id) => onAnswerSelect(id, false))
+        uniqueSelectedIds.forEach((id) => onAnswerSelect(id, true))
+      }
+    } else if (onReplaceSelection) {
+      onReplaceSelection([])
     }
   }
 

--- a/components/projects/07-score-at-once/ScoringGrid/types/grid-types.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/types/grid-types.ts
@@ -1,4 +1,8 @@
-import type { ScoringData } from "@/components/projects/07-score-at-once/types"
+import type {
+  MasterAnswerData,
+  ScoringData,
+} from "@/components/projects/07-score-at-once/types"
 
-// CropRegionWithProjectPage, PageImageWithProjectStudents を使用
-export type GridAnswerItem = ScoringData & { isSelected?: boolean }
+export type GridAnswerItem = (ScoringData | MasterAnswerData) & {
+  isSelected?: boolean
+}

--- a/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -6,6 +6,7 @@ import type {
   CropRegionWithProjectPage,
   GradingMode,
   LayoutDirection,
+  MasterAnswerData,
   PageImageWithProjectStudents,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
@@ -13,39 +14,40 @@ import type {
 interface ScoringContentAreaProps {
   gradingMode: GradingMode
 
-  // 採点データ管理（両View共通）
+  /** 採点データ管理（両View共通） */
   allScoringData: ScoringData[]
-  masterAnswerData: any // Grid表示用の模範解答データ
+  masterAnswerData: MasterAnswerData | null
   filteredScoringDataIds: string[]
   selectedScoringDataIds: Set<string>
 
-  // 設問情報（Individual表示のみ必要）
+  /** 設問情報（Individual表示のみ必要） */
   currentCropRegion?: CropRegionWithProjectPage
 
-  // 操作関数（両View共通）
+  /** 操作関数（両View共通） */
   onScoringDataSelect: (dataId: string, isSelected: boolean) => void
+  onScoringDataReplace?: (ids: string[]) => void
   onScoringDataScore: (
     statusOrAnswerIds: any,
     statusOrPartialScore?: any,
     partialScore?: any,
   ) => void
 
-  // GridView設定
+  /** GridView設定 */
   layoutDirection: LayoutDirection
   itemsPerLine: number[]
   autoScroll: boolean
   showStudentNames: boolean
 
-  // IndividualView設定
+  /** IndividualView設定 */
   pageImages?: PageImageWithProjectStudents[]
 
-  // 生徒データコールバック（個別表示でサイドパネルに渡すため）
+  /** 生徒データコールバック（個別表示でサイドパネルに渡すため） */
   onStudentsExtracted?: (students: any[]) => void
-  
-  // テキスト入力状態変更のコールバック（個別表示でキーボードショートカット制御のため）
+
+  /** テキスト入力状態変更のコールバック（ショートカット制御用） */
   onTextInputStateChange?: (showTextInput: boolean) => void
-  
-  // QuestionScore自動作成用のコンテキスト情報
+
+  /** QuestionScore自動作成用のコンテキスト情報 */
   currentStudentId?: string
   currentUserId?: string
 }
@@ -58,6 +60,7 @@ export function ScoringContentArea({
   selectedScoringDataIds,
   currentCropRegion,
   onScoringDataSelect,
+  onScoringDataReplace,
   onScoringDataScore,
   layoutDirection,
   itemsPerLine,
@@ -69,7 +72,7 @@ export function ScoringContentArea({
   currentStudentId,
   currentUserId,
 }: ScoringContentAreaProps) {
-  // 個別表示時：selectedの最初の要素、または存在しないときはallの最初の要素
+  /** 個別表示時：selectedの最初の要素を利用 */
   const currentScoringDataId =
     gradingMode === "individual"
       ? selectedScoringDataIds.size > 0
@@ -79,9 +82,9 @@ export function ScoringContentArea({
           : null
       : null
 
-  // Grid layoutでは不要な階層を削除し、直接表示
+  /** Grid layoutでは不要な階層を削除し、直接表示 */
   return gradingMode === "individual" ? (
-    // 個別表示はフルサイズ表示
+    /** 個別表示はフルサイズ表示 */
     <AnswerIndividualView
       scoringDatas={allScoringData}
       currentScoringDataId={currentScoringDataId}
@@ -92,7 +95,6 @@ export function ScoringContentArea({
         statusOrPartialScore,
         partialScore,
       ) => {
-        // 個別表示モードでは現在の答案のみを対象にする
         if (currentScoringDataId) {
           onScoringDataScore(
             [currentScoringDataId],
@@ -106,7 +108,7 @@ export function ScoringContentArea({
       currentUserId={currentUserId}
     />
   ) : (
-    // Grid表示：paddingとスクロールを統合
+    /** Grid表示：paddingとスクロールを統合 */
     <AnswerGridView
       allScoringData={allScoringData}
       masterAnswerData={masterAnswerData}
@@ -114,6 +116,7 @@ export function ScoringContentArea({
       selectedScoringDataIds={selectedScoringDataIds}
       layoutDirection={layoutDirection}
       onScoringDataSelect={onScoringDataSelect}
+      onScoringDataReplace={onScoringDataReplace}
       onScoringDataScore={onScoringDataScore}
       itemsPerRow={itemsPerLine}
       autoScroll={autoScroll}

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -24,15 +24,15 @@ import { useCommand } from "@/components/projects/07-score-at-once/hooks/useComm
 import { useContextValue } from "@/components/projects/07-score-at-once/hooks/useContextValue"
 import Head from "next/head"
 import { useParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-// 内部コンポーネント（ShortcutProvider内で使用）
+/** 内部コンポーネント（ShortcutProvider内で使用） */
 function ScoringMainViewContent() {
   const params = useParams()
   const projectId = params.projectId as string
   const { helpButton } = usePageHelp()
 
-  // データローダーフック
+  /** データローダーフック */
   const {
     loading,
     project,
@@ -42,7 +42,7 @@ function ScoringMainViewContent() {
     error: _error,
   } = useScoringDataLoader(projectId)
 
-  // 設定管理フック
+  /** 設定管理フック */
   const {
     itemsPerLine,
     autoScroll,
@@ -52,13 +52,15 @@ function ScoringMainViewContent() {
     setShowStudentNames,
   } = useScoringSettings()
 
-  // 個別表示用の状態
+  const [questionChangeVersion, setQuestionChangeVersion] = useState(0)
+
+  /** 個別表示用の状態 */
   const [scoringBehavior, setScoringBehavior] =
     useState<ScoringBehavior>("next-student")
 
-  // メイン状態管理
+  /** メイン状態管理 */
   const {
-    // 個別の状態
+    /** 個別の状態 */
     gradingMode,
     selectedPageImageIds,
     layoutDirection,
@@ -68,7 +70,7 @@ function ScoringMainViewContent() {
     showScoreComparison,
     showSidePanel,
     modifierKeyLabel,
-    // アクション関数
+    /** アクション関数 */
     setGradingMode,
     setSelectedPageImageIds,
     setLayoutDirection,
@@ -78,23 +80,23 @@ function ScoringMainViewContent() {
     setShowScoreComparison,
     setShowSidePanel,
     setModifierKeyLabel,
-    // ヘルパー関数
+    /** ヘルパー関数 */
     handleAnswerSelect,
+    replaceSelection,
+    manualSelectionVersion,
   } = useScoringMainState()
 
-  // 個別表示モードに切り替え時、selectedPageImageIdsを単一選択に制限
+  /** 個別表示モードでは単一選択を維持 */
   useEffect(() => {
     if (gradingMode === "individual" && selectedPageImageIds.size > 1) {
-      // 複数選択されている場合は最初の1つだけを残す
       const firstSelected = Array.from(selectedPageImageIds)[0]
       setSelectedPageImageIds(new Set([firstSelected]))
     }
   }, [gradingMode, selectedPageImageIds, setSelectedPageImageIds])
 
-  // 設問が未選択時の自動選択
+  /** 設問未選択時は最初の設問を自動選択 */
   useEffect(() => {
     if (cropRegions.length > 0 && !currentCropRegionId) {
-      // 設問タイプ'QUESTION_ANSWER'の最初の設問を自動選択
       const firstQuestionRegion = cropRegions.find(
         (region) => region.type === "QUESTION_ANSWER",
       )
@@ -104,35 +106,27 @@ function ScoringMainViewContent() {
     }
   }, [cropRegions, currentCropRegionId, setCurrentCropRegionId])
 
-  // 現在の答案と設問
+  /** 現在の答案と設問 */
   const currentAnswerSheet = useMemo(() => {
     if (gradingMode === "individual" && selectedPageImageIds.size > 0) {
-      // 個別表示モードでは選択された答案を使用
       const selectedAnswerId = Array.from(selectedPageImageIds)[0]
       return pageImages.find((sheet) => sheet.id === selectedAnswerId)
     }
-    // 一覧表示モードでは従来通り
     return pageImages[currentStudentIndex]
   }, [gradingMode, selectedPageImageIds, pageImages, currentStudentIndex])
 
   const currentCropRegion = cropRegions.find(
     (r) => r.id === currentCropRegionId,
   )
-
-  // 個別表示用の生徒データは後で定義（allScoringDataが必要なため）
-
-  // 個別表示用のナビゲーション関数
+  /** 個別表示用のナビゲーション関数 */
   const handleStudentChange = useCallback(
     (studentId: string) => {
-      // 該当する生徒の答案を選択状態にする
       const studentSheets = pageImages.filter(
         (sheet: any) => sheet.student.id === studentId,
       )
       if (studentSheets.length > 0) {
-        // 個別表示では単一選択なので、最初の答案のみを選択
         setSelectedPageImageIds(new Set([studentSheets[0].id]))
 
-        // currentStudentIndex も更新
         const studentIndex = pageImages.findIndex(
           (sheet: any) => sheet.student.id === studentId,
         )
@@ -144,9 +138,7 @@ function ScoringMainViewContent() {
     [pageImages, setSelectedPageImageIds, setCurrentStudentIndex],
   )
 
-  // Individual navigation callbacks and effects will be defined after students is available
-
-  // 採点データ管理hook
+  /** 採点データ管理hook */
   const {
     questionScores,
     setQuestionScores,
@@ -155,21 +147,21 @@ function ScoringMainViewContent() {
     calculateQuestionProgress,
   } = useScoringData({
     currentUserId,
-    setCurrentUserId: () => {}, // データローダーで管理するため空関数
+    setCurrentUserId: () => {},
     currentCropRegionId,
     pageImages,
     cropRegions,
   })
 
-  // フィルタリング管理hook
+  /** フィルタリング管理hook */
   const {
-    // 新しいデータ構造
+    /** 新しいデータ構造 */
     allScoringData,
     masterAnswerData,
     filteredScoringDataIds,
     selectedScoringDataIds,
 
-    // 従来の互換性維持
+    /** 従来の互換性維持 */
     filterSettings,
     visibleAnswers,
     setRecentlyScoredAnswers,
@@ -185,13 +177,48 @@ function ScoringMainViewContent() {
     selectedPageImageIds: selectedPageImageIds,
     setSelectedPageImageIds: setSelectedPageImageIds,
     project,
+    gradingMode,
+    questionChangeVersion,
+    manualSelectionVersion,
   })
 
-  // 個別表示用の生徒データ（pageImagesから抽出、useMemoで安定化）
+  const previousCropRegionIdRef = useRef<string | null>(currentCropRegionId)
+  const handleReplaceSelection = useCallback(
+    (ids: string[]) => {
+      replaceSelection(ids)
+    },
+    [replaceSelection],
+  )
+
+  /** 設問変更時は一覧表示モードのみ選択をリセット */
+  useEffect(() => {
+    if (gradingMode !== "grid") {
+      previousCropRegionIdRef.current = currentCropRegionId
+      return
+    }
+
+    if (
+      previousCropRegionIdRef.current &&
+      currentCropRegionId &&
+      previousCropRegionIdRef.current !== currentCropRegionId
+    ) {
+      setSelectedPageImageIds(new Set())
+      const scheduleIncrement = () =>
+        setQuestionChangeVersion((version) => version + 1)
+      if (typeof queueMicrotask === "function") {
+        queueMicrotask(scheduleIncrement)
+      } else {
+        Promise.resolve().then(scheduleIncrement)
+      }
+    }
+
+    previousCropRegionIdRef.current = currentCropRegionId
+  }, [gradingMode, currentCropRegionId, setSelectedPageImageIds])
+
+  /** 個別表示用の生徒データ（pageImagesから抽出、useMemoで安定化） */
   const students = useMemo(() => {
     if (!pageImages || pageImages.length === 0) return []
 
-    // pageImagesから重複を除いた生徒データを抽出
     const uniqueStudents = new Map()
 
     pageImages.forEach((sheet, index) => {
@@ -207,14 +234,12 @@ function ScoringMainViewContent() {
       }
     })
 
-    // customOrderでソートして配列に変換
     const sortedStudents = Array.from(uniqueStudents.values()).sort(
       (a, b) => a.customOrder - b.customOrder,
     )
     return sortedStudents
   }, [pageImages])
 
-  // 個別表示モードで最初の生徒を自動選択
   useEffect(() => {
     if (
       gradingMode === "individual" &&
@@ -276,7 +301,6 @@ function ScoringMainViewContent() {
     }
   }, [students, selectedPageImageIds, pageImages, setSelectedPageImageIds])
 
-  // ナビゲーション管理hook
   const {
     viewMode,
     setViewMode,
@@ -304,7 +328,6 @@ function ScoringMainViewContent() {
     cropRegions: cropRegions,
   })
 
-  // バッチ採点と自動進行
   const { handleBatchScoreWithProgress, handleAutoAdvance } =
     useBatchScoringWithProgress({
       selectedAnswers: selectedPageImageIds,
@@ -317,12 +340,10 @@ function ScoringMainViewContent() {
       handleNextStudent,
     })
 
-  // 生徒名表示設定の変更
   const handleToggleStudentNames = useCallback(() => {
     setShowStudentNames(!showStudentNames)
   }, [showStudentNames, setShowStudentNames])
 
-  // 部分点入力管理hook
   const {
     partialScoreInput,
     showPartialScoreModal,
@@ -336,26 +357,16 @@ function ScoringMainViewContent() {
   } = usePartialScore({
     selectedAnswers: selectedPageImageIds,
     currentCropRegion,
-    onBatchScore: handleBatchScoreWithProgress, // 自動進行機能付きに変更
+    onBatchScore: handleBatchScoreWithProgress,
     onAutoAdvance: handleAutoAdvance,
   })
 
-  // ============================================
-  // 新しいショートカットシステム: コンテキスト値の設定
-  // ============================================
   useContextValue("gradingMode", gradingMode)
   useContextValue("hasSelectedAnswers", selectedPageImageIds.size > 0)
   useContextValue("sidePanelVisible", showSidePanel)
   useContextValue("partialScoreModalOpen", showPartialScoreModal)
   useContextValue("modalOpen", showPartialScoreModal || showScoreComparison)
-  // inputFocus は ShortcutProvider が自動検出
-  // textEditorActive は RichTextEditor で設定
 
-  // ============================================
-  // 新しいショートカットシステム: コマンド登録（動作確認用）
-  // ============================================
-
-  // 生徒名表示切り替えコマンド
   useCommand("view.toggleStudentNames", handleToggleStudentNames, {
     when: "!inputFocus && !modalOpen",
     metadata: {
@@ -365,7 +376,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // フィルタ更新コマンド
   useCommand("filter.refresh", handleRefreshFilter, {
     when: "!inputFocus && !modalOpen",
     metadata: {
@@ -375,11 +385,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // ============================================
-  // ナビゲーションコマンドの登録
-  // ============================================
-
-  // 矢印キー: 問題切り替え
   useCommand("navigation.nextQuestionArrow", handleNextQuestion, {
     when: "!inputFocus && !modalOpen",
     metadata: {
@@ -396,7 +401,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // Shift+A/D: 問題切り替え
   useCommand("navigation.nextQuestion", handleNextQuestion, {
     when: "!inputFocus && !modalOpen",
     metadata: {
@@ -413,10 +417,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // 矢印キー: 生徒切り替え（グリッドモードでは使用しない）
-  // WASDがグリッド移動に使われるため、矢印キーの上下は使用しない
-
-  // WASD: グリッド移動（グリッドモードのみ）
   useCommand("navigation.moveUp", () => handleGridNavigation("w"), {
     when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
     metadata: {
@@ -449,7 +449,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // ズーム操作
   useCommand("navigation.zoomIn", handleZoomIn, {
     when: "!inputFocus && !modalOpen",
     metadata: {
@@ -474,9 +473,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // ============================================
-  // Ctrl+数字フィルタコマンド（グリッドモードのみ）
-  // ============================================
   useCommand("filter.toggle1", () => handleToggleFilter("1"), {
     when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
     metadata: {
@@ -525,9 +521,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // ============================================
-  // 部分点モーダルコマンド
-  // ============================================
   useCommand(
     "modal.confirmPartial",
     () => handlePartialScoreConfirm("partial"),
@@ -570,7 +563,6 @@ function ScoringMainViewContent() {
     },
   })
 
-  // 数字入力コマンド（0-9と小数点）
   useCommand("modal.input0", () => handlePartialScoreInput("0"), {
     when: "partialScoreModalOpen",
     metadata: { title: "0を入力", category: "モーダル" },
@@ -626,10 +618,6 @@ function ScoringMainViewContent() {
     metadata: { title: "小数点を入力", category: "モーダル" },
   })
 
-  // ============================================
-  // 部分点モーダルオープンコマンド（数字キー）
-  // ============================================
-  // モーダルが閉じている状態で数字キーを押すと、モーダルを開いてその数字を入力
   useCommand("scoring.openPartialWith0", () => handlePartialScoreInput("0"), {
     when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
     metadata: { title: "0キーで部分点入力", category: "採点" },
@@ -685,7 +673,6 @@ function ScoringMainViewContent() {
     metadata: { title: ".キーで部分点入力", category: "採点" },
   })
 
-  // selectedPageImageIdsから現在の生徒IDを取得
   const currentStudentId = useMemo(() => {
     if (selectedPageImageIds.size > 0) {
       const selectedAnswerId = Array.from(selectedPageImageIds)[0]
@@ -697,7 +684,6 @@ function ScoringMainViewContent() {
     return ""
   }, [selectedPageImageIds, pageImages])
 
-  // スコア状態の変換関数（ScoreStatus → ScoringStatus）
   const convertScoreStatus = useCallback(
     (
       status:
@@ -721,15 +707,12 @@ function ScoringMainViewContent() {
     [],
   )
 
-  // テキスト入力状態管理（キーボードショートカット制御用）
   const [showTextInput, setShowTextInput] = useState(false)
 
-  // 採点データの初期化
   useEffect(() => {
     const initializeGradingData = async () => {
       if (!loading && project) {
         try {
-          // 既存の採点データを読み込み
           const existingScores = await loadQuestionScores(projectId)
           setQuestionScores(existingScores)
         } catch (error) {
@@ -741,7 +724,6 @@ function ScoringMainViewContent() {
     initializeGradingData()
   }, [projectId, loading, project, loadQuestionScores, setQuestionScores])
 
-  // 設定変更ハンドラー
   const handleItemsPerLineChange = (value: number[]) => {
     setItemsPerLine(value)
   }
@@ -750,15 +732,12 @@ function ScoringMainViewContent() {
     setAutoScroll(enabled)
   }
 
-  // 設問別進捗を計算
   const questionProgress = calculateQuestionProgress()
 
-  // ローディング状態
   if (loading) {
     return <ScoringLoadingState />
   }
 
-  // エラー状態
   if (!project || pageImages.length === 0 || cropRegions.length === 0) {
     return (
       <ScoringErrorState
@@ -809,6 +788,7 @@ function ScoringMainViewContent() {
           onScoringDataSelect={(dataId, isSelected) =>
             handleAnswerSelect(dataId, isSelected, pageImages)
           }
+          onScoringDataReplace={handleReplaceSelection}
           onScoringDataScore={handleBatchScoreWithProgress}
           layoutDirection={layoutDirection}
           itemsPerLine={itemsPerLine}
@@ -874,7 +854,6 @@ function ScoringMainViewContent() {
   )
 }
 
-// メインのエクスポートコンポーネント
 export default function ScoringMainView() {
   return (
     <ShortcutProvider>

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -1,13 +1,34 @@
 import { DEFAULT_KEYBINDINGS } from "@/components/projects/07-score-at-once/constants/scoring-keybindings"
 import type {
   CropRegionWithProjectPage,
+  GradingMode,
+  MasterAnswerData,
   PageImageWithProjectStudents,
   QuestionScore,
   ScoringData,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
 import { findQuestionScore } from "@/components/projects/07-score-at-once/types"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+const areArraysEqual = (a: string[], b: string[]) => {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}
 
 interface FilterSettings {
   unscored: boolean
@@ -26,6 +47,9 @@ interface UseScoringFilterProps {
   selectedPageImageIds: Set<string>
   setSelectedPageImageIds: (answers: Set<string>) => void
   project: any
+  gradingMode: GradingMode
+  questionChangeVersion: number
+  manualSelectionVersion: number
 }
 
 export function useScoringFilter({
@@ -36,8 +60,10 @@ export function useScoringFilter({
   selectedPageImageIds,
   setSelectedPageImageIds,
   project,
+  gradingMode,
+  questionChangeVersion,
+  manualSelectionVersion,
 }: UseScoringFilterProps) {
-  // シンプルなフィルタ設計
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({
     unscored: true,
     correct: false,
@@ -56,19 +82,15 @@ export function useScoringFilter({
     (r) => r.id === currentCropRegionId,
   )
 
-  // 全採点データを取得（新しいScoringData型として）
   const allScoringData = useMemo((): ScoringData[] => {
     if (!currentCropRegion) return []
 
-    // projectPageIdでフィルタリングしてから受験生徒順でソート
     const pageFilteredSheets = pageImages.filter(
       (pageImage) =>
         pageImage.projectPageId === currentCropRegion.projectPageId,
     )
 
     const sortedAnswerSheets = [...pageFilteredSheets].sort((a, b) => {
-      // ProjectStudentのcustomOrderで並び替え（小さい値が先）
-      // customOrderが未定義の場合は、学籍番号の数値として比較
       const aOrder =
         a.student?.projectStudents?.[0]?.customOrder !== undefined
           ? a.student.projectStudents[0].customOrder
@@ -78,7 +100,6 @@ export function useScoringFilter({
           ? b.student.projectStudents[0].customOrder
           : 999999
 
-      // customOrderが同じ場合は姓名でソート
       if (aOrder === bOrder) {
         const aName = `${a.student?.lastName ?? ""}${a.student?.firstName ?? ""}`
         const bName = `${b.student?.lastName ?? ""}${b.student?.firstName ?? ""}`
@@ -93,7 +114,6 @@ export function useScoringFilter({
     const studentScoringData: ScoringData[] = sortedAnswerSheets.map(
       (pageImage) => {
         if (!pageImage.studentId) {
-          // studentIdがnullの場合のデフォルトデータ
           return {
             id: pageImage.id,
             studentId: "",
@@ -105,7 +125,7 @@ export function useScoringFilter({
             maxScore: currentCropRegion.points ?? 0,
             status: "unscored" as ScoringStatus,
             questionRegion: currentCropRegion,
-            customOrder: 999999, // 不明な生徒は最後に配置
+            customOrder: 999999,
           }
         }
 
@@ -117,7 +137,7 @@ export function useScoringFilter({
 
         return {
           id: pageImage.id,
-          studentId: pageImage.studentId, // Student.id (UUID) を使用
+          studentId: pageImage.studentId,
           studentName: `${pageImage.student?.lastName ?? ""} ${pageImage.student?.firstName ?? ""}`,
           imageUrl: pageImage.imagePath
             ? `appimg://${pageImage.imagePath}`
@@ -128,18 +148,16 @@ export function useScoringFilter({
               : undefined,
           maxScore: currentCropRegion.points ?? 0,
           status: (score?.status as ScoringStatus) ?? "unscored",
-          questionRegion: currentCropRegion, // 採点領域情報を追加
+          questionRegion: currentCropRegion,
           customOrder:
-            pageImage.student?.projectStudents?.[0]?.customOrder || 999999, // 必須フィールド
+            pageImage.student?.projectStudents?.[0]?.customOrder || 999999,
         }
       },
     )
 
-    // 学生の採点データのみを返す（模範解答は別途管理）
     return studentScoringData
   }, [currentCropRegion, pageImages, questionScores])
 
-  // 採点状況を取得する関数
   const getScoringStatus = useCallback(
     (studentId: string, questionId?: string): ScoringStatus => {
       if (!questionId) return "unscored"
@@ -150,7 +168,6 @@ export function useScoringFilter({
     [questionScores],
   )
 
-  // 表示対象答案の更新（統合版）
   const updateVisibleAnswers = useCallback(
     (customFilterSettings?: FilterSettings) => {
       const activeFilterSettings = customFilterSettings || filterSettings
@@ -160,35 +177,84 @@ export function useScoringFilter({
         return
       }
 
-      // allScoringData（既にソート済み）からフィルタリングして順序を保持
-      const newVisibleAnswers = allScoringData
-        .filter((scoringData) => {
-          const status = scoringData.status
-          const matchesFilter =
-            activeFilterSettings[status as keyof typeof activeFilterSettings]
-          const isRecentlyScored = recentlyScoredAnswers.has(scoringData.id)
+      if (questionChangeVersionRef.current === null) {
+        questionChangeVersionRef.current = questionChangeVersion
+      }
 
-          // フィルター条件チェック（最近採点答案は強制表示）
-          return matchesFilter || isRecentlyScored
-        })
-        .map((scoringData) => scoringData.id) // IDの配列として順序を保持
+      const nextVisibleAnswers: string[] = []
+      let firstStudentAnswerId: string | null = null
+      const nextFilteredSelection: string[] = []
 
-      setVisibleAnswers(newVisibleAnswers)
+      const questionVersionChanged =
+        questionChangeVersionRef.current !== null &&
+        questionChangeVersionRef.current !== questionChangeVersion
+
+      const selectedIdsSet = questionVersionChanged
+        ? new Set<string>()
+        : new Set(selectedPageImageIds)
+
+      for (const scoringData of allScoringData) {
+        const status = scoringData.status
+        const matchesFilter =
+          activeFilterSettings[status as keyof typeof activeFilterSettings]
+        const isRecentlyScored = recentlyScoredAnswers.has(scoringData.id)
+
+        if (matchesFilter || isRecentlyScored) {
+          nextVisibleAnswers.push(scoringData.id)
+
+          if (!scoringData.id.startsWith("master-") && !firstStudentAnswerId) {
+            firstStudentAnswerId = scoringData.id
+          }
+
+          if (selectedIdsSet.has(scoringData.id)) {
+            nextFilteredSelection.push(scoringData.id)
+          }
+        }
+      }
+
+      selectionSnapshotVersionRef.current += 1
+      pendingSelectionSnapshotRef.current = {
+        firstStudentAnswerId,
+        hasVisibleSelection: nextFilteredSelection.length > 0,
+        filteredSelection: nextFilteredSelection,
+        version: selectionSnapshotVersionRef.current,
+      }
+
+      if (questionVersionChanged) {
+        questionChangeVersionRef.current = questionChangeVersion
+      }
+
+      setVisibleAnswers((prev) => {
+        if (areArraysEqual(prev, nextVisibleAnswers)) {
+          return prev
+        }
+        return nextVisibleAnswers
+      })
     },
-    [filterSettings, currentCropRegion, allScoringData, recentlyScoredAnswers],
+    [
+      filterSettings,
+      currentCropRegion,
+      allScoringData,
+      recentlyScoredAnswers,
+      selectedPageImageIds,
+      questionChangeVersion,
+    ],
   )
 
-  // 初期化時と設問変更時に表示対象を設定（選択は別のuseEffectで管理）
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (pageImages.length === 0 || cropRegions.length === 0) {
       return
     }
 
-    const frame = requestAnimationFrame(() => {
+    const runUpdate = () => {
       updateVisibleAnswers()
-    })
+    }
 
-    return () => cancelAnimationFrame(frame)
+    if (typeof queueMicrotask === "function") {
+      queueMicrotask(runUpdate)
+    } else {
+      Promise.resolve().then(runUpdate)
+    }
   }, [
     pageImages.length,
     cropRegions.length,
@@ -196,97 +262,218 @@ export function useScoringFilter({
     updateVisibleAnswers,
   ])
 
-  // 選択状態の管理用ref
-  const selectedPageImageIdsRef = useRef<Set<string>>(new Set())
-  const lastVisibleAnswersRef = useRef<Set<string>>(new Set())
+  const prevGradingModeRef = useRef<GradingMode>(gradingMode)
+  const prevCropRegionIdRef = useRef<string | null>(currentCropRegionId)
+  const pendingGridSelectionRef = useRef(false)
+  const lastVisibleAnswersRef = useRef<string[]>(visibleAnswers)
+  const pendingSelectionSnapshotRef = useRef<{
+    firstStudentAnswerId: string | null
+    hasVisibleSelection: boolean
+    filteredSelection: string[]
+    version: number
+  } | null>(null)
+  const selectionSnapshotVersionRef = useRef(0)
+  const consumedSnapshotVersionRef = useRef(0)
+  const manualSelectionVersionRef = useRef(manualSelectionVersion)
+  const questionChangeVersionRef = useRef<number | null>(null)
 
-  // selectedPageImageIdsが変更されたらrefも更新
   useEffect(() => {
-    selectedPageImageIdsRef.current = selectedPageImageIds
-  }, [selectedPageImageIds])
+    const manualSelectionChanged =
+      manualSelectionVersionRef.current !== manualSelectionVersion
 
-  useEffect(() => {
-    if (selectedPageImageIds.size !== 1) {
+    manualSelectionVersionRef.current = manualSelectionVersion
+
+    if (manualSelectionChanged) {
+      pendingGridSelectionRef.current = false
       return
     }
-    const selectedId = Array.from(selectedPageImageIds)[0]
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(
-        new CustomEvent("score-view:scroll-to-answer", {
-          detail: { answerId: selectedId },
-        }),
-      )
-    }
-  }, [selectedPageImageIds])
 
-  // visibleAnswersが更新されたら適切な答案選択を行う（最適化版）
-  useEffect(() => {
-    // visibleAnswersに変化がない場合はスキップ（パフォーマンス向上）
-    if (visibleAnswers.length === lastVisibleAnswersRef.current.size) {
-      let hasChanged = false
-      for (const id of visibleAnswers) {
-        if (!lastVisibleAnswersRef.current.has(id)) {
-          hasChanged = true
-          break
+    if (selectedPageImageIds.size > 1) {
+      pendingGridSelectionRef.current = false
+      return
+    }
+
+    const previousMode = prevGradingModeRef.current
+    const previousCropRegionId = prevCropRegionIdRef.current
+
+    const modeChangedToGrid = previousMode !== "grid" && gradingMode === "grid"
+    const cropRegionChanged = previousCropRegionId !== currentCropRegionId
+
+    const visibleChanged = !areArraysEqual(
+      visibleAnswers,
+      lastVisibleAnswersRef.current,
+    )
+
+    const questionChangedExternally =
+      questionChangeVersionRef.current !== questionChangeVersion
+
+    if (visibleChanged) {
+      lastVisibleAnswersRef.current = visibleAnswers
+    }
+
+    if (questionChangedExternally) {
+      pendingGridSelectionRef.current = true
+    }
+
+    if ((cropRegionChanged || questionChangedExternally) && !visibleChanged) {
+      prevGradingModeRef.current = gradingMode
+      prevCropRegionIdRef.current = currentCropRegionId
+      return
+    }
+
+    if (
+      modeChangedToGrid ||
+      cropRegionChanged ||
+      visibleChanged ||
+      questionChangedExternally
+    ) {
+      pendingGridSelectionRef.current = true
+    }
+
+    prevGradingModeRef.current = gradingMode
+    prevCropRegionIdRef.current = currentCropRegionId
+
+    if (gradingMode !== "grid") {
+      return
+    }
+
+    const snapshot = pendingSelectionSnapshotRef.current
+    const hasFreshSnapshot = snapshot
+      ? snapshot.version > consumedSnapshotVersionRef.current
+      : false
+    const visibleIds = new Set(visibleAnswers)
+    const filteredSelection = questionChangedExternally
+      ? []
+      : hasFreshSnapshot && snapshot?.filteredSelection
+        ? snapshot.filteredSelection
+        : Array.from(selectedPageImageIds).filter(
+            (id) => visibleIds.has(id) && !id.startsWith("master-"),
+          )
+    const firstStudentAnswerId =
+      questionChangedExternally && visibleAnswers.length > 0
+        ? (visibleAnswers.find((id) => !id.startsWith("master-")) ?? null)
+        : hasFreshSnapshot && snapshot?.firstStudentAnswerId
+          ? snapshot.firstStudentAnswerId
+          : (visibleAnswers.find((id) => !id.startsWith("master-")) ?? null)
+
+    if (pendingGridSelectionRef.current) {
+      const shouldApplySelection =
+        modeChangedToGrid ||
+        cropRegionChanged ||
+        visibleChanged ||
+        visibleAnswers.length === 0
+
+      if (shouldApplySelection) {
+        if (cropRegionChanged) {
+          if (visibleAnswers.length === 0 || !firstStudentAnswerId) {
+            if (selectedPageImageIds.size > 0) {
+              setSelectedPageImageIds(new Set())
+            }
+            pendingGridSelectionRef.current = false
+            return
+          }
+
+          if (
+            selectedPageImageIds.size !== 1 ||
+            !selectedPageImageIds.has(firstStudentAnswerId)
+          ) {
+            setSelectedPageImageIds(new Set([firstStudentAnswerId]))
+          }
+          pendingGridSelectionRef.current = false
+          return
         }
-      }
-      if (!hasChanged) {
+
+        const hasVisibleSelection = questionChangedExternally
+          ? false
+          : hasFreshSnapshot && snapshot?.hasVisibleSelection
+            ? snapshot.hasVisibleSelection
+            : filteredSelection.length > 0
+
+        if (hasVisibleSelection) {
+          if (filteredSelection.length !== selectedPageImageIds.size) {
+            setSelectedPageImageIds(new Set(filteredSelection))
+          }
+          pendingGridSelectionRef.current = false
+          if (hasFreshSnapshot && snapshot) {
+            consumedSnapshotVersionRef.current = snapshot.version
+          }
+          return
+        }
+
+        if (visibleAnswers.length === 0 || !firstStudentAnswerId) {
+          if (selectedPageImageIds.size > 0) {
+            setSelectedPageImageIds(new Set())
+          }
+          if (visibleAnswers.length > 0) {
+            pendingGridSelectionRef.current = false
+          }
+          if (hasFreshSnapshot && snapshot) {
+            consumedSnapshotVersionRef.current = snapshot.version
+          }
+          return
+        }
+
+        if (
+          selectedPageImageIds.size !== 1 ||
+          !selectedPageImageIds.has(firstStudentAnswerId)
+        ) {
+          setSelectedPageImageIds(new Set([firstStudentAnswerId]))
+        }
+        pendingGridSelectionRef.current = false
+        if (hasFreshSnapshot && snapshot) {
+          consumedSnapshotVersionRef.current = snapshot.version
+        }
         return
       }
     }
+  }, [
+    currentCropRegionId,
+    gradingMode,
+    questionChangeVersion,
+    selectedPageImageIds,
+    setSelectedPageImageIds,
+    visibleAnswers,
+    manualSelectionVersion,
+  ])
 
-    // 最新のvisibleAnswersを記録
-    lastVisibleAnswersRef.current = new Set(visibleAnswers)
-
-    // 早期リターンで不要な処理をスキップ
-    if (visibleAnswers.length === 0) {
-      if (selectedPageImageIdsRef.current.size > 0) {
-        setSelectedPageImageIds(new Set())
-      }
+  useEffect(() => {
+    if (gradingMode !== "grid") {
       return
     }
 
-    // 現在の選択状態をrefから取得（最新の状態）
-    const currentSelection = selectedPageImageIdsRef.current
-    if (currentSelection.size > 0) {
-      // 高速な有効性チェック（Set.hasは高速）
-      for (const selectedId of currentSelection) {
-        if (visibleAnswers.includes(selectedId)) {
-          if (typeof window !== "undefined") {
-            window.dispatchEvent(
-              new CustomEvent("score-view:scroll-to-answer", {
-                detail: { answerId: selectedId },
-              }),
-            )
-          }
-          return // 有効な選択があるので処理終了
-        }
-      }
+    if (selectedPageImageIds.size === 0) {
+      return
     }
 
-    // 選択が空か無効な場合のみ、最初の学生答案を選択
-    const visibleAnswersArray = Array.from(visibleAnswers)
+    const snapshot = pendingSelectionSnapshotRef.current
+    const hasFreshSnapshot = snapshot
+      ? snapshot.version > consumedSnapshotVersionRef.current
+      : false
+    const visibleIds = new Set(visibleAnswers)
+    const firstCandidateId =
+      hasFreshSnapshot && snapshot?.filteredSelection?.length
+        ? snapshot.filteredSelection[0]
+        : undefined
+    const firstVisibleSelected = firstCandidateId
+      ? firstCandidateId
+      : Array.from(selectedPageImageIds).find((id) => visibleIds.has(id))
 
-    for (const answerId of visibleAnswers) {
-      if (!answerId.startsWith("master-")) {
-        setSelectedPageImageIds(new Set([answerId]))
-        if (typeof window !== "undefined") {
-          window.dispatchEvent(
-            new CustomEvent("score-view:scroll-to-answer", {
-              detail: { answerId },
-            }),
-          )
-        }
-        return // 見つかったらすぐ終了
-      }
+    if (!firstVisibleSelected) {
+      return
     }
-  }, [visibleAnswers, setSelectedPageImageIds])
 
-  // 模範解答データを取得（Grid表示用）
-  const masterAnswerData = useMemo((): any | null => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("score-view:scroll-to-answer", {
+          detail: { answerId: firstVisibleSelected },
+        }),
+      )
+    }
+  }, [gradingMode, selectedPageImageIds, visibleAnswers])
+
+  const masterAnswerData = useMemo((): MasterAnswerData | null => {
     if (!currentCropRegion || !project?.projectPages) return null
 
-    // projectPageIdに基づいてprojectPageを取得
     const projectPage = project.projectPages.find(
       (page: any) => page.id === currentCropRegion.projectPageId,
     )
@@ -303,15 +490,14 @@ export function useScoringFilter({
       studentId: "MASTER",
       studentName: "模範解答",
       imageUrl: masterImagePath ? `appimg://${masterImagePath}` : "",
-      currentScore: undefined,
       maxScore: currentCropRegion.points || 0,
-      status: "master" as any, // 特別なステータス
-      questionRegion: currentCropRegion, // 採点領域情報を追加
-      isMaster: true, // 模範解答フラグ
+      status: "master",
+      questionRegion: currentCropRegion,
+      customOrder: -1,
+      isMaster: true,
     }
   }, [currentCropRegion, project])
 
-  // 基本的なグリッドデータ取得（後方互換性のため残す）
   const getAllGridAnswerData = useMemo(() => {
     return allScoringData.map((data) => ({
       ...data,
@@ -319,32 +505,24 @@ export function useScoringFilter({
     }))
   }, [allScoringData, selectedPageImageIds])
 
-  // 表示用のグリッドデータ（学生データのみをフィルタリング）
   const getGridAnswerData = useCallback(() => {
-    // allScoringDataの順序を保持したまま、visibleAnswersの順序でフィルタリング
     const filteredAnswers = visibleAnswers
       .map((answerId) =>
         getAllGridAnswerData.find((answer) => answer.id === answerId),
       )
-      .filter(Boolean) // undefinedを除外
+      .filter(Boolean)
 
     return filteredAnswers
   }, [getAllGridAnswerData, visibleAnswers])
 
-  // フィルタリング関連ハンドラー（Rキー押下時およびフィルター変更時）
   const handleRefreshFilter = useCallback(() => {
-    // 最近採点した答案をクリア
     setRecentlyScoredAnswers(new Set())
 
-    // 最新のscoringDataを使用してフィルタリングを実行
     updateVisibleAnswers()
-
-    // 選択は自動管理useEffectに任せる
   }, [updateVisibleAnswers])
 
   const handleToggleFilter = useCallback(
     (key: string) => {
-      // ボタン操作によるフィルター切り替え
       if (key in filterSettings) {
         const newFilterSettings = {
           ...filterSettings,
@@ -352,17 +530,14 @@ export function useScoringFilter({
         }
         setFilterSettings(newFilterSettings)
 
-        // 新しいフィルター設定を直接渡してフィルタリングを実行
         updateVisibleAnswers(newFilterSettings)
 
-        // 最近採点した答案をクリア（選択は自動管理useEffectに任せる）
         setRecentlyScoredAnswers(new Set())
       }
     },
     [filterSettings, updateVisibleAnswers],
   )
 
-  // Alt+採点キーでフィルタ切り替え
   const handleToggleFilterByScoreKey = useCallback(
     (scoreKey: string) => {
       const scoreToFilterMap: { [key: string]: keyof typeof filterSettings } = {
@@ -382,10 +557,8 @@ export function useScoringFilter({
         }
         setFilterSettings(newFilterSettings)
 
-        // 新しいフィルター設定を直接渡してフィルタリングを実行
         updateVisibleAnswers(newFilterSettings)
 
-        // 最近採点した答案をクリア（選択は自動管理useEffectに任せる）
         setRecentlyScoredAnswers(new Set())
       }
     },
@@ -393,13 +566,11 @@ export function useScoringFilter({
   )
 
   return {
-    // 新しいデータ構造
     allScoringData,
-    masterAnswerData, // Grid表示用の模範解答データ
+    masterAnswerData,
     filteredScoringDataIds: visibleAnswers,
     selectedScoringDataIds: selectedPageImageIds,
 
-    // 従来の互換性維持
     filterSettings,
     setFilterSettings,
     visibleAnswers,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
@@ -4,37 +4,50 @@ import type {
   LayoutDirection,
 } from "@/components/projects/07-score-at-once/types"
 import { getModifierKeyLabel } from "@/lib/platform-utils"
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 
 export function useScoringMainState() {
-  // 採点モード状態
+  /** 採点モード状態 */
   const [gradingMode, setGradingMode] = useState<GradingMode>("grid")
+  /** 選択中の答案ID集合 */
   const [selectedPageImageIds, setSelectedPageImageIds] = useState<Set<string>>(
     new Set(),
   )
+  const [manualSelectionVersion, setManualSelectionVersion] = useState(0)
+  const suppressSelectionUpdateRef = useRef(false)
+  /** グリッド表示方向 */
   const [layoutDirection, setLayoutDirection] = useState<LayoutDirection>(
     DEFAULT_LAYOUT_DIRECTION,
   )
+  /** 現在選択中の生徒インデックス */
   const [currentStudentIndex, setCurrentStudentIndex] = useState(0)
+  /** 選択中の設問領域ID */
   const [currentCropRegionId, setCurrentCropRegionId] = useState<string | null>(
     null,
   )
+  /** キーボードヘルプ表示状態 */
   const [showKeyboardHelp, setShowKeyboardHelp] = useState(false)
+  /** 採点結果比較表示状態 */
   const [showScoreComparison, setShowScoreComparison] = useState(false)
+  /** サイドパネル表示状態 */
   const [showSidePanel, setShowSidePanel] = useState(true)
+  /** ショートカットで利用する修飾キー表示ラベル */
   const [modifierKeyLabel, setModifierKeyLabel] = useState(
     () => getModifierKeyLabel() || "Alt",
   )
 
-  // グリッドビュー用のヘルパー関数
+  /**
+   * 単一クリック・ショートカットによる選択更新
+   */
   const handleAnswerSelect = useCallback(
     (answerId: string, isSelected: boolean, pageImages: any[]) => {
-      // 模範解答は選択対象外
+      if (suppressSelectionUpdateRef.current) {
+        return
+      }
       if (answerId.startsWith("master-")) {
         return
       }
 
-      // 答案が実際に存在するかチェック
       const answerExists = pageImages.some((sheet) => sheet.id === answerId)
       if (!answerExists) {
         return
@@ -53,8 +66,20 @@ export function useScoringMainState() {
     [],
   )
 
+  /**
+   * 複数選択置き換え用のヘルパー
+   */
+  const replaceSelection = useCallback((ids: string[]) => {
+    suppressSelectionUpdateRef.current = true
+    setSelectedPageImageIds(new Set(ids))
+    setManualSelectionVersion((version) => version + 1)
+    queueMicrotask(() => {
+      suppressSelectionUpdateRef.current = false
+    })
+  }, [])
+
   return {
-    // 個別の状態
+    /** 個別の状態 */
     gradingMode,
     selectedPageImageIds,
     layoutDirection,
@@ -64,7 +89,8 @@ export function useScoringMainState() {
     showScoreComparison,
     showSidePanel,
     modifierKeyLabel,
-    // アクション関数
+    manualSelectionVersion,
+    /** アクション関数 */
     setGradingMode,
     setSelectedPageImageIds,
     setLayoutDirection,
@@ -74,7 +100,8 @@ export function useScoringMainState() {
     setShowScoreComparison,
     setShowSidePanel,
     setModifierKeyLabel,
-    // ヘルパー関数
+    /** ヘルパー関数 */
     handleAnswerSelect,
+    replaceSelection,
   }
 }

--- a/components/projects/07-score-at-once/types/index.ts
+++ b/components/projects/07-score-at-once/types/index.ts
@@ -3,10 +3,10 @@
  * 複数の機能で使用される型をここに統一
  */
 
-// Prismaから基本型とPayload型をインポート
+/** Prismaから基本型とPayload型をインポート */
 import type { Prisma, QuestionScore } from "@prisma/client"
 
-// Prisma基本型をエクスポート
+/** Prisma基本型をエクスポート */
 export type { CropRegion, PageImage, QuestionScore } from "@prisma/client"
 
 /**
@@ -88,7 +88,7 @@ export function calculateActualScore(
 
   switch (score.status) {
     case "correct":
-      return maxScore // cropRegion.points を返す
+      return maxScore
     case "incorrect":
     case "no_answer":
       return 0
@@ -96,7 +96,7 @@ export function calculateActualScore(
       return null
     case "partial":
     case "pending":
-      return score.partialScore // DBから取得した値をそのまま使用
+      return score.partialScore
     default:
       return null
   }
@@ -108,15 +108,38 @@ export function calculateActualScore(
  * 注意: 学生データのみを管理し、模範解答は別途管理する
  */
 export interface ScoringData {
-  id: string // PageImage.id
-  studentId: string // Student.id (UUID)
-  studentName: string // "${lastName} ${firstName}"
-  imageUrl: string // "appimg://${imagePath}"
-  currentScore?: number // QuestionScore.partialScore
-  maxScore: number // CropRegion.points
-  status: ScoringStatus // QuestionScore.status
-  questionRegion: CropRegionWithProjectPage // CropRegion データ（設問領域情報）
-  customOrder: number // ProjectStudent.customOrder (必須・ソート用)
+  /** PageImage.id */
+  id: string
+  /** Student.id (UUID) */
+  studentId: string
+  /** 生徒氏名 */
+  studentName: string
+  /** 画像URL (appimg://...) */
+  imageUrl: string
+  /** QuestionScore.partialScore */
+  currentScore?: number
+  /** CropRegion.points */
+  maxScore: number
+  /** QuestionScore.status */
+  status: ScoringStatus
+  /** 採点領域情報 */
+  questionRegion: CropRegionWithProjectPage
+  /** ProjectStudent.customOrder (必須・ソート用) */
+  customOrder: number
+}
+
+export type MasterStatus = "master"
+
+export interface MasterAnswerData {
+  id: string
+  studentId: "MASTER"
+  studentName: string
+  imageUrl: string
+  maxScore: number
+  status: MasterStatus
+  questionRegion: CropRegionWithProjectPage
+  customOrder: number
+  isMaster: true
 }
 
 /**
@@ -126,10 +149,11 @@ export interface ScoringData {
 export function findQuestionScore(
   questionScores: QuestionScore[],
   studentId: string,
-  cropRegionId: string
+  cropRegionId: string,
 ): QuestionScore | undefined {
   return questionScores.find(
-    score => score.studentId === studentId && score.cropRegionId === cropRegionId
+    (score) =>
+      score.studentId === studentId && score.cropRegionId === cropRegionId,
   )
 }
 
@@ -139,10 +163,10 @@ export function findQuestionScore(
 export function getScoringStatusFromArray(
   questionScores: QuestionScore[],
   studentId: string,
-  cropRegionId?: string
+  cropRegionId?: string,
 ): ScoringStatus {
   if (!cropRegionId) return "unscored"
-  
+
   const score = findQuestionScore(questionScores, studentId, cropRegionId)
   return (score?.status as ScoringStatus) ?? "unscored"
 }


### PR DESCRIPTION
## 概要
- 手動選択バージョンと置換ヘルパーを追加し、ドラッグ選択を保持
- useScoringFilter の自動選択ロジックを見直し、意図せぬ上書きを防止
- MasterAnswerData 型を導入し、模範解答周りの any を排除

## 関連 Issue
- closes #139

## 動作確認
- npm run lint
- npm run typecheck
- 一覧グリッドで矩形ドラッグ → 複数選択が維持されることを確認
- 設問切り替え時に先頭答案へフォーカスが移ることを確認