### PR TITLE
fix: macOSからのLinuxクロスコンパイルとNext.jsキャッシュ問題を修正

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -39,7 +39,7 @@ module.exports = {
   makers: [
     {
       name: '@electron-forge/maker-zip',
-      platforms: ['darwin', 'win32'],
+      platforms: ['darwin', 'win32', 'linux'],
       config: {
         darwin: {
           options: {
@@ -55,6 +55,8 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-deb',
+      platforms: ['linux'],
+      enabled: process.platform === 'linux',
       config: {
         options: {
           icon: "./public/icons/icon-win.png"
@@ -63,6 +65,8 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-rpm',
+      platforms: ['linux'],
+      enabled: process.platform === 'linux',
       config: {
         options: {
           icon: "./public/icons/icon-win.png"
@@ -79,6 +83,26 @@ module.exports = {
     },
   ],
   hooks: {
+    prePackage: async () => {
+      const fs = require('fs')
+      const path = require('path')
+
+      // Remove .next/node_modules which contains broken symlinks
+      const nextNodeModules = path.join(__dirname, '.next', 'node_modules')
+      if (fs.existsSync(nextNodeModules)) {
+        console.log('🧹 Removing .next/node_modules (broken symlinks)...')
+        fs.rmSync(nextNodeModules, { recursive: true, force: true })
+        console.log('✓ Removed .next/node_modules')
+      }
+
+      // Also clean .next/cache to reduce size
+      const nextCache = path.join(__dirname, '.next', 'cache')
+      if (fs.existsSync(nextCache)) {
+        console.log('🧹 Removing .next/cache...')
+        fs.rmSync(nextCache, { recursive: true, force: true })
+        console.log('✓ Removed .next/cache')
+      }
+    },
     postPackage: async (forgeConfig, options) => {
       const fs = require('fs')
       const path = require('path')


### PR DESCRIPTION
## 概要
Closes #219

macOSからLinux向けElectronアプリをビルドする際に発生する問題を修正します。

## 変更内容

### 1. zip makerにlinuxプラットフォームを追加
```javascript
platforms: ['darwin', 'win32', 'linux'],
```

### 2. deb/rpm makerをLinux環境でのみ有効化
```javascript
enabled: process.platform === 'linux',
```
これにより、macOSでビルド時にdpkg/fakerootが不要になります。

### 3. prePackageフックの追加
```javascript
prePackage: async () => {
  // .next/node_modules（壊れたシンボリックリンク）を削除
  // .next/cache（サイズ削減）を削除
}
```

## テスト項目
- [ ] macOSからLinuxビルドが成功する
- [ ] Linux環境でdeb/rpmビルドが成功する
- [ ] macOS/Windowsビルドに影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)