### PR TITLE
採点設定のカラム別楽観的更新対応

### DIFF
--- a/app/settings/components/DisplaySettingsTab.tsx
+++ b/app/settings/components/DisplaySettingsTab.tsx
@@ -49,7 +49,7 @@ export function DisplaySettingsTab() {
     getCurrentPresetId
   )
 
-  // 初期値をロード
+  // 初期値をロード（カラム別）
   useEffect(() => {
     if (initializedRef.current || !userId) return
     initializedRef.current = true
@@ -57,17 +57,21 @@ export function DisplaySettingsTab() {
     const loadSettings = async () => {
       if (window.electronAPI?.settings) {
         try {
+          // selectionBorderColorカラムのみ読み込み
           const result =
-            await window.electronAPI.settings.getUserScoringPreference(userId)
-          if (result.success && result.preference?.selectionBorderColor) {
-            setSelectionBorderColor(result.preference.selectionBorderColor)
+            await window.electronAPI.settings.getScoringPreferenceColumn(
+              userId,
+              "selectionBorderColor"
+            )
+          if (result.success && result.value) {
+            setSelectionBorderColor(result.value)
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)
         }
       }
 
-      // 採点状態色をDBから読み込み
+      // 採点状態色をDBから読み込み（scoringStatusColorsは内部でカラム別読み込み）
       await loadScoringStatusColors(userId)
       setScoringColors(getScoringStatusColors())
       setCurrentPresetId(getCurrentPresetId())
@@ -76,7 +80,7 @@ export function DisplaySettingsTab() {
     loadSettings()
   }, [userId])
 
-  // 選択枠色の変更
+  // 選択枠色の変更（カラム別・楽観的更新）
   const handleSelectionBorderColorChange = useCallback(
     async (color: string) => {
       const upperColor = color.toUpperCase()
@@ -84,11 +88,10 @@ export function DisplaySettingsTab() {
 
       if (userId && window.electronAPI?.settings) {
         try {
-          await window.electronAPI.settings.upsertUserScoringPreference(
+          await window.electronAPI.settings.setScoringPreferenceColumn(
             userId,
-            {
-              selectionBorderColor: upperColor,
-            }
+            "selectionBorderColor",
+            upperColor
           )
           window.dispatchEvent(new CustomEvent("selectionBorderColorChanged"))
           toast.success("選択枠色が変更されました")

--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -36,6 +36,8 @@ export interface AnswerGridViewProps {
   autoScroll?: boolean
   /** 生徒名表示設定 */
   showStudentNames?: boolean
+  /** 表示領域拡張率 (0-50%) */
+  expandMargin?: number
   className?: string
 }
 
@@ -50,6 +52,7 @@ export default function AnswerGridView({
   itemsPerRow: externalItemsPerRow,
   autoScroll = true,
   showStudentNames = true,
+  expandMargin,
   className = "",
 }: AnswerGridViewProps) {
   /** フィルタリングされた採点データ（模範解答 + 学生データ） */
@@ -225,6 +228,7 @@ export default function AnswerGridView({
               calculatedCellHeight={calculatedCellHeight}
               selectionBorderColor={selectionBorderColor}
               scoringColors={scoringColors}
+              expandMargin={expandMargin}
               onMouseDown={onCellMouseDown}
             />
           )

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -29,6 +29,7 @@ interface GridCellProps {
   calculatedCellHeight: number
   selectionBorderColor: string
   scoringColors: ScoringStatusColors
+  expandMargin?: number
   onMouseDown: (e: React.MouseEvent, answerId: string) => void
 }
 
@@ -40,6 +41,7 @@ export function GridCell({
   calculatedCellHeight,
   selectionBorderColor,
   scoringColors,
+  expandMargin,
   onMouseDown,
 }: GridCellProps) {
   const statusConfig = getDynamicScoreStatusConfig(scoringColors)
@@ -122,6 +124,7 @@ export function GridCell({
         isColumnLayout={isColumnLayout}
         calculatedCellHeight={calculatedCellHeight}
         isSelected={isSelected}
+        expandMargin={expandMargin}
       />
 
       {/* 学生情報と採点状況 */}

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
@@ -1,6 +1,9 @@
 /**
  * 選択枠の色を取得・監視するフック
  * 機能G: ユーザー設定の永続化
+ *
+ * カラム別楽観的更新パターン:
+ * - selectionBorderColorカラムのみを読み書き
  */
 
 import { useAuth } from "@/contexts/AuthContext"
@@ -14,7 +17,7 @@ export function useSelectionBorder(): string {
   const [color, setColor] = useState(DEFAULT_SELECTION_BORDER_COLOR)
   const initializedRef = useRef(false)
 
-  // 設定を読み込む
+  // 設定を読み込む（カラム別）
   useEffect(() => {
     if (initializedRef.current) return
     initializedRef.current = true
@@ -23,9 +26,12 @@ export function useSelectionBorder(): string {
       if (userId && window.electronAPI?.settings) {
         try {
           const result =
-            await window.electronAPI.settings.getUserScoringPreference(userId)
-          if (result.success && result.preference?.selectionBorderColor) {
-            setColor(result.preference.selectionBorderColor)
+            await window.electronAPI.settings.getScoringPreferenceColumn(
+              userId,
+              "selectionBorderColor"
+            )
+          if (result.success && result.value) {
+            setColor(result.value)
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)
@@ -42,9 +48,12 @@ export function useSelectionBorder(): string {
       if (userId && window.electronAPI?.settings) {
         try {
           const result =
-            await window.electronAPI.settings.getUserScoringPreference(userId)
-          if (result.success && result.preference?.selectionBorderColor) {
-            setColor(result.preference.selectionBorderColor)
+            await window.electronAPI.settings.getScoringPreferenceColumn(
+              userId,
+              "selectionBorderColor"
+            )
+          if (result.success && result.value) {
+            setColor(result.value)
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)

--- a/components/projects/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -32,6 +32,7 @@ interface CroppedAnswerImageProps {
   isColumnLayout?: boolean
   calculatedCellHeight?: number // 親から渡された計算済みセル高さ
   isSelected?: boolean
+  expandMargin?: number // 表示領域拡張率 (0-50%)
 }
 
 // セル内の固定オフセット（padding + gap + footer）
@@ -46,6 +47,7 @@ export default function CroppedAnswerImage({
   isColumnLayout = false,
   calculatedCellHeight = 0,
   isSelected = false,
+  expandMargin = 0,
 }: CroppedAnswerImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
@@ -59,9 +61,21 @@ export default function CroppedAnswerImage({
     const ctx = canvas.getContext("2d")
     if (!ctx) return
 
-    // 採点領域のアスペクト比を計算
-    const sourceWidth = cropRegion.width * imageElement.naturalWidth
-    const sourceHeight = cropRegion.height * imageElement.naturalHeight
+    // 表示領域拡張の計算
+    const expandRatio = (expandMargin ?? 0) / 100
+    const expandX = cropRegion.width * expandRatio
+    const expandY = cropRegion.height * expandRatio
+
+    // 拡張後の座標（画像端でクリップ）
+    const newX = Math.max(0, cropRegion.x - expandX)
+    const newY = Math.max(0, cropRegion.y - expandY)
+    // 右端・下端がはみ出さないように制限
+    const newWidth = Math.min(1 - newX, cropRegion.width + expandX * 2)
+    const newHeight = Math.min(1 - newY, cropRegion.height + expandY * 2)
+
+    // 採点領域のアスペクト比を計算（拡張後の領域で計算）
+    const sourceWidth = newWidth * imageElement.naturalWidth
+    const sourceHeight = newHeight * imageElement.naturalHeight
     const aspectRatio = sourceWidth / sourceHeight
 
     let canvasWidth: number
@@ -94,11 +108,11 @@ export default function CroppedAnswerImage({
       canvas.style.flexShrink = ""
     }
 
-    // 採点領域をクロップして描画
-    const sourceX = cropRegion.x * imageElement.naturalWidth
-    const sourceY = cropRegion.y * imageElement.naturalHeight
+    // 拡張後の座標でクロップして描画
+    const sourceX = newX * imageElement.naturalWidth
+    const sourceY = newY * imageElement.naturalHeight
 
-    // 採点領域を直接Canvas全体に描画（アスペクト比は既に調整済み）
+    // 拡張した採点領域を直接Canvas全体に描画（アスペクト比は既に調整済み）
     ctx.drawImage(
       imageElement,
       sourceX,
@@ -110,7 +124,13 @@ export default function CroppedAnswerImage({
       canvas.width,
       canvas.height
     )
-  }, [imageLoaded, cropRegion, isColumnLayout, calculatedCellHeight])
+  }, [
+    imageLoaded,
+    cropRegion,
+    isColumnLayout,
+    calculatedCellHeight,
+    expandMargin,
+  ])
 
   const handleImageLoad = () => {
     setImageLoaded(true)

--- a/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -33,6 +33,7 @@ interface ScoringContentAreaProps {
   itemsPerLine: number[]
   autoScroll: boolean
   showStudentNames: boolean
+  expandMargin?: number
 
   /** IndividualView設定 */
   pageImages?: PageImageWithProjectStudents[]
@@ -61,6 +62,7 @@ export function ScoringContentArea({
   itemsPerLine,
   autoScroll,
   showStudentNames,
+  expandMargin,
   pageImages,
   onTextInputStateChange,
   currentStudentId,
@@ -103,6 +105,7 @@ export function ScoringContentArea({
       itemsPerRow={itemsPerLine}
       autoScroll={autoScroll}
       showStudentNames={showStudentNames}
+      expandMargin={expandMargin}
       className="p-4"
     />
   )

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -59,10 +59,12 @@ function ScoringMainViewContent() {
     autoScroll,
     showStudentNames,
     layoutDirection,
+    expandMargin,
     setItemsPerLine,
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
+    setExpandMargin,
   } = useScoringSettings()
 
   const [questionChangeVersion, setQuestionChangeVersion] = useState(0)
@@ -346,6 +348,7 @@ function ScoringMainViewContent() {
           currentStudentId={currentStudentId || undefined}
           currentUserId={currentUserId || undefined}
           questionScores={questionScores}
+          expandMargin={expandMargin}
         />
 
         {/* 右側サイドパネル */}
@@ -378,6 +381,8 @@ function ScoringMainViewContent() {
             autoScroll={autoScroll}
             onAutoScrollChange={handleAutoScrollChange}
             gradingMode={gradingMode}
+            expandMargin={expandMargin}
+            onExpandMarginChange={setExpandMargin}
             students={students}
             onStudentChange={handleStudentChange}
             pageImages={pageImages}
@@ -394,8 +399,12 @@ function ScoringMainViewContent() {
         currentCropRegion={currentCropRegion}
         onPartialScoreClose={handlePartialScoreCancel}
         onPartialScoreChange={handlePartialScoreChange}
-        onPartialScoreConfirmPartial={() => handlePartialScoreConfirm("partial")}
-        onPartialScoreConfirmPending={() => handlePartialScoreConfirm("pending")}
+        onPartialScoreConfirmPartial={() =>
+          handlePartialScoreConfirm("partial")
+        }
+        onPartialScoreConfirmPending={() =>
+          handlePartialScoreConfirm("pending")
+        }
         keyBindings={modalKeyBindings}
         showScoreComparison={showScoreComparison}
         onScoreComparisonClose={() => setShowScoreComparison(false)}

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview 自動スクロール設定フック
+ * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ */
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useCallback, useEffect, useState, useRef } from "react"
+
+/** デフォルト値 */
+const DEFAULT_AUTO_SCROLL = true
+
+/**
+ * 自動スクロール設定を管理するフック
+ * @returns autoScroll - 現在の自動スクロール設定
+ * @returns setAutoScroll - 設定を更新する関数
+ * @returns isLoading - 読み込み中フラグ
+ */
+export function useAutoScroll() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [autoScroll, setAutoScrollState] = useState<boolean>(DEFAULT_AUTO_SCROLL)
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedRef = useRef(false)
+
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    const load = async () => {
+      if (!userId || !window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const result =
+          await window.electronAPI.settings.getScoringPreferenceColumn(
+            userId,
+            "autoScroll"
+          )
+        if (result.success && result.value !== undefined) {
+          setAutoScrollState(result.value)
+        }
+      } catch (error) {
+        console.error("autoScrollの読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  /**
+   * 楽観的更新: UI即時更新 + DB非同期保存
+   * @param value - 新しい自動スクロール設定
+   */
+  const setAutoScroll = useCallback(
+    (value: boolean) => {
+      setAutoScrollState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setScoringPreferenceColumn(userId, "autoScroll", value)
+          .catch((error) =>
+            console.error("autoScrollの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    autoScroll,
+    setAutoScroll,
+    isLoading,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview 表示領域拡張設定フック
+ * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ */
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useCallback, useEffect, useState, useRef } from "react"
+
+/** デフォルト値（0%） */
+const DEFAULT_EXPAND_MARGIN = 0
+
+/**
+ * 表示領域拡張設定を管理するフック
+ * @description Grid表示時に採点領域の外側をn%拡張して表示する
+ * @returns expandMargin - 現在の拡張率（0-50%）
+ * @returns setExpandMargin - 拡張率を更新する関数
+ * @returns isLoading - 読み込み中フラグ
+ */
+export function useExpandMargin() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [expandMargin, setExpandMarginState] = useState<number>(
+    DEFAULT_EXPAND_MARGIN
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedRef = useRef(false)
+
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    const load = async () => {
+      if (!userId || !window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const result =
+          await window.electronAPI.settings.getScoringPreferenceColumn(
+            userId,
+            "expandMargin"
+          )
+        if (result.success && result.value !== undefined) {
+          setExpandMarginState(result.value)
+        }
+      } catch (error) {
+        console.error("expandMarginの読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  /**
+   * 楽観的更新: UI即時更新 + DB非同期保存
+   * @param value - 新しい拡張率（0-50の整数）
+   */
+  const setExpandMargin = useCallback(
+    (value: number) => {
+      setExpandMarginState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setScoringPreferenceColumn(userId, "expandMargin", value)
+          .catch((error) =>
+            console.error("expandMarginの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    expandMargin,
+    setExpandMargin,
+    isLoading,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview 1行あたりの表示件数設定フック
+ * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ */
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useCallback, useEffect, useState, useRef } from "react"
+
+/** デフォルト値 */
+const DEFAULT_ITEMS_PER_LINE = 5
+
+/**
+ * 1行あたりの表示件数を管理するフック
+ * @returns itemsPerLine - 現在の値（配列形式、Slider互換）
+ * @returns setItemsPerLine - 値を更新する関数
+ * @returns isLoading - 読み込み中フラグ
+ */
+export function useItemsPerLine() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [itemsPerLine, setItemsPerLineState] = useState<number>(
+    DEFAULT_ITEMS_PER_LINE
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedRef = useRef(false)
+
+  // 初期読み込み
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    const load = async () => {
+      if (!userId || !window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const result =
+          await window.electronAPI.settings.getScoringPreferenceColumn(
+            userId,
+            "itemsPerLine"
+          )
+        if (result.success && result.value !== undefined) {
+          setItemsPerLineState(result.value)
+        }
+      } catch (error) {
+        console.error("itemsPerLineの読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  /**
+   * 楽観的更新: UI即時更新 + DB非同期保存
+   * @param value - 新しい値（配列形式、Slider互換）
+   */
+  const setItemsPerLine = useCallback(
+    (value: number[]) => {
+      const newValue = value[0]
+      setItemsPerLineState(newValue)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setScoringPreferenceColumn(userId, "itemsPerLine", newValue)
+          .catch((error) =>
+            console.error("itemsPerLineの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    itemsPerLine: [itemsPerLine],
+    setItemsPerLine,
+    isLoading,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview レイアウト方向設定フック
+ * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ */
+
+import { useAuth } from "@/contexts/AuthContext"
+import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
+import { useCallback, useEffect, useState, useRef } from "react"
+
+/** デフォルト値 */
+const DEFAULT_LAYOUT_DIRECTION: LayoutDirection = "right-down"
+
+/**
+ * レイアウト方向設定を管理するフック
+ * @returns layoutDirection - 現在のレイアウト方向（"right-down" | "down-right"）
+ * @returns setLayoutDirection - レイアウト方向を更新する関数
+ * @returns isLoading - 読み込み中フラグ
+ */
+export function useLayoutDirection() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [layoutDirection, setLayoutDirectionState] = useState<LayoutDirection>(
+    DEFAULT_LAYOUT_DIRECTION
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedRef = useRef(false)
+
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    const load = async () => {
+      if (!userId || !window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const result =
+          await window.electronAPI.settings.getScoringPreferenceColumn(
+            userId,
+            "layoutDirection"
+          )
+        if (result.success && result.value !== undefined) {
+          setLayoutDirectionState(result.value as LayoutDirection)
+        }
+      } catch (error) {
+        console.error("layoutDirectionの読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  /**
+   * 楽観的更新: UI即時更新 + DB非同期保存
+   * @param value - 新しいレイアウト方向
+   */
+  const setLayoutDirection = useCallback(
+    (value: LayoutDirection) => {
+      setLayoutDirectionState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setScoringPreferenceColumn(userId, "layoutDirection", value)
+          .catch((error) =>
+            console.error("layoutDirectionの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    layoutDirection,
+    setLayoutDirection,
+    isLoading,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -1,128 +1,84 @@
 /**
- * 採点設定フック
- * 機能G: ユーザー採点設定の永続化
+ * @fileoverview 採点設定フック（統合版）
+ * @description 機能G: ユーザー採点設定の永続化
+ *
+ * 各設定は独立したフックで管理され、このフックは互換性のために統合して返す。
+ * 楽観的更新時のレースコンディションを防ぐため、各設定は独立したstateを持つ。
  */
 
-import { useAuth } from "@/contexts/AuthContext"
-import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
-import { useCallback, useEffect, useState, useRef } from "react"
+import { useItemsPerLine } from "./useItemsPerLine"
+import { useAutoScroll } from "./useAutoScroll"
+import { useShowStudentNames } from "./useShowStudentNames"
+import { useLayoutDirection } from "./useLayoutDirection"
+import { useExpandMargin } from "./useExpandMargin"
 
-const DEFAULT_LAYOUT_DIRECTION: LayoutDirection = "right-down"
-const DEFAULT_ITEMS_PER_LINE = [5]
-const DEFAULT_AUTO_SCROLL = true
-const DEFAULT_SHOW_STUDENT_NAMES = true
-
-interface ScoringSettings {
-  itemsPerLine: number[]
-  autoScroll: boolean
-  showStudentNames: boolean
-  layoutDirection: LayoutDirection
-}
-
-const DEFAULT_SETTINGS: ScoringSettings = {
-  itemsPerLine: DEFAULT_ITEMS_PER_LINE,
-  autoScroll: DEFAULT_AUTO_SCROLL,
-  showStudentNames: DEFAULT_SHOW_STUDENT_NAMES,
-  layoutDirection: DEFAULT_LAYOUT_DIRECTION,
-}
-
+/**
+ * 全採点設定を統合して返すフック
+ * @description 各設定は独立したフックで管理されるため、競合なく楽観的更新が可能
+ * @returns itemsPerLine - 1行あたりの表示件数（配列形式）
+ * @returns autoScroll - 自動スクロール設定
+ * @returns showStudentNames - 生徒名表示設定
+ * @returns layoutDirection - レイアウト方向
+ * @returns expandMargin - 表示領域拡張率
+ * @returns setItemsPerLine - 表示件数更新関数
+ * @returns setAutoScroll - 自動スクロール更新関数
+ * @returns setShowStudentNames - 生徒名表示更新関数
+ * @returns setLayoutDirection - レイアウト方向更新関数
+ * @returns setExpandMargin - 拡張率更新関数
+ * @returns isLoading - いずれかの設定が読み込み中かどうか
+ */
 export function useScoringSettings() {
-  const { user } = useAuth()
-  const userId = user?.id
+  const {
+    itemsPerLine,
+    setItemsPerLine,
+    isLoading: isLoadingItemsPerLine,
+  } = useItemsPerLine()
+  const {
+    autoScroll,
+    setAutoScroll,
+    isLoading: isLoadingAutoScroll,
+  } = useAutoScroll()
+  const {
+    showStudentNames,
+    setShowStudentNames,
+    isLoading: isLoadingShowStudentNames,
+  } = useShowStudentNames()
+  const {
+    layoutDirection,
+    setLayoutDirection,
+    isLoading: isLoadingLayoutDirection,
+  } = useLayoutDirection()
+  const {
+    expandMargin,
+    setExpandMargin,
+    isLoading: isLoadingExpandMargin,
+  } = useExpandMargin()
 
-  const [settings, setSettings] = useState<ScoringSettings>(DEFAULT_SETTINGS)
-  const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
-
-  // 設定を読み込む
-  useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
-
-    const loadSettings = async () => {
-      if (userId && window.electronAPI?.settings) {
-        try {
-          const result =
-            await window.electronAPI.settings.getUserScoringPreference(userId)
-          if (result.success && result.preference) {
-            setSettings({
-              itemsPerLine: [result.preference.itemsPerLine],
-              autoScroll: result.preference.autoScroll,
-              showStudentNames: result.preference.showStudentNames,
-              layoutDirection: result.preference
-                .layoutDirection as LayoutDirection,
-            })
-          }
-        } catch (error) {
-          console.error("設定の読み込みに失敗しました:", error)
-        }
-      }
-      setIsLoading(false)
-    }
-
-    loadSettings()
-  }, [userId])
-
-  // 設定を保存する共通関数
-  const saveSettings = useCallback(
-    async (newSettings: Partial<ScoringSettings>) => {
-      if (!userId || !window.electronAPI?.settings) return
-
-      try {
-        await window.electronAPI.settings.upsertUserScoringPreference(userId, {
-          itemsPerLine: newSettings.itemsPerLine?.[0],
-          autoScroll: newSettings.autoScroll,
-          showStudentNames: newSettings.showStudentNames,
-          layoutDirection: newSettings.layoutDirection,
-        })
-      } catch (error) {
-        console.error("設定の保存に失敗しました:", error)
-      }
-    },
-    [userId]
-  )
-
-  const setItemsPerLine = useCallback(
-    (value: number[]) => {
-      setSettings((prev) => ({ ...prev, itemsPerLine: value }))
-      saveSettings({ itemsPerLine: value })
-    },
-    [saveSettings]
-  )
-
-  const setAutoScroll = useCallback(
-    (value: boolean) => {
-      setSettings((prev) => ({ ...prev, autoScroll: value }))
-      saveSettings({ autoScroll: value })
-    },
-    [saveSettings]
-  )
-
-  const setShowStudentNames = useCallback(
-    (value: boolean) => {
-      setSettings((prev) => ({ ...prev, showStudentNames: value }))
-      saveSettings({ showStudentNames: value })
-    },
-    [saveSettings]
-  )
-
-  const setLayoutDirection = useCallback(
-    (value: LayoutDirection) => {
-      setSettings((prev) => ({ ...prev, layoutDirection: value }))
-      saveSettings({ layoutDirection: value })
-    },
-    [saveSettings]
-  )
+  const isLoading =
+    isLoadingItemsPerLine ||
+    isLoadingAutoScroll ||
+    isLoadingShowStudentNames ||
+    isLoadingLayoutDirection ||
+    isLoadingExpandMargin
 
   return {
-    itemsPerLine: settings.itemsPerLine,
-    autoScroll: settings.autoScroll,
-    showStudentNames: settings.showStudentNames,
-    layoutDirection: settings.layoutDirection,
+    itemsPerLine,
+    autoScroll,
+    showStudentNames,
+    layoutDirection,
+    expandMargin,
     setItemsPerLine,
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
+    setExpandMargin,
     isLoading,
   }
 }
+
+// 個別フックも再エクスポート
+export { useItemsPerLine } from "./useItemsPerLine"
+export { useAutoScroll } from "./useAutoScroll"
+export { useShowStudentNames } from "./useShowStudentNames"
+export { useLayoutDirection } from "./useLayoutDirection"
+export { useExpandMargin } from "./useExpandMargin"

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview 生徒名表示設定フック
+ * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ */
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useCallback, useEffect, useState, useRef } from "react"
+
+/** デフォルト値 */
+const DEFAULT_SHOW_STUDENT_NAMES = true
+
+/**
+ * 生徒名表示設定を管理するフック
+ * @returns showStudentNames - 生徒名を表示するかどうか
+ * @returns setShowStudentNames - 設定を更新する関数
+ * @returns isLoading - 読み込み中フラグ
+ */
+export function useShowStudentNames() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [showStudentNames, setShowStudentNamesState] = useState<boolean>(
+    DEFAULT_SHOW_STUDENT_NAMES
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedRef = useRef(false)
+
+  useEffect(() => {
+    if (initializedRef.current) return
+    initializedRef.current = true
+
+    const load = async () => {
+      if (!userId || !window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const result =
+          await window.electronAPI.settings.getScoringPreferenceColumn(
+            userId,
+            "showStudentNames"
+          )
+        if (result.success && result.value !== undefined) {
+          setShowStudentNamesState(result.value)
+        }
+      } catch (error) {
+        console.error("showStudentNamesの読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  /**
+   * 楽観的更新: UI即時更新 + DB非同期保存
+   * @param value - 新しい生徒名表示設定
+   */
+  const setShowStudentNames = useCallback(
+    (value: boolean) => {
+      setShowStudentNamesState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setScoringPreferenceColumn(userId, "showStudentNames", value)
+          .catch((error) =>
+            console.error("showStudentNamesの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    showStudentNames,
+    setShowStudentNames,
+    isLoading,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
@@ -24,6 +24,7 @@ import {
   ArrowRight,
   ArrowUp,
   Eye,
+  Maximize2,
   Navigation,
   RotateCcw,
   Settings,
@@ -45,6 +46,8 @@ interface NavigationControlsProps {
   autoScroll?: boolean
   onAutoScrollChange?: (enabled: boolean) => void
   gradingMode?: "grid" | "individual"
+  expandMargin?: number
+  onExpandMarginChange?: (value: number) => void
 }
 
 const LAYOUT_OPTIONS = [
@@ -68,6 +71,8 @@ export default function NavigationControls({
   autoScroll = true,
   onAutoScrollChange,
   gradingMode = "grid",
+  expandMargin,
+  onExpandMarginChange,
 }: NavigationControlsProps) {
   return (
     <TooltipProvider delayDuration={300}>
@@ -116,6 +121,30 @@ export default function NavigationControls({
           </div>
         </SidePanelSection>
       )}
+
+      {/* 表示領域拡張 - 一覧表示モードでのみ表示 */}
+      {gradingMode !== "individual" &&
+        expandMargin !== undefined &&
+        onExpandMarginChange && (
+          <SidePanelSection icon={Maximize2} title="表示領域拡張">
+            <div className="flex items-center space-x-4">
+              <Slider
+                value={[expandMargin]}
+                onValueChange={(value) => onExpandMarginChange(value[0])}
+                max={50}
+                min={0}
+                step={5}
+                className="flex-1"
+              />
+              <span className="text-muted-foreground min-w-[40px] text-sm">
+                {expandMargin}%
+              </span>
+            </div>
+            <p className="text-xs text-gray-500">
+              枠の外側を表示（スキャンズレ対策）
+            </p>
+          </SidePanelSection>
+        )}
 
       {/* 自動スクロール設定 - 一覧表示モードでのみ表示 */}
       {gradingMode !== "individual" && onAutoScrollChange && (

--- a/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -54,6 +54,9 @@ interface ScoringSidePanelProps {
   autoScroll: boolean
   onAutoScrollChange: (enabled: boolean) => void
   gradingMode: "grid" | "individual"
+  // 表示領域拡張
+  expandMargin?: number
+  onExpandMarginChange?: (value: number) => void
   // Individual mode props
   students?: {
     id: string
@@ -96,6 +99,8 @@ export function ScoringSidePanel({
   autoScroll,
   onAutoScrollChange,
   gradingMode,
+  expandMargin,
+  onExpandMarginChange,
   students,
   onStudentChange,
   selectedPageImageIds,
@@ -164,6 +169,8 @@ export function ScoringSidePanel({
         autoScroll={autoScroll}
         onAutoScrollChange={onAutoScrollChange}
         gradingMode={gradingMode}
+        expandMargin={expandMargin}
+        onExpandMarginChange={onExpandMarginChange}
       />
 
       <Separator />

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -9,7 +9,11 @@ import {
   resetUserKeyboardShortcuts,
   getUserScoringPreference,
   upsertUserScoringPreference,
+  getScoringPreferenceColumn,
+  setScoringPreferenceColumn,
   type ScoringPreferenceData,
+  type ScoringPreferenceColumnName,
+  type ScoringPreferenceColumns,
 } from "../lib/prisma/userSettings"
 import {
   getProjectMarkingFormats,
@@ -95,6 +99,53 @@ export function registerSettingsHandlers() {
         return { success: true, preference }
       } catch (error) {
         console.error("Failed to upsert scoring preference:", error)
+        return { success: false, error: String(error) }
+      }
+    }
+  )
+
+  // カラム別取得
+  ipcMain.handle(
+    "settings:getScoringPreferenceColumn",
+    async (
+      _event,
+      userId: string,
+      column: ScoringPreferenceColumnName
+    ): Promise<{
+      success: boolean
+      value?: ScoringPreferenceColumns[typeof column]
+      error?: string
+    }> => {
+      try {
+        const value = await getScoringPreferenceColumn(userId, column)
+        return { success: true, value }
+      } catch (error) {
+        console.error(
+          `Failed to get scoring preference column [${column}]:`,
+          error
+        )
+        return { success: false, error: String(error) }
+      }
+    }
+  )
+
+  // カラム別設定（楽観的更新用）
+  ipcMain.handle(
+    "settings:setScoringPreferenceColumn",
+    async (
+      _event,
+      userId: string,
+      column: ScoringPreferenceColumnName,
+      value: ScoringPreferenceColumns[typeof column]
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        await setScoringPreferenceColumn(userId, column, value)
+        return { success: true }
+      } catch (error) {
+        console.error(
+          `Failed to set scoring preference column [${column}]:`,
+          error
+        )
         return { success: false, error: String(error) }
       }
     }

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -385,6 +385,7 @@ CREATE TABLE "UserScoringPreference" (
     "autoScroll" BOOLEAN NOT NULL DEFAULT true,
     "itemsPerLine" INTEGER NOT NULL DEFAULT 5,
     "layoutDirection" TEXT NOT NULL DEFAULT 'right-down',
+    "expandMargin" INTEGER NOT NULL DEFAULT 0,
     "selectionBorderColor" TEXT,
     "scoringStatusColors" TEXT,
     "scoringColorPresetId" TEXT,

--- a/electron-src/lib/prisma/userSettings.ts
+++ b/electron-src/lib/prisma/userSettings.ts
@@ -1,5 +1,6 @@
 /**
- * ユーザー設定関連のPrisma操作関数
+ * @fileoverview ユーザー設定関連のPrisma操作関数
+ * @description キーボードショートカット、採点画面設定のDB操作を提供
  */
 
 import prisma from "./client"
@@ -8,6 +9,11 @@ import prisma from "./client"
 // UserKeyboardShortcut（キーボードショートカット）
 // =============================================================================
 
+/**
+ * ユーザーのキーボードショートカット設定を取得
+ * @param userId - ユーザーID
+ * @returns action -> key のマッピングオブジェクト
+ */
 export async function getUserKeyboardShortcuts(userId: string) {
   const shortcuts = await prisma.userKeyboardShortcut.findMany({
     where: { userId },
@@ -19,6 +25,12 @@ export async function getUserKeyboardShortcuts(userId: string) {
   }, {})
 }
 
+/**
+ * キーボードショートカットを追加/更新
+ * @param userId - ユーザーID
+ * @param action - アクション名
+ * @param key - 割り当てるキー
+ */
 export async function upsertUserKeyboardShortcut(
   userId: string,
   action: string,
@@ -33,6 +45,11 @@ export async function upsertUserKeyboardShortcut(
   })
 }
 
+/**
+ * 複数のキーボードショートカットを一括で追加/更新
+ * @param userId - ユーザーID
+ * @param shortcuts - action -> key のマッピング
+ */
 export async function bulkUpsertUserKeyboardShortcuts(
   userId: string,
   shortcuts: Record<string, string>
@@ -49,6 +66,11 @@ export async function bulkUpsertUserKeyboardShortcuts(
   return prisma.$transaction(operations)
 }
 
+/**
+ * キーボードショートカットを削除
+ * @param userId - ユーザーID
+ * @param action - 削除するアクション名
+ */
 export async function deleteUserKeyboardShortcut(
   userId: string,
   action: string
@@ -58,6 +80,10 @@ export async function deleteUserKeyboardShortcut(
   })
 }
 
+/**
+ * ユーザーのキーボードショートカット設定を全てリセット
+ * @param userId - ユーザーID
+ */
 export async function resetUserKeyboardShortcuts(userId: string) {
   return prisma.userKeyboardShortcut.deleteMany({
     where: { userId },
@@ -68,22 +94,50 @@ export async function resetUserKeyboardShortcuts(userId: string) {
 // UserScoringPreference（採点画面設定）
 // =============================================================================
 
+/** 採点設定の更新用データ型（全カラムオプショナル） */
 export interface ScoringPreferenceData {
   showStudentNames?: boolean
   autoScroll?: boolean
   itemsPerLine?: number
   layoutDirection?: string
+  expandMargin?: number
   selectionBorderColor?: string | null
   scoringStatusColors?: string | null
   scoringColorPresetId?: string | null
 }
 
+/**
+ * カラム別の型定義
+ */
+export interface ScoringPreferenceColumns {
+  showStudentNames: boolean
+  autoScroll: boolean
+  itemsPerLine: number
+  layoutDirection: string
+  expandMargin: number
+  selectionBorderColor: string | null
+  scoringStatusColors: string | null
+  scoringColorPresetId: string | null
+}
+
+export type ScoringPreferenceColumnName = keyof ScoringPreferenceColumns
+
+/**
+ * ユーザーの採点設定レコードを取得
+ * @param userId - ユーザーID
+ * @returns 採点設定レコード（存在しない場合はnull）
+ */
 export async function getUserScoringPreference(userId: string) {
   return prisma.userScoringPreference.findUnique({
     where: { userId },
   })
 }
 
+/**
+ * 採点設定をまとめて追加/更新（レコード単位）
+ * @param userId - ユーザーID
+ * @param data - 更新する設定データ
+ */
 export async function upsertUserScoringPreference(
   userId: string,
   data: ScoringPreferenceData
@@ -97,9 +151,66 @@ export async function upsertUserScoringPreference(
       autoScroll: data.autoScroll ?? true,
       itemsPerLine: data.itemsPerLine ?? 5,
       layoutDirection: data.layoutDirection ?? "right-down",
+      expandMargin: data.expandMargin ?? 0,
       selectionBorderColor: data.selectionBorderColor ?? null,
       scoringStatusColors: data.scoringStatusColors ?? null,
       scoringColorPresetId: data.scoringColorPresetId ?? null,
+    },
+  })
+}
+
+// =============================================================================
+// カラム別操作（楽観的更新対応）
+// =============================================================================
+
+/** 採点設定のデフォルト値 */
+const SCORING_PREFERENCE_DEFAULTS: ScoringPreferenceColumns = {
+  showStudentNames: true,
+  autoScroll: true,
+  itemsPerLine: 5,
+  layoutDirection: "right-down",
+  expandMargin: 0,
+  selectionBorderColor: null,
+  scoringStatusColors: null,
+  scoringColorPresetId: null,
+}
+
+/**
+ * 指定したカラムの値を取得
+ */
+export async function getScoringPreferenceColumn<
+  K extends ScoringPreferenceColumnName,
+>(userId: string, column: K): Promise<ScoringPreferenceColumns[K]> {
+  const record = await prisma.userScoringPreference.findUnique({
+    where: { userId },
+    select: { [column]: true },
+  })
+
+  if (!record) {
+    return SCORING_PREFERENCE_DEFAULTS[column]
+  }
+
+  // Prismaのselect結果から値を取得
+  return (record as unknown as ScoringPreferenceColumns)[column]
+}
+
+/**
+ * 指定したカラムの値を設定（楽観的更新用 - 単一カラムのみ更新）
+ */
+export async function setScoringPreferenceColumn<
+  K extends ScoringPreferenceColumnName,
+>(
+  userId: string,
+  column: K,
+  value: ScoringPreferenceColumns[K]
+): Promise<void> {
+  await prisma.userScoringPreference.upsert({
+    where: { userId },
+    update: { [column]: value },
+    create: {
+      userId,
+      ...SCORING_PREFERENCE_DEFAULTS,
+      [column]: value,
     },
   })
 }

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -747,12 +747,47 @@ contextBridge.exposeInMainWorld("electronAPI", {
         autoScroll?: boolean
         itemsPerLine?: number
         layoutDirection?: string
+        expandMargin?: number
         selectionBorderColor?: string | null
         scoringStatusColors?: string | null
         scoringColorPresetId?: string | null
       }
     ) =>
       ipcRenderer.invoke("settings:upsertUserScoringPreference", userId, data),
+
+    // カラム別操作（楽観的更新対応）
+    getScoringPreferenceColumn: (
+      userId: string,
+      column:
+        | "showStudentNames"
+        | "autoScroll"
+        | "itemsPerLine"
+        | "layoutDirection"
+        | "expandMargin"
+        | "selectionBorderColor"
+        | "scoringStatusColors"
+        | "scoringColorPresetId"
+    ) =>
+      ipcRenderer.invoke("settings:getScoringPreferenceColumn", userId, column),
+    setScoringPreferenceColumn: (
+      userId: string,
+      column:
+        | "showStudentNames"
+        | "autoScroll"
+        | "itemsPerLine"
+        | "layoutDirection"
+        | "expandMargin"
+        | "selectionBorderColor"
+        | "scoringStatusColors"
+        | "scoringColorPresetId",
+      value: boolean | number | string | null
+    ) =>
+      ipcRenderer.invoke(
+        "settings:setScoringPreferenceColumn",
+        userId,
+        column,
+        value
+      ),
 
     // ProjectMarkingFormat
     getProjectMarkingFormats: (projectId: string) =>

--- a/lib/scoringStatusColors.ts
+++ b/lib/scoringStatusColors.ts
@@ -1,13 +1,14 @@
 /**
- * 採点状態の表示色管理
+ * @fileoverview 採点状態の表示色管理
+ * @description 一括採点画面のPanel・一覧表示の背景色をカスタマイズ可能にする
  *
- * 一括採点画面のPanel・一覧表示の背景色をカスタマイズ可能にする
  * - 4つのプリセットパターン（標準、ビビッド、ソフト、色覚多様性対応）
  * - 各状態の個別カスタマイズ
- * - DBに保存（UserScoringPreference）
+ * - DBに保存（UserScoringPreference.scoringStatusColors, scoringColorPresetId）
+ * - カラム別楽観的更新対応
  */
 
-// 採点状態の種類（DBの値と一致）
+/** 採点状態の種類（DBの値と一致） */
 export type ScoringStatusType =
   | "ungraded"
   | "correct"
@@ -16,7 +17,7 @@ export type ScoringStatusType =
   | "incorrect"
   | "no_answer"
 
-// 各状態の色設定
+/** 各状態の色設定 */
 export interface StatusColorConfig {
   /** 背景色（HEX） */
   bg: string
@@ -26,10 +27,10 @@ export interface StatusColorConfig {
   icon: string
 }
 
-// 全状態の色設定
+/** 全状態の色設定 */
 export type ScoringStatusColors = Record<ScoringStatusType, StatusColorConfig>
 
-// プリセット定義
+/** カラープリセット定義 */
 export interface ScoringColorPreset {
   id: string
   name: string
@@ -37,7 +38,7 @@ export interface ScoringColorPreset {
   colors: ScoringStatusColors
 }
 
-// 状態のラベル（日本語）
+/** 状態のラベル（日本語） */
 export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
   ungraded: "未採点",
   correct: "正答",
@@ -47,7 +48,7 @@ export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
   no_answer: "無答",
 }
 
-// 状態の表示順序
+/** 状態の表示順序 */
 export const SCORING_STATUS_ORDER: ScoringStatusType[] = [
   "ungraded",
   "correct",
@@ -115,29 +116,40 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
   },
 ]
 
-// メモリキャッシュ（同期的なアクセス用）
+/** メモリキャッシュ（同期的なアクセス用） */
 let cachedColors: ScoringStatusColors = SCORING_COLOR_PRESETS[0].colors
+/** 現在選択中のプリセットID */
 let cachedPresetId: string | null = "default"
+/** 現在のユーザーID（保存時に使用） */
 let currentUserId: string | null = null
 
 /**
- * DBから採点状態色を読み込み（初期化用）
+ * DBから採点状態色を読み込み（初期化用・カラム別）
  */
 export async function loadScoringStatusColors(userId: string): Promise<void> {
   if (typeof window === "undefined" || !window.electronAPI?.settings) return
 
   try {
     currentUserId = userId
-    const result =
-      await window.electronAPI.settings.getUserScoringPreference(userId)
-    if (result.success && result.preference) {
-      if (result.preference.scoringStatusColors) {
-        cachedColors = JSON.parse(
-          result.preference.scoringStatusColors
-        ) as ScoringStatusColors
-      }
-      cachedPresetId = result.preference.scoringColorPresetId || null
+    // カラム別に並列で読み込み
+    const [colorsResult, presetIdResult] = await Promise.all([
+      window.electronAPI.settings.getScoringPreferenceColumn(
+        userId,
+        "scoringStatusColors"
+      ),
+      window.electronAPI.settings.getScoringPreferenceColumn(
+        userId,
+        "scoringColorPresetId"
+      ),
+    ])
+
+    if (colorsResult.success && colorsResult.value) {
+      cachedColors = JSON.parse(colorsResult.value) as ScoringStatusColors
     }
+    cachedPresetId =
+      presetIdResult.success && presetIdResult.value
+        ? presetIdResult.value
+        : null
   } catch (error) {
     console.error("Failed to load scoring status colors:", error)
   }
@@ -151,7 +163,7 @@ export function getScoringStatusColors(): ScoringStatusColors {
 }
 
 /**
- * 採点状態色を保存
+ * 採点状態色を保存（カラム別・楽観的更新）
  */
 export async function saveScoringStatusColors(
   colors: ScoringStatusColors,
@@ -169,13 +181,19 @@ export async function saveScoringStatusColors(
   if (!targetUserId || !window.electronAPI?.settings) return
 
   try {
-    await window.electronAPI.settings.upsertUserScoringPreference(
-      targetUserId,
-      {
-        scoringStatusColors: JSON.stringify(colors),
-        scoringColorPresetId: null,
-      }
-    )
+    // カラム別に並列で保存
+    await Promise.all([
+      window.electronAPI.settings.setScoringPreferenceColumn(
+        targetUserId,
+        "scoringStatusColors",
+        JSON.stringify(colors)
+      ),
+      window.electronAPI.settings.setScoringPreferenceColumn(
+        targetUserId,
+        "scoringColorPresetId",
+        null
+      ),
+    ])
   } catch (error) {
     console.error("Failed to save scoring status colors:", error)
   }
@@ -189,7 +207,7 @@ export function getCurrentPresetId(): string | null {
 }
 
 /**
- * プリセットを適用
+ * プリセットを適用（カラム別・楽観的更新）
  */
 export async function applyScoringColorPreset(
   presetId: string,
@@ -213,13 +231,19 @@ export async function applyScoringColorPreset(
   if (!targetUserId || !window.electronAPI?.settings) return
 
   try {
-    await window.electronAPI.settings.upsertUserScoringPreference(
-      targetUserId,
-      {
-        scoringStatusColors: JSON.stringify(preset.colors),
-        scoringColorPresetId: presetId,
-      }
-    )
+    // カラム別に並列で保存
+    await Promise.all([
+      window.electronAPI.settings.setScoringPreferenceColumn(
+        targetUserId,
+        "scoringStatusColors",
+        JSON.stringify(preset.colors)
+      ),
+      window.electronAPI.settings.setScoringPreferenceColumn(
+        targetUserId,
+        "scoringColorPresetId",
+        presetId
+      ),
+    ])
   } catch (error) {
     console.error("Failed to apply scoring color preset:", error)
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -337,6 +337,7 @@ model UserScoringPreference {
   autoScroll           Boolean  @default(true)
   itemsPerLine         Int      @default(5)
   layoutDirection      String   @default("right-down")
+  expandMargin         Int      @default(0)
   selectionBorderColor String?
   scoringStatusColors  String?
   scoringColorPresetId String?

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1567,6 +1567,7 @@ export interface MyAPI {
         autoScroll?: boolean
         itemsPerLine?: number
         layoutDirection?: string
+        expandMargin?: number
         selectionBorderColor?: string | null
         scoringStatusColors?: string | null
         scoringColorPresetId?: string | null
@@ -1574,6 +1575,24 @@ export interface MyAPI {
     ) => Promise<{
       success: boolean
       preference?: UserScoringPreference
+      error?: string
+    }>
+
+    // カラム別操作（楽観的更新対応）
+    getScoringPreferenceColumn: <K extends ScoringPreferenceColumnName>(
+      userId: string,
+      column: K
+    ) => Promise<{
+      success: boolean
+      value?: ScoringPreferenceColumns[K]
+      error?: string
+    }>
+    setScoringPreferenceColumn: <K extends ScoringPreferenceColumnName>(
+      userId: string,
+      column: K,
+      value: ScoringPreferenceColumns[K]
+    ) => Promise<{
+      success: boolean
       error?: string
     }>
 
@@ -1820,11 +1839,39 @@ export interface UserScoringPreference {
   autoScroll: boolean
   itemsPerLine: number
   layoutDirection: string
+  expandMargin: number
   selectionBorderColor: string | null
   scoringStatusColors: string | null
   scoringColorPresetId: string | null
   createdAt: Date
   updatedAt: Date
+}
+
+/**
+ * UserScoringPreferenceのカラム名
+ */
+export type ScoringPreferenceColumnName =
+  | "showStudentNames"
+  | "autoScroll"
+  | "itemsPerLine"
+  | "layoutDirection"
+  | "expandMargin"
+  | "selectionBorderColor"
+  | "scoringStatusColors"
+  | "scoringColorPresetId"
+
+/**
+ * カラム別の値の型マッピング
+ */
+export interface ScoringPreferenceColumns {
+  showStudentNames: boolean
+  autoScroll: boolean
+  itemsPerLine: number
+  layoutDirection: string
+  expandMargin: number
+  selectionBorderColor: string | null
+  scoringStatusColors: string | null
+  scoringColorPresetId: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary
- 採点設定フックを個別ファイルに分離し、各設定が独立したstateを持つように変更
- カラム別のIPC操作（getScoringPreferenceColumn/setScoringPreferenceColumn）を追加
- expandMargin（表示領域拡張）機能を追加
- 全ファイルにJSDoc形式のコメントを追加

Closes #273

## Test plan
- [ ] 採点画面で各設定（表示件数、自動スクロール、生徒名表示、レイアウト方向、表示領域拡張）が正常に保存・読み込みされることを確認
- [ ] 複数の設定を同時に変更しても、それぞれが正しく保存されることを確認
- [ ] 設定画面で選択枠色・採点状態色が正常に保存されることを確認
- [ ] expandMarginスライダーが0-50%の範囲で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)