### PR TITLE
lint警告を修正しJSDocコメントを追加

### DIFF
--- a/components/pdf-tools/export-panel/ExportPanel.tsx
+++ b/components/pdf-tools/export-panel/ExportPanel.tsx
@@ -7,11 +7,11 @@ import type {
   InterleaveConfig,
   OutputPage,
 } from "@/types/pdfTools.types"
+import { useEffect } from "react"
+import ExportActions from "./ExportActions"
 import ExportModeSelector from "./ExportModeSelector"
 import InterleaveSettings from "./InterleaveSettings"
 import OutputPreview from "./OutputPreview"
-import ExportActions from "./ExportActions"
-import { useEffect } from "react"
 
 interface ExportPanelProps {
   importedFiles: ImportedFile[]
@@ -25,6 +25,11 @@ interface ExportPanelProps {
   onProcessingChange: (processing: boolean) => void
 }
 
+/**
+ * PDFエクスポートパネルコンポーネント
+ *
+ * エクスポートモード選択、交互挿入設定、出力プレビュー、エクスポート実行を管理する
+ */
 export default function ExportPanel({
   importedFiles,
   outputPages,
@@ -44,7 +49,7 @@ export default function ExportPanel({
       interleaveConfig
     )
     onOutputPagesChange(pages)
-  }, [importedFiles, exportMode, interleaveConfig])
+  }, [importedFiles, exportMode, interleaveConfig, onOutputPagesChange])
 
   return (
     <div className="flex h-full min-w-0 flex-col">
@@ -95,6 +100,14 @@ export default function ExportPanel({
   )
 }
 
+/**
+ * インポートされたファイルから出力ページリストを生成
+ *
+ * @param files - インポートされたファイル一覧
+ * @param mode - エクスポートモード（merge, split, interleave）
+ * @param interleaveConfig - 交互挿入設定
+ * @returns 生成された出力ページ配列
+ */
 function generateOutputPages(
   files: ImportedFile[],
   mode: ExportMode,

--- a/components/pdf-tools/export-panel/InterleaveSettings.tsx
+++ b/components/pdf-tools/export-panel/InterleaveSettings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -18,7 +17,7 @@ import type {
   RotationDegree,
 } from "@/types/pdfTools.types"
 import { RotateCw, Settings2 } from "lucide-react"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 interface InterleaveSettingsProps {
   files: ImportedFile[]
@@ -27,16 +26,29 @@ interface InterleaveSettingsProps {
   disabled: boolean
 }
 
+/**
+ * 交互挿入設定コンポーネント
+ *
+ * 複数ファイルの交互挿入設定（N-up、回転など）を管理する
+ */
 export default function InterleaveSettings({
   files,
   config,
   onConfigChange,
   disabled,
 }: InterleaveSettingsProps) {
+  // useRefで最新の値を保持（依存配列に入れずに最新値を参照するため）
+  const configRef = useRef(config)
+  configRef.current = config
+
+  const onConfigChangeRef = useRef(onConfigChange)
+  onConfigChangeRef.current = onConfigChange
+
   // ファイルが変更されたらtransformsを同期
   useEffect(() => {
+    const currentConfig = configRef.current
     const currentFileIds = new Set(files.map((f) => f.id))
-    const existingTransforms = config.transforms.filter((t) =>
+    const existingTransforms = currentConfig.transforms.filter((t) =>
       currentFileIds.has(t.fileId)
     )
 
@@ -51,11 +63,11 @@ export default function InterleaveSettings({
       }))
 
     if (
-      existingTransforms.length !== config.transforms.length ||
+      existingTransforms.length !== currentConfig.transforms.length ||
       newTransforms.length > 0
     ) {
-      onConfigChange({
-        ...config,
+      onConfigChangeRef.current({
+        ...currentConfig,
         transforms: [...existingTransforms, ...newTransforms],
       })
     }

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -1,6 +1,5 @@
 import {
   getDynamicScoreStatusConfig,
-  type DynamicScoreStatusConfig,
   type ScoreStatusKey,
 } from "@/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig"
 import type { GridAnswerItem } from "@/components/projects/07-score-at-once/ScoringGrid/types/gridTypes"

--- a/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
@@ -1,3 +1,4 @@
+import type { ScoringStatusColors } from "@/lib/scoringStatusColors"
 import {
   AlertTriangle,
   CheckCircle,
@@ -6,7 +7,6 @@ import {
   Minus,
   X,
 } from "lucide-react"
-import type { ScoringStatusColors } from "@/lib/scoringStatusColors"
 
 // アイコンとキーバインドの定義（静的）
 export const SCORE_STATUS_ICONS = {
@@ -19,20 +19,11 @@ export const SCORE_STATUS_ICONS = {
   master: { icon: CheckCircle, key: "" },
 } as const
 
-// ステータス名のマッピング（SCORE_STATUS_CONFIG のキー → ScoringStatusColors のキー）
-const STATUS_KEY_MAP: Record<string, keyof ScoringStatusColors> = {
-  unscored: "ungraded",
-  correct: "correct",
-  partial: "partial",
-  pending: "pending",
-  incorrect: "incorrect",
-  no_answer: "no_answer",
-  master: "ungraded", // masterは特殊扱い
-}
-
 /**
  * 動的な採点状態色設定を生成
+ *
  * @param colors - 採点状態色（useScoringStatusColorsから取得）
+ * @returns 採点状態ごとのスタイル設定オブジェクト
  */
 export function getDynamicScoreStatusConfig(colors: ScoringStatusColors) {
   return {

--- a/components/projects/08-export/components/individual-report/generatePrintHtml.ts
+++ b/components/projects/08-export/components/individual-report/generatePrintHtml.ts
@@ -5,12 +5,10 @@
  */
 import type {
   AdviceOptions,
-  GraphOptions,
   IndividualReportData,
   IndividualReportOptions,
-  SubtotalGroupSelection,
-  SubtotalRawScores,
   StatisticsData,
+  SubtotalRawScores,
 } from "@/electron-src/lib/export/individual-report/types"
 import { calculateLearningAdvice } from "../../utils/learningAdviceCalculator"
 
@@ -1022,7 +1020,7 @@ function generateQuestionTable(
   const columnWidth = `${100 / columns}%`
 
   const columnsHtml = columnData
-    .map((colData, colIndex) => {
+    .map((colData) => {
       const rowsHtml = colData
         .map((item, index) => {
           const isAlt = index % 2 === 1

--- a/electron-src/lib/prisma/studentAnswer/batch.ts
+++ b/electron-src/lib/prisma/studentAnswer/batch.ts
@@ -8,6 +8,10 @@ import prisma from "../client"
 
 /**
  * 複数の答案の配置を一括で変更（採点情報の移行も対応）
+ *
+ * @param moves - 移動情報の配列（ファイルID、移動先生徒ID、ページ番号）
+ * @param withScoring - 採点情報も一緒に移行するかどうか
+ * @returns 成功/失敗結果
  */
 export async function batchUpdateStudentAnswerPlacements(
   moves: Array<{
@@ -126,6 +130,10 @@ export async function batchUpdateStudentAnswerPlacements(
 
 /**
  * 2つの答案の配置を交換（採点情報も一緒に入れ替え）
+ *
+ * @param answerSheetId1 - 交換する1つ目の答案ID
+ * @param answerSheetId2 - 交換する2つ目の答案ID
+ * @returns 成功時は更新後の答案情報、失敗時はエラー情報
  */
 export async function swapStudentAnswerPlacementsWithScoring(
   answerSheetId1: string,
@@ -166,9 +174,8 @@ export async function swapStudentAnswerPlacementsWithScoring(
         throw new Error("答案が見つかりません")
       }
 
-      // 両方の答案に関連する採点データを取得
       // TODO: QuestionScore queries need to be updated for new schema
-      const [questionScores1, questionScores2] = [[], []] // await Promise.all([
+      // await Promise.all([
       //   tx.questionScore.findMany({
       //     where: { studentId: answerSheet1.studentId },
       //   }),


### PR DESCRIPTION
## Summary

- 未使用の変数・インポートを削除
- useRefパターンを使用してuseEffect依存関係を適切に管理
- トップレベル関数にJSDocコメントを追加

## Test plan

- [x] `npm run lint` が警告なしで通過することを確認

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)