### PR TITLE
パッケージ化ビルドでPDF.js workerファイルが見つからない問題を修正

### DIFF
--- a/electron-src/next-server-embedded.ts
+++ b/electron-src/next-server-embedded.ts
@@ -20,39 +20,38 @@ export async function startEmbeddedNextServer(): Promise<void> {
     // Next.jsアプリの初期化
     let appDir
     if (process.resourcesPath) {
-      // パッケージ化されている場合、まずextraResourcesディレクトリをチェック
-      const extraResourceDir = join(process.resourcesPath, '..')
-      const asarUnpackedDir = join(process.resourcesPath, 'app.asar.unpacked')
-      
-      console.log(`Checking extraResource directory: ${extraResourceDir}`)
-      console.log(`Checking asar.unpacked directory: ${asarUnpackedDir}`)
-      
-      // extraResourcesに.nextがあるかチェック
-      const extraResourceNextDir = join(extraResourceDir, '.next')
-      const asarUnpackedNextDir = join(asarUnpackedDir, '.next')
-      
-      // .nextディレクトリの存在確認
+      // パッケージ化されている場合、Resourcesディレクトリを直接使用
+      // forge.config.jsのextraResourceで.nextとpublicの両方がResourcesディレクトリに配置される
+      appDir = process.resourcesPath
+
+      console.log(`Using Resources directory as app directory: ${appDir}`)
+
+      // .nextとpublicディレクトリの存在確認
       try {
         const fs = require('fs')
-        console.log(`Checking if ${extraResourceNextDir} exists: ${fs.existsSync(extraResourceNextDir)}`)
-        console.log(`Checking if ${asarUnpackedNextDir} exists: ${fs.existsSync(asarUnpackedNextDir)}`)
-        
-        if (fs.existsSync(extraResourceNextDir)) {
-          appDir = extraResourceDir
-          console.log(`✓ Using extraResource Next.js app directory: ${appDir}`)
-        } else if (fs.existsSync(asarUnpackedNextDir)) {
-          appDir = asarUnpackedDir
-          console.log(`✓ Using asar.unpacked Next.js app directory: ${appDir}`)
+        const nextDir = join(appDir, '.next')
+        const publicDir = join(appDir, 'public')
+
+        console.log(`Checking if ${nextDir} exists: ${fs.existsSync(nextDir)}`)
+        console.log(`Checking if ${publicDir} exists: ${fs.existsSync(publicDir)}`)
+
+        if (!fs.existsSync(nextDir)) {
+          console.warn(`⚠ Warning: .next directory not found at ${nextDir}`)
+        }
+        if (!fs.existsSync(publicDir)) {
+          console.warn(`⚠ Warning: public directory not found at ${publicDir}`)
+        }
+
+        // PDF workerファイルの存在確認
+        const pdfWorkerPath = join(publicDir, 'js', 'pdf.worker.min.mjs')
+        console.log(`Checking if PDF worker exists: ${fs.existsSync(pdfWorkerPath)}`)
+        if (!fs.existsSync(pdfWorkerPath)) {
+          console.error(`❌ PDF worker file not found at ${pdfWorkerPath}`)
         } else {
-          // フォールバック: extraResourceディレクトリを使用
-          appDir = extraResourceDir
-          console.log(`⚠ Fallback to extraResource directory: ${appDir}`)
-          console.log(`⚠ Warning: No .next directory found in expected locations`)
+          console.log(`✓ PDF worker file found at ${pdfWorkerPath}`)
         }
       } catch (error) {
-        console.error(`❌ Error checking .next directories:`, error)
-        appDir = extraResourceDir
-        console.log(`❌ Error fallback to extraResource directory: ${appDir}`)
+        console.error(`❌ Error checking directories:`, error)
       }
     } else {
       // 開発環境の場合

--- a/scripts/setup-mathjax-fonts.js
+++ b/scripts/setup-mathjax-fonts.js
@@ -64,3 +64,25 @@ ensureDir(targetDir)
 copyRecursive(sourceDir, targetDir)
 
 console.log("✓ MathJax woff-v2 fonts copied to public assets")
+
+// PDF.js workerファイルのセットアップ
+const pdfWorkerSource = path.join(
+  repoRoot,
+  "node_modules",
+  "pdfjs-dist",
+  "build",
+  "pdf.worker.min.mjs"
+)
+const pdfWorkerDest = path.join(repoRoot, "public", "js", "pdf.worker.min.mjs")
+
+if (!fs.existsSync(pdfWorkerSource)) {
+  console.error("PDF.js workerファイルが見つかりません: " + pdfWorkerSource)
+  process.exit(1)
+}
+
+const pdfWorkerDestDir = path.dirname(pdfWorkerDest)
+ensureDir(pdfWorkerDestDir)
+fs.copyFileSync(pdfWorkerSource, pdfWorkerDest)
+
+console.log(`✓ PDF.js worker file copied from ${pdfWorkerSource}`)
+console.log(`  to ${pdfWorkerDest}`)


### PR DESCRIPTION
## 概要

GitHub Actionsでビルドしたアプリケーション（特にWindows版）で、PDFインポート時に`pdf.worker.min.mjs`が404エラーとなり、PDF変換が失敗する問題を修正しました。

Closes #154

## 変更内容

### 1. electron-src/next-server-embedded.ts
- **問題**: Next.jsサーバーの`appDir`が`process.resourcesPath + '..'`に設定されており、`public`ディレクトリが見つからなかった
- **修正**: `appDir`を`process.resourcesPath`に直接設定し、`Resources/.next`と`Resources/public`の両方を認識できるように変更
- **追加**: PDF workerファイルの存在確認ログを追加し、デバッグを容易化

### 2. scripts/setup-mathjax-fonts.js
- **問題**: PDF workerファイルが手動でコピーされており、ビルド時の自動化が不完全だった
- **修正**: `node_modules/pdfjs-dist/build/pdf.worker.min.mjs`から`public/js/`へ自動コピーする処理を追加
- **効果**: MathJaxフォントと同様に、ビルド時に最新バージョンが確実に配置される

## 技術的詳細

### ファイル配置構造（パッケージ化後）
```
Contents/Resources/       (macOS)
resources/               (Windows/Linux)
├── .next/              # extraResource（forge.config.js）
├── public/             # extraResource（forge.config.js）
│   └── js/
│       └── pdf.worker.min.mjs
└── app.asar.unpacked/
```

### 修正前の問題
```typescript
// appDirが不適切
appDir = join(process.resourcesPath, '..')  // ← publicが見つからない
```

### 修正後
```typescript
// appDirを直接Resourcesディレクトリに設定
appDir = process.resourcesPath  // ← .nextもpublicも見つかる
```

## テスト状況

✅ ローカルビルド成功（`npm run build`）
✅ TypeScriptコンパイル成功
⏳ GitHub Actionsでの検証待ち（このPRマージ後）

## 影響範囲

### 影響を受けるプラットフォーム
- ✅ Windows（主要な問題対象）
- ✅ macOS
- ✅ Linux

### 影響を受ける機能
- PDFファイルのインポート機能
- 模範解答アップロード（PDFファイル）
- 答案アップロード（PDFファイル）

## 期待される効果

1. **完全なオフライン対応**: パッケージ化ビルドでPDF変換が正常動作
2. **バージョン整合性**: PDF.jsのアップデート時も自動的に最新workerが配置される
3. **デバッグ容易性**: 存在確認ログにより、問題の早期発見が可能
4. **ビルドプロセスの自動化**: 手動コピーの必要性を排除

## チェックリスト

- [x] コードの変更内容を確認
- [x] ビルドが成功することを確認
- [x] 関連Issueにリンク
- [x] 変更内容を日本語で文書化
- [ ] GitHub Actionsでのビルドテスト（マージ後に自動実行）
- [ ] 実機でのPDFインポートテスト（ビルド成果物のダウンロード後）

## レビュー依頼事項

特にありません。ロジックは単純化され、可読性も向上しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>