### PR TITLE
feat: ユーザーデータフィルタリングとアーカイブ個人モードを実装

### DIFF
--- a/components/import/ImportWizardModal.tsx
+++ b/components/import/ImportWizardModal.tsx
@@ -1,22 +1,22 @@
 "use client"
 
-import { useEffect } from "react"
+import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
 import { useImportWizard } from "@/hooks/import/useImportWizard"
-import { FileSelectStep } from "./steps/FileSelectStep"
-import { ModeSelectStep } from "./steps/ModeSelectStep"
-import { MatchingConfigStep } from "./steps/MatchingConfigStep"
+import { cn } from "@/lib/utils"
+import type { ImportWizardStep } from "@/types/projectArchive.types"
+import { AlertCircle, Check, ChevronLeft, X } from "lucide-react"
+import { useEffect } from "react"
 import { ConflictResolveStep } from "./steps/ConflictResolveStep"
 import { ExecuteStep } from "./steps/ExecuteStep"
-import type { ImportWizardStep } from "@/types/projectArchive.types"
-import { ChevronLeft, X, AlertCircle, Check } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { FileSelectStep } from "./steps/FileSelectStep"
+import { MatchingConfigStep } from "./steps/MatchingConfigStep"
+import { ModeSelectStep } from "./steps/ModeSelectStep"
 
 interface ImportWizardModalProps {
   isOpen: boolean
@@ -71,7 +71,7 @@ export function ImportWizardModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col gap-0 p-0">
+      <DialogContent className="flex max-h-[90vh] min-w-2xl flex-col gap-0 p-0">
         {/* ヘッダー */}
         <DialogHeader className="bg-muted/30 border-b px-6 py-4">
           <div className="flex items-center justify-between">
@@ -81,7 +81,7 @@ export function ImportWizardModal({
           </div>
 
           {/* ステップインジケーター */}
-          <div className="flex items-center justify-center gap-1 pt-4">
+          <div className="flex items-center justify-center pt-4">
             {effectiveSteps.map((step, index) => {
               const isActive = step === state.currentStep
               const isCompleted =
@@ -92,12 +92,12 @@ export function ImportWizardModal({
                   {index > 0 && (
                     <div
                       className={cn(
-                        "mx-1 h-0.5 w-12 transition-colors",
+                        "h-0.5 w-8 transition-colors",
                         isCompleted ? "bg-primary" : "bg-muted-foreground/20"
                       )}
                     />
                   )}
-                  <div className="flex flex-col items-center gap-1">
+                  <div className="flex w-24 flex-col items-center gap-y-3">
                     <div
                       className={cn(
                         "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-all",
@@ -113,7 +113,7 @@ export function ImportWizardModal({
                     </div>
                     <span
                       className={cn(
-                        "text-xs font-medium whitespace-nowrap",
+                        "text-center text-xs font-medium",
                         isActive && "text-primary",
                         !isActive && "text-muted-foreground"
                       )}
@@ -131,7 +131,7 @@ export function ImportWizardModal({
         {state.error && (
           <div className="bg-destructive/10 border-destructive/20 mx-6 mt-4 rounded-lg border p-4">
             <div className="flex items-start gap-3">
-              <AlertCircle className="text-destructive mt-0.5 h-5 w-5 flex-shrink-0" />
+              <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
               <div className="flex-1">
                 <p className="text-destructive text-sm font-medium">エラー</p>
                 <p className="text-destructive/80 mt-1 text-sm">
@@ -151,7 +151,7 @@ export function ImportWizardModal({
         )}
 
         {/* ステップコンテンツ */}
-        <div className="min-h-[400px] flex-1 overflow-y-auto px-6 py-6">
+        <div className="min-h-100 flex-1 overflow-y-auto px-6 py-6">
           {state.currentStep === "file_select" && (
             <FileSelectStep wizard={wizard} />
           )}

--- a/components/import/steps/FileSelectStep.tsx
+++ b/components/import/steps/FileSelectStep.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
-import { Upload, FileArchive, Loader2, CheckCircle2, Info } from "lucide-react"
+import { CheckCircle2, FileArchive, Info, Loader2, Upload } from "lucide-react"
 
 interface FileSelectStepProps {
   wizard: UseImportWizardReturn
@@ -16,15 +16,21 @@ export function FileSelectStep({ wizard }: FileSelectStepProps) {
     <div className="flex h-full flex-col items-center justify-center py-8">
       {/* メインコンテンツ */}
       <div className="mb-8 text-center">
-        <div className="bg-primary/10 mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl">
+        <div className="bg-primary/10 mx-auto mb-6 flex h-20 w-32 items-center justify-center rounded-2xl">
           <FileArchive className="text-primary h-10 w-10" />
         </div>
         <h3 className="text-foreground mb-2 text-xl font-semibold">
           プロジェクトアーカイブを選択
         </h3>
-        <p className="text-muted-foreground max-w-md">
+        <p className="text-muted-foreground max-w-lg">
           エクスポートされた .score ファイルを選択してください。
-          ファイルにはプロジェクトデータ、採点結果、画像が含まれています。
+          <br />
+          ファイルにはプロジェクトデータ、 採点結果、画像が含まれています。
+        </p>
+        <p className="text-muted-foreground mt-2 max-w-lg">
+          エクスポートしたときにログインしていたユーザーにかかわらず、
+          <br />
+          現在ログインしているユーザーのプロジェクトとして追加されます。
         </p>
       </div>
 
@@ -60,7 +66,7 @@ export function FileSelectStep({ wizard }: FileSelectStepProps) {
           <ul className="space-y-2">
             <li className="text-muted-foreground flex items-center gap-2 text-sm">
               <CheckCircle2 className="h-4 w-4 text-green-500" />
-              Score at Once アーカイブ (.score)
+              一括採点プロジェクトデータ (.score)
             </li>
           </ul>
         </CardContent>

--- a/components/projects/07-score-at-once/ScoringData/utils/dataLoader.ts
+++ b/components/projects/07-score-at-once/ScoringData/utils/dataLoader.ts
@@ -3,13 +3,18 @@ import { decimalToNumber } from "@/components/projects/07-score-at-once/types"
 
 /**
  * 既存の採点データを読み込む関数（QuestionScore配列で返す）
+ * @param projectId プロジェクトID
+ * @param userId ユーザーID（指定時はそのユーザーの採点データのみ取得）
  */
 export async function loadQuestionScores(
-  projectId: string
+  projectId: string,
+  userId?: string
 ): Promise<QuestionScore[]> {
   try {
-    const result =
-      await window.electronAPI.getQuestionScoresForProject(projectId)
+    const result = await window.electronAPI.getQuestionScoresForProject(
+      projectId,
+      userId
+    )
 
     // Handle both direct array and { success, scores } format
     let scores: QuestionScore[]

--- a/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -67,9 +67,11 @@ export default function AnswerIndividualView({
   )
 
   // 透明度制御用：全設問のアノテーション読み込み
+  // currentUserIdを渡してログインユーザーのアノテーションのみ取得
   const { allStudentAnnotations } = useAllStudentAnnotations({
     currentStudentId,
     currentCropRegion,
+    currentUserId,
   })
 
   // テキスト入力状態変更の通知

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
@@ -199,6 +199,7 @@ export function useDrawingAnnotations(
 
   /**
    * アノテーション読み込み
+   * contextのcurrentUserIdを使って、ログインユーザーのアノテーションのみ取得
    */
   const loadAnnotations = useCallback(
     async (questionScoreId: string, type?: DrawingType): Promise<boolean> => {
@@ -208,7 +209,8 @@ export function useDrawingAnnotations(
       try {
         const result = await window.electronAPI.drawing.getByQuestionScore(
           questionScoreId,
-          type
+          type,
+          context?.currentUserId
         )
         if (result.success && result.data) {
           setAnnotations(result.data)
@@ -224,11 +226,12 @@ export function useDrawingAnnotations(
         setIsLoading(false)
       }
     },
-    [handleError]
+    [handleError, context?.currentUserId]
   )
 
   /**
    * 学生の全設問のアノテーションを読み込み（透明度制御用）
+   * contextのcurrentUserIdを使って、ログインユーザーのアノテーションのみ取得
    */
   const loadAllStudentAnnotations = useCallback(
     async (
@@ -243,7 +246,8 @@ export function useDrawingAnnotations(
         const result = await window.electronAPI.drawing.getByStudent(
           studentId,
           projectId,
-          type
+          type,
+          context?.currentUserId
         )
         if (result.success && result.data) {
           return result.data
@@ -263,7 +267,7 @@ export function useDrawingAnnotations(
         setIsLoading(false)
       }
     },
-    [handleError]
+    [handleError, context?.currentUserId]
   )
 
   /**

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
@@ -12,6 +12,8 @@ export interface UseAllStudentAnnotationsParams {
   currentStudentId?: string
   /** 現在の設問領域（プロジェクトID取得用） */
   currentCropRegion?: CropRegionWithProjectPage | null
+  /** 現在のユーザーID（アノテーション取得のフィルタリング用） */
+  currentUserId?: string
 }
 
 /** 全設問アノテーション読み込みフックの戻り値 */
@@ -26,6 +28,7 @@ export interface UseAllStudentAnnotationsReturn {
  * @description
  * 透明度制御用に、現在の学生とプロジェクトの全アノテーションを読み込むフック。
  * Electron APIを直接呼び出してフック依存関係を回避する。
+ * currentUserIdを使って、ログインユーザーのアノテーションのみ取得する。
  *
  * @param params - フックパラメータ
  * @returns 全設問のアノテーション
@@ -33,6 +36,7 @@ export interface UseAllStudentAnnotationsReturn {
 export function useAllStudentAnnotations({
   currentStudentId,
   currentCropRegion,
+  currentUserId,
 }: UseAllStudentAnnotationsParams): UseAllStudentAnnotationsReturn {
   const [allStudentAnnotations, setAllStudentAnnotations] = useState<
     DrawingAnnotation[]
@@ -49,12 +53,16 @@ export function useAllStudentAnnotations({
         console.log("🎨 透明度制御: 全設問アノテーション読み込み開始", {
           studentId: currentStudentId,
           projectId: currentCropRegion.projectPage.projectId,
+          userId: currentUserId,
         })
 
         // ElectronAPIを直接呼び出してフック依存関係を回避
+        // currentUserIdを渡してログインユーザーのアノテーションのみ取得
         const result = await window.electronAPI.drawing.getByStudent(
           currentStudentId,
-          currentCropRegion.projectPage.projectId
+          currentCropRegion.projectPage.projectId,
+          undefined, // type
+          currentUserId
         )
 
         if (result.success && result.data) {
@@ -78,6 +86,7 @@ export function useAllStudentAnnotations({
     currentStudentId,
     currentCropRegion?.projectPage?.projectId,
     currentCropRegion?.id,
+    currentUserId,
   ])
 
   return { allStudentAnnotations }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringData.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringData.ts
@@ -37,9 +37,13 @@ export function useScoringData({
   })
 
   // Data loading function wrapper
-  const loadQuestionScoresCallback = useCallback(async (projectId: string) => {
-    return await loadQuestionScores(projectId)
-  }, [])
+  // currentUserIdを使って、ログインユーザーの採点データのみを取得
+  const loadQuestionScoresCallback = useCallback(
+    async (projectId: string) => {
+      return await loadQuestionScores(projectId, currentUserId ?? undefined)
+    },
+    [currentUserId]
+  )
 
   // Progress calculation function
   const calculateQuestionProgressCallback = useCallback(() => {

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -2,22 +2,22 @@
  * プロジェクトアーカイブ（エクスポート/インポート）IPCハンドラー
  */
 
-import { ipcMain, dialog } from "electron"
+import { dialog, ipcMain } from "electron"
+import type {
+  ConflictResolutions,
+  MatchingConfig,
+} from "../../types/projectArchive.types"
 import {
   exportProject,
   selectExportSavePath,
 } from "../lib/export/project-archive"
+import { detectAllConflicts, executeMergeImport } from "../lib/import/merge"
 import {
   analyzeArchive,
-  importAsNew,
-  extractArchive,
   cleanupTempDir,
+  extractArchive,
+  importAsNew,
 } from "../lib/import/project-archive"
-import { detectAllConflicts, executeMergeImport } from "../lib/import/merge"
-import type {
-  MatchingConfig,
-  ConflictResolutions,
-} from "../../types/projectArchive.types"
 
 /**
  * アーカイブ関連のIPCハンドラーを登録
@@ -26,7 +26,10 @@ export function registerArchiveHandlers(): void {
   // エクスポート
   ipcMain.handle(
     "archive:exportProject",
-    async (_event, options: { projectId: string; outputPath?: string }) => {
+    async (
+      _event,
+      options: { projectId: string; userId: string; outputPath?: string }
+    ) => {
       try {
         return await exportProject(options)
       } catch (error) {
@@ -66,7 +69,9 @@ export function registerArchiveHandlers(): void {
     try {
       const result = await dialog.showOpenDialog({
         title: "プロジェクトをインポート",
-        filters: [{ name: "Score at Once アーカイブ", extensions: ["score"] }],
+        filters: [
+          { name: "一括採点プロジェクトデータ", extensions: ["score"] },
+        ],
         properties: ["openFile"],
       })
 
@@ -109,7 +114,7 @@ export function registerArchiveHandlers(): void {
   // 新規作成インポート
   ipcMain.handle(
     "archive:importAsNew",
-    async (_event, options: { archivePath: string }) => {
+    async (_event, options: { archivePath: string; currentUserId: string }) => {
       try {
         return await importAsNew(options)
       } catch (error) {

--- a/electron-src/ipc-handlers/drawingHandlers.ts
+++ b/electron-src/ipc-handlers/drawingHandlers.ts
@@ -42,12 +42,13 @@ export function setupDrawingHandlers() {
    */
   ipcMain.handle(
     "drawing:getByQuestionScore",
-    async (_, questionScoreId: string, type?: DrawingType) => {
+    async (_, questionScoreId: string, type?: DrawingType, userId?: string) => {
       try {
         const result =
           await drawingService.getDrawingAnnotationsByQuestionScore(
             questionScoreId,
-            type
+            type,
+            userId
           )
         return { success: true, data: result }
       } catch (error) {
@@ -68,12 +69,19 @@ export function setupDrawingHandlers() {
    */
   ipcMain.handle(
     "drawing:getByStudent",
-    async (_, studentId: string, projectId: string, type?: DrawingType) => {
+    async (
+      _,
+      studentId: string,
+      projectId: string,
+      type?: DrawingType,
+      userId?: string
+    ) => {
       try {
         const result = await drawingService.getDrawingAnnotationsByStudent(
           studentId,
           projectId,
-          type
+          type,
+          userId
         )
         return { success: true, data: result }
       } catch (error) {
@@ -94,11 +102,12 @@ export function setupDrawingHandlers() {
    */
   ipcMain.handle(
     "drawing:getByProject",
-    async (_, projectId: string, type?: DrawingType) => {
+    async (_, projectId: string, type?: DrawingType, userId?: string) => {
       try {
         const result = await drawingService.getDrawingAnnotationsByProject(
           projectId,
-          type
+          type,
+          userId
         )
         return { success: true, data: result }
       } catch (error) {

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -43,9 +43,9 @@ export function setupScoringHandlers(): void {
   // QuestionScore 関連のハンドラー
   ipcMain.handle(
     "get-question-scores-for-project",
-    async (_event, projectId: string) => {
+    async (_event, projectId: string, userId?: string) => {
       try {
-        const result = await getQuestionScoresForProject(projectId)
+        const result = await getQuestionScoresForProject(projectId, userId)
 
         if (!result.success) {
           return result
@@ -62,9 +62,9 @@ export function setupScoringHandlers(): void {
 
   ipcMain.handle(
     "get-question-scores-for-student",
-    async (_event, studentId: string) => {
+    async (_event, studentId: string, userId?: string) => {
       try {
-        const result = await getQuestionScoresForStudent(studentId)
+        const result = await getQuestionScoresForStudent(studentId, userId)
 
         if (!result.success) {
           return result

--- a/electron-src/lib/export/project-archive/dataCollector.ts
+++ b/electron-src/lib/export/project-archive/dataCollector.ts
@@ -36,10 +36,12 @@ export interface CollectedData {
  * プロジェクトの全関連データを収集
  *
  * @param projectId - 対象プロジェクトID
+ * @param userId - ログインユーザーID（このユーザーのデータのみ収集）
  * @returns 収集されたデータ
  */
 export async function collectProjectData(
-  projectId: string
+  projectId: string,
+  userId: string
 ): Promise<{ success: boolean; data?: CollectedData; error?: string }> {
   try {
     // 1. プロジェクト基本データを取得
@@ -65,6 +67,7 @@ export async function collectProjectData(
         projectStudents: true,
         userProjects: true,
         projectSubtotalGroups: true,
+        projectClasses: true,
       },
     })
 
@@ -103,25 +106,10 @@ export async function collectProjectData(
       where: { id: { in: Array.from(classIds) } },
     })
 
-    // 5. 関連するユーザーIDを収集
-    const userIds = new Set<string>()
-    for (const up of project.userProjects) {
-      userIds.add(up.userId)
-    }
-    for (const page of project.projectPages) {
-      for (const region of page.cropRegions) {
-        for (const score of region.questionScores) {
-          if (score.scoredByUserId) userIds.add(score.scoredByUserId)
-          for (const ann of score.drawingAnnotations) {
-            if (ann.createdByUserId) userIds.add(ann.createdByUserId)
-          }
-        }
-      }
-    }
-
-    // 6. ユーザーデータを取得（パスコードは除外）
-    const users = await prisma.user.findMany({
-      where: { id: { in: Array.from(userIds) } },
+    // 5. 現在のユーザーのみを取得（パスコードは除外）
+    // v0.3.0以降: ログインユーザーのデータのみをエクスポート
+    const currentUser = await prisma.user.findUnique({
+      where: { id: userId },
       select: {
         id: true,
         username: true,
@@ -131,6 +119,12 @@ export async function collectProjectData(
         updatedAt: true,
       },
     })
+
+    if (!currentUser) {
+      return { success: false, error: "ユーザーが見つかりません" }
+    }
+
+    const users = [currentUser]
 
     // 7. 小計グループと小計を取得
     const subtotalGroupIds = new Set(
@@ -173,12 +167,18 @@ export async function collectProjectData(
     }
 
     // 9. QuestionScoreとDrawingAnnotationを収集
+    // v0.3.0以降: ログインユーザーのデータのみをエクスポート
     const questionScores: ArchiveScoresData["questionScores"] = []
     const drawingAnnotations: ArchiveScoresData["drawingAnnotations"] = []
 
     for (const page of project.projectPages) {
       for (const region of page.cropRegions) {
         for (const score of region.questionScores) {
+          // ログインユーザーの採点データのみを収集
+          if (score.scoredByUserId !== userId) {
+            continue
+          }
+
           questionScores.push({
             id: score.id,
             cropRegionId: score.cropRegionId,
@@ -191,6 +191,11 @@ export async function collectProjectData(
           })
 
           for (const ann of score.drawingAnnotations) {
+            // ログインユーザーのアノテーションのみを収集
+            if (ann.createdByUserId !== userId) {
+              continue
+            }
+
             drawingAnnotations.push({
               id: ann.id,
               questionScoreId: ann.questionScoreId,
@@ -276,22 +281,24 @@ export async function collectProjectData(
         createdAt: ps.createdAt.toISOString(),
         updatedAt: ps.updatedAt.toISOString(),
       })),
-      userProjects: project.userProjects.map((up) => ({
-        id: up.id,
-        userId: up.userId,
-        projectId: up.projectId,
-        role: up.role,
-        invitedAt: up.invitedAt.toISOString(),
-        invitedBy: up.invitedBy,
-        createdAt: up.createdAt.toISOString(),
-        updatedAt: up.updatedAt.toISOString(),
-      })),
+      // v0.3.0以降: UserProjectは無視（インポート時に現在のユーザーで作成）
+      userProjects: [],
       projectSubtotalGroups: project.projectSubtotalGroups.map((psg) => ({
         id: psg.id,
         projectId: psg.projectId,
         subtotalGroupId: psg.subtotalGroupId,
         createdAt: psg.createdAt.toISOString(),
         updatedAt: psg.updatedAt.toISOString(),
+      })),
+      projectClasses: project.projectClasses.map((pc) => ({
+        id: pc.id,
+        projectId: pc.projectId,
+        classId: pc.classId,
+        administered: pc.administered,
+        statistics: pc.statistics,
+        order: pc.order,
+        createdAt: pc.createdAt.toISOString(),
+        updatedAt: pc.updatedAt.toISOString(),
       })),
     }
 

--- a/electron-src/lib/export/project-archive/index.ts
+++ b/electron-src/lib/export/project-archive/index.ts
@@ -5,13 +5,13 @@
  */
 
 import { app, dialog } from "electron"
-import { collectProjectData } from "./dataCollector"
-import { createArchive, generateExportFileName } from "./archiveCreator"
 import type {
   ExportProjectOptions,
   ExportProjectResult,
 } from "../../../../types/projectArchive.types"
 import { getProjectById } from "../../prisma/project"
+import { createArchive, generateExportFileName } from "./archiveCreator"
+import { collectProjectData } from "./dataCollector"
 
 /**
  * プロジェクトをエクスポート
@@ -22,7 +22,7 @@ import { getProjectById } from "../../prisma/project"
 export async function exportProject(
   options: ExportProjectOptions
 ): Promise<ExportProjectResult> {
-  const { projectId, outputPath } = options
+  const { projectId, userId, outputPath } = options
 
   try {
     // 1. プロジェクト情報を取得
@@ -31,8 +31,8 @@ export async function exportProject(
       return { success: false, error: "プロジェクトが見つかりません" }
     }
 
-    // 2. データを収集
-    const collectResult = await collectProjectData(projectId)
+    // 2. データを収集（ログインユーザーのデータのみ）
+    const collectResult = await collectProjectData(projectId, userId)
     if (!collectResult.success || !collectResult.data) {
       return { success: false, error: collectResult.error }
     }
@@ -44,7 +44,9 @@ export async function exportProject(
       const result = await dialog.showSaveDialog({
         title: "プロジェクトをエクスポート",
         defaultPath: defaultFileName,
-        filters: [{ name: "Score at Once アーカイブ", extensions: ["score"] }],
+        filters: [
+          { name: "一括採点プロジェクトデータ", extensions: ["score"] },
+        ],
       })
 
       if (result.canceled || !result.filePath) {
@@ -70,8 +72,8 @@ export async function exportProject(
       success: true,
       outputPath: archiveResult.outputPath,
       manifest: {
-        version: "1.0.0",
-        schemaVersion: "unknown",
+        version: "1.1.0", // v0.3.z format
+        schemaVersion: "v0.3.0",
         appVersion: app.getVersion(),
         exportedAt: new Date().toISOString(),
         projectId,
@@ -106,7 +108,7 @@ export async function selectExportSavePath(options: {
   const result = await dialog.showSaveDialog({
     title: "プロジェクトをエクスポート",
     defaultPath: defaultFileName,
-    filters: [{ name: "Score at Once アーカイブ", extensions: ["score"] }],
+    filters: [{ name: "一括採点プロジェクトデータ", extensions: ["score"] }],
   })
 
   if (result.canceled) {
@@ -117,5 +119,5 @@ export async function selectExportSavePath(options: {
 }
 
 // Re-export types
-export * from "./dataCollector"
 export * from "./archiveCreator"
+export * from "./dataCollector"

--- a/electron-src/lib/import/project-archive/dataCreator.ts
+++ b/electron-src/lib/import/project-archive/dataCreator.ts
@@ -28,14 +28,17 @@ export interface DataCreationResult {
  * 新規作成モードでデータをインポート
  *
  * 全てのデータを新規UUIDで作成し、参照関係を維持
+ * v0.3.0以降: userIdは現在ログインしているユーザーで上書き
  *
  * @param data - 展開されたアーカイブデータ
  * @param mappings - IDマッピング
+ * @param currentUserId - 現在ログインしているユーザーID
  * @returns 作成結果
  */
 export async function createImportedData(
   data: ExtractedArchiveData,
-  mappings: IdMappings
+  mappings: IdMappings,
+  currentUserId: string
 ): Promise<DataCreationResult> {
   const warnings: string[] = []
   const newProjectId = remapIdRequired(
@@ -95,23 +98,8 @@ export async function createImportedData(
         }
       }
 
-      // 4. ユーザーを作成（パスコードなしで作成）
-      for (const user of data.usersData.users) {
-        await tx.user.create({
-          data: {
-            id: remapIdRequired(user.id, mappings.user),
-            username: user.username,
-            name: user.name,
-            role: user.role,
-            passcode: "", // パスコードは空で作成
-          },
-        })
-      }
-      if (data.usersData.users.length > 0) {
-        warnings.push(
-          "インポートされたユーザーのパスコードは空に設定されています。必要に応じて再設定してください。"
-        )
-      }
+      // 4. ユーザー作成をスキップ
+      // v0.3.0以降: アーカイブ内のユーザーは作成せず、現在のログインユーザーを使用
 
       // 5. 小計グループを作成
       for (const sg of data.subtotalsData.subtotalGroups) {
@@ -150,25 +138,17 @@ export async function createImportedData(
         },
       })
 
-      // 8. UserProjectを作成
-      for (const up of data.projectData.userProjects) {
-        const newUserId = remapId(up.userId, mappings.user)
-        const newInvitedBy = up.invitedBy
-          ? remapId(up.invitedBy, mappings.user)
-          : null
-        if (newUserId) {
-          await tx.userProject.create({
-            data: {
-              id: remapIdRequired(up.id, mappings.userProject),
-              userId: newUserId,
-              projectId: newProjectId,
-              role: up.role,
-              invitedAt: up.invitedAt ? new Date(up.invitedAt) : new Date(),
-              invitedBy: newInvitedBy,
-            },
-          })
-        }
-      }
+      // 8. UserProjectを作成（現在のログインユーザーのみ）
+      // v0.3.0以降: アーカイブ内のUserProjectは無視し、現在のユーザーをOWNERとして作成
+      await tx.userProject.create({
+        data: {
+          userId: currentUserId,
+          projectId: newProjectId,
+          role: "OWNER",
+          invitedAt: new Date(),
+          invitedBy: null,
+        },
+      })
 
       // 9. ProjectSubtotalGroupを作成
       for (const psg of data.projectData.projectSubtotalGroups) {
@@ -182,6 +162,23 @@ export async function createImportedData(
               id: remapIdRequired(psg.id, mappings.projectSubtotalGroup),
               projectId: newProjectId,
               subtotalGroupId: newSubtotalGroupId,
+            },
+          })
+        }
+      }
+
+      // 9.5. ProjectClassを作成 (v1.1.0+)
+      for (const pc of data.projectData.projectClasses || []) {
+        const newClassId = remapId(pc.classId, mappings.class)
+        if (newClassId) {
+          await tx.projectClass.create({
+            data: {
+              id: remapIdRequired(pc.id, mappings.projectClass),
+              projectId: newProjectId,
+              classId: newClassId,
+              administered: pc.administered,
+              statistics: pc.statistics,
+              order: pc.order,
             },
           })
         }
@@ -252,10 +249,10 @@ export async function createImportedData(
       }
 
       // 14. QuestionScoreを作成
+      // v0.3.0以降: scoredByUserIdを現在のログインユーザーで上書き
       for (const qs of data.scoresData.questionScores) {
         const newCropRegionId = remapId(qs.cropRegionId, mappings.cropRegion)
         const newStudentId = remapId(qs.studentId, mappings.student)
-        const newScoredByUserId = remapId(qs.scoredByUserId, mappings.user)
 
         if (newCropRegionId) {
           await tx.questionScore.create({
@@ -267,19 +264,19 @@ export async function createImportedData(
                 ? parseFloat(qs.partialScore)
                 : null,
               status: qs.status,
-              scoredByUserId: newScoredByUserId,
+              scoredByUserId: currentUserId,
             },
           })
         }
       }
 
       // 15. DrawingAnnotationを作成
+      // v0.3.0以降: createdByUserIdを現在のログインユーザーで上書き
       for (const da of data.scoresData.drawingAnnotations) {
         const newQuestionScoreId = remapId(
           da.questionScoreId,
           mappings.questionScore
         )
-        const newCreatedByUserId = remapId(da.createdByUserId, mappings.user)
 
         if (newQuestionScoreId) {
           await tx.drawingAnnotation.create({
@@ -305,7 +302,7 @@ export async function createImportedData(
               anchorDirection: da.anchorDirection,
               displayX: da.displayX,
               displayY: da.displayY,
-              createdByUserId: newCreatedByUserId,
+              createdByUserId: currentUserId,
             },
           })
         }

--- a/electron-src/lib/import/project-archive/idRemapper.ts
+++ b/electron-src/lib/import/project-archive/idRemapper.ts
@@ -25,6 +25,8 @@ export interface IdMappings {
   userProject: Record<string, string>
   /** ProjectSubtotalGroup ID: 旧ID -> 新ID */
   projectSubtotalGroup: Record<string, string>
+  /** ProjectClass ID: 旧ID -> 新ID (v1.1.0+) */
+  projectClass: Record<string, string>
   /** Student ID: 旧ID -> 新ID */
   student: Record<string, string>
   /** Class ID: 旧ID -> 新ID */
@@ -62,6 +64,7 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     projectStudent: {},
     userProject: {},
     projectSubtotalGroup: {},
+    projectClass: {},
     student: {},
     class: {},
     membership: {},
@@ -104,6 +107,11 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // ProjectSubtotalGroup
   for (const psg of data.projectData.projectSubtotalGroups) {
     mappings.projectSubtotalGroup[psg.id] = randomUUID()
+  }
+
+  // ProjectClass (v1.1.0+)
+  for (const pc of data.projectData.projectClasses || []) {
+    mappings.projectClass[pc.id] = randomUUID()
   }
 
   // 生徒

--- a/electron-src/lib/import/project-archive/index.ts
+++ b/electron-src/lib/import/project-archive/index.ts
@@ -69,6 +69,7 @@ export async function analyzeArchive(
  * 新規作成モードでインポート
  *
  * 全てのデータを新規UUIDで作成
+ * v0.3.0以降: userIdは現在ログインしているユーザーで上書き
  *
  * @param options - インポートオプション
  * @returns インポート結果
@@ -107,8 +108,12 @@ export async function importAsNew(
     // 4. 新しいIDマッピングを生成
     const mappings = generateNewIdMappings(processedData)
 
-    // 5. データを作成
-    const createResult = await createImportedData(processedData, mappings)
+    // 5. データを作成（現在のログインユーザーIDを渡す）
+    const createResult = await createImportedData(
+      processedData,
+      mappings,
+      options.currentUserId
+    )
     if (!createResult.success) {
       return { success: false, error: createResult.error }
     }

--- a/electron-src/lib/import/versionedImporter.ts
+++ b/electron-src/lib/import/versionedImporter.ts
@@ -72,14 +72,17 @@ export function detectArchiveVersion(
 
 /**
  * v0.2.z (1.0.0) のUserProject形式
+ *
+ * v0.2.20時点では role は存在する（デフォルト "OWNER"）
+ * v0.2.z では invitedAt, invitedBy がない
  */
 interface V1_0_0_UserProject {
   id: string
   userId: string
   projectId: string
+  role?: string // v0.2.20では存在する
   createdAt: string
   updatedAt: string
-  // v0.2.z では role, invitedAt, invitedBy がない
 }
 
 /**
@@ -131,32 +134,40 @@ export class V1_0_0_Transformer implements VersionTransformer {
   supportedVersion: ArchiveVersion = "1.0.0"
 
   transformProjectData(data: ArchiveProjectData): ArchiveProjectData {
-    // UserProjectにデフォルトのrole, invitedAt, invitedByを追加
-    const transformedUserProjects = data.userProjects.map((up) => {
+    // UserProjectにinvitedAt, invitedByを追加
+    // v0.2.20では role は既に存在するので、あれば保持、なければデフォルト値を設定
+    const transformedUserProjects = data.userProjects.map((up, index) => {
       const v1Up = up as unknown as V1_0_0_UserProject
+
+      // roleが存在する場合は保持、なければデフォルト値を設定
+      // 最初のユーザーはOWNER、それ以外はGRADER
+      const role = v1Up.role ?? (index === 0 ? "OWNER" : "GRADER")
+
       const v11Up: V1_1_0_UserProject = {
         ...v1Up,
-        // v0.2.zの最初のユーザーをOWNERとして扱う
-        role: "OWNER",
+        role,
         invitedAt: v1Up.createdAt,
         invitedBy: null,
       }
       return v11Up as unknown as ArchiveProjectData["userProjects"][0]
     })
 
-    // 最初以外のユーザーはGRADERとして設定
+    // invitedByを設定（最初のユーザー以外）
     if (transformedUserProjects.length > 1) {
       const ownerUserId = transformedUserProjects[0]?.userId
       for (let i = 1; i < transformedUserProjects.length; i++) {
         const up = transformedUserProjects[i] as unknown as V1_1_0_UserProject
-        up.role = "GRADER"
         up.invitedBy = ownerUserId || null
       }
     }
 
+    // v0.2.zにはprojectClassesがないので空の配列を追加
+    const projectClasses = data.projectClasses ?? []
+
     return {
       ...data,
       userProjects: transformedUserProjects,
+      projectClasses,
     }
   }
 

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -121,11 +121,13 @@ export async function createDrawingAnnotation(
  * QuestionScoreに紐づく描画アノテーションを取得する
  * @param questionScoreId QuestionScoreのID
  * @param type フィルタする描画タイプ（オプション）
+ * @param userId 作成者のユーザーID（指定時はそのユーザーのアノテーションのみ取得）
  * @returns Promise<DrawingAnnotation[]> 描画アノテーション配列
  */
 export async function getDrawingAnnotationsByQuestionScore(
   questionScoreId: string,
-  type?: DrawingType
+  type?: DrawingType,
+  userId?: string
 ): Promise<DrawingAnnotation[]> {
   // 読み取り専用操作のためバックアップ不要
   try {
@@ -133,6 +135,8 @@ export async function getDrawingAnnotationsByQuestionScore(
       where: {
         questionScoreId,
         ...(type && { type }),
+        // userIdが指定されている場合、そのユーザーのアノテーションのみ取得
+        ...(userId && { createdByUserId: userId }),
       },
       orderBy: { createdAt: "asc" },
       include: {
@@ -158,12 +162,14 @@ export async function getDrawingAnnotationsByQuestionScore(
  * @param studentId 学生ID
  * @param projectId プロジェクトID
  * @param type フィルタする描画タイプ（オプション）
+ * @param userId 作成者のユーザーID（指定時はそのユーザーのアノテーションのみ取得）
  * @returns Promise<DrawingAnnotationWithQuestionScore[]> 描画アノテーション配列（設問情報付き）
  */
 export async function getDrawingAnnotationsByStudent(
   studentId: string,
   projectId: string,
-  type?: DrawingType
+  type?: DrawingType,
+  userId?: string
 ): Promise<DrawingAnnotation[]> {
   try {
     const result = await prisma.drawingAnnotation.findMany({
@@ -177,6 +183,8 @@ export async function getDrawingAnnotationsByStudent(
           },
         },
         ...(type && { type }),
+        // userIdが指定されている場合、そのユーザーのアノテーションのみ取得
+        ...(userId && { createdByUserId: userId }),
       },
       orderBy: { createdAt: "asc" },
       include: {
@@ -213,11 +221,13 @@ export async function getDrawingAnnotationsByStudent(
  * プロジェクト全体の描画アノテーションを取得する（PDF出力用）
  * @param projectId プロジェクトID
  * @param type フィルタする描画タイプ（オプション）
+ * @param userId 作成者のユーザーID（指定時はそのユーザーのアノテーションのみ取得）
  * @returns Promise<DrawingAnnotation[]> 描画アノテーション配列（設問情報付き）
  */
 export async function getDrawingAnnotationsByProject(
   projectId: string,
-  type?: DrawingType
+  type?: DrawingType,
+  userId?: string
 ): Promise<DrawingAnnotation[]> {
   try {
     const result = await prisma.drawingAnnotation.findMany({
@@ -230,6 +240,8 @@ export async function getDrawingAnnotationsByProject(
           },
         },
         ...(type && { type }),
+        // userIdが指定されている場合、そのユーザーのアノテーションのみ取得
+        ...(userId && { createdByUserId: userId }),
       },
       orderBy: [
         { questionScore: { studentId: "asc" } },

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -66,9 +66,14 @@ export interface UpdateQuestionScoreData {
 }
 
 /**
- * プロジェクトの全採点データを取得
+ * プロジェクトの採点データを取得
+ * @param projectId プロジェクトID
+ * @param userId 採点者のユーザーID（指定時はそのユーザーの採点データのみ取得）
  */
-export const getQuestionScoresForProject = async (projectId: string) => {
+export const getQuestionScoresForProject = async (
+  projectId: string,
+  userId?: string
+) => {
   try {
     const scores = await prisma.questionScore.findMany({
       where: {
@@ -77,6 +82,8 @@ export const getQuestionScoresForProject = async (projectId: string) => {
             projectId,
           },
         },
+        // userIdが指定されている場合、そのユーザーの採点データのみ取得
+        ...(userId && { scoredByUserId: userId }),
       },
       include: {
         student: true,
@@ -106,12 +113,19 @@ export const getQuestionScoresForProject = async (projectId: string) => {
 
 /**
  * 特定の生徒の採点データを取得
+ * @param studentId 生徒ID
+ * @param userId 採点者のユーザーID（指定時はそのユーザーの採点データのみ取得）
  */
-export const getQuestionScoresForStudent = async (studentId: string) => {
+export const getQuestionScoresForStudent = async (
+  studentId: string,
+  userId?: string
+) => {
   try {
     const scores = await prisma.questionScore.findMany({
       where: {
         studentId: studentId,
+        // userIdが指定されている場合、そのユーザーの採点データのみ取得
+        ...(userId && { scoredByUserId: userId }),
       },
       include: {
         cropRegion: true,

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -279,8 +279,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   ) => ipcRenderer.invoke("update-student-orders", projectId, studentOrders),
 
   // QuestionScore related functions
-  getQuestionScoresForProject: (projectId: string) =>
-    ipcRenderer.invoke("get-question-scores-for-project", projectId),
+  getQuestionScoresForProject: (projectId: string, userId?: string) =>
+    ipcRenderer.invoke("get-question-scores-for-project", projectId, userId),
   getQuestionScoresForAnswerSheet: (answerSheetId: string) =>
     ipcRenderer.invoke("get-question-scores-for-answer-sheet", answerSheetId),
   createQuestionScore: (data: QuestionScoreCreateData) =>
@@ -569,12 +569,32 @@ contextBridge.exposeInMainWorld("electronAPI", {
   drawing: {
     create: (data: Partial<DrawingAnnotation>) =>
       ipcRenderer.invoke("drawing:create", data),
-    getByQuestionScore: (questionScoreId: string, type?: string) =>
-      ipcRenderer.invoke("drawing:getByQuestionScore", questionScoreId, type),
-    getByStudent: (studentId: string, projectId: string, type?: string) =>
-      ipcRenderer.invoke("drawing:getByStudent", studentId, projectId, type),
-    getByProject: (projectId: string, type?: string) =>
-      ipcRenderer.invoke("drawing:getByProject", projectId, type),
+    getByQuestionScore: (
+      questionScoreId: string,
+      type?: string,
+      userId?: string
+    ) =>
+      ipcRenderer.invoke(
+        "drawing:getByQuestionScore",
+        questionScoreId,
+        type,
+        userId
+      ),
+    getByStudent: (
+      studentId: string,
+      projectId: string,
+      type?: string,
+      userId?: string
+    ) =>
+      ipcRenderer.invoke(
+        "drawing:getByStudent",
+        studentId,
+        projectId,
+        type,
+        userId
+      ),
+    getByProject: (projectId: string, type?: string, userId?: string) =>
+      ipcRenderer.invoke("drawing:getByProject", projectId, type, userId),
     update: (id: string, data: Partial<DrawingAnnotation>) =>
       ipcRenderer.invoke("drawing:update", id, data),
     delete: (id: string) => ipcRenderer.invoke("drawing:delete", id),
@@ -596,11 +616,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Project Archive (Export/Import) related
   archive: {
-    exportProject: (options: { projectId: string; outputPath?: string }) =>
-      ipcRenderer.invoke("archive:exportProject", options),
+    exportProject: (options: {
+      projectId: string
+      userId: string
+      outputPath?: string
+    }) => ipcRenderer.invoke("archive:exportProject", options),
     analyzeArchive: (options: { archivePath: string }) =>
       ipcRenderer.invoke("archive:analyzeArchive", options),
-    importAsNew: (options: { archivePath: string }) =>
+    importAsNew: (options: { archivePath: string; currentUserId: string }) =>
       ipcRenderer.invoke("archive:importAsNew", options),
     detectConflicts: (options: {
       archivePath: string

--- a/hooks/useDrawingAnnotations.ts
+++ b/hooks/useDrawingAnnotations.ts
@@ -102,6 +102,7 @@ export function useDrawingAnnotations(
 
   /**
    * アノテーション読み込み
+   * contextのcurrentUserIdを使って、ログインユーザーのアノテーションのみ取得
    */
   const loadAnnotations = useCallback(
     async (questionScoreId: string, type?: DrawingType): Promise<void> => {
@@ -111,10 +112,12 @@ export function useDrawingAnnotations(
       try {
         console.log(`📖 手動アノテーション読み込み: ${questionScoreId}`, {
           type,
+          userId: context?.currentUserId,
         })
         const result = await window.electronAPI.drawing.getByQuestionScore(
           questionScoreId,
-          type
+          type,
+          context?.currentUserId
         )
 
         if (result.success && result.data) {
@@ -137,7 +140,7 @@ export function useDrawingAnnotations(
         setIsLoading(false)
       }
     },
-    []
+    [context?.currentUserId]
   )
 
   /**

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -846,7 +846,10 @@ export interface MyAPI {
   }>
 
   // QuestionScore関連のAPI
-  getQuestionScoresForProject: (projectId: string) => Promise<{
+  getQuestionScoresForProject: (
+    projectId: string,
+    userId?: string
+  ) => Promise<{
     success: boolean
     scores?: QuestionScore[]
     error?: string
@@ -1281,7 +1284,8 @@ export interface MyAPI {
     }>
     getByQuestionScore: (
       questionScoreId: string,
-      type?: import("./drawing-annotation.types").DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
+      userId?: string
     ) => Promise<{
       success: boolean
       data?: import("./drawing-annotation.types").DrawingAnnotation[]
@@ -1290,7 +1294,8 @@ export interface MyAPI {
     getByStudent: (
       studentId: string,
       projectId: string,
-      type?: import("./drawing-annotation.types").DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
+      userId?: string
     ) => Promise<{
       success: boolean
       data?: import("./drawing-annotation.types").DrawingAnnotation[]
@@ -1298,7 +1303,8 @@ export interface MyAPI {
     }>
     getByProject: (
       projectId: string,
-      type?: import("./drawing-annotation.types").DrawingType
+      type?: import("./drawing-annotation.types").DrawingType,
+      userId?: string
     ) => Promise<{
       success: boolean
       data?: import("./drawing-annotation.types").DrawingAnnotation[]

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -213,6 +213,8 @@ export interface ImportOptions {
  */
 export interface ExportProjectOptions {
   projectId: string
+  /** ログインユーザーID（このユーザーのデータのみエクスポート） */
+  userId: string
   outputPath?: string
 }
 
@@ -261,6 +263,8 @@ export interface DetectConflictsOptions {
  */
 export interface ImportAsNewOptions {
   archivePath: string
+  /** 現在ログインしているユーザーID（このユーザーのデータとしてインポート） */
+  currentUserId: string
 }
 
 /**
@@ -372,6 +376,17 @@ export interface ArchiveProjectData {
     id: string
     projectId: string
     subtotalGroupId: string
+    createdAt: string
+    updatedAt: string
+  }>
+  /** v1.1.0+ ProjectClass関係 */
+  projectClasses: Array<{
+    id: string
+    projectId: string
+    classId: string
+    administered: boolean
+    statistics: boolean
+    order: number
     createdAt: string
     updatedAt: string
   }>


### PR DESCRIPTION
## 概要

Closes #253

ログインユーザーに基づいたデータフィルタリングと、アーカイブの個人モードを実装しました。

## 変更内容

### userIdによるデータフィルタリング

- QuestionScoreとDrawingAnnotationの取得をログインユーザーでフィルタリング
- 各API（getQuestionScoresForProject, getByQuestionScore, getByStudent, getByProject）にuserId引数を追加
- フロントエンドフックでcurrentUserIdを渡すよう更新

### アーカイブエクスポート（個人用）

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| QuestionScore | 全員分 | ログインユーザーのみ |
| DrawingAnnotation | 全員分 | ログインユーザーのみ |
| UserProject | 全員分 | 除外（空配列） |
| usersData | 全員分 | ログインユーザーのみ |

### アーカイブインポート（個人用）

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| User | アーカイブから作成 | スキップ |
| UserProject | アーカイブから作成 | 現在ユーザーをOWNERとして作成 |
| scoredByUserId | アーカイブの値 | 現在ユーザーで上書き |
| createdByUserId | アーカイブの値 | 現在ユーザーで上書き |

### v0.2.20互換性修正

- V1_0_0_TransformerでUserProject.roleが存在する場合は保持するよう修正

### UI改善

- インポートウィザードモーダルの横幅を調整（min-w-2xl）
- ステップインジケーターを均等幅に修正（w-24）

## テスト項目

- [ ] ログインユーザーのQuestionScoreのみが表示される
- [ ] ログインユーザーのDrawingAnnotationのみが表示される
- [ ] エクスポートしたアーカイブに自分のデータのみ含まれる
- [ ] インポート後のデータが現在のユーザーに紐づく
- [ ] v0.2.20のアーカイブが正しくインポートできる
- [ ] インポートウィザードのUIが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)