### PR TITLE
fix: Linux向けElectronビルドで@react-pdf/rendererのENOENTエラーを修正

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,31 @@ const nextConfig = {
     ],
   },
   reactStrictMode: false, // Strict Modeを無効化してテスト
+  // @react-pdf/renderer をサーバー外部パッケージとして扱い、
+  // Next.jsのモジュールトレースキャッシュからハッシュ付きシンボリックリンクが
+  // 作成されるのを防ぐ（Electronパッケージング時のエラー回避）
+  serverExternalPackages: [
+    "@react-pdf/renderer",
+    "@react-pdf/font",
+    "@react-pdf/layout",
+    "@react-pdf/pdfkit",
+    "@react-pdf/primitives",
+    "@react-pdf/reconciler",
+    "@react-pdf/render",
+    "@react-pdf/types",
+    "@react-pdf/fns",
+    "@react-pdf/image",
+    "@react-pdf/png-js",
+    "@react-pdf/stylesheet",
+    "@react-pdf/textkit",
+  ],
+  // モジュールトレースから@react-pdf関連パッケージを除外
+  // これによりハッシュ付きシンボリックリンクの生成を防ぐ
+  outputFileTracingExcludes: {
+    "*": [
+      "node_modules/@react-pdf/**",
+    ],
+  },
   // PDF.jsワーカーファイルを静的ファイルとして配信
   async headers() {
     return [


### PR DESCRIPTION
## Summary

- Next.jsのモジュールトレースキャッシュがハッシュ付きシンボリックリンクを生成する問題を修正
- `serverExternalPackages` と `outputFileTracingExcludes` の設定追加

Fixes #215

## Test plan

- [ ] GitHub Actionsで`make:linux`が正常に完了することを確認
- [ ] 生成されたLinux向けdistributableが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)