### PR TITLE
EditableTable の初期化順序を修正

### DIFF
--- a/components/common/EditableTable.tsx
+++ b/components/common/EditableTable.tsx
@@ -84,20 +84,18 @@ function useLocalReactTable<TData>(options: TableOptions<TData>) {
 
   const [internalState, setInternalState] = useState(() => table.initialState)
 
-  useEffect(() => {
-    table.setOptions((prev) => ({
-      ...prev,
-      ...options,
-      state: {
-        ...internalState,
-        ...options.state,
-      },
-      onStateChange: (updater) => {
-        setInternalState(updater)
-        options.onStateChange?.(updater)
-      },
-    }))
-  }, [table, options, internalState])
+  table.setOptions((prev) => ({
+    ...prev,
+    ...options,
+    state: {
+      ...internalState,
+      ...options.state,
+    },
+    onStateChange: (updater) => {
+      setInternalState(updater)
+      options.onStateChange?.(updater)
+    },
+  }))
 
   return table
 }


### PR DESCRIPTION
## 変更内容\n- useLocalReactTable で table.setOptions を同期実行するよう修正\n- TanStack Table の columnPinning state が未初期化になることで発生していた headerGroup エラーを解消\n\nCloses #141