### PR TITLE
fix: 設問移動時のフィルター後最初の生徒選択が不安定な問題を修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -276,6 +276,12 @@ export function useScoringFilter({
   const consumedSnapshotVersionRef = useRef(0)
   const manualSelectionVersionRef = useRef(manualSelectionVersion)
   const questionChangeVersionRef = useRef<number | null>(null)
+  const visibleAnswersRef = useRef(visibleAnswers)
+
+  // visibleAnswersの最新値を追跡
+  useLayoutEffect(() => {
+    visibleAnswersRef.current = visibleAnswers
+  }, [visibleAnswers])
 
   useEffect(() => {
     const manualSelectionChanged =
@@ -304,29 +310,17 @@ export function useScoringFilter({
       lastVisibleAnswersRef.current,
     )
 
-    const questionChangedExternally =
-      questionChangeVersionRef.current !== questionChangeVersion
-
     if (visibleChanged) {
       lastVisibleAnswersRef.current = visibleAnswers
     }
 
-    if (questionChangedExternally) {
-      pendingGridSelectionRef.current = true
-    }
-
-    if ((cropRegionChanged || questionChangedExternally) && !visibleChanged) {
+    if (cropRegionChanged && !visibleChanged) {
       prevGradingModeRef.current = gradingMode
       prevCropRegionIdRef.current = currentCropRegionId
       return
     }
 
-    if (
-      modeChangedToGrid ||
-      cropRegionChanged ||
-      visibleChanged ||
-      questionChangedExternally
-    ) {
+    if (modeChangedToGrid || cropRegionChanged || visibleChanged) {
       pendingGridSelectionRef.current = true
     }
 
@@ -342,19 +336,16 @@ export function useScoringFilter({
       ? snapshot.version > consumedSnapshotVersionRef.current
       : false
     const visibleIds = new Set(visibleAnswers)
-    const filteredSelection = questionChangedExternally
-      ? []
-      : hasFreshSnapshot && snapshot?.filteredSelection
+    const filteredSelection =
+      hasFreshSnapshot && snapshot?.filteredSelection
         ? snapshot.filteredSelection
         : Array.from(selectedPageImageIds).filter(
             (id) => visibleIds.has(id) && !id.startsWith("master-"),
           )
     const firstStudentAnswerId =
-      questionChangedExternally && visibleAnswers.length > 0
-        ? (visibleAnswers.find((id) => !id.startsWith("master-")) ?? null)
-        : hasFreshSnapshot && snapshot?.firstStudentAnswerId
-          ? snapshot.firstStudentAnswerId
-          : (visibleAnswers.find((id) => !id.startsWith("master-")) ?? null)
+      hasFreshSnapshot && snapshot?.firstStudentAnswerId
+        ? snapshot.firstStudentAnswerId
+        : (visibleAnswers.find((id) => !id.startsWith("master-")) ?? null)
 
     if (pendingGridSelectionRef.current) {
       const shouldApplySelection =
@@ -383,9 +374,8 @@ export function useScoringFilter({
           return
         }
 
-        const hasVisibleSelection = questionChangedExternally
-          ? false
-          : hasFreshSnapshot && snapshot?.hasVisibleSelection
+        const hasVisibleSelection =
+          hasFreshSnapshot && snapshot?.hasVisibleSelection
             ? snapshot.hasVisibleSelection
             : filteredSelection.length > 0
 
@@ -429,7 +419,6 @@ export function useScoringFilter({
   }, [
     currentCropRegionId,
     gradingMode,
-    questionChangeVersion,
     selectedPageImageIds,
     setSelectedPageImageIds,
     visibleAnswers,
@@ -470,6 +459,37 @@ export function useScoringFilter({
       )
     }
   }, [gradingMode, selectedPageImageIds, visibleAnswers])
+
+  // 設問変更時の選択処理用のref
+  const questionChangeVersionForSelectionRef = useRef(questionChangeVersion)
+
+  // 設問変更時の選択処理（グリッドモード専用）
+  useEffect(() => {
+    // 個別モードでは何もしない
+    if (gradingMode !== "grid") return
+
+    // バージョンが変わっていなければスキップ（初回も含む）
+    if (questionChangeVersionForSelectionRef.current === questionChangeVersion) {
+      return
+    }
+    questionChangeVersionForSelectionRef.current = questionChangeVersion
+
+    // setTimeout(0)で全ての状態更新がコミットされた後に実行
+    const timeoutId = setTimeout(() => {
+      const currentVisible = visibleAnswersRef.current
+      const firstStudentAnswerId = currentVisible.find(
+        (id) => !id.startsWith("master-"),
+      )
+
+      if (firstStudentAnswerId) {
+        setSelectedPageImageIds(new Set([firstStudentAnswerId]))
+      } else {
+        setSelectedPageImageIds(new Set())
+      }
+    }, 0)
+
+    return () => clearTimeout(timeoutId)
+  }, [questionChangeVersion, gradingMode, setSelectedPageImageIds])
 
   const masterAnswerData = useMemo((): MasterAnswerData | null => {
     if (!currentCropRegion || !project?.projectPages) return null


### PR DESCRIPTION
## Summary

- 一括採点ページで設問移動時（Shift+D）にフィルター後の最初の生徒答案が確実に選択されるよう修正
- レンダリングサイクル間のタイミング問題を解決

## 変更内容

- `visibleAnswersRef` を追加して最新の可視答案リストを追跡
- 設問変更専用の `useEffect` を追加
- `setTimeout(0)` で状態更新完了後に選択処理を実行
- 既存ロジックから `questionChangedExternally` 関連処理を削除

## Test plan

- [ ] 設問1で採点後、Shift+Dで設問2に移動 → 最初の生徒が選択されることを確認
- [ ] Reloadなしで動作することを確認
- [ ] フィルター変更時の選択処理が正常に動作することを確認
- [ ] 個別モードでは設問移動時に生徒が移動しないことを確認

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)