### PR TITLE
refactor: アーカイブ変換器を連鎖変換パターンに分離

### DIFF
--- a/docs/schema-history/README.md
+++ b/docs/schema-history/README.md
@@ -1,0 +1,94 @@
+# Prisma Schema History
+
+アーカイブバージョンごとのPrismaスキーマ履歴
+
+## バージョン対応表
+
+| Archive Version | App Version | Git Tag | ファイル |
+|----------------|-------------|---------|---------|
+| 1.0.0 | v0.2.x | v0.2.21-alpha.0 | schema-v1.0.0-v0.2.x.prisma |
+| 1.1.0 | v0.3.x | v0.3.2-beta.0 | schema-v1.1.0-v0.3.x.prisma |
+| 1.2.0 | v0.4.x | (current) | schema-v1.2.0-v0.4.x.prisma |
+
+## バージョン間の主な変更点
+
+### v1.0.0 → v1.1.0 (v0.2.x → v0.3.x)
+
+#### 追加されたテーブル
+- `ProjectClass` - プロジェクトと学級の関連付け
+- `Subject` - 教科マスター
+- `SubjectSubtotalGroup` - 教科と小計グループの関連
+- `UserKeyboardShortcut` - ユーザー別キーボードショートカット
+- `UserScoringPreference` - ユーザー別採点設定
+- `ProjectMarkingFormat` - プロジェクト別採点マーク設定
+- `ProjectExportSettings` - プロジェクト別エクスポート設定
+- `CropRegionMarkingOverride` - 領域別マーク上書き設定
+
+#### 変更されたテーブル
+- `UserProject`
+  - `invitedAt` フィールド追加
+  - `invitedBy` フィールド追加
+  - `@@unique([userId, projectId])` 制約追加
+
+- `User`
+  - `invitedUserProjects` リレーション追加
+  - `keyboardShortcuts` リレーション追加
+  - `scoringPreference` リレーション追加
+
+- `Class`
+  - `projectClasses` リレーション追加
+
+- `SubtotalGroup`
+  - `subjectSubtotalGroups` リレーション追加
+
+- `CropRegion`
+  - `markingOverrides` リレーション追加
+
+### v1.1.0 → v1.2.0 (v0.3.x → v0.4.x)
+
+#### 追加されたテーブル
+- `MasterImage` - 模範解答画像（PageImageから分離）
+- `StudentAnswerImage` - 答案画像（PageImageから分離）
+
+#### 削除されたテーブル
+- `PageImage` - MasterImage/StudentAnswerImageに分離
+
+#### 変更されたテーブル
+- `QuestionScore`
+  - `scoredByUserId` → `userId` にリネーム
+  - `studentId` が非NULL化（必須フィールド）
+  - `userId` が非NULL化（必須フィールド）
+
+- `DrawingAnnotation`
+  - `createdByUserId` → `userId` にリネーム
+  - `userId` が非NULL化（必須フィールド）
+
+- `Student`
+  - `pageImages` → `studentAnswerImages` に変更
+
+- `ProjectPage`
+  - `pageImages` → `masterImages` + `studentAnswerImages` に変更
+
+## インポート時の変換ロジック
+
+### v1.0.0 アーカイブのインポート
+1. `UserProject.invitedAt` = `createdAt` で補完
+2. `UserProject.invitedBy` = null で補完
+3. `projectClasses` = 空配列で初期化
+
+### v1.1.0 アーカイブのインポート
+1. `pageImages` → `masterImages` / `studentAnswerImages` に変換
+   - `imageType === "MODEL_ANSWER"` → `MasterImage`
+   - `imageType === "STUDENT_ANSWER"` → `StudentAnswerImage`
+2. `scoredByUserId` → `userId` にリネーム
+3. `createdByUserId` → `userId` にリネーム
+4. `studentId`/`userId` が null のスコアはスキップ
+
+## 連鎖変換パターン
+
+```
+1.0.0 → 1.1.0 → 1.2.0
+```
+
+各変換器は「次のバージョンへの変換」のみを担当し、
+古いバージョンからのインポートは変換器を連鎖的に適用することで実現する。

--- a/docs/schema-history/schema-v1.0.0-v0.2.x.prisma
+++ b/docs/schema-history/schema-v1.0.0-v0.2.x.prisma
@@ -1,0 +1,246 @@
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "darwin", "darwin-arm64", "windows", "debian-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                 String              @id @default(uuid())
+  username           String              @unique
+  passcode           String?
+  name               String
+  role               String              @default("teacher")
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  passcodeType       String?             @default("none")
+  drawingAnnotations DrawingAnnotation[]
+  questionScores     QuestionScore[]
+  userProjects       UserProject[]
+}
+
+model Class {
+  id          String                   @id @default(uuid())
+  name        String                   @unique
+  classCode   String?
+  grade       Int?
+  description String?
+  isVisible   Boolean                  @default(true)
+  createdAt   DateTime                 @default(now())
+  updatedAt   DateTime                 @updatedAt
+  memberships StudentClassMembership[]
+
+  @@map("classes")
+}
+
+model Student {
+  id              String                   @id @default(uuid())
+  studentId       String                   @unique
+  lastName        String
+  firstName       String
+  lastNameKana    String
+  firstNameKana   String
+  enrollmentYear  Int?
+  createdAt       DateTime                 @default(now())
+  updatedAt       DateTime                 @updatedAt
+  pageImages      PageImage[]
+  projectStudents ProjectStudent[]
+  questionScores  QuestionScore[]
+  memberships     StudentClassMembership[]
+}
+
+model StudentClassMembership {
+  id               String    @id @default(uuid())
+  studentId        String
+  classId          String
+  startDate        DateTime  @default(now())
+  endDate          DateTime?
+  attendanceNumber Int?
+  notes            String?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  student          Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  class            Class     @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@index([studentId])
+  @@index([classId])
+  @@index([classId, attendanceNumber])
+  @@index([startDate, endDate])
+}
+
+model Project {
+  id                    String                 @id @default(uuid())
+  examName              String
+  examDate              DateTime?
+  subject               String?
+  description           String?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectPages          ProjectPage[]
+  projectStudents       ProjectStudent[]
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  userProjects          UserProject[]
+}
+
+model ProjectStudent {
+  id          String   @id @default(uuid())
+  projectId   String
+  studentId   String
+  status      String   @default("PARTICIPATING")
+  customOrder Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  student     Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, studentId])
+  @@index([projectId])
+  @@index([studentId])
+  @@index([projectId, customOrder])
+}
+
+model ProjectPage {
+  id          String       @id @default(uuid())
+  projectId   String
+  pageNumber  Int
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @default(now()) @updatedAt
+  cropRegions CropRegion[]
+  pageImages  PageImage[]
+  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model PageImage {
+  id            String      @id @default(uuid())
+  projectPageId String
+  studentId     String?
+  imagePath     String
+  imageType     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @default(now()) @updatedAt
+  projectPage   ProjectPage @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student       Student?    @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model CropRegion {
+  id             String          @id @default(uuid())
+  projectPageId  String
+  label          String
+  type           String
+  x              Float
+  y              Float
+  width          Float
+  height         Float
+  points         Int?
+  orderIndex     Int?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @default(now()) @updatedAt
+  projectPage    ProjectPage     @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  cropSubtotals  CropSubtotal[]
+  questionScores QuestionScore[]
+}
+
+model SubtotalGroup {
+  id                    String                 @id @default(uuid())
+  name                  String
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  subtotals             Subtotal[]
+}
+
+model Subtotal {
+  id              String         @id @default(uuid())
+  name            String
+  subtotalGroupId String
+  order           Int            @default(0)
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @default(now()) @updatedAt
+  cropSubtotals   CropSubtotal[]
+  subtotalGroup   SubtotalGroup  @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([subtotalGroupId, name], map: "sqlite_autoindex_Subtotal_2")
+}
+
+model CropSubtotal {
+  id             String     @id @default(uuid())
+  cropRegionId   String
+  subtotalId     String
+  assignmentType String
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @default(now()) @updatedAt
+  cropRegion     CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotal       Subtotal   @relation(fields: [subtotalId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model UserProject {
+  id        String   @id @default(uuid())
+  userId    String
+  projectId String
+  role      String   @default("GRADER")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model ProjectSubtotalGroup {
+  id              String        @id @default(uuid())
+  projectId       String
+  subtotalGroupId String
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @default(now()) @updatedAt
+  project         Project       @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotalGroup   SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model QuestionScore {
+  id                 String              @id @default(uuid())
+  cropRegionId       String
+  studentId          String?
+  partialScore       Decimal?
+  status             String              @default("unscored")
+  scoredByUserId     String?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @default(now()) @updatedAt
+  drawingAnnotations DrawingAnnotation[]
+  cropRegion         CropRegion          @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student            Student?            @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  scoredByUser       User?               @relation(fields: [scoredByUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model DrawingAnnotation {
+  id              String        @id @default(uuid())
+  questionScoreId String
+  type            String
+  x               Float
+  y               Float
+  color           String        @default("#ef4444")
+  strokeWidth     Int           @default(3)
+  width           Float         @default(0.0)
+  height          Float         @default(0.0)
+  endX            Float         @default(0.0)
+  endY            Float         @default(0.0)
+  lineStyle       String        @default("solid")
+  text            String        @default("")
+  fontSize        Int           @default(16)
+  textBoxWidth    Float         @default(0.0)
+  textBoxHeight   Float         @default(0.0)
+  horizontalAlign String        @default("left")
+  verticalAlign   String        @default("top")
+  anchorDirection String        @default("top-left")
+  displayX        Float         @default(0.0)
+  displayY        Float         @default(0.0)
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  createdByUserId String?
+  createdByUser   User?         @relation(fields: [createdByUserId], references: [id])
+  questionScore   QuestionScore @relation(fields: [questionScoreId], references: [id], onDelete: Cascade)
+
+  @@index([questionScoreId])
+  @@index([type])
+  @@index([createdAt])
+}

--- a/docs/schema-history/schema-v1.1.0-v0.3.x.prisma
+++ b/docs/schema-history/schema-v1.1.0-v0.3.x.prisma
@@ -1,0 +1,376 @@
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "darwin", "darwin-arm64", "windows", "debian-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                  String                 @id @default(uuid())
+  username            String                 @unique
+  passcode            String?
+  name                String
+  role                String                 @default("teacher")
+  createdAt           DateTime               @default(now())
+  updatedAt           DateTime               @updatedAt
+  passcodeType        String?                @default("none")
+  drawingAnnotations  DrawingAnnotation[]
+  questionScores      QuestionScore[]
+  userProjects        UserProject[]
+  invitedUserProjects UserProject[]          @relation("InvitedByUser")
+  keyboardShortcuts   UserKeyboardShortcut[]
+  scoringPreference   UserScoringPreference?
+}
+
+model Class {
+  id             String                   @id @default(uuid())
+  name           String                   @unique
+  classCode      String?
+  grade          Int?
+  description    String?
+  isVisible      Boolean                  @default(true)
+  createdAt      DateTime                 @default(now())
+  updatedAt      DateTime                 @updatedAt
+  memberships    StudentClassMembership[]
+  projectClasses ProjectClass[]
+
+  @@map("classes")
+}
+
+model Student {
+  id              String                   @id @default(uuid())
+  studentId       String                   @unique
+  lastName        String
+  firstName       String
+  lastNameKana    String
+  firstNameKana   String
+  enrollmentYear  Int?
+  createdAt       DateTime                 @default(now())
+  updatedAt       DateTime                 @updatedAt
+  pageImages      PageImage[]
+  projectStudents ProjectStudent[]
+  questionScores  QuestionScore[]
+  memberships     StudentClassMembership[]
+}
+
+model StudentClassMembership {
+  id               String    @id @default(uuid())
+  studentId        String
+  classId          String
+  startDate        DateTime  @default(now())
+  endDate          DateTime?
+  attendanceNumber Int?
+  notes            String?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  student          Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  class            Class     @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@index([studentId])
+  @@index([classId])
+  @@index([classId, attendanceNumber])
+  @@index([startDate, endDate])
+}
+
+model Project {
+  id                    String                 @id @default(uuid())
+  examName              String
+  examDate              DateTime?
+  subject               String?
+  description           String?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectPages          ProjectPage[]
+  projectStudents       ProjectStudent[]
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  userProjects          UserProject[]
+  projectClasses        ProjectClass[]
+  markingFormats        ProjectMarkingFormat[]
+  exportSettings        ProjectExportSettings?
+}
+
+model ProjectStudent {
+  id          String   @id @default(uuid())
+  projectId   String
+  studentId   String
+  status      String   @default("PARTICIPATING")
+  customOrder Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  student     Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, studentId])
+  @@index([projectId])
+  @@index([studentId])
+  @@index([projectId, customOrder])
+}
+
+model ProjectPage {
+  id          String       @id @default(uuid())
+  projectId   String
+  pageNumber  Int
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @default(now()) @updatedAt
+  cropRegions CropRegion[]
+  pageImages  PageImage[]
+  project     Project      @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model PageImage {
+  id            String      @id @default(uuid())
+  projectPageId String
+  studentId     String?
+  imagePath     String
+  imageType     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @default(now()) @updatedAt
+  projectPage   ProjectPage @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student       Student?    @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model CropRegion {
+  id               String                      @id @default(uuid())
+  projectPageId    String
+  label            String
+  type             String
+  x                Float
+  y                Float
+  width            Float
+  height           Float
+  points           Int?
+  orderIndex       Int?
+  createdAt        DateTime                    @default(now())
+  updatedAt        DateTime                    @default(now()) @updatedAt
+  projectPage      ProjectPage                 @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  cropSubtotals    CropSubtotal[]
+  questionScores   QuestionScore[]
+  markingOverrides CropRegionMarkingOverride[]
+}
+
+model SubtotalGroup {
+  id                    String                 @id @default(uuid())
+  name                  String
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  subtotals             Subtotal[]
+  subjectSubtotalGroups SubjectSubtotalGroup[]
+}
+
+model Subtotal {
+  id              String         @id @default(uuid())
+  name            String
+  subtotalGroupId String
+  order           Int            @default(0)
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @default(now()) @updatedAt
+  cropSubtotals   CropSubtotal[]
+  subtotalGroup   SubtotalGroup  @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([subtotalGroupId, name], map: "sqlite_autoindex_Subtotal_2")
+}
+
+model CropSubtotal {
+  id             String     @id @default(uuid())
+  cropRegionId   String
+  subtotalId     String
+  assignmentType String
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @default(now()) @updatedAt
+  cropRegion     CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotal       Subtotal   @relation(fields: [subtotalId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model UserProject {
+  id        String   @id @default(uuid())
+  userId    String
+  projectId String
+  role      String   @default("GRADER") // "OWNER" | "GRADER"
+  invitedAt DateTime @default(now())
+  invitedBy String? // Null for OWNER (project creator)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  inviter   User?    @relation("InvitedByUser", fields: [invitedBy], references: [id], onDelete: SetNull, onUpdate: NoAction)
+
+  @@unique([userId, projectId])
+  @@index([projectId])
+}
+
+model ProjectSubtotalGroup {
+  id              String        @id @default(uuid())
+  projectId       String
+  subtotalGroupId String
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @default(now()) @updatedAt
+  project         Project       @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotalGroup   SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model QuestionScore {
+  id                 String              @id @default(uuid())
+  cropRegionId       String
+  studentId          String?
+  partialScore       Decimal?
+  status             String              @default("unscored")
+  scoredByUserId     String?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @default(now()) @updatedAt
+  drawingAnnotations DrawingAnnotation[]
+  cropRegion         CropRegion          @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student            Student?            @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  scoredByUser       User?               @relation(fields: [scoredByUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model DrawingAnnotation {
+  id              String        @id @default(uuid())
+  questionScoreId String
+  type            String
+  x               Float
+  y               Float
+  color           String        @default("#ef4444")
+  strokeWidth     Int           @default(3)
+  width           Float         @default(0.0)
+  height          Float         @default(0.0)
+  endX            Float         @default(0.0)
+  endY            Float         @default(0.0)
+  lineStyle       String        @default("solid")
+  text            String        @default("")
+  fontSize        Int           @default(16)
+  textBoxWidth    Float         @default(0.0)
+  textBoxHeight   Float         @default(0.0)
+  horizontalAlign String        @default("left")
+  verticalAlign   String        @default("top")
+  anchorDirection String        @default("top-left")
+  displayX        Float         @default(0.0)
+  displayY        Float         @default(0.0)
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  createdByUserId String?
+  createdByUser   User?         @relation(fields: [createdByUserId], references: [id])
+  questionScore   QuestionScore @relation(fields: [questionScoreId], references: [id], onDelete: Cascade)
+
+  @@index([questionScoreId])
+  @@index([type])
+  @@index([createdAt])
+}
+
+model ProjectClass {
+  id           String   @id @default(uuid())
+  projectId    String
+  classId      String
+  administered Boolean  @default(false) // 学級・出席番号表示の対象
+  statistics   Boolean  @default(false) // 統計集計の対象
+  order        Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  class   Class   @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, classId])
+  @@index([projectId])
+  @@index([classId])
+}
+
+model Subject {
+  id        String   @id @default(uuid())
+  name      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  subjectSubtotalGroups SubjectSubtotalGroup[]
+}
+
+model SubjectSubtotalGroup {
+  id              String   @id @default(uuid())
+  subjectId       String
+  subtotalGroupId String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  subject       Subject       @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  subtotalGroup SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade)
+
+  @@unique([subjectId, subtotalGroupId])
+  @@index([subjectId])
+  @@index([subtotalGroupId])
+}
+
+model UserKeyboardShortcut {
+  id        String   @id @default(uuid())
+  userId    String
+  action    String
+  key       String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, action])
+  @@index([userId])
+}
+
+model UserScoringPreference {
+  id                   String   @id @default(uuid())
+  userId               String   @unique
+  showStudentNames     Boolean  @default(true)
+  autoScroll           Boolean  @default(true)
+  itemsPerLine         Int      @default(5)
+  layoutDirection      String   @default("right-down")
+  selectionBorderColor String?
+  scoringStatusColors  String?
+  scoringColorPresetId String?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model ProjectMarkingFormat {
+  id          String   @id @default(uuid())
+  projectId   String
+  markType    String
+  symbol      String
+  color       String
+  fontSize    Int?
+  strokeWidth Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, markType])
+  @@index([projectId])
+}
+
+model ProjectExportSettings {
+  id           String   @id @default(uuid())
+  projectId    String   @unique
+  settingsJson String // JSON形式で保存
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+}
+
+model CropRegionMarkingOverride {
+  id           String   @id @default(uuid())
+  cropRegionId String
+  markType     String
+  symbol       String?
+  color        String?
+  visible      Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  cropRegion CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade)
+
+  @@unique([cropRegionId, markType])
+  @@index([cropRegionId])
+}

--- a/docs/schema-history/schema-v1.2.0-v0.4.x.prisma
+++ b/docs/schema-history/schema-v1.2.0-v0.4.x.prisma
@@ -1,0 +1,390 @@
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "darwin", "darwin-arm64", "windows", "debian-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id                  String                 @id @default(uuid())
+  username            String                 @unique
+  passcode            String?
+  name                String
+  role                String                 @default("teacher")
+  createdAt           DateTime               @default(now())
+  updatedAt           DateTime               @updatedAt
+  passcodeType        String?                @default("none")
+  drawingAnnotations  DrawingAnnotation[]
+  questionScores      QuestionScore[]
+  userProjects        UserProject[]
+  invitedUserProjects UserProject[]          @relation("InvitedByUser")
+  keyboardShortcuts   UserKeyboardShortcut[]
+  scoringPreference   UserScoringPreference?
+}
+
+model Class {
+  id             String                   @id @default(uuid())
+  name           String                   @unique
+  classCode      String?
+  grade          Int?
+  description    String?
+  isVisible      Boolean                  @default(true)
+  createdAt      DateTime                 @default(now())
+  updatedAt      DateTime                 @updatedAt
+  memberships    StudentClassMembership[]
+  projectClasses ProjectClass[]
+
+  @@map("classes")
+}
+
+model Student {
+  id                  String                   @id @default(uuid())
+  studentId           String                   @unique
+  lastName            String
+  firstName           String
+  lastNameKana        String
+  firstNameKana       String
+  enrollmentYear      Int?
+  createdAt           DateTime                 @default(now())
+  updatedAt           DateTime                 @updatedAt
+  studentAnswerImages StudentAnswerImage[]
+  projectStudents     ProjectStudent[]
+  questionScores      QuestionScore[]
+  memberships         StudentClassMembership[]
+}
+
+model StudentClassMembership {
+  id               String    @id @default(uuid())
+  studentId        String
+  classId          String
+  startDate        DateTime  @default(now())
+  endDate          DateTime?
+  attendanceNumber Int?
+  notes            String?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  student          Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  class            Class     @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@index([studentId])
+  @@index([classId])
+  @@index([classId, attendanceNumber])
+  @@index([startDate, endDate])
+}
+
+model Project {
+  id                    String                 @id @default(uuid())
+  examName              String
+  examDate              DateTime?
+  subject               String?
+  description           String?
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectPages          ProjectPage[]
+  projectStudents       ProjectStudent[]
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  userProjects          UserProject[]
+  projectClasses        ProjectClass[]
+  markingFormats        ProjectMarkingFormat[]
+  exportSettings        ProjectExportSettings?
+}
+
+model ProjectStudent {
+  id          String   @id @default(uuid())
+  projectId   String
+  studentId   String
+  status      String   @default("PARTICIPATING")
+  customOrder Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  student     Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, studentId])
+  @@index([projectId])
+  @@index([studentId])
+  @@index([projectId, customOrder])
+}
+
+model ProjectPage {
+  id                  String               @id @default(uuid())
+  projectId           String
+  pageNumber          Int
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @default(now()) @updatedAt
+  cropRegions         CropRegion[]
+  masterImages        MasterImage[]
+  studentAnswerImages StudentAnswerImage[]
+  project             Project              @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+/// 模範解答画像
+model MasterImage {
+  id            String      @id @default(uuid())
+  projectPageId String
+  imagePath     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @default(now()) @updatedAt
+  projectPage   ProjectPage @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+/// 答案画像
+model StudentAnswerImage {
+  id            String      @id @default(uuid())
+  projectPageId String
+  studentId     String
+  imagePath     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @default(now()) @updatedAt
+  projectPage   ProjectPage @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student       Student     @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([projectPageId])
+  @@index([studentId])
+}
+
+model CropRegion {
+  id               String                      @id @default(uuid())
+  projectPageId    String
+  label            String
+  type             String
+  x                Float
+  y                Float
+  width            Float
+  height           Float
+  points           Int?
+  orderIndex       Int?
+  createdAt        DateTime                    @default(now())
+  updatedAt        DateTime                    @default(now()) @updatedAt
+  projectPage      ProjectPage                 @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  cropSubtotals    CropSubtotal[]
+  questionScores   QuestionScore[]
+  markingOverrides CropRegionMarkingOverride[]
+}
+
+model SubtotalGroup {
+  id                    String                 @id @default(uuid())
+  name                  String
+  createdAt             DateTime               @default(now())
+  updatedAt             DateTime               @default(now()) @updatedAt
+  projectSubtotalGroups ProjectSubtotalGroup[]
+  subtotals             Subtotal[]
+  subjectSubtotalGroups SubjectSubtotalGroup[]
+}
+
+model Subtotal {
+  id              String         @id @default(uuid())
+  name            String
+  subtotalGroupId String
+  order           Int            @default(0)
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @default(now()) @updatedAt
+  cropSubtotals   CropSubtotal[]
+  subtotalGroup   SubtotalGroup  @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([subtotalGroupId, name], map: "sqlite_autoindex_Subtotal_2")
+}
+
+model CropSubtotal {
+  id             String     @id @default(uuid())
+  cropRegionId   String
+  subtotalId     String
+  assignmentType String
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @default(now()) @updatedAt
+  cropRegion     CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotal       Subtotal   @relation(fields: [subtotalId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model UserProject {
+  id        String   @id @default(uuid())
+  userId    String
+  projectId String
+  role      String   @default("GRADER") // "OWNER" | "GRADER"
+  invitedAt DateTime @default(now())
+  invitedBy String? // Null for OWNER (project creator)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  inviter   User?    @relation("InvitedByUser", fields: [invitedBy], references: [id], onDelete: SetNull, onUpdate: NoAction)
+
+  @@unique([userId, projectId])
+  @@index([projectId])
+}
+
+model ProjectSubtotalGroup {
+  id              String        @id @default(uuid())
+  projectId       String
+  subtotalGroupId String
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @default(now()) @updatedAt
+  project         Project       @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotalGroup   SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+model QuestionScore {
+  id                 String              @id @default(uuid())
+  cropRegionId       String
+  studentId          String
+  partialScore       Decimal?
+  status             String              @default("unscored")
+  userId             String
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @default(now()) @updatedAt
+  drawingAnnotations DrawingAnnotation[]
+  cropRegion         CropRegion          @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student            Student             @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  user               User                @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model DrawingAnnotation {
+  id              String        @id @default(uuid())
+  questionScoreId String
+  type            String
+  x               Float
+  y               Float
+  color           String        @default("#ef4444")
+  strokeWidth     Int           @default(3)
+  width           Float         @default(0.0)
+  height          Float         @default(0.0)
+  endX            Float         @default(0.0)
+  endY            Float         @default(0.0)
+  lineStyle       String        @default("solid")
+  text            String        @default("")
+  fontSize        Int           @default(16)
+  textBoxWidth    Float         @default(0.0)
+  textBoxHeight   Float         @default(0.0)
+  horizontalAlign String        @default("left")
+  verticalAlign   String        @default("top")
+  anchorDirection String        @default("top-left")
+  displayX        Float         @default(0.0)
+  displayY        Float         @default(0.0)
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  userId          String
+  user            User          @relation(fields: [userId], references: [id])
+  questionScore   QuestionScore @relation(fields: [questionScoreId], references: [id], onDelete: Cascade)
+
+  @@index([questionScoreId])
+  @@index([type])
+  @@index([createdAt])
+}
+
+model ProjectClass {
+  id           String   @id @default(uuid())
+  projectId    String
+  classId      String
+  administered Boolean  @default(false) // 学級・出席番号表示の対象
+  statistics   Boolean  @default(false) // 統計集計の対象
+  order        Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  class   Class   @relation(fields: [classId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, classId])
+  @@index([projectId])
+  @@index([classId])
+}
+
+model Subject {
+  id        String   @id @default(uuid())
+  name      String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  subjectSubtotalGroups SubjectSubtotalGroup[]
+}
+
+model SubjectSubtotalGroup {
+  id              String   @id @default(uuid())
+  subjectId       String
+  subtotalGroupId String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  subject       Subject       @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  subtotalGroup SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade)
+
+  @@unique([subjectId, subtotalGroupId])
+  @@index([subjectId])
+  @@index([subtotalGroupId])
+}
+
+model UserKeyboardShortcut {
+  id        String   @id @default(uuid())
+  userId    String
+  action    String
+  key       String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, action])
+  @@index([userId])
+}
+
+model UserScoringPreference {
+  id                   String   @id @default(uuid())
+  userId               String   @unique
+  showStudentNames     Boolean  @default(true)
+  autoScroll           Boolean  @default(true)
+  itemsPerLine         Int      @default(5)
+  layoutDirection      String   @default("right-down")
+  selectionBorderColor String?
+  scoringStatusColors  String?
+  scoringColorPresetId String?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model ProjectMarkingFormat {
+  id          String   @id @default(uuid())
+  projectId   String
+  markType    String
+  symbol      String
+  color       String
+  fontSize    Int?
+  strokeWidth Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, markType])
+  @@index([projectId])
+}
+
+model ProjectExportSettings {
+  id           String   @id @default(uuid())
+  projectId    String   @unique
+  settingsJson String // JSON形式で保存
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+}
+
+model CropRegionMarkingOverride {
+  id           String   @id @default(uuid())
+  cropRegionId String
+  markType     String
+  symbol       String?
+  color        String?
+  visible      Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  cropRegion CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade)
+
+  @@unique([cropRegionId, markType])
+  @@index([cropRegionId])
+}

--- a/electron-src/lib/import/transformers/V1_0_0_to_V1_1_0.ts
+++ b/electron-src/lib/import/transformers/V1_0_0_to_V1_1_0.ts
@@ -1,0 +1,108 @@
+/**
+ * v1.0.0 → v1.1.0 変換器
+ *
+ * アプリバージョン: v0.2.x → v0.3.x
+ *
+ * 主な変更点:
+ * - UserProject: invitedAt, invitedBy フィールド追加
+ * - ProjectClass テーブル追加
+ * - その他新規テーブル追加（インポート時は空で初期化）
+ *
+ * @see docs/schema-history/README.md
+ */
+
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  TransformResult,
+  VersionTransformer,
+} from "./types"
+
+/**
+ * v1.0.0 の UserProject 形式
+ */
+interface V1_0_0_UserProject {
+  id: string
+  userId: string
+  projectId: string
+  role?: string // v0.2.20では存在するが、それ以前はない場合がある
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.1.0 の UserProject 形式
+ */
+interface V1_1_0_UserProject {
+  id: string
+  userId: string
+  projectId: string
+  role: string
+  invitedAt: string
+  invitedBy: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.0.0 → v1.1.0 変換器
+ */
+export class V1_0_0_to_V1_1_0_Transformer implements VersionTransformer {
+  readonly fromVersion: ArchiveVersion = "1.0.0"
+  readonly toVersion: ArchiveVersion = "1.1.0"
+
+  transform(data: ArchiveData): TransformResult {
+    const warnings: string[] = []
+
+    // UserProject の変換
+    const transformedUserProjects = this.transformUserProjects(
+      data.projectData.userProjects as unknown as V1_0_0_UserProject[]
+    )
+
+    // projectClasses が存在しない場合は空配列で初期化
+    const projectClasses = data.projectData.projectClasses ?? []
+
+    // 警告メッセージを追加
+    warnings.push(
+      `アーカイブはv0.2.x形式(archive v${this.fromVersion})で作成されています。` +
+        `UserProject.invitedAt/invitedByはデフォルト値で補完されました。`
+    )
+
+    return {
+      data: {
+        ...data,
+        manifest: {
+          ...data.manifest,
+          version: this.toVersion,
+        },
+        projectData: {
+          ...data.projectData,
+          userProjects:
+            transformedUserProjects as unknown as typeof data.projectData.userProjects,
+          projectClasses,
+        },
+      },
+      warnings,
+    }
+  }
+
+  /**
+   * UserProject を v1.1.0 形式に変換
+   */
+  private transformUserProjects(
+    userProjects: V1_0_0_UserProject[]
+  ): V1_1_0_UserProject[] {
+    return userProjects.map((up, index) => {
+      // roleが存在する場合は保持、なければデフォルト値を設定
+      // 最初のユーザーはOWNER、それ以外はGRADER
+      const role = up.role ?? (index === 0 ? "OWNER" : "GRADER")
+
+      return {
+        ...up,
+        role,
+        invitedAt: up.createdAt, // createdAtで代用
+        invitedBy: index === 0 ? null : userProjects[0]?.userId ?? null,
+      }
+    })
+  }
+}

--- a/electron-src/lib/import/transformers/V1_1_0_to_V1_2_0.ts
+++ b/electron-src/lib/import/transformers/V1_1_0_to_V1_2_0.ts
@@ -1,0 +1,387 @@
+/**
+ * v1.1.0 → v1.2.0 変換器
+ *
+ * アプリバージョン: v0.3.x → v0.4.x
+ *
+ * 主な変更点:
+ * - PageImage → MasterImage + StudentAnswerImage に分離
+ * - QuestionScore: scoredByUserId → userId (非NULL化)
+ * - DrawingAnnotation: createdByUserId → userId (非NULL化)
+ * - studentId の非NULL化
+ *
+ * @see docs/schema-history/README.md
+ */
+
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  TransformResult,
+  VersionTransformer,
+} from "./types"
+
+/**
+ * v1.1.0 の PageImage 形式
+ */
+interface V1_1_0_PageImage {
+  id: string
+  projectPageId: string
+  studentId: string | null
+  imagePath: string
+  imageType: string // "MODEL_ANSWER" | "STUDENT_ANSWER"
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.2.0 の MasterImage 形式
+ */
+interface V1_2_0_MasterImage {
+  id: string
+  projectPageId: string
+  imagePath: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.2.0 の StudentAnswerImage 形式
+ */
+interface V1_2_0_StudentAnswerImage {
+  id: string
+  projectPageId: string
+  studentId: string
+  imagePath: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.1.0 の QuestionScore 形式（旧フィールド名対応）
+ */
+interface V1_1_0_QuestionScore {
+  id: string
+  cropRegionId: string
+  studentId: string | null
+  partialScore: string | null
+  status: string
+  scoredByUserId?: string | null // 旧フィールド名
+  userId?: string | null // 新フィールド名（既に変換済みの場合）
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.1.0 の DrawingAnnotation 形式（旧フィールド名対応）
+ */
+interface V1_1_0_DrawingAnnotation {
+  id: string
+  questionScoreId: string
+  type: string
+  x: number
+  y: number
+  color: string
+  strokeWidth: number
+  width: number
+  height: number
+  endX: number
+  endY: number
+  lineStyle: string
+  text: string
+  fontSize: number
+  textBoxWidth: number
+  textBoxHeight: number
+  horizontalAlign: string
+  verticalAlign: string
+  anchorDirection: string
+  displayX: number
+  displayY: number
+  createdByUserId?: string | null // 旧フィールド名
+  userId?: string | null // 新フィールド名（既に変換済みの場合）
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * v1.1.0 → v1.2.0 変換器
+ */
+export class V1_1_0_to_V1_2_0_Transformer implements VersionTransformer {
+  readonly fromVersion: ArchiveVersion = "1.1.0"
+  readonly toVersion: ArchiveVersion = "1.2.0"
+
+  transform(data: ArchiveData): TransformResult {
+    const warnings: string[] = []
+
+    // PageImage → MasterImage / StudentAnswerImage に分離
+    const { masterImages, studentAnswerImages, imageWarnings } =
+      this.transformPageImages(
+        data.projectData.pageImages as unknown as V1_1_0_PageImage[]
+      )
+    warnings.push(...imageWarnings)
+
+    // QuestionScore の変換（フィールド名変更 + NULL除外）
+    const { questionScores, scoreWarnings } = this.transformQuestionScores(
+      data.scoresData.questionScores as unknown as V1_1_0_QuestionScore[]
+    )
+    warnings.push(...scoreWarnings)
+
+    // DrawingAnnotation の変換（フィールド名変更 + NULL除外）
+    // 注意: 親のQuestionScoreがスキップされた場合、その子もスキップする必要がある
+    const validScoreIds = new Set(questionScores.map((qs) => qs.id))
+    const { drawingAnnotations, annotationWarnings } =
+      this.transformDrawingAnnotations(
+        data.scoresData
+          .drawingAnnotations as unknown as V1_1_0_DrawingAnnotation[],
+        validScoreIds
+      )
+    warnings.push(...annotationWarnings)
+
+    // 警告メッセージを追加
+    if (warnings.length === 0) {
+      warnings.push(
+        `アーカイブはv0.3.x形式(archive v${this.fromVersion})で作成されています。` +
+          `PageImageはMasterImage/StudentAnswerImageに変換されました。`
+      )
+    }
+
+    return {
+      data: {
+        ...data,
+        manifest: {
+          ...data.manifest,
+          version: this.toVersion,
+        },
+        projectData: {
+          ...data.projectData,
+          // pageImagesは後方互換性のため維持（空にはしない）
+          masterImages:
+            masterImages as unknown as NonNullable<
+              typeof data.projectData.masterImages
+            >,
+          studentAnswerImages:
+            studentAnswerImages as unknown as NonNullable<
+              typeof data.projectData.studentAnswerImages
+            >,
+        },
+        scoresData: {
+          questionScores:
+            questionScores as unknown as typeof data.scoresData.questionScores,
+          drawingAnnotations:
+            drawingAnnotations as unknown as typeof data.scoresData.drawingAnnotations,
+        },
+      },
+      warnings,
+    }
+  }
+
+  /**
+   * PageImage を MasterImage / StudentAnswerImage に分離
+   */
+  private transformPageImages(pageImages: V1_1_0_PageImage[]): {
+    masterImages: V1_2_0_MasterImage[]
+    studentAnswerImages: V1_2_0_StudentAnswerImage[]
+    imageWarnings: string[]
+  } {
+    const masterImages: V1_2_0_MasterImage[] = []
+    const studentAnswerImages: V1_2_0_StudentAnswerImage[] = []
+    const imageWarnings: string[] = []
+    let skippedCount = 0
+
+    for (const img of pageImages) {
+      if (img.imageType === "MODEL_ANSWER") {
+        masterImages.push({
+          id: img.id,
+          projectPageId: img.projectPageId,
+          imagePath: img.imagePath,
+          createdAt: img.createdAt,
+          updatedAt: img.updatedAt,
+        })
+      } else if (img.imageType === "STUDENT_ANSWER") {
+        if (img.studentId) {
+          studentAnswerImages.push({
+            id: img.id,
+            projectPageId: img.projectPageId,
+            studentId: img.studentId,
+            imagePath: img.imagePath,
+            createdAt: img.createdAt,
+            updatedAt: img.updatedAt,
+          })
+        } else {
+          // studentIdがnullの答案画像はスキップ
+          skippedCount++
+        }
+      }
+    }
+
+    if (skippedCount > 0) {
+      imageWarnings.push(
+        `studentIdが未設定の答案画像${skippedCount}件がスキップされました。`
+      )
+    }
+
+    return { masterImages, studentAnswerImages, imageWarnings }
+  }
+
+  /**
+   * QuestionScore を変換（フィールド名変更 + NULL除外）
+   */
+  private transformQuestionScores(questionScores: V1_1_0_QuestionScore[]): {
+    questionScores: Array<{
+      id: string
+      cropRegionId: string
+      studentId: string
+      partialScore: string | null
+      status: string
+      userId: string
+      createdAt: string
+      updatedAt: string
+    }>
+    scoreWarnings: string[]
+  } {
+    const scoreWarnings: string[] = []
+    let skippedCount = 0
+
+    const transformed = questionScores
+      .map((qs) => {
+        // 旧フィールド名から新フィールド名への変換
+        const userId = qs.userId || qs.scoredByUserId || ""
+        const studentId = qs.studentId || ""
+
+        if (!userId || !studentId) {
+          skippedCount++
+          return null
+        }
+
+        return {
+          id: qs.id,
+          cropRegionId: qs.cropRegionId,
+          studentId,
+          partialScore: qs.partialScore,
+          status: qs.status,
+          userId,
+          createdAt: qs.createdAt,
+          updatedAt: qs.updatedAt,
+        }
+      })
+      .filter(
+        (
+          qs
+        ): qs is {
+          id: string
+          cropRegionId: string
+          studentId: string
+          partialScore: string | null
+          status: string
+          userId: string
+          createdAt: string
+          updatedAt: string
+        } => qs !== null
+      )
+
+    if (skippedCount > 0) {
+      scoreWarnings.push(
+        `userId/studentIdが未設定の採点データ${skippedCount}件がスキップされました。`
+      )
+    }
+
+    return { questionScores: transformed, scoreWarnings }
+  }
+
+  /**
+   * DrawingAnnotation を変換（フィールド名変更 + NULL除外）
+   */
+  private transformDrawingAnnotations(
+    annotations: V1_1_0_DrawingAnnotation[],
+    validScoreIds: Set<string>
+  ): {
+    drawingAnnotations: Array<{
+      id: string
+      questionScoreId: string
+      type: string
+      x: number
+      y: number
+      color: string
+      strokeWidth: number
+      width: number
+      height: number
+      endX: number
+      endY: number
+      lineStyle: string
+      text: string
+      fontSize: number
+      textBoxWidth: number
+      textBoxHeight: number
+      horizontalAlign: string
+      verticalAlign: string
+      anchorDirection: string
+      displayX: number
+      displayY: number
+      userId: string
+      createdAt: string
+      updatedAt: string
+    }>
+    annotationWarnings: string[]
+  } {
+    const annotationWarnings: string[] = []
+    let skippedByUserId = 0
+    let skippedByParent = 0
+
+    const transformed = annotations
+      .map((da) => {
+        // 親のQuestionScoreがスキップされた場合はスキップ
+        if (!validScoreIds.has(da.questionScoreId)) {
+          skippedByParent++
+          return null
+        }
+
+        // 旧フィールド名から新フィールド名への変換
+        const userId = da.userId || da.createdByUserId || ""
+
+        if (!userId) {
+          skippedByUserId++
+          return null
+        }
+
+        return {
+          id: da.id,
+          questionScoreId: da.questionScoreId,
+          type: da.type,
+          x: da.x,
+          y: da.y,
+          color: da.color,
+          strokeWidth: da.strokeWidth,
+          width: da.width,
+          height: da.height,
+          endX: da.endX,
+          endY: da.endY,
+          lineStyle: da.lineStyle,
+          text: da.text,
+          fontSize: da.fontSize,
+          textBoxWidth: da.textBoxWidth,
+          textBoxHeight: da.textBoxHeight,
+          horizontalAlign: da.horizontalAlign,
+          verticalAlign: da.verticalAlign,
+          anchorDirection: da.anchorDirection,
+          displayX: da.displayX,
+          displayY: da.displayY,
+          userId,
+          createdAt: da.createdAt,
+          updatedAt: da.updatedAt,
+        }
+      })
+      .filter((da): da is NonNullable<typeof da> => da !== null)
+
+    if (skippedByUserId > 0) {
+      annotationWarnings.push(
+        `userIdが未設定のアノテーション${skippedByUserId}件がスキップされました。`
+      )
+    }
+
+    if (skippedByParent > 0) {
+      annotationWarnings.push(
+        `親の採点データがスキップされたアノテーション${skippedByParent}件がスキップされました。`
+      )
+    }
+
+    return { drawingAnnotations: transformed, annotationWarnings }
+  }
+}

--- a/electron-src/lib/import/transformers/index.ts
+++ b/electron-src/lib/import/transformers/index.ts
@@ -1,0 +1,231 @@
+/**
+ * アーカイブ変換器のファクトリとチェーン実行
+ *
+ * 連鎖変換パターン: 1.0.0 → 1.1.0 → 1.2.0 → ...
+ */
+
+import type { ArchiveManifest } from "../../../../types/projectArchive.types"
+import { V1_0_0_to_V1_1_0_Transformer } from "./V1_0_0_to_V1_1_0"
+import { V1_1_0_to_V1_2_0_Transformer } from "./V1_1_0_to_V1_2_0"
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  ChainTransformResult,
+  VersionPair,
+  VersionTransformer,
+} from "./types"
+import { CURRENT_VERSION, SUPPORTED_VERSIONS } from "./types"
+
+// =============================================================================
+// Transformer Registry
+// =============================================================================
+
+/**
+ * 全ての変換器を登録
+ *
+ * 新バージョン追加時はここに変換器を追加
+ */
+const TRANSFORMERS: VersionTransformer[] = [
+  new V1_0_0_to_V1_1_0_Transformer(),
+  new V1_1_0_to_V1_2_0_Transformer(),
+  // 将来: new V1_2_0_to_V1_3_0_Transformer(),
+]
+
+/**
+ * 変換元バージョンから変換器を取得
+ */
+function getTransformerByFromVersion(
+  fromVersion: ArchiveVersion
+): VersionTransformer | undefined {
+  return TRANSFORMERS.find((t) => t.fromVersion === fromVersion)
+}
+
+// =============================================================================
+// Version Detection
+// =============================================================================
+
+/**
+ * バージョン文字列を比較
+ *
+ * @returns 負: v1 < v2, 0: v1 == v2, 正: v1 > v2
+ */
+function compareVersions(v1: string, v2: string): number {
+  const parts1 = v1.split(".").map(Number)
+  const parts2 = v2.split(".").map(Number)
+
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const p1 = parts1[i] || 0
+    const p2 = parts2[i] || 0
+    if (p1 !== p2) {
+      return p1 - p2
+    }
+  }
+  return 0
+}
+
+/**
+ * マニフェストからバージョンを検出
+ */
+export function detectArchiveVersion(
+  manifest: ArchiveManifest
+): ArchiveVersion | "unknown" {
+  const version = manifest.version
+
+  // サポートされているバージョンを逆順で確認（新しい順）
+  for (let i = SUPPORTED_VERSIONS.length - 1; i >= 0; i--) {
+    const supported = SUPPORTED_VERSIONS[i]
+    const nextVersion = SUPPORTED_VERSIONS[i + 1]
+
+    if (nextVersion) {
+      // 次のバージョン未満かつ現在のバージョン以上
+      if (
+        compareVersions(version, supported) >= 0 &&
+        compareVersions(version, nextVersion) < 0
+      ) {
+        return supported
+      }
+    } else {
+      // 最新バージョン以上（将来のバージョンも含む）
+      if (compareVersions(version, supported) >= 0) {
+        return supported
+      }
+    }
+  }
+
+  // 最も古いバージョンより古い場合
+  if (
+    SUPPORTED_VERSIONS.length > 0 &&
+    compareVersions(version, SUPPORTED_VERSIONS[0]) < 0
+  ) {
+    return SUPPORTED_VERSIONS[0]
+  }
+
+  return "unknown"
+}
+
+/**
+ * バージョンがサポートされているか確認
+ */
+export function isSupportedVersion(manifest: ArchiveManifest): boolean {
+  return detectArchiveVersion(manifest) !== "unknown"
+}
+
+/**
+ * 変換が必要か確認
+ */
+export function requiresTransformation(manifest: ArchiveManifest): boolean {
+  const version = detectArchiveVersion(manifest)
+  return version !== "unknown" && version !== CURRENT_VERSION
+}
+
+// =============================================================================
+// Transformation Chain
+// =============================================================================
+
+/**
+ * 変換チェーンを構築
+ *
+ * @param fromVersion - 開始バージョン
+ * @param toVersion - 終了バージョン（デフォルト: 現在の最新バージョン）
+ * @returns 適用する変換器のリスト（順序付き）
+ */
+export function buildTransformChain(
+  fromVersion: ArchiveVersion,
+  toVersion: ArchiveVersion = CURRENT_VERSION
+): VersionTransformer[] {
+  const chain: VersionTransformer[] = []
+  let currentVersion = fromVersion
+
+  while (currentVersion !== toVersion) {
+    const transformer = getTransformerByFromVersion(currentVersion)
+    if (!transformer) {
+      throw new Error(
+        `No transformer found for version ${currentVersion}. ` +
+          `Cannot transform from ${fromVersion} to ${toVersion}.`
+      )
+    }
+
+    chain.push(transformer)
+    currentVersion = transformer.toVersion
+  }
+
+  return chain
+}
+
+/**
+ * 変換チェーンを実行
+ *
+ * @param data - 変換元のアーカイブデータ
+ * @param targetVersion - 目標バージョン（デフォルト: 現在の最新バージョン）
+ * @returns 変換結果
+ */
+export function transformToLatest(
+  data: ArchiveData,
+  targetVersion: ArchiveVersion = CURRENT_VERSION
+): ChainTransformResult {
+  const originalVersion = detectArchiveVersion(data.manifest)
+
+  if (originalVersion === "unknown") {
+    throw new Error(
+      `Unknown archive version: ${data.manifest.version}. ` +
+        `Supported versions: ${SUPPORTED_VERSIONS.join(", ")}`
+    )
+  }
+
+  if (originalVersion === targetVersion) {
+    // 変換不要
+    return {
+      data,
+      originalVersion,
+      finalVersion: targetVersion,
+      appliedTransformations: [],
+      warnings: [],
+    }
+  }
+
+  // 変換チェーンを構築
+  const chain = buildTransformChain(originalVersion, targetVersion)
+
+  // チェーンを実行
+  let currentData = data
+  const appliedTransformations: VersionPair[] = []
+  const allWarnings: string[] = []
+
+  for (const transformer of chain) {
+    const result = transformer.transform(currentData)
+    currentData = result.data
+    allWarnings.push(...result.warnings)
+    appliedTransformations.push({
+      from: transformer.fromVersion,
+      to: transformer.toVersion,
+    })
+  }
+
+  return {
+    data: currentData,
+    originalVersion,
+    finalVersion: targetVersion,
+    appliedTransformations,
+    warnings: allWarnings,
+  }
+}
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+// 型のエクスポート
+export type {
+  ArchiveData,
+  ArchiveVersion,
+  ChainTransformResult,
+  TransformResult,
+  VersionPair,
+  VersionTransformer,
+} from "./types"
+
+export { CURRENT_VERSION, SUPPORTED_VERSIONS } from "./types"
+
+// 変換器のエクスポート（テスト用）
+export { V1_0_0_to_V1_1_0_Transformer } from "./V1_0_0_to_V1_1_0"
+export { V1_1_0_to_V1_2_0_Transformer } from "./V1_1_0_to_V1_2_0"

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -1,0 +1,114 @@
+/**
+ * アーカイブ変換器の型定義
+ *
+ * 連鎖変換パターン: 1.0.0 → 1.1.0 → 1.2.0 → ...
+ * 各変換器は「次のバージョンへの変換」のみを担当する
+ */
+
+import type {
+  ArchiveClassesData,
+  ArchiveManifest,
+  ArchiveProjectData,
+  ArchiveScoresData,
+  ArchiveStudentsData,
+  ArchiveSubtotalsData,
+  ArchiveUsersData,
+} from "../../../../types/projectArchive.types"
+
+// =============================================================================
+// Archive Version Types
+// =============================================================================
+
+/**
+ * サポートされているアーカイブバージョン
+ *
+ * - 1.0.0: v0.2.x (UserProject.invitedAt/invitedBy なし, PageImage使用)
+ * - 1.1.0: v0.3.x (UserProject完全対応, ProjectClass追加, PageImage使用)
+ * - 1.2.0: v0.4.x (MasterImage/StudentAnswerImage分離, userId/studentId非NULL)
+ */
+export type ArchiveVersion = "1.0.0" | "1.1.0" | "1.2.0"
+
+/** 現在の最新バージョン */
+export const CURRENT_VERSION: ArchiveVersion = "1.2.0"
+
+/** サポートされている全バージョン（古い順） */
+export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
+  "1.0.0",
+  "1.1.0",
+  "1.2.0",
+] as const
+
+// =============================================================================
+// Transformer Interface
+// =============================================================================
+
+/**
+ * アーカイブデータ（変換対象）
+ */
+export interface ArchiveData {
+  manifest: ArchiveManifest
+  projectData: ArchiveProjectData
+  studentsData: ArchiveStudentsData
+  classesData: ArchiveClassesData
+  usersData: ArchiveUsersData
+  subtotalsData: ArchiveSubtotalsData
+  scoresData: ArchiveScoresData
+}
+
+/**
+ * 変換結果
+ */
+export interface TransformResult {
+  /** 変換後のデータ */
+  data: ArchiveData
+  /** 変換時の警告メッセージ */
+  warnings: string[]
+}
+
+/**
+ * バージョン変換器インターフェース
+ *
+ * 各変換器は「特定のバージョンから次のバージョンへ」の変換を担当する
+ */
+export interface VersionTransformer {
+  /** 変換元バージョン */
+  readonly fromVersion: ArchiveVersion
+  /** 変換先バージョン */
+  readonly toVersion: ArchiveVersion
+
+  /**
+   * アーカイブデータを次のバージョンに変換
+   *
+   * @param data - 変換元のアーカイブデータ
+   * @returns 変換結果（データと警告）
+   */
+  transform(data: ArchiveData): TransformResult
+}
+
+// =============================================================================
+// Utility Types
+// =============================================================================
+
+/**
+ * 変換チェーン構築用のバージョンペア
+ */
+export interface VersionPair {
+  from: ArchiveVersion
+  to: ArchiveVersion
+}
+
+/**
+ * 変換チェーンの実行結果
+ */
+export interface ChainTransformResult {
+  /** 変換後のデータ */
+  data: ArchiveData
+  /** 元のバージョン */
+  originalVersion: ArchiveVersion
+  /** 最終バージョン */
+  finalVersion: ArchiveVersion
+  /** 適用された変換のリスト */
+  appliedTransformations: VersionPair[]
+  /** 累積された警告メッセージ */
+  warnings: string[]
+}

--- a/electron-src/lib/import/versionedImporter.ts
+++ b/electron-src/lib/import/versionedImporter.ts
@@ -1,7 +1,9 @@
 /**
  * バージョン別インポーター
  *
- * v0.2.z 以前のアーカイブ形式を v0.3.0 形式に変換
+ * 連鎖変換パターンを使用してアーカイブを最新形式に変換
+ *
+ * @see docs/schema-history/README.md
  */
 
 import type {
@@ -13,364 +15,36 @@ import type {
   ArchiveSubtotalsData,
   ArchiveUsersData,
 } from "../../../types/projectArchive.types"
+import {
+  CURRENT_VERSION,
+  SUPPORTED_VERSIONS,
+  detectArchiveVersion,
+  isSupportedVersion,
+  requiresTransformation,
+  transformToLatest,
+} from "./transformers"
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  ChainTransformResult,
+} from "./transformers"
 
 // =============================================================================
-// Version Detection
+// Re-exports from transformers
 // =============================================================================
 
-/**
- * アーカイブバージョンの種類
- * - 1.0.0: v0.2.z (UserProject.role nullable, invitedAt/invitedBy なし)
- * - 1.1.0: v0.3.z (UserProject完全対応, ProjectClass追加)
- * - 1.2.0: v0.4.z (userId/studentId非NULL化)
- */
-export type ArchiveVersion = "1.0.0" | "1.1.0" | "1.2.0" | "unknown"
-
-/**
- * バージョン文字列を比較
- *
- * @returns 負: v1 < v2, 0: v1 == v2, 正: v1 > v2
- */
-function compareVersions(v1: string, v2: string): number {
-  const parts1 = v1.split(".").map(Number)
-  const parts2 = v2.split(".").map(Number)
-
-  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    const p1 = parts1[i] || 0
-    const p2 = parts2[i] || 0
-    if (p1 !== p2) {
-      return p1 - p2
-    }
-  }
-  return 0
+export {
+  CURRENT_VERSION,
+  SUPPORTED_VERSIONS,
+  detectArchiveVersion,
+  isSupportedVersion,
+  requiresTransformation,
 }
 
-/**
- * マニフェストからバージョンを検出
- */
-export function detectArchiveVersion(
-  manifest: ArchiveManifest
-): ArchiveVersion {
-  const version = manifest.version
-
-  // v0.2.z (archive format 1.0.0)
-  if (compareVersions(version, "1.1.0") < 0) {
-    return "1.0.0"
-  }
-
-  // v0.3.z (archive format 1.1.0)
-  if (
-    compareVersions(version, "1.1.0") >= 0 &&
-    compareVersions(version, "1.2.0") < 0
-  ) {
-    return "1.1.0"
-  }
-
-  // v0.4.z+ (archive format 1.2.0)
-  if (
-    compareVersions(version, "1.2.0") >= 0 &&
-    compareVersions(version, "2.0.0") < 0
-  ) {
-    return "1.2.0"
-  }
-
-  return "unknown"
-}
+export type { ArchiveVersion }
 
 // =============================================================================
-// Data Transformation Types
-// =============================================================================
-
-/**
- * v0.2.z (1.0.0) のUserProject形式
- *
- * v0.2.20時点では role は存在する（デフォルト "OWNER"）
- * v0.2.z では invitedAt, invitedBy がない
- */
-interface V1_0_0_UserProject {
-  id: string
-  userId: string
-  projectId: string
-  role?: string // v0.2.20では存在する
-  createdAt: string
-  updatedAt: string
-}
-
-/**
- * v0.3.0 (1.1.0) のUserProject形式
- */
-interface V1_1_0_UserProject {
-  id: string
-  userId: string
-  projectId: string
-  role: string
-  invitedAt: string
-  invitedBy: string | null
-  createdAt: string
-  updatedAt: string
-}
-
-// =============================================================================
-// Version Transformers
-// =============================================================================
-
-/**
- * バージョン別変換インターフェース
- */
-export interface VersionTransformer {
-  /** 対応するアーカイブバージョン */
-  supportedVersion: ArchiveVersion
-  /** プロジェクトデータを変換 */
-  transformProjectData(data: ArchiveProjectData): ArchiveProjectData
-  /** 生徒データを変換 */
-  transformStudentsData(data: ArchiveStudentsData): ArchiveStudentsData
-  /** クラスデータを変換 */
-  transformClassesData(data: ArchiveClassesData): ArchiveClassesData
-  /** ユーザーデータを変換 */
-  transformUsersData(data: ArchiveUsersData): ArchiveUsersData
-  /** 小計データを変換 */
-  transformSubtotalsData(data: ArchiveSubtotalsData): ArchiveSubtotalsData
-  /** 採点データを変換 */
-  transformScoresData(data: ArchiveScoresData): ArchiveScoresData
-  /** マニフェストを変換 */
-  transformManifest(manifest: ArchiveManifest): ArchiveManifest
-}
-
-/**
- * v1.0.0 → v1.1.0 変換器
- *
- * v0.2.z のアーカイブを v0.3.0 形式に変換
- */
-export class V1_0_0_Transformer implements VersionTransformer {
-  supportedVersion: ArchiveVersion = "1.0.0"
-
-  transformProjectData(data: ArchiveProjectData): ArchiveProjectData {
-    // UserProjectにinvitedAt, invitedByを追加
-    // v0.2.20では role は既に存在するので、あれば保持、なければデフォルト値を設定
-    const transformedUserProjects = data.userProjects.map((up, index) => {
-      const v1Up = up as unknown as V1_0_0_UserProject
-
-      // roleが存在する場合は保持、なければデフォルト値を設定
-      // 最初のユーザーはOWNER、それ以外はGRADER
-      const role = v1Up.role ?? (index === 0 ? "OWNER" : "GRADER")
-
-      const v11Up: V1_1_0_UserProject = {
-        ...v1Up,
-        role,
-        invitedAt: v1Up.createdAt,
-        invitedBy: null,
-      }
-      return v11Up as unknown as ArchiveProjectData["userProjects"][0]
-    })
-
-    // invitedByを設定（最初のユーザー以外）
-    if (transformedUserProjects.length > 1) {
-      const ownerUserId = transformedUserProjects[0]?.userId
-      for (let i = 1; i < transformedUserProjects.length; i++) {
-        const up = transformedUserProjects[i] as unknown as V1_1_0_UserProject
-        up.invitedBy = ownerUserId || null
-      }
-    }
-
-    // v0.2.zにはprojectClassesがないので空の配列を追加
-    const projectClasses = data.projectClasses ?? []
-
-    return {
-      ...data,
-      userProjects: transformedUserProjects,
-      projectClasses,
-    }
-  }
-
-  transformStudentsData(data: ArchiveStudentsData): ArchiveStudentsData {
-    // v0.2.z → v0.3.0 での生徒データの変更はなし
-    return data
-  }
-
-  transformClassesData(data: ArchiveClassesData): ArchiveClassesData {
-    // v0.2.z → v0.3.0 でのクラスデータの変更はなし
-    return data
-  }
-
-  transformUsersData(data: ArchiveUsersData): ArchiveUsersData {
-    // v0.2.z → v0.3.0 でのユーザーデータの変更はなし
-    return data
-  }
-
-  transformSubtotalsData(data: ArchiveSubtotalsData): ArchiveSubtotalsData {
-    // v0.2.z → v0.3.0 での小計データの変更はなし
-    return data
-  }
-
-  transformScoresData(data: ArchiveScoresData): ArchiveScoresData {
-    // v0.2.z → v0.3.0 での採点データの変更はなし
-    return data
-  }
-
-  transformManifest(manifest: ArchiveManifest): ArchiveManifest {
-    return {
-      ...manifest,
-      // バージョンを最新に更新
-      version: "1.1.0",
-      schemaVersion: manifest.schemaVersion || "unknown",
-    }
-  }
-}
-
-/**
- * v1.1.0 → v1.2.0 変換器
- *
- * v0.3.z のアーカイブを v0.4.0 形式に変換
- * - QuestionScore: scoredByUserId → userId, studentId null対応
- * - DrawingAnnotation: createdByUserId → userId
- */
-export class V1_1_0_Transformer implements VersionTransformer {
-  supportedVersion: ArchiveVersion = "1.1.0"
-
-  transformProjectData(data: ArchiveProjectData): ArchiveProjectData {
-    return data
-  }
-
-  transformStudentsData(data: ArchiveStudentsData): ArchiveStudentsData {
-    return data
-  }
-
-  transformClassesData(data: ArchiveClassesData): ArchiveClassesData {
-    return data
-  }
-
-  transformUsersData(data: ArchiveUsersData): ArchiveUsersData {
-    return data
-  }
-
-  transformSubtotalsData(data: ArchiveSubtotalsData): ArchiveSubtotalsData {
-    return data
-  }
-
-  transformScoresData(data: ArchiveScoresData): ArchiveScoresData {
-    // v1.1.0では scoredByUserId / createdByUserId が使われている可能性がある
-    // v1.2.0では userId に統一、かつ非NULL
-    const transformedScores = data.questionScores
-      .map((qs) => {
-        // 旧フィールド名からの変換
-        const rawScore = qs as unknown as Record<string, unknown>
-        const userId =
-          (rawScore.userId as string) ||
-          (rawScore.scoredByUserId as string) ||
-          ""
-        const studentId = qs.studentId || ""
-
-        // userId または studentId が空の場合はスキップ（後でフィルター）
-        return {
-          ...qs,
-          userId,
-          studentId,
-        }
-      })
-      .filter((qs) => qs.userId !== "" && qs.studentId !== "")
-
-    const transformedAnnotations = data.drawingAnnotations
-      .map((da) => {
-        const rawAnnotation = da as unknown as Record<string, unknown>
-        const userId =
-          (rawAnnotation.userId as string) ||
-          (rawAnnotation.createdByUserId as string) ||
-          ""
-
-        return {
-          ...da,
-          userId,
-        }
-      })
-      .filter((da) => da.userId !== "")
-
-    return {
-      questionScores: transformedScores,
-      drawingAnnotations: transformedAnnotations,
-    }
-  }
-
-  transformManifest(manifest: ArchiveManifest): ArchiveManifest {
-    return {
-      ...manifest,
-      version: "1.2.0",
-    }
-  }
-}
-
-/**
- * v1.2.0 (現行バージョン) の変換器
- *
- * 変換不要、パススルー
- */
-export class V1_2_0_Transformer implements VersionTransformer {
-  supportedVersion: ArchiveVersion = "1.2.0"
-
-  transformProjectData(data: ArchiveProjectData): ArchiveProjectData {
-    return data
-  }
-
-  transformStudentsData(data: ArchiveStudentsData): ArchiveStudentsData {
-    return data
-  }
-
-  transformClassesData(data: ArchiveClassesData): ArchiveClassesData {
-    return data
-  }
-
-  transformUsersData(data: ArchiveUsersData): ArchiveUsersData {
-    return data
-  }
-
-  transformSubtotalsData(data: ArchiveSubtotalsData): ArchiveSubtotalsData {
-    return data
-  }
-
-  transformScoresData(data: ArchiveScoresData): ArchiveScoresData {
-    return data
-  }
-
-  transformManifest(manifest: ArchiveManifest): ArchiveManifest {
-    return manifest
-  }
-}
-
-// =============================================================================
-// Transformer Factory
-// =============================================================================
-
-/**
- * バージョンに応じた変換器を取得
- */
-export function getTransformer(version: ArchiveVersion): VersionTransformer {
-  switch (version) {
-    case "1.0.0":
-      return new V1_0_0_Transformer()
-    case "1.1.0":
-      return new V1_1_0_Transformer()
-    case "1.2.0":
-      return new V1_2_0_Transformer()
-    default:
-      // 未知のバージョンはパススルー（警告付き）
-      console.warn(
-        `Unknown archive version: ${version}, using passthrough transformer`
-      )
-      return new V1_2_0_Transformer()
-  }
-}
-
-/**
- * マニフェストから適切な変換器を取得
- */
-export function getTransformerFromManifest(
-  manifest: ArchiveManifest
-): VersionTransformer {
-  const version = detectArchiveVersion(manifest)
-  return getTransformer(version)
-}
-
-// =============================================================================
-// Archive Data Transformation
+// Extended Types for Archive Processing
 // =============================================================================
 
 /**
@@ -396,64 +70,89 @@ export interface ExtractedArchiveData {
  */
 export interface TransformedArchiveData extends ExtractedArchiveData {
   /** 変換前のバージョン */
-  originalVersion: ArchiveVersion
+  originalVersion: ArchiveVersion | "unknown"
   /** 変換時の警告 */
   transformWarnings: string[]
 }
 
+// =============================================================================
+// Archive Transformation
+// =============================================================================
+
 /**
  * アーカイブデータを最新形式に変換
+ *
+ * 連鎖変換パターンを使用:
+ * 1.0.0 → 1.1.0 → 1.2.0
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @returns 変換済みデータ
  */
 export function transformArchiveData(
   data: ExtractedArchiveData
 ): TransformedArchiveData {
   const originalVersion = detectArchiveVersion(data.manifest)
-  const transformer = getTransformer(originalVersion)
-  const warnings: string[] = []
 
-  // 古いバージョンからの変換の場合は警告を追加
-  if (originalVersion === "1.0.0") {
-    warnings.push(
-      `アーカイブは古い形式(v${originalVersion})で作成されています。` +
-        `一部のデータ（ユーザー権限等）はデフォルト値で補完されました。`
+  if (originalVersion === "unknown") {
+    // 未知のバージョンは警告付きでパススルー
+    console.warn(
+      `Unknown archive version: ${data.manifest.version}. ` +
+        `Attempting to process as ${CURRENT_VERSION}.`
     )
+
+    return {
+      ...data,
+      originalVersion: "unknown",
+      transformWarnings: [
+        `アーカイブバージョン ${data.manifest.version} は認識できません。` +
+          `処理は続行しますが、データの整合性を確認してください。`,
+      ],
+    }
   }
 
-  if (originalVersion === "1.1.0") {
-    warnings.push(
-      `アーカイブはv0.3.z形式(v${originalVersion})で作成されています。` +
-        `userId/studentIdがnullの採点データはスキップされます。`
-    )
+  // 変換不要の場合
+  if (originalVersion === CURRENT_VERSION) {
+    return {
+      ...data,
+      originalVersion,
+      transformWarnings: [],
+    }
+  }
+
+  // 連鎖変換を実行
+  const archiveData: ArchiveData = {
+    manifest: data.manifest,
+    projectData: data.projectData,
+    studentsData: data.studentsData,
+    classesData: data.classesData,
+    usersData: data.usersData,
+    subtotalsData: data.subtotalsData,
+    scoresData: data.scoresData,
+  }
+
+  const result: ChainTransformResult = transformToLatest(archiveData)
+
+  // ログ出力
+  if (result.appliedTransformations.length > 0) {
+    const transformPath = result.appliedTransformations
+      .map((t) => `${t.from}→${t.to}`)
+      .join(" → ")
+    console.info(`Archive transformation applied: ${transformPath}`)
   }
 
   return {
-    manifest: transformer.transformManifest(data.manifest),
-    projectData: transformer.transformProjectData(data.projectData),
-    studentsData: transformer.transformStudentsData(data.studentsData),
-    classesData: transformer.transformClassesData(data.classesData),
-    usersData: transformer.transformUsersData(data.usersData),
-    subtotalsData: transformer.transformSubtotalsData(data.subtotalsData),
-    scoresData: transformer.transformScoresData(data.scoresData),
+    manifest: result.data.manifest,
+    projectData: result.data.projectData,
+    studentsData: result.data.studentsData,
+    classesData: result.data.classesData,
+    usersData: result.data.usersData,
+    subtotalsData: result.data.subtotalsData,
+    scoresData: result.data.scoresData,
     tempDir: data.tempDir,
     masterImagePaths: data.masterImagePaths,
     answerSheetPaths: data.answerSheetPaths,
-    originalVersion,
-    transformWarnings: warnings,
+    originalVersion: result.originalVersion,
+    transformWarnings: result.warnings,
   }
 }
 
-/**
- * バージョン変換が必要か確認
- */
-export function requiresTransformation(manifest: ArchiveManifest): boolean {
-  const version = detectArchiveVersion(manifest)
-  return version !== "1.2.0"
-}
-
-/**
- * サポートされているバージョンか確認
- */
-export function isSupportedVersion(manifest: ArchiveManifest): boolean {
-  const version = detectArchiveVersion(manifest)
-  return version !== "unknown"
-}


### PR DESCRIPTION
## Summary

- アーカイブ変換器を連鎖変換パターンにリファクタリング
- 各バージョン変換器を個別ファイルに分離（V1_0_0_to_V1_1_0, V1_1_0_to_V1_2_0）
- 履歴スキーマを `docs/schema-history/` にドキュメント化
- deprecated コードを削除

Closes #267

## 変更ファイル

### 新規作成
- `docs/schema-history/README.md` - バージョン間の変更点ドキュメント
- `docs/schema-history/schema-v1.0.0-v0.2.x.prisma` - v0.2.x スキーマ
- `docs/schema-history/schema-v1.1.0-v0.3.x.prisma` - v0.3.x スキーマ
- `docs/schema-history/schema-v1.2.0-v0.4.x.prisma` - v0.4.x スキーマ
- `electron-src/lib/import/transformers/types.ts` - 共通型定義
- `electron-src/lib/import/transformers/V1_0_0_to_V1_1_0.ts` - 1.0.0→1.1.0 変換器
- `electron-src/lib/import/transformers/V1_1_0_to_V1_2_0.ts` - 1.1.0→1.2.0 変換器
- `electron-src/lib/import/transformers/index.ts` - ファクトリと連鎖実行

### 修正
- `electron-src/lib/import/versionedImporter.ts` - 新しい変換器モジュールを使用

## Test plan

- [ ] 型チェックが通ること（`npm run typecheck`）
- [ ] v1.0.0 形式のアーカイブがインポートできること
- [ ] v1.1.0 形式のアーカイブがインポートできること
- [ ] v1.2.0 形式のアーカイブがインポートできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)