### PR TITLE
Potential fix for code scanning alert no. 4: Insecure randomness

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -2,6 +2,7 @@ import { dialog } from "electron"
 import fs from "fs"
 import path from "path"
 import { PageSizes, PDFDocument } from "pdf-lib"
+import crypto from "crypto"
 import { getAbsolutePathFromData } from "../dataManager"
 import { calculateSubtotalScoreForStudent } from "../shared/calculations/subtotal-calculator"
 import { getCropRegionsByProjectId } from "./cropRegion"
@@ -570,7 +571,8 @@ export async function createPdfStreamingSession(options: {
     }
 
     // セッションIDを生成
-    const sessionId = `pdf-stream-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
+    const randomSuffix = crypto.randomBytes(8).toString("hex")
+    const sessionId = `pdf-stream-${Date.now()}-${randomSuffix}`
 
     // セッションを保存
     streamingSessions.set(sessionId, {


### PR DESCRIPTION
Potential fix for [https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/4](https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/4)

In general, to fix this type of issue you should replace uses of `Math.random()` for any security-sensitive identifier (tokens, session IDs, reset codes, etc.) with a cryptographically secure random generator. In Node.js, the standard way is to use `crypto.randomBytes` (or `randomUUID` where appropriate) and encode the bytes as hex or base64 to get a string.

For this specific case in `electron-src/lib/prisma/pdfExport.ts`, we should change the `sessionId` creation so that the random suffix is generated using Node’s `crypto` module instead of `Math.random()`. The rest of the behavior (a string of similar length and format) can be preserved by generating a few random bytes and encoding them as hex. A good approach:

- Add an import for Node’s `crypto` module at the top of the file (without removing existing imports).
- Replace the `Math.random().toString(36).substring(2, 11)` part with something like `crypto.randomBytes(8).toString("hex")`, which yields a 16‑character hex string (slightly longer but functionally equivalent as an opaque ID).
- Keep the `pdf-stream-${Date.now()}-` prefix intact so existing logs or references are not dramatically changed.

Concretely:
- Edit `electron-src/lib/prisma/pdfExport.ts`, adding `import crypto from "crypto"` (or `import * as crypto from "crypto"` depending on style) near the other imports.
- On line 573, replace the `Math.random()` based string with a `crypto.randomBytes` based string.

No new helper methods are strictly necessary; a direct inline call to `crypto.randomBytes` is enough.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
