### PR TITLE
refactor: useStudentImport と useDragDropState の未使用コード削除

### DIFF
--- a/components/projects/06-student-answers/student-answer-table/hooks/useDragDrop.ts
+++ b/components/projects/06-student-answers/student-answer-table/hooks/useDragDrop.ts
@@ -22,21 +22,15 @@ export function useDragDrop({
   onUpdatePendingChanges,
 }: UseDragDropParams): UseDragDropReturn {
   // 状態管理
-  const {
-    activeFile,
-    setActiveFile,
-    setIsDraggingFromTrash,
-    fileStatesRef,
-    initialFileStatesRef,
-    buildDnDArray: _buildDnDArray,
-  } = useDragDropState({
-    files,
-    students,
-    modelAnswerCount,
-    mode,
-    fileOrder,
-    onFilesChange,
-  })
+  const { activeFile, setActiveFile, fileStatesRef, initialFileStatesRef } =
+    useDragDropState({
+      files,
+      students,
+      modelAnswerCount,
+      mode,
+      fileOrder,
+      onFilesChange,
+    })
 
   // イベントハンドラー
   const { handleDragStart, handleDragEnd } = useDragDropHandlers({
@@ -51,7 +45,6 @@ export function useDragDrop({
     onReloadData,
     onUpdatePendingChanges,
     setActiveFile,
-    setIsDraggingFromTrash,
     fileStatesRef,
     initialFileStatesRef,
   })

--- a/components/projects/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
+++ b/components/projects/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
@@ -31,7 +31,6 @@ interface UseDragDropHandlersParams {
     }>
   ) => void
   setActiveFile: (file: UnifiedFile | null) => void
-  setIsDraggingFromTrash: (isDragging: boolean) => void
   fileStatesRef: React.MutableRefObject<FileState[]>
   initialFileStatesRef: React.MutableRefObject<FileState[]>
 }
@@ -49,7 +48,6 @@ export function useDragDropHandlers({
   mode,
   onUpdatePendingChanges,
   setActiveFile,
-  setIsDraggingFromTrash,
   fileStatesRef,
   initialFileStatesRef,
 }: UseDragDropHandlersParams) {
@@ -67,13 +65,11 @@ export function useDragDropHandlers({
 
       if (activeFileFromEnabled) {
         setActiveFile(activeFileFromEnabled)
-        setIsDraggingFromTrash(false)
       } else if (activeFileFromDisabled) {
         setActiveFile(activeFileFromDisabled)
-        setIsDraggingFromTrash(true)
       }
     },
-    [getEnabledFiles, getDisabledFiles, setActiveFile, setIsDraggingFromTrash]
+    [getEnabledFiles, getDisabledFiles, setActiveFile]
   )
 
   const handleDragEnd = useCallback(
@@ -81,7 +77,6 @@ export function useDragDropHandlers({
       const { active, over } = event
       if (!over) {
         setActiveFile(null)
-        setIsDraggingFromTrash(false)
         return
       }
 
@@ -90,7 +85,6 @@ export function useDragDropHandlers({
 
       if (activeId === overId) {
         setActiveFile(null)
-        setIsDraggingFromTrash(false)
         return
       }
 
@@ -178,7 +172,6 @@ export function useDragDropHandlers({
       }
 
       setActiveFile(null)
-      setIsDraggingFromTrash(false)
     },
     [
       files,
@@ -190,7 +183,6 @@ export function useDragDropHandlers({
       modelAnswerCount,
       onUpdatePendingChanges,
       setActiveFile,
-      setIsDraggingFromTrash,
       fileStatesRef,
       initialFileStatesRef,
     ]

--- a/components/projects/06-student-answers/student-answer-table/hooks/useDragDropState.ts
+++ b/components/projects/06-student-answers/student-answer-table/hooks/useDragDropState.ts
@@ -1,8 +1,5 @@
 import type { FileState } from "@/components/projects/06-student-answers/student-answer-table/types/drag-drop-types"
-import {
-  buildDnDArrayFromFileStates,
-  updateFileStatesFromDnDArray,
-} from "@/components/projects/06-student-answers/student-answer-table/utils/drag-drop-utils"
+import { buildDnDArrayFromFileStates } from "@/components/projects/06-student-answers/student-answer-table/utils/drag-drop-utils"
 import type {
   PlacementStrategy,
   UnifiedFile,
@@ -31,7 +28,6 @@ export function useDragDropState({
   onFilesChange,
 }: UseDragDropStateParams) {
   const [activeFile, setActiveFile] = useState<UnifiedFile | null>(null)
-  const [isDraggingFromTrash, setIsDraggingFromTrash] = useState(false)
 
   // メイン状態: 3つ組を管理
   const fileStatesRef = useRef<FileState[]>([])
@@ -51,14 +47,6 @@ export function useDragDropState({
       )
     },
     [students, modelAnswerCount, files]
-  )
-
-  // DnD配列から3つ組を更新する関数（メモ化）
-  const updateFileStates = useCallback(
-    (dndArray: UnifiedFile[]): FileState[] => {
-      return updateFileStatesFromDnDArray(dndArray)
-    },
-    []
   )
 
   // 1. 初期化: DB → 3つ組（実データから直接生成）
@@ -98,11 +86,7 @@ export function useDragDropState({
   return {
     activeFile,
     setActiveFile,
-    isDraggingFromTrash,
-    setIsDraggingFromTrash,
     fileStatesRef,
     initialFileStatesRef,
-    buildDnDArray,
-    updateFileStates,
   }
 }

--- a/components/student/SpreadsheetImportModal.tsx
+++ b/components/student/SpreadsheetImportModal.tsx
@@ -67,15 +67,6 @@ function ValidationMessages({
   )
 }
 
-interface ClassWithMemberships {
-  id: string
-  name: string
-  classCode?: string | null
-  grade?: number | null
-  description?: string | null
-  isVisible?: boolean
-}
-
 interface StudentWithMemberships {
   id: string
   studentId: string
@@ -102,14 +93,12 @@ interface SpreadsheetImportModalProps {
   isOpen: boolean
   onClose: () => void
   onImportSuccess: (importedStudents: StudentWithMemberships[]) => void
-  existingClasses: ClassWithMemberships[]
 }
 
 export default function SpreadsheetImportModal({
   isOpen,
   onClose,
   onImportSuccess,
-  existingClasses,
 }: SpreadsheetImportModalProps) {
   const {
     studentData,
@@ -117,7 +106,7 @@ export default function SpreadsheetImportModal({
     isProcessing,
     handleStudentDataChange,
     handleImportStudents,
-  } = useStudentImport(existingClasses)
+  } = useStudentImport()
 
   const handleStudentImport = async () => {
     try {

--- a/components/student/StudentTable.tsx
+++ b/components/student/StudentTable.tsx
@@ -390,7 +390,6 @@ export default function StudentTable() {
           isOpen={isSpreadsheetImportModalOpen}
           onClose={() => setIsSpreadsheetImportModalOpen(false)}
           onImportSuccess={onStudentsImported}
-          existingClasses={classes}
         />
       )}
     </div>

--- a/docs/design/project-class-relation.md
+++ b/docs/design/project-class-relation.md
@@ -1,0 +1,356 @@
+# ProjectClass リレーション設計書
+
+## 概要
+
+プロジェクトとクラスの多対多関係を管理するテーブル。
+受験生徒の追加元クラスと、統計集計用クラスを柔軟に設定可能にする。
+
+---
+
+## 背景・課題
+
+### 現状の問題
+
+1. **クラス認識が固定的**
+   - 生徒のクラスは `StudentClassMembership` の最新レコードから取得
+   - プロジェクト単位でのクラス指定ができない
+
+2. **複数グループでの集計不可**
+   - 例: 生徒は「1-A」から追加したいが、統計は「サッカー部」でも出したい
+   - 現状は1つのクラスでしか集計できない
+
+3. **プロジェクトとクラスの関連が不明確**
+   - どのクラスがこのテストの対象なのか、データとして保存されていない
+
+---
+
+## 設計
+
+### データモデル
+
+```prisma
+model ProjectClass {
+  id           String   @id @default(uuid())
+  projectId    String
+  classId      String
+  administered Boolean  @default(false)  // 受験生徒追加用
+  statistics   Boolean  @default(false)  // 統計集計用
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  class        Class    @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, classId])
+  @@index([projectId])
+  @@index([classId])
+}
+```
+
+### カラム説明
+
+| カラム         | 型      | 説明                                       |
+| -------------- | ------- | ------------------------------------------ |
+| `administered` | Boolean | `true`: このクラスから受験生徒を追加できる |
+| `statistics`   | Boolean | `true`: このクラスで統計集計を行う         |
+
+### フラグの組み合わせ
+
+| administered | statistics | 用途                                 |
+| ------------ | ---------- | ------------------------------------ |
+| true         | false      | 受験生徒追加のみ（統計には使わない） |
+| false        | true       | 統計集計のみ（生徒追加には使わない） |
+| true         | true       | 両方で使用                           |
+| false        | false      | 無効（削除候補）                     |
+
+---
+
+## 使用例
+
+### シナリオ: 学年末テスト
+
+1年生全クラス（1-A, 1-B, 1-C）が受験し、クラス別・学年全体で統計を出す。
+
+```
+| projectId | classId   | administered | statistics |
+|-----------|-----------|--------------|------------|
+| exam-001  | class-1A  | true         | true       |
+| exam-001  | class-1B  | true         | true       |
+| exam-001  | class-1C  | true         | true       |
+```
+
+### シナリオ: 部活動の学力テスト
+
+サッカー部員（複数クラスに所属）のテスト。クラス別ではなく部活単位で統計。
+
+```
+| projectId | classId       | administered | statistics |
+|-----------|---------------|--------------|------------|
+| exam-002  | class-1A      | true         | false      |
+| exam-002  | class-1B      | true         | false      |
+| exam-002  | class-2A      | true         | false      |
+| exam-002  | club-soccer   | false        | true       |
+```
+
+### シナリオ: 習熟度別クラスのテスト
+
+生徒は通常クラスから追加、統計は習熟度別クラスで集計。
+
+```
+| projectId | classId        | administered | statistics |
+|-----------|----------------|--------------|------------|
+| exam-003  | class-1A       | true         | false      |
+| exam-003  | class-1B       | true         | false      |
+| exam-003  | math-advanced  | false        | true       |
+| exam-003  | math-standard  | false        | true       |
+| exam-003  | math-basic     | false        | true       |
+```
+
+---
+
+## API設計
+
+### クラス取得
+
+```typescript
+// 受験生徒追加用クラス一覧
+async function getAdministeredClasses(projectId: string): Promise<Class[]> {
+  const projectClasses = await prisma.projectClass.findMany({
+    where: { projectId, administered: true },
+    include: { class: true },
+  })
+  return projectClasses.map((pc) => pc.class)
+}
+
+// 統計集計用クラス一覧
+async function getStatisticsClasses(projectId: string): Promise<Class[]> {
+  const projectClasses = await prisma.projectClass.findMany({
+    where: { projectId, statistics: true },
+    include: { class: true },
+  })
+  return projectClasses.map((pc) => pc.class)
+}
+```
+
+### クラス設定
+
+```typescript
+// プロジェクトにクラスを追加
+async function addProjectClass(
+  projectId: string,
+  classId: string,
+  options: { administered?: boolean; statistics?: boolean }
+): Promise<ProjectClass> {
+  return prisma.projectClass.upsert({
+    where: { projectId_classId: { projectId, classId } },
+    create: {
+      projectId,
+      classId,
+      administered: options.administered ?? false,
+      statistics: options.statistics ?? false,
+    },
+    update: {
+      administered: options.administered,
+      statistics: options.statistics,
+    },
+  })
+}
+```
+
+---
+
+## UI設計
+
+### プロジェクト設定画面
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 対象クラス設定                                        │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  クラス名     │ 受験生徒 │ 統計集計 │               │
+│  ─────────────┼──────────┼──────────┤               │
+│  1年A組       │   [✓]    │   [✓]    │               │
+│  1年B組       │   [✓]    │   [✓]    │               │
+│  サッカー部   │   [ ]    │   [✓]    │               │
+│                                                     │
+│  [+ クラスを追加]                                    │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### 受験生徒追加モーダル
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 受験生徒を追加                                        │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  追加元クラス:  [1年A組 ▼]  ← administered=true のみ │
+│                                                     │
+│  □ 全員選択                                         │
+│  ☑ 山田太郎 (1)                                     │
+│  ☑ 鈴木花子 (2)                                     │
+│  ☑ 佐藤次郎 (3)                                     │
+│  ...                                                │
+│                                                     │
+│            [キャンセル]  [追加]                       │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 出力への影響
+
+### Excel出力
+
+#### 変更前
+
+- クラス列: 生徒の最新 membership から取得
+- クラス別集計: なし
+
+#### 変更後
+
+- クラス列: 生徒の最新 membership から取得（変更なし）
+- **クラス別集計シート追加**: `statistics=true` のクラスごとに平均・最高・最低・人数
+
+```
+┌─────────────────────────────────────────────────────┐
+│ シート: クラス別集計                                  │
+├─────────────────────────────────────────────────────┤
+│ クラス名 │ 人数 │ 平均点 │ 最高点 │ 最低点 │ 標準偏差 │
+│ ─────────┼──────┼────────┼────────┼────────┼─────────│
+│ 1年A組   │  35  │  72.5  │   98   │   45   │  12.3   │
+│ 1年B組   │  34  │  68.2  │   95   │   32   │  15.1   │
+│ サッカー部│  22  │  70.1  │   92   │   48   │  11.8   │
+└─────────────────────────────────────────────────────┘
+```
+
+### 個人成績表PDF
+
+#### 変更前
+
+- クラス統計: 生徒の membership クラスで集計
+
+#### 変更後
+
+- クラス統計: `statistics=true` のクラスのうち、その生徒が所属するクラスで集計
+- 複数該当する場合は、最初に見つかったクラスを使用（または全て表示）
+
+---
+
+## 統計集計ロジック
+
+### 生徒のクラス判定
+
+```typescript
+function getStudentStatisticsClass(
+  student: StudentWithMemberships,
+  statisticsClasses: Class[]
+): Class | null {
+  // 統計用クラスのうち、生徒が所属しているものを探す
+  for (const statsClass of statisticsClasses) {
+    const membership = student.memberships.find(
+      (m) => m.classId === statsClass.id
+    )
+    if (membership) {
+      return statsClass
+    }
+  }
+  // 該当なし: 統計集計から除外、または「その他」グループに
+  return null
+}
+```
+
+### 集計処理
+
+```typescript
+function calculateClassStatistics(
+  students: StudentWithScores[],
+  statisticsClasses: Class[]
+): Map<string, ClassStatistics> {
+  const result = new Map<string, ClassStatistics>()
+
+  for (const statsClass of statisticsClasses) {
+    // このクラスに所属する生徒を抽出
+    const classStudents = students.filter((s) =>
+      s.memberships.some((m) => m.classId === statsClass.id)
+    )
+
+    const scores = classStudents.map((s) => s.totalScore)
+
+    result.set(statsClass.id, {
+      className: statsClass.name,
+      count: classStudents.length,
+      average: calculateAverage(scores),
+      max: Math.max(...scores),
+      min: Math.min(...scores),
+      stdDev: calculateStdDev(scores),
+    })
+  }
+
+  return result
+}
+```
+
+---
+
+## マイグレーション計画
+
+### Phase 1: スキーマ追加
+
+1. `ProjectClass` テーブルを作成
+2. Project モデルに `projectClasses` リレーション追加
+3. Class モデルに `projectClasses` リレーション追加
+
+### Phase 2: バックエンド実装
+
+1. CRUD用のPrisma関数作成
+2. IPC ハンドラー追加
+3. 既存の出力ロジックに統計クラス対応追加
+
+### Phase 3: フロントエンド実装
+
+1. プロジェクト設定画面にクラス設定UIを追加
+2. 受験生徒追加モーダルを `administered` クラスでフィルタ
+3. 出力設定画面で統計クラスを確認可能に
+
+### Phase 4: データ移行（オプション）
+
+- 既存プロジェクトに対して、受験生徒の membership から自動的に ProjectClass を生成
+- `administered=true, statistics=true` として追加
+
+---
+
+## 関連ファイル
+
+### 変更が必要なファイル
+
+**スキーマ**
+
+- `prisma/schema.prisma`
+
+**バックエンド**
+
+- `electron-src/lib/prisma/projectClass.ts` (新規)
+- `electron-src/lib/export/excel/data-fetcher.ts`
+- `electron-src/lib/export/individual-report/data-fetcher.ts`
+- `electron-src/ipc-handlers/project-handlers.ts`
+
+**フロントエンド**
+
+- `components/projects/05-students/components/project-student-add-modal/`
+- `app/projects/[projectId]/settings/` (新規または既存拡張)
+
+**型定義**
+
+- `types/common.types.ts`
+- `types/electron.d.ts`
+
+---
+
+## 今後の拡張可能性
+
+1. **クラス別の配点設定**: クラスによって異なる配点を適用
+2. **クラス別のレポート生成**: クラス単位でPDFを分割出力
+3. **クラス担任への共有**: 特定クラスの結果のみを担任に共有

--- a/hooks/useStudentImport.ts
+++ b/hooks/useStudentImport.ts
@@ -1,14 +1,5 @@
 import { useState } from "react"
 
-interface ClassWithMemberships {
-  id: string
-  name: string
-  classCode?: string | null
-  grade?: number | null
-  description?: string | null
-  isVisible?: boolean
-}
-
 interface StudentWithMemberships {
   id: string
   studentId: string
@@ -41,18 +32,13 @@ interface StudentImportRow {
   isDuplicate?: boolean
 }
 
-interface ClassAssignmentRow {
-  studentId: string
-  classCode: string
-}
-
 interface ValidationResult {
   valid: number
   errors: string[]
   warnings: string[]
 }
 
-export function useStudentImport(existingClasses: ClassWithMemberships[]) {
+export function useStudentImport() {
   const [studentData, setStudentData] = useState<StudentImportRow[]>([
     {
       studentId: "",
@@ -64,35 +50,12 @@ export function useStudentImport(existingClasses: ClassWithMemberships[]) {
     },
   ])
 
-  const [classAssignmentData, setClassAssignmentData] = useState<
-    ClassAssignmentRow[]
-  >([{ studentId: "", classCode: "" }])
-
   const [studentValidation, setStudentValidation] = useState<ValidationResult>({
     valid: 0,
     errors: [],
     warnings: [],
   })
-  const [classValidation, setClassValidation] = useState<ValidationResult>({
-    valid: 0,
-    errors: [],
-    warnings: [],
-  })
   const [isProcessing, setIsProcessing] = useState(false)
-  const [importedStudents, setImportedStudents] = useState<
-    StudentWithMemberships[]
-  >([])
-
-  // 学級コードと名前のマッピングを作成
-  const classMap = new Map<string, ClassWithMemberships>()
-  existingClasses
-    .filter((cls) => cls.isVisible !== false)
-    .forEach((cls) => {
-      classMap.set(cls.name, cls)
-      if (cls.classCode) {
-        classMap.set(cls.classCode, cls)
-      }
-    })
 
   const handleStudentDataChange = (data: StudentImportRow[]) => {
     // 重複チェックとフラグ設定
@@ -119,11 +82,6 @@ export function useStudentImport(existingClasses: ClassWithMemberships[]) {
       ...row,
       isDuplicate: existingStudentIds.has(row.studentId?.trim() || ""),
     }))
-  }
-
-  const handleClassAssignmentDataChange = (data: ClassAssignmentRow[]) => {
-    setClassAssignmentData(data)
-    validateClassAssignmentData(data)
   }
 
   const validateStudentData = async (data: StudentImportRow[]) => {
@@ -188,51 +146,6 @@ export function useStudentImport(existingClasses: ClassWithMemberships[]) {
     setStudentValidation({ valid: validCount, errors, warnings })
   }
 
-  const validateClassAssignmentData = (data: ClassAssignmentRow[]) => {
-    const errors: string[] = []
-    const warnings: string[] = []
-    let validCount = 0
-
-    const availableStudentIds = new Set(
-      studentData
-        .filter((s) => s.studentId?.trim())
-        .map((s) => s.studentId.trim())
-    )
-
-    const filteredData = data.filter(
-      (row) => row.studentId?.trim() || row.classCode?.trim()
-    )
-
-    filteredData.forEach((row, index) => {
-      const rowNum = index + 1
-
-      if (!row.studentId?.trim()) {
-        errors.push(`行${rowNum}: 学籍番号が入力されていません`)
-        return
-      }
-      if (!row.classCode?.trim()) {
-        errors.push(`行${rowNum}: クラスコードが入力されていません`)
-        return
-      }
-
-      if (!availableStudentIds.has(row.studentId.trim())) {
-        warnings.push(
-          `行${rowNum}: 学籍番号「${row.studentId}」の生徒が見つかりません`
-        )
-      }
-
-      if (!classMap.has(row.classCode.trim())) {
-        warnings.push(
-          `行${rowNum}: クラスコード「${row.classCode}」が見つかりません`
-        )
-      }
-
-      validCount++
-    })
-
-    setClassValidation({ valid: validCount, errors, warnings })
-  }
-
   const handleImportStudents = async () => {
     if (studentValidation.errors.length > 0) return
 
@@ -286,8 +199,6 @@ export function useStudentImport(existingClasses: ClassWithMemberships[]) {
         }
       }
 
-      setImportedStudents(imported)
-
       return imported
     } catch (error) {
       console.error("Student import failed:", error)
@@ -297,65 +208,11 @@ export function useStudentImport(existingClasses: ClassWithMemberships[]) {
     }
   }
 
-  const handleImportClassAssignments = async () => {
-    if (classValidation.errors.length > 0) return
-
-    setIsProcessing(true)
-
-    try {
-      const studentMap = new Map(importedStudents.map((s) => [s.studentId, s]))
-
-      const validClassAssignmentData = classAssignmentData.filter(
-        (row) => row.studentId?.trim() && row.classCode?.trim()
-      )
-
-      for (const row of validClassAssignmentData) {
-        const student = studentMap.get(row.studentId.trim())
-        const classRecord = classMap.get(row.classCode.trim())
-
-        if (student && classRecord) {
-          await window.electronAPI.addStudentToClass(
-            student.id,
-            classRecord.id,
-            new Date(),
-            undefined, // attendanceNumber
-            undefined // notes
-          )
-        }
-      }
-
-      const updatedStudents = await window.electronAPI.fetchStudents()
-      const finalImportedStudents = updatedStudents.filter((s) =>
-        importedStudents.some((imported) => imported.id === s.id)
-      )
-
-      return finalImportedStudents
-    } catch (error) {
-      console.error("Class assignment failed:", error)
-      throw error
-    } finally {
-      setIsProcessing(false)
-    }
-  }
-
   return {
-    // State
     studentData,
-    classAssignmentData,
     studentValidation,
-    classValidation,
     isProcessing,
-    importedStudents,
-
-    // Helpers
-    classMap,
-
-    // Actions
     handleStudentDataChange,
-    handleClassAssignmentDataChange,
-    validateStudentData,
-    validateClassAssignmentData,
     handleImportStudents,
-    handleImportClassAssignments,
   }
 }


### PR DESCRIPTION
## Summary

- useStudentImport からクラス割り当て関連の未使用コードを削除
- useDragDropState から isDraggingFromTrash 状態を削除
- ProjectClass リレーション設計書を追加

Closes #233

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `hooks/useStudentImport.ts` | クラス割り当て機能削除、パラメータ簡素化 |
| `components/student/SpreadsheetImportModal.tsx` | existingClasses prop 削除 |
| `components/student/StudentTable.tsx` | existingClasses 受け渡し削除 |
| `useDragDropState.ts` | isDraggingFromTrash 状態削除 |
| `useDragDrop.ts` | setIsDraggingFromTrash 削除 |
| `useDragDropHandlers.ts` | setIsDraggingFromTrash パラメータ・呼び出し削除 |
| `docs/design/project-class-relation.md` | 設計書追加 |

## Test plan

- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [ ] 生徒インポート機能の動作確認
- [ ] 答案ドラッグ&ドロップ機能の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)