### PR TITLE
採点済み答案PDF出力の並列化とUI改善

### DIFF
--- a/app/projects/[projectId]/08-export/types.ts
+++ b/app/projects/[projectId]/08-export/types.ts
@@ -1,3 +1,20 @@
+// 個人成績表用型定義をre-export
+export type {
+  IndividualReportOptions,
+  GraphOptions,
+  AdviceOptions,
+  ReportDisplayMode,
+  ScoreRateFormat,
+  AverageDisplayType,
+  QuestionFilterMode,
+  RankDisplayType,
+} from "@/electron-src/lib/export/individual-report/types"
+export {
+  DEFAULT_INDIVIDUAL_REPORT_OPTIONS,
+  DEFAULT_GRAPH_OPTIONS,
+  DEFAULT_ADVICE_OPTIONS,
+} from "@/electron-src/lib/export/individual-report/types"
+
 // 生徒の状態を表す型
 export type StudentStatus = "participating" | "expected" | "absent"
 
@@ -36,4 +53,49 @@ export interface ExportOptions {
   markSize: number
   showMarks: boolean
   pdfOrientation: PdfOrientation
+  parallelCount: number // 並列処理数（1-8）
+}
+
+// PDF出力フェーズの型
+export type ExportPhase = 'initializing' | 'rendering' | 'embedding' | 'saving' | 'complete'
+
+// Canvas描画の詳細プログレス
+export interface RenderProgress {
+  phase: 'preload' | 'rendering' | 'complete'
+  total: number
+  completed: number
+  inProgress: number      // 現在描画中のページ数
+  currentPages: number[]  // 描画中のページインデックス
+}
+
+// PDF埋め込みの詳細プログレス
+export interface EmbedProgress {
+  total: number
+  completed: number
+}
+
+// 詳細なプログレス状態
+export interface DetailedProgressState {
+  overallPercentage: number
+  phase: ExportPhase
+
+  // Canvas描画の詳細
+  rendering: RenderProgress
+
+  // PDF埋め込みの詳細
+  embedding: EmbedProgress
+
+  // タイミング情報
+  timing: {
+    startTime: number
+    estimatedRemaining: number | null  // 秒
+  }
+}
+
+// レンダリングされたページデータ
+export interface RenderedPageData {
+  pageIndex: number
+  studentId: string
+  pageNumber: number
+  imageData: ArrayBuffer
 }

--- a/components/projects/08-export/ExportMainView.tsx
+++ b/components/projects/08-export/ExportMainView.tsx
@@ -1,11 +1,14 @@
 "use client"
 
+import { pdf } from "@react-pdf/renderer"
+import type { RenderProgress, RenderedPageData } from "@/app/projects/[projectId]/08-export/types"
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 import { ExportOptionsCard } from "@/components/projects/08-export/components/ExportOptionsCard"
 import ExportProgressModal from "@/components/projects/08-export/components/ExportProgressModal"
 import ExportWarningModal from "@/components/projects/08-export/components/ExportWarningModal"
+import { IndividualReportDocument, registerFonts } from "@/components/projects/08-export/components/individual-report-pdf"
 import {
   PdfCanvasRenderer,
   type PdfExportPageData,
@@ -13,7 +16,7 @@ import {
 import { StudentSelectionCard } from "@/components/projects/08-export/components/StudentSelectionCard"
 import { useExportPage } from "@/components/projects/08-export/hooks/useExportPage"
 import type { ScoringMarkConfigForPdf } from "@/components/projects/08-export/utils/pdf-canvas-renderer"
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 export default function ExportMainView() {
   const { helpButton } = usePageHelp()
@@ -27,17 +30,17 @@ export default function ExportMainView() {
   // Canvas描画用の状態
   const [pdfExportPages, setPdfExportPages] = useState<PdfExportPageData[]>([])
   const [startCanvasRendering, setStartCanvasRendering] = useState(false)
-  const [pdfOutputPath, setPdfOutputPath] = useState<string>("")
 
-  // 並行処理用のref（保存先選択とCanvas描画の同期用）
-  const savePathResolverRef = useRef<((path: string | null) => void) | null>(null)
-  const pdfOutputPathRef = useRef<string>("") // 保存先パス（即座に反映用）
-  const renderedPagesRef = useRef<Array<{
-    studentId: string
-    pageNumber: number
-    imageData: ArrayBuffer
-  }> | null>(null)
-  const isWaitingForSavePathRef = useRef(false)
+  // 保存先選択のPromiseを保持（並行処理用）
+  const savePathPromiseRef = useRef<Promise<{ success: boolean; filePath?: string; canceled?: boolean }> | null>(null)
+
+  // ストリーミングセッション用の状態
+  const streamingSessionIdRef = useRef<string | null>(null)
+  const [embeddedPagesCount, setEmbeddedPagesCount] = useState(0)
+  const [totalPagesCount, setTotalPagesCount] = useState(0)
+  const [canvasRenderingComplete, setCanvasRenderingComplete] = useState(false)
+  const savePathResultRef = useRef<{ filePath: string } | null>(null)
+  const isExportCancelledRef = useRef(false)
 
   const {
     project,
@@ -56,6 +59,8 @@ export default function ExportMainView() {
     setExportOptions,
     scoringMarkConfig,
     setScoringMarkConfig,
+    individualReportOptions,
+    setIndividualReportOptions,
     showProgressModal,
     setShowProgressModal,
     exportProgress,
@@ -70,23 +75,43 @@ export default function ExportMainView() {
 
   /**
    * scoringMarkConfigをScoringMarkConfigForPdf形式に変換
+   * 常にpartialScoreオブジェクトから読み取る（UIが常にpartialScoreに保存するため）
    */
   const getScoringMarkConfigForPdf = useCallback((): ScoringMarkConfigForPdf => {
+    // 部分点設定を取得（partialScoreが存在する場合はそれを使用、なければ旧式設定からフォールバック）
+    const partialScore = scoringMarkConfig.partialScore
+    const partialScoreConfig = partialScore && partialScore.size !== undefined
+      ? partialScore
+      : {
+          position: scoringMarkConfig.scorePosition || "middle-center",
+          size: scoringMarkConfig.scoreSize || 14,
+          offsetX: scoringMarkConfig.scoreOffsetX || 0,
+          offsetY: scoringMarkConfig.scoreOffsetY || 0,
+        }
+
+    console.log("[DEBUG] getScoringMarkConfigForPdf:", {
+      useSeparateScoreSettings: scoringMarkConfig.useSeparateScoreSettings,
+      partialScore: scoringMarkConfig.partialScore,
+      partialScoreConfig,
+    })
+
     return {
       markPosition: scoringMarkConfig.markPosition,
       markSize: scoringMarkConfig.markSize,
       useTransparent: scoringMarkConfig.useTransparent,
       showPartialScore: true, // 部分点を表示
-      partialScorePosition: scoringMarkConfig.scorePosition || "bottom-right",
-      partialScoreSize: scoringMarkConfig.scoreSize || 14,
-      partialScoreOffsetX: scoringMarkConfig.scoreOffsetX || 0,
-      partialScoreOffsetY: scoringMarkConfig.scoreOffsetY || 0,
+      partialScorePosition: partialScoreConfig.position || "middle-center",
+      partialScoreSize: partialScoreConfig.size || 14,
+      partialScoreOffsetX: partialScoreConfig.offsetX || 0,
+      partialScoreOffsetY: partialScoreConfig.offsetY || 0,
+      // ステータスごとの点数表示設定
+      showScoreForStatus: scoringMarkConfig.showScoreForStatus,
     }
   }, [scoringMarkConfig])
 
   /**
-   * Canvas描画ベースのPDF出力（並行処理フロー）
-   * 保存先選択とデータ取得→Canvas描画を完全並行処理で実行
+   * Canvas描画ベースのPDF出力（ストリーミング処理フロー）
+   * 1. データ取得 → 2. ストリーミングセッション作成 & 保存先選択 → 3. Canvas描画（完了次第PDF埋め込み） → 4. PDF保存
    */
   const handleExportScoredAnswers = async () => {
     if (selectedStudents.size === 0) {
@@ -94,205 +119,236 @@ export default function ExportMainView() {
       return
     }
 
-    try {
-      // 状態リセット
-      renderedPagesRef.current = null
-      isWaitingForSavePathRef.current = false
-      pdfOutputPathRef.current = ""
+    if (isExporting) {
+      return
+    }
 
+    try {
       // 処理開始
       setIsExporting(true)
       setShowProgressModal(true)
       setExportProgress(0)
       setExportStatus("processing")
-      setCurrentStep("保存先を選択してください（バックグラウンドで処理中...）")
+      setCurrentStep("データを取得中...")
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathResultRef.current = null
+      isExportCancelledRef.current = false
 
       const selectedStudentIds = Array.from(selectedStudents)
 
-      // 保存先選択のPromiseを作成（Canvas描画完了時に解決を待つ）
-      const savePathPromise = new Promise<string | null>((resolve) => {
-        savePathResolverRef.current = resolve
+      // 1. データ取得
+      const dataResult = await window.electronAPI.export.getPdfExportData({
+        projectId: project.id,
+        selectedStudentIds,
       })
 
-      // 並行処理開始: 保存先選択とデータ取得を同時に開始
-      const savePathTask = (async () => {
-        const result = await window.electronAPI.export.selectPdfSavePath({
-          projectName: project?.examName,
-        })
-        const path = result.canceled || !result.filePath ? null : result.filePath
-        // 保存先が決まったらrefに即座に反映
-        if (path) {
-          pdfOutputPathRef.current = path
-        }
-        // resolverを呼び出す（Canvas描画完了待ちの場合に通知）
-        if (savePathResolverRef.current) {
-          savePathResolverRef.current(path)
-        }
-        return path
-      })()
-
-      const dataTask = (async () => {
-        const dataResult = await window.electronAPI.export.getPdfExportData({
-          projectId: project.id,
-          selectedStudentIds,
-        })
-
-        // データ取得エラーチェック
-        if (!dataResult.success || !dataResult.pages) {
-          throw new Error(dataResult.error || "データ取得に失敗しました")
-        }
-
-        if (dataResult.pages.length === 0) {
-          throw new Error("出力対象のページがありません")
-        }
-
-        // Canvas描画を開始（保存先の決定を待たずに）
-        setExportProgress(5)
-        setCurrentStep("保存先を選択してください（Canvas描画を開始...）")
-        setPdfExportPages(dataResult.pages)
-        setStartCanvasRendering(true)
-
-        return dataResult.pages
-      })()
-
-      // 保存先選択の結果を待つ（Canvas描画は並行して進行中）
-      const savePath = await savePathTask
-
-      // 保存先のキャンセルチェック
-      if (!savePath) {
-        // ユーザーがキャンセルした場合は中止
-        setStartCanvasRendering(false)
-        setPdfExportPages([])
-        setShowProgressModal(false)
-        setIsExporting(false)
-        return
+      if (!dataResult.success || !dataResult.pages) {
+        throw new Error(dataResult.error || "データ取得に失敗しました")
       }
 
-      setPdfOutputPath(savePath)
+      if (dataResult.pages.length === 0) {
+        throw new Error("出力対象のページがありません")
+      }
 
-      // データ取得タスクの完了を待つ（Canvas描画が開始されていることを確認）
-      await dataTask
+      setTotalPagesCount(dataResult.pages.length)
+      setExportProgress(5)
+
+      // 2. ストリーミングセッション作成（空ページを事前に作成）
+      setCurrentStep("PDFセッションを作成中...")
+      const sessionResult = await window.electronAPI.export.createPdfStreamingSession({
+        totalPages: dataResult.pages.length,
+        pdfOrientation: exportOptions.pdfOrientation,
+      })
+
+      if (!sessionResult.success || !sessionResult.sessionId) {
+        throw new Error(sessionResult.error || "PDFセッションの作成に失敗しました")
+      }
+
+      streamingSessionIdRef.current = sessionResult.sessionId
+
+      // 3. 保存先選択を並行で開始
+      setCurrentStep("保存先を選択してください...")
+      const savePathPromise = window.electronAPI.export.selectPdfSavePath({
+        projectName: project?.examName,
+      })
+      savePathPromiseRef.current = savePathPromise
+
+      // キャンセル監視：Canvas描画完了前にキャンセルされたら即座に中断
+      savePathPromise.then(result => {
+        if (!result.success || result.canceled || !result.filePath) {
+          // キャンセルフラグを立てる
+          isExportCancelledRef.current = true
+          // キャンセルされた場合、Canvas描画中なら中断
+          setStartCanvasRendering(false)
+          setPdfExportPages([])
+          setShowProgressModal(false)
+          setIsExporting(false)
+          setEmbeddedPagesCount(0)
+          setTotalPagesCount(0)
+          setCanvasRenderingComplete(false)
+          savePathPromiseRef.current = null
+          savePathResultRef.current = null
+          // セッションのクリーンアップ
+          if (streamingSessionIdRef.current) {
+            window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+            streamingSessionIdRef.current = null
+          }
+        }
+      })
+
+      // 4. Canvas描画を開始（onPageCompleteでPDFに逐次埋め込み）
+      setPdfExportPages(dataResult.pages)
+      setStartCanvasRendering(true)
+
+      // handlePageComplete と handleCanvasComplete がストリーミング処理を実行
 
     } catch (error) {
       console.error("Export error:", error)
       setExportStatus("error")
-      setCurrentStep(`出力中にエラーが発生しました: ${error instanceof Error ? error.message : "不明なエラー"}`)
+      setCurrentStep(`エラー: ${error instanceof Error ? error.message : "不明なエラー"}`)
       setIsExporting(false)
       setStartCanvasRendering(false)
       setPdfExportPages([])
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathPromiseRef.current = null
+      savePathResultRef.current = null
+      // セッションのクリーンアップ
+      if (streamingSessionIdRef.current) {
+        window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+        streamingSessionIdRef.current = null
+      }
     }
   }
 
   /**
-   * Canvas描画進捗コールバック
+   * Canvas描画進捗コールバック（並列処理対応）
    */
   const handleCanvasProgress = useCallback(
-    (current: number, total: number, step: string) => {
-      // 10-80%をCanvas描画に割り当て（0-10%はデータ取得）
-      const canvasProgress = 10 + Math.round((current / total) * 70)
-      setExportProgress(canvasProgress)
-      setCurrentStep(`Canvas描画中: ${current} / ${total} ページ`)
+    (progress: RenderProgress) => {
+      if (progress.phase === "preload") {
+        setExportProgress(5)
+        setCurrentStep("採点マーク画像を読み込み中...")
+      } else if (progress.phase === "rendering") {
+        // 10-90%をCanvas描画+PDF埋め込みに割り当て
+        // Canvas描画進捗とPDF埋め込み進捗を合成
+        const canvasWeight = 0.7  // Canvas描画に70%
+        const embedWeight = 0.3   // PDF埋め込みに30%
+        const canvasProgress = progress.completed / progress.total
+        const embedProgress = embeddedPagesCount / (totalPagesCount || 1)
+        const combinedProgress = 10 + Math.round((canvasProgress * canvasWeight + embedProgress * embedWeight) * 80)
+        setExportProgress(combinedProgress)
+        const parallelStr = progress.inProgress > 0 ? ` (${progress.inProgress}並列)` : ""
+        setCurrentStep(`Canvas: ${progress.completed}/${progress.total}ページ${parallelStr} | PDF: ${embeddedPagesCount}/${totalPagesCount}ページ埋め込み済み`)
+      } else if (progress.phase === "complete") {
+        setExportProgress(90)
+        setCurrentStep("Canvas描画完了、PDF保存中...")
+      }
     },
-    [setExportProgress, setCurrentStep]
+    [setExportProgress, setCurrentStep, embeddedPagesCount, totalPagesCount]
   )
 
   /**
-   * PDF生成・保存処理（Canvas描画完了後に呼び出し）
+   * 1ページ完了時のコールバック（ストリーミング埋め込み）
    */
-  const createAndSavePdf = useCallback(
-    async (
-      renderedPages: Array<{
-        studentId: string
-        pageNumber: number
-        imageData: ArrayBuffer
-      }>,
-      outputPath: string
-    ) => {
-      try {
-        setExportProgress(85)
-        setCurrentStep("PDFを作成中...")
+  const handlePageComplete = useCallback(
+    async (pageData: RenderedPageData) => {
+      // キャンセル済みなら何もしない
+      if (isExportCancelledRef.current) {
+        return
+      }
 
-        const result = await window.electronAPI.export.createPdfFromRenderedImages({
-          projectId: project.id,
-          renderedPages,
-          pdfOrientation: exportOptions.pdfOrientation,
-          outputPath,
+      if (!streamingSessionIdRef.current) {
+        console.error("Streaming session not found")
+        return
+      }
+
+      try {
+        const result = await window.electronAPI.export.addPageToStreamingSession({
+          sessionId: streamingSessionIdRef.current,
+          pageIndex: pageData.pageIndex,
+          imageData: pageData.imageData,
         })
 
         if (result.success) {
-          setExportProgress(100)
-          setExportStatus("completed")
-          setCurrentStep("完了しました")
+          setEmbeddedPagesCount(prev => prev + 1)
         } else {
-          setExportStatus("error")
-          setCurrentStep(`エラー: ${result.error}`)
+          console.error(`Failed to embed page ${pageData.pageIndex}:`, result.error)
         }
       } catch (error) {
-        console.error("PDF creation error:", error)
-        setExportStatus("error")
-        setCurrentStep("PDF作成中にエラーが発生しました")
-      } finally {
-        setIsExporting(false)
+        console.error(`Error embedding page ${pageData.pageIndex}:`, error)
       }
     },
-    [project?.id, exportOptions.pdfOrientation, setExportProgress, setCurrentStep, setExportStatus, setIsExporting]
+    []
   )
 
   /**
    * Canvas描画完了コールバック
-   * 保存先が決まっていれば即座にPDF生成、まだなら待機
+   * 保存先選択を待ち、埋め込み完了フラグを立てる
    */
   const handleCanvasComplete = useCallback(
     async (
-      renderedPages: Array<{
+      _renderedPages: Array<{
         studentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }>
     ) => {
-      setStartCanvasRendering(false)
-      setPdfExportPages([])
-
-      if (renderedPages.length === 0) {
-        setExportStatus("error")
-        setCurrentStep("描画されたページがありません")
-        setIsExporting(false)
+      // キャンセル済みなら何もしない
+      if (isExportCancelledRef.current) {
         return
       }
 
-      // 保存先が既に決まっているかチェック（Refで即座に確認）
-      if (pdfOutputPathRef.current) {
-        // 保存先が決まっている → 即座にPDF生成
-        await createAndSavePdf(renderedPages, pdfOutputPathRef.current)
-      } else {
-        // 保存先がまだ決まっていない → 結果を保存して待機
-        renderedPagesRef.current = renderedPages
-        isWaitingForSavePathRef.current = true
-        setCurrentStep("保存先の選択を待っています...")
+      setStartCanvasRendering(false)
+      setPdfExportPages([])
 
-        // 保存先が決まるまで待機
-        const savePath = await new Promise<string | null>((resolve) => {
-          // 既にresolverが設定されている場合はそれを使う
-          const existingResolver = savePathResolverRef.current
-          savePathResolverRef.current = (path) => {
-            if (existingResolver) existingResolver(path)
-            resolve(path)
-          }
-        })
-
-        isWaitingForSavePathRef.current = false
-
-        if (!savePath) {
-          // キャンセルされた場合
-          setShowProgressModal(false)
-          setIsExporting(false)
-          return
-        }
-
-        await createAndSavePdf(renderedPages, savePath)
+      // ストリーミングセッションがない場合はエラー
+      if (!streamingSessionIdRef.current) {
+        setExportStatus("error")
+        setCurrentStep("PDFセッションが見つかりません")
+        setIsExporting(false)
+        savePathPromiseRef.current = null
+        return
       }
+
+      // 保存先選択の完了を待つ
+      if (!savePathPromiseRef.current) {
+        setExportStatus("error")
+        setCurrentStep("保存先選択が開始されていません")
+        setIsExporting(false)
+        // セッションのクリーンアップ
+        window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+        streamingSessionIdRef.current = null
+        return
+      }
+
+      setCurrentStep("保存先の選択を待っています...")
+      const savePathResult = await savePathPromiseRef.current
+      savePathPromiseRef.current = null
+
+      if (!savePathResult.success || savePathResult.canceled || !savePathResult.filePath) {
+        // キャンセルされた場合 - 全状態をリセット
+        setShowProgressModal(false)
+        setIsExporting(false)
+        setEmbeddedPagesCount(0)
+        setTotalPagesCount(0)
+        setCanvasRenderingComplete(false)
+        savePathResultRef.current = null
+        // セッションのクリーンアップ
+        window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+        streamingSessionIdRef.current = null
+        return
+      }
+
+      // 保存先を保持し、Canvas描画完了フラグを立てる
+      // PDF埋め込み完了を待ってからuseEffectでPDF保存を実行
+      savePathResultRef.current = { filePath: savePathResult.filePath }
+      setCanvasRenderingComplete(true)
     },
-    [createAndSavePdf, setExportStatus, setCurrentStep, setIsExporting, setShowProgressModal]
+    [setExportStatus, setCurrentStep, setIsExporting, setShowProgressModal]
   )
 
   /**
@@ -306,9 +362,66 @@ export default function ExportMainView() {
       setExportStatus("error")
       setCurrentStep(`Canvas描画エラー: ${error.message}`)
       setIsExporting(false)
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathPromiseRef.current = null
+      savePathResultRef.current = null
+      // セッションのクリーンアップ
+      if (streamingSessionIdRef.current) {
+        window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+        streamingSessionIdRef.current = null
+      }
     },
     [setExportStatus, setCurrentStep, setIsExporting]
   )
+
+  /**
+   * Canvas描画完了 + PDF埋め込み完了時にPDF保存を実行
+   */
+  useEffect(() => {
+    const finalizePdf = async () => {
+      if (!canvasRenderingComplete) return
+      if (embeddedPagesCount < totalPagesCount) return
+      if (!streamingSessionIdRef.current) return
+      if (!savePathResultRef.current) return
+
+      try {
+        setExportProgress(95)
+        setCurrentStep("PDFを保存中...")
+
+        const result = await window.electronAPI.export.finalizeStreamingSession({
+          sessionId: streamingSessionIdRef.current,
+          outputPath: savePathResultRef.current.filePath,
+        })
+
+        streamingSessionIdRef.current = null
+        savePathResultRef.current = null
+        setCanvasRenderingComplete(false)
+
+        if (result.success) {
+          setExportProgress(100)
+          setExportStatus("completed")
+          setCurrentStep("完了しました")
+        } else {
+          setExportStatus("error")
+          setCurrentStep(`エラー: ${result.error}`)
+        }
+      } catch (error) {
+        console.error("PDF finalization error:", error)
+        setExportStatus("error")
+        setCurrentStep("PDF保存中にエラーが発生しました")
+        if (streamingSessionIdRef.current) {
+          window.electronAPI.export.cancelStreamingSession(streamingSessionIdRef.current)
+          streamingSessionIdRef.current = null
+        }
+      } finally {
+        setIsExporting(false)
+      }
+    }
+
+    finalizePdf()
+  }, [canvasRenderingComplete, embeddedPagesCount, totalPagesCount, setExportProgress, setCurrentStep, setExportStatus, setIsExporting])
 
   const handleExportGradingData = async () => {
     if (selectedStudents.size === 0) {
@@ -374,7 +487,109 @@ export default function ExportMainView() {
   }
 
   const handleExportIndividualReports = async () => {
-    alert("個人成績表PDF出力機能は現在開発中です。")
+    if (selectedStudents.size === 0) {
+      alert("出力する生徒を選択してください")
+      return
+    }
+
+    if (isExporting) {
+      return
+    }
+
+    try {
+      setIsExporting(true)
+      setShowProgressModal(true)
+      setExportProgress(0)
+      setExportStatus("processing")
+      setCurrentStep("データを取得中...")
+
+      const selectedStudentIds = Array.from(selectedStudents)
+
+      // 1. 保存先選択
+      setCurrentStep("保存先を選択してください...")
+      const savePathResult = await window.electronAPI.export.selectIndividualReportSavePath({
+        projectName: project?.examName,
+      })
+
+      if (!savePathResult.success || savePathResult.canceled || !savePathResult.filePath) {
+        setShowProgressModal(false)
+        setIsExporting(false)
+        return
+      }
+
+      setExportProgress(10)
+      setCurrentStep("個人成績表データを生成中...")
+
+      // 2. データ取得（統計・アドバイス含む）
+      const dataResult = await window.electronAPI.export.getIndividualReportData({
+        projectId: project.id,
+        selectedStudentIds,
+        options: individualReportOptions,
+      })
+
+      if (!dataResult.success || !dataResult.reports) {
+        throw new Error(dataResult.error || "データ取得に失敗しました")
+      }
+
+      setExportProgress(30)
+      setCurrentStep(`${dataResult.reports.length}名分のレポートを生成中...`)
+
+      // 3. React-PDFでPDFを生成
+      setExportProgress(50)
+      setCurrentStep("PDFを生成中...")
+
+      // フォント登録（初回のみ実行される）
+      registerFonts()
+
+      const pdfDocument = (
+        <IndividualReportDocument
+          reports={dataResult.reports}
+          options={individualReportOptions}
+        />
+      )
+
+      const blob = await pdf(pdfDocument).toBlob()
+      const arrayBuffer = await blob.arrayBuffer()
+
+      setExportProgress(80)
+      setCurrentStep("PDFを保存中...")
+
+      // 4. PDFを保存
+      const saveResult = await window.electronAPI.export.saveIndividualReportPdf({
+        filePath: savePathResult.filePath,
+        pdfBuffer: arrayBuffer,
+      })
+
+      if (!saveResult.success) {
+        throw new Error(saveResult.error || "PDF保存に失敗しました")
+      }
+
+      setExportProgress(100)
+      setExportStatus("completed")
+      setCurrentStep("完了しました")
+
+      // 少し待ってからモーダルを閉じる
+      setTimeout(() => {
+        setShowProgressModal(false)
+        setExportProgress(0)
+        setExportStatus("processing")
+        setCurrentStep("")
+      }, 1500)
+
+    } catch (error) {
+      console.error("Individual report export error:", error)
+      setExportStatus("error")
+      setCurrentStep(`エラー: ${error instanceof Error ? error.message : "不明なエラー"}`)
+      // エラー時は3秒後にモーダルを閉じる
+      setTimeout(() => {
+        setShowProgressModal(false)
+        setExportProgress(0)
+        setExportStatus("processing")
+        setCurrentStep("")
+      }, 3000)
+    } finally {
+      setIsExporting(false)
+    }
   }
 
   if (loading) {
@@ -412,6 +627,8 @@ export default function ExportMainView() {
               setExportOptions={setExportOptions}
               scoringMarkConfig={scoringMarkConfig}
               setScoringMarkConfig={setScoringMarkConfig}
+              individualReportOptions={individualReportOptions}
+              setIndividualReportOptions={setIndividualReportOptions}
               selectedStudents={selectedStudents}
               isExporting={isExporting}
               onExportScoredAnswers={handleExportScoredAnswers}
@@ -428,6 +645,9 @@ export default function ExportMainView() {
           progress={exportProgress}
           status={exportStatus}
           currentStep={currentStep}
+          embeddedPagesCount={embeddedPagesCount}
+          totalPagesCount={totalPagesCount}
+          canvasRenderingComplete={canvasRenderingComplete}
         />
 
         {/* 警告モーダル */}
@@ -443,7 +663,9 @@ export default function ExportMainView() {
           pages={pdfExportPages}
           scoringMarkConfig={getScoringMarkConfigForPdf()}
           startRendering={startCanvasRendering}
+          poolSize={exportOptions.parallelCount}
           onProgress={handleCanvasProgress}
+          onPageComplete={handlePageComplete}
           onComplete={handleCanvasComplete}
           onError={handleCanvasError}
         />

--- a/components/projects/08-export/components/ExportOptionsCard.tsx
+++ b/components/projects/08-export/components/ExportOptionsCard.tsx
@@ -2,13 +2,16 @@
 
 import {
   ExportOptions,
+  IndividualReportOptions,
   PdfOrientation,
 } from "@/app/projects/[projectId]/08-export/types"
 import ScoringMarkSettings, {
   ScoringMarkConfig,
 } from "@/components/projects/08-export/components/ScoringMarkSettings"
+import { IndividualReportSettings } from "@/components/projects/08-export/components/IndividualReportSettings"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
+import { Slider } from "@/components/ui/slider"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Download } from "lucide-react"
 
@@ -17,6 +20,8 @@ interface ExportOptionsCardProps {
   setExportOptions: (options: ExportOptions) => void
   scoringMarkConfig: ScoringMarkConfig
   setScoringMarkConfig: (config: ScoringMarkConfig) => void
+  individualReportOptions: IndividualReportOptions
+  setIndividualReportOptions: (options: IndividualReportOptions) => void
   selectedStudents: Set<string>
   isExporting: boolean
   onExportScoredAnswers: () => void
@@ -29,6 +34,8 @@ export function ExportOptionsCard({
   setExportOptions,
   scoringMarkConfig,
   setScoringMarkConfig,
+  individualReportOptions,
+  setIndividualReportOptions,
   selectedStudents,
   isExporting,
   onExportScoredAnswers,
@@ -39,6 +46,13 @@ export function ExportOptionsCard({
     setExportOptions({
       ...exportOptions,
       pdfOrientation: value,
+    })
+  }
+
+  const handleParallelCountChange = (value: number[]) => {
+    setExportOptions({
+      ...exportOptions,
+      parallelCount: value[0],
     })
   }
 
@@ -110,6 +124,28 @@ export function ExportOptionsCard({
           </div>
         </div>
 
+        {/* 並列処理設定 */}
+        <div className="space-y-3">
+          <h4 className="text-base font-semibold">処理設定</h4>
+          <div>
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">並列処理数</Label>
+              <span className="text-sm font-medium">{exportOptions.parallelCount}</span>
+            </div>
+            <Slider
+              value={[exportOptions.parallelCount]}
+              onValueChange={handleParallelCountChange}
+              min={1}
+              max={8}
+              step={1}
+              className="mt-2"
+            />
+            <p className="text-muted-foreground mt-1 text-xs">
+              値を大きくすると処理が速くなりますが、メモリ使用量が増えます
+            </p>
+          </div>
+        </div>
+
         {/* 採点マーク設定 */}
         <ScoringMarkSettings
           config={scoringMarkConfig}
@@ -156,20 +192,24 @@ export function ExportOptionsCard({
           <Button
             className="w-full"
             size="lg"
-            disabled
             onClick={onExportIndividualReports}
+            disabled={selectedStudents.size === 0 || isExporting}
           >
             <Download className="mr-2 h-4 w-4" />
-            個人成績表PDFをダウンロード（開発中）
+            個人成績表PDFをダウンロード
           </Button>
+          {selectedStudents.size === 0 && (
+            <p className="text-muted-foreground mt-2 text-center text-xs">
+              生徒を選択してください
+            </p>
+          )}
         </div>
 
-        <div className="space-y-3">
-          <h4 className="text-base font-semibold">個人成績表設定</h4>
-          <p className="text-muted-foreground text-sm">
-            個人成績表PDFの出力機能は現在開発中です。
-          </p>
-        </div>
+        {/* 個人成績表設定 */}
+        <IndividualReportSettings
+          options={individualReportOptions}
+          onChange={setIndividualReportOptions}
+        />
       </TabsContent>
     </Tabs>
   )

--- a/components/projects/08-export/components/ExportProgressModal.tsx
+++ b/components/projects/08-export/components/ExportProgressModal.tsx
@@ -10,12 +10,11 @@ import {
 import { Progress } from "@/components/ui/progress"
 import {
   CheckCircle,
-  CheckSquare,
+  Circle,
   Loader2,
-  Square,
   XCircle,
 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 interface ExportProgressModalProps {
   isOpen: boolean
@@ -25,13 +24,21 @@ interface ExportProgressModalProps {
   currentStep: string
   error?: string
   outputPath?: string
+  // ストリーミング処理の詳細進捗
+  embeddedPagesCount?: number
+  totalPagesCount?: number
+  canvasRenderingComplete?: boolean
 }
 
-// PDF出力のステップを定義（並行処理対応）
-const PDF_EXPORT_STEPS = [
-  { id: 1, name: "保存先選択・データ取得", progressRange: [0, 10], isParallel: true },
-  { id: 2, name: "Canvas描画", progressRange: [10, 85] },
-  { id: 3, name: "PDF生成・保存", progressRange: [85, 100] },
+// PDF出力のフェーズ定義
+type ExportPhase = "initializing" | "rendering" | "saving" | "complete"
+
+// フェーズ定義
+const PHASES: { id: ExportPhase; label: string }[] = [
+  { id: "initializing", label: "初期化" },
+  { id: "rendering", label: "描画・埋め込み" },
+  { id: "saving", label: "保存" },
+  { id: "complete", label: "完了" },
 ]
 
 export default function ExportProgressModal({
@@ -42,49 +49,70 @@ export default function ExportProgressModal({
   currentStep,
   error,
   outputPath,
+  embeddedPagesCount = 0,
+  totalPagesCount = 0,
+  canvasRenderingComplete = false,
 }: ExportProgressModalProps) {
   const [isVisible, setIsVisible] = useState(isOpen)
   const [isClosing, setIsClosing] = useState(false)
 
-  // 現在の進捗に基づいてステップの状態を計算
-  const getStepStatus = (step: (typeof PDF_EXPORT_STEPS)[0]) => {
-    const [minProgress, maxProgress] = step.progressRange
-    if (progress >= maxProgress) {
-      return "completed"
-    } else if (progress >= minProgress) {
-      return "processing"
-    } else {
-      return "pending"
+  // 現在のフェーズを計算
+  const currentPhase = useMemo((): ExportPhase => {
+    if (status === "completed") return "complete"
+    if (progress < 10) return "initializing"
+    // Canvas描画完了でも埋め込み未完了なら描画フェーズのまま
+    if (canvasRenderingComplete && totalPagesCount > 0 && embeddedPagesCount < totalPagesCount) {
+      return "rendering"
     }
-  }
+    if (progress < 95) return "rendering"
+    return "saving"
+  }, [progress, status, canvasRenderingComplete, totalPagesCount, embeddedPagesCount])
 
-  // Canvas描画のページ数を抽出する関数
-  const getPageProgress = () => {
-    // currentStepから「答案 X / Y を処理中...」や「ページ X / Y を作成中...」などの形式を抽出
-    const pageMatch =
-      currentStep.match(/(?:答案|ページ)\s*(\d+)\s*\/\s*(\d+)/) ||
-      currentStep.match(/(\d+)\s*\/\s*(\d+)/)
-    if (pageMatch) {
-      return {
-        current: parseInt(pageMatch[1]),
-        total: parseInt(pageMatch[2]),
-      }
+  // currentStepからCanvas/PDF進捗を抽出
+  const progressDetails = useMemo(() => {
+    // 「Canvas: X/Yページ (N並列) | PDF: M/Yページ埋め込み済み」形式を解析
+    const canvasMatch = currentStep.match(/Canvas:\s*(\d+)\/(\d+)ページ/)
+    const parallelMatch = currentStep.match(/\((\d+)並列\)/)
+    const pdfMatch = currentStep.match(/PDF:\s*(\d+)\/(\d+)ページ/)
+
+    return {
+      canvasCompleted: canvasMatch ? parseInt(canvasMatch[1]) : 0,
+      canvasTotal: canvasMatch ? parseInt(canvasMatch[2]) : 0,
+      parallelCount: parallelMatch ? parseInt(parallelMatch[1]) : 0,
+      pdfEmbedded: pdfMatch ? parseInt(pdfMatch[1]) : 0,
+      pdfTotal: pdfMatch ? parseInt(pdfMatch[2]) : 0,
     }
-    return null
-  }
+  }, [currentStep])
 
-  // 並行処理ステップかどうかを判定
-  const isParallelStep = () => {
-    return currentStep.includes("保存先を選択") || currentStep.includes("バックグラウンド")
-  }
+  // 保存先選択待ちかどうか
+  const isWaitingForSavePath = useMemo(() => {
+    return currentStep.includes("保存先を選択") || currentStep.includes("保存先の選択を待っています")
+  }, [currentStep])
 
-  // Canvas描画完了後、保存先待ちの状態かどうか
-  const isWaitingForSavePath = () => {
-    return currentStep.includes("保存先の選択を待っています")
-  }
+  // フェーズインデックスを取得
+  const currentPhaseIndex = useMemo(() => {
+    return PHASES.findIndex(p => p.id === currentPhase)
+  }, [currentPhase])
+
+  // ページ完了グリッド用の計算値（propsから直接取得）
+  const gridInfo = useMemo(() => {
+    // propsのtotalPagesCountを優先、なければcurrentStepから抽出
+    const total = totalPagesCount > 0 ? totalPagesCount : progressDetails.canvasTotal
+    const embedded = embeddedPagesCount
+
+    if (total === 0) return null
+
+    const displayCount = Math.min(total, 40)
+    const groupSize = total > 40 ? Math.ceil(total / 40) : 1
+
+    return { displayCount, groupSize, canvasTotal: total, pdfEmbedded: embedded }
+  }, [totalPagesCount, embeddedPagesCount, progressDetails.canvasTotal])
 
   useEffect(() => {
     if (!isOpen) {
+      // isOpenがfalseになったらモーダルを閉じる
+      setIsVisible(false)
+      setIsClosing(false)
       return
     }
 
@@ -130,7 +158,7 @@ export default function ExportProgressModal({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {status === "processing" && (
-              <Loader2 className="h-5 w-5 animate-spin" />
+              <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
             )}
             {status === "completed" && (
               <CheckCircle className="h-5 w-5 text-green-600" />
@@ -143,104 +171,151 @@ export default function ExportProgressModal({
         <div className="space-y-4">
           {status === "processing" && (
             <>
-              <div className="space-y-3">
+              {/* 全体プログレス */}
+              <div className="space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span>進行状況</span>
+                  <span>全体の進行状況</span>
                   <span className="font-medium">{progress}%</span>
                 </div>
-                <Progress value={progress} className="h-2 w-full" />
+                <Progress value={progress} className="h-3 w-full" />
               </div>
 
-              {/* 並行処理時の特別な表示 */}
-              {(isParallelStep() || isWaitingForSavePath()) && (
-                <div className="rounded-lg border-2 border-amber-300 bg-amber-50 p-4">
-                  <div className="flex items-start space-x-3">
-                    <div className="mt-0.5 shrink-0">
-                      <Loader2 className="h-5 w-5 animate-spin text-amber-600" />
+              {/* フェーズインジケーター */}
+              <div className="flex items-center justify-center gap-1 text-xs">
+                {PHASES.map((phase, index) => {
+                  const isCompleted = index < currentPhaseIndex
+                  const isCurrent = index === currentPhaseIndex
+                  const isPending = index > currentPhaseIndex
+
+                  return (
+                    <div key={phase.id} className="flex items-center">
+                      <div className={`flex items-center gap-1 rounded-full px-2 py-1 ${
+                        isCurrent
+                          ? "bg-blue-100 text-blue-700 font-medium"
+                          : isCompleted
+                            ? "bg-green-100 text-green-700"
+                            : "bg-gray-100 text-gray-400"
+                      }`}>
+                        {isCompleted && <CheckCircle className="h-3 w-3" />}
+                        {isCurrent && <Loader2 className="h-3 w-3 animate-spin" />}
+                        {isPending && <Circle className="h-3 w-3" />}
+                        <span>{phase.label}</span>
+                      </div>
+                      {index < PHASES.length - 1 && (
+                        <div className={`mx-1 h-0.5 w-4 ${
+                          index < currentPhaseIndex ? "bg-green-400" : "bg-gray-200"
+                        }`} />
+                      )}
                     </div>
+                  )
+                })}
+              </div>
+
+              {/* 保存先選択待ち + 埋め込み進行中でない場合の特別表示 */}
+              {isWaitingForSavePath && !(canvasRenderingComplete && totalPagesCount > 0 && embeddedPagesCount < totalPagesCount) && (
+                <div className="rounded-lg border-2 border-amber-300 bg-amber-50 p-3">
+                  <div className="flex items-start space-x-3">
+                    <Loader2 className="mt-0.5 h-5 w-5 shrink-0 animate-spin text-amber-600" />
                     <div className="flex-1">
                       <p className="font-medium text-amber-800">
                         保存先を選択してください
                       </p>
-                      <p className="mt-1 text-sm text-amber-700">
-                        {isWaitingForSavePath()
-                          ? "Canvas描画が完了しました。保存先を選択するとPDF生成を開始します。"
-                          : "ダイアログで保存先を選んでいる間、バックグラウンドで処理を進めています。"}
+                      <p className="mt-1 text-xs text-amber-700">
+                        バックグラウンドで処理を進めています
                       </p>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* ステップ表示 */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-medium">処理ステップ</h4>
-                <div className="space-y-2">
-                  {PDF_EXPORT_STEPS.map((step) => {
-                    const stepStatus = getStepStatus(step)
-                    const pageProgress = getPageProgress()
-                    const isCurrentParallel = step.id === 1 && isParallelStep()
-
-                    return (
-                      <div
-                        key={step.id}
-                        className={`flex items-center space-x-3 rounded-md p-2 transition-colors ${
-                          stepStatus === "processing"
-                            ? isCurrentParallel
-                              ? "border border-amber-300 bg-amber-50"
-                              : "border border-blue-200 bg-blue-50"
-                            : stepStatus === "completed"
-                              ? "bg-green-50"
-                              : "bg-gray-50"
-                        }`}
-                      >
-                        <div className="shrink-0">
-                          {stepStatus === "completed" && (
-                            <CheckSquare className="h-4 w-4 text-green-600" />
-                          )}
-                          {stepStatus === "processing" && (
-                            <Loader2 className={`h-4 w-4 animate-spin ${isCurrentParallel ? "text-amber-600" : "text-blue-600"}`} />
-                          )}
-                          {stepStatus === "pending" && (
-                            <Square className="h-4 w-4 text-gray-400" />
-                          )}
-                        </div>
-                        <div className="flex-1">
-                          <span
-                            className={`text-sm ${
-                              stepStatus === "processing"
-                                ? isCurrentParallel
-                                  ? "font-medium text-amber-700"
-                                  : "font-medium text-blue-700"
-                                : stepStatus === "completed"
-                                  ? "text-green-700"
-                                  : "text-gray-500"
-                            }`}
-                          >
-                            Step {step.id}: {step.name}
-                            {stepStatus === "completed" && "：完了"}
-                            {stepStatus === "processing" &&
-                              step.id === 2 &&
-                              pageProgress && (
-                                <span className="ml-2 text-blue-600">
-                                  ({pageProgress.current} / {pageProgress.total})
-                                </span>
-                              )}
-                            {stepStatus === "processing" &&
-                              step.id === 1 &&
-                              isCurrentParallel &&
-                              "（並行処理中）"}
-                            {stepStatus === "processing" &&
-                              !isCurrentParallel &&
-                              step.id !== 2 &&
-                              "中..."}
-                          </span>
-                        </div>
+              {/* 描画フェーズの詳細表示（Canvas完了後の埋め込み中も表示） */}
+              {(currentPhase === "rendering" || (canvasRenderingComplete && totalPagesCount > 0 && embeddedPagesCount < totalPagesCount)) && (
+                <div className="space-y-4 rounded-lg bg-gray-50 p-3">
+                  {/* Canvas描画完了・埋め込み待機中の表示 */}
+                  {canvasRenderingComplete && totalPagesCount > 0 && embeddedPagesCount < totalPagesCount && (
+                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-2">
+                      <div className="flex items-center gap-2 text-sm text-blue-700">
+                        <CheckCircle className="h-4 w-4 text-green-600" />
+                        <span>Canvas描画完了</span>
+                        <span className="text-blue-500">→</span>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        <span>PDF埋め込み中...</span>
                       </div>
-                    )
-                  })}
+                    </div>
+                  )}
+
+                  {/* 並列処理状況 */}
+                  {progressDetails.canvasTotal > 0 && !canvasRenderingComplete && (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-gray-600">Canvas描画</span>
+                        <span className="font-medium">
+                          {progressDetails.canvasCompleted}/{progressDetails.canvasTotal}ページ
+                        </span>
+                      </div>
+                      <Progress
+                        value={(progressDetails.canvasCompleted / progressDetails.canvasTotal) * 100}
+                        className="h-2"
+                      />
+                      {progressDetails.parallelCount > 0 && (
+                        <div className="flex items-center gap-2 text-xs text-blue-600">
+                          <div className="flex gap-1">
+                            {Array.from({ length: progressDetails.parallelCount }).map((_, i) => (
+                              <div key={i} className="h-3 w-3 animate-pulse rounded bg-blue-400" />
+                            ))}
+                          </div>
+                          <span>{progressDetails.parallelCount}並列描画中</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* ページ完了グリッド */}
+                  {gridInfo && (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-gray-600">PDF埋め込み進捗</span>
+                        <span className="font-medium">
+                          {gridInfo.pdfEmbedded}/{gridInfo.canvasTotal}ページ
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap gap-0.5">
+                        {Array.from({ length: gridInfo.displayCount }).map((_, i) => {
+                          const pageIndex = i * gridInfo.groupSize
+                          // 全ページ埋め込み完了時は全て緑に
+                          const isEmbedded = gridInfo.pdfEmbedded >= gridInfo.canvasTotal || pageIndex < gridInfo.pdfEmbedded
+                          return (
+                            <div
+                              key={i}
+                              className={`h-2 w-2 rounded-sm ${
+                                isEmbedded ? "bg-green-500" : "bg-gray-200"
+                              }`}
+                              title={
+                                gridInfo.groupSize > 1
+                                  ? `ページ ${pageIndex + 1}-${Math.min((i + 1) * gridInfo.groupSize, gridInfo.canvasTotal)}`
+                                  : `ページ ${i + 1}`
+                              }
+                            />
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              </div>
+              )}
+
+              {/* 保存フェーズ */}
+              {currentPhase === "saving" && (
+                <div className="rounded-lg bg-blue-50 p-3">
+                  <div className="flex items-center space-x-3">
+                    <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                    <div>
+                      <p className="font-medium text-blue-800">PDFを保存中...</p>
+                      <p className="text-xs text-blue-600">しばらくお待ちください</p>
+                    </div>
+                  </div>
+                </div>
+              )}
             </>
           )}
 
@@ -250,32 +325,10 @@ export default function ExportProgressModal({
                 <CheckCircle className="mx-auto mb-2 h-12 w-12 text-green-600" />
                 <p className="font-medium">PDF出力が完了しました</p>
                 {outputPath && (
-                  <p className="text-muted-foreground mt-1 text-sm">
+                  <p className="text-muted-foreground mt-1 text-sm break-all">
                     保存先: {outputPath}
                   </p>
                 )}
-              </div>
-
-              {/* 完了したステップの一覧 */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-medium">完了したステップ</h4>
-                <div className="space-y-2">
-                  {PDF_EXPORT_STEPS.map((step) => (
-                    <div
-                      key={step.id}
-                      className="flex items-center space-x-3 rounded-md bg-green-50 p-2"
-                    >
-                      <div className="shrink-0">
-                        <CheckSquare className="h-4 w-4 text-green-600" />
-                      </div>
-                      <div className="flex-1">
-                        <span className="text-sm text-green-700">
-                          Step {step.id}: {step.name}：完了
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
               </div>
             </div>
           )}
@@ -285,60 +338,12 @@ export default function ExportProgressModal({
               <div className="text-center">
                 <XCircle className="mx-auto mb-2 h-12 w-12 text-red-600" />
                 <p className="font-medium">PDF出力に失敗しました</p>
-                {error && (
-                  <p className="text-muted-foreground mt-1 text-sm">
-                    エラー: {error}
-                  </p>
-                )}
               </div>
-
-              {/* エラー時のステップ状況 */}
-              <div className="space-y-3">
-                <h4 className="text-sm font-medium">処理状況</h4>
-                <div className="space-y-2">
-                  {PDF_EXPORT_STEPS.map((step) => {
-                    const stepStatus = getStepStatus(step)
-                    return (
-                      <div
-                        key={step.id}
-                        className={`flex items-center space-x-3 rounded-md p-2 ${
-                          stepStatus === "processing"
-                            ? "border border-red-200 bg-red-50"
-                            : stepStatus === "completed"
-                              ? "bg-green-50"
-                              : "bg-gray-50"
-                        }`}
-                      >
-                        <div className="shrink-0">
-                          {stepStatus === "completed" && (
-                            <CheckSquare className="h-4 w-4 text-green-600" />
-                          )}
-                          {stepStatus === "processing" && (
-                            <XCircle className="h-4 w-4 text-red-600" />
-                          )}
-                          {stepStatus === "pending" && (
-                            <Square className="h-4 w-4 text-gray-400" />
-                          )}
-                        </div>
-                        <div className="flex-1">
-                          <span
-                            className={`text-sm ${
-                              stepStatus === "processing"
-                                ? "font-medium text-red-700"
-                                : stepStatus === "completed"
-                                  ? "text-green-700"
-                                  : "text-gray-500"
-                            }`}
-                          >
-                            Step {step.id}: {step.name}
-                            {stepStatus === "completed" && "：完了"}
-                            {stepStatus === "processing" && "：エラー"}
-                          </span>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
+              <div className="rounded-lg bg-red-50 p-3">
+                <p className="text-sm text-red-700">{currentStep}</p>
+                {error && (
+                  <p className="mt-1 text-xs text-red-600">{error}</p>
+                )}
               </div>
             </div>
           )}

--- a/components/projects/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/projects/08-export/components/PdfCanvasRenderer.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { RenderProgress, RenderedPageData } from "@/app/projects/[projectId]/08-export/types"
 import type { DrawingAnnotation } from "@/types/drawing-annotation.types"
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
@@ -7,6 +8,8 @@ import {
   renderAnswerSheetToCanvas,
   type ScoringDataForPdf,
   type ScoringMarkConfigForPdf,
+  type SubtotalDataForPdf,
+  type TotalScoreDataForPdf,
 } from "../utils/pdf-canvas-renderer"
 
 /**
@@ -33,6 +36,31 @@ export interface PdfExportPageData {
       pageNumber: number
     }
   }>
+  // 小計点データ
+  subtotalData?: Array<{
+    regionId: string
+    label: string
+    score: number
+    x: number
+    y: number
+    width: number
+    height: number
+    pageNumber: number
+  }>
+  // 合計点領域データ
+  totalScoreData?: Array<{
+    regionId: string
+    score: number
+    maxScore: number
+    x: number
+    y: number
+    width: number
+    height: number
+    pageNumber: number
+  }>
+  // 合計点データ（後方互換性のため維持）
+  totalScore?: number | null
+  totalMaxScore?: number | null
   annotations: Array<{
     id: string
     questionScoreId: string
@@ -54,6 +82,16 @@ export interface PdfExportPageData {
   }>
 }
 
+/** Canvas Pool のアイテム */
+interface CanvasPoolItem {
+  canvas: HTMLCanvasElement
+  busy: boolean
+  pageIndex: number | null
+}
+
+/** デフォルトのCanvas Pool サイズ */
+const DEFAULT_POOL_SIZE = 4
+
 interface PdfCanvasRendererProps {
   /** レンダリングするページのリスト */
   pages: PdfExportPageData[]
@@ -61,8 +99,12 @@ interface PdfCanvasRendererProps {
   scoringMarkConfig: ScoringMarkConfigForPdf
   /** レンダリング開始トリガー */
   startRendering: boolean
-  /** 進捗コールバック */
-  onProgress?: (current: number, total: number, step: string) => void
+  /** Canvas Pool サイズ（デフォルト4） */
+  poolSize?: number
+  /** 詳細な進捗コールバック */
+  onProgress?: (progress: RenderProgress) => void
+  /** 1ページ完了時のコールバック */
+  onPageComplete?: (pageData: RenderedPageData) => void
   /** 全ページのレンダリング完了時のコールバック */
   onComplete?: (
     renderedPages: Array<{
@@ -70,39 +112,70 @@ interface PdfCanvasRendererProps {
       pageNumber: number
       imageData: ArrayBuffer
     }>,
-  ) => void
+  ) => void | Promise<void>
   /** エラー発生時のコールバック */
   onError?: (error: Error) => void
 }
 
 /**
- * PDF出力用Canvas描画コンポーネント
+ * PDF出力用Canvas描画コンポーネント（並列処理対応）
  *
- * 非表示のCanvas要素を持ち、PDF出力時に各答案シートを順次描画する。
- * 描画完了後、全ページの画像データをonCompleteコールバックで返す。
+ * Canvas Poolを使用して複数ページを同時に描画する。
+ * 描画完了したページは即座にonPageCompleteで通知される。
  */
 export function PdfCanvasRenderer({
   pages,
   scoringMarkConfig,
   startRendering,
+  poolSize = DEFAULT_POOL_SIZE,
   onProgress,
+  onPageComplete,
   onComplete,
   onError,
 }: PdfCanvasRendererProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
   const [isRendering, setIsRendering] = useState(false)
-  const scoringMarkImagesRef = useRef<Map<string, HTMLImageElement> | null>(
-    null,
-  )
+  const scoringMarkImagesRef = useRef<Map<string, HTMLImageElement> | null>(null)
+  const canvasPoolRef = useRef<CanvasPoolItem[]>([])
+  const isCancelledRef = useRef(false)
+
+  /**
+   * Canvas Poolを初期化
+   */
+  const initCanvasPool = useCallback((size: number): CanvasPoolItem[] => {
+    // 既存のCanvasを削除
+    canvasPoolRef.current.forEach(item => {
+      if (item.canvas.parentNode) {
+        item.canvas.parentNode.removeChild(item.canvas)
+      }
+    })
+
+    // 新しいCanvas Poolを作成
+    const pool: CanvasPoolItem[] = []
+    for (let i = 0; i < size; i++) {
+      const canvas = document.createElement("canvas")
+      canvas.style.cssText = "position:absolute;left:-9999px;top:-9999px;visibility:hidden;pointer-events:none"
+      document.body.appendChild(canvas)
+      pool.push({ canvas, busy: false, pageIndex: null })
+    }
+    return pool
+  }, [])
+
+  /**
+   * Canvas Poolをクリーンアップ
+   */
+  const cleanupCanvasPool = useCallback(() => {
+    canvasPoolRef.current.forEach(item => {
+      if (item.canvas.parentNode) {
+        item.canvas.parentNode.removeChild(item.canvas)
+      }
+    })
+    canvasPoolRef.current = []
+  }, [])
 
   /**
    * 画像を読み込む
-   *
-   * data URLの場合はそのまま読み込み、それ以外はfetch + ObjectURLで読み込む
-   * これによりCanvasのtainted問題を回避
    */
   const loadImage = useCallback(async (url: string): Promise<HTMLImageElement> => {
-    // data URLの場合はそのまま読み込み
     if (url.startsWith("data:")) {
       return new Promise((resolve, reject) => {
         const img = new Image()
@@ -112,7 +185,6 @@ export function PdfCanvasRenderer({
       })
     }
 
-    // それ以外はfetch + ObjectURLで読み込み
     try {
       const response = await fetch(url)
       const blob = await response.blob()
@@ -130,8 +202,7 @@ export function PdfCanvasRenderer({
         }
         img.src = objectUrl
       })
-    } catch (error) {
-      // フォールバック: 直接読み込み
+    } catch {
       return new Promise((resolve, reject) => {
         const img = new Image()
         img.crossOrigin = "anonymous"
@@ -143,160 +214,269 @@ export function PdfCanvasRenderer({
   }, [])
 
   /**
-   * 全ページをレンダリング
+   * 1ページを描画
    */
-  const renderAllPages = useCallback(async () => {
-    if (!canvasRef.current || pages.length === 0) {
-      onComplete?.([])
+  const renderSinglePage = useCallback(async (
+    canvas: HTMLCanvasElement,
+    page: PdfExportPageData,
+    pageIndex: number,
+    markImages: Map<string, HTMLImageElement>
+  ): Promise<RenderedPageData> => {
+    const image = await loadImage(page.imageUrl)
+
+    const scoringDataForPdf: ScoringDataForPdf[] = page.scoringData.map((sd) => ({
+      questionScoreId: sd.questionScoreId,
+      status: sd.status,
+      partialScore: sd.partialScore,
+      cropRegion: {
+        id: sd.cropRegion.id,
+        x: sd.cropRegion.x,
+        y: sd.cropRegion.y,
+        width: sd.cropRegion.width,
+        height: sd.cropRegion.height,
+        label: sd.cropRegion.label,
+        maxScore: sd.cropRegion.maxScore,
+      },
+    }))
+
+    const annotations: DrawingAnnotation[] = page.annotations.map((a) => ({
+      id: a.id,
+      questionScoreId: a.questionScoreId,
+      type: a.type as "text" | "line" | "rectangle" | "ellipse",
+      x: a.x,
+      y: a.y,
+      color: a.color,
+      strokeWidth: a.strokeWidth,
+      width: a.width,
+      height: a.height,
+      endX: a.endX,
+      endY: a.endY,
+      lineStyle: a.lineStyle as "solid" | "wave" | "zigzag" | "double" | "arrow" | "both_arrow",
+      text: a.text,
+      fontSize: a.fontSize,
+      textBoxWidth: 0,
+      textBoxHeight: 0,
+      horizontalAlign: "left" as const,
+      verticalAlign: "top" as const,
+      displayX: a.displayX,
+      displayY: a.displayY,
+      anchorDirection: a.anchorDirection as
+        | "top-left" | "top" | "top-right"
+        | "left" | "center" | "right"
+        | "bottom-left" | "bottom" | "bottom-right",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      createdByUserId: null,
+    }))
+
+    const subtotalDataForPdf: SubtotalDataForPdf[] = (page.subtotalData || []).map((st) => ({
+      regionId: st.regionId,
+      label: st.label,
+      score: st.score,
+      x: st.x,
+      y: st.y,
+      width: st.width,
+      height: st.height,
+      pageNumber: st.pageNumber,
+    }))
+
+    const totalScoreDataForPdf: TotalScoreDataForPdf[] = (page.totalScoreData || []).map((ts) => ({
+      regionId: ts.regionId,
+      score: ts.score,
+      maxScore: ts.maxScore,
+      x: ts.x,
+      y: ts.y,
+      width: ts.width,
+      height: ts.height,
+      pageNumber: ts.pageNumber,
+    }))
+
+    const blob = await renderAnswerSheetToCanvas(
+      canvas,
+      image,
+      scoringDataForPdf,
+      annotations,
+      scoringMarkConfig,
+      markImages,
+      subtotalDataForPdf,
+      totalScoreDataForPdf,
+    )
+
+    const arrayBuffer = await blob.arrayBuffer()
+
+    return {
+      pageIndex,
+      studentId: page.studentId,
+      pageNumber: page.pageNumber,
+      imageData: arrayBuffer,
+    }
+  }, [loadImage, scoringMarkConfig])
+
+  /**
+   * 全ページを並列レンダリング
+   */
+  const renderAllPagesParallel = useCallback(async () => {
+    if (pages.length === 0) {
+      await onComplete?.([])
       return
     }
 
     setIsRendering(true)
 
     try {
+      // Canvas Poolを初期化
+      const actualPoolSize = Math.min(poolSize, pages.length)
+      canvasPoolRef.current = initCanvasPool(actualPoolSize)
+
       // 採点マーク画像をプリロード
       if (!scoringMarkImagesRef.current) {
-        onProgress?.(0, pages.length, "採点マーク画像を読み込み中...")
+        onProgress?.({
+          phase: "preload",
+          total: pages.length,
+          completed: 0,
+          inProgress: 0,
+          currentPages: [],
+        })
         scoringMarkImagesRef.current = await preloadScoringMarkImages(
           scoringMarkConfig.useTransparent,
         )
       }
 
-      const renderedPages: Array<{
+      const markImages = scoringMarkImagesRef.current
+      const renderedPages: Map<number, RenderedPageData> = new Map()
+      const pendingQueue = pages.map((_, i) => i)
+      let completedCount = 0
+      const currentlyRendering: Set<number> = new Set()
+
+      // プログレス更新関数
+      const updateProgress = () => {
+        onProgress?.({
+          phase: completedCount === pages.length ? "complete" : "rendering",
+          total: pages.length,
+          completed: completedCount,
+          inProgress: currentlyRendering.size,
+          currentPages: Array.from(currentlyRendering),
+        })
+      }
+
+      // 次のページを描画する関数
+      const renderNext = async (poolItem: CanvasPoolItem): Promise<void> => {
+        if (pendingQueue.length === 0) return
+        if (isCancelledRef.current) return
+
+        const pageIndex = pendingQueue.shift()!
+        poolItem.busy = true
+        poolItem.pageIndex = pageIndex
+        currentlyRendering.add(pageIndex)
+        updateProgress()
+
+        try {
+          const result = await renderSinglePage(
+            poolItem.canvas,
+            pages[pageIndex],
+            pageIndex,
+            markImages
+          )
+
+          // キャンセルされていたら通知しない
+          if (isCancelledRef.current) return
+
+          renderedPages.set(pageIndex, result)
+          completedCount++
+
+          // 1ページ完了を通知
+          onPageComplete?.(result)
+        } catch (error) {
+          if (!isCancelledRef.current) {
+            console.error(`Error rendering page ${pageIndex + 1}:`, error)
+          }
+          // エラーでも続行
+        } finally {
+          poolItem.busy = false
+          poolItem.pageIndex = null
+          currentlyRendering.delete(pageIndex)
+
+          // キャンセルされていたら終了
+          if (isCancelledRef.current) return
+
+          updateProgress()
+
+          // 次のページがあれば描画
+          if (pendingQueue.length > 0) {
+            await renderNext(poolItem)
+          }
+        }
+      }
+
+      // Pool サイズ分の並列描画を開始
+      await Promise.all(
+        canvasPoolRef.current.map(poolItem => renderNext(poolItem))
+      )
+
+      // キャンセルされていたら終了
+      if (isCancelledRef.current) return
+
+      // 結果を順序通りに並べて返す
+      const orderedResults: Array<{
         studentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }> = []
-
       for (let i = 0; i < pages.length; i++) {
-        const page = pages[i]
-        onProgress?.(
-          i + 1,
-          pages.length,
-          `${page.studentName} (${i + 1}/${pages.length})`,
-        )
-
-        try {
-          // 答案画像を読み込み
-          const image = await loadImage(page.imageUrl)
-
-          // scoringDataをScoringDataForPdf形式に変換
-          const scoringDataForPdf: ScoringDataForPdf[] = page.scoringData.map(
-            (sd) => ({
-              questionScoreId: sd.questionScoreId,
-              status: sd.status,
-              partialScore: sd.partialScore,
-              cropRegion: {
-                id: sd.cropRegion.id,
-                x: sd.cropRegion.x,
-                y: sd.cropRegion.y,
-                width: sd.cropRegion.width,
-                height: sd.cropRegion.height,
-                label: sd.cropRegion.label,
-              },
-            }),
-          )
-
-          // annotationsをDrawingAnnotation形式に変換
-          const annotations: DrawingAnnotation[] = page.annotations.map(
-            (a) => ({
-              id: a.id,
-              questionScoreId: a.questionScoreId,
-              type: a.type as "text" | "line" | "rectangle" | "ellipse",
-              x: a.x,
-              y: a.y,
-              color: a.color,
-              strokeWidth: a.strokeWidth,
-              width: a.width,
-              height: a.height,
-              endX: a.endX,
-              endY: a.endY,
-              lineStyle: a.lineStyle as
-                | "solid"
-                | "wave"
-                | "zigzag"
-                | "double"
-                | "arrow"
-                | "both_arrow",
-              text: a.text,
-              fontSize: a.fontSize,
-              textBoxWidth: 0,
-              textBoxHeight: 0,
-              horizontalAlign: "left" as const,
-              verticalAlign: "top" as const,
-              displayX: a.displayX,
-              displayY: a.displayY,
-              anchorDirection: a.anchorDirection as
-                | "top-left"
-                | "top"
-                | "top-right"
-                | "left"
-                | "center"
-                | "right"
-                | "bottom-left"
-                | "bottom"
-                | "bottom-right",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-              createdByUserId: null,
-            }),
-          )
-
-          // Canvas描画
-          const blob = await renderAnswerSheetToCanvas(
-            canvasRef.current,
-            image,
-            scoringDataForPdf,
-            annotations,
-            scoringMarkConfig,
-            scoringMarkImagesRef.current,
-          )
-
-          // BlobをArrayBufferに変換
-          const arrayBuffer = await blob.arrayBuffer()
-
-          renderedPages.push({
-            studentId: page.studentId,
-            pageNumber: page.pageNumber,
-            imageData: arrayBuffer,
+        const result = renderedPages.get(i)
+        if (result) {
+          orderedResults.push({
+            studentId: result.studentId,
+            pageNumber: result.pageNumber,
+            imageData: result.imageData,
           })
-        } catch (pageError) {
-          console.error(
-            `Error rendering page ${i + 1} (${page.studentName}):`,
-            pageError,
-          )
-          // エラーが発生しても続行（スキップ）
         }
       }
 
-      onComplete?.(renderedPages)
+      await onComplete?.(orderedResults)
     } catch (error) {
-      console.error("Error during PDF rendering:", error)
-      onError?.(error instanceof Error ? error : new Error(String(error)))
+      if (!isCancelledRef.current) {
+        console.error("Error during parallel PDF rendering:", error)
+        onError?.(error instanceof Error ? error : new Error(String(error)))
+      }
     } finally {
+      cleanupCanvasPool()
       setIsRendering(false)
     }
-  }, [pages, scoringMarkConfig, loadImage, onProgress, onComplete, onError])
+  }, [
+    pages,
+    poolSize,
+    scoringMarkConfig,
+    initCanvasPool,
+    cleanupCanvasPool,
+    renderSinglePage,
+    onProgress,
+    onPageComplete,
+    onComplete,
+    onError,
+  ])
 
-  /**
-   * レンダリング開始トリガーを監視
-   */
+  // レンダリング開始トリガーを監視
+  const renderAllPagesRef = useRef(renderAllPagesParallel)
+  renderAllPagesRef.current = renderAllPagesParallel
+
   useEffect(() => {
     if (startRendering && !isRendering && pages.length > 0) {
-      renderAllPages()
+      isCancelledRef.current = false
+      renderAllPagesRef.current()
+    } else if (!startRendering && isRendering) {
+      // startRenderingがfalseになったらキャンセル
+      isCancelledRef.current = true
     }
-  }, [startRendering, isRendering, pages.length, renderAllPages])
+  }, [startRendering, pages.length, isRendering])
 
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{
-        position: "absolute",
-        left: "-9999px",
-        top: "-9999px",
-        visibility: "hidden",
-        pointerEvents: "none",
-      }}
-    />
-  )
+  // コンポーネントがアンマウントされたらCanvas Poolをクリーンアップ
+  useEffect(() => {
+    return () => {
+      cleanupCanvasPool()
+    }
+  }, [cleanupCanvasPool])
+
+  // このコンポーネント自体はDOMにCanvasを持たない（動的に作成する）
+  return null
 }

--- a/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
+++ b/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
@@ -129,7 +129,7 @@ export function ScoringMarkSettingsContainer({
           value={scoreConfig.size}
           onChange={(e) => onUpdate({ size: parseInt(e.target.value) || 14 })}
           min={8}
-          max={48}
+          max={200}
           className="h-9 w-full"
         />
       </div>

--- a/components/projects/08-export/hooks/useExportPage.ts
+++ b/components/projects/08-export/hooks/useExportPage.ts
@@ -1,7 +1,9 @@
 "use client"
 
 import {
+  DEFAULT_INDIVIDUAL_REPORT_OPTIONS,
   ExportOptions,
+  IndividualReportOptions,
   Student,
 } from "@/app/projects/[projectId]/08-export/types"
 import {
@@ -43,11 +45,16 @@ export function useExportPage() {
     markSize: 50,
     showMarks: true,
     pdfOrientation: "portrait", // デフォルトはA4縦
+    parallelCount: 4, // デフォルト並列数
   })
 
   const [scoringMarkConfig, setScoringMarkConfig] = useState<ScoringMarkConfig>(
     loadConfigFromStorage(),
   )
+
+  // 個人成績表オプション
+  const [individualReportOptions, setIndividualReportOptions] =
+    useState<IndividualReportOptions>(DEFAULT_INDIVIDUAL_REPORT_OPTIONS)
 
   // プログレス状態
   const [showProgressModal, setShowProgressModal] = useState(false)
@@ -194,6 +201,8 @@ export function useExportPage() {
     setExportOptions,
     scoringMarkConfig,
     setScoringMarkConfig,
+    individualReportOptions,
+    setIndividualReportOptions,
 
     // プログレス
     showProgressModal,

--- a/components/projects/08-export/utils/pdf-canvas-renderer.ts
+++ b/components/projects/08-export/utils/pdf-canvas-renderer.ts
@@ -24,6 +24,7 @@ export interface ScoringDataForPdf {
     width: number
     height: number
     label: string
+    maxScore?: number | null // 配点
     projectPage?: {
       pageNumber: number
     }
@@ -42,6 +43,36 @@ export interface ScoringMarkConfigForPdf {
   partialScoreSize: number
   partialScoreOffsetX: number
   partialScoreOffsetY: number
+  // ステータスごとの点数表示設定
+  showScoreForStatus?: Record<string, boolean>
+}
+
+/**
+ * 小計点データ（PDF出力用）
+ */
+export interface SubtotalDataForPdf {
+  regionId: string
+  label: string
+  score: number
+  x: number
+  y: number
+  width: number
+  height: number
+  pageNumber: number
+}
+
+/**
+ * 合計点データ（PDF出力用）
+ */
+export interface TotalScoreDataForPdf {
+  regionId: string
+  score: number
+  maxScore: number
+  x: number
+  y: number
+  width: number
+  height: number
+  pageNumber: number
 }
 
 /**
@@ -459,12 +490,32 @@ function calculatePartialScorePosition(
       baseX = regionX
       baseY = regionY
       break
+    case "top-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY
+      break
     case "top-right":
       baseX = regionX + regionWidth
       baseY = regionY
       break
+    case "middle-left":
+      baseX = regionX
+      baseY = regionY + regionHeight / 2
+      break
+    case "middle-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight / 2
+      break
+    case "middle-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight / 2
+      break
     case "bottom-left":
       baseX = regionX
+      baseY = regionY + regionHeight
+      break
+    case "bottom-center":
+      baseX = regionX + regionWidth / 2
       baseY = regionY + regionHeight
       break
     case "bottom-right":
@@ -472,8 +523,9 @@ function calculatePartialScorePosition(
       baseY = regionY + regionHeight
       break
     default:
-      baseX = regionX + regionWidth
-      baseY = regionY + regionHeight
+      // デフォルトは中央
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight / 2
       break
   }
 
@@ -517,9 +569,10 @@ function drawScoringMark(
 }
 
 /**
- * 部分点テキストを描画
+ * 点数テキストを描画（赤色）
+ * @param score - 表示する点数
  */
-function drawPartialScoreText(
+function drawScoreText(
   ctx: CanvasRenderingContext2D,
   score: number,
   region: ScoringDataForPdf["cropRegion"],
@@ -546,10 +599,66 @@ function drawPartialScoreText(
 
   ctx.save()
   ctx.font = `bold ${config.partialScoreSize}px sans-serif`
-  ctx.fillStyle = "#ef4444" // 赤色
+  ctx.fillStyle = "#ef4444" // 点数は全て赤色
   ctx.textAlign = "center"
   ctx.textBaseline = "middle"
   ctx.fillText(String(score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 小計点テキストを描画（青色）
+ */
+function drawSubtotalScoreText(
+  ctx: CanvasRenderingContext2D,
+  subtotalData: SubtotalDataForPdf,
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number,
+): void {
+  const regionX = subtotalData.x * imageWidth
+  const regionY = subtotalData.y * imageHeight
+  const regionWidth = subtotalData.width * imageWidth
+  const regionHeight = subtotalData.height * imageHeight
+
+  // 小計点領域の中央に表示
+  const x = regionX + regionWidth / 2
+  const y = regionY + regionHeight / 2
+
+  ctx.save()
+  ctx.font = `bold ${config.partialScoreSize}px sans-serif`
+  ctx.fillStyle = "#2563eb" // 小計点は青色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(subtotalData.score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 合計点テキストを描画（青色）
+ */
+function drawTotalScoreText(
+  ctx: CanvasRenderingContext2D,
+  totalScoreData: TotalScoreDataForPdf,
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number,
+): void {
+  const regionX = totalScoreData.x * imageWidth
+  const regionY = totalScoreData.y * imageHeight
+  const regionWidth = totalScoreData.width * imageWidth
+  const regionHeight = totalScoreData.height * imageHeight
+
+  // 合計点領域の中央に表示
+  const x = regionX + regionWidth / 2
+  const y = regionY + regionHeight / 2
+
+  ctx.save()
+  ctx.font = `bold ${config.partialScoreSize}px sans-serif`
+  ctx.fillStyle = "#2563eb" // 合計点も青色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(totalScoreData.score), x, y)
   ctx.restore()
 }
 
@@ -562,6 +671,8 @@ function drawPartialScoreText(
  * @param annotations - 全アノテーション
  * @param config - 採点マーク設定
  * @param scoringMarkImages - 採点マーク画像のMap
+ * @param subtotalDataList - 小計点データのリスト
+ * @param totalScoreDataList - 合計点データのリスト
  * @returns PNG Blob
  */
 export async function renderAnswerSheetToCanvas(
@@ -571,6 +682,8 @@ export async function renderAnswerSheetToCanvas(
   annotations: DrawingAnnotation[],
   config: ScoringMarkConfigForPdf,
   scoringMarkImages: Map<string, HTMLImageElement>,
+  subtotalDataList: SubtotalDataForPdf[] = [],
+  totalScoreDataList: TotalScoreDataForPdf[] = [],
 ): Promise<Blob> {
   const ctx = canvas.getContext("2d")
   if (!ctx) {
@@ -622,24 +735,50 @@ export async function renderAnswerSheetToCanvas(
       )
     }
 
-    // 部分点テキストの描画
-    if (
-      scoringData.status === "partial" &&
-      scoringData.partialScore !== null &&
-      scoringData.partialScore !== undefined
-    ) {
-      drawPartialScoreText(
-        ctx,
-        scoringData.partialScore,
-        scoringData.cropRegion,
-        config,
-        imageWidth,
-        imageHeight,
-      )
+    // 点数テキストの描画
+    // showScoreForStatusがある場合はステータスごとに判定、ない場合は後方互換性のためpartialのみ
+    const shouldShowScore = config.showScoreForStatus
+      ? config.showScoreForStatus[scoringData.status] ?? false
+      : scoringData.status === "partial"
+
+    if (shouldShowScore) {
+      // ステータスに応じた点数を決定
+      let scoreToDisplay: number | null = null
+      if (scoringData.status === "correct") {
+        // 正解: 配点を表示
+        scoreToDisplay = scoringData.cropRegion.maxScore ?? null
+      } else if (scoringData.status === "partial") {
+        // 部分点: 部分点を表示
+        scoreToDisplay = scoringData.partialScore ?? null
+      } else if (scoringData.status === "incorrect" || scoringData.status === "no_answer") {
+        // 誤答/無答: 0点を表示
+        scoreToDisplay = 0
+      }
+
+      if (scoreToDisplay !== null) {
+        drawScoreText(
+          ctx,
+          scoreToDisplay,
+          scoringData.cropRegion,
+          config,
+          imageWidth,
+          imageHeight,
+        )
+      }
     }
   }
 
-  // 3. 全アノテーションを描画
+  // 3. 小計点を描画（青色）
+  for (const subtotalData of subtotalDataList) {
+    drawSubtotalScoreText(ctx, subtotalData, config, imageWidth, imageHeight)
+  }
+
+  // 4. 合計点を描画（青色）
+  for (const totalScoreData of totalScoreDataList) {
+    drawTotalScoreText(ctx, totalScoreData, config, imageWidth, imageHeight)
+  }
+
+  // 5. 全アノテーションを描画
   for (const annotation of annotations) {
     const element = convertAnnotationToDrawingElement(annotation)
     await drawElement(ctx, element, imageWidth, imageHeight)

--- a/electron-src/ipc-handlers/export-handlers.ts
+++ b/electron-src/ipc-handlers/export-handlers.ts
@@ -1,11 +1,15 @@
-import { ipcMain } from "electron"
+import { ipcMain, BrowserWindow, dialog } from "electron"
 import { exportGradingDataExcel } from "../lib/prisma/excelExport"
 import {
   createPdfFromRenderedImages,
   getPdfExportData,
+  createPdfStreamingSession,
+  addPageToStreamingSession,
+  finalizeStreamingSession,
+  cancelStreamingSession,
 } from "../lib/prisma/pdfExport"
-
-import { BrowserWindow } from "electron"
+import { fetchIndividualReportData } from "../lib/export/individual-report"
+import type { GetIndividualReportDataOptions } from "../lib/export/individual-report"
 
 export function setupExportHandlers(): void {
   // Excel Export handlers
@@ -57,7 +61,7 @@ export function setupExportHandlers(): void {
   ipcMain.handle(
     "export:createPdfFromRenderedImages",
     async (
-      event,
+      _event,
       options: {
         projectId: string
         renderedPages: Array<{
@@ -69,21 +73,11 @@ export function setupExportHandlers(): void {
       },
     ) => {
       try {
-        // プログレスコールバックを設定
-        const progressCallback = (progress: {
-          current: number
-          total: number
-          step: string
-          percentage: number
-          currentStepIndex: number
-          totalSteps: number
-        }) => {
-          event.sender.send("export-progress", progress)
-        }
-
+        // プログレスコールバックは渡さない（React側で管理するため）
+        // Electron側のprogressCallbackはReact側のプログレス更新と競合し、
+        // プログレスバーが0%にリセットされて2周するように見える問題を引き起こしていた
         return await createPdfFromRenderedImages({
           ...options,
-          progressCallback,
         })
       } catch (err) {
         console.error("Error creating PDF from rendered images:", err)
@@ -217,6 +211,180 @@ export function setupExportHandlers(): void {
         return {
           success: false,
           error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // ============================================================
+  // ストリーミングPDF生成API
+  // ============================================================
+
+  // ストリーミングセッション作成
+  ipcMain.handle(
+    "export:createPdfStreamingSession",
+    async (
+      _event,
+      options: {
+        totalPages: number
+        pdfOrientation?: "portrait" | "landscape"
+      },
+    ) => {
+      try {
+        return await createPdfStreamingSession(options)
+      } catch (err) {
+        console.error("Error creating PDF streaming session:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // ストリーミングセッションにページを追加
+  ipcMain.handle(
+    "export:addPageToStreamingSession",
+    async (
+      _event,
+      options: {
+        sessionId: string
+        pageIndex: number
+        imageData: ArrayBuffer
+      },
+    ) => {
+      try {
+        return await addPageToStreamingSession(options)
+      } catch (err) {
+        console.error("Error adding page to streaming session:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // ストリーミングセッションを完了してPDF保存
+  ipcMain.handle(
+    "export:finalizeStreamingSession",
+    async (
+      _event,
+      options: {
+        sessionId: string
+        outputPath: string
+      },
+    ) => {
+      try {
+        return await finalizeStreamingSession(options)
+      } catch (err) {
+        console.error("Error finalizing streaming session:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // ストリーミングセッションをキャンセル
+  ipcMain.handle(
+    "export:cancelStreamingSession",
+    async (
+      _event,
+      sessionId: string,
+    ) => {
+      try {
+        cancelStreamingSession(sessionId)
+        return { success: true }
+      } catch (err) {
+        console.error("Error canceling streaming session:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // ============================================================
+  // 個人成績表PDF API
+  // ============================================================
+
+  // 個人成績表用データ取得
+  ipcMain.handle(
+    "export:getIndividualReportData",
+    async (_event, options: GetIndividualReportDataOptions) => {
+      try {
+        return await fetchIndividualReportData(options)
+      } catch (err) {
+        console.error("Error getting individual report data:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    },
+  )
+
+  // 個人成績表PDF保存先選択ダイアログ
+  ipcMain.handle(
+    "export:selectIndividualReportSavePath",
+    async (
+      _event,
+      options: {
+        projectName?: string
+      },
+    ): Promise<{ success: boolean; filePath?: string; canceled?: boolean }> => {
+      try {
+        const dateStr = new Date().toISOString().split("T")[0]
+        const safeProjectName = options.projectName
+          ? options.projectName.replace(/[<>:"/\\|?*]/g, "_")
+          : null
+        const defaultFileName = safeProjectName
+          ? `個人成績表_${safeProjectName}_${dateStr}.pdf`
+          : `個人成績表_${dateStr}.pdf`
+
+        const result = await dialog.showSaveDialog({
+          title: "個人成績表PDFの保存先",
+          defaultPath: defaultFileName,
+          filters: [{ name: "PDF Files", extensions: ["pdf"] }],
+        })
+
+        if (result.canceled || !result.filePath) {
+          return { success: false, canceled: true }
+        }
+
+        return { success: true, filePath: result.filePath }
+      } catch (err) {
+        console.error("Error selecting individual report save path:", err)
+        return {
+          success: false,
+          canceled: false,
+        }
+      }
+    },
+  )
+
+  // 個人成績表PDFバッファを保存
+  ipcMain.handle(
+    "export:saveIndividualReportPdf",
+    async (
+      _event,
+      options: {
+        filePath: string
+        pdfBuffer: ArrayBuffer
+      },
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const fs = require("fs").promises
+        await fs.writeFile(options.filePath, Buffer.from(options.pdfBuffer))
+        return { success: true }
+      } catch (err) {
+        console.error("Error saving individual report PDF:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "ファイル保存に失敗しました",
         }
       }
     },

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -3,11 +3,12 @@ import fs from "fs"
 import path from "path"
 import { PageSizes, PDFDocument } from "pdf-lib"
 import { getAbsolutePathFromData } from "../dataManager"
+import { calculateSubtotalScoreForStudent } from "../shared/calculations/subtotal-calculator"
 import { getCropRegionsByProjectId } from "./cropRegion"
 import { getDrawingAnnotationsByQuestionScore } from "./drawingAnnotation"
 import { getProjectById } from "./project"
 import { getStudentsForProject } from "./projectStudent"
-import { getQuestionScoresForProject } from "./questionScore"
+import { getQuestionScoresForProject, calculateActualScore } from "./questionScore"
 import { getStudentAnswersByProjectId } from "./studentAnswer"
 
 /**
@@ -72,6 +73,31 @@ export interface PdfExportPageData {
       pageNumber: number
     }
   }>
+  // 小計点データ
+  subtotalData: Array<{
+    regionId: string
+    label: string
+    score: number
+    x: number
+    y: number
+    width: number
+    height: number
+    pageNumber: number
+  }>
+  // 合計点領域データ
+  totalScoreData: Array<{
+    regionId: string
+    score: number
+    maxScore: number
+    x: number
+    y: number
+    width: number
+    height: number
+    pageNumber: number
+  }>
+  // 合計点データ（後方互換性のため維持）
+  totalScore: number | null
+  totalMaxScore: number | null
   annotations: Array<{
     id: string
     questionScoreId: string
@@ -238,6 +264,86 @@ export async function getPdfExportData(options: {
           continue // この画像をスキップ
         }
 
+        // 小計点領域を取得（このページのSUBTOTAL_SCORE領域）
+        const subtotalRegions = pageRegions.filter(
+          (cr) => cr.type === "SUBTOTAL_SCORE"
+        )
+
+        // 小計点データを計算
+        const subtotalData: PdfExportPageData["subtotalData"] = []
+        for (const subtotalRegion of subtotalRegions) {
+          if (!subtotalRegion.projectPage) continue
+
+          // 小計点を計算
+          const subtotalScore = await calculateSubtotalScoreForStudent(
+            student.id,
+            subtotalRegion.id,
+            allScores
+              .filter(s => s.studentId !== null)
+              .map(s => ({
+                studentId: s.studentId as string,
+                cropRegionId: s.cropRegionId,
+                status: s.status,
+                partialScore: s.partialScore !== null ? Number(s.partialScore) : null,
+              })),
+            cropRegions as any, // CropRegion型として渡す
+          )
+
+          subtotalData.push({
+            regionId: subtotalRegion.id,
+            label: subtotalRegion.label,
+            score: subtotalScore,
+            x: subtotalRegion.x,
+            y: subtotalRegion.y,
+            width: subtotalRegion.width,
+            height: subtotalRegion.height,
+            pageNumber: subtotalRegion.projectPage.pageNumber,
+          })
+        }
+
+        // 合計点を計算（全設問の合計）
+        const questionRegions = cropRegions.filter(
+          (cr) => cr.type === "QUESTION_ANSWER"
+        )
+        let totalScore = 0
+        let totalMaxScore = 0
+        for (const region of questionRegions) {
+          const score = allScores.find(
+            (s) => s.cropRegionId === region.id && s.studentId === student.id
+          )
+          if (score) {
+            const maxScore = region.points !== null ? Number(region.points) : 0
+            totalMaxScore += maxScore
+            const actualScore = calculateActualScore(
+              { status: score.status, partialScore: score.partialScore !== null ? Number(score.partialScore) : null },
+              maxScore
+            )
+            totalScore += actualScore ?? 0
+          }
+        }
+
+        // 合計点領域を取得（このページのTOTAL_SCORE領域）
+        const totalScoreRegions = pageRegions.filter(
+          (cr) => cr.type === "TOTAL_SCORE"
+        )
+
+        // 合計点領域データを構築
+        const totalScoreData: PdfExportPageData["totalScoreData"] = []
+        for (const totalRegion of totalScoreRegions) {
+          if (!totalRegion.projectPage) continue
+
+          totalScoreData.push({
+            regionId: totalRegion.id,
+            score: totalScore,
+            maxScore: totalMaxScore,
+            x: totalRegion.x,
+            y: totalRegion.y,
+            width: totalRegion.width,
+            height: totalRegion.height,
+            pageNumber: totalRegion.projectPage.pageNumber,
+          })
+        }
+
         pages.push({
           studentId: student.id,
           studentName: `${student.lastName} ${student.firstName}`,
@@ -245,6 +351,10 @@ export async function getPdfExportData(options: {
           imagePath,
           imageUrl,
           scoringData,
+          subtotalData,
+          totalScoreData,
+          totalScore,
+          totalMaxScore,
           annotations,
         })
       }
@@ -272,7 +382,7 @@ export async function getPdfExportData(options: {
 }
 
 /**
- * Canvas描画済み画像からPDFを作成
+ * Canvas描画済み画像からPDFを作成（バッチ処理版）
  */
 export async function createPdfFromRenderedImages(options: {
   projectId: string
@@ -332,60 +442,66 @@ export async function createPdfFromRenderedImages(options: {
       ? [PageSizes.A4[1], PageSizes.A4[0]] as [number, number]
       : PageSizes.A4
 
-    // 各ページを追加
-    for (let i = 0; i < renderedPages.length; i++) {
-      const pageData = renderedPages[i]
+    // バッチサイズ（並列embedPng）
+    const BATCH_SIZE = 4
+
+    // 各ページを追加（バッチ処理）
+    for (let batchStart = 0; batchStart < renderedPages.length; batchStart += BATCH_SIZE) {
+      const batch = renderedPages.slice(batchStart, batchStart + BATCH_SIZE)
 
       progressCallback?.({
-        current: i + 1,
+        current: batchStart,
         total: renderedPages.length,
-        step: `ページ ${i + 1}/${renderedPages.length} を処理中...`,
-        percentage: Math.round(((i + 1) / renderedPages.length) * 100),
+        step: `画像埋め込み中... (${batchStart + 1}-${Math.min(batchStart + BATCH_SIZE, renderedPages.length)}/${renderedPages.length})`,
+        percentage: Math.round((batchStart / renderedPages.length) * 90),
         currentStepIndex: 1,
         totalSteps: 2,
       })
 
-      try {
-        // ArrayBufferからUint8Arrayに変換
-        const imageBytes = new Uint8Array(pageData.imageData)
+      // バッチ内で並列embedPng
+      const embedPromises = batch.map(async (pageData) => {
+        try {
+          const imageBytes = new Uint8Array(pageData.imageData)
+          const image = await pdfDoc.embedPng(imageBytes)
+          return { success: true, image, pageData }
+        } catch (error) {
+          console.error(`Error embedding image:`, error)
+          return { success: false, image: null, pageData }
+        }
+      })
 
-        // 画像をPDFに埋め込み
-        const image = await pdfDoc.embedPng(imageBytes)
+      const embedResults = await Promise.all(embedPromises)
 
-        // 新しいページを追加
+      // 順序通りにページを追加
+      for (const result of embedResults) {
+        if (!result.success || !result.image) continue
+
         const page = pdfDoc.addPage(pageSize)
         const { width: pageWidth, height: pageHeight } = page.getSize()
 
-        // 画像をページにフィットさせる
-        const imageAspectRatio = image.width / image.height
+        const imageAspectRatio = result.image.width / result.image.height
         const pageAspectRatio = pageWidth / pageHeight
 
         let imageWidth: number
         let imageHeight: number
 
         if (imageAspectRatio > pageAspectRatio) {
-          // 画像の方が横長 -> 幅に合わせる
           imageWidth = pageWidth
           imageHeight = pageWidth / imageAspectRatio
         } else {
-          // 画像の方が縦長 -> 高さに合わせる
           imageHeight = pageHeight
           imageWidth = pageHeight * imageAspectRatio
         }
 
-        // 画像を中央に配置
         const imageX = (pageWidth - imageWidth) / 2
         const imageY = (pageHeight - imageHeight) / 2
 
-        page.drawImage(image, {
+        page.drawImage(result.image, {
           x: imageX,
           y: imageY,
           width: imageWidth,
           height: imageHeight,
         })
-      } catch (pageError) {
-        console.error(`Error processing page ${i + 1}:`, pageError)
-        // エラーが発生しても続行
       }
     }
 
@@ -410,4 +526,172 @@ export async function createPdfFromRenderedImages(options: {
       error: error instanceof Error ? error.message : "Unknown error",
     }
   }
+}
+
+// ============================================================
+// ストリーミングPDF生成API
+// ============================================================
+
+import type { PDFPage, PDFImage } from "pdf-lib"
+
+/** ストリーミングセッションの状態 */
+interface PdfStreamingSession {
+  pdfDoc: PDFDocument
+  pages: PDFPage[]
+  pageSize: [number, number]
+  embeddedImages: Map<number, PDFImage>
+  totalPages: number
+}
+
+/** アクティブなストリーミングセッション */
+const streamingSessions = new Map<string, PdfStreamingSession>()
+
+/**
+ * ストリーミングPDF生成用のセッションを作成
+ * 全ページ分の空ページを事前に作成する
+ */
+export async function createPdfStreamingSession(options: {
+  totalPages: number
+  pdfOrientation?: "portrait" | "landscape"
+}): Promise<{ success: boolean; sessionId?: string; error?: string }> {
+  const { totalPages, pdfOrientation = "portrait" } = options
+
+  try {
+    const pdfDoc = await PDFDocument.create()
+    const pageSize: [number, number] = pdfOrientation === "landscape"
+      ? [PageSizes.A4[1], PageSizes.A4[0]]
+      : [PageSizes.A4[0], PageSizes.A4[1]]
+
+    // 全ページ分の空ページを作成
+    const pages: PDFPage[] = []
+    for (let i = 0; i < totalPages; i++) {
+      const page = pdfDoc.addPage(pageSize)
+      pages.push(page)
+    }
+
+    // セッションIDを生成
+    const sessionId = `pdf-stream-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
+
+    // セッションを保存
+    streamingSessions.set(sessionId, {
+      pdfDoc,
+      pages,
+      pageSize,
+      embeddedImages: new Map(),
+      totalPages,
+    })
+
+    return { success: true, sessionId }
+  } catch (error) {
+    console.error("Error creating PDF streaming session:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * ストリーミングでページに画像を描画
+ * 空ページに画像を追加する
+ */
+export async function addPageToStreamingSession(options: {
+  sessionId: string
+  pageIndex: number
+  imageData: ArrayBuffer
+}): Promise<{ success: boolean; error?: string }> {
+  const { sessionId, pageIndex, imageData } = options
+
+  try {
+    const session = streamingSessions.get(sessionId)
+    if (!session) {
+      return { success: false, error: "セッションが見つかりません" }
+    }
+
+    if (pageIndex < 0 || pageIndex >= session.totalPages) {
+      return { success: false, error: `ページインデックスが範囲外です: ${pageIndex}` }
+    }
+
+    const page = session.pages[pageIndex]
+    const { width: pageWidth, height: pageHeight } = page.getSize()
+
+    // 画像を埋め込み
+    const imageBytes = new Uint8Array(imageData)
+    const image = await session.pdfDoc.embedPng(imageBytes)
+    session.embeddedImages.set(pageIndex, image)
+
+    // 画像をページにフィットさせる
+    const imageAspectRatio = image.width / image.height
+    const pageAspectRatio = pageWidth / pageHeight
+
+    let imageWidth: number
+    let imageHeight: number
+
+    if (imageAspectRatio > pageAspectRatio) {
+      imageWidth = pageWidth
+      imageHeight = pageWidth / imageAspectRatio
+    } else {
+      imageHeight = pageHeight
+      imageWidth = pageHeight * imageAspectRatio
+    }
+
+    const imageX = (pageWidth - imageWidth) / 2
+    const imageY = (pageHeight - imageHeight) / 2
+
+    page.drawImage(image, {
+      x: imageX,
+      y: imageY,
+      width: imageWidth,
+      height: imageHeight,
+    })
+
+    return { success: true }
+  } catch (error) {
+    console.error(`Error adding page ${pageIndex} to streaming session:`, error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * ストリーミングセッションを完了してPDFを保存
+ */
+export async function finalizeStreamingSession(options: {
+  sessionId: string
+  outputPath: string
+}): Promise<{ success: boolean; outputPath?: string; error?: string }> {
+  const { sessionId, outputPath } = options
+
+  try {
+    const session = streamingSessions.get(sessionId)
+    if (!session) {
+      return { success: false, error: "セッションが見つかりません" }
+    }
+
+    // PDFを保存
+    const pdfBytes = await session.pdfDoc.save()
+    fs.writeFileSync(outputPath, pdfBytes)
+
+    // セッションをクリーンアップ
+    streamingSessions.delete(sessionId)
+
+    return { success: true, outputPath }
+  } catch (error) {
+    console.error("Error finalizing streaming session:", error)
+    // エラー時もセッションをクリーンアップ
+    streamingSessions.delete(sessionId)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * ストリーミングセッションをキャンセル
+ */
+export function cancelStreamingSession(sessionId: string): void {
+  streamingSessions.delete(sessionId)
 }

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -486,6 +486,32 @@ contextBridge.exposeInMainWorld("electronAPI", {
     selectPdfSavePath: (options: {
       projectName?: string
     }) => ipcRenderer.invoke("export:selectPdfSavePath", options),
+    // ストリーミングPDF生成API
+    createPdfStreamingSession: (options: {
+      totalPages: number
+      pdfOrientation?: "portrait" | "landscape"
+    }) => ipcRenderer.invoke("export:createPdfStreamingSession", options),
+    addPageToStreamingSession: (options: {
+      sessionId: string
+      pageIndex: number
+      imageData: ArrayBuffer
+    }) => ipcRenderer.invoke("export:addPageToStreamingSession", options),
+    finalizeStreamingSession: (options: {
+      sessionId: string
+      outputPath: string
+    }) => ipcRenderer.invoke("export:finalizeStreamingSession", options),
+    cancelStreamingSession: (sessionId: string) =>
+      ipcRenderer.invoke("export:cancelStreamingSession", sessionId),
+    // 個人成績表PDF API
+    getIndividualReportData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+      options: import("./lib/export/individual-report").IndividualReportOptions
+    }) => ipcRenderer.invoke("export:getIndividualReportData", options),
+    selectIndividualReportSavePath: (options: { projectName?: string }) =>
+      ipcRenderer.invoke("export:selectIndividualReportSavePath", options),
+    saveIndividualReportPdf: (options: { filePath: string; pdfBuffer: ArrayBuffer }) =>
+      ipcRenderer.invoke("export:saveIndividualReportPdf", options),
   },
 
   // Excel Export related

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1122,6 +1122,77 @@ export interface MyAPI {
       filePath?: string
       canceled?: boolean
     }>
+
+    // ============================================================
+    // ストリーミングPDF生成API
+    // ============================================================
+
+    // ストリーミングセッション作成（空ページを事前に作成）
+    createPdfStreamingSession: (options: {
+      totalPages: number
+      pdfOrientation?: "portrait" | "landscape"
+    }) => Promise<{
+      success: boolean
+      sessionId?: string
+      error?: string
+    }>
+
+    // ストリーミングセッションにページを追加（Canvas描画完了次第呼び出し）
+    addPageToStreamingSession: (options: {
+      sessionId: string
+      pageIndex: number
+      imageData: ArrayBuffer
+    }) => Promise<{
+      success: boolean
+      error?: string
+    }>
+
+    // ストリーミングセッションを完了してPDF保存
+    finalizeStreamingSession: (options: {
+      sessionId: string
+      outputPath: string
+    }) => Promise<{
+      success: boolean
+      outputPath?: string
+      error?: string
+    }>
+
+    // ストリーミングセッションをキャンセル
+    cancelStreamingSession: (sessionId: string) => Promise<{
+      success: boolean
+      error?: string
+    }>
+
+    // ============================================================
+    // 個人成績表PDF API
+    // ============================================================
+
+    // 個人成績表用データ取得
+    getIndividualReportData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+      options: import("../electron-src/lib/export/individual-report").IndividualReportOptions
+    }) => Promise<
+      import("../electron-src/lib/export/individual-report").GetIndividualReportDataResult
+    >
+
+    // 個人成績表PDF保存先選択ダイアログ
+    selectIndividualReportSavePath: (options: {
+      projectName?: string
+    }) => Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+    }>
+
+    // 個人成績表PDFバッファを保存
+    saveIndividualReportPdf: (options: {
+      filePath: string
+      pdfBuffer: ArrayBuffer
+    }) => Promise<{
+      success: boolean
+      error?: string
+    }>
   }
 
   // Excel Export related


### PR DESCRIPTION
## Summary
- Canvas Pool による並列描画（最大8並列）
- ストリーミングPDF生成とページ埋め込みの並列化
- エクスポートキャンセル機能の追加
- 点数印字位置の9方向対応
- 並列処理数設定UIの追加（1-8）
- 点数サイズ上限を48→200に拡張
- プログレスモーダルの改善

Closes #209

## Test plan
- [ ] 採点済み答案PDFを書き出し、並列処理数を変更して動作確認
- [ ] キャンセルボタンで正常に中断できることを確認
- [ ] 点数印字の位置・サイズ設定が反映されることを確認
- [ ] プログレスモーダルが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)