### PR TITLE
fix: プロジェクトエクスポート時のuserIdが渡されない問題を修正

### DIFF
--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -9,6 +9,7 @@ import EditProjectWindow from "@/components/projects/forms/EditProjectWindow"
 import DeleteProjectModal from "@/components/projects/shared/DeleteProjectModal"
 import { useProjectDetail } from "@/hooks/useProjectDetail"
 import { useWorkflowData } from "@/components/projects/detail/hooks/useWorkflowData"
+import { useAuth } from "@/contexts/AuthContext"
 import type { Project } from "@prisma/client"
 import Head from "next/head"
 import { useParams, useRouter } from "next/navigation"
@@ -18,6 +19,7 @@ import { toast } from "sonner"
 export default function ProjectDetailPage() {
   const params = useParams()
   const router = useRouter()
+  const { user } = useAuth()
   const projectId = params.projectId as string
 
   const [showEditModal, setShowEditModal] = useState(false)
@@ -65,6 +67,13 @@ export default function ProjectDetailPage() {
   const handleExport = async () => {
     if (isExporting) return
 
+    if (!user?.id) {
+      toast.error("エクスポート失敗", {
+        description: "ログインが必要です。",
+      })
+      return
+    }
+
     setIsExporting(true)
     toast("エクスポート中...", {
       description: "プロジェクトをエクスポートしています。",
@@ -73,6 +82,7 @@ export default function ProjectDetailPage() {
     try {
       const result = await window.electronAPI.archive.exportProject({
         projectId,
+        userId: user.id,
       })
 
       if (result.success) {


### PR DESCRIPTION
## Summary

- プロジェクトエクスポート時に`userId`が渡されずエラーになる問題を修正
- `useAuth`フックを使用してログインユーザーIDを取得
- ユーザー未ログイン時のエラーハンドリングを追加

Closes #275

## 変更内容

- `app/projects/[projectId]/page.tsx`
  - `useAuth`フックのインポートを追加
  - `user`を取得して`exportProject`呼び出し時に`userId`を渡す
  - ユーザーが存在しない場合のエラーチェックを追加

## Test plan

- [ ] プロジェクト詳細ページでエクスポートボタンをクリック
- [ ] エラーなくエクスポートダイアログが表示される
- [ ] .scoreファイルが正常に保存される

🤖 Generated with [Claude Code](https://claude.com/claude-code)