### PR TITLE
refactor: QuestionScore自動作成ロジックを設問表示時に移動

### DIFF
--- a/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useMemo } from "react"
 import { DrawingToolPalette } from "./DrawingToolPalette"
 import { RichTextEditorModalV4 } from "./RichTextEditorModalV4"
 import { useDrawingState } from "./hooks/core/useDrawingState"
@@ -8,12 +7,13 @@ import { useImageCanvas } from "./hooks/core/useImageCanvas"
 import { useImageNavigation } from "./hooks/navigation/useImageNavigation"
 import { useAnswerIndividualEvents } from "./hooks/useAnswerIndividualEvents"
 import {
-  useZoomAndScroll,
+  useAllStudentAnnotations,
+  useAutoCreateQuestionScore,
+  useCanvasV4Integration,
   useDrawingToolShortcuts,
   useQuestionAutoScroll,
-  useCanvasV4Integration,
   useTextInputStateNotifier,
-  useAllStudentAnnotations,
+  useZoomAndScroll,
 } from "./hooks/view"
 import type {
   AnswerIndividualViewProps,
@@ -31,6 +31,7 @@ export default function AnswerIndividualView({
   currentStudentId,
   currentUserId,
   questionScores,
+  onQuestionScoreCreated,
 }: AnswerIndividualViewProps) {
   // 画像ナビゲーション状態管理（内部管理）
   const { zoom, position, onZoomChange, onPositionChange } =
@@ -42,18 +43,14 @@ export default function AnswerIndividualView({
       (scoringData) => scoringData.id === currentScoringDataId
     ) ?? null
 
-  // 正しいQuestionScore.idを取得（studentIdとcropRegionIdで検索）
-  const currentQuestionScoreId = useMemo(() => {
-    if (!questionScores || !currentStudentId || !currentCropRegion?.id) {
-      return null
-    }
-    const found = questionScores.find(
-      (qs) =>
-        qs.studentId === currentStudentId &&
-        qs.cropRegionId === currentCropRegion.id
-    )
-    return found?.id ?? null
-  }, [questionScores, currentStudentId, currentCropRegion])
+  // QuestionScore自動作成フック（設問表示時にQuestionScoreが存在しない場合は自動作成）
+  const { currentQuestionScoreId } = useAutoCreateQuestionScore({
+    currentStudentId,
+    currentCropRegionId: currentCropRegion?.id,
+    currentUserId,
+    questionScores,
+    onQuestionScoreCreated,
+  })
 
   // 描画状態管理（データベース統合対応）
   const drawingState = useDrawingState(

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
@@ -30,11 +30,13 @@ interface DrawingContext {
 
 /**
  * 既存DrawingElementからDrawingCreateDataへの変換
+ * questionScoreIdは必須（事前にQuestionScoreが作成されている必要がある）
+ * @throws Error questionScoreIdがない場合
  */
 export function convertElementToCreateData(
   element: DrawingElement,
   questionScoreId: string,
-  context?: DrawingContext
+  userId: string
 ): DrawingCreateData {
   return {
     id: element.id, // フロントエンドで生成したUUIDをDBでも使用
@@ -60,10 +62,7 @@ export function convertElementToCreateData(
     }),
     horizontalAlign: "left", // デフォルト値
     verticalAlign: "top", // デフォルト値
-    // QuestionScore自動作成用の情報
-    studentId: context?.currentStudentId,
-    cropRegionId: context?.currentCropRegionId,
-    userId: context?.currentUserId || "",
+    userId,
   }
 }
 
@@ -272,6 +271,7 @@ export function useDrawingAnnotations(
 
   /**
    * 描画要素保存（新規作成）
+   * questionScoreIdは必須（事前にQuestionScoreが作成されている必要がある）
    */
   const saveElement = useCallback(
     async (
@@ -281,11 +281,18 @@ export function useDrawingAnnotations(
       setIsLoading(true)
       setError(null)
 
+      // userIdがない場合はエラー
+      if (!context?.currentUserId) {
+        handleError("ユーザーIDが設定されていません")
+        setIsLoading(false)
+        return null
+      }
+
       try {
         const createData = convertElementToCreateData(
           element,
           questionScoreId,
-          context
+          context.currentUserId
         )
         const result = await window.electronAPI.drawing.create(createData)
 
@@ -443,6 +450,7 @@ export function useDrawingAnnotations(
 
   /**
    * 描画要素の同期（既存システムからデータベースへ）
+   * questionScoreIdは必須（事前にQuestionScoreが作成されている必要がある）
    */
   const syncElements = useCallback(
     async (
@@ -452,13 +460,24 @@ export function useDrawingAnnotations(
       setIsLoading(true)
       setError(null)
 
+      // userIdがない場合はエラー
+      if (!context?.currentUserId) {
+        handleError("ユーザーIDが設定されていません")
+        setIsLoading(false)
+        return []
+      }
+
       try {
         // 既存のアノテーションをクリア
         await deleteByType(questionScoreId)
 
         // 新しい要素を一括作成
         const createDataList = elements.map((element) =>
-          convertElementToCreateData(element, questionScoreId, context)
+          convertElementToCreateData(
+            element,
+            questionScoreId,
+            context.currentUserId!
+          )
         )
 
         const result =

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
@@ -163,6 +163,15 @@ export function useDrawingState(
   // 描画要素操作（データベース統合対応）
   const addDrawingElement = useCallback(
     async (element: DrawingElement) => {
+      // questionScoreIdがない場合は追加できない
+      // （QuestionScoreは設問表示時に自動作成されるはず）
+      if (enablePersistence && !questionScoreId) {
+        console.error(
+          "描画要素の追加には QuestionScore が必要です。設問表示時に自動作成されるまでお待ちください。"
+        )
+        return
+      }
+
       // ローカル状態を即座に更新
       setDrawingElements((prev) => [...prev, element])
 
@@ -197,7 +206,8 @@ export function useDrawingState(
       })
 
       // データベース更新（バックグラウンド）
-      if (enablePersistence && questionScoreId && previousElement !== null) {
+      // 既存アノテーションの更新はアノテーションIDで行うためquestionScoreIdは不要
+      if (enablePersistence && previousElement !== null) {
         const elementToUpdate: DrawingElement = previousElement
         try {
           const updatedElement: DrawingElement = {
@@ -216,7 +226,7 @@ export function useDrawingState(
         }
       }
     },
-    [enablePersistence, questionScoreId, updateElement]
+    [enablePersistence, updateElement]
   )
 
   // 複数要素を一括更新（1回のsetStateで全て更新）
@@ -240,7 +250,8 @@ export function useDrawingState(
       })
 
       // データベース更新（バックグラウンド、各要素を個別に更新）
-      if (enablePersistence && questionScoreId) {
+      // 既存アノテーションの更新はアノテーションIDで行うためquestionScoreIdは不要
+      if (enablePersistence) {
         for (const { id, updates: elementUpdates } of updates) {
           const previousElement = previousElements.get(id)
           if (previousElement) {
@@ -254,7 +265,7 @@ export function useDrawingState(
         }
       }
     },
-    [enablePersistence, questionScoreId, updateElement]
+    [enablePersistence, updateElement]
   )
 
   const removeDrawingElement = useCallback(
@@ -273,7 +284,8 @@ export function useDrawingState(
       )
 
       // データベースから削除（バックグラウンド）
-      if (enablePersistence && questionScoreId) {
+      // 既存アノテーションの削除はアノテーションIDで行うためquestionScoreIdは不要
+      if (enablePersistence) {
         try {
           await deleteElement(id)
         } catch (error) {
@@ -285,7 +297,7 @@ export function useDrawingState(
         }
       }
     },
-    [enablePersistence, questionScoreId, deleteElement]
+    [enablePersistence, deleteElement]
   )
 
   // 複数選択操作

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/view/index.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/view/index.ts
@@ -27,3 +27,9 @@ export type {
   UseAllStudentAnnotationsParams,
   UseAllStudentAnnotationsReturn,
 } from "./useAllStudentAnnotations"
+
+export { useAutoCreateQuestionScore } from "./useAutoCreateQuestionScore"
+export type {
+  UseAutoCreateQuestionScoreParams,
+  UseAutoCreateQuestionScoreReturn,
+} from "./useAutoCreateQuestionScore"

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useAutoCreateQuestionScore.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useAutoCreateQuestionScore.ts
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview 設問表示時にQuestionScoreを自動作成するフック
+ * @description 設問を表示した際にQuestionScoreが存在しない場合、unscoredステータスで自動作成
+ */
+
+import { useCallback, useEffect, useRef } from "react"
+
+export interface UseAutoCreateQuestionScoreParams {
+  /** 現在の生徒ID */
+  currentStudentId?: string
+  /** 現在の設問領域ID */
+  currentCropRegionId?: string
+  /** 現在のユーザーID */
+  currentUserId?: string
+  /** QuestionScore配列（既存のスコアを検索用） */
+  questionScores?: Array<{
+    id: string
+    studentId: string
+    cropRegionId: string
+  }>
+  /** QuestionScore作成後のコールバック（リストの更新用） */
+  onQuestionScoreCreated?: () => void
+}
+
+export interface UseAutoCreateQuestionScoreReturn {
+  /** 現在のQuestionScoreのID（存在しない場合はnull） */
+  currentQuestionScoreId: string | null
+}
+
+/**
+ * 設問表示時にQuestionScoreを自動作成するフック
+ */
+export function useAutoCreateQuestionScore({
+  currentStudentId,
+  currentCropRegionId,
+  currentUserId,
+  questionScores,
+  onQuestionScoreCreated,
+}: UseAutoCreateQuestionScoreParams): UseAutoCreateQuestionScoreReturn {
+  // 作成中のリクエストを追跡（重複作成防止）
+  const creatingRef = useRef<string | null>(null)
+
+  // 現在のQuestionScoreを検索
+  const currentQuestionScoreId =
+    questionScores?.find(
+      (qs) =>
+        qs.studentId === currentStudentId &&
+        qs.cropRegionId === currentCropRegionId
+    )?.id ?? null
+
+  // QuestionScore作成関数
+  const createQuestionScore = useCallback(async () => {
+    if (!currentStudentId || !currentCropRegionId || !currentUserId) {
+      return
+    }
+
+    const key = `${currentStudentId}-${currentCropRegionId}-${currentUserId}`
+
+    // 既に作成中の場合はスキップ
+    if (creatingRef.current === key) {
+      return
+    }
+
+    creatingRef.current = key
+
+    try {
+      const result = await window.electronAPI.createQuestionScore({
+        studentId: currentStudentId,
+        cropRegionId: currentCropRegionId,
+        userId: currentUserId,
+        status: "unscored",
+        partialScore: undefined,
+      })
+
+      if (result.success) {
+        // 作成成功 - 親コンポーネントに通知してリストを更新
+        onQuestionScoreCreated?.()
+      } else {
+        console.error("QuestionScore作成失敗:", result.error)
+      }
+    } catch (error) {
+      console.error("QuestionScore作成エラー:", error)
+    } finally {
+      // 作成完了後にリセット（別の設問に移動可能にする）
+      if (creatingRef.current === key) {
+        creatingRef.current = null
+      }
+    }
+  }, [
+    currentStudentId,
+    currentCropRegionId,
+    currentUserId,
+    onQuestionScoreCreated,
+  ])
+
+  // 設問表示時にQuestionScoreが存在しない場合は自動作成
+  useEffect(() => {
+    if (
+      currentStudentId &&
+      currentCropRegionId &&
+      currentUserId &&
+      currentQuestionScoreId === null
+    ) {
+      createQuestionScore()
+    }
+  }, [
+    currentStudentId,
+    currentCropRegionId,
+    currentUserId,
+    currentQuestionScoreId,
+    createQuestionScore,
+  ])
+
+  return {
+    currentQuestionScoreId,
+  }
+}

--- a/components/projects/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -82,6 +82,9 @@ export interface AnswerIndividualViewProps {
   // アノテーション用: QuestionScore配列（正しいquestionScoreIdを取得するため）
   questionScores?: QuestionScore[]
 
+  // QuestionScore自動作成後のコールバック（リストの更新用）
+  onQuestionScoreCreated?: () => void
+
   // Individual表示固有設定
   pageImages?: PageImageWithProjectStudents[] // 全答案データ
   showMultiplePages?: boolean // 複数画像の縦並び表示設定

--- a/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -47,6 +47,9 @@ interface ScoringContentAreaProps {
 
   /** アノテーション用: QuestionScore配列 */
   questionScores?: QuestionScore[]
+
+  /** QuestionScore自動作成後のコールバック（リストの更新用） */
+  onQuestionScoreCreated?: () => void
 }
 
 export function ScoringContentArea({
@@ -68,6 +71,7 @@ export function ScoringContentArea({
   currentStudentId,
   currentUserId,
   questionScores,
+  onQuestionScoreCreated,
 }: ScoringContentAreaProps) {
   /** 個別表示時：selectedの最初の要素を利用 */
   const currentScoringDataId =
@@ -91,6 +95,7 @@ export function ScoringContentArea({
       currentStudentId={currentStudentId}
       currentUserId={currentUserId}
       questionScores={questionScores}
+      onQuestionScoreCreated={onQuestionScoreCreated}
     />
   ) : (
     /** Grid表示：paddingとスクロールを統合 */

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -149,6 +149,12 @@ function ScoringMainViewContent() {
     cropRegions,
   })
 
+  /** QuestionScore作成後のリロードコールバック */
+  const handleQuestionScoreCreated = useCallback(async () => {
+    const scores = await loadQuestionScores(projectId)
+    setQuestionScores(scores)
+  }, [loadQuestionScores, projectId, setQuestionScores])
+
   /** フィルタリング管理hook */
   const {
     /** 新しいデータ構造 */
@@ -348,6 +354,7 @@ function ScoringMainViewContent() {
           currentStudentId={currentStudentId || undefined}
           currentUserId={currentUserId || undefined}
           questionScores={questionScores}
+          onQuestionScoreCreated={handleQuestionScoreCreated}
           expandMargin={expandMargin}
         />
 

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -11,71 +11,45 @@ import type {
   DrawingUpdateData,
 } from "../../../types/drawingAnnotation.types"
 import prisma from "./client"
-import { createQuestionScore } from "./questionScore"
 
 /**
  * 描画アノテーションを作成する
- * @param data 作成データ
+ * @param data 作成データ（questionScoreIdは必須）
  * @returns Promise<DrawingAnnotation> 作成された描画アノテーション
  */
 export async function createDrawingAnnotation(
   data: DrawingCreateData
 ): Promise<DrawingAnnotation> {
   try {
-    // 外部キー制約の事前検証と自動作成
-    if (data.questionScoreId) {
-      const questionScoreExists = await prisma.questionScore.findUnique({
-        where: { id: data.questionScoreId },
-        select: { id: true },
-      })
-
-      if (!questionScoreExists) {
-        // QuestionScoreが存在しない場合、自動作成を試行
-        if (data.studentId && data.cropRegionId && data.userId) {
-          try {
-            const result = await createQuestionScore({
-              studentId: data.studentId,
-              cropRegionId: data.cropRegionId,
-              userId: data.userId,
-              partialScore: undefined,
-              status: "unscored",
-              comment: undefined,
-            })
-
-            if (result.success && result.score) {
-              data.questionScoreId = result.score.id
-            } else {
-              throw new Error(
-                `QuestionScore creation failed: ${"error" in result ? result.error : "Unknown error"}`
-              )
-            }
-          } catch (createError) {
-            console.error("QuestionScore自動作成失敗:", createError)
-            throw new Error(
-              `QuestionScore not found and auto-creation failed: ${data.questionScoreId}. Original error: ${createError instanceof Error ? createError.message : String(createError)}`
-            )
-          }
-        } else {
-          throw new Error(
-            `QuestionScore not found: ${data.questionScoreId}. To auto-create, provide studentId, cropRegionId, and userId`
-          )
-        }
-      }
-    } else {
-      throw new Error("questionScoreId is required but was undefined/null")
+    // questionScoreIdは必須
+    if (!data.questionScoreId) {
+      throw new Error(
+        "questionScoreId is required. QuestionScore must be created before adding annotations."
+      )
     }
 
-    if (data.userId) {
-      const userExists = await prisma.user.findUnique({
-        where: { id: data.userId },
-        select: { id: true },
-      })
+    // 外部キー制約の事前検証
+    const questionScoreExists = await prisma.questionScore.findUnique({
+      where: { id: data.questionScoreId },
+      select: { id: true },
+    })
 
-      if (!userExists) {
-        throw new Error(`User not found: ${data.userId}`)
-      }
-    } else {
+    if (!questionScoreExists) {
+      throw new Error(`QuestionScore not found: ${data.questionScoreId}`)
+    }
+
+    // ユーザー存在チェック
+    if (!data.userId) {
       throw new Error("userId is required but was undefined/null")
+    }
+
+    const userExists = await prisma.user.findUnique({
+      where: { id: data.userId },
+      select: { id: true },
+    })
+
+    if (!userExists) {
+      throw new Error(`User not found: ${data.userId}`)
     }
 
     const result = await prisma.drawingAnnotation.create({
@@ -109,6 +83,28 @@ export async function createDrawingAnnotation(
         displayY: data.displayY || 0.0,
         // メタデータ
         userId: data.userId,
+      },
+      // 透明度制御に必要なquestionScore情報を含める
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+          },
+        },
       },
     })
 
@@ -310,6 +306,28 @@ export async function updateDrawingAnnotation(
         ...data,
         updatedAt: new Date(),
       },
+      // 透明度制御に必要なquestionScore情報を含める
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+          },
+        },
+      },
     })
 
     return result as DrawingAnnotation
@@ -398,6 +416,28 @@ export async function batchUpdateDrawingAnnotations(
           data: {
             ...data,
             updatedAt: new Date(),
+          },
+          // 透明度制御に必要なquestionScore情報を含める
+          include: {
+            user: {
+              select: {
+                id: true,
+                username: true,
+                name: true,
+              },
+            },
+            questionScore: {
+              select: {
+                id: true,
+                cropRegionId: true,
+                cropRegion: {
+                  select: {
+                    id: true,
+                    label: true,
+                  },
+                },
+              },
+            },
           },
         })
       })

--- a/types/drawingAnnotation.types.ts
+++ b/types/drawingAnnotation.types.ts
@@ -71,14 +71,14 @@ export interface DrawingAnnotation {
 // 作成用データ型
 export interface DrawingCreateData {
   id?: string // フロントエンドで生成したUUIDを使用可能（指定なしの場合はDB側で自動生成）
-  questionScoreId: string
+  questionScoreId: string // 必須: QuestionScoreは事前に作成されている必要がある
   type: DrawingType
   x: number
   y: number
   color?: string
   strokeWidth?: number
 
-  // QuestionScore自動作成用の追加情報（questionScoreIdが存在しない場合に使用）
+  // コンテキスト情報（参照用、自動作成には使用しない）
   studentId?: string
   cropRegionId?: string
 


### PR DESCRIPTION
## 概要

Closes #279

アノテーション追加時のQuestionScore自動作成ロジックを、より堅牢でシンプルな設計に変更しました。

## 変更内容

### 新しい設計

設問表示時（ビュー側）でQuestionScoreを自動作成し、アノテーション追加時にはquestionScoreIdを必須とするシンプルな設計に変更

### 動作フロー

```
設問表示 → useAutoCreateQuestionScore がQuestionScoreの存在を確認
            ↓
         存在しない場合 → IPC経由でQuestionScore作成（unscored）
                          → onQuestionScoreCreated でリスト更新
            ↓
         questionScoreId が利用可能に
            ↓
         アノテーション追加が可能
```

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `useAutoCreateQuestionScore.ts` | 新規作成 - 設問表示時の自動作成フック |
| `drawingAnnotation.ts` | 自動作成ロジック削除、questionScoreId必須化 |
| `drawingAnnotation.types.ts` | questionScoreIdを必須に変更 |
| `useDrawingAnnotations.ts` | 関数シグネチャ簡素化 |
| `useDrawingState.ts` | questionScoreIdなしの場合のガード追加 |
| `AnswerIndividualView.tsx` | 新フック使用、コールバック追加 |
| `ScoringContentArea.tsx` | コールバック伝播 |
| `ScoringMainView.tsx` | コールバック実装 |

## テスト計画

- [ ] 設問表示時にQuestionScoreが自動作成されることを確認
- [ ] アノテーション追加・編集・削除が正常に動作することを確認
- [ ] 透明度制御が正しく動作することを確認
- [ ] 設問切り替え時の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)