### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,4 +1,6 @@
 name: Discord Notifications
+permissions:
+  contents: read
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/2](https://github.com/KeppyNaushika/score-at-once-electron/security/code-scanning/2)

In general, to fix this issue you add an explicit `permissions` block either at the top level of the workflow (affecting all jobs) or per job, granting only the minimal scopes required. Since this workflow only reads event data and secrets and posts to Discord, it does not need any GitHub write privileges; `contents: read` is a safe minimal baseline recommended by GitHub, and you can omit write permissions entirely.

The best fix with minimal behavior change is to add a top-level `permissions` block right under the `name:` line so it applies to both `notify-issue-opened` and `notify-pr-merged`. Neither job needs to modify issues, PRs, or repository contents, so `contents: read` is sufficient and aligns with the principle of least privilege.

Concretely, in `.github/workflows/discord-notify.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Discord Notifications` line. No other imports, methods, or definitions are needed, and no existing steps require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
