### PR TITLE
複数アノテーション選択時の編集機能を修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable @next/next/no-img-element */
 "use client"
 
+import type { DrawingAnnotation } from "@/types/drawing-annotation.types"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useCommand } from "../hooks/useCommand"
 import { DrawingToolPalette } from "./DrawingToolPalette"
 import { RichTextEditorModalV4 } from "./RichTextEditorModalV4"
 import { ZOOM_SETTINGS } from "./constants/drawing-constants"
-import { useAnswerIndividualEvents } from "./hooks/useAnswerIndividualEvents"
 import { useDrawingState } from "./hooks/core/useDrawingState"
 import { useImageCanvas } from "./hooks/core/useImageCanvas"
 import { useImageNavigation } from "./hooks/navigation/useImageNavigation"
 import { useTextboxV4Integration } from "./hooks/text/useTextboxIntegration"
+import { useAnswerIndividualEvents } from "./hooks/useAnswerIndividualEvents"
 import type { AnswerIndividualViewProps } from "./types/answer-individual-types"
-import type { DrawingAnnotation } from "@/types/drawing-annotation.types"
 
 export default function AnswerIndividualView({
   scoringDatas,
@@ -46,7 +46,9 @@ export default function AnswerIndividualView({
       return null
     }
     const found = questionScores.find(
-      (qs) => qs.studentId === currentStudentId && qs.cropRegionId === currentCropRegion.id
+      (qs) =>
+        qs.studentId === currentStudentId &&
+        qs.cropRegionId === currentCropRegion.id,
     )
     return found?.id ?? null
   }, [questionScores, currentStudentId, currentCropRegion])
@@ -61,12 +63,14 @@ export default function AnswerIndividualView({
       currentStudentId,
       currentCropRegionId: currentCropRegion?.id,
       currentUserId,
-    }
+    },
   )
 
   // 透明度制御用：全設問のアノテーション読み込み
-  const [allStudentAnnotations, setAllStudentAnnotations] = useState<DrawingAnnotation[]>([])
-  
+  const [allStudentAnnotations, setAllStudentAnnotations] = useState<
+    DrawingAnnotation[]
+  >([])
+
   // 現在の学生とプロジェクトの全アノテーションを読み込み（透明度制御用）
   useEffect(() => {
     const loadAllAnnotations = async () => {
@@ -76,35 +80,39 @@ export default function AnswerIndividualView({
       }
 
       try {
-        console.log('🎨 透明度制御: 全設問アノテーション読み込み開始', {
+        console.log("🎨 透明度制御: 全設問アノテーション読み込み開始", {
           studentId: currentStudentId,
-          projectId: currentCropRegion.projectPage.projectId
+          projectId: currentCropRegion.projectPage.projectId,
         })
-        
+
         // ElectronAPIを直接呼び出してフック依存関係を回避
         const result = await window.electronAPI.drawing.getByStudent(
           currentStudentId,
-          currentCropRegion.projectPage.projectId
+          currentCropRegion.projectPage.projectId,
         )
-        
+
         if (result.success && result.data) {
-          console.log('🎨 透明度制御: 読み込み完了', {
+          console.log("🎨 透明度制御: 読み込み完了", {
             annotationCount: result.data.length,
-            currentCropRegionId: currentCropRegion?.id
+            currentCropRegionId: currentCropRegion?.id,
           })
           setAllStudentAnnotations(result.data)
         } else {
-          console.error('全設問アノテーション読み込みエラー:', result.error)
+          console.error("全設問アノテーション読み込みエラー:", result.error)
           setAllStudentAnnotations([])
         }
       } catch (error) {
-        console.error('全設問アノテーション読み込みエラー:', error)
+        console.error("全設問アノテーション読み込みエラー:", error)
         setAllStudentAnnotations([])
       }
     }
 
     loadAllAnnotations()
-  }, [currentStudentId, currentCropRegion?.projectPage?.projectId, currentCropRegion?.id])
+  }, [
+    currentStudentId,
+    currentCropRegion?.projectPage?.projectId,
+    currentCropRegion?.id,
+  ])
 
   // テキスト入力状態変更の通知
   useEffect(() => {
@@ -116,33 +124,41 @@ export default function AnswerIndividualView({
   // currentCropRegionはすでにpropsで渡されている（派生済み）
 
   // 画像とキャンバス管理（透明度制御統合）
-  const { canvasRef, overlayCanvasRef, textCanvasRef, imageRef, containerRef, imageLoaded, loadedImages, textBoundsCache } =
-    useImageCanvas({
-      currentScoringData,
-      currentCropRegion,
-      pageImages,
-      zoom,
-      position,
-      drawingElements: drawingState.drawingElements,
-      currentDrawing: drawingState.currentDrawing,
-      isDrawing: drawingState.isDrawing,
-      isCreatingTextBox: drawingState.isCreatingTextBox,
-      strokeColor: drawingState.strokeColor,
-      strokeWidth: drawingState.strokeWidth,
-      lineStyle: drawingState.lineStyle,
-      isShiftPressed: drawingState.isShiftPressed,
-      selectedElementIds: drawingState.selectedElementIds,
-      isDrawingSelection: drawingState.isDrawingSelection,
-      selectionRectangle: drawingState.selectionRectangle,
-      showMultiplePages,
-      pageSpacing,
-      isDraggingElement: drawingState.isDraggingElement,
-      // 透明度制御用の全アノテーション
-      allAnnotations: allStudentAnnotations,
-      currentCropRegionId: currentCropRegion?.id,
-      // ホバー要素ID（ハンドル表示用）
-      hoveredElementId: drawingState.hoveredElementId,
-    })
+  const {
+    canvasRef,
+    overlayCanvasRef,
+    textCanvasRef,
+    imageRef,
+    containerRef,
+    imageLoaded,
+    loadedImages,
+    textBoundsCache,
+  } = useImageCanvas({
+    currentScoringData,
+    currentCropRegion,
+    pageImages,
+    zoom,
+    position,
+    drawingElements: drawingState.drawingElements,
+    currentDrawing: drawingState.currentDrawing,
+    isDrawing: drawingState.isDrawing,
+    isCreatingTextBox: drawingState.isCreatingTextBox,
+    strokeColor: drawingState.strokeColor,
+    strokeWidth: drawingState.strokeWidth,
+    lineStyle: drawingState.lineStyle,
+    isShiftPressed: drawingState.isShiftPressed,
+    selectedElementIds: drawingState.selectedElementIds,
+    isDrawingSelection: drawingState.isDrawingSelection,
+    selectionRectangle: drawingState.selectionRectangle,
+    showMultiplePages,
+    pageSpacing,
+    isDraggingElement: drawingState.isDraggingElement,
+    // 透明度制御用の全アノテーション
+    allAnnotations: allStudentAnnotations,
+    currentCropRegionId: currentCropRegion?.id,
+    // ホバー要素ID（ハンドル表示用）
+    hoveredElementId: drawingState.hoveredElementId,
+  })
 
   // V4統合フック（画像サイズが確定してから初期化）
   const canvasWidth = loadedImages.length > 0 ? loadedImages[0].width : 800
@@ -529,7 +545,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "画面のパン操作を行います",
       },
-    }
+    },
   )
 
   // 選択ツール
@@ -543,7 +559,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "図形を選択・移動・編集します",
       },
-    }
+    },
   )
 
   // テキストツール
@@ -557,7 +573,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "テキストを追加します",
       },
-    }
+    },
   )
 
   // 線ツール
@@ -571,7 +587,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "直線を描画します",
       },
-    }
+    },
   )
 
   // 矩形ツール
@@ -585,7 +601,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "矩形を描画します",
       },
-    }
+    },
   )
 
   // 楕円ツール
@@ -599,7 +615,7 @@ export default function AnswerIndividualView({
         category: "描画ツール",
         description: "楕円・円を描画します",
       },
-    }
+    },
   )
 
   // 設問変更時に選択設問を画面内で中央寄せ表示（ズームは維持）
@@ -664,9 +680,20 @@ export default function AnswerIndividualView({
       const scrollLeft = Math.max(0, Math.min(idealScrollLeft, maxScrollLeft))
       const scrollTop = Math.max(0, Math.min(idealScrollTop, maxScrollTop))
 
-      container.scrollTo({ left: scrollLeft, top: scrollTop, behavior: "smooth" })
+      container.scrollTo({
+        left: scrollLeft,
+        top: scrollTop,
+        behavior: "smooth",
+      })
     })
-  }, [currentCropRegion?.id, containerRef, imageLoaded, loadedImages, pageSpacing, zoom])
+  }, [
+    currentCropRegion?.id,
+    containerRef,
+    imageLoaded,
+    loadedImages,
+    pageSpacing,
+    zoom,
+  ])
 
   // 採点データが選択されていない場合の早期リターン
   if (!currentScoringData) {
@@ -736,7 +763,7 @@ export default function AnswerIndividualView({
                   )
                 : 600
             }
-            className="absolute left-0 top-0 block"
+            className="absolute top-0 left-0 block"
             style={{
               width:
                 loadedImages.length > 0
@@ -780,7 +807,7 @@ export default function AnswerIndividualView({
                   )
                 : 600
             }
-            className="absolute left-0 top-0 block pointer-events-none"
+            className="pointer-events-none absolute top-0 left-0 block"
             style={{
               width:
                 loadedImages.length > 0
@@ -819,7 +846,7 @@ export default function AnswerIndividualView({
                   )
                 : 600
             }
-            className="absolute left-0 top-0 block pointer-events-none"
+            className="pointer-events-none absolute top-0 left-0 block"
             style={{
               width:
                 loadedImages.length > 0
@@ -872,10 +899,10 @@ export default function AnswerIndividualView({
         onStrokeColorChange={drawingState.setStrokeColor}
         onStrokeWidthChange={drawingState.setStrokeWidth}
         onLineStyleChange={(style) => drawingState.setLineStyle(style as any)}
-        selectedElements={drawingState.drawingElements.filter(el =>
-          drawingState.selectedElementIds.includes(el.id)
+        selectedElements={drawingState.drawingElements.filter((el) =>
+          drawingState.selectedElementIds.includes(el.id),
         )}
-        onUpdateSelectedElement={drawingState.updateDrawingElement}
+        onUpdateSelectedElements={drawingState.updateDrawingElements}
         onClearSelection={drawingState.clearSelection}
       />
 

--- a/components/projects/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
@@ -4,8 +4,8 @@ import type { CropRegionWithProjectPage } from "@/components/projects/07-score-a
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { cn } from "@/lib/utils"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import {
   Crop,
   Hand,
@@ -19,7 +19,10 @@ import { EllipseToolPopover } from "./EllipseToolPopover"
 import { LineToolPopover } from "./LineToolPopover"
 import { RectangleToolPopover } from "./RectangleToolPopover"
 import { TextToolPopover } from "./TextToolPopover"
-import type { DrawingElement, DrawingTool } from "./types/answer-individual-types"
+import type {
+  DrawingElement,
+  DrawingTool,
+} from "./types/answer-individual-types"
 
 const FADE_OUT_DELAY = 3000 // 3秒無操作でフェードアウト
 
@@ -48,7 +51,9 @@ interface DrawingToolPaletteProps {
 
   // 選択中の要素（スタイル編集用）
   selectedElements?: DrawingElement[]
-  onUpdateSelectedElement?: (id: string, updates: Partial<DrawingElement>) => void
+  onUpdateSelectedElements?: (
+    updates: Array<{ id: string; updates: Partial<DrawingElement> }>,
+  ) => void
   onClearSelection?: () => void
 }
 
@@ -68,14 +73,18 @@ export function DrawingToolPalette({
   onStrokeWidthChange,
   onLineStyleChange,
   selectedElements = [],
-  onUpdateSelectedElement,
+  onUpdateSelectedElements,
   onClearSelection,
 }: DrawingToolPaletteProps) {
   // 選択中の各タイプの要素を取得（複数選択対応）
-  const selectedLines = selectedElements.filter(el => el.type === "line")
-  const selectedRectangles = selectedElements.filter(el => el.type === "rectangle")
-  const selectedEllipses = selectedElements.filter(el => el.type === "ellipse")
-  const selectedTexts = selectedElements.filter(el => el.type === "text")
+  const selectedLines = selectedElements.filter((el) => el.type === "line")
+  const selectedRectangles = selectedElements.filter(
+    (el) => el.type === "rectangle",
+  )
+  const selectedEllipses = selectedElements.filter(
+    (el) => el.type === "ellipse",
+  )
+  const selectedTexts = selectedElements.filter((el) => el.type === "text")
 
   // 代表要素（UI表示用に最初の要素を使用）
   const firstLine = selectedLines[0]
@@ -99,81 +108,121 @@ export function DrawingToolPalette({
   // 選択中のテキストがある場合はその色を使用
   const effectiveTextColor = firstText?.color || strokeColor
 
-  // ===== 線用ハンドラ（複数選択対応） =====
-  const handleLineStyleChange = useCallback((style: string) => {
-    if (selectedLines.length > 0 && onUpdateSelectedElement) {
-      selectedLines.forEach(el => {
-        onUpdateSelectedElement(el.id, { lineStyle: style as any })
-      })
-    }
-    onLineStyleChange(style)
-  }, [selectedLines, onUpdateSelectedElement, onLineStyleChange])
+  // ===== 線用ハンドラ（線のみに適用） =====
+  const handleLineColorChange = useCallback(
+    (color: string) => {
+      if (selectedLines.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedLines.map((el) => ({
+          id: el.id,
+          updates: { color },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeColorChange(color)
+    },
+    [selectedLines, onUpdateSelectedElements, onStrokeColorChange],
+  )
 
-  const handleLineColorChange = useCallback((color: string) => {
-    if (selectedLines.length > 0 && onUpdateSelectedElement) {
-      selectedLines.forEach(el => {
-        onUpdateSelectedElement(el.id, { color })
-      })
-    }
-    onStrokeColorChange(color)
-  }, [selectedLines, onUpdateSelectedElement, onStrokeColorChange])
+  const handleLineWidthChange = useCallback(
+    (width: number) => {
+      if (selectedLines.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedLines.map((el) => ({
+          id: el.id,
+          updates: { strokeWidth: width },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeWidthChange(width)
+    },
+    [selectedLines, onUpdateSelectedElements, onStrokeWidthChange],
+  )
 
-  const handleLineWidthChange = useCallback((width: number) => {
-    if (selectedLines.length > 0 && onUpdateSelectedElement) {
-      selectedLines.forEach(el => {
-        onUpdateSelectedElement(el.id, { strokeWidth: width })
-      })
-    }
-    onStrokeWidthChange(width)
-  }, [selectedLines, onUpdateSelectedElement, onStrokeWidthChange])
+  const handleLineStyleChange = useCallback(
+    (style: string) => {
+      if (selectedLines.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedLines.map((el) => ({
+          id: el.id,
+          updates: { lineStyle: style as any },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onLineStyleChange(style)
+    },
+    [selectedLines, onUpdateSelectedElements, onLineStyleChange],
+  )
 
-  // ===== 長方形用ハンドラ（複数選択対応） =====
-  const handleRectColorChange = useCallback((color: string) => {
-    if (selectedRectangles.length > 0 && onUpdateSelectedElement) {
-      selectedRectangles.forEach(el => {
-        onUpdateSelectedElement(el.id, { color })
-      })
-    }
-    onStrokeColorChange(color)
-  }, [selectedRectangles, onUpdateSelectedElement, onStrokeColorChange])
+  // ===== 長方形用ハンドラ（長方形のみに適用） =====
+  const handleRectColorChange = useCallback(
+    (color: string) => {
+      if (selectedRectangles.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedRectangles.map((el) => ({
+          id: el.id,
+          updates: { color },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeColorChange(color)
+    },
+    [selectedRectangles, onUpdateSelectedElements, onStrokeColorChange],
+  )
 
-  const handleRectWidthChange = useCallback((width: number) => {
-    if (selectedRectangles.length > 0 && onUpdateSelectedElement) {
-      selectedRectangles.forEach(el => {
-        onUpdateSelectedElement(el.id, { strokeWidth: width })
-      })
-    }
-    onStrokeWidthChange(width)
-  }, [selectedRectangles, onUpdateSelectedElement, onStrokeWidthChange])
+  const handleRectWidthChange = useCallback(
+    (width: number) => {
+      if (selectedRectangles.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedRectangles.map((el) => ({
+          id: el.id,
+          updates: { strokeWidth: width },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeWidthChange(width)
+    },
+    [selectedRectangles, onUpdateSelectedElements, onStrokeWidthChange],
+  )
 
-  // ===== 楕円用ハンドラ（複数選択対応） =====
-  const handleEllipseColorChange = useCallback((color: string) => {
-    if (selectedEllipses.length > 0 && onUpdateSelectedElement) {
-      selectedEllipses.forEach(el => {
-        onUpdateSelectedElement(el.id, { color })
-      })
-    }
-    onStrokeColorChange(color)
-  }, [selectedEllipses, onUpdateSelectedElement, onStrokeColorChange])
+  // ===== 楕円用ハンドラ（楕円のみに適用） =====
+  const handleEllipseColorChange = useCallback(
+    (color: string) => {
+      if (selectedEllipses.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedEllipses.map((el) => ({
+          id: el.id,
+          updates: { color },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeColorChange(color)
+    },
+    [selectedEllipses, onUpdateSelectedElements, onStrokeColorChange],
+  )
 
-  const handleEllipseWidthChange = useCallback((width: number) => {
-    if (selectedEllipses.length > 0 && onUpdateSelectedElement) {
-      selectedEllipses.forEach(el => {
-        onUpdateSelectedElement(el.id, { strokeWidth: width })
-      })
-    }
-    onStrokeWidthChange(width)
-  }, [selectedEllipses, onUpdateSelectedElement, onStrokeWidthChange])
+  const handleEllipseWidthChange = useCallback(
+    (width: number) => {
+      if (selectedEllipses.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedEllipses.map((el) => ({
+          id: el.id,
+          updates: { strokeWidth: width },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeWidthChange(width)
+    },
+    [selectedEllipses, onUpdateSelectedElements, onStrokeWidthChange],
+  )
 
-  // ===== テキスト用ハンドラ（複数選択対応） =====
-  const handleTextColorChange = useCallback((color: string) => {
-    if (selectedTexts.length > 0 && onUpdateSelectedElement) {
-      selectedTexts.forEach(el => {
-        onUpdateSelectedElement(el.id, { color })
-      })
-    }
-    onStrokeColorChange(color)
-  }, [selectedTexts, onUpdateSelectedElement, onStrokeColorChange])
+  // ===== テキスト用ハンドラ（テキストのみに適用） =====
+  const handleTextColorChange = useCallback(
+    (color: string) => {
+      if (selectedTexts.length > 0 && onUpdateSelectedElements) {
+        const updates = selectedTexts.map((el) => ({
+          id: el.id,
+          updates: { color },
+        }))
+        onUpdateSelectedElements(updates)
+      }
+      onStrokeColorChange(color)
+    },
+    [selectedTexts, onUpdateSelectedElements, onStrokeColorChange],
+  )
   const [isVisible, setIsVisible] = useState(true)
   const [isHovered, setIsHovered] = useState(false)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
@@ -249,14 +298,17 @@ export function DrawingToolPalette({
     "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95",
     "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
     "data-[side=right]:slide-in-from-left-2",
-    "z-50 w-fit rounded-md px-3 py-1.5 text-xs"
+    "z-50 w-fit rounded-md px-3 py-1.5 text-xs",
   )
 
   return (
     <TooltipPrimitive.Provider delayDuration={300} disableHoverableContent>
       <div
         className="absolute top-4 left-4 transition-opacity duration-300"
-        style={{ opacity: isVisible ? 1 : 0, pointerEvents: isVisible ? "auto" : "none" }}
+        style={{
+          opacity: isVisible ? 1 : 0,
+          pointerEvents: isVisible ? "auto" : "none",
+        }}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
@@ -270,7 +322,11 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">拡大</div>
                     <div className="mt-1 text-xs text-gray-400">
@@ -291,7 +347,11 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">縮小</div>
                     <div className="mt-1 text-xs text-gray-400">
@@ -312,7 +372,11 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">全体表示</div>
                     <div className="mt-1 text-xs text-gray-400">
@@ -338,7 +402,11 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">設問表示</div>
                     <div className="mt-1 text-xs text-gray-400">
@@ -367,7 +435,11 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">ハンドツール</div>
                     <div className="text-xs text-gray-400">ドラッグで移動</div>
@@ -387,10 +459,16 @@ export function DrawingToolPalette({
                 </Button>
               </TooltipPrimitive.Trigger>
               <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content side="right" sideOffset={5} className={tooltipContentClass}>
+                <TooltipPrimitive.Content
+                  side="right"
+                  sideOffset={5}
+                  className={tooltipContentClass}
+                >
                   <div className="text-center">
                     <div className="font-medium">選択ツール</div>
-                    <div className="text-xs text-gray-400">図形を選択・移動・削除</div>
+                    <div className="text-xs text-gray-400">
+                      図形を選択・移動・削除
+                    </div>
                   </div>
                 </TooltipPrimitive.Content>
               </TooltipPrimitive.Portal>
@@ -406,7 +484,11 @@ export function DrawingToolPalette({
               onStrokeWidthChange={handleLineWidthChange}
               onLineStyleChange={handleLineStyleChange}
               hasSelectedElement={selectedLines.length > 0}
-              hasOtherTypeSelected={selectedRectangles.length > 0 || selectedEllipses.length > 0 || selectedTexts.length > 0}
+              hasOtherTypeSelected={
+                selectedRectangles.length > 0 ||
+                selectedEllipses.length > 0 ||
+                selectedTexts.length > 0
+              }
               onClearSelection={onClearSelection}
             />
 
@@ -418,7 +500,11 @@ export function DrawingToolPalette({
               onStrokeColorChange={handleRectColorChange}
               onStrokeWidthChange={handleRectWidthChange}
               hasSelectedElement={selectedRectangles.length > 0}
-              hasOtherTypeSelected={selectedLines.length > 0 || selectedEllipses.length > 0 || selectedTexts.length > 0}
+              hasOtherTypeSelected={
+                selectedLines.length > 0 ||
+                selectedEllipses.length > 0 ||
+                selectedTexts.length > 0
+              }
               onClearSelection={onClearSelection}
             />
 
@@ -430,7 +516,11 @@ export function DrawingToolPalette({
               onStrokeColorChange={handleEllipseColorChange}
               onStrokeWidthChange={handleEllipseWidthChange}
               hasSelectedElement={selectedEllipses.length > 0}
-              hasOtherTypeSelected={selectedLines.length > 0 || selectedRectangles.length > 0 || selectedTexts.length > 0}
+              hasOtherTypeSelected={
+                selectedLines.length > 0 ||
+                selectedRectangles.length > 0 ||
+                selectedTexts.length > 0
+              }
               onClearSelection={onClearSelection}
             />
 
@@ -440,10 +530,13 @@ export function DrawingToolPalette({
               textColor={effectiveTextColor}
               onTextColorChange={handleTextColorChange}
               hasSelectedElement={selectedTexts.length > 0}
-              hasOtherTypeSelected={selectedLines.length > 0 || selectedRectangles.length > 0 || selectedEllipses.length > 0}
+              hasOtherTypeSelected={
+                selectedLines.length > 0 ||
+                selectedRectangles.length > 0 ||
+                selectedEllipses.length > 0
+              }
               onClearSelection={onClearSelection}
             />
-
           </div>
         </Card>
       </div>

--- a/components/projects/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
@@ -42,8 +42,8 @@ export function EllipseToolPopover({
     // イベント伝播を停止（キャンバスのクリックハンドラに伝播しないように）
     e.stopPropagation()
 
-    // 他のタイプの要素が選択されている場合は選択を解除
-    if (hasOtherTypeSelected && onClearSelection) {
+    // このタイプの要素が選択されていない場合のみ選択を解除
+    if (!hasSelectedElement && hasOtherTypeSelected && onClearSelection) {
       onClearSelection()
     }
 
@@ -70,7 +70,12 @@ export function EllipseToolPopover({
           size="sm"
           variant={isActive ? "default" : "ghost"}
           onClick={handleClick}
-          title={hasSelectedElement ? "選択中の楕円を編集" : "楕円ツール - Shift+ドラッグで正円"}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={
+            hasSelectedElement
+              ? "選択中の楕円を編集"
+              : "楕円ツール - Shift+ドラッグで正円"
+          }
           style={{
             backgroundColor: isActive ? strokeColor : undefined,
             borderColor: isActive ? strokeColor : undefined,
@@ -89,7 +94,7 @@ export function EllipseToolPopover({
           </h4>
 
           {/* 線幅 */}
-          <div>
+          <div onPointerDown={(e) => e.stopPropagation()}>
             <Label className="text-xs">線幅: {strokeWidth}px</Label>
             <Slider
               min={1}
@@ -108,7 +113,11 @@ export function EllipseToolPopover({
               {COLOR_PALETTE.map((color, index) => (
                 <button
                   key={index}
-                  onClick={() => onStrokeColorChange(color)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onStrokeColorChange(color)
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
                   className={`h-5 w-5 rounded border transition-transform hover:scale-110 ${
                     strokeColor === color
                       ? "border-2 border-gray-800"

--- a/components/projects/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
@@ -47,8 +47,8 @@ export function LineToolPopover({
     // イベント伝播を停止（キャンバスのクリックハンドラに伝播しないように）
     e.stopPropagation()
 
-    // 他のタイプの要素が選択されている場合は選択を解除
-    if (hasOtherTypeSelected && onClearSelection) {
+    // このタイプの要素が選択されていない場合のみ選択を解除
+    if (!hasSelectedElement && hasOtherTypeSelected && onClearSelection) {
       onClearSelection()
     }
 
@@ -75,7 +75,12 @@ export function LineToolPopover({
           size="sm"
           variant={isActive ? "default" : "ghost"}
           onClick={handleClick}
-          title={hasSelectedElement ? "選択中の線を編集" : "自由線ツール - Shift+ドラッグで鉛直・水平線"}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={
+            hasSelectedElement
+              ? "選択中の線を編集"
+              : "自由線ツール - Shift+ドラッグで鉛直・水平線"
+          }
           style={{
             backgroundColor: isActive ? strokeColor : undefined,
             borderColor: isActive ? strokeColor : undefined,
@@ -94,13 +99,16 @@ export function LineToolPopover({
           </h4>
 
           {/* 線種選択 */}
-          <div>
+          <div onPointerDown={(e) => e.stopPropagation()}>
             <Label className="text-xs">線種</Label>
             <div className="mt-1 grid grid-cols-2 gap-1">
               <Button
                 size="sm"
                 variant={lineStyle === "solid" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("solid")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("solid")
+                }}
                 className="h-8 text-xs"
               >
                 直線
@@ -108,7 +116,10 @@ export function LineToolPopover({
               <Button
                 size="sm"
                 variant={lineStyle === "wave" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("wave")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("wave")
+                }}
                 className="h-8 text-xs"
               >
                 波線
@@ -116,7 +127,10 @@ export function LineToolPopover({
               <Button
                 size="sm"
                 variant={lineStyle === "zigzag" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("zigzag")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("zigzag")
+                }}
                 className="h-8 text-xs"
               >
                 折線
@@ -124,7 +138,10 @@ export function LineToolPopover({
               <Button
                 size="sm"
                 variant={lineStyle === "double" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("double")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("double")
+                }}
                 className="h-8 text-xs"
               >
                 二重線
@@ -132,7 +149,10 @@ export function LineToolPopover({
               <Button
                 size="sm"
                 variant={lineStyle === "arrow" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("arrow")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("arrow")
+                }}
                 className="h-8 text-xs"
               >
                 矢印 →
@@ -140,7 +160,10 @@ export function LineToolPopover({
               <Button
                 size="sm"
                 variant={lineStyle === "both_arrow" ? "default" : "outline"}
-                onClick={() => onLineStyleChange("both_arrow")}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onLineStyleChange("both_arrow")
+                }}
                 className="h-8 text-xs"
               >
                 両矢印 ↔
@@ -149,7 +172,7 @@ export function LineToolPopover({
           </div>
 
           {/* 線幅 */}
-          <div>
+          <div onPointerDown={(e) => e.stopPropagation()}>
             <Label className="text-xs">線幅: {strokeWidth}px</Label>
             <Slider
               min={1}
@@ -168,7 +191,11 @@ export function LineToolPopover({
               {COLOR_PALETTE.map((color, index) => (
                 <button
                   key={index}
-                  onClick={() => onStrokeColorChange(color)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onStrokeColorChange(color)
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
                   className={`h-5 w-5 rounded border transition-transform hover:scale-110 ${
                     strokeColor === color
                       ? "border-2 border-gray-800"

--- a/components/projects/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
@@ -42,8 +42,8 @@ export function RectangleToolPopover({
     // イベント伝播を停止（キャンバスのクリックハンドラに伝播しないように）
     e.stopPropagation()
 
-    // 他のタイプの要素が選択されている場合は選択を解除
-    if (hasOtherTypeSelected && onClearSelection) {
+    // このタイプの要素が選択されていない場合のみ選択を解除
+    if (!hasSelectedElement && hasOtherTypeSelected && onClearSelection) {
       onClearSelection()
     }
 
@@ -70,7 +70,12 @@ export function RectangleToolPopover({
           size="sm"
           variant={isActive ? "default" : "ghost"}
           onClick={handleClick}
-          title={hasSelectedElement ? "選択中の長方形を編集" : "矩形ツール - Shift+ドラッグで正方形"}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={
+            hasSelectedElement
+              ? "選択中の長方形を編集"
+              : "矩形ツール - Shift+ドラッグで正方形"
+          }
           style={{
             backgroundColor: isActive ? strokeColor : undefined,
             borderColor: isActive ? strokeColor : undefined,
@@ -89,7 +94,7 @@ export function RectangleToolPopover({
           </h4>
 
           {/* 線幅 */}
-          <div>
+          <div onPointerDown={(e) => e.stopPropagation()}>
             <Label className="text-xs">線幅: {strokeWidth}px</Label>
             <Slider
               min={1}
@@ -108,7 +113,11 @@ export function RectangleToolPopover({
               {COLOR_PALETTE.map((color, index) => (
                 <button
                   key={index}
-                  onClick={() => onStrokeColorChange(color)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onStrokeColorChange(color)
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
                   className={`h-5 w-5 rounded border transition-transform hover:scale-110 ${
                     strokeColor === color
                       ? "border-2 border-gray-800"

--- a/components/projects/07-score-at-once/ScoringIndividual/TextToolPopover.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/TextToolPopover.tsx
@@ -37,8 +37,8 @@ export function TextToolPopover({
     // イベント伝播を停止（キャンバスのクリックハンドラに伝播しないように）
     e.stopPropagation()
 
-    // 他のタイプの要素が選択されている場合は選択を解除
-    if (hasOtherTypeSelected && onClearSelection) {
+    // このタイプの要素が選択されていない場合のみ選択を解除
+    if (!hasSelectedElement && hasOtherTypeSelected && onClearSelection) {
       onClearSelection()
     }
 
@@ -65,7 +65,12 @@ export function TextToolPopover({
           size="sm"
           variant={isActive ? "default" : "ghost"}
           onClick={handleClick}
-          title={hasSelectedElement ? "選択中のテキストを編集" : "テキストアンカー - クリックでテキスト配置"}
+          onPointerDown={(e) => e.stopPropagation()}
+          title={
+            hasSelectedElement
+              ? "選択中のテキストを編集"
+              : "テキストアンカー - クリックでテキスト配置"
+          }
           style={{
             backgroundColor: isActive ? textColor : undefined,
             borderColor: isActive ? textColor : undefined,
@@ -90,7 +95,11 @@ export function TextToolPopover({
               {COLOR_PALETTE.map((color, index) => (
                 <button
                   key={index}
-                  onClick={() => onTextColorChange(color)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onTextColorChange(color)
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
                   className={`h-5 w-5 rounded border transition-transform hover:scale-110 ${
                     textColor === color
                       ? "border-2 border-gray-800"

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
@@ -9,7 +9,13 @@ import type {
   RectangleEditMode,
   SelectionRectangle,
 } from "@/components/projects/07-score-at-once/ScoringIndividual/types/answer-individual-types"
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 
 // データベース統合フックのインポート
 import {
@@ -130,6 +136,7 @@ export function useDrawingState(
 
       // 設問変更時は即座にdrawingElementsと選択をクリア
       // useLayoutEffectにより、描画effectが実行される前にクリアが完了する
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 意図的：設問変更時に古いデータ表示を防ぐため描画前にクリアが必要
       setDrawingElements([])
       setSelectedElementIds([])
 
@@ -149,6 +156,7 @@ export function useDrawingState(
 
     // annotationsをdrawingElementsに変換（同期的に更新）
     const elements = annotations.map(convertAnnotationToElement)
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 意図的：DBアノテーション変更時にローカル状態を同期するため必要
     setDrawingElements(elements)
   }, [annotations])
 
@@ -202,6 +210,44 @@ export function useDrawingState(
                 element.id === id ? previousElement! : element,
               ),
             )
+          }
+        }
+      }
+    },
+    [enablePersistence, questionScoreId, updateElement],
+  )
+
+  // 複数要素を一括更新（1回のsetStateで全て更新）
+  const updateDrawingElements = useCallback(
+    async (
+      updates: Array<{ id: string; updates: Partial<DrawingElement> }>,
+    ) => {
+      const previousElements: Map<string, DrawingElement> = new Map()
+      const updateMap = new Map(updates.map((u) => [u.id, u.updates]))
+
+      // ローカル状態を即座に更新（1回のsetStateで全て更新）
+      setDrawingElements((prev) => {
+        return prev.map((element) => {
+          const elementUpdates = updateMap.get(element.id)
+          if (elementUpdates) {
+            previousElements.set(element.id, element)
+            return { ...element, ...elementUpdates }
+          }
+          return element
+        })
+      })
+
+      // データベース更新（バックグラウンド、各要素を個別に更新）
+      if (enablePersistence && questionScoreId) {
+        for (const { id, updates: elementUpdates } of updates) {
+          const previousElement = previousElements.get(id)
+          if (previousElement) {
+            try {
+              const updatedElement = { ...previousElement, ...elementUpdates }
+              await updateElement(updatedElement)
+            } catch (error) {
+              console.error("描画要素更新エラー:", error)
+            }
           }
         }
       }
@@ -418,6 +464,7 @@ export function useDrawingState(
     setDrawingElements,
     addDrawingElement,
     updateDrawingElement,
+    updateDrawingElements,
     removeDrawingElement,
     // 複数選択システム
     setSelectedElementIds,

--- a/components/projects/07-score-at-once/ScoringIndividual/types/answer-individual-types.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/types/answer-individual-types.ts
@@ -53,7 +53,13 @@ export interface DrawingElement {
 }
 
 // 描画ツールの型定義
-export type DrawingTool = "hand" | "text" | "line" | "rectangle" | "ellipse" | "select"
+export type DrawingTool =
+  | "hand"
+  | "text"
+  | "line"
+  | "rectangle"
+  | "ellipse"
+  | "select"
 
 // 線の編集モード
 export type LineEditMode = "move" | "start" | "end" | null
@@ -88,7 +94,7 @@ export interface AnswerIndividualViewProps {
   pageImages?: PageImageWithProjectStudents[] // 全答案データ
   showMultiplePages?: boolean // 複数画像の縦並び表示設定
   pageSpacing?: number // ページ間の余白（ピクセル）
-  
+
   // テキスト入力状態変更のコールバック
   onTextInputStateChange?: (showTextInput: boolean) => void
 }
@@ -146,9 +152,15 @@ export interface DrawingActions {
   setDrawingElements: (
     elements: DrawingElement[] | ((prev: DrawingElement[]) => DrawingElement[]),
   ) => void
-  addDrawingElement: (element: DrawingElement) => void
-  updateDrawingElement: (id: string, updates: Partial<DrawingElement>) => void
-  removeDrawingElement: (id: string) => void
+  addDrawingElement: (element: DrawingElement) => void | Promise<void>
+  updateDrawingElement: (
+    id: string,
+    updates: Partial<DrawingElement>,
+  ) => void | Promise<void>
+  updateDrawingElements: (
+    updates: Array<{ id: string; updates: Partial<DrawingElement> }>,
+  ) => void | Promise<void>
+  removeDrawingElement: (id: string) => void | Promise<void>
   // 複数選択システム
   setSelectedElementIds: (ids: string[]) => void
   addToSelection: (id: string) => void


### PR DESCRIPTION
## Summary
- 複数種類のアノテーション選択時にツールボタンクリックで選択が解除される問題を修正
- 選択アノテーションの一括更新機能を追加（React State Batching問題を解決）
- 各ポップオーバーが自分の種類のアノテーションのみを更新するよう修正

## Test plan
- [ ] 選択モードで線と長方形を複数選択
- [ ] 線ツールボタンをクリック → 選択が維持されることを確認
- [ ] 線ポップオーバーで色を変更 → 選択中の線のみ色が変わることを確認
- [ ] 長方形ツールボタンをクリック → 選択が維持されることを確認
- [ ] 長方形ポップオーバーで色を変更 → 選択中の長方形のみ色が変わることを確認
- [ ] 楕円・テキストでも同様に動作することを確認

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)