### PR TITLE
生徒詳細ページの試験成績表示と所属学級判定の修正

### DIFF
--- a/app/classes/[classId]/page.tsx
+++ b/app/classes/[classId]/page.tsx
@@ -63,6 +63,12 @@ export default function ClassDetailPage() {
     router.push("/classes")
   }
 
+  // 現在所属中かどうかを判定するヘルパー関数
+  const isCurrentMembership = (m: { endDate?: Date | null }) => {
+    if (!m.endDate) return true
+    return new Date(m.endDate) >= new Date()
+  }
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -262,7 +268,7 @@ export default function ClassDetailPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {classData.memberships.filter((m) => !m.endDate).length}
+              {classData.memberships.filter((m) => isCurrentMembership(m)).length}
             </div>
           </CardContent>
         </Card>
@@ -275,7 +281,7 @@ export default function ClassDetailPage() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-gray-600">
-              {classData.memberships.filter((m) => m.endDate).length}
+              {classData.memberships.filter((m) => !isCurrentMembership(m)).length}
             </div>
           </CardContent>
         </Card>

--- a/app/students/[studentId]/components/current-memberships-card.tsx
+++ b/app/students/[studentId]/components/current-memberships-card.tsx
@@ -22,7 +22,10 @@ export function CurrentMembershipsCard({
   onEditMembership,
   onEndMembership,
 }: CurrentMembershipsCardProps) {
-  const currentMemberships = student.memberships.filter((m) => !m.endDate)
+  const now = new Date()
+  const currentMemberships = student.memberships.filter(
+    (m) => !m.endDate || new Date(m.endDate) >= now,
+  )
 
   return (
     <Card className="mb-6">

--- a/app/students/[studentId]/components/exam-results-card.tsx
+++ b/app/students/[studentId]/components/exam-results-card.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { ClipboardList } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+interface ExamResult {
+  projectId: string
+  examName: string
+  examDate: Date | null
+  subject: string | null
+  totalScore: number
+  maxScore: number
+  scoredCount: number
+  totalQuestions: number
+  status: "complete" | "partial" | "unscored"
+}
+
+interface ExamResultsCardProps {
+  studentId: string
+}
+
+export function ExamResultsCard({ studentId }: ExamResultsCardProps) {
+  const router = useRouter()
+  const [results, setResults] = useState<ExamResult[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      try {
+        const data = await window.electronAPI.getStudentExamResults(studentId)
+        setResults(data)
+      } catch (error) {
+        console.error("Failed to fetch exam results:", error)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchResults()
+  }, [studentId])
+
+  const formatDate = (date: Date | null) => {
+    if (!date) return "-"
+    return new Date(date).toLocaleDateString("ja-JP")
+  }
+
+  const getStatusBadge = (result: ExamResult) => {
+    if (result.status === "complete") {
+      return <Badge className="bg-green-500">採点完了</Badge>
+    } else if (result.status === "partial") {
+      return (
+        <Badge variant="outline" className="border-yellow-500 text-yellow-600">
+          採点中 ({result.scoredCount}/{result.totalQuestions})
+        </Badge>
+      )
+    }
+    return (
+      <Badge variant="secondary">
+        未採点
+      </Badge>
+    )
+  }
+
+  const getScoreDisplay = (result: ExamResult) => {
+    if (result.status === "unscored") {
+      return <span className="text-muted-foreground">-</span>
+    }
+    const percentage =
+      result.maxScore > 0
+        ? Math.round((result.totalScore / result.maxScore) * 100)
+        : 0
+    return (
+      <div className="flex items-center gap-2">
+        <span className="font-medium">
+          {result.totalScore} / {result.maxScore}
+        </span>
+        <span className="text-muted-foreground text-sm">({percentage}%)</span>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ClipboardList className="h-5 w-5" />
+            試験成績
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground py-4 text-center">
+            読み込み中...
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ClipboardList className="h-5 w-5" />
+          試験成績 ({results.length}件)
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {results.length > 0 ? (
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>試験名</TableHead>
+                  <TableHead>教科</TableHead>
+                  <TableHead>実施日</TableHead>
+                  <TableHead>得点</TableHead>
+                  <TableHead>状態</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.map((result) => (
+                  <TableRow
+                    key={result.projectId}
+                    className="hover:bg-muted/50 cursor-pointer"
+                    onClick={() =>
+                      router.push(`/projects/${result.projectId}/07-score-at-once`)
+                    }
+                  >
+                    <TableCell className="font-medium">
+                      {result.examName}
+                    </TableCell>
+                    <TableCell>{result.subject || "-"}</TableCell>
+                    <TableCell>{formatDate(result.examDate)}</TableCell>
+                    <TableCell>{getScoreDisplay(result)}</TableCell>
+                    <TableCell>{getStatusBadge(result)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <div className="text-muted-foreground py-8 text-center">
+            <ClipboardList className="mx-auto mb-2 h-12 w-12 opacity-50" />
+            <p>試験の記録がありません</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/students/[studentId]/page.tsx
+++ b/app/students/[studentId]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { CurrentMembershipsCard } from "@/app/students/[studentId]/components/current-memberships-card"
+import { ExamResultsCard } from "@/app/students/[studentId]/components/exam-results-card"
 import {
   LoadingState,
   StudentNotFoundState,
@@ -86,6 +87,8 @@ export default function StudentDetailPage() {
         onEditStudent={handleEditStudentClick}
         onDeleteStudent={handleDeleteStudent}
       />
+
+      <ExamResultsCard studentId={studentId} />
 
       <CurrentMembershipsCard
         student={student}

--- a/components/class/ClassManagementTable.tsx
+++ b/components/class/ClassManagementTable.tsx
@@ -2,13 +2,7 @@
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
 import {
   Table,
   TableBody,
@@ -17,17 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import {
-  BookOpen,
-  Calendar,
-  Edit,
-  GraduationCap,
-  Info,
-  PlusCircle,
-  Search,
-  Trash2,
-  Users,
-} from "lucide-react"
+import { Edit, PlusCircle, Search, Trash2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
@@ -150,182 +134,108 @@ export default function ClassManagementTable() {
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header with Help */}
-      <div className="mb-6 flex items-center gap-2">
-        <h1 className="text-3xl font-bold">学級管理</h1>
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <Info className="h-4 w-4" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[450px]" align="start" side="bottom">
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <GraduationCap className="h-5 w-5 text-purple-600" />
-                  <h3 className="text-base font-semibold">学級管理について</h3>
-                </div>
-                <p className="text-muted-foreground pl-7 text-sm">
-                  学級やクラスの情報を管理し、生徒を組織化します。
-                </p>
-              </div>
-
-              <div className="space-y-3 pl-7">
-                <div className="rounded-lg border border-purple-200 bg-purple-50 p-3 text-sm text-purple-800">
-                  <strong>柔軟な学級設計</strong>
-                  <br />
-                  様々なタイプの学級を作成できます：
-                  <ul className="mt-2 list-disc space-y-1 pl-5">
-                    <li>ホームルーム（例：1年A組）</li>
-                    <li>習熟度別クラス（例：英語E1）</li>
-                    <li>特別活動クラブ（例：吹奏楽部）</li>
-                    <li>選択授業（例：物理選択）</li>
-                  </ul>
-                </div>
-
-                <div className="space-y-2">
-                  <p className="text-sm font-medium">管理項目：</p>
-                  <div className="grid grid-cols-2 gap-2 text-sm">
-                    <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4 text-blue-600" />
-                      <span>所属生徒数</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Calendar className="h-4 w-4 text-green-600" />
-                      <span>所属期間</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <BookOpen className="h-4 w-4 text-orange-600" />
-                      <span>学級コード</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Edit className="h-4 w-4 text-purple-600" />
-                      <span>説明・備考</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-                  <strong>便利な機能:</strong> 生徒は複数の学級に所属可能で、
-                  所属期間も管理できるため、年度途中のクラス変更にも対応します。
-                </div>
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
+    <div className="flex h-full flex-col gap-4">
+      {/* Controls */}
+      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-3">
+        <div className="bg-muted/30 flex flex-wrap items-center gap-3 rounded-lg p-3">
+          <div className="flex items-center gap-2">
+            <Search className="text-muted-foreground h-4 w-4" />
+            <Input
+              placeholder="学級名で検索"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-60"
+            />
+          </div>
+          <span className="text-muted-foreground text-sm">
+            {filteredClasses.length}学級
+          </span>
+        </div>
+        <Button onClick={handleAddNewClass} size="sm">
+          <PlusCircle className="mr-2 h-4 w-4" />
+          学級追加
+        </Button>
       </div>
 
-      {/* Classes List */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="mb-3 flex items-center justify-between">
-            <CardTitle className="flex items-center gap-2">
-              <BookOpen className="h-5 w-5" />
-              学級一覧 ({filteredClasses.length}学級)
-            </CardTitle>
-            <Button onClick={handleAddNewClass} size="sm">
-              <PlusCircle className="mr-2 h-4 w-4" />
-              学級追加
-            </Button>
-          </div>
-          {/* Search Controls */}
-          <div className="bg-muted/30 flex items-center gap-3 rounded-lg p-3">
-            <div className="flex items-center gap-2">
-              <Search className="text-muted-foreground h-4 w-4" />
-              <Input
-                placeholder="学級名で検索"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-60"
-              />
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <div className="max-h-[500px] overflow-auto rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>学級名・コード</TableHead>
-                  <TableHead>学年</TableHead>
-                  <TableHead>説明</TableHead>
-                  <TableHead>現在の所属数</TableHead>
-                  <TableHead className="text-right">操作</TableHead>
+      {/* Classes Table */}
+      <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>学級名・コード</TableHead>
+              <TableHead>学年</TableHead>
+              <TableHead>説明</TableHead>
+              <TableHead>現在の所属数</TableHead>
+              <TableHead className="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredClasses.map((classItem) => {
+              const sortedClass = getClassWithSortedStudents(classItem)
+              return (
+                <TableRow
+                  key={classItem.id}
+                  onClick={() => router.push(`/classes/${classItem.id}`)}
+                  className="hover:bg-muted/50 cursor-pointer"
+                >
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <span>{classItem.name}</span>
+                      {classItem.classCode && (
+                        <Badge variant="outline" className="text-xs">
+                          {classItem.classCode}
+                        </Badge>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell>{classItem.grade || "未設定"}</TableCell>
+                  <TableCell>
+                    {classItem.description ? (
+                      <span className="text-sm">{classItem.description}</span>
+                    ) : (
+                      <span className="text-muted-foreground text-sm">
+                        なし
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell>{sortedClass.memberships.length}名</TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleEditClass(classItem)
+                        }}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleDeleteClass(classItem.id)
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4 text-red-500" />
+                      </Button>
+                    </div>
+                  </TableCell>
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredClasses.map((classItem) => {
-                  const sortedClass = getClassWithSortedStudents(classItem)
-                  return (
-                    <TableRow
-                      key={classItem.id}
-                      onClick={() => router.push(`/classes/${classItem.id}`)}
-                      className="hover:bg-muted/50 cursor-pointer"
-                    >
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <span>{classItem.name}</span>
-                          {classItem.classCode && (
-                            <Badge variant="outline" className="text-xs">
-                              {classItem.classCode}
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>{classItem.grade || "未設定"}</TableCell>
-                      <TableCell>
-                        {classItem.description ? (
-                          <span className="text-sm">
-                            {classItem.description}
-                          </span>
-                        ) : (
-                          <span className="text-muted-foreground text-sm">
-                            なし
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell>{sortedClass.memberships.length}名</TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex gap-1">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleEditClass(classItem)
-                            }}
-                          >
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              handleDeleteClass(classItem.id)
-                            }}
-                          >
-                            <Trash2 className="h-4 w-4 text-red-500" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-                {filteredClasses.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center">
-                      該当する学級が見つかりません。
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
+              )
+            })}
+            {filteredClasses.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center">
+                  該当する学級が見つかりません。
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
       {/* Modals */}
       {isClassModalOpen && (

--- a/components/class/MembershipTable.tsx
+++ b/components/class/MembershipTable.tsx
@@ -30,13 +30,22 @@ export default function MembershipTable({
   onBulkDelete,
 }: MembershipTableProps) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  // 現在所属中かどうかを判定するヘルパー関数
+  const isCurrentMembership = (m: { endDate?: Date | null }) => {
+    if (!m.endDate) return true
+    return new Date(m.endDate) >= new Date()
+  }
+
   // すべての所属を現在の所属を優先してソート
   const sortedMemberships = memberships
     .sort((a, b) => {
-      // 現在の所属（endDateがnull）を先に表示
-      if (!a.endDate && b.endDate) return -1
-      if (a.endDate && !b.endDate) return 1
-      
+      // 現在の所属を先に表示
+      const aIsCurrent = isCurrentMembership(a)
+      const bIsCurrent = isCurrentMembership(b)
+      if (aIsCurrent && !bIsCurrent) return -1
+      if (!aIsCurrent && bIsCurrent) return 1
+
       // 両方とも現在の所属または両方とも終了した所属の場合、出席番号順
       if (a.attendanceNumber && b.attendanceNumber) {
         return a.attendanceNumber - b.attendanceNumber
@@ -138,12 +147,12 @@ export default function MembershipTable({
                         <div className="flex items-center gap-2">
                           {membership.student.lastName}{" "}
                           {membership.student.firstName}
-                          {!membership.endDate && (
+                          {isCurrentMembership(membership) && (
                             <Badge variant="default" className="text-xs">
                               在籍中
                             </Badge>
                           )}
-                          {membership.endDate && (
+                          {!isCurrentMembership(membership) && (
                             <Badge variant="secondary" className="text-xs">
                               終了
                             </Badge>

--- a/components/student/StudentMembershipTimeline.tsx
+++ b/components/student/StudentMembershipTimeline.tsx
@@ -66,10 +66,16 @@ export default function StudentMembershipTimeline({
     )
   }
 
+  // 現在所属中かどうかを判定するヘルパー関数
+  const isCurrentMembership = (m: { endDate?: Date | null }) => {
+    if (!m.endDate) return true
+    return new Date(m.endDate) >= new Date()
+  }
+
   return (
     <div className="space-y-4">
       {sortedMemberships.map((membership, index) => {
-        const isActive = !membership.endDate
+        const isActive = isCurrentMembership(membership)
         const duration = membership.endDate
           ? `${formatDate(new Date(membership.startDate))} - ${formatDate(new Date(membership.endDate))}`
           : `${formatDate(new Date(membership.startDate))} - 現在`

--- a/components/student/StudentTable.tsx
+++ b/components/student/StudentTable.tsx
@@ -2,13 +2,7 @@
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
 import {
   Select,
   SelectContent,
@@ -24,22 +18,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { StudentData } from "@/types/common.types"
-import {
-  Edit,
-  Info,
-  PlusCircle,
-  Search,
-  Trash2,
-  Upload,
-  Users,
-} from "lucide-react"
+import { Edit, PlusCircle, Search, Trash2, Upload } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 
@@ -128,6 +108,12 @@ export default function StudentTable() {
     fetchData()
   }, [])
 
+  // 現在所属中かどうかを判定するヘルパー関数
+  const isCurrentMembership = (m: { endDate?: Date | null }) => {
+    if (!m.endDate) return true
+    return new Date(m.endDate) >= new Date()
+  }
+
   // Filter and sort students
   const filteredStudents = students
     .filter((student) => {
@@ -140,18 +126,20 @@ export default function StudentTable() {
 
       if (filterClassId !== "all") {
         const belongsToClass = student.memberships.some(
-          (m) => m.class.id === filterClassId && !m.endDate,
+          (m) => m.class.id === filterClassId && isCurrentMembership(m),
         )
         if (!belongsToClass) return false
       }
 
       if (filterMembershipStatus === "current") {
-        return matchesSearch && student.memberships.some((m) => !m.endDate)
+        return (
+          matchesSearch && student.memberships.some((m) => isCurrentMembership(m))
+        )
       } else if (filterMembershipStatus === "past") {
         return (
           matchesSearch &&
           student.memberships.length > 0 &&
-          student.memberships.every((m) => m.endDate)
+          student.memberships.every((m) => !isCurrentMembership(m))
         )
       } else if (filterMembershipStatus === "unassigned") {
         return matchesSearch && student.memberships.length === 0
@@ -226,248 +214,163 @@ export default function StudentTable() {
   // Get current classes for display
   const getCurrentClasses = (student: StudentWithMemberships) => {
     return student.memberships
-      .filter((m) => !m.endDate)
+      .filter((m) => isCurrentMembership(m))
       .map((m) => ({
         name: m.class.name,
       }))
   }
 
   return (
-    <TooltipProvider>
-      <div className="space-y-6">
-        {/* Header with Help */}
-        <div className="mb-6 flex items-center gap-2">
-          <h1 className="text-3xl font-bold">生徒管理</h1>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <Info className="h-4 w-4" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-[450px]" align="start" side="bottom">
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Users className="h-5 w-5 text-blue-600" />
-                    <h3 className="text-base font-semibold">
-                      生徒管理について
-                    </h3>
-                  </div>
-                  <p className="text-muted-foreground pl-7 text-sm">
-                    生徒の基本情報と学級所属状況を一元管理できます。
-                  </p>
-                </div>
-
-                <div className="space-y-3 pl-7">
-                  <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-                    <strong>複数学級対応システム</strong>
-                    <br />
-                    生徒は同時に複数のクラスに所属できます。
-                    <ul className="mt-2 list-disc space-y-1 pl-5">
-                      <li>ホームルーム：1年A組</li>
-                      <li>英語：E1クラス（習熟度別）</li>
-                      <li>数学：M2クラス（習熟度別）</li>
-                    </ul>
-                  </div>
-
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium">主な機能：</p>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div className="flex items-center gap-2">
-                        <PlusCircle className="h-4 w-4 text-green-600" />
-                        <span>個別追加</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Upload className="h-4 w-4 text-blue-600" />
-                        <span>一括インポート</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Edit className="h-4 w-4 text-orange-600" />
-                        <span>情報編集</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Trash2 className="h-4 w-4 text-red-600" />
-                        <span>削除</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="rounded-lg border border-orange-200 bg-orange-50 p-3 text-sm text-orange-800">
-                    <strong>ヒント:</strong>{" "}
-                    行をクリックすると生徒の詳細ページへ移動します。
-                    所属履歴の確認や編集が可能です。
-                  </div>
-                </div>
-              </div>
-            </PopoverContent>
-          </Popover>
+    <div className="flex h-full flex-col gap-4">
+        {/* Controls */}
+        <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-3">
+          <div className="bg-muted/30 flex flex-wrap items-center gap-3 rounded-lg p-3">
+            <div className="flex items-center gap-2">
+              <Search className="text-muted-foreground h-4 w-4" />
+              <Input
+                placeholder="生徒名・学籍番号で検索"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-60"
+              />
+            </div>
+            <Select value={filterClassId} onValueChange={setFilterClassId}>
+              <SelectTrigger className="w-44">
+                <SelectValue placeholder="学級フィルタ" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべての学級</SelectItem>
+                {classes
+                  .filter((c) => c.isVisible !== false)
+                  .sort((a, b) => a.name.localeCompare(b.name))
+                  .map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={filterMembershipStatus}
+              onValueChange={setFilterMembershipStatus}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder="所属状況" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべて</SelectItem>
+                <SelectItem value="current">現在所属中</SelectItem>
+                <SelectItem value="past">過去の所属</SelectItem>
+                <SelectItem value="unassigned">未所属</SelectItem>
+              </SelectContent>
+            </Select>
+            <span className="text-muted-foreground text-sm">
+              {filteredStudents.length}名
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              onClick={handleAddNewStudent}
+              size="sm"
+              variant="outline"
+            >
+              <PlusCircle className="mr-2 h-4 w-4" />
+              生徒追加
+            </Button>
+            <Button
+              onClick={() => setIsSpreadsheetImportModalOpen(true)}
+              size="sm"
+            >
+              <Upload className="mr-2 h-4 w-4" />
+              表形式インポート
+            </Button>
+          </div>
         </div>
-        {/* Students List */}
-        <Card>
-          <CardHeader className="pb-3">
-            <div className="mb-3 flex items-center justify-between">
-              <CardTitle className="flex items-center gap-2">
-                <Users className="h-5 w-5" />
-                生徒一覧 ({filteredStudents.length}名)
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="text-muted-foreground h-4 w-4" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-sm">
-                    <p>生徒は名前順に表示されます。</p>
-                    <p className="mt-1">
-                      特定の学級でフィルタすると、その学級での生徒のみが表示されます。
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </CardTitle>
-              <div className="flex gap-2">
-                <Button
-                  onClick={handleAddNewStudent}
-                  size="sm"
-                  variant="outline"
-                >
-                  <PlusCircle className="mr-2 h-4 w-4" />
-                  生徒追加
-                </Button>
-                <Button
-                  onClick={() => setIsSpreadsheetImportModalOpen(true)}
-                  size="sm"
-                >
-                  <Upload className="mr-2 h-4 w-4" />
-                  表形式インポート
-                </Button>
-              </div>
-            </div>
-            {/* Search and Filter Controls */}
-            <div className="bg-muted/30 flex flex-wrap items-center gap-3 rounded-lg p-3">
-              <div className="flex items-center gap-2">
-                <Search className="text-muted-foreground h-4 w-4" />
-                <Input
-                  placeholder="生徒名・学籍番号で検索"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-60"
-                />
-              </div>
-              <Select value={filterClassId} onValueChange={setFilterClassId}>
-                <SelectTrigger className="w-44">
-                  <SelectValue placeholder="学級フィルタ" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">すべての学級</SelectItem>
-                  {classes
-                    .filter((c) => c.isVisible !== false)
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((c) => (
-                      <SelectItem key={c.id} value={c.id}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
-              <Select
-                value={filterMembershipStatus}
-                onValueChange={setFilterMembershipStatus}
-              >
-                <SelectTrigger className="w-36">
-                  <SelectValue placeholder="所属状況" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">すべて</SelectItem>
-                  <SelectItem value="current">現在所属中</SelectItem>
-                  <SelectItem value="past">過去の所属</SelectItem>
-                  <SelectItem value="unassigned">未所属</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <div className="max-h-[500px] overflow-auto rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>学籍番号</TableHead>
-                    <TableHead>氏名</TableHead>
-                    <TableHead>入学年度</TableHead>
-                    <TableHead>所属学級</TableHead>
-                    <TableHead className="text-right">操作</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredStudents.map((student) => {
-                    const currentClasses = getCurrentClasses(student)
 
-                    return (
-                      <TableRow
-                        key={student.id}
-                        onClick={() => router.push(`/students/${student.id}`)}
-                        className="hover:bg-muted/50 cursor-pointer"
-                      >
-                        <TableCell>{student.studentId}</TableCell>
-                        <TableCell>
-                          {student.lastName} {student.firstName}
-                        </TableCell>
-                        <TableCell>
-                          {student.enrollmentYear || "未設定"}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex flex-wrap gap-1">
-                            {currentClasses.map((cls, idx) => (
-                              <Badge
-                                key={idx}
-                                variant="secondary"
-                                className="text-xs"
-                              >
-                                {cls.name}
-                              </Badge>
-                            ))}
-                            {currentClasses.length === 0 && (
-                              <span className="text-muted-foreground text-sm">
-                                未所属
-                              </span>
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex justify-end gap-1">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                handleEditStudent(student)
-                              }}
-                            >
-                              <Edit className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                handleDeleteStudent(student.id)
-                              }}
-                            >
-                              <Trash2 className="h-4 w-4 text-red-500" />
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                  {filteredStudents.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={5} className="text-center">
-                        該当する生徒が見つかりません。
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
+        {/* Students Table */}
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>学籍番号</TableHead>
+                <TableHead>氏名</TableHead>
+                <TableHead>入学年度</TableHead>
+                <TableHead>所属学級</TableHead>
+                <TableHead className="text-right">操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredStudents.map((student) => {
+                const currentClasses = getCurrentClasses(student)
+
+                return (
+                  <TableRow
+                    key={student.id}
+                    onClick={() => router.push(`/students/${student.id}`)}
+                    className="hover:bg-muted/50 cursor-pointer"
+                  >
+                    <TableCell>{student.studentId}</TableCell>
+                    <TableCell>
+                      {student.lastName} {student.firstName}
+                    </TableCell>
+                    <TableCell>
+                      {student.enrollmentYear || "未設定"}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {currentClasses.map((cls, idx) => (
+                          <Badge
+                            key={idx}
+                            variant="secondary"
+                            className="text-xs"
+                          >
+                            {cls.name}
+                          </Badge>
+                        ))}
+                        {currentClasses.length === 0 && (
+                          <span className="text-muted-foreground text-sm">
+                            未所属
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleEditStudent(student)
+                          }}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleDeleteStudent(student.id)
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4 text-red-500" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+              {filteredStudents.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center">
+                    該当する生徒が見つかりません。
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
 
         {/* Modals */}
         {isStudentModalOpen && (
@@ -489,7 +392,6 @@ export default function StudentTable() {
             existingClasses={classes}
           />
         )}
-      </div>
-    </TooltipProvider>
+    </div>
   )
 }

--- a/electron-src/ipc-handlers/student-handlers.ts
+++ b/electron-src/ipc-handlers/student-handlers.ts
@@ -5,6 +5,7 @@ import {
   createStudent,
   updateStudent,
   deleteStudent,
+  getStudentExamResults,
 } from "../lib/prisma/student"
 import {
   getStudentsForProject,
@@ -309,6 +310,18 @@ export function setupStudentHandlers(): void {
         return await updateStudentOrders(projectId, studentOrders)
       } catch (err) {
         console.error("Error updating student orders:", err)
+        throw err
+      }
+    },
+  )
+
+  ipcMain.handle(
+    "get-student-exam-results",
+    async (_event, studentId: string) => {
+      try {
+        return await getStudentExamResults(studentId)
+      } catch (err) {
+        console.error("Error getting student exam results:", err)
         throw err
       }
     },

--- a/electron-src/lib/prisma/student.ts
+++ b/electron-src/lib/prisma/student.ts
@@ -208,5 +208,107 @@ export const deleteClass = async (id: string): Promise<void> => {
 }
 
 
+// 生徒の試験成績を取得
+export interface StudentExamResult {
+  projectId: string
+  examName: string
+  examDate: Date | null
+  subject: string | null
+  totalScore: number
+  maxScore: number
+  scoredCount: number
+  totalQuestions: number
+  status: "complete" | "partial" | "unscored"
+}
+
+export const getStudentExamResults = async (
+  studentId: string,
+): Promise<StudentExamResult[]> => {
+  try {
+    // 生徒が参加しているプロジェクトを取得
+    const projectStudents = await prisma.projectStudent.findMany({
+      where: { studentId },
+      include: {
+        project: {
+          include: {
+            projectPages: {
+              include: {
+                cropRegions: {
+                  where: { type: "QUESTION_ANSWER" },
+                  include: {
+                    questionScores: {
+                      where: { studentId },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const results: StudentExamResult[] = []
+
+    for (const ps of projectStudents) {
+      const project = ps.project
+      let totalScore = 0
+      let maxScore = 0
+      let scoredCount = 0
+      let totalQuestions = 0
+
+      for (const page of project.projectPages) {
+        for (const region of page.cropRegions) {
+          totalQuestions++
+          maxScore += region.points || 0
+
+          const score = region.questionScores[0]
+          if (score && score.status !== "unscored") {
+            scoredCount++
+            if (score.status === "correct") {
+              totalScore += region.points || 0
+            } else if (score.status === "partial" && score.partialScore) {
+              totalScore += Number(score.partialScore)
+            }
+            // incorrect の場合は 0 点
+          }
+        }
+      }
+
+      let status: "complete" | "partial" | "unscored" = "unscored"
+      if (scoredCount === totalQuestions && totalQuestions > 0) {
+        status = "complete"
+      } else if (scoredCount > 0) {
+        status = "partial"
+      }
+
+      results.push({
+        projectId: project.id,
+        examName: project.examName,
+        examDate: project.examDate,
+        subject: project.subject,
+        totalScore,
+        maxScore,
+        scoredCount,
+        totalQuestions,
+        status,
+      })
+    }
+
+    // 試験日の降順でソート
+    results.sort((a, b) => {
+      if (!a.examDate && !b.examDate) return 0
+      if (!a.examDate) return 1
+      if (!b.examDate) return -1
+      return new Date(b.examDate).getTime() - new Date(a.examDate).getTime()
+    })
+
+    return results
+  } catch (error) {
+    console.error("Failed to get student exam results:", error)
+    throw error
+  }
+}
+
 // Export the updated types
 export { type ClassWithMemberships, type StudentWithMemberships }

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -158,6 +158,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   updateStudent: (id: string, studentData: Prisma.StudentUpdateInput) =>
     ipcRenderer.invoke("update-student", id, studentData),
   deleteStudent: (id: string) => ipcRenderer.invoke("delete-student", id),
+  getStudentExamResults: (studentId: string) =>
+    ipcRenderer.invoke("get-student-exam-results", studentId),
 
   // Student Class Membership related
   createStudentClassMembership: (

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -134,6 +134,19 @@ type StudentClassMembershipWithDetails =
     }
   }>
 
+// Student exam result type
+interface StudentExamResult {
+  projectId: string
+  examName: string
+  examDate: Date | null
+  subject: string | null
+  totalScore: number
+  maxScore: number
+  scoredCount: number
+  totalQuestions: number
+  status: "complete" | "partial" | "unscored"
+}
+
 // Legacy types for backward compatibility
 type ClassWithStudents = ClassWithMemberships
 type StudentWithClass = StudentWithMemberships
@@ -473,6 +486,7 @@ export interface MyAPI {
     studentData: Prisma.StudentUpdateInput,
   ) => Promise<StudentWithMemberships>
   deleteStudent: (id: string) => Promise<Student | void>
+  getStudentExamResults: (studentId: string) => Promise<StudentExamResult[]>
 
   // Student Class Membership related
   createStudentClassMembership: (


### PR DESCRIPTION
## 概要

Closes #197

生徒詳細ページに試験成績一覧表示を追加し、所属学級の判定ロジックを修正しました。

## 変更内容

### 試験成績表示機能
- `ExamResultsCard` コンポーネントを新規作成
- プロジェクトごとの得点・最大点・採点進捗を表示
- 採点完了（緑）/採点中（黄）/未採点（グレー）のバッジ表示
- 行クリックで採点ページへ遷移

### 所属学級判定の修正
- `endDate` が null または将来日付の場合を「現在の所属」と判定
- 全関連ファイルで統一ロジックを適用

### UI簡素化
- 生徒管理・学級管理ページの不要なCard・タイトルを削除
- flexbox による適切なスクロール対応

## テスト手順

1. 生徒詳細ページを開き、試験成績一覧が表示されることを確認
2. 採点済みプロジェクトで得点が正しく表示されることを確認
3. 所属学級が期間内（endDate >= 今日）の場合に「現在の所属」に表示されることを確認

## スクリーンショット

（必要に応じて追加）