### PR TITLE
ui: 検出モード切替をshadcn Tabsに変更

### DIFF
--- a/components/projects/02-template/components/DetectionModeToggle.tsx
+++ b/components/projects/02-template/components/DetectionModeToggle.tsx
@@ -5,11 +5,9 @@
 "use client"
 
 import { memo } from "react"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { DetectionMode } from "../types"
-import {
-  DETECTION_MODE_LABELS,
-  DETECTION_MODE_DESCRIPTIONS,
-} from "../constants/detection"
+import { DETECTION_MODE_LABELS } from "../constants/detection"
 import { cn } from "@/lib/utils"
 
 interface DetectionModeToggleProps {
@@ -25,7 +23,8 @@ interface DetectionModeToggleProps {
   disabled?: boolean
 }
 
-const MODES: DetectionMode[] = ["manual", "auto"]
+/** モードの順序: 自動検出 → 手動指定 */
+const MODES: DetectionMode[] = ["auto", "manual"]
 
 /**
  * 検出モード切替コンポーネント
@@ -39,28 +38,24 @@ export const DetectionModeToggle = memo(function DetectionModeToggle({
 }: DetectionModeToggleProps) {
   return (
     <div className="flex flex-col gap-2">
-      {/* モード切替ボタン */}
-      <div className="flex items-center gap-1">
-        <span className="mr-2 text-xs text-gray-500">検出:</span>
-        {MODES.map((m) => (
-          <button
-            key={m}
-            type="button"
-            className={cn(
-              "rounded px-2 py-1 text-xs transition-colors",
-              mode === m
-                ? "bg-blue-600 text-white"
-                : "bg-gray-100 text-gray-700 hover:bg-gray-200",
-              disabled && "cursor-not-allowed opacity-50"
-            )}
-            onClick={() => onModeChange(m)}
-            disabled={disabled}
-            title={DETECTION_MODE_DESCRIPTIONS[m]}
-          >
-            {DETECTION_MODE_LABELS[m]}
-          </button>
-        ))}
-      </div>
+      {/* モード切替タブ */}
+      <Tabs
+        value={mode}
+        onValueChange={(value) => onModeChange(value as DetectionMode)}
+      >
+        <TabsList className="w-full">
+          {MODES.map((m) => (
+            <TabsTrigger
+              key={m}
+              value={m}
+              disabled={disabled}
+              className="flex-1 text-xs"
+            >
+              {DETECTION_MODE_LABELS[m]}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       {/* 一括検出ボタン（モードがmanual以外のとき表示） */}
       {mode !== "manual" && onDetectAll && (

--- a/components/projects/02-template/constants/detection.ts
+++ b/components/projects/02-template/constants/detection.ts
@@ -16,22 +16,22 @@ export const DEFAULT_DETECTION_SETTINGS: DetectionSettings = {
 /**
  * デフォルトの検出モード
  */
-export const DEFAULT_DETECTION_MODE: DetectionMode = "manual"
+export const DEFAULT_DETECTION_MODE: DetectionMode = "auto"
 
 /**
  * 検出モードのラベル
  */
 export const DETECTION_MODE_LABELS: Record<DetectionMode, string> = {
-  manual: "手動",
-  auto: "自動",
+  auto: "自動検出",
+  manual: "手動指定",
 }
 
 /**
  * 検出モードの説明
  */
 export const DETECTION_MODE_DESCRIPTIONS: Record<DetectionMode, string> = {
-  manual: "手動で領域を作成",
   auto: "枠を自動検出してスナップ補正",
+  manual: "手動で領域を作成",
 }
 
 /**


### PR DESCRIPTION
## Summary

- 検出モード切替UIをカスタムボタンからshadcn Tabsに変更
- デフォルトモードを「自動検出」に変更
- ラベルを「自動検出 / 手動指定」に更新

Closes #271

## 変更ファイル

- `components/projects/02-template/components/DetectionModeToggle.tsx`
  - カスタムボタン → shadcn Tabs
- `components/projects/02-template/constants/detection.ts`
  - デフォルトモード: `"manual"` → `"auto"`
  - ラベル更新

## Test plan

- [ ] 採点領域作成画面でタブが正しく表示されること
- [ ] 「自動検出」タブがデフォルトで選択されていること
- [ ] タブ切替が正常に動作すること
- [ ] 自動検出モードで枠検出ボタンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)