### PR TITLE
fix: 小計点グループ選択の新規作成ボタンを同一ウィンドウ遷移に変更

### DIFF
--- a/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
+++ b/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
@@ -12,7 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { Calculator, Plus, Search, Trash2, ExternalLink } from "lucide-react"
+import { Calculator, Plus, Search, Trash2 } from "lucide-react"
 import Link from "next/link"
 import type { SubtotalGroup } from "@/components/subtotal-groups/types/subtotalGroupTypes"
 import LoadingSpinner from "@/components/common/LoadingSpinner"
@@ -177,14 +177,13 @@ export function SubtotalGroupSelector({
               <span className="font-medium text-green-800">
                 新しいグループを作成
               </span>
-              <Link href="/subtotal-groups" target="_blank">
+              <Link href="/subtotal-groups">
                 <Button
                   size="sm"
                   className="bg-green-600 text-white hover:bg-green-700"
                 >
                   <Plus className="mr-1 h-4 w-4" />
                   新規作成
-                  <ExternalLink className="ml-1 h-4 w-4" />
                 </Button>
               </Link>
             </div>


### PR DESCRIPTION
## 概要
小計点グループ選択ダイアログの「新規作成」ボタンを、新規ウィンドウではなく同一ウィンドウでのページ遷移に変更。

Closes #261

## 変更内容
- `target="_blank"`属性を削除
- ExternalLinkアイコンを削除
- 未使用のExternalLinkインポートを削除

## 対象ファイル
- `components/projects/04-question-group/components/SubtotalGroupSelector.tsx`

## テスト方法
1. プロジェクトの小計点グループ設定画面を開く
2. 「小計点グループを選択」ダイアログを表示
3. 「新規作成」ボタンをクリック
4. 同一ウィンドウで `/subtotal-groups` ページに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)