### PR TITLE
fix: インポート時にcurrentUserIdを渡すように修正

### DIFF
--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -177,6 +177,7 @@ export function registerArchiveHandlers(): void {
         archivePath: string
         matchingConfig: MatchingConfig
         conflictResolutions: ConflictResolutions
+        currentUserId: string
       }
     ) => {
       let tempDir: string | null = null
@@ -193,7 +194,8 @@ export function registerArchiveHandlers(): void {
         const result = await executeMergeImport(
           extractResult.data,
           options.matchingConfig,
-          options.conflictResolutions
+          options.conflictResolutions,
+          options.currentUserId
         )
 
         return result

--- a/electron-src/lib/import/merge/dataMerger.ts
+++ b/electron-src/lib/import/merge/dataMerger.ts
@@ -46,11 +46,17 @@ function createEmptyCounts(): ArchiveDataCounts {
 
 /**
  * マージインポートを実行
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @param config - マッチング設定
+ * @param resolutions - 競合解決設定
+ * @param currentUserId - 現在ログインしているユーザーID
  */
 export async function executeMergeImport(
   data: ExtractedArchiveData,
   config: MatchingConfig,
-  resolutions: ConflictResolutions
+  resolutions: ConflictResolutions,
+  currentUserId: string
 ): Promise<MergeImportResult> {
   const warnings: string[] = []
   const counts: MergeCounts = {
@@ -280,22 +286,18 @@ export async function executeMergeImport(
       })
       idMappings.project[project.id] = newProjectId
 
-      // 7. UserProject
-      for (const up of data.projectData.userProjects) {
-        const newUserId = idMappings.user[up.userId]
-        if (newUserId) {
-          const newId = randomUUID()
-          await tx.userProject.create({
-            data: {
-              id: newId,
-              userId: newUserId,
-              projectId: newProjectId,
-              role: up.role,
-            },
-          })
-          idMappings.userProject[up.id] = newId
-        }
-      }
+      // 7. UserProject - 現在のログインユーザーをOWNERとして追加
+      // アーカイブ内のUserProjectは無視し、現在のユーザーのみを追加
+      await tx.userProject.create({
+        data: {
+          id: randomUUID(),
+          userId: currentUserId,
+          projectId: newProjectId,
+          role: "OWNER",
+          invitedAt: new Date(),
+          invitedBy: null,
+        },
+      })
 
       // 8. ProjectSubtotalGroup
       for (const psg of data.projectData.projectSubtotalGroups) {
@@ -388,15 +390,15 @@ export async function executeMergeImport(
       }
 
       // 13. QuestionScore
+      // userIdは現在のログインユーザーで上書き
       for (const qs of data.scoresData.questionScores) {
         const newRegionId = idMappings.cropRegion[qs.cropRegionId]
         const newStudentId = qs.studentId
           ? idMappings.student[qs.studentId]
           : null
-        const newUserId = qs.userId ? idMappings.user[qs.userId] : null
 
-        // studentIdとuserIdは必須フィールド
-        if (newRegionId && newStudentId && newUserId) {
+        // studentIdは必須フィールド
+        if (newRegionId && newStudentId) {
           const newId = randomUUID()
           await tx.questionScore.create({
             data: {
@@ -407,7 +409,7 @@ export async function executeMergeImport(
                 ? parseFloat(qs.partialScore)
                 : null,
               status: qs.status,
-              userId: newUserId,
+              userId: currentUserId,
             },
           })
           idMappings.questionScore[qs.id] = newId
@@ -416,12 +418,11 @@ export async function executeMergeImport(
       }
 
       // 14. DrawingAnnotation
+      // userIdは現在のログインユーザーで上書き
       for (const da of data.scoresData.drawingAnnotations) {
         const newScoreId = idMappings.questionScore[da.questionScoreId]
-        const newUserId = da.userId ? idMappings.user[da.userId] : null
 
-        // userIdは必須フィールド
-        if (newScoreId && newUserId) {
+        if (newScoreId) {
           const newId = randomUUID()
           await tx.drawingAnnotation.create({
             data: {
@@ -446,7 +447,7 @@ export async function executeMergeImport(
               anchorDirection: da.anchorDirection,
               displayX: da.displayX,
               displayY: da.displayY,
-              userId: newUserId,
+              userId: currentUserId,
             },
           })
           idMappings.drawingAnnotation[da.id] = newId

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -633,6 +633,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       archivePath: string
       matchingConfig: import("../types/projectArchive.types").MatchingConfig
       conflictResolutions: import("../types/projectArchive.types").ConflictResolutions
+      currentUserId: string
     }) => ipcRenderer.invoke("archive:mergeImport", options),
     selectExportSavePath: (options: { projectName?: string }) =>
       ipcRenderer.invoke("archive:selectExportSavePath", options),

--- a/hooks/import/useImportWizard.ts
+++ b/hooks/import/useImportWizard.ts
@@ -10,11 +10,13 @@ import type {
   CategoryConflictResolution,
   ConflictCategory,
 } from "@/types/projectArchive.types"
+import { useAuth } from "@/contexts/AuthContext"
 
 /**
  * インポートウィザードの状態管理フック
  */
 export function useImportWizard() {
+  const { user } = useAuth()
   const [state, setState] = useState<ImportWizardState>({
     currentStep: "file_select",
     archivePath: null,
@@ -183,12 +185,20 @@ export function useImportWizard() {
   // インポート実行（新規作成モード）
   const executeImportAsNew = useCallback(async () => {
     if (!state.archivePath) return null
+    if (!user?.id) {
+      setState((prev) => ({
+        ...prev,
+        error: "ログインが必要です",
+      }))
+      return null
+    }
 
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
 
     try {
       const result = await window.electronAPI.archive.importAsNew({
         archivePath: state.archivePath,
+        currentUserId: user.id,
       })
 
       setState((prev) => ({ ...prev, isProcessing: false }))
@@ -210,11 +220,18 @@ export function useImportWizard() {
       }))
       return null
     }
-  }, [state.archivePath])
+  }, [state.archivePath, user?.id])
 
   // インポート実行（マージモード）
   const executeMergeImport = useCallback(async () => {
     if (!state.archivePath) return null
+    if (!user?.id) {
+      setState((prev) => ({
+        ...prev,
+        error: "ログインが必要です",
+      }))
+      return null
+    }
 
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
 
@@ -223,6 +240,7 @@ export function useImportWizard() {
         archivePath: state.archivePath,
         matchingConfig: state.matchingConfig,
         conflictResolutions: state.conflictResolutions,
+        currentUserId: user.id,
       })
 
       setState((prev) => ({ ...prev, isProcessing: false }))
@@ -244,7 +262,7 @@ export function useImportWizard() {
       }))
       return null
     }
-  }, [state.archivePath, state.matchingConfig, state.conflictResolutions])
+  }, [state.archivePath, state.matchingConfig, state.conflictResolutions, user?.id])
 
   // ステップを戻る
   const goBack = useCallback(() => {

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -287,6 +287,8 @@ export interface MergeImportOptions {
   archivePath: string
   matchingConfig: MatchingConfig
   conflictResolutions: ConflictResolutions
+  /** 現在ログインしているユーザーID（このユーザーをプロジェクトのOWNERとして追加） */
+  currentUserId: string
 }
 
 /**


### PR DESCRIPTION
## 概要

Fixes #284

インポート機能でログインユーザーとプロジェクトが関連付けられず、プロジェクト一覧に表示されない問題を修正しました。

## 変更内容

### フロントエンド
- `hooks/import/useImportWizard.ts`
  - `useAuth` を追加してログインユーザーIDを取得
  - `executeImportAsNew` と `executeMergeImport` で `currentUserId` を渡すように修正

### 型定義
- `types/projectArchive.types.ts`
  - `MergeImportOptions` に `currentUserId` を追加

### バックエンド
- `electron-src/preload.ts`
  - `mergeImport` の型定義に `currentUserId` を追加
- `electron-src/ipc-handlers/archiveHandlers.ts`
  - マージインポートハンドラーで `currentUserId` を受け取り渡すように修正
- `electron-src/lib/import/merge/dataMerger.ts`
  - `executeMergeImport` に `currentUserId` パラメータを追加
  - UserProjectで現在のログインユーザーをOWNERとして設定
  - QuestionScore/DrawingAnnotationのuserIdを現在のユーザーに設定

## テスト方法

1. プロジェクトをエクスポート
2. 新規インポートを実行
3. プロジェクト一覧に表示されることを確認
4. マージインポートでも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)