### PR TITLE
v4テキストエンジンのfontSize対応とPDF出力のRetina対応

### DIFF
--- a/app/textbox-on-canvas-v4/utils/canvasUtils.ts
+++ b/app/textbox-on-canvas-v4/utils/canvasUtils.ts
@@ -85,16 +85,16 @@ export async function renderSvgToCanvas(
 
       img.onload = () => {
         try {
-          // 実際のSVGサイズを取得
-          const actualWidth = img.width
-          const actualHeight = img.height
+          // 実際のSVGサイズをそのまま使用（fontSizeは生成時に適用済み）
+          const width = img.width
+          const height = img.height
 
           // アンカー方向に基づいて描画位置を計算
           const textPosition = getTextPositionFromAnchor(
             anchorX,
             anchorY,
-            actualWidth,
-            actualHeight,
+            width,
+            height,
             anchorDirection,
           )
 
@@ -105,8 +105,8 @@ export async function renderSvgToCanvas(
             img,
             textPosition.x,
             textPosition.y,
-            actualWidth,
-            actualHeight,
+            width,
+            height,
           )
           ctx.restore()
 
@@ -116,15 +116,15 @@ export async function renderSvgToCanvas(
               ctx,
               textPosition.x,
               textPosition.y,
-              actualWidth,
-              actualHeight,
+              width,
+              height,
             )
           }
 
           URL.revokeObjectURL(svgUrl)
           resolve({
-            width: actualWidth,
-            height: actualHeight,
+            width: width,
+            height: height,
           })
         } catch (drawError) {
           URL.revokeObjectURL(svgUrl)

--- a/app/textbox-on-canvas-v4/utils/mathJaxUtils.ts
+++ b/app/textbox-on-canvas-v4/utils/mathJaxUtils.ts
@@ -154,12 +154,14 @@ export function cleanupElementStyles(container: HTMLElement): void {
  * @param htmlContent 測定対象のHTML文字列
  * @param initialWidth 初期幅
  * @param initialHeight 初期高さ
+ * @param fontSize フォントサイズ（デフォルト: FONT_SETTINGS.DEFAULT_SIZE）
  * @returns Promise<MeasuredSize> 測定されたサイズ
  */
 export async function measureMathJaxContentSize(
   htmlContent: string,
   initialWidth: number,
   initialHeight: number,
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): Promise<MeasuredSize> {
   // 一時的なDOM要素を作成（scrollWidth/scrollHeight専用設定）
   const tempDiv = document.createElement("div")
@@ -167,7 +169,7 @@ export async function measureMathJaxContentSize(
     position: absolute;
     left: -9999px;
     top: -9999px;
-    font-size: ${FONT_SETTINGS.DEFAULT_SIZE}px;
+    font-size: ${fontSize}px;
     line-height: ${FONT_SETTINGS.DEFAULT_LINE_HEIGHT};
     color: ${FONT_SETTINGS.DEFAULT_COLOR};
     visibility: hidden;
@@ -263,11 +265,13 @@ async function waitForMathJaxDefsGeneration(): Promise<boolean> {
  * 測定結果に基づいて最適なSVGを生成する（軽量版）
  * @param htmlContent HTML内容
  * @param measuredSize 測定されたサイズ
+ * @param fontSize フォントサイズ（デフォルト: FONT_SETTINGS.DEFAULT_SIZE）
  * @returns 生成されたSVG要素
  */
 export async function createOptimizedSVG(
   htmlContent: string,
   measuredSize: MeasuredSize,
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): Promise<SVGSVGElement> {
   // MathJax defsを抽出（軽量化）
   const mathJaxDefs = extractMathJaxDefs()
@@ -285,7 +289,7 @@ export async function createOptimizedSVG(
                      height="${measuredSize.height}"
                      overflow="${SVG_SETTINGS.DEFAULT_OVERFLOW}">
         <div xmlns="${SVG_SETTINGS.XHTML_NAMESPACE}">
-          <div style="font-size: ${FONT_SETTINGS.DEFAULT_SIZE}px;
+          <div style="font-size: ${fontSize}px;
                      line-height: ${FONT_SETTINGS.DEFAULT_LINE_HEIGHT};
                      color: ${FONT_SETTINGS.DEFAULT_COLOR};
                      overflow: visible;
@@ -315,20 +319,23 @@ export async function createOptimizedSVG(
  * @param htmlContent 変換対象のHTML文字列
  * @param initialWidth 初期幅
  * @param initialHeight 初期高さ
+ * @param fontSize フォントサイズ（デフォルト: FONT_SETTINGS.DEFAULT_SIZE）
  * @returns Promise<SVGSVGElement> 生成されたSVG要素
  */
 export async function createMathJaxSVG(
   htmlContent: string,
   initialWidth: number,
   initialHeight: number,
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): Promise<SVGSVGElement> {
-  // MathJax処理後の正確なサイズを測定
+  // MathJax処理後の正確なサイズを測定（fontSizeを渡す）
   const measuredSize = await measureMathJaxContentSize(
     htmlContent,
     initialWidth,
     initialHeight,
+    fontSize,
   )
 
-  // 測定結果に基づいて最適なSVGを生成
-  return await createOptimizedSVG(htmlContent, measuredSize)
+  // 測定結果に基づいて最適なSVGを生成（fontSizeを渡す）
+  return await createOptimizedSVG(htmlContent, measuredSize, fontSize)
 }

--- a/app/textbox-on-canvas-v4/utils/textConversionUtils.ts
+++ b/app/textbox-on-canvas-v4/utils/textConversionUtils.ts
@@ -180,16 +180,17 @@ export function parseTextWithMath(text: string): string {
 /**
  * MathJax処理用の一時的なDOM容器を作成する
  * 各テキスト要素ごとに独立したコンテナを使用し、並列処理を可能にする
+ * @param fontSize フォントサイズ（デフォルト: FONT_SETTINGS.DEFAULT_SIZE）
  * @returns 新しいDIV要素
  */
-function createMathJaxContainer(): HTMLDivElement {
+function createMathJaxContainer(fontSize: number = FONT_SETTINGS.DEFAULT_SIZE): HTMLDivElement {
   const container = document.createElement("div")
   container.style.cssText = `
     position: absolute;
     left: -9999px;
     top: -9999px;
     font-family: ${FONT_SETTINGS.DEFAULT_FAMILY};
-    font-size: ${FONT_SETTINGS.DEFAULT_SIZE}px;
+    font-size: ${fontSize}px;
     line-height: ${FONT_SETTINGS.DEFAULT_LINE_HEIGHT};
     color: ${FONT_SETTINGS.DEFAULT_COLOR};
     background: white;
@@ -255,17 +256,19 @@ export async function processMathJaxContent(
 /**
  * SVG変換のための処理
  * @param container 処理済みのDOM要素
+ * @param fontSize フォントサイズ
  * @returns Promise<SVGSVGElement | null> 生成されたSVG要素またはnull
  */
 async function convertContainerToSvg(
   container: HTMLDivElement,
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): Promise<SVGSVGElement | null> {
   try {
     // MathJax処理済みのHTML内容を取得
     const processedHtml = container.innerHTML
 
-    // SVG生成
-    const svgElement = await createMathJaxSVG(processedHtml, 200, 50)
+    // SVG生成（fontSizeを渡す）
+    const svgElement = await createMathJaxSVG(processedHtml, 200, 50, fontSize)
 
     // SVGプレビューに表示（デバッグ用）
     displaySvgPreview(svgElement)
@@ -331,11 +334,11 @@ export async function convertTextToSvg(
       return null
     }
 
-    // 2. 各行をSVGに変換
+    // 2. 各行をSVGに変換（fontSizeを渡す）
     const lineSvgs: SVGSVGElement[] = []
 
     for (const line of lines) {
-      const lineSvg = await convertSingleLineToSvg(line.trim())
+      const lineSvg = await convertSingleLineToSvg(line.trim(), textSize)
       if (lineSvg) {
         lineSvgs.push(lineSvg)
       }
@@ -345,7 +348,7 @@ export async function convertTextToSvg(
       return null
     }
 
-    // 3. 複数行SVGを結合（5px間隔）
+    // 3. 複数行SVGを結合（5px間隔、fontSizeを渡す）
     return combineLineSvgs(
       lineSvgs,
       5,
@@ -354,6 +357,7 @@ export async function convertTextToSvg(
       horizontalAlign,
       verticalAlign,
       textColor,
+      textSize,
     )
   } catch (error) {
     return null
@@ -364,17 +368,19 @@ export async function convertTextToSvg(
  * 単一行をSVGに変換（改行なし）
  * 並列処理対応: 各呼び出しで独立したコンテナを使用
  * @param lineText 単一行のテキスト
+ * @param fontSize フォントサイズ
  * @returns Promise<SVGSVGElement | null> 生成されたSVG要素またはnull
  */
 async function convertSingleLineToSvg(
   lineText: string,
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): Promise<SVGSVGElement | null> {
   if (!lineText.trim()) {
     return null
   }
 
   // 各行ごとに独立したコンテナを作成（並列処理で競合しない）
-  const container = createMathJaxContainer()
+  const container = createMathJaxContainer(fontSize)
 
   try {
     // 1. テキストをHTMLに変換
@@ -383,8 +389,8 @@ async function convertSingleLineToSvg(
     // 2. MathJax処理を実行（単一行、overflow: hidden）
     await processSingleLineMathJax(container, htmlContent)
 
-    // 3. 処理済みコンテナをSVGに変換
-    return await convertContainerToSvg(container)
+    // 3. 処理済みコンテナをSVGに変換（fontSizeを渡す）
+    return await convertContainerToSvg(container, fontSize)
   } catch {
     return null
   } finally {
@@ -424,6 +430,7 @@ function combineLineSvgs(
   horizontalAlign: "left" | "center" | "right" = "left",
   verticalAlign: "top" | "center" | "bottom" = "top",
   textColor: string = "#000000",
+  fontSize: number = FONT_SETTINGS.DEFAULT_SIZE,
 ): SVGSVGElement {
   // 各行のサイズを取得
   const lineInfos = lineSvgs.map((svg) => ({
@@ -484,7 +491,7 @@ function combineLineSvgs(
             .map(
               (content) => `
             <div style="
-              font-size: 24px;
+              font-size: ${fontSize}px;
               line-height: 1;
               color: ${textColor};
               text-align: left;

--- a/components/projects/07-score-at-once/ScoringIndividual/utils/canvasTextRendererV4.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/utils/canvasTextRendererV4.ts
@@ -8,8 +8,13 @@ import {
   isAnchorClicked
 } from "../../../../../app/textbox-on-canvas-v4/utils/canvasUtils"
 
-const svgCache = new Map<string, { text: string; color: string; svg: SVGSVGElement }>()
+/** SVGキャッシュ（elementId → {text, color, fontSize, svg}） */
+const svgCache = new Map<string, { text: string; color: string; fontSize: number; svg: SVGSVGElement }>()
 
+/**
+ * SVGキャッシュをクリアする
+ * @param elementId 特定の要素のみクリアする場合はそのID
+ */
 export function clearSvgCache(elementId?: string): void {
   if (elementId) {
     svgCache.delete(elementId)
@@ -18,16 +23,22 @@ export function clearSvgCache(elementId?: string): void {
   }
 }
 
-function getCachedSvg(elementId: string, text: string, color: string): SVGSVGElement | null {
+/**
+ * キャッシュからSVGを取得する
+ */
+function getCachedSvg(elementId: string, text: string, color: string, fontSize: number): SVGSVGElement | null {
   const cached = svgCache.get(elementId)
-  if (cached && cached.text === text && cached.color === color) {
+  if (cached && cached.text === text && cached.color === color && cached.fontSize === fontSize) {
     return cached.svg.cloneNode(true) as SVGSVGElement
   }
   return null
 }
 
-function cacheSvg(elementId: string, text: string, color: string, svg: SVGSVGElement): void {
-  svgCache.set(elementId, { text, color, svg: svg.cloneNode(true) as SVGSVGElement })
+/**
+ * SVGをキャッシュに保存する
+ */
+function cacheSvg(elementId: string, text: string, color: string, fontSize: number, svg: SVGSVGElement): void {
+  svgCache.set(elementId, { text, color, fontSize, svg: svg.cloneNode(true) as SVGSVGElement })
 }
 
 export interface V4TextRenderResult {
@@ -38,6 +49,9 @@ export interface V4TextRenderResult {
   textBounds: { x: number; y: number; width: number; height: number }
 }
 
+/**
+ * DrawingElementからAnchorDirectionに変換する
+ */
 function convertToAnchorDirection(element: DrawingElement): AnchorDirection {
   if ((element as any).anchorDirection) {
     return (element as any).anchorDirection as AnchorDirection
@@ -63,6 +77,17 @@ function convertToAnchorDirection(element: DrawingElement): AnchorDirection {
   return "top-left"
 }
 
+/**
+ * V4テキスト要素をCanvasに描画する
+ * @param ctx Canvas描画コンテキスト
+ * @param element 描画する要素
+ * @param canvasWidth Canvasの幅
+ * @param canvasHeight Canvasの高さ
+ * @param isSelected 選択状態かどうか
+ * @param showAnchor アンカーを表示するかどうか
+ * @param opacity 透明度（0.0-1.0）
+ * @returns 描画結果
+ */
 export async function renderTextElementV4(
   ctx: CanvasRenderingContext2D,
   element: DrawingElement,
@@ -87,8 +112,9 @@ export async function renderTextElementV4(
     const anchorY = element.y * canvasHeight
     const anchorDirection = convertToAnchorDirection(element)
     const textColor = element.color || "#000000"
+    const fontSize = element.fontSize ?? 16
 
-    let svgElement = getCachedSvg(element.id, element.text, textColor)
+    let svgElement = getCachedSvg(element.id, element.text, textColor, fontSize)
 
     if (!svgElement) {
       svgElement = await convertTextToSvg(
@@ -97,12 +123,12 @@ export async function renderTextElementV4(
         canvasHeight,
         "left",
         "top",
-        24,
+        fontSize,
         textColor
       )
 
       if (svgElement) {
-        cacheSvg(element.id, element.text, textColor, svgElement)
+        cacheSvg(element.id, element.text, textColor, fontSize, svgElement)
       }
     }
 
@@ -161,6 +187,9 @@ export async function renderTextElementV4(
   }
 }
 
+/**
+ * テキスト要素のアンカーがクリックされたかどうかを判定する
+ */
 export function isTextAnchorClicked(
   mouseX: number,
   mouseY: number,
@@ -176,6 +205,9 @@ export function isTextAnchorClicked(
   return isAnchorClicked(mouseX, mouseY, anchorX, anchorY)
 }
 
+/**
+ * 複数のV4テキスト要素をCanvasに描画する
+ */
 export async function renderTextElementsV4(
   ctx: CanvasRenderingContext2D,
   elements: DrawingElement[],
@@ -201,6 +233,10 @@ export async function renderTextElementsV4(
   return results
 }
 
+/**
+ * テキスト要素のヒットテストを行う
+ * @returns "anchor" | "text" | null
+ */
 export function hitTestTextElement(
   mouseX: number,
   mouseY: number,

--- a/components/projects/08-export/ExportMainView.tsx
+++ b/components/projects/08-export/ExportMainView.tsx
@@ -27,6 +27,7 @@ export default function ExportMainView() {
   // Canvas描画用の状態
   const [pdfExportPages, setPdfExportPages] = useState<PdfExportPageData[]>([])
   const [startCanvasRendering, setStartCanvasRendering] = useState(false)
+  const [pdfOutputPath, setPdfOutputPath] = useState<string>("")
 
   const {
     project,
@@ -82,16 +83,29 @@ export default function ExportMainView() {
       return
     }
 
-    setIsExporting(true)
-    setShowProgressModal(true)
-    setExportProgress(0)
-    setExportStatus("processing")
-    setCurrentStep("データを取得中...")
-
     try {
+      // Step 1: 最初に保存先を選択（ユーザー操作を先に済ませる）
+      const savePathResult = await window.electronAPI.export.selectPdfSavePath({
+        projectName: project?.examName,
+      })
+
+      if (savePathResult.canceled || !savePathResult.filePath) {
+        // ユーザーがキャンセルした場合は何もしない
+        return
+      }
+
+      setPdfOutputPath(savePathResult.filePath)
+
+      // Step 2: 処理開始
+      setIsExporting(true)
+      setShowProgressModal(true)
+      setExportProgress(0)
+      setExportStatus("processing")
+      setCurrentStep("データを取得中...")
+
       const selectedStudentIds = Array.from(selectedStudents)
 
-      // Step 1: PDF出力データを取得
+      // Step 3: PDF出力データを取得
       const dataResult = await window.electronAPI.export.getPdfExportData({
         projectId: project.id,
         selectedStudentIds,
@@ -111,7 +125,7 @@ export default function ExportMainView() {
         return
       }
 
-      // Step 2: Canvas描画を開始
+      // Step 4: Canvas描画を開始
       setCurrentStep("Canvas描画を準備中...")
       setPdfExportPages(dataResult.pages)
       setStartCanvasRendering(true)
@@ -159,11 +173,12 @@ export default function ExportMainView() {
         setExportProgress(85)
         setCurrentStep("PDFを作成中...")
 
-        // Step 3: Canvas描画結果からPDFを作成
+        // Step 5: Canvas描画結果からPDFを作成（保存先は事前に選択済み）
         const result = await window.electronAPI.export.createPdfFromRenderedImages({
           projectId: project.id,
           renderedPages,
           pdfOrientation: exportOptions.pdfOrientation,
+          outputPath: pdfOutputPath,
         })
 
         if (result.success) {
@@ -182,7 +197,7 @@ export default function ExportMainView() {
         setIsExporting(false)
       }
     },
-    [project?.id, exportOptions.pdfOrientation, setExportProgress, setCurrentStep, setExportStatus, setIsExporting]
+    [project?.id, exportOptions.pdfOrientation, pdfOutputPath, setExportProgress, setCurrentStep, setExportStatus, setIsExporting]
   )
 
   /**

--- a/components/projects/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/projects/08-export/components/PdfCanvasRenderer.tsx
@@ -1,0 +1,302 @@
+"use client"
+
+import type { DrawingAnnotation } from "@/types/drawing-annotation.types"
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  preloadScoringMarkImages,
+  renderAnswerSheetToCanvas,
+  type ScoringDataForPdf,
+  type ScoringMarkConfigForPdf,
+} from "../utils/pdf-canvas-renderer"
+
+/**
+ * PDF出力ページデータ
+ */
+export interface PdfExportPageData {
+  studentId: string
+  studentName: string
+  pageNumber: number
+  imagePath: string
+  imageUrl: string
+  scoringData: Array<{
+    questionScoreId: string
+    status: string
+    partialScore: number | null
+    cropRegion: {
+      id: string
+      x: number
+      y: number
+      width: number
+      height: number
+      label: string
+      maxScore: number | null
+      pageNumber: number
+    }
+  }>
+  annotations: Array<{
+    id: string
+    questionScoreId: string
+    type: string
+    x: number
+    y: number
+    color: string
+    strokeWidth: number
+    width: number
+    height: number
+    endX: number
+    endY: number
+    lineStyle: string
+    text: string
+    fontSize: number
+    displayX: number
+    displayY: number
+    anchorDirection: string
+  }>
+}
+
+interface PdfCanvasRendererProps {
+  /** レンダリングするページのリスト */
+  pages: PdfExportPageData[]
+  /** 採点マーク設定 */
+  scoringMarkConfig: ScoringMarkConfigForPdf
+  /** レンダリング開始トリガー */
+  startRendering: boolean
+  /** 進捗コールバック */
+  onProgress?: (current: number, total: number, step: string) => void
+  /** 全ページのレンダリング完了時のコールバック */
+  onComplete?: (
+    renderedPages: Array<{
+      studentId: string
+      pageNumber: number
+      imageData: ArrayBuffer
+    }>,
+  ) => void
+  /** エラー発生時のコールバック */
+  onError?: (error: Error) => void
+}
+
+/**
+ * PDF出力用Canvas描画コンポーネント
+ *
+ * 非表示のCanvas要素を持ち、PDF出力時に各答案シートを順次描画する。
+ * 描画完了後、全ページの画像データをonCompleteコールバックで返す。
+ */
+export function PdfCanvasRenderer({
+  pages,
+  scoringMarkConfig,
+  startRendering,
+  onProgress,
+  onComplete,
+  onError,
+}: PdfCanvasRendererProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [isRendering, setIsRendering] = useState(false)
+  const scoringMarkImagesRef = useRef<Map<string, HTMLImageElement> | null>(
+    null,
+  )
+
+  /**
+   * 画像を読み込む
+   *
+   * data URLの場合はそのまま読み込み、それ以外はfetch + ObjectURLで読み込む
+   * これによりCanvasのtainted問題を回避
+   */
+  const loadImage = useCallback(async (url: string): Promise<HTMLImageElement> => {
+    // data URLの場合はそのまま読み込み
+    if (url.startsWith("data:")) {
+      return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.onload = () => resolve(img)
+        img.onerror = () => reject(new Error(`Failed to load image from data URL`))
+        img.src = url
+      })
+    }
+
+    // それ以外はfetch + ObjectURLで読み込み
+    try {
+      const response = await fetch(url)
+      const blob = await response.blob()
+      const objectUrl = URL.createObjectURL(blob)
+
+      return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.onload = () => {
+          URL.revokeObjectURL(objectUrl)
+          resolve(img)
+        }
+        img.onerror = () => {
+          URL.revokeObjectURL(objectUrl)
+          reject(new Error(`Failed to load image: ${url}`))
+        }
+        img.src = objectUrl
+      })
+    } catch (error) {
+      // フォールバック: 直接読み込み
+      return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.crossOrigin = "anonymous"
+        img.onload = () => resolve(img)
+        img.onerror = () => reject(new Error(`Failed to load image: ${url}`))
+        img.src = url
+      })
+    }
+  }, [])
+
+  /**
+   * 全ページをレンダリング
+   */
+  const renderAllPages = useCallback(async () => {
+    if (!canvasRef.current || pages.length === 0) {
+      onComplete?.([])
+      return
+    }
+
+    setIsRendering(true)
+
+    try {
+      // 採点マーク画像をプリロード
+      if (!scoringMarkImagesRef.current) {
+        onProgress?.(0, pages.length, "採点マーク画像を読み込み中...")
+        scoringMarkImagesRef.current = await preloadScoringMarkImages(
+          scoringMarkConfig.useTransparent,
+        )
+      }
+
+      const renderedPages: Array<{
+        studentId: string
+        pageNumber: number
+        imageData: ArrayBuffer
+      }> = []
+
+      for (let i = 0; i < pages.length; i++) {
+        const page = pages[i]
+        onProgress?.(
+          i + 1,
+          pages.length,
+          `${page.studentName} (${i + 1}/${pages.length})`,
+        )
+
+        try {
+          // 答案画像を読み込み
+          const image = await loadImage(page.imageUrl)
+
+          // scoringDataをScoringDataForPdf形式に変換
+          const scoringDataForPdf: ScoringDataForPdf[] = page.scoringData.map(
+            (sd) => ({
+              questionScoreId: sd.questionScoreId,
+              status: sd.status,
+              partialScore: sd.partialScore,
+              cropRegion: {
+                id: sd.cropRegion.id,
+                x: sd.cropRegion.x,
+                y: sd.cropRegion.y,
+                width: sd.cropRegion.width,
+                height: sd.cropRegion.height,
+                label: sd.cropRegion.label,
+              },
+            }),
+          )
+
+          // annotationsをDrawingAnnotation形式に変換
+          const annotations: DrawingAnnotation[] = page.annotations.map(
+            (a) => ({
+              id: a.id,
+              questionScoreId: a.questionScoreId,
+              type: a.type as "text" | "line" | "rectangle" | "ellipse",
+              x: a.x,
+              y: a.y,
+              color: a.color,
+              strokeWidth: a.strokeWidth,
+              width: a.width,
+              height: a.height,
+              endX: a.endX,
+              endY: a.endY,
+              lineStyle: a.lineStyle as
+                | "solid"
+                | "wave"
+                | "zigzag"
+                | "double"
+                | "arrow"
+                | "both_arrow",
+              text: a.text,
+              fontSize: a.fontSize,
+              textBoxWidth: 0,
+              textBoxHeight: 0,
+              horizontalAlign: "left" as const,
+              verticalAlign: "top" as const,
+              displayX: a.displayX,
+              displayY: a.displayY,
+              anchorDirection: a.anchorDirection as
+                | "top-left"
+                | "top"
+                | "top-right"
+                | "left"
+                | "center"
+                | "right"
+                | "bottom-left"
+                | "bottom"
+                | "bottom-right",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              createdByUserId: null,
+            }),
+          )
+
+          // Canvas描画
+          const blob = await renderAnswerSheetToCanvas(
+            canvasRef.current,
+            image,
+            scoringDataForPdf,
+            annotations,
+            scoringMarkConfig,
+            scoringMarkImagesRef.current,
+          )
+
+          // BlobをArrayBufferに変換
+          const arrayBuffer = await blob.arrayBuffer()
+
+          renderedPages.push({
+            studentId: page.studentId,
+            pageNumber: page.pageNumber,
+            imageData: arrayBuffer,
+          })
+        } catch (pageError) {
+          console.error(
+            `Error rendering page ${i + 1} (${page.studentName}):`,
+            pageError,
+          )
+          // エラーが発生しても続行（スキップ）
+        }
+      }
+
+      onComplete?.(renderedPages)
+    } catch (error) {
+      console.error("Error during PDF rendering:", error)
+      onError?.(error instanceof Error ? error : new Error(String(error)))
+    } finally {
+      setIsRendering(false)
+    }
+  }, [pages, scoringMarkConfig, loadImage, onProgress, onComplete, onError])
+
+  /**
+   * レンダリング開始トリガーを監視
+   */
+  useEffect(() => {
+    if (startRendering && !isRendering && pages.length > 0) {
+      renderAllPages()
+    }
+  }, [startRendering, isRendering, pages.length, renderAllPages])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: "absolute",
+        left: "-9999px",
+        top: "-9999px",
+        visibility: "hidden",
+        pointerEvents: "none",
+      }}
+    />
+  )
+}

--- a/components/projects/08-export/utils/pdf-canvas-renderer.ts
+++ b/components/projects/08-export/utils/pdf-canvas-renderer.ts
@@ -1,0 +1,715 @@
+/**
+ * PDF出力用Canvas描画ユーティリティ
+ *
+ * 一括採点個別表示のCanvas描画エンジン（useImageCanvas.ts）を流用し、
+ * PDF出力に適した形式でCanvas上に描画を行う。
+ */
+
+import { convertTextToSvg } from "@/app/textbox-on-canvas-v4/utils/textConversionUtils"
+import { getTextPositionFromAnchor } from "@/app/textbox-on-canvas-v4/utils/canvasUtils"
+import type { AnchorDirection } from "@/app/textbox-on-canvas-v4/types"
+import type { DrawingAnnotation } from "@/types/drawing-annotation.types"
+
+/**
+ * 採点データ（PDF出力用）
+ */
+export interface ScoringDataForPdf {
+  questionScoreId: string
+  status: string // "unscored" | "correct" | "partial" | "pending" | "incorrect" | "no_answer"
+  partialScore?: number | null
+  cropRegion: {
+    id: string
+    x: number
+    y: number
+    width: number
+    height: number
+    label: string
+    projectPage?: {
+      pageNumber: number
+    }
+  }
+}
+
+/**
+ * 採点マーク設定
+ */
+export interface ScoringMarkConfigForPdf {
+  markPosition: string // "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" etc.
+  markSize: number
+  useTransparent: boolean
+  showPartialScore: boolean
+  partialScorePosition: string
+  partialScoreSize: number
+  partialScoreOffsetX: number
+  partialScoreOffsetY: number
+}
+
+/**
+ * 描画要素（内部用、DrawingAnnotationから変換）
+ */
+interface DrawingElement {
+  id: string
+  type: "text" | "line" | "rectangle" | "ellipse"
+  x: number
+  y: number
+  color: string
+  strokeWidth: number
+  width?: number
+  height?: number
+  endX?: number
+  endY?: number
+  lineStyle?: string
+  text?: string
+  fontSize?: number
+  displayX?: number
+  displayY?: number
+  anchorDirection?: string
+}
+
+/**
+ * DrawingAnnotationをDrawingElementに変換
+ */
+function convertAnnotationToDrawingElement(
+  annotation: DrawingAnnotation,
+): DrawingElement {
+  return {
+    id: annotation.id,
+    type: annotation.type as "text" | "line" | "rectangle" | "ellipse",
+    x: annotation.x,
+    y: annotation.y,
+    color: annotation.color,
+    strokeWidth: annotation.strokeWidth,
+    width: annotation.width,
+    height: annotation.height,
+    endX: annotation.endX,
+    endY: annotation.endY,
+    lineStyle: annotation.lineStyle,
+    text: annotation.text,
+    fontSize: annotation.fontSize,
+    displayX: annotation.displayX,
+    displayY: annotation.displayY,
+    anchorDirection: annotation.anchorDirection,
+  }
+}
+
+/**
+ * 単一の描画要素をCanvas上に描画
+ *
+ * useImageCanvas.ts の drawSingleElement を純粋関数として抽出
+ */
+async function drawElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  imageWidth: number,
+  imageHeight: number,
+  offsetX: number = 0,
+  offsetY: number = 0,
+): Promise<void> {
+  // 座標計算（テキストも含めてelement.x/yを使用 - 一括採点個別表示と同じ）
+  const currentX = element.x * imageWidth + offsetX
+  const currentY = element.y * imageHeight + offsetY
+
+  ctx.strokeStyle = element.color
+  ctx.fillStyle = element.color
+  ctx.lineWidth = element.strokeWidth
+
+  switch (element.type) {
+    case "text":
+      if (element.text) {
+        const anchorDir = (element.anchorDirection || "top-left") as AnchorDirection
+        const fontSize = element.fontSize ?? 16
+        const textColor = element.color || "#000000"
+
+        try {
+          const svgElement = await convertTextToSvg(
+            element.text,
+            imageWidth,
+            imageHeight,
+            "left",
+            "top",
+            fontSize,
+            textColor,
+          )
+
+          if (svgElement) {
+            let svgData = new XMLSerializer().serializeToString(svgElement)
+
+            // MathJax defsを埋め込み
+            const hasMathJaxElements =
+              svgData.includes("mjx-container") || svgData.includes("<use")
+            if (hasMathJaxElements) {
+              const globalDefs = document.querySelector("#MJX-SVG-global-cache defs")
+              if (globalDefs && globalDefs.innerHTML.length > 10) {
+                const defsContent = globalDefs.outerHTML
+                svgData = svgData.replace(/(<svg[^>]*>)/, `$1${defsContent}`)
+              }
+            }
+
+            // SVG→PNG変換（Canvas taint問題を回避するためmainプロセスで実行）
+            const result = await window.electronAPI.export.convertSvgToPng({
+              svgString: svgData,
+            })
+
+            if (result.success && result.dataUrl) {
+              const img = new Image()
+              await new Promise<void>((resolve, reject) => {
+                img.onload = () => resolve()
+                img.onerror = () => reject(new Error("Failed to load converted PNG"))
+                img.src = result.dataUrl!
+              })
+
+              // 論理サイズで描画（Retinaではimg.width/heightが2倍になるため）
+              const width = result.width ?? img.width
+              const height = result.height ?? img.height
+
+              const textPosition = getTextPositionFromAnchor(
+                currentX,
+                currentY,
+                width,
+                height,
+                anchorDir,
+              )
+
+              ctx.drawImage(img, textPosition.x, textPosition.y, width, height)
+            } else {
+              throw new Error(result.error || "SVG to PNG conversion failed")
+            }
+          } else {
+            throw new Error("Failed to generate SVG")
+          }
+        } catch (error) {
+          console.error("MathJaxテキスト描画エラー:", error)
+          // フォールバック: シンプルテキスト描画
+          ctx.font = `${fontSize}px sans-serif`
+          ctx.fillStyle = textColor
+          ctx.textBaseline = "top"
+          const lines = element.text.split("\n")
+          const lineHeight = fontSize * 1.4
+          lines.forEach((line, index) => {
+            ctx.fillText(line, currentX, currentY + index * lineHeight)
+          })
+        }
+      }
+      break
+
+    case "line":
+      if (element.endX !== undefined && element.endY !== undefined) {
+        const currentEndX = element.endX * imageWidth + offsetX
+        const currentEndY = element.endY * imageHeight + offsetY
+
+        ctx.save()
+        ctx.strokeStyle = element.color
+        ctx.fillStyle = element.color
+        ctx.lineWidth = element.strokeWidth
+        ctx.setLineDash([])
+        ctx.lineCap = "round"
+        ctx.lineJoin = "round"
+
+        // 線の長さと角度を計算
+        const dx = currentEndX - currentX
+        const dy = currentEndY - currentY
+        const lineLength = Math.sqrt(dx * dx + dy * dy)
+        const angle = Math.atan2(dy, dx)
+
+        // 矢印のサイズ
+        const arrowSize = Math.max(element.strokeWidth * 5, 12)
+
+        switch (element.lineStyle) {
+          case "wave": {
+            const waveAmplitude = element.strokeWidth * 2
+            const waveLength = element.strokeWidth * 4
+            const segments = Math.max(Math.floor(lineLength / waveLength), 1)
+
+            ctx.beginPath()
+            for (let i = 0; i <= segments; i++) {
+              const t = i / segments
+              const x = currentX + dx * t
+              const y = currentY + dy * t
+              const waveOffset =
+                Math.sin(t * segments * Math.PI * 2) * waveAmplitude
+              const perpX = -Math.sin(angle) * waveOffset
+              const perpY = Math.cos(angle) * waveOffset
+
+              if (i === 0) {
+                ctx.moveTo(x + perpX, y + perpY)
+              } else {
+                ctx.lineTo(x + perpX, y + perpY)
+              }
+            }
+            ctx.stroke()
+            break
+          }
+
+          case "zigzag": {
+            const zigHeight = element.strokeWidth * 2
+            const zigLength = element.strokeWidth * 3
+            const segments = Math.max(Math.floor(lineLength / zigLength), 1)
+
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            for (let i = 1; i <= segments; i++) {
+              const t = i / segments
+              const x = currentX + dx * t
+              const y = currentY + dy * t
+              const zigOffset = i % 2 === 1 ? zigHeight : -zigHeight
+              const perpX = -Math.sin(angle) * zigOffset
+              const perpY = Math.cos(angle) * zigOffset
+              ctx.lineTo(x + perpX, y + perpY)
+            }
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+            break
+          }
+
+          case "double": {
+            const offset = element.strokeWidth
+            const perpX = -Math.sin(angle) * offset
+            const perpY = Math.cos(angle) * offset
+
+            ctx.beginPath()
+            ctx.moveTo(currentX + perpX, currentY + perpY)
+            ctx.lineTo(currentEndX + perpX, currentEndY + perpY)
+            ctx.stroke()
+
+            ctx.beginPath()
+            ctx.moveTo(currentX - perpX, currentY - perpY)
+            ctx.lineTo(currentEndX - perpX, currentEndY - perpY)
+            ctx.stroke()
+            break
+          }
+
+          case "arrow": {
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+
+            ctx.beginPath()
+            ctx.moveTo(currentEndX, currentEndY)
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle - Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle - Math.PI / 6),
+            )
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle + Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle + Math.PI / 6),
+            )
+            ctx.closePath()
+            ctx.fill()
+            break
+          }
+
+          case "both_arrow": {
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+
+            // 終点の矢印
+            ctx.beginPath()
+            ctx.moveTo(currentEndX, currentEndY)
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle - Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle - Math.PI / 6),
+            )
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle + Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle + Math.PI / 6),
+            )
+            ctx.closePath()
+            ctx.fill()
+
+            // 始点の矢印
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(
+              currentX + arrowSize * Math.cos(angle - Math.PI / 6),
+              currentY + arrowSize * Math.sin(angle - Math.PI / 6),
+            )
+            ctx.lineTo(
+              currentX + arrowSize * Math.cos(angle + Math.PI / 6),
+              currentY + arrowSize * Math.sin(angle + Math.PI / 6),
+            )
+            ctx.closePath()
+            ctx.fill()
+            break
+          }
+
+          default:
+            // solid - 通常の直線
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+            break
+        }
+
+        ctx.restore()
+      }
+      break
+
+    case "rectangle":
+      if (element.width !== undefined && element.height !== undefined) {
+        const rectWidth = element.width * imageWidth
+        const rectHeight = element.height * imageHeight
+        ctx.strokeRect(currentX, currentY, rectWidth, rectHeight)
+      }
+      break
+
+    case "ellipse":
+      if (element.width !== undefined && element.height !== undefined) {
+        const rectWidth = element.width * imageWidth
+        const rectHeight = element.height * imageHeight
+
+        ctx.beginPath()
+        ctx.ellipse(
+          currentX + rectWidth / 2,
+          currentY + rectHeight / 2,
+          Math.abs(rectWidth) / 2,
+          Math.abs(rectHeight) / 2,
+          0,
+          0,
+          2 * Math.PI,
+        )
+        ctx.stroke()
+      }
+      break
+  }
+}
+
+/**
+ * 採点マークの位置を計算
+ */
+function calculateMarkPosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  markSize: number,
+  position: string,
+): { x: number; y: number } {
+  const padding = 5
+
+  switch (position) {
+    case "top-left":
+      return { x: regionX + padding, y: regionY + padding }
+    case "top":
+      return { x: regionX + (regionWidth - markSize) / 2, y: regionY + padding }
+    case "top-right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + padding,
+      }
+    case "left":
+      return {
+        x: regionX + padding,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "center":
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "bottom-left":
+      return {
+        x: regionX + padding,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    case "bottom":
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    case "bottom-right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    default:
+      // デフォルトは中央
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+  }
+}
+
+/**
+ * 部分点テキストの位置を計算
+ */
+function calculatePartialScorePosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  position: string,
+  offsetX: number,
+  offsetY: number,
+): { x: number; y: number } {
+  let baseX: number
+  let baseY: number
+
+  switch (position) {
+    case "top-left":
+      baseX = regionX
+      baseY = regionY
+      break
+    case "top-right":
+      baseX = regionX + regionWidth
+      baseY = regionY
+      break
+    case "bottom-left":
+      baseX = regionX
+      baseY = regionY + regionHeight
+      break
+    case "bottom-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight
+      break
+    default:
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight
+      break
+  }
+
+  return {
+    x: baseX + offsetX,
+    y: baseY + offsetY,
+  }
+}
+
+/**
+ * 採点マーク画像を描画
+ */
+function drawScoringMark(
+  ctx: CanvasRenderingContext2D,
+  markImage: HTMLImageElement,
+  region: ScoringDataForPdf["cropRegion"],
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number,
+): void {
+  const regionX = region.x * imageWidth
+  const regionY = region.y * imageHeight
+  const regionWidth = region.width * imageWidth
+  const regionHeight = region.height * imageHeight
+
+  const markSize = Math.min(
+    config.markSize,
+    regionWidth * 0.8,
+    regionHeight * 0.8,
+  )
+  const { x, y } = calculateMarkPosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    markSize,
+    config.markPosition,
+  )
+
+  ctx.drawImage(markImage, x, y, markSize, markSize)
+}
+
+/**
+ * 部分点テキストを描画
+ */
+function drawPartialScoreText(
+  ctx: CanvasRenderingContext2D,
+  score: number,
+  region: ScoringDataForPdf["cropRegion"],
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number,
+): void {
+  if (!config.showPartialScore) return
+
+  const regionX = region.x * imageWidth
+  const regionY = region.y * imageHeight
+  const regionWidth = region.width * imageWidth
+  const regionHeight = region.height * imageHeight
+
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.partialScorePosition,
+    config.partialScoreOffsetX,
+    config.partialScoreOffsetY,
+  )
+
+  ctx.save()
+  ctx.font = `bold ${config.partialScoreSize}px sans-serif`
+  ctx.fillStyle = "#ef4444" // 赤色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 答案シート1枚分をCanvas上に描画
+ *
+ * @param canvas - 描画先のCanvas要素
+ * @param image - 答案画像
+ * @param scoringDataList - 採点データのリスト（設問ごと）
+ * @param annotations - 全アノテーション
+ * @param config - 採点マーク設定
+ * @param scoringMarkImages - 採点マーク画像のMap
+ * @returns PNG Blob
+ */
+export async function renderAnswerSheetToCanvas(
+  canvas: HTMLCanvasElement,
+  image: HTMLImageElement,
+  scoringDataList: ScoringDataForPdf[],
+  annotations: DrawingAnnotation[],
+  config: ScoringMarkConfigForPdf,
+  scoringMarkImages: Map<string, HTMLImageElement>,
+): Promise<Blob> {
+  const ctx = canvas.getContext("2d")
+  if (!ctx) {
+    throw new Error("Canvas context not available")
+  }
+
+  const imageWidth = image.naturalWidth
+  const imageHeight = image.naturalHeight
+
+  // Canvasサイズを画像サイズに設定
+  canvas.width = imageWidth
+  canvas.height = imageHeight
+
+  // Canvasをクリア
+  ctx.clearRect(0, 0, imageWidth, imageHeight)
+
+  // Canvas Context設定
+  ctx.globalCompositeOperation = "source-over"
+  ctx.globalAlpha = 1.0
+  ctx.lineCap = "butt"
+  ctx.lineJoin = "miter"
+  ctx.miterLimit = 10
+  ctx.setLineDash([])
+
+  // 1. 答案画像を描画
+  ctx.drawImage(image, 0, 0)
+
+  // 2. 各設問に対して採点マークと部分点を描画
+  for (const scoringData of scoringDataList) {
+    if (scoringData.status === "unscored") continue
+
+    // 採点マーク画像の取得
+    const markKey =
+      scoringData.status === "pending"
+        ? "hold"
+        : scoringData.status === "no_answer"
+          ? "incorrect"
+          : scoringData.status
+    const markImage = scoringMarkImages.get(markKey)
+
+    if (markImage) {
+      drawScoringMark(
+        ctx,
+        markImage,
+        scoringData.cropRegion,
+        config,
+        imageWidth,
+        imageHeight,
+      )
+    }
+
+    // 部分点テキストの描画
+    if (
+      scoringData.status === "partial" &&
+      scoringData.partialScore !== null &&
+      scoringData.partialScore !== undefined
+    ) {
+      drawPartialScoreText(
+        ctx,
+        scoringData.partialScore,
+        scoringData.cropRegion,
+        config,
+        imageWidth,
+        imageHeight,
+      )
+    }
+  }
+
+  // 3. 全アノテーションを描画
+  for (const annotation of annotations) {
+    const element = convertAnnotationToDrawingElement(annotation)
+    await drawElement(ctx, element, imageWidth, imageHeight)
+  }
+
+  // Canvas結果をBlobとして取得
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+        } else {
+          reject(new Error("Failed to create blob from canvas"))
+        }
+      },
+      "image/png",
+      1.0,
+    )
+  })
+}
+
+/**
+ * 採点マーク画像をプリロード
+ *
+ * fetchしてBlobからObjectURLを作成することで、Canvasのtainted問題を回避
+ */
+export async function preloadScoringMarkImages(
+  useTransparent: boolean,
+): Promise<Map<string, HTMLImageElement>> {
+  const prefix = useTransparent ? "tp_" : ""
+  const markTypes = ["correct", "partial", "hold", "incorrect"]
+  const images = new Map<string, HTMLImageElement>()
+
+  await Promise.all(
+    markTypes.map(async (type) => {
+      try {
+        // fetchしてBlobとして取得
+        const response = await fetch(`/score-assets/${prefix}${type}.png`)
+        const blob = await response.blob()
+        const objectUrl = URL.createObjectURL(blob)
+
+        const img = new Image()
+        img.src = objectUrl
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => {
+            // ObjectURLを解放（画像は既にメモリにロード済み）
+            URL.revokeObjectURL(objectUrl)
+            resolve()
+          }
+          img.onerror = () => {
+            URL.revokeObjectURL(objectUrl)
+            reject(new Error(`Failed to load ${type} mark image`))
+          }
+        })
+        images.set(type, img)
+      } catch (error) {
+        console.error(`Failed to fetch ${type} mark image:`, error)
+        // フォールバック: 直接読み込み
+        const img = new Image()
+        img.crossOrigin = "anonymous"
+        img.src = `/score-assets/${prefix}${type}.png`
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve()
+          img.onerror = () =>
+            reject(new Error(`Failed to load ${type} mark image`))
+        })
+        images.set(type, img)
+      }
+    }),
+  )
+
+  return images
+}

--- a/electron-src/ipc-handlers/export-handlers.ts
+++ b/electron-src/ipc-handlers/export-handlers.ts
@@ -1,6 +1,12 @@
 import { ipcMain } from "electron"
-import { exportScoredAnswersPDF } from "../lib/prisma/pdfExport"
 import { exportGradingDataExcel } from "../lib/prisma/excelExport"
+import {
+  createPdfFromRenderedImages,
+  exportScoredAnswersPDF,
+  getPdfExportData,
+} from "../lib/prisma/pdfExport"
+
+import { BrowserWindow } from "electron"
 
 export function setupExportHandlers(): void {
   // PDF Export handlers
@@ -58,6 +64,197 @@ export function setupExportHandlers(): void {
         return await exportGradingDataExcel(options)
       } catch (err) {
         console.error("Error exporting grading data Excel:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // Canvas描画用PDF出力データ取得
+  ipcMain.handle(
+    "export:getPdfExportData",
+    async (
+      _event,
+      options: {
+        projectId: string
+        selectedStudentIds: string[]
+      },
+    ) => {
+      try {
+        return await getPdfExportData(options)
+      } catch (err) {
+        console.error("Error getting PDF export data:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // Canvas描画済み画像からPDF作成
+  ipcMain.handle(
+    "export:createPdfFromRenderedImages",
+    async (
+      event,
+      options: {
+        projectId: string
+        renderedPages: Array<{
+          studentId: string
+          pageNumber: number
+          imageData: ArrayBuffer
+        }>
+        pdfOrientation?: "portrait" | "landscape"
+      },
+    ) => {
+      try {
+        // プログレスコールバックを設定
+        const progressCallback = (progress: {
+          current: number
+          total: number
+          step: string
+          percentage: number
+          currentStepIndex: number
+          totalSteps: number
+        }) => {
+          event.sender.send("export-progress", progress)
+        }
+
+        return await createPdfFromRenderedImages({
+          ...options,
+          progressCallback,
+        })
+      } catch (err) {
+        console.error("Error creating PDF from rendered images:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // PDF保存先選択ダイアログ（Canvas描画前に呼び出す）
+  ipcMain.handle(
+    "export:selectPdfSavePath",
+    async (
+      _event,
+      options: {
+        projectName?: string
+      },
+    ): Promise<{ success: boolean; filePath?: string; canceled?: boolean }> => {
+      try {
+        const { dialog } = require("electron")
+        const dateStr = new Date().toISOString().split("T")[0]
+        const safeProjectName = options.projectName
+          ? options.projectName.replace(/[<>:"/\\|?*]/g, "_")
+          : null
+        const defaultFileName = safeProjectName
+          ? `採点済み答案_${safeProjectName}_${dateStr}.pdf`
+          : `採点済み答案_${dateStr}.pdf`
+
+        const result = await dialog.showSaveDialog({
+          title: "採点済み答案PDFの保存先",
+          defaultPath: defaultFileName,
+          filters: [{ name: "PDF Files", extensions: ["pdf"] }],
+        })
+
+        if (result.canceled || !result.filePath) {
+          return { success: false, canceled: true }
+        }
+
+        return { success: true, filePath: result.filePath }
+      } catch (err) {
+        console.error("Error selecting PDF save path:", err)
+        return {
+          success: false,
+          canceled: false,
+        }
+      }
+    },
+  )
+
+  // SVG→PNG変換ハンドラ（MathJaxテキストのtaint問題回避用）
+  ipcMain.handle(
+    "export:convertSvgToPng",
+    async (
+      _event,
+      options: {
+        svgString: string
+        width?: number
+        height?: number
+      },
+    ): Promise<{
+      success: boolean
+      dataUrl?: string
+      width?: number
+      height?: number
+      error?: string
+    }> => {
+      try {
+        const { svgString } = options
+
+        const widthMatch = svgString.match(/width="([\d.]+)"/)
+        const heightMatch = svgString.match(/height="([\d.]+)"/)
+        const width = widthMatch ? Math.ceil(parseFloat(widthMatch[1])) : 200
+        const height = heightMatch ? Math.ceil(parseFloat(heightMatch[1])) : 50
+
+        const win = new BrowserWindow({
+          width: width + 20,
+          height: height + 20,
+          show: false,
+          transparent: true,
+          frame: false,
+          hasShadow: false,
+          webPreferences: {
+            offscreen: true,
+          },
+        })
+
+        try {
+          const html = `
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <style>
+                * { margin: 0; padding: 0; }
+                html, body { background: transparent; overflow: hidden; }
+              </style>
+            </head>
+            <body>
+              ${svgString}
+            </body>
+            </html>
+          `
+          const dataUri = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+          await win.loadURL(dataUri)
+
+          await new Promise((resolve) => setTimeout(resolve, 100))
+
+          // capturePageはRetinaで2倍のピクセル数を返すため、論理サイズも返す
+          const image = await win.webContents.capturePage({
+            x: 0,
+            y: 0,
+            width,
+            height,
+          })
+          const pngBuffer = image.toPNG()
+          const base64 = pngBuffer.toString("base64")
+          const dataUrl = `data:image/png;base64,${base64}`
+
+          return {
+            success: true,
+            dataUrl,
+            width,
+            height,
+          }
+        } finally {
+          win.destroy()
+        }
+      } catch (err) {
+        console.error("Error converting SVG to PNG:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "Unknown error occurred",

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -1741,12 +1741,24 @@ export async function getPdfExportData(options: {
           }
         }
 
+        // 画像をbase64データURLに変換（Canvasのtainted問題を回避）
+        let imageUrl = ""
+        try {
+          const imageBuffer = fs.readFileSync(imagePath)
+          const ext = path.extname(imagePath).toLowerCase()
+          const mimeType = ext === ".png" ? "image/png" : ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png"
+          imageUrl = `data:${mimeType};base64,${imageBuffer.toString("base64")}`
+        } catch (imgError) {
+          console.error(`Failed to read image: ${imagePath}`, imgError)
+          continue // この画像をスキップ
+        }
+
         pages.push({
           studentId: student.id,
           studentName: `${student.lastName} ${student.firstName}`,
           pageNumber,
           imagePath,
-          imageUrl: `file://${imagePath}`,
+          imageUrl,
           scoringData,
           annotations,
         })
@@ -1785,6 +1797,7 @@ export async function createPdfFromRenderedImages(options: {
     imageData: ArrayBuffer
   }>
   pdfOrientation?: "portrait" | "landscape"
+  outputPath?: string
   progressCallback?: (progress: {
     current: number
     total: number
@@ -1794,7 +1807,7 @@ export async function createPdfFromRenderedImages(options: {
     totalSteps: number
   }) => void
 }): Promise<{ success: boolean; outputPath?: string; error?: string }> {
-  const { projectId, renderedPages, pdfOrientation = "portrait", progressCallback } = options
+  const { projectId, renderedPages, pdfOrientation = "portrait", outputPath: providedOutputPath, progressCallback } = options
 
   try {
     // プロジェクト情報を取得
@@ -1803,16 +1816,20 @@ export async function createPdfFromRenderedImages(options: {
       return { success: false, error: "プロジェクトが見つかりません" }
     }
 
-    // 保存先を選択
-    const sanitizedExamName = sanitizeFileName(project.examName || "採点済み答案")
-    const { filePath: outputPath, canceled } = await dialog.showSaveDialog({
-      title: "採点済み答案PDFの保存先",
-      defaultPath: `${sanitizedExamName}_採点済み.pdf`,
-      filters: [{ name: "PDF", extensions: ["pdf"] }],
-    })
+    // 保存先を決定（事前に指定されている場合はダイアログをスキップ）
+    let outputPath = providedOutputPath
+    if (!outputPath) {
+      const sanitizedExamName = sanitizeFileName(project.examName || "採点済み答案")
+      const { filePath, canceled } = await dialog.showSaveDialog({
+        title: "採点済み答案PDFの保存先",
+        defaultPath: `${sanitizedExamName}_採点済み.pdf`,
+        filters: [{ name: "PDF", extensions: ["pdf"] }],
+      })
 
-    if (canceled || !outputPath) {
-      return { success: false, error: "保存がキャンセルされました" }
+      if (canceled || !filePath) {
+        return { success: false, error: "保存がキャンセルされました" }
+      }
+      outputPath = filePath
     }
 
     progressCallback?.({

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -1,7 +1,6 @@
-import { Prisma } from "@prisma/client"
 import type { DrawingAnnotation } from "@prisma/client"
+import { Prisma } from "@prisma/client"
 import { contextBridge, ipcRenderer, IpcRenderer } from "electron"
-import { CreateProjectArgs } from "../types/electron"
 import {
   CropRegionCreateData,
   CropRegionUpdateData,
@@ -9,6 +8,7 @@ import {
   QuestionScoreUpdateData,
   ScoringMarkConfig,
 } from "../types/common.types"
+import { CreateProjectArgs } from "../types/electron"
 
 declare global {
   namespace NodeJS {
@@ -89,7 +89,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("get-answer-sheets-by-project-id", projectId),
   deleteStudentAnswer: (answerSheetId: string) =>
     ipcRenderer.invoke("delete-answer-sheet", answerSheetId),
-  associateStudentAnswerWithStudent: (answerSheetId: string, studentId: string) =>
+  associateStudentAnswerWithStudent: (
+    answerSheetId: string,
+    studentId: string,
+  ) =>
     ipcRenderer.invoke(
       "associate-answer-sheet-with-student",
       answerSheetId,
@@ -110,7 +113,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
       studentId,
       pageNumber,
     ),
-  swapStudentAnswerPlacements: (answerSheetId1: string, answerSheetId2: string) =>
+  swapStudentAnswerPlacements: (
+    answerSheetId1: string,
+    answerSheetId2: string,
+  ) =>
     ipcRenderer.invoke(
       "swap-answer-sheet-placements",
       answerSheetId1,
@@ -465,6 +471,32 @@ contextBridge.exposeInMainWorld("electronAPI", {
     scoringMarkConfig?: ScoringMarkConfig
   }) => ipcRenderer.invoke("export-scored-answers-pdf", options),
 
+  // Canvas描画エンジン用PDF出力API
+  export: {
+    getPdfExportData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+    }) => ipcRenderer.invoke("export:getPdfExportData", options),
+    createPdfFromRenderedImages: (options: {
+      projectId: string
+      renderedPages: Array<{
+        studentId: string
+        pageNumber: number
+        imageData: ArrayBuffer
+      }>
+      pdfOrientation?: "portrait" | "landscape"
+      outputPath?: string
+    }) => ipcRenderer.invoke("export:createPdfFromRenderedImages", options),
+    convertSvgToPng: (options: {
+      svgString: string
+      width?: number
+      height?: number
+    }) => ipcRenderer.invoke("export:convertSvgToPng", options),
+    selectPdfSavePath: (options: {
+      projectName?: string
+    }) => ipcRenderer.invoke("export:selectPdfSavePath", options),
+  },
+
   // Excel Export related
   exportGradingDataExcel: (options: {
     projectId: string
@@ -492,20 +524,30 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Drawing Annotation related
   drawing: {
-    create: (data: Partial<DrawingAnnotation>) => ipcRenderer.invoke("drawing:create", data),
-    getByQuestionScore: (questionScoreId: string, type?: string) => 
+    create: (data: Partial<DrawingAnnotation>) =>
+      ipcRenderer.invoke("drawing:create", data),
+    getByQuestionScore: (questionScoreId: string, type?: string) =>
       ipcRenderer.invoke("drawing:getByQuestionScore", questionScoreId, type),
     getByStudent: (studentId: string, projectId: string, type?: string) =>
       ipcRenderer.invoke("drawing:getByStudent", studentId, projectId, type),
     getByProject: (projectId: string, type?: string) =>
       ipcRenderer.invoke("drawing:getByProject", projectId, type),
-    update: (id: string, data: Partial<DrawingAnnotation>) => ipcRenderer.invoke("drawing:update", id, data),
+    update: (id: string, data: Partial<DrawingAnnotation>) =>
+      ipcRenderer.invoke("drawing:update", id, data),
     delete: (id: string) => ipcRenderer.invoke("drawing:delete", id),
-    deleteByQuestionScore: (questionScoreId: string, type?: string) => 
-      ipcRenderer.invoke("drawing:deleteByQuestionScore", questionScoreId, type),
-    batchCreate: (annotations: Partial<DrawingAnnotation>[]) => ipcRenderer.invoke("drawing:batchCreate", annotations),
-    batchUpdate: (updates: Array<{id: string; data: Partial<DrawingAnnotation>}>) => ipcRenderer.invoke("drawing:batchUpdate", updates),
-    getStats: (questionScoreId: string) => ipcRenderer.invoke("drawing:getStats", questionScoreId),
+    deleteByQuestionScore: (questionScoreId: string, type?: string) =>
+      ipcRenderer.invoke(
+        "drawing:deleteByQuestionScore",
+        questionScoreId,
+        type,
+      ),
+    batchCreate: (annotations: Partial<DrawingAnnotation>[]) =>
+      ipcRenderer.invoke("drawing:batchCreate", annotations),
+    batchUpdate: (
+      updates: Array<{ id: string; data: Partial<DrawingAnnotation> }>,
+    ) => ipcRenderer.invoke("drawing:batchUpdate", updates),
+    getStats: (questionScoreId: string) =>
+      ipcRenderer.invoke("drawing:getStats", questionScoreId),
     getById: (id: string) => ipcRenderer.invoke("drawing:getById", id),
   },
 })

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1,34 +1,30 @@
 import type {
-  Prisma,
-  User,
   Class,
-  Student,
-  Project,
-  ProjectPage,
-  PageImage,
   CropRegion,
-  SubtotalGroup,
-  Subtotal,
   CropSubtotal,
-  UserProject,
+  PageImage,
+  Prisma,
+  Project,
   ProjectSubtotalGroup,
   QuestionScore,
-  StudentAnswer,
-  ProjectStudent,
-  StudentClassMembership,
+  Student,
+  Subtotal,
+  SubtotalGroup,
+  User,
+  UserProject,
 } from "@prisma/client"
 
 // PDF.js module declarations
-declare module 'pdfjs-dist/legacy/build/pdf.min.mjs' {
-  export * from 'pdfjs-dist'
-  export { default } from 'pdfjs-dist'
+declare module "pdfjs-dist/legacy/build/pdf.min.mjs" {
+  export * from "pdfjs-dist"
+  export { default } from "pdfjs-dist"
 }
 
-declare module 'pdfjs-dist' {
+declare module "pdfjs-dist" {
   export const GlobalWorkerOptions: {
     workerSrc: string
   }
-  
+
   export function getDocument(params: {
     data: ArrayBuffer
     password?: string
@@ -202,7 +198,6 @@ export type SaveCropRegionArgs = Omit<
   Prisma.CropRegionUncheckedCreateInput,
   "id" | "createdAt" | "updatedAt"
 > & { id?: string; projectPageId: string }
-
 
 // SubtotalGroup and Subtotal related types (updated from QuestionGroup/Item)
 export type SubtotalGroupWithItems = Prisma.SubtotalGroupGetPayload<{
@@ -573,9 +568,7 @@ export interface MyAPI {
       path?: string
     }[],
   ) => Promise<ProjectPageWithDetails[]>
-  deleteMasterAnswer: (
-    answerId: string,
-  ) => Promise<MasterAnswerDeletionResult>
+  deleteMasterAnswer: (answerId: string) => Promise<MasterAnswerDeletionResult>
   updateMasterAnswersOrder: (
     answerOrders: { id: string; pageNumber: number }[],
   ) => Promise<Prisma.BatchPayload>
@@ -628,7 +621,6 @@ export interface MyAPI {
   updateCropRegionOrders: (
     updates: Array<{ id: string; orderIndex: number }>,
   ) => Promise<CropRegion[]>
-
 
   // SubtotalGroup related (updated from QuestionGroup)
   getSubtotalGroups: () => Promise<{
@@ -797,7 +789,7 @@ export interface MyAPI {
   getSubtotalDefinitionsByCropRegionId: (
     cropRegionId: string,
   ) => Promise<CropSubtotalWithRelations[]>
-  
+
   // Backward compatibility aliases
   deleteSubtotalDefinitionsByLayoutRegionId: (
     cropRegionId: string,
@@ -850,7 +842,7 @@ export interface MyAPI {
   deleteAssignmentsByQuestionCropRegionId: (
     questionCropRegionId: string,
   ) => Promise<Prisma.BatchPayload>
-  
+
   // Backward compatibility alias
   deleteAssignmentsByQuestionLayoutRegionId: (
     questionLayoutRegionId: string,
@@ -1057,6 +1049,98 @@ export interface MyAPI {
     error?: string
   }>
 
+  // Canvas描画エンジン用PDF出力API
+  export: {
+    // PDF出力に必要なデータを取得
+    getPdfExportData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+    }) => Promise<{
+      success: boolean
+      projectName?: string
+      pages?: Array<{
+        studentId: string
+        studentName: string
+        pageNumber: number
+        imagePath: string
+        imageUrl: string
+        scoringData: Array<{
+          questionScoreId: string
+          status: string
+          partialScore: number | null
+          cropRegion: {
+            id: string
+            x: number
+            y: number
+            width: number
+            height: number
+            label: string
+            maxScore: number | null
+            pageNumber: number
+          }
+        }>
+        annotations: Array<{
+          id: string
+          questionScoreId: string
+          type: string
+          x: number
+          y: number
+          color: string
+          strokeWidth: number
+          width: number
+          height: number
+          endX: number
+          endY: number
+          lineStyle: string
+          text: string
+          fontSize: number
+          displayX: number
+          displayY: number
+          anchorDirection: string
+        }>
+      }>
+      error?: string
+    }>
+
+    // Canvas描画済み画像からPDF作成
+    createPdfFromRenderedImages: (options: {
+      projectId: string
+      renderedPages: Array<{
+        studentId: string
+        pageNumber: number
+        imageData: ArrayBuffer
+      }>
+      pdfOrientation?: "portrait" | "landscape"
+      outputPath?: string
+    }) => Promise<{
+      success: boolean
+      outputPath?: string
+      error?: string
+    }>
+
+    // SVG→PNG変換（MathJaxテキストのtaint問題回避用）
+    convertSvgToPng: (options: {
+      svgString: string
+      width?: number
+      height?: number
+    }) => Promise<{
+      success: boolean
+      dataUrl?: string
+      width?: number   // 描画時に使用すべき論理サイズ（Retinaでimg.widthは2倍になるため）
+      height?: number
+      error?: string
+    }>
+
+    // PDF保存先選択ダイアログ（Canvas描画前に呼び出す）
+    selectPdfSavePath: (options: {
+      projectName?: string
+    }) => Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+    }>
+  }
+
   // Excel Export related
   exportGradingDataExcel: (options: {
     projectId: string
@@ -1113,42 +1197,44 @@ export interface MyAPI {
 
   // Drawing Annotation related
   drawing: {
-    create: (data: import('./drawing-annotation.types').DrawingCreateData) => Promise<{
+    create: (
+      data: import("./drawing-annotation.types").DrawingCreateData,
+    ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation
+      data?: import("./drawing-annotation.types").DrawingAnnotation
       error?: string
     }>
     getByQuestionScore: (
       questionScoreId: string,
-      type?: import('./drawing-annotation.types').DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation[]
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
     getByStudent: (
       studentId: string,
       projectId: string,
-      type?: import('./drawing-annotation.types').DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation[]
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
     getByProject: (
       projectId: string,
-      type?: import('./drawing-annotation.types').DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation[]
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
     update: (
       id: string,
-      data: import('./drawing-annotation.types').DrawingUpdateData
+      data: import("./drawing-annotation.types").DrawingUpdateData,
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation
+      data?: import("./drawing-annotation.types").DrawingAnnotation
       error?: string
     }>
     delete: (id: string) => Promise<{
@@ -1157,36 +1243,36 @@ export interface MyAPI {
     }>
     deleteByQuestionScore: (
       questionScoreId: string,
-      type?: import('./drawing-annotation.types').DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
     ) => Promise<{
       success: boolean
       error?: string
     }>
     batchCreate: (
-      annotations: import('./drawing-annotation.types').DrawingCreateData[]
+      annotations: import("./drawing-annotation.types").DrawingCreateData[],
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation[]
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
     batchUpdate: (
       updates: Array<{
         id: string
-        data: import('./drawing-annotation.types').DrawingUpdateData
-      }>
+        data: import("./drawing-annotation.types").DrawingUpdateData
+      }>,
     ) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation[]
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
     getStats: (questionScoreId: string) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotationStats
+      data?: import("./drawing-annotation.types").DrawingAnnotationStats
       error?: string
     }>
     getById: (id: string) => Promise<{
       success: boolean
-      data?: import('./drawing-annotation.types').DrawingAnnotation | null
+      data?: import("./drawing-annotation.types").DrawingAnnotation | null
       error?: string
     }>
   }


### PR DESCRIPTION
## 概要

Closes #205

v4テキストエンジンでfontSizeが正しく反映されるよう修正し、PDF出力がRetina環境でも正しいサイズで出力されるよう対応しました。

## 変更内容

### v4テキストエンジンのfontSize対応
- `textConversionUtils.ts`: fontSizeを内部関数に伝播
- `mathJaxUtils.ts`: 測定・SVG生成でfontSizeパラメータを使用
- `canvasUtils.ts`: 不要なscale引数を削除
- `canvasTextRendererV4.ts`: スケーリングロジック削除、キャッシュにfontSize追加

### PDF出力のRetina対応
- `export-handlers.ts`: capturePageの論理サイズ（width/height）を戻り値に追加
- `pdf-canvas-renderer.ts`: 論理サイズで描画
- `electron.d.ts`: 型定義更新

### PDF出力フロー
- `PdfCanvasRenderer.tsx`: 新規PDFレンダリングコンポーネント
- `ExportMainView.tsx`, `pdfExport.ts`, `preload.ts`: PDF出力フロー対応

## 技術的詳細

### Retina対応の仕組み

| デバイス | capturePage結果 | img.width | 論理サイズ | 描画サイズ |
|---------|----------------|-----------|-----------|-----------|
| 1x (非Retina) | 100x50 px | 100 | 100 | 100x50 ✓ |
| 2x (Retina) | 200x100 px | 200 | 100 | 100x50 ✓ |

SVGの宣言サイズを信頼の源とし、全環境で一貫した出力サイズを保証します。

## テスト

- [x] 型チェック通過
- [x] Lint通過（既存警告のみ）
- [x] 一括採点個別表示で動作確認
- [x] PDF出力で動作確認（Retina環境）

🤖 Generated with [Claude Code](https://claude.com/claude-code)