### PR TITLE
試験編集画面のexamDate型エラーを修正

### DIFF
--- a/components/projects/forms/EditProjectWindow.tsx
+++ b/components/projects/forms/EditProjectWindow.tsx
@@ -34,9 +34,13 @@ const EditProjectWindow = ({
   onSave,
 }: EditProjectWindowProps) => {
   const [examName, setExamName] = useState(projectToEdit.examName)
-  const [examDate, setExamDate] = useState<Date | undefined>(
-    projectToEdit.examDate ?? undefined,
-  )
+  const [examDate, setExamDate] = useState<Date | undefined>(() => {
+    if (!projectToEdit.examDate) return undefined
+    // examDateが文字列の場合はDateオブジェクトに変換
+    return projectToEdit.examDate instanceof Date
+      ? projectToEdit.examDate
+      : new Date(projectToEdit.examDate)
+  })
   const [description, setDescription] = useState<string | null>(
     projectToEdit.description ?? null,
   )


### PR DESCRIPTION
## 概要
試験編集画面（EditProjectWindow）を開く際に発生するTypeErrorを修正します。

## 修正内容
- `useState` の初期化時に `examDate` の型チェックを追加
- 文字列の場合は `new Date()` でDateオブジェクトに変換

## 原因
`projectToEdit.examDate` がAPIレスポンスから文字列として渡される場合に、`toISOString()` が呼び出せずエラーが発生していた。

## 変更ファイル
- `components/projects/forms/EditProjectWindow.tsx`

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)