### PR TITLE
fix: 部分点確定モーダルのボタンとショートカットキーが動作しない問題を修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/PartialScoreModal.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/PartialScoreModal.tsx
@@ -9,6 +9,24 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { useCallback } from "react"
+
+/** キーバインディングの型 */
+interface KeyBindings {
+  partialKey?: string
+  pendingKey?: string
+  cancelKey?: string
+}
+
+/** キー表示を整形する */
+function formatKeyDisplay(key: string | undefined): string {
+  if (!key) return ""
+  // 小文字キーは大文字に変換して表示
+  if (key.length === 1) {
+    return key.toUpperCase()
+  }
+  return key
+}
 
 interface PartialScoreModalProps {
   isOpen: boolean
@@ -17,6 +35,9 @@ interface PartialScoreModalProps {
   questionLabel: string
   onClose: () => void
   onChange?: (value: string) => void
+  onConfirmPartial?: () => void
+  onConfirmPending?: () => void
+  keyBindings?: KeyBindings
 }
 
 export default function PartialScoreModal({
@@ -26,7 +47,50 @@ export default function PartialScoreModal({
   questionLabel,
   onClose,
   onChange,
+  onConfirmPartial,
+  onConfirmPending,
+  keyBindings,
 }: PartialScoreModalProps) {
+  // デフォルト値を設定
+  const partialKey = keyBindings?.partialKey || "f"
+  const pendingKey = keyBindings?.pendingKey || "j"
+  const cancelKey = keyBindings?.cancelKey || "Escape"
+
+  const partialKeyDisplay = formatKeyDisplay(partialKey)
+  const pendingKeyDisplay = formatKeyDisplay(pendingKey)
+  const cancelKeyDisplay = formatKeyDisplay(cancelKey)
+
+  /** Input内でのキーボードハンドラー */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const key = e.key.toLowerCase()
+
+      // 部分点確定キー
+      if (key === partialKey.toLowerCase()) {
+        e.preventDefault()
+        e.stopPropagation()
+        onConfirmPartial?.()
+        return
+      }
+
+      // 保留確定キー
+      if (key === pendingKey.toLowerCase()) {
+        e.preventDefault()
+        e.stopPropagation()
+        onConfirmPending?.()
+        return
+      }
+
+      // キャンセルキー
+      if (e.key === cancelKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+        return
+      }
+    },
+    [partialKey, pendingKey, cancelKey, onConfirmPartial, onConfirmPending, onClose]
+  )
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
@@ -51,6 +115,7 @@ export default function PartialScoreModal({
                   onChange(e.target.value)
                 }
               }}
+              onKeyDown={handleKeyDown}
               autoFocus
             />
             {value.endsWith(".") && (
@@ -77,15 +142,21 @@ export default function PartialScoreModal({
                 削除
               </div>
               <div>
-                <kbd className="rounded border bg-white px-2 py-1">F</kbd>{" "}
+                <kbd className="rounded border bg-white px-2 py-1">
+                  {partialKeyDisplay}
+                </kbd>{" "}
                 部分点で確定
               </div>
               <div>
-                <kbd className="rounded border bg-white px-2 py-1">J</kbd>{" "}
+                <kbd className="rounded border bg-white px-2 py-1">
+                  {pendingKeyDisplay}
+                </kbd>{" "}
                 保留で確定
               </div>
               <div>
-                <kbd className="rounded border bg-white px-2 py-1">Escape</kbd>{" "}
+                <kbd className="rounded border bg-white px-2 py-1">
+                  {cancelKeyDisplay}
+                </kbd>{" "}
                 キャンセル
               </div>
             </div>
@@ -100,31 +171,23 @@ export default function PartialScoreModal({
               variant="default"
               className="bg-yellow-600 hover:bg-yellow-700"
               onClick={() => {
-                // F キーのエミュレート - 実際の処理はキーボードハンドラーで
-                const event = new KeyboardEvent("keydown", {
-                  key: "f",
-                  code: "KeyF",
-                  bubbles: true,
-                })
-                document.dispatchEvent(event)
+                if (onConfirmPartial) {
+                  onConfirmPartial()
+                }
               }}
             >
-              部分点で確定 (F)
+              部分点で確定 ({partialKeyDisplay})
             </Button>
             <Button
               variant="default"
               className="bg-blue-600 hover:bg-blue-700"
               onClick={() => {
-                // J キーのエミュレート
-                const event = new KeyboardEvent("keydown", {
-                  key: "j",
-                  code: "KeyJ",
-                  bubbles: true,
-                })
-                document.dispatchEvent(event)
+                if (onConfirmPending) {
+                  onConfirmPending()
+                }
               }}
             >
-              保留で確定 (J)
+              保留で確定 ({pendingKeyDisplay})
             </Button>
           </div>
         </div>

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -10,7 +10,10 @@ import {
   ScoringErrorState,
   ScoringLoadingState,
 } from "@/components/projects/07-score-at-once/ScoringMain/ScoringStates"
-import { ShortcutProvider } from "@/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider"
+import {
+  ShortcutProvider,
+  useShortcutContext,
+} from "@/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider"
 import { useBatchScoringWithProgress } from "@/components/projects/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress"
 import { usePartialScore } from "@/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore"
 import { useScoringActions } from "@/components/projects/07-score-at-once/ScoringMain/hooks/useScoringActions"
@@ -34,6 +37,17 @@ function ScoringMainViewContent() {
   const params = useParams()
   const projectId = params.projectId as string
   const { helpButton } = usePageHelp()
+  const { keyBindings } = useShortcutContext()
+
+  /** モーダル用のキーバインディング */
+  const modalKeyBindings = useMemo(
+    () => ({
+      partialKey: keyBindings["scoring.partial"],
+      pendingKey: keyBindings["scoring.pending"],
+      cancelKey: keyBindings["modal.cancel"],
+    }),
+    [keyBindings]
+  )
 
   /** データローダーフック */
   const { loading, project, pageImages, cropRegions, currentUserId } =
@@ -380,6 +394,9 @@ function ScoringMainViewContent() {
         currentCropRegion={currentCropRegion}
         onPartialScoreClose={handlePartialScoreCancel}
         onPartialScoreChange={handlePartialScoreChange}
+        onPartialScoreConfirmPartial={() => handlePartialScoreConfirm("partial")}
+        onPartialScoreConfirmPending={() => handlePartialScoreConfirm("pending")}
+        keyBindings={modalKeyBindings}
         showScoreComparison={showScoreComparison}
         onScoreComparisonClose={() => setShowScoreComparison(false)}
         currentAnswerSheet={currentAnswerSheet}

--- a/components/projects/07-score-at-once/ScoringMain/ScoringModals.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringModals.tsx
@@ -7,6 +7,13 @@ import type {
   PageImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/types"
 
+/** キーバインディングの型 */
+interface ModalKeyBindings {
+  partialKey?: string
+  pendingKey?: string
+  cancelKey?: string
+}
+
 interface ScoringModalsProps {
   // Partial Score Modal props
   showPartialScoreModal: boolean
@@ -14,6 +21,9 @@ interface ScoringModalsProps {
   currentCropRegion?: CropRegionWithProjectPage
   onPartialScoreClose: () => void
   onPartialScoreChange: (value: string) => void
+  onPartialScoreConfirmPartial?: () => void
+  onPartialScoreConfirmPending?: () => void
+  keyBindings?: ModalKeyBindings
   // Score Comparison Modal props
   showScoreComparison: boolean
   onScoreComparisonClose: () => void
@@ -26,6 +36,9 @@ export function ScoringModals({
   currentCropRegion,
   onPartialScoreClose,
   onPartialScoreChange,
+  onPartialScoreConfirmPartial,
+  onPartialScoreConfirmPending,
+  keyBindings,
   showScoreComparison,
   onScoreComparisonClose,
   currentAnswerSheet,
@@ -42,6 +55,9 @@ export function ScoringModals({
         }
         onClose={onPartialScoreClose}
         onChange={onPartialScoreChange}
+        onConfirmPartial={onPartialScoreConfirmPartial}
+        onConfirmPending={onPartialScoreConfirmPending}
+        keyBindings={keyBindings}
       />
 
       {/* 採点比較モーダル */}

--- a/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
@@ -86,17 +86,43 @@ const DEAD_KEY_CODE_MAP: { [code: string]: string } = {
 }
 
 /**
+ * 大文字小文字を保持すべき特殊キー
+ * これらのキーはキーバインディング設定と同じ形式で返す
+ */
+const SPECIAL_KEYS = new Set([
+  "Escape",
+  "Backspace",
+  "Enter",
+  "Tab",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Delete",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+  "Insert",
+])
+
+/**
  * キー入力を正規化する
  * macOSデッドキー対応と修飾キーの処理を含む
  */
 function normalizeKey(event: KeyboardEvent): string {
-  let key = event.key.toLowerCase()
+  let key = event.key
 
   // macOSデッドキー対応
-  if (key === "dead" && event.code && DEAD_KEY_CODE_MAP[event.code]) {
+  if (key === "Dead" && event.code && DEAD_KEY_CODE_MAP[event.code]) {
     key = DEAD_KEY_CODE_MAP[event.code]
   } else if (event.code && DEAD_KEY_CODE_MAP[event.code]) {
     key = DEAD_KEY_CODE_MAP[event.code]
+  }
+
+  // 特殊キーは大文字小文字を保持、通常キーは小文字に正規化
+  if (!SPECIAL_KEYS.has(key)) {
+    key = key.toLowerCase()
   }
 
   // スペースキーの正規化
@@ -349,16 +375,21 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
         target instanceof HTMLTextAreaElement ||
         (target instanceof HTMLElement && target.isContentEditable)
 
-      // input要素内では、モーダル制御キー（F, J, Escape）以外をスルー
+      // input要素内では、モーダル制御キー以外をスルー
       // これにより、通常の文字入力（0-9, a-z, .等）とBackspace等は正常に動作する
       if (isInputElement) {
-        const modalControlKeys = ["f", "j", "Escape"]
+        // ユーザー設定から部分点・保留・キャンセルのキーを取得
+        const modalControlKeys = [
+          keyBindings["scoring.partial"],
+          keyBindings["scoring.pending"],
+          keyBindings["modal.cancel"],
+        ].filter(Boolean)
 
         if (!modalControlKeys.includes(key)) {
           // モーダル制御キー以外は通常の入力として処理（Backspace含む）
           return
         }
-        // F, J, Escapeの場合は、後続のコマンド評価に進む
+        // 部分点/保留/キャンセルキーの場合は、後続のコマンド評価に進む
       }
 
       // 逆引き: key -> commandId[] (複数のコマンドが同じキーにバインドされている可能性)


### PR DESCRIPTION
## 概要
部分点確定モーダルにおいて、「部分点で確定(F)」ボタンとショートカットキーが動作しない問題を修正しました。

Closes #263

## 変更内容
### PartialScoreModal.tsx
- ボタンクリック時に合成イベントではなく、直接ハンドラーを呼び出すよう変更
- Input要素に直接`onKeyDown`ハンドラーを追加して、F/Jキーで確定できるよう修正
- キーボードガイドとボタン表示を設定のショートカットキーに連動

### ShortcutProvider.tsx
- `normalizeKey`関数で特殊キー（Escape, Backspace, 矢印キー等）の大文字小文字を保持するよう修正
- モーダル制御キーをユーザー設定から動的に取得するよう変更

### ScoringModals.tsx / ScoringMainView.tsx
- キーバインディング情報をモーダルに渡すよう更新

## テスト項目
- [ ] 部分点モーダルで「部分点で確定」ボタンをクリックして確定できること
- [ ] 部分点モーダルで「保留で確定」ボタンをクリックして確定できること
- [ ] 部分点モーダル内でFキーを押して確定できること
- [ ] 部分点モーダル内でJキーを押して保留確定できること
- [ ] 部分点モーダル内でEscapeキーを押してキャンセルできること
- [ ] 設定画面でショートカットキーを変更した際、モーダル内の表示が連動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)