### PR TITLE
fix: 複数ページ答案のアノテーション座標をページ内相対座標で保存

### DIFF
--- a/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -172,6 +172,9 @@ export default function AnswerIndividualView({
       onZoomChange,
       onPositionChange,
       imageLoaded,
+      // 複数ページ対応
+      loadedImages,
+      pageSpacing,
       currentTool: drawingState.currentTool,
       drawingElements: drawingState.drawingElements,
       // 複数選択システム

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
@@ -27,6 +27,9 @@ interface UseAnswerDisplayEventsProps {
   onZoomChange: (zoom: number) => void
   onPositionChange: (position: { x: number; y: number }) => void
   imageLoaded: boolean
+  // 複数ページ対応
+  loadedImages?: HTMLImageElement[]
+  pageSpacing?: number
 
   // Drawing state
   currentTool: DrawingTool
@@ -131,6 +134,8 @@ export function useAnswerIndividualEvents(props: UseAnswerDisplayEventsProps) {
       canvasRef,
       imageRef,
       zoom,
+      loadedImages: props.loadedImages,
+      pageSpacing: props.pageSpacing,
     })
 
   // Initialize wheel zoom handling

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/utils/useCoordinates.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/utils/useCoordinates.ts
@@ -12,6 +12,10 @@ export interface UseCoordinatesProps {
   imageRef: React.RefObject<HTMLImageElement | null>
   /** ズーム倍率 */
   zoom: number
+  /** 読み込み済み画像配列（複数ページ対応用） */
+  loadedImages?: HTMLImageElement[]
+  /** ページ間のスペーシング */
+  pageSpacing?: number
 }
 
 /** 座標フックの戻り値 */
@@ -42,6 +46,8 @@ export function useCoordinates({
   canvasRef,
   imageRef,
   zoom,
+  loadedImages = [],
+  pageSpacing = 20,
 }: UseCoordinatesProps): UseCoordinatesReturn {
   /**
    * イベントから画像座標（正規化）を取得
@@ -49,6 +55,8 @@ export function useCoordinates({
    * @description
    * ポインターイベントからCSS scale方式を考慮して
    * 0-1の正規化座標を計算する。
+   * 複数ページ対応：クリック位置がどのページに属するかを判断し、
+   * そのページ内の相対座標（0-1）を返す。
    *
    * @param e - マウス/ポインターイベント
    * @returns 正規化座標またはnull
@@ -82,15 +90,43 @@ export function useCoordinates({
       const imageOffsetX = (canvasWidth - img.naturalWidth) / 2
 
       const imageX = actualX - imageOffsetX
-      const imageY = actualY
+      let imageY = actualY
 
-      // 画像サイズで正規化（0-1の範囲）
+      // 複数ページ対応：クリック位置がどのページに属するかを判断
+      // loadedImagesが2枚以上ある場合、Y座標をページ内座標に変換
+      if (loadedImages.length > 1) {
+        let pageOffsetY = 0
+        let targetPageHeight = img.naturalHeight // デフォルトは1ページ目の高さ
+
+        for (let i = 0; i < loadedImages.length; i++) {
+          const pageHeight = loadedImages[i].naturalHeight
+          const pageBottom = pageOffsetY + pageHeight
+
+          if (actualY < pageBottom || i === loadedImages.length - 1) {
+            // このページに属する
+            imageY = actualY - pageOffsetY
+            targetPageHeight = pageHeight
+            break
+          }
+
+          // 次のページへ
+          pageOffsetY += pageHeight + pageSpacing
+        }
+
+        // ページ内座標で正規化（0-1の範囲）
+        return {
+          x: imageX / img.naturalWidth,
+          y: imageY / targetPageHeight,
+        }
+      }
+
+      // 単一ページの場合：従来通りの正規化（0-1の範囲）
       return {
         x: imageX / img.naturalWidth,
         y: imageY / img.naturalHeight,
       }
     },
-    [canvasRef, imageRef, zoom]
+    [canvasRef, imageRef, zoom, loadedImages, pageSpacing]
   )
 
   /**

--- a/components/projects/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/projects/08-export/components/PdfCanvasRenderer.tsx
@@ -329,7 +329,8 @@ export function PdfCanvasRenderer({
         scoringMarkConfig,
         markImages,
         subtotalDataForPdf,
-        totalScoreDataForPdf
+        totalScoreDataForPdf,
+        page.pageNumber
       )
 
       const arrayBuffer = await blob.arrayBuffer()

--- a/components/projects/08-export/utils/pdfCanvasRenderer.ts
+++ b/components/projects/08-export/utils/pdfCanvasRenderer.ts
@@ -808,13 +808,17 @@ export async function renderAnswerSheetToCanvas(
   }
 
   // 5. 全アノテーションを描画
-  // pageOffset: UI側で複数ページが縦に結合されたキャンバス上で描画された場合、
-  // アノテーションのy座標は1ページ目の高さで正規化されるため、
-  // 2ページ目以降のアノテーションはy > 1.0になる。
-  // pageNumber - 1 を引くことで正しいページ内座標に変換する。
-  const pageOffset = pageNumber - 1
+  // 座標系の互換性処理:
+  // - 旧データ: y座標がキャンバス全体に対する相対座標（2ページ目以降はy > 1.0）
+  // - 新データ: y座標がページ内の相対座標（常に0.0 - 1.0）
+  // y >= 1.0の場合は旧データとみなし、pageOffsetを引いて変換する
+  // y < 1.0の場合は新データとみなし、そのまま使用する
+  const basePageOffset = pageNumber - 1
   for (const annotation of annotations) {
     const element = convertAnnotationToDrawingElement(annotation)
+    // y座標が1.0以上の場合のみpageOffsetを適用（旧座標系の互換性対応）
+    const needsPageOffset = element.y >= 1.0 || (element.endY !== undefined && element.endY >= 1.0)
+    const pageOffset = needsPageOffset ? basePageOffset : 0
     await drawElement(ctx, element, imageWidth, imageHeight, 0, 0, pageOffset)
   }
 


### PR DESCRIPTION
## Summary

- 複数ページ答案でアノテーションがPDF出力時に正しく印字されない問題を修正
- 新規アノテーションをページ内相対座標(0-1)で保存するよう変更
- 既存データ(y >= 1.0)との互換性を維持

## Test plan

- [ ] 単一ページ答案でアノテーションを追加し、PDF出力で正しい位置に印字されることを確認
- [ ] 複数ページ答案の1ページ目にアノテーションを追加し、PDF出力で正しい位置に印字されることを確認
- [ ] 複数ページ答案の2ページ目以降にアノテーションを追加し、PDF出力で正しい位置に印字されることを確認
- [ ] 既存のアノテーションデータがPDF出力で正しい位置に印字されることを確認

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)