### PR TITLE
操作パネルのpadding削減とSeparator区切りに変更

### DIFF
--- a/components/projects/07-score-at-once/ScoringSidePanel/QuestionNavigator.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/QuestionNavigator.tsx
@@ -75,7 +75,7 @@ export default function QuestionNavigator({
     <TooltipProvider delayDuration={300}>
       <SidePanelSection icon={FileText} title="設問">
         {/* ナビゲーション: [前] [設問プルダウン] [次] */}
-        <div className="mb-4 flex items-center gap-2">
+        <div className="flex items-center gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -173,7 +173,7 @@ export default function QuestionNavigator({
         </div>
 
         {/* 設問一覧（サムネイル表示） */}
-        <div className="mt-4 border-t pt-4">
+        <div className="mt-3 border-t border-gray-100 pt-3">
           <div className="mb-2 text-xs text-gray-500">
             設問一覧（クリックで移動）
           </div>

--- a/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -11,6 +11,7 @@ import type {
   LayoutDirection,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
+import { Separator } from "@/components/ui/separator"
 
 interface ScoringSidePanelProps {
   projectId: string
@@ -104,7 +105,7 @@ export function ScoringSidePanel({
   onScoringBehaviorChange,
 }: ScoringSidePanelProps) {
   return (
-    <div className="w-96 overflow-y-auto border-l border-gray-200 bg-gray-50 p-4">
+    <div className="w-96 overflow-y-auto border-l border-gray-200 bg-white px-4">
       {/* 設問ナビゲーター */}
       <QuestionNavigator
         questionRegions={cropRegions}
@@ -114,6 +115,8 @@ export function ScoringSidePanel({
         onNextQuestion={onNextQuestion}
         questionProgress={questionProgress}
       />
+
+      <Separator />
 
       {/* 採点ツールバー */}
       <ScoringToolbar
@@ -134,15 +137,20 @@ export function ScoringSidePanel({
         onStudentChange &&
         onScoringBehaviorChange &&
         scoringBehavior && (
-          <IndividualModePanel
-            students={students}
-            selectedAnswers={selectedPageImageIds}
-            pageImages={pageImages}
-            onStudentChange={onStudentChange}
-            scoringBehavior={scoringBehavior}
-            onScoringBehaviorChange={onScoringBehaviorChange}
-          />
+          <>
+            <Separator />
+            <IndividualModePanel
+              students={students}
+              selectedAnswers={selectedPageImageIds}
+              pageImages={pageImages}
+              onStudentChange={onStudentChange}
+              scoringBehavior={scoringBehavior}
+              onScoringBehaviorChange={onScoringBehaviorChange}
+            />
+          </>
         )}
+
+      <Separator />
 
       {/* ナビゲーション制御 */}
       <NavigationControls
@@ -160,8 +168,12 @@ export function ScoringSidePanel({
         gradingMode={gradingMode}
       />
 
+      <Separator />
+
       {/* プロジェクト進捗 */}
-      <ProjectProgressCard projectId={projectId} />
+      <div className="py-3">
+        <ProjectProgressCard projectId={projectId} />
+      </div>
     </div>
   )
 }

--- a/components/projects/07-score-at-once/ScoringSidePanel/SidePanelSection.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/SidePanelSection.tsx
@@ -9,13 +9,12 @@ interface SidePanelSectionProps {
   title: string
   badge?: string | number
   rightElement?: ReactNode
-  
+
   // セクション内容
   children: ReactNode
-  
+
   // スタイル設定
   className?: string
-  spacing?: "normal" | "compact" // 間隔設定
 }
 
 /**
@@ -29,12 +28,9 @@ export function SidePanelSection({
   rightElement,
   children,
   className = "",
-  spacing = "normal",
 }: SidePanelSectionProps) {
-  const spacingClass = spacing === "compact" ? "mb-2" : "mb-4"
-  
   return (
-    <div className={`bg-white p-4 ${spacingClass} ${className}`}>
+    <div className={`py-3 ${className}`}>
       {/* セクションヘッダー（統一スタイル） */}
       <div className="mb-2 flex items-center gap-2">
         <Icon className="h-4 w-4 text-gray-500" />


### PR DESCRIPTION
## Summary
- 操作パネルのpaddingを削減し、よりコンパクトな表示に変更
- パネル間の区切りをmargin-bottomからSeparatorコンポーネントに変更

## Changes
- **SidePanelSection**: `p-4` → `py-3` に変更、`bg-white`削除、`margin-bottom`削除
- **ScoringSidePanel**: 各セクション間に`<Separator />`を追加、背景を`bg-white`に統一
- **QuestionNavigator**: 設問一覧の区切り線のpaddingを縮小

## Test plan
- [ ] 一括採点画面のサイドパネルが正常に表示される
- [ ] 各セクション間がSeparatorで区切られている
- [ ] paddingが適切に縮小されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)