### PR TITLE
fix: インポート時のPageImage.imagePathを相対パスで保存するよう修正

### DIFF
--- a/electron-src/lib/import/project-archive/data-creator.ts
+++ b/electron-src/lib/import/project-archive/data-creator.ts
@@ -386,8 +386,6 @@ async function createPageImageRecords(
   data: ExtractedArchiveData,
   mappings: IdMappings,
 ): Promise<void> {
-  const dataDir = getDataDirectory()
-
   for (const img of data.projectData.pageImages) {
     const newProjectPageId = remapId(img.projectPageId, mappings.projectPage)
     const newStudentId = remapId(img.studentId, mappings.student)
@@ -395,30 +393,18 @@ async function createPageImageRecords(
 
     if (!newProjectPageId) continue
 
-    // 新しいパスを計算
+    // 新しいパスを計算（相対パスで保存）
     const filename = path.basename(img.imagePath)
     let newImagePath: string
 
     if (img.imageType === "MODEL_ANSWER") {
-      newImagePath = path.join(
-        dataDir,
-        "projects",
-        newProjectId,
-        "master-images",
-        filename,
-      )
+      newImagePath = `projects/${newProjectId}/master-images/${filename}`
     } else {
       // STUDENT_ANSWERの場合、元のパス構造を維持
       const relativePath = img.imagePath.substring(
         img.imagePath.indexOf("answer-sheets") + "answer-sheets".length + 1,
       )
-      newImagePath = path.join(
-        dataDir,
-        "projects",
-        newProjectId,
-        "answer-sheets",
-        relativePath,
-      )
+      newImagePath = `projects/${newProjectId}/answer-sheets/${relativePath}`.replace(/\\/g, "/")
     }
 
     await prisma.pageImage.create({


### PR DESCRIPTION
## Summary

- インポートしたプロジェクトの画像が404エラーで表示されない問題を修正
- `createPageImageRecords`関数で絶対パスではなく相対パスを保存するように変更
- `appimg://`プロトコルでの画像読み込みを正常に動作させる

## 変更内容

- `getDataDirectory()`を使用した絶対パス構築を削除
- テンプレートリテラルで相対パスを直接生成
- Windows互換性のため`\\`を`/`に置換

## 関連Issue

Closes #225

## Test plan

- [ ] プロジェクトをエクスポート
- [ ] 別の環境でインポート
- [ ] 画像が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)