### PR TITLE
列レイアウト表示高さ修正とlayoutDirectionのlocalStorage保存

### DIFF
--- a/app/test/grid-layout-debug/page.tsx
+++ b/app/test/grid-layout-debug/page.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { useState, useRef, useEffect, useCallback } from "react"
+
+type LayoutDirection = "right-down" | "left-down" | "down-right" | "down-left"
+
+interface TestImageProps {
+  index: number
+  isColumnLayout: boolean
+  itemsPerRow: number
+  aspectRatio: number // width / height
+  containerRef: React.RefObject<HTMLDivElement | null>
+  calculatedCellHeight: number // 親から渡された計算済み高さ
+}
+
+function TestImage({ index, isColumnLayout, itemsPerRow, aspectRatio, containerRef, calculatedCellHeight }: TestImageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const parentRef = useRef<HTMLDivElement>(null)
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
+  const [parentSize, setParentSize] = useState({ width: 0, height: 0 })
+  const [canvasCssSize, setCanvasCssSize] = useState({ width: 0, height: 0 })
+
+  const calculateAndDraw = useCallback(() => {
+    const canvas = canvasRef.current
+    const parent = parentRef.current
+    const container = containerRef.current
+    if (!canvas || !parent || !container) return
+
+    // 方法1: 親要素から直接取得（デバッグ用）
+    const parentWidth = parent.offsetWidth
+    const parentHeight = parent.offsetHeight
+    setParentSize({ width: parentWidth, height: parentHeight })
+
+    // 方法2: グリッドコンテナから計算
+    const containerWidth = container.offsetWidth
+    const containerHeight = container.offsetHeight
+    const gap = 8 // gap-2 = 8px
+    const padding = 4 // p-1 = 4px
+
+    let calculatedCellWidth: number
+    let cellHeight: number
+
+    if (isColumnLayout) {
+      // 列レイアウト: 親から渡された計算済み高さを使用
+      cellHeight = calculatedCellHeight
+      calculatedCellWidth = cellHeight * aspectRatio
+    } else {
+      // 行レイアウト: 幅を均等分割
+      const availableWidth = containerWidth - padding * 2 - gap * (itemsPerRow - 1)
+      calculatedCellWidth = availableWidth / itemsPerRow
+      cellHeight = calculatedCellWidth / aspectRatio
+    }
+
+    // 計算されたサイズを使用
+    let canvasWidth: number
+    let canvasHeight: number
+
+    if (isColumnLayout) {
+      // セル内: pt-1(4px) + pb-0(0px) + gap-0.5(2px) + footer(~14px) = 20px
+      canvasHeight = cellHeight - 20
+      canvasWidth = canvasHeight * aspectRatio
+    } else {
+      // セル内: p-1(8px) = 左右で8px
+      canvasWidth = calculatedCellWidth - 8
+      canvasHeight = canvasWidth / aspectRatio
+    }
+
+    canvas.width = Math.max(10, canvasWidth)
+    canvas.height = Math.max(10, canvasHeight)
+    setDimensions({ width: canvas.width, height: canvas.height })
+    setCanvasCssSize({ width: canvas.width, height: canvas.height })
+
+    // 描画
+    const ctx = canvas.getContext("2d")
+    if (ctx) {
+      ctx.fillStyle = `hsl(${(index * 60) % 360}, 70%, 80%)`
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = "#000"
+      ctx.font = "12px sans-serif"
+      ctx.textAlign = "center"
+      ctx.fillText(`C:${canvas.width.toFixed(0)}x${canvas.height.toFixed(0)}`, canvas.width / 2, canvas.height / 2 - 8)
+      ctx.fillText(`P:${parentWidth.toFixed(0)}x${parentHeight.toFixed(0)}`, canvas.width / 2, canvas.height / 2 + 8)
+    }
+  }, [index, isColumnLayout, itemsPerRow, aspectRatio, containerRef, calculatedCellHeight])
+
+  // itemsPerRow変更時に再計算（タイミングを調整）
+  useEffect(() => {
+    // 即座に計算
+    calculateAndDraw()
+
+    // レイアウト後にも再計算（CSS gridのレイアウト完了を待つ）
+    const timeoutId = setTimeout(calculateAndDraw, 0)
+    const animationId = requestAnimationFrame(calculateAndDraw)
+
+    return () => {
+      clearTimeout(timeoutId)
+      cancelAnimationFrame(animationId)
+    }
+  }, [calculateAndDraw])
+
+  // 列レイアウト時は明示的に高さを設定
+  const cellStyle = isColumnLayout
+    ? { height: `${calculatedCellHeight}px`, maxHeight: `${calculatedCellHeight}px`, overflow: "hidden" }
+    : {}
+
+  // canvas の CSS サイズを明示的に設定（ピクセルバッファサイズと一致させる）
+  const canvasStyle = isColumnLayout
+    ? { width: canvasCssSize.width, height: canvasCssSize.height, flexShrink: 0 }
+    : { width: "100%" }
+
+  return (
+    <div
+      ref={parentRef}
+      className="flex flex-col gap-0.5 border-2 border-gray-300 bg-white pt-1 px-1 pb-0"
+      style={cellStyle}
+    >
+      <canvas
+        ref={canvasRef}
+        style={canvasStyle}
+      />
+      <div className="text-[10px] text-gray-500 whitespace-nowrap flex-shrink-0 truncate">
+        #{index} C:{dimensions.width.toFixed(0)}x{dimensions.height.toFixed(0)}
+      </div>
+    </div>
+  )
+}
+
+export default function GridLayoutDebugPage() {
+  const [layoutDirection, setLayoutDirection] = useState<LayoutDirection>("right-down")
+  const [itemsPerRow, setItemsPerRow] = useState(5)
+  const [itemCount, setItemCount] = useState(15)
+  const [aspectRatio, setAspectRatio] = useState(2) // 横長
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
+
+  const isColumnLayout = layoutDirection === "down-right" || layoutDirection === "down-left"
+
+  // コンテナサイズを監視
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const updateSize = () => {
+      setContainerSize({
+        width: container.offsetWidth,
+        height: container.offsetHeight,
+      })
+    }
+
+    updateSize()
+
+    const observer = new ResizeObserver(updateSize)
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [])
+
+  // 列レイアウト時のセルの高さを計算
+  const gap = 4 // gap-1 = 4px
+  const padding = 2 // p-0.5 = 2px
+  const calculatedCellHeight = isColumnLayout
+    ? (containerSize.height - padding * 2 - gap * (itemsPerRow - 1)) / itemsPerRow
+    : 0
+
+  const effectiveGridSize = {
+    columns: isColumnLayout ? Math.ceil(itemCount / itemsPerRow) : itemsPerRow,
+    rows: isColumnLayout ? itemsPerRow : Math.ceil(itemCount / itemsPerRow),
+  }
+
+  return (
+    <div className="flex h-screen flex-col p-4">
+      <h1 className="mb-4 text-xl font-bold">Grid Layout Debug Page</h1>
+
+      {/* コントロールパネル */}
+      <div className="mb-4 flex flex-wrap gap-4 rounded bg-gray-100 p-4">
+        <div>
+          <label className="block text-sm font-medium">Layout Direction</label>
+          <select
+            value={layoutDirection}
+            onChange={(e) => setLayoutDirection(e.target.value as LayoutDirection)}
+            className="mt-1 rounded border p-2"
+          >
+            <option value="right-down">右→下 (Row)</option>
+            <option value="left-down">左→下 (Row)</option>
+            <option value="down-right">下→右 (Column)</option>
+            <option value="down-left">下→左 (Column)</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Items Per {isColumnLayout ? "Column" : "Row"}</label>
+          <input
+            type="range"
+            min="1"
+            max="10"
+            value={itemsPerRow}
+            onChange={(e) => setItemsPerRow(Number(e.target.value))}
+            className="mt-1 w-32"
+          />
+          <span className="ml-2">{itemsPerRow}</span>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Item Count</label>
+          <input
+            type="range"
+            min="1"
+            max="30"
+            value={itemCount}
+            onChange={(e) => setItemCount(Number(e.target.value))}
+            className="mt-1 w-32"
+          />
+          <span className="ml-2">{itemCount}</span>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Aspect Ratio (W/H)</label>
+          <input
+            type="range"
+            min="0.5"
+            max="4"
+            step="0.1"
+            value={aspectRatio}
+            onChange={(e) => setAspectRatio(Number(e.target.value))}
+            className="mt-1 w-32"
+          />
+          <span className="ml-2">{aspectRatio.toFixed(1)}</span>
+        </div>
+      </div>
+
+      {/* デバッグ情報 */}
+      <div className="mb-4 rounded bg-blue-50 p-2 text-sm">
+        <p>Container: {containerSize.width}x{containerSize.height}</p>
+        <p>Grid: {effectiveGridSize.columns} cols x {effectiveGridSize.rows} rows</p>
+        <p>isColumnLayout: {String(isColumnLayout)}</p>
+        <p>calculatedCellHeight: {calculatedCellHeight.toFixed(1)}px</p>
+      </div>
+
+      {/* グリッドコンテナ */}
+      <div
+        ref={containerRef}
+        className={`flex-1 min-h-0 border-2 border-blue-500 ${
+          isColumnLayout ? "overflow-x-auto overflow-y-hidden" : "overflow-y-auto"
+        }`}
+      >
+        <div
+          className="relative grid gap-1 p-0.5 select-none"
+          style={{
+            gridTemplateColumns: isColumnLayout
+              ? "none"
+              : `repeat(${effectiveGridSize.columns}, 1fr)`,
+            gridTemplateRows: isColumnLayout
+              ? `repeat(${effectiveGridSize.rows}, 1fr)`
+              : "none",
+            gridAutoRows: "auto",
+            gridAutoColumns: isColumnLayout
+              ? "auto"  // minmax(200px, max-content)から変更
+              : undefined,
+            gridAutoFlow: isColumnLayout ? "column" : "row",
+            width: isColumnLayout ? "max-content" : "100%",
+            height: isColumnLayout ? "100%" : "max-content",
+          }}
+        >
+          {Array.from({ length: itemCount }, (_, i) => (
+            <TestImage
+              key={i}
+              index={i}
+              isColumnLayout={isColumnLayout}
+              itemsPerRow={itemsPerRow}
+              aspectRatio={aspectRatio}
+              containerRef={containerRef}
+              calculatedCellHeight={calculatedCellHeight}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -14,6 +14,7 @@ import {
   Calculator,
   ChevronsLeft,
   ChevronsRight,
+  Grid2X2,
   Home,
   LogIn,
   LogOut,
@@ -44,6 +45,11 @@ const navItems = [
     href: "/textbox-on-canvas-v4",
     label: "Textbox Canvas V4",
     icon: FlaskConical,
+  },
+  {
+    href: "/test/grid-layout-debug",
+    label: "Grid Layout Debug",
+    icon: Grid2X2,
   },
   { href: "/settings", label: "設定", icon: Settings },
 ]

--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -14,7 +14,7 @@ import type {
   ScoringData,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
-import { useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 export interface AnswerGridViewProps {
   /** 統一されたデータ引数 */
@@ -75,6 +75,28 @@ export default function AnswerGridView({
 
   const containerRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
+
+  /** コンテナサイズ監視（列レイアウト用） */
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const updateSize = () => {
+      setContainerSize({
+        width: container.offsetWidth,
+        height: container.offsetHeight,
+      })
+    }
+
+    updateSize()
+
+    const observer = new ResizeObserver(updateSize)
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [])
 
   /** 主要なカスタムフック */
   const { itemsPerRow } = useGridNavigation({
@@ -146,32 +168,41 @@ export default function AnswerGridView({
     handleMouseDown(event, answerId)
   }
 
+  const isColumnLayout =
+    layoutDirection === "down-right" || layoutDirection === "down-left"
+
+  /** 列レイアウト時のセル高さを計算（トップダウンで明示的に計算） */
+  const OUTER_PADDING = 16 // p-4 = 16px（外側コンテナのpadding）
+  const GRID_GAP = 8 // gap-2 = 8px
+  const GRID_PADDING = 4 // p-1 = 4px
+  const calculatedCellHeight = isColumnLayout
+    ? (containerSize.height - OUTER_PADDING * 2 - GRID_PADDING * 2 - GRID_GAP * (itemsPerRow[0] - 1)) / itemsPerRow[0]
+    : 0
+
   return (
-    <div ref={containerRef} className={`h-full min-h-0 overflow-y-auto ${className}`}>
+    <div
+      ref={containerRef}
+      className={`h-full min-h-0 ${isColumnLayout ? "overflow-x-auto overflow-y-hidden" : "overflow-y-auto"} ${className}`}
+    >
       {/* 答案グリッド */}
       <div
         ref={gridRef}
         className="relative grid min-w-0 gap-2 p-1 select-none"
         style={{
-          gridTemplateColumns:
-            layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "none"
-              : `repeat(${effectiveGridSize.columns}, 1fr)`,
-          gridTemplateRows:
-            layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? `repeat(${effectiveGridSize.rows}, 1fr)`
-              : "none",
+          gridTemplateColumns: isColumnLayout
+            ? "none"
+            : `repeat(${effectiveGridSize.columns}, 1fr)`,
+          gridTemplateRows: isColumnLayout
+            ? `repeat(${effectiveGridSize.rows}, 1fr)`
+            : "none",
           gridAutoRows: "auto",
-          gridAutoColumns:
-            layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "minmax(200px, max-content)"
-              : undefined,
-          gridAutoFlow:
-            layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "column"
-              : "row",
-          width: "100%",
-          height: "max-content",
+          gridAutoColumns: isColumnLayout
+            ? "minmax(200px, max-content)"
+            : undefined,
+          gridAutoFlow: isColumnLayout ? "column" : "row",
+          width: isColumnLayout ? "max-content" : "100%",
+          // 列レイアウト時は高さを100%にして、行ごとに均等分割
+          height: isColumnLayout ? "100%" : "max-content",
         }}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
@@ -189,7 +220,7 @@ export default function AnswerGridView({
               isSelected={isSelected}
               showStudentNames={showStudentNames}
               layoutDirection={layoutDirection}
-              itemsPerRow={itemsPerRow[0]}
+              calculatedCellHeight={calculatedCellHeight}
               selectionBorderSettings={selectionBorderSettings}
               onMouseDown={onCellMouseDown}
             />

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -21,7 +21,7 @@ interface GridCellProps {
   isSelected: boolean
   showStudentNames: boolean
   layoutDirection: LayoutDirection
-  itemsPerRow: number
+  calculatedCellHeight: number
   selectionBorderSettings: {
     tailwindClass: string
   }
@@ -33,7 +33,7 @@ export function GridCell({
   isSelected,
   showStudentNames,
   layoutDirection,
-  itemsPerRow,
+  calculatedCellHeight,
   selectionBorderSettings,
   onMouseDown,
 }: GridCellProps) {
@@ -79,10 +79,23 @@ export function GridCell({
     return "採点中"
   }
 
+  const isColumnLayout =
+    layoutDirection === "down-right" || layoutDirection === "down-left"
+
+  // 列レイアウト時は明示的に高さを設定
+  const cellStyle: React.CSSProperties = isColumnLayout
+    ? {
+        height: calculatedCellHeight,
+        maxHeight: calculatedCellHeight,
+        overflow: "hidden",
+      }
+    : {}
+
   return (
     <div
       data-answer-id={answer.id}
       className={cellClasses.join(" ")}
+      style={cellStyle}
       onMouseDown={(e) => onMouseDown(e, answer.id)}
     >
       {/* 答案画像 */}
@@ -91,14 +104,12 @@ export function GridCell({
         cropRegion={answer.questionRegion}
         alt={isMaster ? "模範解答" : `${answer.studentName}の答案`}
         className={
-          layoutDirection === "down-right" || layoutDirection === "down-left"
+          isColumnLayout
             ? "h-full w-auto flex-1" // 列表示: 高さ目一杯、幅は縦横比で自動、余白占有
             : "h-auto w-full" // 行表示: 幅目一杯、高さは縦横比で自動
         }
-        isColumnLayout={
-          layoutDirection === "down-right" || layoutDirection === "down-left"
-        }
-        itemsPerRow={itemsPerRow}
+        isColumnLayout={isColumnLayout}
+        calculatedCellHeight={calculatedCellHeight}
         isSelected={isSelected}
       />
 
@@ -106,7 +117,9 @@ export function GridCell({
       <div className="flex items-center justify-between">
         <div className="flex min-w-0 flex-1 items-center space-x-1">
           <span
-            title={isMaster || showStudentNames ? answer.studentName : undefined}
+            title={
+              isMaster || showStudentNames ? answer.studentName : undefined
+            }
             className={`block max-w-full truncate text-xs ${
               isMaster ? "font-bold text-black" : "font-medium"
             }`}
@@ -135,7 +148,7 @@ export function GridCell({
         </div>
 
         {!isMaster && (
-          <Icon className={`h-3 w-3 ${config.textColor} flex-shrink-0`} />
+          <Icon className={`h-3 w-3 ${config.textColor} shrink-0`} />
         )}
       </div>
     </div>

--- a/components/projects/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -30,9 +30,12 @@ interface CroppedAnswerImageProps {
   alt: string
   className?: string
   isColumnLayout?: boolean
-  itemsPerRow?: number // 1行あたりの表示数
+  calculatedCellHeight?: number // 親から渡された計算済みセル高さ
   isSelected?: boolean
 }
+
+// セル内の固定オフセット（padding + gap + footer）
+const CELL_CONTENT_OFFSET = 32 // p-2(16px) + gap-1(4px) + footer(~12px)
 
 // 採点領域をクロップして表示するコンポーネント
 export default function CroppedAnswerImage({
@@ -41,7 +44,7 @@ export default function CroppedAnswerImage({
   alt,
   className = "",
   isColumnLayout = false,
-  itemsPerRow,
+  calculatedCellHeight = 0,
   isSelected = false,
 }: CroppedAnswerImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -61,18 +64,34 @@ export default function CroppedAnswerImage({
     const sourceHeight = cropRegion.height * imageElement.naturalHeight
     const aspectRatio = sourceWidth / sourceHeight
 
-    // コンテナサイズを取得
-    const containerWidth = canvas.offsetWidth
-    const containerHeight = canvas.offsetHeight
+    let canvasWidth: number
+    let canvasHeight: number
 
-    if (isColumnLayout) {
-      // 列表示: 高さベースで幅を計算
-      canvas.height = containerHeight
-      canvas.width = containerHeight * aspectRatio
+    if (isColumnLayout && calculatedCellHeight > 0) {
+      // 列表示: 計算済みセル高さからcanvas高さを算出
+      canvasHeight = Math.max(10, calculatedCellHeight - CELL_CONTENT_OFFSET)
+      canvasWidth = canvasHeight * aspectRatio
     } else {
-      // 行表示: 幅ベースで高さを計算
-      canvas.width = containerWidth
-      canvas.height = containerWidth / aspectRatio
+      // 行表示: 親要素の幅を基準に計算
+      const parent = canvas.parentElement
+      if (!parent) return
+      const containerWidth = parent.offsetWidth
+      canvasWidth = Math.max(10, containerWidth)
+      canvasHeight = canvasWidth / aspectRatio
+    }
+
+    canvas.width = canvasWidth
+    canvas.height = canvasHeight
+
+    // canvas の CSS サイズを直接設定（ピクセルバッファサイズと一致させる）
+    if (isColumnLayout) {
+      canvas.style.width = `${canvasWidth}px`
+      canvas.style.height = `${canvasHeight}px`
+      canvas.style.flexShrink = "0"
+    } else {
+      canvas.style.width = "100%"
+      canvas.style.height = ""
+      canvas.style.flexShrink = ""
     }
 
     // 採点領域をクロップして描画
@@ -91,15 +110,19 @@ export default function CroppedAnswerImage({
       canvas.width,
       canvas.height,
     )
-  }, [imageLoaded, cropRegion, isColumnLayout, itemsPerRow])
+  }, [imageLoaded, cropRegion, isColumnLayout, calculatedCellHeight])
 
   const handleImageLoad = () => {
     setImageLoaded(true)
   }
 
+  // 行表示: 幅100%、高さは自動
+  // 列表示: 明示的にサイズ指定（useEffect内で直接設定）
+  const containerClass = isColumnLayout ? "" : "w-full"
+
   return (
     <div
-      className={`relative w-full ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""} ${className}`}
+      className={`relative ${containerClass} ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""} ${className}`}
     >
       {/* Canvas描画用の画像データ取得のため、Next.js Imageではなく通常のimgタグを使用 */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -113,7 +136,6 @@ export default function CroppedAnswerImage({
       />
       <canvas
         ref={canvasRef}
-        className="h-full w-full"
         style={{ display: imageLoaded ? "block" : "none" }}
       />
       {!imageLoaded && (

--- a/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -121,7 +121,7 @@ export function ScoringContentArea({
       itemsPerRow={itemsPerLine}
       autoScroll={autoScroll}
       showStudentNames={showStudentNames}
-      className="p-6"
+      className="p-4"
     />
   )
 }

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -47,9 +47,11 @@ function ScoringMainViewContent() {
     itemsPerLine,
     autoScroll,
     showStudentNames,
+    layoutDirection,
     setItemsPerLine,
     setAutoScroll,
     setShowStudentNames,
+    setLayoutDirection,
   } = useScoringSettings()
 
   const [questionChangeVersion, setQuestionChangeVersion] = useState(0)
@@ -63,7 +65,6 @@ function ScoringMainViewContent() {
     /** 個別の状態 */
     gradingMode,
     selectedPageImageIds,
-    layoutDirection,
     currentStudentIndex,
     currentCropRegionId,
     showKeyboardHelp,
@@ -73,7 +74,6 @@ function ScoringMainViewContent() {
     /** アクション関数 */
     setGradingMode,
     setSelectedPageImageIds,
-    setLayoutDirection,
     setCurrentStudentIndex,
     setCurrentCropRegionId,
     setShowKeyboardHelp,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
@@ -1,8 +1,4 @@
-import { DEFAULT_LAYOUT_DIRECTION } from "@/components/projects/07-score-at-once/ScoringMain/constants/keyboard-shortcuts"
-import type {
-  GradingMode,
-  LayoutDirection,
-} from "@/components/projects/07-score-at-once/types"
+import type { GradingMode } from "@/components/projects/07-score-at-once/types"
 import { getModifierKeyLabel } from "@/lib/platform-utils"
 import { useCallback, useRef, useState } from "react"
 
@@ -15,10 +11,6 @@ export function useScoringMainState() {
   )
   const [manualSelectionVersion, setManualSelectionVersion] = useState(0)
   const suppressSelectionUpdateRef = useRef(false)
-  /** グリッド表示方向 */
-  const [layoutDirection, setLayoutDirection] = useState<LayoutDirection>(
-    DEFAULT_LAYOUT_DIRECTION,
-  )
   /** 現在選択中の生徒インデックス */
   const [currentStudentIndex, setCurrentStudentIndex] = useState(0)
   /** 選択中の設問領域ID */
@@ -82,7 +74,6 @@ export function useScoringMainState() {
     /** 個別の状態 */
     gradingMode,
     selectedPageImageIds,
-    layoutDirection,
     currentStudentIndex,
     currentCropRegionId,
     showKeyboardHelp,
@@ -93,7 +84,6 @@ export function useScoringMainState() {
     /** アクション関数 */
     setGradingMode,
     setSelectedPageImageIds,
-    setLayoutDirection,
     setCurrentStudentIndex,
     setCurrentCropRegionId,
     setShowKeyboardHelp,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -1,9 +1,13 @@
+import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
 import { useEffect, useState } from "react"
+
+const DEFAULT_LAYOUT_DIRECTION: LayoutDirection = "right-down"
 
 export function useScoringSettings() {
   const [itemsPerLine, setItemsPerLine] = useState([5])
   const [autoScroll, setAutoScroll] = useState(true)
   const [showStudentNames, setShowStudentNames] = useState(true)
+  const [layoutDirection, setLayoutDirection] = useState<LayoutDirection>(DEFAULT_LAYOUT_DIRECTION)
 
   // localStorage から設定を読み込む
   useEffect(() => {
@@ -24,6 +28,11 @@ export function useScoringSettings() {
         )
         if (savedShowStudentNames) {
           setShowStudentNames(JSON.parse(savedShowStudentNames))
+        }
+
+        const savedLayoutDirection = localStorage.getItem("scoring-layoutDirection")
+        if (savedLayoutDirection) {
+          setLayoutDirection(JSON.parse(savedLayoutDirection))
         }
       } catch (error) {
         console.error("設定の読み込みに失敗しました:", error)
@@ -49,12 +58,19 @@ export function useScoringSettings() {
     localStorage.setItem("scoring-showStudentNames", JSON.stringify(value))
   }
 
+  const saveLayoutDirection = (value: LayoutDirection) => {
+    setLayoutDirection(value)
+    localStorage.setItem("scoring-layoutDirection", JSON.stringify(value))
+  }
+
   return {
     itemsPerLine,
     autoScroll,
     showStudentNames,
+    layoutDirection,
     setItemsPerLine: saveItemsPerLine,
     setAutoScroll: saveAutoScroll,
     setShowStudentNames: saveShowStudentNames,
+    setLayoutDirection: saveLayoutDirection,
   }
 }


### PR DESCRIPTION
## Summary
- 列レイアウト（下→右、下→左）の表示高さ問題を修正
- コンテナサイズからセル高さを明示的に計算する方式に変更
- layoutDirectionをlocalStorageに保存

## Changes
- AnswerGridView: ResizeObserverでコンテナサイズ監視、セル高さ計算
- GridCell: 計算済みセル高さを適用
- CroppedAnswerImage: Canvas のピクセルバッファサイズとCSS表示サイズを一致
- useScoringSettings: layoutDirection の localStorage 保存機能追加
- グリッドレイアウトデバッグ用テストページを追加

## Test plan
- [ ] 行レイアウト（右→下、左→下）で1-10件表示が正常動作
- [ ] 列レイアウト（下→右、下→左）で1-10件表示が正常動作
- [ ] layoutDirectionがリロード後も保持される
- [ ] itemsPerLineの変更が即座に反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)