### PR TITLE
feat: 採点状態色の設定画面統合と採点画面への反映

### DIFF
--- a/app/settings/components/DisplaySettingsTab.tsx
+++ b/app/settings/components/DisplaySettingsTab.tsx
@@ -1,0 +1,230 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+import { ColorPicker } from "@/components/ui/color-picker"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import {
+  getSelectionBorderSettings,
+  saveSelectionBorderColor,
+  SELECTION_BORDER_PRESETS,
+} from "@/lib/utils"
+import {
+  getScoringStatusColors,
+  saveScoringStatusColors,
+  applyScoringColorPreset,
+  getCurrentPresetId,
+  SCORING_COLOR_PRESETS,
+  SCORING_STATUS_LABELS,
+  SCORING_STATUS_ORDER,
+  type ScoringStatusColors,
+  type ScoringStatusType,
+} from "@/lib/scoringStatusColors"
+import { RotateCcw } from "lucide-react"
+
+export function DisplaySettingsTab() {
+  // 選択枠色の状態
+  const [selectionBorderColor, setSelectionBorderColor] = useState(
+    getSelectionBorderSettings().color
+  )
+
+  // 採点状態色の状態
+  const [scoringColors, setScoringColors] = useState<ScoringStatusColors>(
+    getScoringStatusColors
+  )
+  const [currentPresetId, setCurrentPresetId] = useState<string | null>(
+    getCurrentPresetId
+  )
+
+  // 初期値をロード
+  useEffect(() => {
+    setScoringColors(getScoringStatusColors())
+    setCurrentPresetId(getCurrentPresetId())
+  }, [])
+
+  // 選択枠色の変更
+  const handleSelectionBorderColorChange = useCallback((color: string) => {
+    setSelectionBorderColor(color.toUpperCase())
+    saveSelectionBorderColor(color)
+    window.dispatchEvent(new CustomEvent("selectionBorderColorChanged"))
+    toast.success("選択枠色が変更されました")
+  }, [])
+
+  // プリセット選択
+  const handlePresetSelect = useCallback((presetId: string) => {
+    applyScoringColorPreset(presetId)
+    setScoringColors(getScoringStatusColors())
+    setCurrentPresetId(presetId)
+    toast.success("カラープリセットが適用されました")
+  }, [])
+
+  // 個別の色変更
+  const handleStatusColorChange = useCallback(
+    (status: ScoringStatusType, type: "bg" | "text" | "icon", color: string) => {
+      const updated: ScoringStatusColors = {
+        ...scoringColors,
+        [status]: {
+          ...scoringColors[status],
+          [type]: color.toUpperCase(),
+        },
+      }
+      setScoringColors(updated)
+      saveScoringStatusColors(updated)
+      setCurrentPresetId(null) // カスタム変更したのでプリセットをクリア
+    },
+    [scoringColors]
+  )
+
+  // リセット
+  const handleReset = useCallback(() => {
+    handlePresetSelect("default")
+    toast.success("デフォルト設定にリセットしました")
+  }, [handlePresetSelect])
+
+  const isPresetSelected = (presetId: string) => currentPresetId === presetId
+
+  return (
+    <div className="space-y-8">
+      {/* 選択枠の色 */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">選択枠の色</h2>
+          <p className="text-muted-foreground text-sm">
+            一括採点における選択答案の枠色を変更できます
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* プリセット色 */}
+          {SELECTION_BORDER_PRESETS.map((color) => (
+            <button
+              key={color}
+              onClick={() => handleSelectionBorderColorChange(color)}
+              className={cn(
+                "h-8 w-8 rounded-lg border-2 transition-all hover:scale-105",
+                selectionBorderColor === color
+                  ? "border-gray-800 shadow-md scale-110"
+                  : "border-gray-200 hover:border-gray-300"
+              )}
+              style={{ backgroundColor: color }}
+              aria-label={`色 ${color}`}
+            />
+          ))}
+
+          {/* カスタム色ピッカー */}
+          <div className="ml-2 flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">カスタム:</span>
+            <ColorPicker
+              value={selectionBorderColor}
+              onChange={handleSelectionBorderColorChange}
+              className={cn(
+                !SELECTION_BORDER_PRESETS.includes(selectionBorderColor) &&
+                  "ring-2 ring-gray-400"
+              )}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 採点状態の表示色 */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">採点状態の表示色</h2>
+            <p className="text-muted-foreground text-sm">
+              採点パネル・一覧の背景色を変更できます
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={handleReset}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            リセット
+          </Button>
+        </div>
+
+        {/* プリセット選択 */}
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">プリセット</Label>
+          <div className="flex flex-wrap gap-2">
+            {SCORING_COLOR_PRESETS.map((preset) => (
+              <Button
+                key={preset.id}
+                variant={isPresetSelected(preset.id) ? "default" : "outline"}
+                size="sm"
+                onClick={() => handlePresetSelect(preset.id)}
+                title={preset.description}
+              >
+                {preset.name}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        {/* 個別カスタマイズ */}
+        <div className="rounded-lg border p-4">
+          <div className="space-y-3">
+            {SCORING_STATUS_ORDER.map((status) => {
+              const colors = scoringColors[status]
+              return (
+                <div
+                  key={status}
+                  className="flex items-center justify-between gap-4"
+                >
+                  {/* ステータスラベル */}
+                  <div className="w-20 text-sm font-medium">
+                    {SCORING_STATUS_LABELS[status]}
+                  </div>
+
+                  {/* プレビュー */}
+                  <div
+                    className="flex h-8 w-24 items-center justify-center rounded text-xs font-medium"
+                    style={{
+                      backgroundColor: colors.bg,
+                      color: colors.text,
+                    }}
+                  >
+                    サンプル
+                  </div>
+
+                  {/* 色設定 */}
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground text-xs">背景</span>
+                      <ColorPicker
+                        value={colors.bg}
+                        onChange={(c) =>
+                          handleStatusColorChange(status, "bg", c)
+                        }
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground text-xs">文字</span>
+                      <ColorPicker
+                        value={colors.text}
+                        onChange={(c) =>
+                          handleStatusColorChange(status, "text", c)
+                        }
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground text-xs">
+                        アイコン
+                      </span>
+                      <ColorPicker
+                        value={colors.icon}
+                        onChange={(c) =>
+                          handleStatusColorChange(status, "icon", c)
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/settings/components/UserManagementTab.tsx
+++ b/app/settings/components/UserManagementTab.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Edit3, UserPen } from "lucide-react"
+
+interface User {
+  id: string
+  username: string
+  name: string
+  role: string
+  passcodeType?: string | null
+}
+
+interface UserManagementTabProps {
+  users: User[]
+  onEditUser: (user: User) => void
+  onEditPasscode: (user: User) => void
+}
+
+export function UserManagementTab({
+  users,
+  onEditUser,
+  onEditPasscode,
+}: UserManagementTabProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">ユーザー管理</h2>
+        <p className="text-muted-foreground text-sm">
+          ユーザー情報とパスコードを管理します
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {users.map((user) => (
+          <div
+            key={user.id}
+            className="flex items-center justify-between rounded-lg border p-3"
+          >
+            <div>
+              <div className="font-medium">{user.name}</div>
+              <div className="text-muted-foreground text-sm">
+                @{user.username} • {user.role}
+                {user.passcodeType && user.passcodeType !== "none" && (
+                  <span className="ml-2 rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
+                    パスコード: {user.passcodeType}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEditUser(user)}
+              >
+                <Edit3 className="mr-2 h-4 w-4" />
+                ユーザー情報編集
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEditPasscode(user)}
+              >
+                <UserPen className="mr-2 h-4 w-4" />
+                パスコード編集
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/settings/constants.ts
+++ b/app/settings/constants.ts
@@ -50,23 +50,13 @@ export const SHORTCUT_LABELS: {
   "navigation.zoomOut": "縮小",
   "navigation.resetZoom": "ズームリセット",
 
-  // フィルタ - Alt + 採点キー
+  // フィルタ
   "filter.toggleUnscored": "未採点フィルタ",
   "filter.toggleCorrect": "正答フィルタ",
   "filter.togglePartial": "部分点フィルタ",
   "filter.togglePending": "保留フィルタ",
   "filter.toggleIncorrect": "誤答フィルタ",
   "filter.toggleNoAnswer": "無答フィルタ",
-
-  // フィルタ - Ctrl + 数字
-  "filter.toggle1": "フィルタ1",
-  "filter.toggle2": "フィルタ2",
-  "filter.toggle3": "フィルタ3",
-  "filter.toggle4": "フィルタ4",
-  "filter.toggle5": "フィルタ5",
-  "filter.toggle6": "フィルタ6",
-
-  // フィルタ - 更新
   "filter.refresh": "フィルタ更新",
 
   // 表示
@@ -76,8 +66,6 @@ export const SHORTCUT_LABELS: {
   "view.questionView": "設問表示",
 
   // モーダル
-  "modal.confirmPartial": "部分点として確定",
-  "modal.confirmPending": "保留として確定",
   "modal.cancel": "キャンセル",
   "modal.backspace": "文字削除",
   "modal.input0": "0",
@@ -91,12 +79,10 @@ export const SHORTCUT_LABELS: {
   "modal.input8": "8",
   "modal.input9": "9",
   "modal.inputDot": ".",
-
-  // 保存
-  "save.all": "すべて保存",
 }
 
 // カテゴリ別の設定項目（新しいコマンドID形式）
+// 順序: 採点操作 → モーダル操作 → フィルタ → ナビゲーション → 表示制御
 export const SHORTCUT_CATEGORIES = {
   scoring: {
     label: "採点操作",
@@ -109,6 +95,38 @@ export const SHORTCUT_CATEGORIES = {
       "scoring.noAnswer",
     ] as const,
     description: "採点状態を設定するキー",
+  },
+  modal: {
+    label: "モーダル操作",
+    keys: [
+      "modal.cancel",
+      "modal.backspace",
+      "modal.input0",
+      "modal.input1",
+      "modal.input2",
+      "modal.input3",
+      "modal.input4",
+      "modal.input5",
+      "modal.input6",
+      "modal.input7",
+      "modal.input8",
+      "modal.input9",
+      "modal.inputDot",
+    ] as const,
+    description: "部分点入力モーダル内の操作（確定キーは採点操作と共通）",
+  },
+  filter: {
+    label: "フィルタ",
+    keys: [
+      "filter.toggleUnscored",
+      "filter.toggleCorrect",
+      "filter.togglePartial",
+      "filter.togglePending",
+      "filter.toggleIncorrect",
+      "filter.toggleNoAnswer",
+      "filter.refresh",
+    ] as const,
+    description: "フィルタの切り替え・更新",
   },
   navigation: {
     label: "ナビゲーション",
@@ -129,25 +147,6 @@ export const SHORTCUT_CATEGORIES = {
     ] as const,
     description: "設問・生徒の移動、ズーム操作",
   },
-  filter: {
-    label: "フィルタ",
-    keys: [
-      "filter.toggleUnscored",
-      "filter.toggleCorrect",
-      "filter.togglePartial",
-      "filter.togglePending",
-      "filter.toggleIncorrect",
-      "filter.toggleNoAnswer",
-      "filter.toggle1",
-      "filter.toggle2",
-      "filter.toggle3",
-      "filter.toggle4",
-      "filter.toggle5",
-      "filter.toggle6",
-      "filter.refresh",
-    ] as const,
-    description: "フィルタの切り替え・更新",
-  },
   view: {
     label: "表示制御",
     keys: [
@@ -157,31 +156,5 @@ export const SHORTCUT_CATEGORIES = {
       "view.questionView",
     ] as const,
     description: "表示の切り替え",
-  },
-  modal: {
-    label: "モーダル操作",
-    keys: [
-      "modal.confirmPartial",
-      "modal.confirmPending",
-      "modal.cancel",
-      "modal.backspace",
-      "modal.input0",
-      "modal.input1",
-      "modal.input2",
-      "modal.input3",
-      "modal.input4",
-      "modal.input5",
-      "modal.input6",
-      "modal.input7",
-      "modal.input8",
-      "modal.input9",
-      "modal.inputDot",
-    ] as const,
-    description: "部分点入力モーダル内の操作",
-  },
-  save: {
-    label: "保存",
-    keys: ["save.all"] as const,
-    description: "保存操作",
   },
 } as const

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,21 +1,14 @@
 "use client"
 
+import { DisplaySettingsTab } from "@/app/settings/components/DisplaySettingsTab"
 import { KeyboardShortcutSection } from "@/app/settings/components/KeyboardShortcutSection"
+import { UserManagementTab } from "@/app/settings/components/UserManagementTab"
 import { useKeyboardSettings } from "@/app/settings/hooks/useKeyboardSettings"
 import { PasscodeEditModal } from "@/components/auth/PasscodeEditModal"
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
 import { UserEditModal } from "@/components/auth/UserEditModal"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Separator } from "@/components/ui/separator"
-import {
-  getSelectionBorderSettings,
-  saveSelectionBorderColor,
-  SELECTION_BORDER_COLORS,
-} from "@/lib/utils"
-import { Edit3, UserPen } from "lucide-react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Keyboard, Monitor, Users } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -44,9 +37,6 @@ export default function SettingsPage() {
   const [isPasscodeEditOpen, setIsPasscodeEditOpen] = useState(false)
   const [isUserEditOpen, setIsUserEditOpen] = useState(false)
   const [selectedUser, setSelectedUser] = useState<User | null>(null)
-  const [selectionBorderColor, setSelectionBorderColor] = useState(
-    getSelectionBorderSettings().color
-  )
 
   const loadUsers = useCallback(async () => {
     try {
@@ -81,15 +71,7 @@ export default function SettingsPage() {
   }
 
   const handlePasscodeUpdated = () => {
-    void loadUsers() // ユーザー一覧を再読み込み
-  }
-
-  const handleSelectionBorderColorChange = (color: string) => {
-    setSelectionBorderColor(color)
-    saveSelectionBorderColor(color)
-    // カスタムイベントを発火して他のコンポーネントに通知
-    window.dispatchEvent(new CustomEvent("selectionBorderColorChanged"))
-    toast.success("選択枠色が変更されました")
+    void loadUsers()
   }
 
   return (
@@ -102,162 +84,48 @@ export default function SettingsPage() {
           </p>
         </div>
 
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>ユーザー管理</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                {users.map((user) => (
-                  <div
-                    key={user.id}
-                    className="flex items-center justify-between rounded-lg border p-3"
-                  >
-                    <div>
-                      <div className="font-medium">{user.name}</div>
-                      <div className="text-muted-foreground text-sm">
-                        @{user.username} • {user.role}
-                        {user.passcodeType && user.passcodeType !== "none" && (
-                          <span className="ml-2 rounded bg-blue-100 px-2 py-1 text-xs text-blue-800">
-                            パスコード: {user.passcodeType}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex space-x-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleEditUser(user)}
-                      >
-                        <Edit3 className="mr-2 h-4 w-4" />
-                        ユーザー情報編集
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleEditPasscode(user)}
-                      >
-                        <UserPen className="mr-2 h-4 w-4" />
-                        パスコード編集
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+        <Tabs defaultValue="keyboard" className="space-y-6">
+          <TabsList>
+            <TabsTrigger value="keyboard" className="gap-2">
+              <Keyboard className="h-4 w-4" />
+              キーボード
+            </TabsTrigger>
+            <TabsTrigger value="display" className="gap-2">
+              <Monitor className="h-4 w-4" />
+              表示設定
+            </TabsTrigger>
+            <TabsTrigger value="user" className="gap-2">
+              <Users className="h-4 w-4" />
+              ユーザー管理
+            </TabsTrigger>
+          </TabsList>
 
-          <Separator />
+          <TabsContent value="keyboard">
+            <KeyboardShortcutSection
+              shortcuts={shortcuts}
+              editingKey={editingKey}
+              pendingKey={pendingKey}
+              modifierKeyLabel={modifierKeyLabel}
+              onKeyEdit={handleKeyEdit}
+              onKeySave={handleKeySave}
+              onKeyCancel={handleKeyCancel}
+              onReset={handleReset}
+              getKeyDisplayName={getKeyDisplayName}
+            />
+          </TabsContent>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>表示設定</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <Label className="text-base font-medium">選択枠の色</Label>
-                <p className="text-muted-foreground mb-3 text-sm">
-                  答案選択時の枠色を変更できます
-                </p>
-                <div className="grid grid-cols-3 gap-3">
-                  {Object.entries(SELECTION_BORDER_COLORS).map(
-                    ([colorValue, config]) => (
-                      <button
-                        key={colorValue}
-                        onClick={() =>
-                          handleSelectionBorderColorChange(colorValue)
-                        }
-                        className={`relative flex items-center justify-center rounded-lg border-2 p-3 transition-all hover:scale-105 ${
-                          selectionBorderColor === colorValue
-                            ? "border-gray-800 shadow-md"
-                            : "border-gray-200 hover:border-gray-300"
-                        }`}
-                      >
-                        <div
-                          className="h-8 w-8 rounded border-2"
-                          style={{ borderColor: config.color }}
-                        />
-                        {selectionBorderColor === colorValue && (
-                          <div className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-blue-500" />
-                        )}
-                      </button>
-                    )
-                  )}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <TabsContent value="display">
+            <DisplaySettingsTab />
+          </TabsContent>
 
-          <Separator />
-
-          <KeyboardShortcutSection
-            shortcuts={shortcuts}
-            editingKey={editingKey}
-            pendingKey={pendingKey}
-            modifierKeyLabel={modifierKeyLabel}
-            onKeyEdit={handleKeyEdit}
-            onKeySave={handleKeySave}
-            onKeyCancel={handleKeyCancel}
-            onReset={handleReset}
-            getKeyDisplayName={getKeyDisplayName}
-          />
-
-          <Card>
-            <CardHeader>
-              <CardTitle>画像前処理設定</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid w-full max-w-sm items-center gap-1.5">
-                <Label htmlFor="setting-threshold">二値化閾値</Label>
-                <Input
-                  type="number"
-                  id="setting-threshold"
-                  placeholder="例: 128"
-                />
-              </div>
-              <Button>保存</Button>
-            </CardContent>
-          </Card>
-
-          <Separator />
-
-          <Card>
-            <CardHeader>
-              <CardTitle>デフォルト出力先設定</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid w-full max-w-lg items-center gap-1.5">
-                <Label htmlFor="setting-output-excel">
-                  Excel出力先フォルダ
-                </Label>
-                <div className="flex space-x-2">
-                  <Input
-                    type="text"
-                    id="setting-output-excel"
-                    placeholder="未設定"
-                    readOnly
-                  />
-                  <Button variant="outline">選択</Button>
-                </div>
-              </div>
-              <div className="grid w-full max-w-lg items-center gap-1.5">
-                <Label htmlFor="setting-output-pdf">PDF出力先フォルダ</Label>
-                <div className="flex space-x-2">
-                  <Input
-                    type="text"
-                    id="setting-output-pdf"
-                    placeholder="未設定"
-                    readOnly
-                  />
-                  <Button variant="outline">選択</Button>
-                </div>
-              </div>
-              <Button>保存</Button>
-            </CardContent>
-          </Card>
-        </div>
+          <TabsContent value="user">
+            <UserManagementTab
+              users={users}
+              onEditUser={handleEditUser}
+              onEditPasscode={handleEditPasscode}
+            />
+          </TabsContent>
+        </Tabs>
 
         <UserEditModal
           isOpen={isUserEditOpen}

--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -13,6 +13,7 @@ import type {
   MasterGridItem,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
+import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
 import { useEffect, useRef, useState } from "react"
 
 export interface AnswerGridViewProps {
@@ -103,7 +104,8 @@ export default function AnswerGridView({
   const { dragStart, isDragging, dragCurrent, startDrag, updateDrag, endDrag } =
     useGridSelection()
 
-  const selectionBorderSettings = useSelectionBorder()
+  const selectionBorderColor = useSelectionBorder()
+  const scoringColors = useScoringStatusColors()
 
   const { effectiveGridSize, sortedAnswers } = useGridLayout({
     answers,
@@ -221,7 +223,8 @@ export default function AnswerGridView({
               showStudentNames={showStudentNames}
               layoutDirection={layoutDirection}
               calculatedCellHeight={calculatedCellHeight}
-              selectionBorderSettings={selectionBorderSettings}
+              selectionBorderColor={selectionBorderColor}
+              scoringColors={scoringColors}
               onMouseDown={onCellMouseDown}
             />
           )

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -1,20 +1,26 @@
-import { SCORE_STATUS_CONFIG } from "@/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig"
+import {
+  getDynamicScoreStatusConfig,
+  type DynamicScoreStatusConfig,
+  type ScoreStatusKey,
+} from "@/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig"
 import type { GridAnswerItem } from "@/components/projects/07-score-at-once/ScoringGrid/types/gridTypes"
 import CroppedAnswerImage from "@/components/projects/07-score-at-once/ScoringMain/CroppedAnswerImage"
 import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
 import { Badge } from "@/components/ui/badge"
+import type { ScoringStatusColors } from "@/lib/scoringStatusColors"
 
-const SCORE_STATUS_KEYS = Object.keys(SCORE_STATUS_CONFIG) as Array<
-  keyof typeof SCORE_STATUS_CONFIG
->
+const VALID_STATUS_KEYS: ScoreStatusKey[] = [
+  "unscored",
+  "correct",
+  "partial",
+  "pending",
+  "incorrect",
+  "no_answer",
+  "master",
+]
 
-type ScoreStatusConfig =
-  (typeof SCORE_STATUS_CONFIG)[keyof typeof SCORE_STATUS_CONFIG]
-
-const isScoreStatusKey = (
-  status: keyof typeof SCORE_STATUS_CONFIG
-): status is keyof typeof SCORE_STATUS_CONFIG =>
-  SCORE_STATUS_KEYS.includes(status)
+const isValidStatusKey = (status: string): status is ScoreStatusKey =>
+  VALID_STATUS_KEYS.includes(status as ScoreStatusKey)
 
 interface GridCellProps {
   answer: GridAnswerItem
@@ -22,9 +28,8 @@ interface GridCellProps {
   showStudentNames: boolean
   layoutDirection: LayoutDirection
   calculatedCellHeight: number
-  selectionBorderSettings: {
-    tailwindClass: string
-  }
+  selectionBorderColor: string
+  scoringColors: ScoringStatusColors
   onMouseDown: (e: React.MouseEvent, answerId: string) => void
 }
 
@@ -34,33 +39,39 @@ export function GridCell({
   showStudentNames,
   layoutDirection,
   calculatedCellHeight,
-  selectionBorderSettings,
+  selectionBorderColor,
+  scoringColors,
   onMouseDown,
 }: GridCellProps) {
-  const statusKey: keyof typeof SCORE_STATUS_CONFIG = isScoreStatusKey(
-    answer.status
-  )
+  const statusConfig = getDynamicScoreStatusConfig(scoringColors)
+  const statusKey: ScoreStatusKey = isValidStatusKey(answer.status)
     ? answer.status
     : "unscored"
-  const config: ScoreStatusConfig =
-    SCORE_STATUS_CONFIG[statusKey] ?? SCORE_STATUS_CONFIG.unscored
+  const config = statusConfig[statusKey]
   const Icon = config.icon
   const isMaster =
     answer.studentId === "MASTER" || answer.studentName === "模範解答"
 
-  const cellClasses = ["flex flex-shrink-0 flex-col gap-1 p-2"]
+  // 基本のセルクラス
+  const cellClasses = ["flex flex-shrink-0 flex-col gap-1 p-2 border-2"]
+
+  // スタイルを構築
+  let cellBgStyle: React.CSSProperties = {}
 
   if (isMaster) {
-    cellClasses.push("border-2 border-black bg-white")
+    cellClasses.push("border-black bg-white")
   } else {
-    cellClasses.push("border-2")
     if (isSelected) {
-      cellClasses.push(
-        selectionBorderSettings.tailwindClass,
-        config.selectedBgColor
-      )
+      cellBgStyle = {
+        ...config.selectedBgStyle,
+        borderColor: selectionBorderColor,
+      }
     } else {
-      cellClasses.push(config.borderColor, config.bgColor ?? "bg-white")
+      cellBgStyle = {
+        ...config.bgStyle,
+        borderColor: "transparent",
+      }
+      cellClasses.push("border-transparent")
     }
   }
 
@@ -82,14 +93,15 @@ export function GridCell({
   const isColumnLayout =
     layoutDirection === "down-right" || layoutDirection === "down-left"
 
-  // 列レイアウト時は明示的に高さを設定
-  const cellStyle: React.CSSProperties = isColumnLayout
-    ? {
-        height: calculatedCellHeight,
-        maxHeight: calculatedCellHeight,
-        overflow: "hidden",
-      }
-    : {}
+  // 列レイアウト時は明示的に高さを設定、背景色・ボーダー色を適用
+  const cellStyle: React.CSSProperties = {
+    ...(isColumnLayout && {
+      height: calculatedCellHeight,
+      maxHeight: calculatedCellHeight,
+      overflow: "hidden",
+    }),
+    ...cellBgStyle,
+  }
 
   return (
     <div
@@ -123,6 +135,7 @@ export function GridCell({
             className={`block max-w-full truncate text-xs ${
               isMaster ? "font-bold text-black" : "font-medium"
             }`}
+            style={isMaster ? undefined : config.textStyle}
           >
             {isMaster
               ? answer.studentName
@@ -148,7 +161,7 @@ export function GridCell({
         </div>
 
         {!isMaster && (
-          <Icon className={`h-3 w-3 ${config.textColor} shrink-0`} />
+          <Icon className="h-3 w-3 shrink-0" style={config.iconStyle} />
         )}
       </div>
     </div>

--- a/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
@@ -6,8 +6,99 @@ import {
   Minus,
   X,
 } from "lucide-react"
+import type { ScoringStatusColors } from "@/lib/scoringStatusColors"
 
-// 採点状態のアイコンと色を定義
+// アイコンとキーバインドの定義（静的）
+export const SCORE_STATUS_ICONS = {
+  unscored: { icon: Circle, key: "q" },
+  correct: { icon: CheckCircle, key: "e" },
+  partial: { icon: AlertTriangle, key: "f" },
+  pending: { icon: Clock, key: "j" },
+  incorrect: { icon: X, key: "o" },
+  no_answer: { icon: Minus, key: "p" },
+  master: { icon: CheckCircle, key: "" },
+} as const
+
+// ステータス名のマッピング（SCORE_STATUS_CONFIG のキー → ScoringStatusColors のキー）
+const STATUS_KEY_MAP: Record<string, keyof ScoringStatusColors> = {
+  unscored: "ungraded",
+  correct: "correct",
+  partial: "partial",
+  pending: "pending",
+  incorrect: "incorrect",
+  no_answer: "no_answer",
+  master: "ungraded", // masterは特殊扱い
+}
+
+/**
+ * 動的な採点状態色設定を生成
+ * @param colors - 採点状態色（useScoringStatusColorsから取得）
+ */
+export function getDynamicScoreStatusConfig(colors: ScoringStatusColors) {
+  return {
+    unscored: {
+      icon: Circle,
+      bgStyle: { backgroundColor: colors.ungraded.bg },
+      selectedBgStyle: { backgroundColor: colors.ungraded.bg, opacity: 0.8 },
+      textStyle: { color: colors.ungraded.text },
+      iconStyle: { color: colors.ungraded.icon },
+      key: "q",
+    },
+    correct: {
+      icon: CheckCircle,
+      bgStyle: { backgroundColor: colors.correct.bg },
+      selectedBgStyle: { backgroundColor: colors.correct.bg, opacity: 0.8 },
+      textStyle: { color: colors.correct.text },
+      iconStyle: { color: colors.correct.icon },
+      key: "e",
+    },
+    partial: {
+      icon: AlertTriangle,
+      bgStyle: { backgroundColor: colors.partial.bg },
+      selectedBgStyle: { backgroundColor: colors.partial.bg, opacity: 0.8 },
+      textStyle: { color: colors.partial.text },
+      iconStyle: { color: colors.partial.icon },
+      key: "f",
+    },
+    pending: {
+      icon: Clock,
+      bgStyle: { backgroundColor: colors.pending.bg },
+      selectedBgStyle: { backgroundColor: colors.pending.bg, opacity: 0.8 },
+      textStyle: { color: colors.pending.text },
+      iconStyle: { color: colors.pending.icon },
+      key: "j",
+    },
+    incorrect: {
+      icon: X,
+      bgStyle: { backgroundColor: colors.incorrect.bg },
+      selectedBgStyle: { backgroundColor: colors.incorrect.bg, opacity: 0.8 },
+      textStyle: { color: colors.incorrect.text },
+      iconStyle: { color: colors.incorrect.icon },
+      key: "o",
+    },
+    no_answer: {
+      icon: Minus,
+      bgStyle: { backgroundColor: colors.no_answer.bg },
+      selectedBgStyle: { backgroundColor: colors.no_answer.bg, opacity: 0.8 },
+      textStyle: { color: colors.no_answer.text },
+      iconStyle: { color: colors.no_answer.icon },
+      key: "p",
+    },
+    master: {
+      icon: CheckCircle,
+      bgStyle: { backgroundColor: "#EFF6FF" }, // blue-50 固定
+      selectedBgStyle: { backgroundColor: "#DBEAFE" }, // blue-100 固定
+      textStyle: { color: "#1E40AF" }, // blue-800 固定
+      iconStyle: { color: "#1E40AF" },
+      key: "",
+    },
+  }
+}
+
+export type DynamicScoreStatusConfig = ReturnType<typeof getDynamicScoreStatusConfig>
+export type ScoreStatusKey = keyof DynamicScoreStatusConfig
+
+// 後方互換のため旧定義も維持（Tailwindクラスベース）
 export const SCORE_STATUS_CONFIG = {
   unscored: {
     icon: Circle,

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
@@ -1,15 +1,17 @@
 import { useEffect, useState } from "react"
 import { getSelectionBorderSettings } from "@/lib/utils"
 
-export function useSelectionBorder() {
-  const [selectionBorderSettings, setSelectionBorderSettings] = useState(
-    getSelectionBorderSettings()
-  )
+/**
+ * 選択枠の色を取得・監視するフック
+ * @returns 選択枠の色（HEX形式）
+ */
+export function useSelectionBorder(): string {
+  const [color, setColor] = useState(() => getSelectionBorderSettings().color)
 
   // 選択枠色の設定変更を監視
   useEffect(() => {
     const handleStorageChange = () => {
-      setSelectionBorderSettings(getSelectionBorderSettings())
+      setColor(getSelectionBorderSettings().color)
     }
 
     window.addEventListener("storage", handleStorageChange)
@@ -25,5 +27,5 @@ export function useSelectionBorder() {
     }
   }, [])
 
-  return selectionBorderSettings
+  return color
 }

--- a/components/projects/07-score-at-once/ScoringMain/StatusIcon.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/StatusIcon.tsx
@@ -8,6 +8,11 @@ import {
   Minus,
   X,
 } from "lucide-react"
+import {
+  getScoringStatusColors,
+  SCORING_STATUS_LABELS,
+  type ScoringStatusType,
+} from "@/lib/scoringStatusColors"
 
 type ScoringStatus =
   | "ungraded"
@@ -19,61 +24,122 @@ type ScoringStatus =
   | "proposed"
   | "final"
 
+// ScoringStatus -> ScoringStatusType へのマッピング
+function toScoringStatusType(status: ScoringStatus): ScoringStatusType {
+  switch (status) {
+    case "correct":
+      return "correct"
+    case "incorrect":
+      return "incorrect"
+    case "partial":
+      return "partial"
+    case "pending":
+      return "pending"
+    case "no_answer":
+      return "no_answer"
+    case "ungraded":
+    case "proposed":
+    case "final":
+    default:
+      return "ungraded"
+  }
+}
+
 interface StatusIconProps {
   status: ScoringStatus
   className?: string
+  /** 動的色を使用するかどうか（デフォルト: false - Tailwindクラス使用） */
+  useDynamicColors?: boolean
 }
 
-export function StatusIcon({ status, className = "h-4 w-4" }: StatusIconProps) {
-  switch (status) {
-    case "correct":
-      return <CheckCircle className={`text-green-600 ${className}`} />
-    case "incorrect":
-      return <X className={`text-red-600 ${className}`} />
-    case "partial":
-      return <Circle className={`text-yellow-600 ${className}`} />
-    case "pending":
-      return <Clock className={`text-blue-600 ${className}`} />
-    case "no_answer":
-      return <Minus className={`text-gray-600 ${className}`} />
-    case "ungraded":
-    default:
-      return <AlertTriangle className={`text-gray-400 ${className}`} />
+/**
+ * アイコンコンポーネントのマッピング
+ */
+const STATUS_ICONS = {
+  correct: CheckCircle,
+  incorrect: X,
+  partial: Circle,
+  pending: Clock,
+  no_answer: Minus,
+  ungraded: AlertTriangle,
+} as const
+
+export function StatusIcon({
+  status,
+  className = "h-4 w-4",
+  useDynamicColors = false,
+}: StatusIconProps) {
+  const statusType = toScoringStatusType(status)
+  const Icon = STATUS_ICONS[statusType]
+
+  if (useDynamicColors) {
+    const colors = getScoringStatusColors()
+    return (
+      <Icon
+        className={className}
+        style={{ color: colors[statusType].icon }}
+      />
+    )
   }
-}
 
-export function getStatusColor(status: ScoringStatus): string {
-  switch (status) {
-    case "correct":
-      return "bg-green-100 text-green-800"
-    case "incorrect":
-      return "bg-red-100 text-red-800"
-    case "partial":
-      return "bg-yellow-100 text-yellow-800"
-    case "pending":
-      return "bg-blue-100 text-blue-800"
-    case "no_answer":
-      return "bg-gray-100 text-gray-800"
-    case "ungraded":
-    default:
-      return "bg-gray-50 text-gray-600"
+  // 既存のTailwindクラス（後方互換性のため）
+  const tailwindColors: Record<ScoringStatusType, string> = {
+    correct: "text-green-600",
+    incorrect: "text-red-600",
+    partial: "text-yellow-600",
+    pending: "text-blue-600",
+    no_answer: "text-violet-600",
+    ungraded: "text-gray-400",
   }
+
+  return <Icon className={`${tailwindColors[statusType]} ${className}`} />
 }
 
+/**
+ * ステータスの背景色とテキスト色を取得
+ * @param status - 採点状態
+ * @param useDynamicColors - 動的色を使用するかどうか
+ * @returns Tailwindクラス文字列またはCSSスタイルオブジェクト
+ */
+export function getStatusColor(
+  status: ScoringStatus,
+  useDynamicColors?: false
+): string
+export function getStatusColor(
+  status: ScoringStatus,
+  useDynamicColors: true
+): React.CSSProperties
+export function getStatusColor(
+  status: ScoringStatus,
+  useDynamicColors = false
+): string | React.CSSProperties {
+  const statusType = toScoringStatusType(status)
+
+  if (useDynamicColors) {
+    const colors = getScoringStatusColors()
+    return {
+      backgroundColor: colors[statusType].bg,
+      color: colors[statusType].text,
+    }
+  }
+
+  // 既存のTailwindクラス（後方互換性のため）
+  const tailwindColors: Record<ScoringStatusType, string> = {
+    correct: "bg-green-100 text-green-800",
+    incorrect: "bg-red-100 text-red-800",
+    partial: "bg-yellow-100 text-yellow-800",
+    pending: "bg-blue-100 text-blue-800",
+    no_answer: "bg-violet-100 text-violet-800",
+    ungraded: "bg-gray-50 text-gray-600",
+  }
+
+  return tailwindColors[statusType]
+}
+
+/**
+ * ステータスのラベルを取得
+ */
 export function getStatusLabel(status: ScoringStatus): string {
-  switch (status) {
-    case "correct":
-      return "正答"
-    case "incorrect":
-      return "誤答"
-    case "partial":
-      return "部分点"
-    case "pending":
-      return "保留"
-    case "no_answer":
-      return "無答"
-    case "ungraded":
-    default:
-      return "未採点"
-  }
+  const statusType = toScoringStatusType(status)
+  return SCORING_STATUS_LABELS[statusType]
 }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -174,9 +174,10 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   // ========================================
-  // モーダル内ショートカット
+  // モーダル内ショートカット（採点キーと共通）
   // ========================================
-  useCommand("modal.confirmPartial", handlePartialScoreConfirmPartial, {
+  // 部分点/保留キーはモーダル内でも同じキーで確定動作
+  useCommand("scoring.partial", handlePartialScoreConfirmPartial, {
     when: "partialScoreModalOpen",
     metadata: {
       title: "部分点として確定",
@@ -185,7 +186,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     },
   })
 
-  useCommand("modal.confirmPending", handlePartialScoreConfirmPending, {
+  useCommand("scoring.pending", handlePartialScoreConfirmPending, {
     when: "partialScoreModalOpen",
     metadata: {
       title: "保留として確定",

--- a/components/projects/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -11,6 +11,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
+import type { ScoringStatusType } from "@/lib/scoringStatusColors"
 import {
   AlertTriangle,
   CheckCircle,
@@ -43,114 +45,64 @@ interface ScoringToolbarProps {
   gradingMode?: "grid" | "individual" // 採点モード
 }
 
-// 採点ボタン設定
+// ScoringStatus -> ScoringStatusType へのマッピング
+const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
+  unscored: "ungraded",
+  correct: "correct",
+  partial: "partial",
+  pending: "pending",
+  incorrect: "incorrect",
+  no_answer: "no_answer",
+}
+
+// 採点ボタン設定（色はuseScoringStatusColorsから動的取得）
 const SCORING_BUTTONS = [
   {
     status: "unscored" as ScoringStatus,
-    shortcutKey: "unscored",
     label: "未採点",
     icon: Circle,
-    color: "bg-gray-100 text-gray-700 hover:bg-gray-200",
     description: "未採点にする",
   },
   {
     status: "correct" as ScoringStatus,
-    shortcutKey: "correct",
     label: "正答",
     icon: CheckCircle,
-    color: "bg-green-100 text-green-700 hover:bg-green-200",
     description: "正答にする",
   },
   {
     status: "partial" as ScoringStatus,
-    shortcutKey: "partial",
     label: "部分点",
     icon: AlertTriangle,
-    color: "bg-yellow-100 text-yellow-700 hover:bg-yellow-200",
     description: "部分点にする",
   },
   {
     status: "pending" as ScoringStatus,
-    shortcutKey: "pending",
     label: "保留",
     icon: Clock,
-    color: "bg-blue-100 text-blue-700 hover:bg-blue-200",
     description: "保留にする",
   },
   {
     status: "incorrect" as ScoringStatus,
-    shortcutKey: "incorrect",
     label: "誤答",
     icon: X,
-    color: "bg-red-100 text-red-700 hover:bg-red-200",
     description: "誤答にする",
   },
   {
     status: "no_answer" as ScoringStatus,
-    shortcutKey: "no_answer",
     label: "無答",
     icon: Minus,
-    color: "bg-purple-100 text-purple-700 hover:bg-purple-200",
     description: "無答にする",
   },
 ] as const
 
-// フィルターボタン設定
+// フィルターボタン設定（色はuseScoringStatusColorsから動的取得）
 const FILTER_BUTTONS = [
-  {
-    key: "unscored",
-    filterKey: "unscored",
-    shortcutKey: "unscored",
-    label: "未採点",
-    icon: Circle,
-    color: "border-gray-400 text-gray-600",
-    activeColor: "bg-gray-300 border-gray-700 text-gray-900",
-  },
-  {
-    key: "correct",
-    filterKey: "correct",
-    shortcutKey: "correct",
-    label: "正答",
-    icon: CheckCircle,
-    color: "border-green-400 text-green-600",
-    activeColor: "bg-green-300 border-green-700 text-green-900",
-  },
-  {
-    key: "incorrect",
-    filterKey: "incorrect",
-    shortcutKey: "incorrect",
-    label: "誤答",
-    icon: X,
-    color: "border-red-400 text-red-600",
-    activeColor: "bg-red-300 border-red-700 text-red-900",
-  },
-  {
-    key: "partial",
-    filterKey: "partial",
-    shortcutKey: "partial",
-    label: "部分点",
-    icon: AlertTriangle,
-    color: "border-yellow-400 text-yellow-600",
-    activeColor: "bg-yellow-300 border-yellow-700 text-yellow-900",
-  },
-  {
-    key: "pending",
-    filterKey: "pending",
-    shortcutKey: "pending",
-    label: "保留",
-    icon: Clock,
-    color: "border-blue-400 text-blue-600",
-    activeColor: "bg-blue-300 border-blue-700 text-blue-900",
-  },
-  {
-    key: "no_answer",
-    filterKey: "no_answer",
-    shortcutKey: "no_answer",
-    label: "無答",
-    icon: Minus,
-    color: "border-purple-400 text-purple-600",
-    activeColor: "bg-purple-300 border-purple-700 text-purple-900",
-  },
+  { key: "unscored", filterKey: "unscored", label: "未採点", icon: Circle },
+  { key: "correct", filterKey: "correct", label: "正答", icon: CheckCircle },
+  { key: "incorrect", filterKey: "incorrect", label: "誤答", icon: X },
+  { key: "partial", filterKey: "partial", label: "部分点", icon: AlertTriangle },
+  { key: "pending", filterKey: "pending", label: "保留", icon: Clock },
+  { key: "no_answer", filterKey: "no_answer", label: "無答", icon: Minus },
 ] as const
 
 export default function ScoringToolbar({
@@ -164,6 +116,8 @@ export default function ScoringToolbar({
 }: ScoringToolbarProps) {
   // 新しいショートカットシステム: キーバインディング取得
   const { keyBindings } = useKeyBindings()
+  // 動的採点状態色を取得
+  const scoringColors = useScoringStatusColors()
 
   // コンテキスト値の設定（不要だがサンプルとして残す）
   // hasSelectedAnswers は ScoringMainView で設定済み
@@ -328,17 +282,25 @@ export default function ScoringToolbar({
             // コマンドIDからキーバインディングを取得
             const commandId = `scoring.${button.status === "no_answer" ? "noAnswer" : button.status}`
             const keyBinding = keyBindings[commandId] || "?"
+            // 動的色を取得
+            const statusType = STATUS_MAP[button.status]
+            const colors = scoringColors[statusType]
             return (
               <Tooltip key={button.status}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="outline"
                     size="sm"
-                    className={`${button.color} flex h-12 flex-col gap-1 border-2 ${
+                    className={`flex h-12 flex-col gap-1 border-2 ${
                       selectedAnswersCount === 0
                         ? "cursor-not-allowed opacity-50"
-                        : ""
+                        : "hover:opacity-80"
                     }`}
+                    style={{
+                      backgroundColor: colors.bg,
+                      color: colors.text,
+                      borderColor: colors.bg,
+                    }}
                     onClick={() => onScore(button.status)}
                     disabled={selectedAnswersCount === 0}
                   >
@@ -397,15 +359,29 @@ export default function ScoringToolbar({
                     : button.key.charAt(0).toUpperCase() + button.key.slice(1)
                 const commandId = `filter.toggle${statusKey}`
                 const keyBinding = keyBindings[commandId] || "?"
+                // 動的色を取得
+                const statusType = STATUS_MAP[button.key as ScoringStatus]
+                const colors = scoringColors[statusType]
                 return (
                   <Tooltip key={button.key}>
                     <TooltipTrigger asChild>
                       <Button
                         variant="outline"
                         size="sm"
-                        className={`flex h-10 items-center gap-2 border-2 ${
-                          isActive ? button.activeColor : button.color
-                        }`}
+                        className="flex h-10 items-center gap-2 border-2"
+                        style={
+                          isActive
+                            ? {
+                                backgroundColor: colors.bg,
+                                color: colors.text,
+                                borderColor: colors.icon,
+                              }
+                            : {
+                                backgroundColor: "transparent",
+                                color: colors.icon,
+                                borderColor: colors.icon,
+                              }
+                        }
                         onClick={() => onToggleFilter(button.key)}
                       >
                         <Icon className="h-3 w-3" />

--- a/components/projects/07-score-at-once/constants/scoringKeybindings.ts
+++ b/components/projects/07-score-at-once/constants/scoringKeybindings.ts
@@ -1,28 +1,28 @@
 /**
  * 一括採点画面のデフォルトキーバインディング定義
- * VSCodeライクなコマンドID方式を採用
+ *
+ * - VSCodeライクなコマンドID方式を採用
+ * - 設定画面からカスタマイズ可能
+ * - ユーザー設定はDBに保存される
  */
 
 import type { KeyBinding } from "../ScoringMain/contexts/shortcutContextTypes"
 
-/**
- * デフォルトキーバインディング
- * 設定画面からカスタマイズ可能
- * localStorageに保存される
- */
 export const DEFAULT_KEYBINDINGS: KeyBinding = {
   // ============================================
-  // 採点コマンド (Scoring)
+  // 採点 (Scoring)
+  // 答案の採点状態を設定
   // ============================================
-  "scoring.unscored": "q", // 未採点
-  "scoring.correct": "e", // 正答
-  "scoring.partial": "f", // 部分点
-  "scoring.pending": "j", // 保留
-  "scoring.incorrect": "o", // 誤答
-  "scoring.noAnswer": "p", // 無答
+  "scoring.unscored": "q",
+  "scoring.correct": "e",
+  "scoring.partial": "f", // モーダル内でも確定キーとして機能
+  "scoring.pending": "j", // モーダル内でも確定キーとして機能
+  "scoring.incorrect": "o",
+  "scoring.noAnswer": "p",
 
   // ============================================
-  // ナビゲーションコマンド (Navigation)
+  // ナビゲーション (Navigation)
+  // 設問・生徒の移動、ズーム操作
   // ============================================
   // 矢印キー
   "navigation.nextQuestionArrow": "ArrowRight",
@@ -30,25 +30,26 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "navigation.nextStudentArrow": "ArrowDown",
   "navigation.prevStudentArrow": "ArrowUp",
 
-  // Shift + A/D (問題切り替え)
+  // Shift + A/D（設問切り替え）
   "navigation.nextQuestion": "Shift+d",
   "navigation.prevQuestion": "Shift+a",
 
-  // WASD (グリッド移動)
+  // WASD（グリッド移動）
   "navigation.moveUp": "w",
   "navigation.moveLeft": "a",
   "navigation.moveDown": "s",
   "navigation.moveRight": "d",
 
-  // ズーム操作
+  // ズーム
   "navigation.zoomIn": "=",
   "navigation.zoomOut": "-",
   "navigation.resetZoom": "0",
 
   // ============================================
-  // フィルタコマンド (Filter)
+  // フィルタ (Filter)
+  // 採点状態による絞り込み
   // ============================================
-  // Alt + 採点キー (フィルタトグル)
+  // Alt + 採点キー
   "filter.toggleUnscored": "Alt+q",
   "filter.toggleCorrect": "Alt+e",
   "filter.togglePartial": "Alt+f",
@@ -56,27 +57,27 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "filter.toggleIncorrect": "Alt+o",
   "filter.toggleNoAnswer": "Alt+p",
 
-  // フィルタ更新
+  // 更新
   "filter.refresh": "r",
 
   // ============================================
-  // 表示切り替えコマンド (View)
+  // 表示 (View)
+  // 表示モードの切り替え
   // ============================================
-  "view.toggleStudentNames": "n", // 生徒名表示切り替え
-  "view.toggleViewMode": "v", // 表示モード切り替え（将来用）
-  "view.fullView": "a", // 全体表示（個別モード専用）- All
-  "view.questionView": "c", // 設問表示（個別モード専用）- Crop
+  "view.toggleStudentNames": "n",
+  "view.toggleViewMode": "v",
+  "view.fullView": "a", // 全体表示（個別モード）
+  "view.questionView": "c", // 設問表示（個別モード）
 
   // ============================================
-  // モーダルコマンド (Modal)
+  // モーダル (Modal)
+  // 部分点入力モーダル内の操作
+  // 注: 確定キー(f/j)は採点コマンドと共通
   // ============================================
-  // 部分点入力モーダル内（優先度：高 - より具体的な条件）
-  "modal.confirmPartial": "f", // 部分点として確定してモーダルを閉じる
-  "modal.confirmPending": "j", // 保留として確定してモーダルを閉じる
-  "modal.cancel": "Escape", // キャンセル（採点状態変更なし）
-  "modal.backspace": "Backspace", // 文字削除
+  "modal.cancel": "Escape",
+  "modal.backspace": "Backspace",
 
-  // 数字入力（0-9と小数点） - モーダルが開いている場合に実行
+  // 数字入力（モーダル内）
   "modal.input0": "0",
   "modal.input1": "1",
   "modal.input2": "2",
@@ -90,12 +91,11 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "modal.inputDot": ".",
 
   // ============================================
-  // 部分点モーダルオープンコマンド (Scoring - Open Partial Modal)
+  // 部分点モーダルオープン (Scoring - Partial Modal)
+  // 数字キーでモーダルを開いて入力開始
   // ============================================
-  // モーダルが閉じている場合、数字キーでモーダルを開く
-  // 優先度：低 - より一般的な条件（上記のモーダル内コマンドが先に評価される）
-  "scoring.openPartialWith0": "0", // 0キーでモーダルを開く+0を入力
-  "scoring.openPartialWith1": "1", // 1キーでモーダルを開く+1を入力
+  "scoring.openPartialWith0": "0",
+  "scoring.openPartialWith1": "1",
   "scoring.openPartialWith2": "2",
   "scoring.openPartialWith3": "3",
   "scoring.openPartialWith4": "4",
@@ -104,22 +104,18 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "scoring.openPartialWith7": "7",
   "scoring.openPartialWith8": "8",
   "scoring.openPartialWith9": "9",
-  "scoring.openPartialWithDot": ".", // .キーでモーダルを開く+.を入力
+  "scoring.openPartialWithDot": ".",
 
   // ============================================
-  // 保存コマンド (Save)
+  // 描画ツール (Drawing Tools)
+  // アノテーション用ツール選択
   // ============================================
-  "save.all": "Ctrl+s", // すべて保存（将来用）
-
-  // ============================================
-  // 描画ツールコマンド (Drawing Tools)
-  // ============================================
-  "tool.hand": "h", // ハンドツール（パン操作）
-  "tool.select": "g", // 選択ツール（移動・編集）
-  "tool.text": "t", // テキストツール
-  "tool.line": "l", // 線ツール
-  "tool.rectangle": "b", // 矩形ツール (Box)
-  "tool.ellipse": "y", // 楕円ツール
+  "tool.hand": "h",
+  "tool.select": "g",
+  "tool.text": "t",
+  "tool.line": "l",
+  "tool.rectangle": "b",
+  "tool.ellipse": "y",
 } as const
 
 /**
@@ -132,7 +128,6 @@ export const KEYBINDING_CATEGORIES = {
   filter: "フィルタ",
   view: "表示",
   modal: "モーダル",
-  save: "保存",
   tool: "描画ツール",
 } as const
 

--- a/components/ui/color-picker.tsx
+++ b/components/ui/color-picker.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ColorPickerProps {
+  /** 現在の色（HEX形式） */
+  value: string
+  /** 色が変更された時のコールバック */
+  onChange: (color: string) => void
+  /** プリセット色の配列 */
+  presets?: string[]
+  /** 無効状態 */
+  disabled?: boolean
+  /** カスタムクラス名 */
+  className?: string
+}
+
+/**
+ * カラーピッカーコンポーネント
+ *
+ * - HEX形式の色を選択・入力可能
+ * - プリセット色から選択可能
+ * - ネイティブカラーピッカーと連携
+ */
+export function ColorPicker({
+  value,
+  onChange,
+  presets = [],
+  disabled = false,
+  className,
+}: ColorPickerProps) {
+  const [open, setOpen] = React.useState(false)
+  const [inputValue, setInputValue] = React.useState(value)
+
+  // 外部からのvalue変更を反映
+  React.useEffect(() => {
+    setInputValue(value)
+  }, [value])
+
+  // HEX形式のバリデーション
+  const isValidHex = (hex: string): boolean => {
+    return /^#[0-9A-Fa-f]{6}$/.test(hex)
+  }
+
+  // 入力値の変更処理
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let newValue = e.target.value
+    // #がなければ追加
+    if (!newValue.startsWith("#")) {
+      newValue = "#" + newValue
+    }
+    setInputValue(newValue)
+
+    // 有効なHEX形式なら親に通知
+    if (isValidHex(newValue)) {
+      onChange(newValue)
+    }
+  }
+
+  // ネイティブカラーピッカーからの変更
+  const handleNativeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newColor = e.target.value.toUpperCase()
+    setInputValue(newColor)
+    onChange(newColor)
+  }
+
+  // プリセット選択
+  const handlePresetClick = (color: string) => {
+    setInputValue(color)
+    onChange(color)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild disabled={disabled}>
+        <Button
+          variant="outline"
+          className={cn(
+            "h-9 w-9 p-0 border-2",
+            disabled && "opacity-50 cursor-not-allowed",
+            className
+          )}
+          style={{ backgroundColor: value }}
+          aria-label="色を選択"
+        >
+          <span className="sr-only">色を選択</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64" align="start">
+        <div className="space-y-3">
+          {/* カラーピッカーとHEX入力 */}
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <input
+                type="color"
+                value={value}
+                onChange={handleNativeChange}
+                className="h-9 w-9 cursor-pointer rounded border-0 p-0"
+                style={{ backgroundColor: value }}
+              />
+            </div>
+            <Input
+              value={inputValue}
+              onChange={handleInputChange}
+              placeholder="#000000"
+              className="flex-1 font-mono text-sm"
+              maxLength={7}
+            />
+          </div>
+
+          {/* プリセット色 */}
+          {presets.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs text-muted-foreground">プリセット</p>
+              <div className="flex flex-wrap gap-1">
+                {presets.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => handlePresetClick(color)}
+                    className={cn(
+                      "h-6 w-6 rounded border-2 transition-transform hover:scale-110",
+                      value === color
+                        ? "border-gray-800 ring-2 ring-gray-400"
+                        : "border-gray-300"
+                    )}
+                    style={{ backgroundColor: color }}
+                    aria-label={`色 ${color}`}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+/**
+ * インラインカラーピッカー（プリセット + カスタム選択）
+ *
+ * 設定画面での使用を想定した、プリセットとカスタム色を
+ * 横並びで表示するコンポーネント
+ */
+interface InlineColorPickerProps {
+  /** 現在の色（HEX形式） */
+  value: string
+  /** 色が変更された時のコールバック */
+  onChange: (color: string) => void
+  /** プリセット色の配列 */
+  presets: string[]
+  /** 無効状態 */
+  disabled?: boolean
+}
+
+export function InlineColorPicker({
+  value,
+  onChange,
+  presets,
+  disabled = false,
+}: InlineColorPickerProps) {
+  const isPresetColor = presets.includes(value)
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* プリセット色 */}
+      {presets.map((color) => (
+        <button
+          key={color}
+          type="button"
+          onClick={() => !disabled && onChange(color)}
+          disabled={disabled}
+          className={cn(
+            "h-8 w-8 rounded-lg border-2 transition-all",
+            value === color
+              ? "border-gray-800 shadow-md scale-110"
+              : "border-gray-200 hover:border-gray-300 hover:scale-105",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+          style={{ backgroundColor: color }}
+          aria-label={`色 ${color}`}
+        />
+      ))}
+
+      {/* カスタム色ピッカー */}
+      <ColorPicker
+        value={isPresetColor ? "#808080" : value}
+        onChange={onChange}
+        disabled={disabled}
+        className={cn(
+          !isPresetColor && "ring-2 ring-gray-400"
+        )}
+      />
+    </div>
+  )
+}

--- a/hooks/07-score-at-once/useScoringStatusColors.ts
+++ b/hooks/07-score-at-once/useScoringStatusColors.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+import {
+  getScoringStatusColors,
+  type ScoringStatusColors,
+} from "@/lib/scoringStatusColors"
+
+/**
+ * 採点状態色を取得・監視するフック
+ *
+ * 設定画面で色が変更された際にリアルタイムで反映される
+ */
+export function useScoringStatusColors(): ScoringStatusColors {
+  const [colors, setColors] = useState<ScoringStatusColors>(
+    getScoringStatusColors
+  )
+
+  useEffect(() => {
+    const handleChange = () => {
+      setColors(getScoringStatusColors())
+    }
+
+    // 設定画面からの変更イベントを監視
+    window.addEventListener("scoringStatusColorsChanged", handleChange)
+    // 他タブからのlocalStorage変更も監視
+    window.addEventListener("storage", handleChange)
+
+    return () => {
+      window.removeEventListener("scoringStatusColorsChanged", handleChange)
+      window.removeEventListener("storage", handleChange)
+    }
+  }, [])
+
+  return colors
+}

--- a/lib/scoringStatusColors.ts
+++ b/lib/scoringStatusColors.ts
@@ -1,0 +1,234 @@
+/**
+ * 採点状態の表示色管理
+ *
+ * 一括採点画面のPanel・一覧表示の背景色をカスタマイズ可能にする
+ * - 4つのプリセットパターン（標準、ビビッド、ソフト、色覚多様性対応）
+ * - 各状態の個別カスタマイズ
+ * - localStorageに保存
+ */
+
+// 採点状態の種類（DBの値と一致）
+export type ScoringStatusType =
+  | "ungraded"
+  | "correct"
+  | "partial"
+  | "pending"
+  | "incorrect"
+  | "no_answer"
+
+// 各状態の色設定
+export interface StatusColorConfig {
+  /** 背景色（HEX） */
+  bg: string
+  /** テキスト色（HEX） */
+  text: string
+  /** アイコン色（HEX） */
+  icon: string
+}
+
+// 全状態の色設定
+export type ScoringStatusColors = Record<ScoringStatusType, StatusColorConfig>
+
+// プリセット定義
+export interface ScoringColorPreset {
+  id: string
+  name: string
+  description: string
+  colors: ScoringStatusColors
+}
+
+// 状態のラベル（日本語）
+export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
+  ungraded: "未採点",
+  correct: "正答",
+  partial: "部分点",
+  pending: "保留",
+  incorrect: "誤答",
+  no_answer: "無答",
+}
+
+// 状態の表示順序
+export const SCORING_STATUS_ORDER: ScoringStatusType[] = [
+  "ungraded",
+  "correct",
+  "partial",
+  "pending",
+  "incorrect",
+  "no_answer",
+]
+
+/**
+ * プリセット定義
+ */
+export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
+  {
+    id: "default",
+    name: "標準",
+    description: "デフォルトの配色",
+    colors: {
+      ungraded: { bg: "#F9FAFB", text: "#4B5563", icon: "#9CA3AF" },
+      correct: { bg: "#DCFCE7", text: "#166534", icon: "#16A34A" },
+      partial: { bg: "#FEF9C3", text: "#854D0E", icon: "#CA8A04" },
+      pending: { bg: "#DBEAFE", text: "#1E40AF", icon: "#2563EB" },
+      incorrect: { bg: "#FEE2E2", text: "#991B1B", icon: "#DC2626" },
+      no_answer: { bg: "#EDE9FE", text: "#5B21B6", icon: "#7C3AED" },
+    },
+  },
+  {
+    id: "vivid",
+    name: "ビビッド",
+    description: "より鮮やかな配色",
+    colors: {
+      ungraded: { bg: "#E5E7EB", text: "#374151", icon: "#6B7280" },
+      correct: { bg: "#BBF7D0", text: "#14532D", icon: "#22C55E" },
+      partial: { bg: "#FDE047", text: "#713F12", icon: "#EAB308" },
+      pending: { bg: "#93C5FD", text: "#1E3A8A", icon: "#3B82F6" },
+      incorrect: { bg: "#FECACA", text: "#7F1D1D", icon: "#EF4444" },
+      no_answer: { bg: "#DDD6FE", text: "#4C1D95", icon: "#8B5CF6" },
+    },
+  },
+  {
+    id: "soft",
+    name: "ソフト",
+    description: "淡い配色で目に優しい",
+    colors: {
+      ungraded: { bg: "#FAFAFA", text: "#737373", icon: "#A3A3A3" },
+      correct: { bg: "#ECFCCB", text: "#365314", icon: "#84CC16" },
+      partial: { bg: "#FEF3C7", text: "#92400E", icon: "#D97706" },
+      pending: { bg: "#E0F2FE", text: "#075985", icon: "#0EA5E9" },
+      incorrect: { bg: "#FFE4E6", text: "#9F1239", icon: "#F43F5E" },
+      no_answer: { bg: "#F3E8FF", text: "#6B21A8", icon: "#A855F7" },
+    },
+  },
+  {
+    id: "colorblind",
+    name: "色覚多様性対応",
+    description: "Wong配色パレット準拠",
+    colors: {
+      ungraded: { bg: "#E8E8E8", text: "#4D4D4D", icon: "#999999" },
+      correct: { bg: "#C8EDE0", text: "#005C45", icon: "#009E73" },
+      partial: { bg: "#FCF6C8", text: "#6B5A00", icon: "#F0E442" },
+      pending: { bg: "#D0EBFA", text: "#0066A0", icon: "#56B4E9" },
+      incorrect: { bg: "#FADDC8", text: "#8B3A00", icon: "#D55E00" },
+      no_answer: { bg: "#F5E0EC", text: "#7A3F66", icon: "#CC79A7" },
+    },
+  },
+]
+
+const STORAGE_KEY = "scoringStatusColors"
+const PRESET_KEY = "scoringStatusColorPreset"
+
+/**
+ * 保存されている採点状態色を取得
+ * 保存されていない場合はデフォルトプリセットを返す
+ */
+export function getScoringStatusColors(): ScoringStatusColors {
+  if (typeof window === "undefined") {
+    return SCORING_COLOR_PRESETS[0].colors
+  }
+
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      return JSON.parse(saved) as ScoringStatusColors
+    }
+  } catch (error) {
+    console.error("Failed to load scoring status colors:", error)
+  }
+
+  return SCORING_COLOR_PRESETS[0].colors
+}
+
+/**
+ * 採点状態色を保存
+ */
+export function saveScoringStatusColors(colors: ScoringStatusColors): void {
+  if (typeof window === "undefined") return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(colors))
+    // カスタム色を設定したらプリセットIDをクリア
+    localStorage.removeItem(PRESET_KEY)
+    // 変更を通知
+    window.dispatchEvent(new CustomEvent("scoringStatusColorsChanged"))
+  } catch (error) {
+    console.error("Failed to save scoring status colors:", error)
+  }
+}
+
+/**
+ * 現在選択されているプリセットIDを取得
+ */
+export function getCurrentPresetId(): string | null {
+  if (typeof window === "undefined") return "default"
+
+  try {
+    return localStorage.getItem(PRESET_KEY)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * プリセットを適用
+ */
+export function applyScoringColorPreset(presetId: string): void {
+  const preset = SCORING_COLOR_PRESETS.find((p) => p.id === presetId)
+  if (!preset) {
+    console.error(`Preset not found: ${presetId}`)
+    return
+  }
+
+  if (typeof window === "undefined") return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preset.colors))
+    localStorage.setItem(PRESET_KEY, presetId)
+    // 変更を通知
+    window.dispatchEvent(new CustomEvent("scoringStatusColorsChanged"))
+  } catch (error) {
+    console.error("Failed to apply scoring color preset:", error)
+  }
+}
+
+/**
+ * 個別の状態色を更新
+ */
+export function updateScoringStatusColor(
+  status: ScoringStatusType,
+  config: Partial<StatusColorConfig>
+): void {
+  const current = getScoringStatusColors()
+  const updated: ScoringStatusColors = {
+    ...current,
+    [status]: {
+      ...current[status],
+      ...config,
+    },
+  }
+  saveScoringStatusColors(updated)
+}
+
+/**
+ * 採点状態色をリセット（デフォルトプリセットに戻す）
+ */
+export function resetScoringStatusColors(): void {
+  applyScoringColorPreset("default")
+}
+
+/**
+ * CSSカスタムプロパティとして色を適用
+ * （将来的にTailwindクラスから移行する際に使用）
+ */
+export function applyScoringColorsToCSS(): void {
+  if (typeof window === "undefined") return
+
+  const colors = getScoringStatusColors()
+  const root = document.documentElement
+
+  for (const [status, config] of Object.entries(colors)) {
+    root.style.setProperty(`--scoring-${status}-bg`, config.bg)
+    root.style.setProperty(`--scoring-${status}-text`, config.text)
+    root.style.setProperty(`--scoring-${status}-icon`, config.icon)
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,35 +8,46 @@ export function cn(...inputs: ClassValue[]) {
 // 選択枠色の設定
 export interface SelectionBorderSettings {
   color: string
-  tailwindClass: string
+  isPreset: boolean
 }
 
-export const DEFAULT_SELECTION_BORDER_COLOR = "#f97316" // orange-500
-export const SELECTION_BORDER_COLORS = {
-  "#f97316": { color: "#f97316", tailwindClass: "border-orange-500" }, // オレンジ
-  "#3b82f6": { color: "#3b82f6", tailwindClass: "border-blue-500" }, // 青
-  "#ef4444": { color: "#ef4444", tailwindClass: "border-red-500" }, // 赤
-  "#10b981": { color: "#10b981", tailwindClass: "border-emerald-500" }, // エメラルド
-  "#8b5cf6": { color: "#8b5cf6", tailwindClass: "border-violet-500" }, // バイオレット
-  "#f59e0b": { color: "#f59e0b", tailwindClass: "border-amber-500" }, // アンバー
+export const DEFAULT_SELECTION_BORDER_COLOR = "#F97316" // orange-500
+
+// プリセット色（大文字HEXで統一）
+export const SELECTION_BORDER_COLORS: Record<string, { color: string }> = {
+  "#F97316": { color: "#F97316" }, // オレンジ
+  "#3B82F6": { color: "#3B82F6" }, // 青
+  "#EF4444": { color: "#EF4444" }, // 赤
+  "#10B981": { color: "#10B981" }, // エメラルド
+  "#8B5CF6": { color: "#8B5CF6" }, // バイオレット
+  "#F59E0B": { color: "#F59E0B" }, // アンバー
 }
 
+// プリセット色の配列（設定画面で使用）
+export const SELECTION_BORDER_PRESETS = Object.keys(SELECTION_BORDER_COLORS)
+
+/**
+ * 選択枠色の設定を取得
+ * プリセット色またはカスタム色を返す
+ */
 export function getSelectionBorderSettings(): SelectionBorderSettings {
   if (typeof window === "undefined") {
-    return SELECTION_BORDER_COLORS[DEFAULT_SELECTION_BORDER_COLOR]
+    return { color: DEFAULT_SELECTION_BORDER_COLOR, isPreset: true }
   }
 
   const stored = localStorage.getItem("selectionBorderColor")
-  const color = stored || DEFAULT_SELECTION_BORDER_COLOR
+  const color = stored?.toUpperCase() || DEFAULT_SELECTION_BORDER_COLOR
+  const isPreset = color in SELECTION_BORDER_COLORS
 
-  return (
-    SELECTION_BORDER_COLORS[color as keyof typeof SELECTION_BORDER_COLORS] ||
-    SELECTION_BORDER_COLORS[DEFAULT_SELECTION_BORDER_COLOR]
-  )
+  return { color, isPreset }
 }
 
+/**
+ * 選択枠色を保存
+ * @param color HEX形式の色（例: #F97316）
+ */
 export function saveSelectionBorderColor(color: string): void {
   if (typeof window !== "undefined") {
-    localStorage.setItem("selectionBorderColor", color)
+    localStorage.setItem("selectionBorderColor", color.toUpperCase())
   }
 }


### PR DESCRIPTION
## Summary
- 設定画面で設定した採点状態色を採点画面にリアルタイム反映
- ColorPickerコンポーネントで直感的な色選択を実現
- 設定画面をタブ構造に再編成
- 無答(no_answer)の色を紫色に変更

## 関連Issue
Closes #243

## Test plan
- [ ] 設定画面で採点状態色を変更できることを確認
- [ ] 採点画面(GridCell)に変更した色が反映されることを確認
- [ ] ScoringToolbarのボタン色が変更されることを確認
- [ ] ブラウザリロード後も色設定が保持されることを確認
- [ ] プリセット色とカスタムカラーの両方が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)