### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Send Discord Notification
         env:
           DISCORD_WEBHOOK_ISSUES: ${{ secrets.DISCORD_WEBHOOK_ISSUES }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_ISSUES" ]; then
             echo "DISCORD_WEBHOOK_ISSUES is not set, skipping notification"
@@ -79,11 +83,6 @@ jobs:
           req.end();
           EOF
 
-          DISCORD_WEBHOOK_ISSUES="${{ secrets.DISCORD_WEBHOOK_ISSUES }}" \
-          ISSUE_TITLE="${{ github.event.issue.title }}" \
-          ISSUE_URL="${{ github.event.issue.html_url }}" \
-          ISSUE_NUMBER="${{ github.event.issue.number }}" \
-          ISSUE_AUTHOR="${{ github.event.issue.user.login }}" \
           node discord_notify.js
 
   notify-pr-merged:


### PR DESCRIPTION
Potential fix for [https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/1](https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/1)

To fix this, avoid interpolating the untrusted `${{ github.event.issue.title }}` (and similar fields) directly into the `run:` shell command. Instead, follow GitHub’s recommended pattern: assign the event values to environment variables using the workflow `env:` mechanism, and then read those environment variables using native shell/Node syntax (`$ISSUE_TITLE` in shell, `process.env.ISSUE_TITLE` in Node). This keeps the untrusted data out of the shell’s command line parsing.

Concretely, within `.github/workflows/discord-notify.yml` in the `notify-issue-opened` job:

- Extend the `env:` block of the "Send Discord Notification" step to include `ISSUE_TITLE`, `ISSUE_URL`, `ISSUE_NUMBER`, and `ISSUE_AUTHOR`, each set via expressions like `${{ github.event.issue.title }}`. These assignments are safe because GitHub Actions treats them as data, not as part of a shell command.
- In the `run:` section, remove the final line that reassigns those environment variables via inline shell assignments before `node discord_notify.js`. Instead, simply call `node discord_notify.js`. The Node script already reads `process.env.ISSUE_TITLE`, etc., so no change is needed inside the script.

No new Node modules or other imports are required; all changes are confined to the YAML workflow and preserve existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
