### PR TITLE
fix: CodeQL Security Alertsを修正しappimg://カスタムプロトコルを実装

### DIFF
--- a/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
+++ b/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
@@ -154,8 +154,8 @@ async function generateThumbnailsFromPath(
   pageCount: number
 ): Promise<string[]> {
   try {
-    // file:// プロトコルでローカルファイルを読み込み
-    const response = await fetch(`file://${filePath}`)
+    // appimg:// プロトコルでローカルファイルを読み込み
+    const response = await fetch(`appimg://${filePath}`)
     const arrayBuffer = await response.arrayBuffer()
 
     // ArrayBufferからFileオブジェクトを作成

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
@@ -75,12 +75,12 @@ export function useImageLoader({
             reject(error)
           }
 
-          // ファイル存在確認して読み込み
+          // ファイル存在確認して読み込み（appimg://プロトコル使用）
           window.electronAPI
             .checkFileExists(imageInfo.path)
             .then((result) => {
               if (result.success && result.exists) {
-                img.src = `file://${result.path}`
+                img.src = `appimg://${result.path}`
               } else {
                 console.warn(`File does not exist: ${imageInfo.path}`)
                 reject(new Error(`File not found: ${imageInfo.path}`))
@@ -88,7 +88,7 @@ export function useImageLoader({
             })
             .catch((error) => {
               console.error("Error checking file existence:", error)
-              img.src = `file://${imageInfo.path}` // フォールバック
+              img.src = `appimg://${imageInfo.path}` // フォールバック
             })
         })
       })

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useCanvasV4Integration.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/view/useCanvasV4Integration.ts
@@ -86,10 +86,8 @@ export function useCanvasV4Integration({
     return 1
   }, [loadedImages])
 
-  // 答案画像のURL取得
-  const backgroundImageUrl = currentScoringData
-    ? currentScoringData.imageUrl.replace("appimg://", "file://")
-    : undefined
+  // 答案画像のURL取得（appimg://プロトコルをそのまま使用）
+  const backgroundImageUrl = currentScoringData?.imageUrl
 
   // V4統合フック
   const v4Integration = useTextboxV4Integration({

--- a/components/student/StudentMembershipTimeline.tsx
+++ b/components/student/StudentMembershipTimeline.tsx
@@ -6,13 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Calendar, Clock, Edit, Users } from "lucide-react"
 
 const formatDate = (date: Date) => {
-  return new Date(date)
-    .toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
-    .replace(/\//g, "/")
+  return new Date(date).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
 }
 
 interface Membership {

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -1,5 +1,6 @@
-import { app } from "electron"
+import { app, protocol, net } from "electron"
 import { initializeApp } from "./appInitializer"
+import { pathToFileURL } from "url"
 import { setupAllIPCHandlers } from "./ipc-handlers"
 import { startEmbeddedNextServer } from "./nextServerEmbedded"
 import { createMainWindow, setupWindowEvents } from "./windowManager"
@@ -40,8 +41,43 @@ if (process.platform === "win32" && app.isPackaged) {
   }
 }
 
+// カスタムプロトコル 'appimg://' を登録（webSecurity有効時にローカルファイルへアクセスするため）
+// 注意: app.whenReady() より前に protocol.registerSchemesAsPrivileged を呼ぶ必要がある
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "appimg",
+    privileges: {
+      secure: true,
+      standard: true,
+      supportFetchAPI: true,
+      stream: true,
+    },
+  },
+])
+
 app.on("ready", async () => {
   try {
+    // appimg:// プロトコルハンドラを登録
+    // appimg:///path/to/file → file:///path/to/file としてローカルファイルを読み込む
+    protocol.handle("appimg", (request) => {
+      try {
+        const url = new URL(request.url)
+        // pathnameをデコード（日本語やスペースを含むパス対応）
+        let filePath = decodeURIComponent(url.pathname)
+
+        // Windowsの場合、先頭の/を削除（/C:/path → C:/path）
+        if (process.platform === "win32" && filePath.startsWith("/")) {
+          filePath = filePath.slice(1)
+        }
+
+        const fileUrl = pathToFileURL(filePath).href
+        return net.fetch(fileUrl)
+      } catch (error) {
+        console.error("appimg:// protocol error:", error)
+        return new Response("File not found", { status: 404 })
+      }
+    })
+
     // アプリケーションの初期化
     await initializeApp()
 

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -446,7 +446,7 @@ export function setupExportHandlers(): void {
         // HTMLを一時ファイルに書き込み
         await fs.writeFile(tempHtmlPath, options.html, "utf-8")
 
-        // file:// URLでロード
+        // 一時HTMLファイルをロード
         await win.loadFile(tempHtmlPath)
 
         // レンダリング完了を待つ
@@ -613,7 +613,7 @@ export function setupExportHandlers(): void {
         // HTMLを一時ファイルに書き込み
         await fs.writeFile(tempHtmlPath, options.html, "utf-8")
 
-        // file:// URLでロード
+        // 一時HTMLファイルをロード
         await win.loadFile(tempHtmlPath)
 
         // レンダリング完了を待つ

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -684,8 +684,8 @@ export function setupMiscHandlers(): void {
 
       const fullPath = path.join(publicDir, assetPath)
 
-      // file:// プロトコルを使用してパスを返す
-      return { success: true, path: `file://${fullPath}` }
+      // appimg:// プロトコルを使用してパスを返す（webSecurity有効時のローカルファイルアクセス用）
+      return { success: true, path: `appimg://${fullPath}` }
     } catch (err) {
       return {
         success: false,

--- a/electron-src/windowManager.ts
+++ b/electron-src/windowManager.ts
@@ -39,7 +39,7 @@ export function createMainWindow(): BrowserWindow {
       preload: join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
-      webSecurity: false,
+      webSecurity: true, // セキュリティ有効化（ローカルファイルアクセスはappimg://プロトコルで対応）
       backgroundThrottling: false,
     },
   })

--- a/hooks/useFileUpload.ts
+++ b/hooks/useFileUpload.ts
@@ -42,7 +42,7 @@ export function useFileUpload(options: FileUploadOptions = {}) {
           if (type.startsWith(".")) {
             return file.name.toLowerCase().endsWith(type.toLowerCase())
           }
-          return file.type.match(type.replace("*", ".*"))
+          return file.type.match(type.replace(/\*/g, ".*"))
         })
 
         if (!isAccepted) {


### PR DESCRIPTION
## 概要

Closes #290

GitHub CodeQLによるCode Scanning Alertsで検出されたセキュリティ問題を修正し、webSecurity有効化に対応するためのカスタムプロトコルを実装しました。

## 変更内容

### セキュリティ修正
- `webSecurity: false` → `true` に変更（Electron推奨設定）
- `useFileUpload.ts`: `replace("*", ".*")` → `replace(/\*/g, ".*")` にgフラグを追加
- `StudentMembershipTimeline.tsx`: 無意味な`.replace(/\//g, "/")`を削除

### カスタムプロトコル実装
- `appimg://`プロトコルを登録してローカルファイルアクセスを安全に提供
- `file://`を`appimg://`に置き換え
- URLエンコーディング対応（日本語・スペースを含むパス）
- Windowsパス対応（`/C:/path` → `C:/path`）

## 技術的詳細

```typescript
// カスタムプロトコル登録
protocol.registerSchemesAsPrivileged([{
  scheme: "appimg",
  privileges: { secure: true, standard: true, supportFetchAPI: true, stream: true }
}])

// プロトコルハンドラ
protocol.handle("appimg", (request) => {
  const url = new URL(request.url)
  let filePath = decodeURIComponent(url.pathname)
  if (process.platform === "win32" && filePath.startsWith("/")) {
    filePath = filePath.slice(1)
  }
  return net.fetch(pathToFileURL(filePath).href)
})
```

## テスト計画

- [ ] 答案画像の表示確認
- [ ] PDF出力時の画像埋め込み確認
- [ ] 日本語・スペースを含むパスでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)