### PR TITLE
fix: 領域一覧がウィンドウからはみ出る問題を修正

### DIFF
--- a/components/projects/02-template/components/CropRegionEditor.tsx
+++ b/components/projects/02-template/components/CropRegionEditor.tsx
@@ -222,9 +222,9 @@ const CropRegionEditor = ({
       </div>
 
       {/* Right Side - Region List with independent scroll */}
-      <div className="bg-background relative w-80 flex-shrink-0 border-l">
+      <div className="bg-background relative flex h-full w-80 flex-shrink-0 flex-col overflow-hidden border-l">
         {/* 検出モード切替と設定 */}
-        <div className="space-y-3 border-b p-3">
+        <div className="flex-shrink-0 space-y-3 border-b p-3">
           <DetectionModeToggle
             mode={detectionMode}
             onModeChange={setDetectionMode}

--- a/components/projects/02-template/components/CropRegionList.tsx
+++ b/components/projects/02-template/components/CropRegionList.tsx
@@ -52,7 +52,7 @@ const CropRegionList = ({
   disabled,
 }: CropRegionListProps) => {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="bg-background flex-shrink-0 border-b p-4">
         <h3 className="text-lg font-medium">領域一覧 ({areas.length})</h3>
         {areas.length > 0 && (


### PR DESCRIPTION
## Summary
- 採点領域作成ページで「領域一覧」のヘッダーがウィンドウからはみ出す問題を修正

## 変更内容
- `CropRegionEditor.tsx`: 右側パネルに `h-full flex flex-col overflow-hidden` を追加
- `CropRegionEditor.tsx`: 検出モード設定部分に `flex-shrink-0` を追加
- `CropRegionList.tsx`: `h-full` を `min-h-0 flex-1` に変更

## Test plan
- [ ] 採点領域作成ページを開く
- [ ] 領域一覧のヘッダー「領域一覧 (N)」がウィンドウ内に収まることを確認
- [ ] 領域が多数ある場合にリスト部分がスクロール可能であることを確認

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)