### PR TITLE
採点枠自動認識機能のシンプル化

### DIFF
--- a/components/projects/02-template/components/CropRegionEditor.tsx
+++ b/components/projects/02-template/components/CropRegionEditor.tsx
@@ -1,9 +1,13 @@
 "use client"
 
 import { CropRegionArea, CropRegionAreaType } from "@/types/common.types"
-import { useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
+import { useFrameDetection } from "../hooks/useFrameDetection"
+import { DetectedRect } from "../types"
 import CropRegionList from "./CropRegionList"
+import { DetectionModeToggle } from "./DetectionModeToggle"
+import { DetectionSettingsPanel } from "./DetectionSettingsPanel"
 import ImageCanvas from "./ImageCanvas"
 
 type CropRegionEditorProps = {
@@ -35,6 +39,52 @@ const CropRegionEditor = ({
 }: CropRegionEditorProps) => {
   const [selectedAreaIndex, setSelectedAreaIndex] = useState<number | null>(
     null
+  )
+  const [settingsCollapsed, setSettingsCollapsed] = useState(true)
+
+  // 検出機能フック
+  const {
+    detectedRects,
+    isDetecting,
+    detectionMode,
+    settings,
+    setDetectionMode,
+    updateSettings,
+    resetSettings,
+    detectAll,
+    detectAtPoint: _detectAtPoint, // 将来のクリック検出モードで使用予定
+    findSnappedRects,
+    clearDetectedRects,
+  } = useFrameDetection({ imageUrl: backgroundImageUrl })
+
+  // 画像が変更されたら検出結果をクリア
+  useEffect(() => {
+    clearDetectedRects()
+  }, [backgroundImageUrl, clearDetectedRects])
+
+  // 検出モードが変更されたら一括検出を実行
+  useEffect(() => {
+    if (detectionMode !== "manual" && backgroundImageUrl) {
+      detectAll()
+    }
+  }, [detectionMode, backgroundImageUrl, detectAll])
+
+  // 検出枠クリック時のハンドラ
+  const handleDetectedRectClick = useCallback(
+    async (rect: DetectedRect) => {
+      if (!projectPageId) return
+
+      // クリックした検出枠を採点領域として作成
+      if (onCreateRegion) {
+        await onCreateRegion("QUESTION_ANSWER", {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        })
+      }
+    },
+    [projectPageId, onCreateRegion]
   )
 
   const handleUpdateArea = async (
@@ -164,11 +214,40 @@ const CropRegionEditor = ({
           onDeleteArea={handleDeleteArea}
           disabled={disabled}
           projectPageId={projectPageId}
+          detectedRects={detectedRects}
+          detectionMode={detectionMode}
+          onDetectedRectClick={handleDetectedRectClick}
+          onSnapToDetectedRects={findSnappedRects}
         />
       </div>
 
       {/* Right Side - Region List with independent scroll */}
       <div className="bg-background relative w-80 flex-shrink-0 border-l">
+        {/* 検出モード切替と設定 */}
+        <div className="space-y-3 border-b p-3">
+          <DetectionModeToggle
+            mode={detectionMode}
+            onModeChange={setDetectionMode}
+            isDetecting={isDetecting}
+            onDetectAll={detectAll}
+            disabled={disabled}
+          />
+          {detectionMode !== "manual" && (
+            <DetectionSettingsPanel
+              settings={settings}
+              onSettingsChange={updateSettings}
+              onReset={resetSettings}
+              collapsed={settingsCollapsed}
+              onToggleCollapse={() => setSettingsCollapsed(!settingsCollapsed)}
+            />
+          )}
+          {detectedRects.length > 0 && (
+            <div className="text-xs text-gray-500">
+              検出枠: {detectedRects.length}個
+            </div>
+          )}
+        </div>
+
         <CropRegionList
           areas={areas}
           selectedAreaIndex={selectedAreaIndex}

--- a/components/projects/02-template/components/DetectedRectOverlay.tsx
+++ b/components/projects/02-template/components/DetectedRectOverlay.tsx
@@ -1,0 +1,105 @@
+/**
+ * 検出枠オーバーレイコンポーネント
+ * 検出された枠を青い破線で表示
+ */
+
+"use client"
+
+import { memo, useState, useCallback } from "react"
+import { DetectedRect, ImageDimensions } from "../types"
+import { OVERLAY_STYLES } from "../constants/detection"
+
+interface DetectedRectOverlayProps {
+  /** 検出された矩形 */
+  detectedRects: DetectedRect[]
+  /** 画像の寸法 */
+  imageDimensions: ImageDimensions | null
+  /** ズーム倍率 */
+  zoom: number
+  /** 表示/非表示 */
+  visible: boolean
+  /** クリックハンドラ */
+  onRectClick?: (rect: DetectedRect) => void
+}
+
+/**
+ * 検出枠オーバーレイコンポーネント
+ */
+export const DetectedRectOverlay = memo(function DetectedRectOverlay({
+  detectedRects,
+  imageDimensions,
+  zoom,
+  visible,
+  onRectClick,
+}: DetectedRectOverlayProps) {
+  const [hoveredRectId, setHoveredRectId] = useState<string | null>(null)
+
+  const handleMouseEnter = useCallback((rectId: string) => {
+    setHoveredRectId(rectId)
+  }, [])
+
+  const handleMouseLeave = useCallback(() => {
+    setHoveredRectId(null)
+  }, [])
+
+  const handleClick = useCallback(
+    (rect: DetectedRect) => {
+      if (onRectClick) {
+        onRectClick(rect)
+      }
+    },
+    [onRectClick]
+  )
+
+  if (!visible || !imageDimensions || detectedRects.length === 0) {
+    return null
+  }
+
+  const { width: imgWidth, height: imgHeight } = imageDimensions
+
+  return (
+    <div
+      className="pointer-events-none absolute top-0 left-0"
+      style={{
+        width: imgWidth * zoom,
+        height: imgHeight * zoom,
+      }}
+    >
+      {detectedRects.map((rect) => {
+        const isHovered = hoveredRectId === rect.id
+        const left = rect.x * imgWidth * zoom
+        const top = rect.y * imgHeight * zoom
+        const width = rect.width * imgWidth * zoom
+        const height = rect.height * imgHeight * zoom
+
+        return (
+          <div
+            key={rect.id}
+            className="pointer-events-auto absolute cursor-pointer transition-all duration-100"
+            style={{
+              left,
+              top,
+              width,
+              height,
+              border: `${isHovered ? OVERLAY_STYLES.strokeWidthHover : OVERLAY_STYLES.strokeWidth}px dashed ${isHovered ? OVERLAY_STYLES.strokeColorHover : OVERLAY_STYLES.strokeColor}`,
+              backgroundColor: isHovered
+                ? OVERLAY_STYLES.fillColorHover
+                : OVERLAY_STYLES.fillColor,
+              boxSizing: "border-box",
+            }}
+            onMouseEnter={() => handleMouseEnter(rect.id)}
+            onMouseLeave={handleMouseLeave}
+            onClick={() => handleClick(rect)}
+          >
+            {isHovered && (
+              <div className="absolute -top-6 left-0 rounded bg-blue-600 px-2 py-0.5 text-xs whitespace-nowrap text-white">
+                {Math.round(rect.width * 100)}% ×{" "}
+                {Math.round(rect.height * 100)}%
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+})

--- a/components/projects/02-template/components/DetectionModeToggle.tsx
+++ b/components/projects/02-template/components/DetectionModeToggle.tsx
@@ -1,0 +1,121 @@
+/**
+ * 検出モード切替コンポーネント
+ */
+
+"use client"
+
+import { memo } from "react"
+import { DetectionMode } from "../types"
+import {
+  DETECTION_MODE_LABELS,
+  DETECTION_MODE_DESCRIPTIONS,
+} from "../constants/detection"
+import { cn } from "@/lib/utils"
+
+interface DetectionModeToggleProps {
+  /** 現在のモード */
+  mode: DetectionMode
+  /** モード変更ハンドラ */
+  onModeChange: (mode: DetectionMode) => void
+  /** 検出中フラグ */
+  isDetecting?: boolean
+  /** 一括検出ハンドラ */
+  onDetectAll?: () => void
+  /** 無効化フラグ */
+  disabled?: boolean
+}
+
+const MODES: DetectionMode[] = ["manual", "auto"]
+
+/**
+ * 検出モード切替コンポーネント
+ */
+export const DetectionModeToggle = memo(function DetectionModeToggle({
+  mode,
+  onModeChange,
+  isDetecting = false,
+  onDetectAll,
+  disabled = false,
+}: DetectionModeToggleProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {/* モード切替ボタン */}
+      <div className="flex items-center gap-1">
+        <span className="mr-2 text-xs text-gray-500">検出:</span>
+        {MODES.map((m) => (
+          <button
+            key={m}
+            type="button"
+            className={cn(
+              "rounded px-2 py-1 text-xs transition-colors",
+              mode === m
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200",
+              disabled && "cursor-not-allowed opacity-50"
+            )}
+            onClick={() => onModeChange(m)}
+            disabled={disabled}
+            title={DETECTION_MODE_DESCRIPTIONS[m]}
+          >
+            {DETECTION_MODE_LABELS[m]}
+          </button>
+        ))}
+      </div>
+
+      {/* 一括検出ボタン（モードがmanual以外のとき表示） */}
+      {mode !== "manual" && onDetectAll && (
+        <button
+          type="button"
+          className={cn(
+            "flex items-center justify-center gap-1 rounded bg-blue-500 px-3 py-1.5 text-xs text-white transition-colors hover:bg-blue-600",
+            (disabled || isDetecting) && "cursor-not-allowed opacity-50"
+          )}
+          onClick={onDetectAll}
+          disabled={disabled || isDetecting}
+        >
+          {isDetecting ? (
+            <>
+              <svg
+                className="h-3 w-3 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              検出中...
+            </>
+          ) : (
+            <>
+              <svg
+                className="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              枠を一括検出
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  )
+})

--- a/components/projects/02-template/components/DetectionSettingsPanel.tsx
+++ b/components/projects/02-template/components/DetectionSettingsPanel.tsx
@@ -1,0 +1,131 @@
+/**
+ * 検出設定パネルコンポーネント（シンプル版）
+ */
+
+"use client"
+
+import { memo, useCallback } from "react"
+import { DetectionSettings } from "../types"
+
+interface DetectionSettingsPanelProps {
+  settings: DetectionSettings
+  onSettingsChange: (partial: Partial<DetectionSettings>) => void
+  onReset?: () => void
+  collapsed?: boolean
+  onToggleCollapse?: () => void
+}
+
+export const DetectionSettingsPanel = memo(function DetectionSettingsPanel({
+  settings,
+  onSettingsChange,
+  onReset,
+  collapsed = true,
+  onToggleCollapse,
+}: DetectionSettingsPanelProps) {
+  const handleChange = useCallback(
+    (key: keyof DetectionSettings, value: number) => {
+      onSettingsChange({ [key]: value })
+    },
+    [onSettingsChange]
+  )
+
+  return (
+    <div className="rounded border border-gray-200 bg-white">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-medium text-gray-700 hover:bg-gray-50"
+        onClick={onToggleCollapse}
+      >
+        <span>検出設定</span>
+        <svg
+          className={`h-4 w-4 transform transition-transform ${collapsed ? "" : "rotate-180"}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {!collapsed && (
+        <div className="space-y-3 border-t border-gray-200 px-3 py-2">
+          {/* 線の延長 */}
+          <div>
+            <label className="mb-1 flex items-center justify-between text-xs text-gray-600">
+              <span>線の延長</span>
+              <span className="font-mono">{settings.lineExtension}px</span>
+            </label>
+            <input
+              type="range"
+              min={0}
+              max={30}
+              step={1}
+              value={settings.lineExtension}
+              onChange={(e) =>
+                handleChange("lineExtension", parseInt(e.target.value))
+              }
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
+            />
+          </div>
+
+          {/* 最小幅 */}
+          <div>
+            <label className="mb-1 flex items-center justify-between text-xs text-gray-600">
+              <span>最小幅</span>
+              <span className="font-mono">
+                {Math.round(settings.minWidth * 100)}%
+              </span>
+            </label>
+            <input
+              type="range"
+              min={0.01}
+              max={0.3}
+              step={0.01}
+              value={settings.minWidth}
+              onChange={(e) =>
+                handleChange("minWidth", parseFloat(e.target.value))
+              }
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
+            />
+          </div>
+
+          {/* 最小高さ */}
+          <div>
+            <label className="mb-1 flex items-center justify-between text-xs text-gray-600">
+              <span>最小高さ</span>
+              <span className="font-mono">
+                {Math.round(settings.minHeight * 100)}%
+              </span>
+            </label>
+            <input
+              type="range"
+              min={0.01}
+              max={0.3}
+              step={0.01}
+              value={settings.minHeight}
+              onChange={(e) =>
+                handleChange("minHeight", parseFloat(e.target.value))
+              }
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
+            />
+          </div>
+
+          {onReset && (
+            <button
+              type="button"
+              className="w-full rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+              onClick={onReset}
+            >
+              デフォルトに戻す
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+})

--- a/components/projects/02-template/components/ImageCanvas.tsx
+++ b/components/projects/02-template/components/ImageCanvas.tsx
@@ -6,6 +6,7 @@
  * - Zoom and pan functionality
  * - Keyboard shortcuts for area management
  * - Area rendering and interaction
+ * - Auto-detection overlay for detected frames
  *
  * @param props - Configuration properties for the canvas
  * @returns JSX component for the image canvas
@@ -18,7 +19,9 @@ import { useMemo } from "react"
 import { useImageCanvasInteraction } from "../hooks/useImageCanvasInteraction"
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts"
 import { useZoomControls } from "../hooks/useZoomControls"
+import { DetectedRect, DetectionMode, DragSelectionResult } from "../types"
 import { AreaRenderer } from "./AreaRenderer"
+import { DetectedRectOverlay } from "./DetectedRectOverlay"
 import { DragPreview } from "./DragPreview"
 import { ZoomControls } from "./ZoomControls"
 
@@ -39,6 +42,16 @@ type ImageCanvasProps = {
   onDeleteArea: (index: number) => void
   disabled: boolean
   projectPageId: string | null
+  // 検出関連のプロパティ
+  detectedRects?: DetectedRect[]
+  detectionMode?: DetectionMode
+  onDetectedRectClick?: (rect: DetectedRect) => void
+  onSnapToDetectedRects?: (dragRect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }) => DragSelectionResult
 }
 
 const ImageCanvas = ({
@@ -52,6 +65,10 @@ const ImageCanvas = ({
   onDeleteArea,
   disabled,
   projectPageId,
+  detectedRects = [],
+  detectionMode = "manual",
+  onDetectedRectClick,
+  onSnapToDetectedRects,
 }: ImageCanvasProps) => {
   // Get zoom controls first
   const { zoom, showZoomHelp, setShowZoomHelp, imageContainerRef } =
@@ -74,6 +91,8 @@ const ImageCanvas = ({
     onUpdateArea,
     zoom,
     imageContainerRef: imageContainerRef as React.RefObject<HTMLDivElement>,
+    detectionMode,
+    onSnapToDetectedRects,
   })
 
   useKeyboardShortcuts(selectedAreaIndex, onDeleteArea)
@@ -117,6 +136,15 @@ const ImageCanvas = ({
           }}
           onMouseDown={handleMouseDown}
         >
+          {/* 検出枠オーバーレイ（確定済み領域より下に表示） */}
+          <DetectedRectOverlay
+            detectedRects={detectedRects}
+            imageDimensions={imageDimensions}
+            zoom={zoom}
+            visible={detectionMode !== "manual"}
+            onRectClick={onDetectedRectClick}
+          />
+
           <AreaRenderer
             areas={areas}
             selectedAreaIndex={selectedAreaIndex}

--- a/components/projects/02-template/constants/detection.ts
+++ b/components/projects/02-template/constants/detection.ts
@@ -1,0 +1,48 @@
+/**
+ * 採点枠自動認識機能の定数
+ */
+
+import { DetectionSettings, DetectionMode } from "../types"
+
+/**
+ * デフォルトの検出設定（シンプル版）
+ */
+export const DEFAULT_DETECTION_SETTINGS: DetectionSettings = {
+  lineExtension: 0, // 線の延長なし
+  minWidth: 0.02, // 画像幅の2%以上
+  minHeight: 0.01, // 画像高さの1%以上
+}
+
+/**
+ * デフォルトの検出モード
+ */
+export const DEFAULT_DETECTION_MODE: DetectionMode = "manual"
+
+/**
+ * 検出モードのラベル
+ */
+export const DETECTION_MODE_LABELS: Record<DetectionMode, string> = {
+  manual: "手動",
+  auto: "自動",
+}
+
+/**
+ * 検出モードの説明
+ */
+export const DETECTION_MODE_DESCRIPTIONS: Record<DetectionMode, string> = {
+  manual: "手動で領域を作成",
+  auto: "枠を自動検出してスナップ補正",
+}
+
+/**
+ * オーバーレイ表示のスタイル設定
+ */
+export const OVERLAY_STYLES = {
+  strokeColor: "rgba(59, 130, 246, 0.8)", // Tailwind blue-500
+  strokeColorHover: "rgba(37, 99, 235, 1)", // Tailwind blue-600
+  strokeWidth: 2,
+  strokeWidthHover: 3,
+  strokeDasharray: "5,5",
+  fillColor: "rgba(59, 130, 246, 0.1)",
+  fillColorHover: "rgba(59, 130, 246, 0.2)",
+} as const

--- a/components/projects/02-template/hooks/useFrameDetection.ts
+++ b/components/projects/02-template/hooks/useFrameDetection.ts
@@ -1,0 +1,177 @@
+/**
+ * 採点枠検出フック
+ */
+
+import { useCallback, useState, useRef } from "react"
+import {
+  DetectedRect,
+  DetectionSettings,
+  DetectionMode,
+  DragSelectionResult,
+} from "../types"
+import {
+  DEFAULT_DETECTION_SETTINGS,
+  DEFAULT_DETECTION_MODE,
+} from "../constants/detection"
+import { frameDetector } from "../utils/frameDetector"
+import {
+  findIntersectingRects,
+  findSmallestContainingRect,
+} from "../utils/rectUtils"
+
+interface UseFrameDetectionProps {
+  imageUrl: string | null
+}
+
+interface UseFrameDetectionReturn {
+  /** 検出された矩形 */
+  detectedRects: DetectedRect[]
+  /** 検出中フラグ */
+  isDetecting: boolean
+  /** 検出モード */
+  detectionMode: DetectionMode
+  /** 検出設定 */
+  settings: DetectionSettings
+  /** 検出モードを設定 */
+  setDetectionMode: (mode: DetectionMode) => void
+  /** 検出設定を更新 */
+  updateSettings: (partial: Partial<DetectionSettings>) => void
+  /** 設定をリセット */
+  resetSettings: () => void
+  /** 画像全体から一括検出 */
+  detectAll: () => Promise<void>
+  /** クリック位置の枠を検出 */
+  detectAtPoint: (x: number, y: number) => DetectedRect | null
+  /** ドラッグ後にスナップする矩形を取得 */
+  findSnappedRects: (dragRect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }) => DragSelectionResult
+  /** 検出結果をクリア */
+  clearDetectedRects: () => void
+}
+
+/**
+ * 採点枠検出フック
+ */
+export function useFrameDetection({
+  imageUrl,
+}: UseFrameDetectionProps): UseFrameDetectionReturn {
+  const [detectedRects, setDetectedRects] = useState<DetectedRect[]>([])
+  const [isDetecting, setIsDetecting] = useState(false)
+  const [detectionMode, setDetectionMode] = useState<DetectionMode>(
+    DEFAULT_DETECTION_MODE
+  )
+  const [settings, setSettings] = useState<DetectionSettings>(
+    DEFAULT_DETECTION_SETTINGS
+  )
+
+  // キャッシュ用（同じ画像・設定で再検出を防ぐ）
+  const cacheRef = useRef<{
+    imageUrl: string | null
+    settings: DetectionSettings
+    rects: DetectedRect[]
+  } | null>(null)
+
+  /**
+   * 検出設定を更新
+   */
+  const updateSettings = useCallback((partial: Partial<DetectionSettings>) => {
+    setSettings((prev) => ({ ...prev, ...partial }))
+    // キャッシュを無効化
+    cacheRef.current = null
+  }, [])
+
+  /**
+   * 設定をリセット
+   */
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_DETECTION_SETTINGS)
+    cacheRef.current = null
+  }, [])
+
+  /**
+   * 画像全体から一括検出
+   */
+  const detectAll = useCallback(async () => {
+    if (!imageUrl) return
+
+    // キャッシュチェック
+    if (
+      cacheRef.current &&
+      cacheRef.current.imageUrl === imageUrl &&
+      JSON.stringify(cacheRef.current.settings) === JSON.stringify(settings)
+    ) {
+      setDetectedRects(cacheRef.current.rects)
+      return
+    }
+
+    setIsDetecting(true)
+
+    try {
+      const rects = await frameDetector.detectFromUrl(imageUrl, settings)
+      setDetectedRects(rects)
+
+      // キャッシュを更新
+      cacheRef.current = {
+        imageUrl,
+        settings: { ...settings },
+        rects,
+      }
+    } catch (error) {
+      console.error("Frame detection failed:", error)
+      setDetectedRects([])
+    } finally {
+      setIsDetecting(false)
+    }
+  }, [imageUrl, settings])
+
+  /**
+   * クリック位置の枠を検出
+   */
+  const detectAtPoint = useCallback(
+    (x: number, y: number): DetectedRect | null => {
+      return findSmallestContainingRect(x, y, detectedRects)
+    },
+    [detectedRects]
+  )
+
+  /**
+   * ドラッグ後にスナップする矩形を取得
+   */
+  const findSnappedRects = useCallback(
+    (dragRect: {
+      x: number
+      y: number
+      width: number
+      height: number
+    }): DragSelectionResult => {
+      return findIntersectingRects(dragRect, detectedRects)
+    },
+    [detectedRects]
+  )
+
+  /**
+   * 検出結果をクリア
+   */
+  const clearDetectedRects = useCallback(() => {
+    setDetectedRects([])
+    cacheRef.current = null
+  }, [])
+
+  return {
+    detectedRects,
+    isDetecting,
+    detectionMode,
+    settings,
+    setDetectionMode,
+    updateSettings,
+    resetSettings,
+    detectAll,
+    detectAtPoint,
+    findSnappedRects,
+    clearDetectedRects,
+  }
+}

--- a/components/projects/02-template/hooks/useImageCanvasInteraction.ts
+++ b/components/projects/02-template/hooks/useImageCanvasInteraction.ts
@@ -33,6 +33,8 @@ export function useImageCanvasInteraction({
   onUpdateArea,
   zoom,
   imageContainerRef,
+  detectionMode = "manual",
+  onSnapToDetectedRects,
 }: UseImageCanvasInteractionProps & {
   imageContainerRef: React.RefObject<HTMLDivElement>
 }) {
@@ -75,6 +77,8 @@ export function useImageCanvasInteraction({
     setDragCurrentCoords,
     setResizing,
     setMoving,
+    detectionMode,
+    onSnapToDetectedRects,
   })
 
   // Event listeners setup

--- a/components/projects/02-template/hooks/useMouseHandlers.ts
+++ b/components/projects/02-template/hooks/useMouseHandlers.ts
@@ -3,6 +3,8 @@
  */
 
 import {
+  DetectionMode,
+  DragSelectionResult,
   DragState,
   MoveState,
   ResizeState,
@@ -35,6 +37,8 @@ export function useMouseHandlers({
   setDragCurrentCoords,
   setResizing,
   setMoving,
+  detectionMode = "manual",
+  onSnapToDetectedRects,
 }: {
   disabled: boolean
   backgroundImageUrl: string | null
@@ -71,6 +75,13 @@ export function useMouseHandlers({
   setDragCurrentCoords: (value: DragState | null) => void
   setResizing: (value: ResizeState | null) => void
   setMoving: (value: MoveState | null) => void
+  detectionMode?: DetectionMode
+  onSnapToDetectedRects?: (dragRect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }) => DragSelectionResult
 }) {
   const isCreatingRef = useRef(false) // 重複作成防止
 
@@ -281,12 +292,22 @@ export function useMouseHandlers({
 
       // Only create area if drag is large enough
       if (width > 0.01 && height > 0.01) {
-        onAddAreaByDrag("QUESTION_ANSWER", {
-          x: startX,
-          y: startY,
-          width,
-          height,
-        })
+        const dragRect = { x: startX, y: startY, width, height }
+
+        // 自動モードの場合は検出枠にスナップ
+        if (detectionMode === "auto" && onSnapToDetectedRects) {
+          const snapped = onSnapToDetectedRects(dragRect)
+          if (snapped.selectedRects.length > 0) {
+            // 検出枠にスナップした場合は、マージされた境界を使用
+            onAddAreaByDrag("QUESTION_ANSWER", snapped.mergedBounds)
+          } else {
+            // 検出枠にヒットしなかった場合は、元のドラッグ領域を使用
+            onAddAreaByDrag("QUESTION_ANSWER", dragRect)
+          }
+        } else {
+          // 手動モードの場合は通常通り
+          onAddAreaByDrag("QUESTION_ANSWER", dragRect)
+        }
       }
 
       // 即座にフラグをリセット（setTimeoutは不要）
@@ -310,6 +331,8 @@ export function useMouseHandlers({
     setDragging,
     setMoving,
     setResizing,
+    detectionMode,
+    onSnapToDetectedRects,
   ])
 
   return {

--- a/components/projects/02-template/hooks/useTemplateData.ts
+++ b/components/projects/02-template/hooks/useTemplateData.ts
@@ -108,13 +108,9 @@ export function useTemplateData(projectId: string | undefined) {
       ) {
         // projectPagesからmaster imagesを抽出してソート
         const masterImages = fetchedProject.projectPages
-          .filter((page) =>
-            page.pageImages?.some((img) => img.imageType === "MODEL_ANSWER")
-          )
+          .filter((page) => page.masterImages && page.masterImages.length > 0)
           .map((page) => {
-            const masterImage = page.pageImages?.find(
-              (img) => img.imageType === "MODEL_ANSWER"
-            )
+            const masterImage = page.masterImages?.[0]
             return {
               id: page.id,
               projectId: page.projectId,

--- a/components/projects/02-template/types/index.ts
+++ b/components/projects/02-template/types/index.ts
@@ -197,4 +197,68 @@ export interface UseImageCanvasInteractionProps {
     coords: { x: number; y: number; width: number; height: number }
   ) => void
   zoom: number
+  // 検出関連のプロパティ（オプション）
+  detectionMode?: DetectionMode
+  onSnapToDetectedRects?: (dragRect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }) => DragSelectionResult
+}
+
+// ============================================================================
+// Frame Detection Types (採点枠自動認識)
+// ============================================================================
+
+/**
+ * 検出された長方形
+ */
+export interface DetectedRect {
+  /** 一意識別子（UUID） */
+  id: string
+  /** X座標（相対座標 0-1） */
+  x: number
+  /** Y座標（相対座標 0-1） */
+  y: number
+  /** 幅（相対座標 0-1） */
+  width: number
+  /** 高さ（相対座標 0-1） */
+  height: number
+  /** 検出信頼度 0-1 */
+  confidence: number
+}
+
+/**
+ * 検出設定（シンプル版）
+ */
+export interface DetectionSettings {
+  /** 線の延長ピクセル デフォルト: 0 */
+  lineExtension: number
+  /** 最小幅（相対座標）デフォルト: 0.02 */
+  minWidth: number
+  /** 最小高さ（相対座標）デフォルト: 0.01 */
+  minHeight: number
+}
+
+/**
+ * 検出モード
+ * - manual: 手動
+ * - auto: 自動（オーバーレイ表示 + スナップ補正）
+ */
+export type DetectionMode = "manual" | "auto"
+
+/**
+ * ドラッグ選択結果
+ */
+export interface DragSelectionResult {
+  /** 選択された検出枠 */
+  selectedRects: DetectedRect[]
+  /** マージされた境界 */
+  mergedBounds: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
 }

--- a/components/projects/02-template/utils/frameDetector.ts
+++ b/components/projects/02-template/utils/frameDetector.ts
@@ -1,0 +1,532 @@
+/**
+ * 採点枠検出アルゴリズム
+ *
+ * 印刷された答案用紙の枠線（黒い罫線）を自動検出し、
+ * 採点領域として使用可能な矩形座標を返す。
+ *
+ * ## 処理フロー
+ *
+ * 1. **前処理**: グレースケール変換 → Sobelエッジ検出 → 二値化
+ *    - RGB画像を輝度値に変換し、エッジ（輪郭）を強調
+ *    - 閾値128で二値化し、線分を抽出
+ *
+ * 2. **線検出**: 水平線・垂直線を走査して検出
+ *    - 連続する白ピクセル（エッジ）を線分として認識
+ *    - 最小長（画像サイズの2%）未満の線は除外
+ *    - 近接する線分（3px以内）をマージして1本に統合
+ *
+ * 3. **線延長**: ユーザー指定のピクセル分だけ線を延長
+ *    - 途切れた枠線を補完し、閉じた矩形を形成しやすくする
+ *
+ * 4. **矩形構築**: 4本の線（上下左右）の交点から矩形を生成
+ *    - 水平線ペア × 垂直線ペアの組み合わせを全探索
+ *    - 4つの交点が成立する場合のみ矩形として採用
+ *
+ * 5. **フィルタリング**:
+ *    - 最小幅・最小高さ未満の矩形を除外
+ *    - 重複する矩形のうち、内包関係にある大きい方を除外
+ *      （例: 「日」のような入れ子構造で外枠を除去）
+ *
+ * ## 座標系
+ * - 入力: ピクセル座標（画像サイズ依存）
+ * - 出力: 相対座標（0-1、画像サイズ非依存）
+ */
+
+import { DetectedRect, DetectionSettings } from "../types"
+import { generateId } from "./rectUtils"
+
+/** 水平線 */
+type HLine = { y: number; x1: number; x2: number }
+
+/** 垂直線 */
+type VLine = { x: number; y1: number; y2: number }
+
+/** ピクセル座標の矩形 */
+type PixelRect = { x: number; y: number; width: number; height: number }
+
+/** 線マージの許容ピクセル */
+const LINE_MERGE_TOLERANCE = 3
+
+/** 交点判定の許容ピクセル */
+const INTERSECTION_TOLERANCE = 5
+
+/** 重複判定の許容ピクセル */
+const DUPLICATE_TOLERANCE = 5
+
+/** 最小線長（画像サイズの2%） */
+const MIN_LINE_LENGTH_RATIO = 0.02
+
+/** 二値化の閾値 */
+const BINARIZE_THRESHOLD = 128
+
+/**
+ * 枠検出クラス
+ */
+export class FrameDetector {
+  private imageData: ImageData | null = null
+  private width = 0
+  private height = 0
+  private settings: DetectionSettings | null = null
+
+  /**
+   * 画像URLから検出を実行
+   */
+  async detectFromUrl(
+    imageUrl: string,
+    settings: DetectionSettings
+  ): Promise<DetectedRect[]> {
+    const canvas = await this.loadImageToCanvas(imageUrl)
+    return this.detect(canvas, settings)
+  }
+
+  /**
+   * 画像をCanvasにロード
+   */
+  private async loadImageToCanvas(
+    imageUrl: string
+  ): Promise<HTMLCanvasElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image()
+      img.crossOrigin = "anonymous"
+      img.onload = () => {
+        const canvas = document.createElement("canvas")
+        canvas.width = img.width
+        canvas.height = img.height
+        const ctx = canvas.getContext("2d")
+        if (!ctx) {
+          reject(new Error("Failed to get canvas context"))
+          return
+        }
+        ctx.drawImage(img, 0, 0)
+        resolve(canvas)
+      }
+      img.onerror = () => reject(new Error("Failed to load image"))
+      img.src = imageUrl
+    })
+  }
+
+  /**
+   * Canvasから枠を検出
+   *
+   * @param canvas - 画像が描画されたCanvas要素
+   * @param settings - 検出設定（線延長、最小幅、最小高さ）
+   * @returns 検出された矩形の配列（相対座標0-1）
+   */
+  detect(
+    canvas: HTMLCanvasElement,
+    settings: DetectionSettings
+  ): DetectedRect[] {
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return []
+
+    this.width = canvas.width
+    this.height = canvas.height
+    this.settings = settings
+    this.imageData = ctx.getImageData(0, 0, this.width, this.height)
+
+    // Step 1: グレースケール変換
+    // RGB値を輝度値に変換（ITU-R BT.709準拠）
+    const gray = this.toGrayscale()
+
+    // Step 2: エッジ検出（Sobel）
+    // 輝度の急激な変化（=線の境界）を検出
+    const edges = this.detectEdges(gray)
+
+    // Step 3: 二値化
+    // エッジ強度を閾値で白黒に分離
+    const binary = this.binarize(edges, BINARIZE_THRESHOLD)
+
+    // Step 4: 線検出 → 延長 → 矩形構築
+    // 水平・垂直線を検出し、4線の交点から矩形を生成
+    const rects = this.findRectangles(binary)
+
+    // Step 5: フィルタリング
+    // サイズ制約と重複除去を適用
+    return this.filterRects(rects, settings)
+  }
+
+  /**
+   * グレースケール変換
+   * ITU-R BT.709の輝度係数を使用: Y = 0.2126R + 0.7152G + 0.0722B
+   */
+  private toGrayscale(): Uint8ClampedArray {
+    const gray = new Uint8ClampedArray(this.width * this.height)
+    const data = this.imageData!.data
+
+    for (let i = 0; i < gray.length; i++) {
+      const idx = i * 4
+      gray[i] = Math.round(
+        data[idx] * 0.2126 + data[idx + 1] * 0.7152 + data[idx + 2] * 0.0722
+      )
+    }
+    return gray
+  }
+
+  /**
+   * Sobelフィルタによるエッジ検出
+   * 3x3カーネルで水平・垂直方向の勾配を計算し、勾配強度を出力
+   * 黒い線の両端（白→黒、黒→白の境界）が白く検出される
+   */
+  private detectEdges(gray: Uint8ClampedArray): Uint8ClampedArray {
+    const edges = new Uint8ClampedArray(this.width * this.height)
+    const w = this.width
+    const h = this.height
+
+    for (let y = 1; y < h - 1; y++) {
+      for (let x = 1; x < w - 1; x++) {
+        const idx = y * w + x
+
+        const tl = gray[(y - 1) * w + (x - 1)]
+        const t = gray[(y - 1) * w + x]
+        const tr = gray[(y - 1) * w + (x + 1)]
+        const l = gray[y * w + (x - 1)]
+        const r = gray[y * w + (x + 1)]
+        const bl = gray[(y + 1) * w + (x - 1)]
+        const b = gray[(y + 1) * w + x]
+        const br = gray[(y + 1) * w + (x + 1)]
+
+        const gx = -tl + tr - 2 * l + 2 * r - bl + br
+        const gy = -tl - 2 * t - tr + bl + 2 * b + br
+        const magnitude = Math.sqrt(gx * gx + gy * gy)
+        edges[idx] = Math.min(255, magnitude)
+      }
+    }
+
+    return edges
+  }
+
+  /**
+   * 二値化
+   */
+  private binarize(
+    edges: Uint8ClampedArray,
+    threshold: number
+  ): Uint8ClampedArray {
+    const binary = new Uint8ClampedArray(edges.length)
+    for (let i = 0; i < edges.length; i++) {
+      binary[i] = edges[i] > threshold ? 255 : 0
+    }
+    return binary
+  }
+
+  /**
+   * 矩形を検出
+   * 水平線・垂直線を検出し、ユーザー指定分延長した後、
+   * 4線が交差する組み合わせを矩形として出力
+   */
+  private findRectangles(binary: Uint8ClampedArray): DetectedRect[] {
+    const w = this.width
+    const h = this.height
+    const rects: DetectedRect[] = []
+
+    // 水平線と垂直線を検出
+    let horizontalLines = this.detectHorizontalLines(binary)
+    let verticalLines = this.detectVerticalLines(binary)
+
+    // 線を延長（設定されている場合）
+    const extension = this.settings?.lineExtension ?? 0
+    if (extension > 0) {
+      horizontalLines = horizontalLines.map((line) => ({
+        y: line.y,
+        x1: Math.max(0, line.x1 - extension),
+        x2: Math.min(w - 1, line.x2 + extension),
+      }))
+      verticalLines = verticalLines.map((line) => ({
+        x: line.x,
+        y1: Math.max(0, line.y1 - extension),
+        y2: Math.min(h - 1, line.y2 + extension),
+      }))
+    }
+
+    // 線の交点から矩形を構築
+    const candidateRects = this.buildRectsFromLines(
+      horizontalLines,
+      verticalLines
+    )
+
+    for (const rect of candidateRects) {
+      const normalizedRect: DetectedRect = {
+        id: generateId(),
+        x: rect.x / w,
+        y: rect.y / h,
+        width: rect.width / w,
+        height: rect.height / h,
+        confidence: 1,
+      }
+      rects.push(normalizedRect)
+    }
+
+    return rects
+  }
+
+  /**
+   * 水平線を検出
+   */
+  private detectHorizontalLines(binary: Uint8ClampedArray): HLine[] {
+    const lines: HLine[] = []
+    const w = this.width
+    const h = this.height
+    const minLength = Math.floor(w * MIN_LINE_LENGTH_RATIO)
+
+    for (let y = 0; y < h; y++) {
+      let lineStart = -1
+      for (let x = 0; x < w; x++) {
+        const idx = y * w + x
+        if (binary[idx] === 255) {
+          if (lineStart === -1) lineStart = x
+        } else {
+          if (lineStart !== -1 && x - lineStart >= minLength) {
+            lines.push({ y, x1: lineStart, x2: x - 1 })
+          }
+          lineStart = -1
+        }
+      }
+      if (lineStart !== -1 && w - lineStart >= minLength) {
+        lines.push({ y, x1: lineStart, x2: w - 1 })
+      }
+    }
+
+    return this.mergeLines(lines, "horizontal")
+  }
+
+  /**
+   * 垂直線を検出
+   */
+  private detectVerticalLines(binary: Uint8ClampedArray): VLine[] {
+    const lines: VLine[] = []
+    const w = this.width
+    const h = this.height
+    const minLength = Math.floor(h * MIN_LINE_LENGTH_RATIO)
+
+    for (let x = 0; x < w; x++) {
+      let lineStart = -1
+      for (let y = 0; y < h; y++) {
+        const idx = y * w + x
+        if (binary[idx] === 255) {
+          if (lineStart === -1) lineStart = y
+        } else {
+          if (lineStart !== -1 && y - lineStart >= minLength) {
+            lines.push({ x, y1: lineStart, y2: y - 1 })
+          }
+          lineStart = -1
+        }
+      }
+      if (lineStart !== -1 && h - lineStart >= minLength) {
+        lines.push({ x, y1: lineStart, y2: h - 1 })
+      }
+    }
+
+    return this.mergeLines(lines, "vertical")
+  }
+
+  /**
+   * 近接する線をマージ
+   */
+  private mergeLines<T extends HLine | VLine>(
+    lines: T[],
+    direction: "horizontal" | "vertical"
+  ): T[] {
+    if (lines.length === 0) return []
+
+    const merged: T[] = []
+
+    if (direction === "horizontal") {
+      const hLines = lines as HLine[]
+      hLines.sort((a, b) => a.y - b.y || a.x1 - b.x1)
+
+      for (const line of hLines) {
+        const last = merged[merged.length - 1] as HLine | undefined
+        if (
+          last &&
+          Math.abs(last.y - line.y) <= LINE_MERGE_TOLERANCE &&
+          line.x1 <= last.x2 + LINE_MERGE_TOLERANCE
+        ) {
+          last.x2 = Math.max(last.x2, line.x2)
+        } else {
+          merged.push({ ...line } as T)
+        }
+      }
+    } else {
+      const vLines = lines as VLine[]
+      vLines.sort((a, b) => a.x - b.x || a.y1 - b.y1)
+
+      for (const line of vLines) {
+        const last = merged[merged.length - 1] as VLine | undefined
+        if (
+          last &&
+          Math.abs(last.x - line.x) <= LINE_MERGE_TOLERANCE &&
+          line.y1 <= last.y2 + LINE_MERGE_TOLERANCE
+        ) {
+          last.y2 = Math.max(last.y2, line.y2)
+        } else {
+          merged.push({ ...line } as T)
+        }
+      }
+    }
+
+    return merged
+  }
+
+  /**
+   * 水平線と垂直線から矩形を構築
+   */
+  private buildRectsFromLines(hLines: HLine[], vLines: VLine[]): PixelRect[] {
+    const rects: PixelRect[] = []
+
+    for (let i = 0; i < hLines.length; i++) {
+      for (let j = i + 1; j < hLines.length; j++) {
+        const top = hLines[i]
+        const bottom = hLines[j]
+
+        // 上下の線がオーバーラップしているか
+        const overlapX1 = Math.max(top.x1, bottom.x1)
+        const overlapX2 = Math.min(top.x2, bottom.x2)
+        if (overlapX2 - overlapX1 < 10) continue
+
+        for (let k = 0; k < vLines.length; k++) {
+          for (let l = k + 1; l < vLines.length; l++) {
+            const left = vLines[k]
+            const right = vLines[l]
+
+            // 4つの線が交差するか
+            if (
+              this.linesIntersect(top, left) &&
+              this.linesIntersect(top, right) &&
+              this.linesIntersect(bottom, left) &&
+              this.linesIntersect(bottom, right)
+            ) {
+              const x = left.x
+              const y = top.y
+              const width = right.x - left.x
+              const height = bottom.y - top.y
+
+              if (width > 10 && height > 10) {
+                rects.push({ x, y, width, height })
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return this.deduplicateRects(rects)
+  }
+
+  /**
+   * 水平線と垂直線が交わるか判定
+   */
+  private linesIntersect(hLine: HLine, vLine: VLine): boolean {
+    return (
+      vLine.x >= hLine.x1 - INTERSECTION_TOLERANCE &&
+      vLine.x <= hLine.x2 + INTERSECTION_TOLERANCE &&
+      hLine.y >= vLine.y1 - INTERSECTION_TOLERANCE &&
+      hLine.y <= vLine.y2 + INTERSECTION_TOLERANCE
+    )
+  }
+
+  /**
+   * 重複する矩形を除去
+   */
+  private deduplicateRects(rects: PixelRect[]): PixelRect[] {
+    const unique: PixelRect[] = []
+
+    for (const rect of rects) {
+      const isDuplicate = unique.some(
+        (r) =>
+          Math.abs(r.x - rect.x) <= DUPLICATE_TOLERANCE &&
+          Math.abs(r.y - rect.y) <= DUPLICATE_TOLERANCE &&
+          Math.abs(r.width - rect.width) <= DUPLICATE_TOLERANCE &&
+          Math.abs(r.height - rect.height) <= DUPLICATE_TOLERANCE
+      )
+      if (!isDuplicate) {
+        unique.push(rect)
+      }
+    }
+
+    return unique
+  }
+
+  /**
+   * サイズでフィルタリング
+   */
+  private filterRects(
+    rects: DetectedRect[],
+    settings: DetectionSettings
+  ): DetectedRect[] {
+    // 1. 最小サイズでフィルタ
+    let filtered = rects.filter((rect) => {
+      return (
+        rect.width >= settings.minWidth && rect.height >= settings.minHeight
+      )
+    })
+
+    // 2. 重なっている場合、大きい方を除外
+    filtered = this.removeOverlappingLarger(filtered)
+
+    return filtered
+  }
+
+  /**
+   * 重なっている矩形のうち、内包関係にある大きい方を除外
+   *
+   * ロジック:
+   * - 2つの矩形A, B（A < B）が重なっている場合
+   * - Aのはみ出し部分 = A の面積 - 共通部分の面積
+   * - はみ出し部分 < 共通部分 なら、AはほぼBに含まれているとみなしBを除外
+   *
+   * 例: 「日」のような入れ子構造
+   * - 内側の2つの矩形と外側の大枠が検出される
+   * - 内側の矩形は外側にほぼ含まれるため、外側が除外される
+   */
+  private removeOverlappingLarger(rects: DetectedRect[]): DetectedRect[] {
+    const toRemove = new Set<string>()
+
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        const a = rects[i]
+        const b = rects[j]
+
+        const intersection = this.getIntersectionArea(a, b)
+        if (intersection > 0) {
+          const areaA = a.width * a.height
+          const areaB = b.width * b.height
+
+          // 小さい方の面積と大きい方の矩形を特定
+          const smallerArea = Math.min(areaA, areaB)
+          const larger = areaA < areaB ? b : a
+
+          // 小さい方のはみ出し部分 = 小さい方の面積 - 共通部分
+          const smallerNonOverlap = smallerArea - intersection
+
+          // はみ出し < 共通部分 なら、大きい方を除外
+          if (smallerNonOverlap < intersection) {
+            toRemove.add(larger.id)
+          }
+        }
+      }
+    }
+
+    return rects.filter((rect) => !toRemove.has(rect.id))
+  }
+
+  /**
+   * 2つの矩形の共通部分の面積を計算
+   */
+  private getIntersectionArea(a: DetectedRect, b: DetectedRect): number {
+    const x1 = Math.max(a.x, b.x)
+    const y1 = Math.max(a.y, b.y)
+    const x2 = Math.min(a.x + a.width, b.x + b.width)
+    const y2 = Math.min(a.y + a.height, b.y + b.height)
+
+    if (x2 <= x1 || y2 <= y1) {
+      return 0
+    }
+
+    return (x2 - x1) * (y2 - y1)
+  }
+}
+
+/**
+ * シングルトンインスタンス
+ */
+export const frameDetector = new FrameDetector()

--- a/components/projects/02-template/utils/rectUtils.ts
+++ b/components/projects/02-template/utils/rectUtils.ts
@@ -1,0 +1,196 @@
+/**
+ * 長方形計算ユーティリティ
+ */
+
+import { DetectedRect, DragSelectionResult } from "../types"
+
+/**
+ * 矩形座標のインターフェース
+ */
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * 2つの矩形が交差しているか判定
+ */
+export function hasIntersection(rect1: Rect, rect2: Rect): boolean {
+  return !(
+    rect1.x + rect1.width <= rect2.x ||
+    rect2.x + rect2.width <= rect1.x ||
+    rect1.y + rect1.height <= rect2.y ||
+    rect2.y + rect2.height <= rect1.y
+  )
+}
+
+/**
+ * 点が矩形内に含まれるか判定
+ */
+export function containsPoint(rect: Rect, x: number, y: number): boolean {
+  return (
+    x >= rect.x &&
+    x <= rect.x + rect.width &&
+    y >= rect.y &&
+    y <= rect.y + rect.height
+  )
+}
+
+/**
+ * 複数の矩形の外接矩形を計算
+ */
+export function getBoundingRect(rects: Rect[]): Rect | null {
+  if (rects.length === 0) return null
+
+  const minX = Math.min(...rects.map((r) => r.x))
+  const minY = Math.min(...rects.map((r) => r.y))
+  const maxX = Math.max(...rects.map((r) => r.x + r.width))
+  const maxY = Math.max(...rects.map((r) => r.y + r.height))
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}
+
+/**
+ * ドラッグ領域と交差する検出枠を取得し、マージされた領域を返す
+ */
+export function findIntersectingRects(
+  dragRect: Rect,
+  detectedRects: DetectedRect[]
+): DragSelectionResult {
+  const intersecting = detectedRects.filter((rect) =>
+    hasIntersection(dragRect, rect)
+  )
+
+  if (intersecting.length === 0) {
+    return {
+      selectedRects: [],
+      mergedBounds: dragRect,
+    }
+  }
+
+  const boundingRect = getBoundingRect(intersecting)!
+
+  return {
+    selectedRects: intersecting,
+    mergedBounds: boundingRect,
+  }
+}
+
+/**
+ * 点を含む最小の矩形を取得（入れ子対応）
+ */
+export function findSmallestContainingRect(
+  x: number,
+  y: number,
+  rects: DetectedRect[]
+): DetectedRect | null {
+  const containing = rects.filter((rect) => containsPoint(rect, x, y))
+
+  if (containing.length === 0) return null
+
+  // 面積が最小の矩形を返す
+  return containing.reduce((smallest, rect) => {
+    const smallestArea = smallest.width * smallest.height
+    const rectArea = rect.width * rect.height
+    return rectArea < smallestArea ? rect : smallest
+  })
+}
+
+/**
+ * 入れ子の矩形を除外（最外周と最内周を除外）
+ */
+export function removeNestedRects(
+  rects: DetectedRect[],
+  minAreaRatio: number = 0.0005,
+  maxAreaRatio: number = 0.9
+): DetectedRect[] {
+  return rects.filter((rect) => {
+    const area = rect.width * rect.height
+    return area >= minAreaRatio && area <= maxAreaRatio
+  })
+}
+
+/**
+ * 矩形Aが矩形Bを含むかどうか判定
+ */
+export function containsRect(outer: Rect, inner: Rect): boolean {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.width <= outer.x + outer.width &&
+    inner.y + inner.height <= outer.y + outer.height
+  )
+}
+
+/**
+ * 入れ子の外側矩形を除外（内側優先）
+ * 「日」のような構造で、内側の矩形が存在する場合は外側を除外
+ */
+export function removeOuterNestedRects(rects: DetectedRect[]): DetectedRect[] {
+  const toRemove = new Set<string>()
+
+  for (let i = 0; i < rects.length; i++) {
+    for (let j = 0; j < rects.length; j++) {
+      if (i === j) continue
+
+      const outer = rects[i]
+      const inner = rects[j]
+
+      // outer が inner を含んでいる場合、outer を除外対象にする
+      if (containsRect(outer, inner)) {
+        // ただし、ほぼ同じサイズの場合は除外しない（重複検出対策）
+        const outerArea = outer.width * outer.height
+        const innerArea = inner.width * inner.height
+        if (innerArea / outerArea < 0.95) {
+          toRemove.add(outer.id)
+        }
+      }
+    }
+  }
+
+  return rects.filter((rect) => !toRemove.has(rect.id))
+}
+
+/**
+ * 矩形がサイズ制限内かどうかを判定
+ */
+export function isWithinSizeLimits(
+  rect: Rect,
+  minWidth: number,
+  maxWidth: number,
+  minHeight: number,
+  maxHeight: number
+): boolean {
+  return (
+    rect.width >= minWidth &&
+    rect.width <= maxWidth &&
+    rect.height >= minHeight &&
+    rect.height <= maxHeight
+  )
+}
+
+/**
+ * 矩形が画像端からのマージン内にあるかどうかを判定
+ */
+export function isWithinMargin(rect: Rect, margin: number): boolean {
+  return (
+    rect.x > margin &&
+    rect.y > margin &&
+    rect.x + rect.width < 1 - margin &&
+    rect.y + rect.height < 1 - margin
+  )
+}
+
+/**
+ * UUIDを生成
+ */
+export function generateId(): string {
+  return crypto.randomUUID()
+}


### PR DESCRIPTION
## Summary
- 採点領域作成ページに枠線自動認識機能を追加
- 設定を3項目（線延長、最小幅、最小高さ）に簡略化
- Canvas APIベースの軽量な検出アルゴリズムを実装

## 変更内容
- 新規: frameDetector.ts（検出エンジン）
- 新規: DetectionSettingsPanel.tsx（設定UI）
- 新規: DetectionModeToggle.tsx（モード切替）
- 新規: DetectedRectOverlay.tsx（検出枠表示）
- 変更: useMouseHandlers.ts（スナップ処理統合）

## Test plan
- [ ] 手動モードで従来通りの領域作成が可能
- [ ] 自動モードで検出枠へのスナップが動作
- [ ] 線延長スライダーで途切れた枠が認識される
- [ ] 最小サイズ設定で小さい枠がフィルタされる
- [ ] 入れ子構造（「日」形）で外枠が除去される

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)