### PR TITLE
style: コードフォーマットの統一

### DIFF
--- a/components/projects/08-export/utils/pdfCanvasRenderer.ts
+++ b/components/projects/08-export/utils/pdfCanvasRenderer.ts
@@ -817,7 +817,8 @@ export async function renderAnswerSheetToCanvas(
   for (const annotation of annotations) {
     const element = convertAnnotationToDrawingElement(annotation)
     // y座標が1.0以上の場合のみpageOffsetを適用（旧座標系の互換性対応）
-    const needsPageOffset = element.y >= 1.0 || (element.endY !== undefined && element.endY >= 1.0)
+    const needsPageOffset =
+      element.y >= 1.0 || (element.endY !== undefined && element.endY >= 1.0)
     const pageOffset = needsPageOffset ? basePageOffset : 0
     await drawElement(ctx, element, imageWidth, imageHeight, 0, 0, pageOffset)
   }

--- a/hooks/import/useImportWizard.ts
+++ b/hooks/import/useImportWizard.ts
@@ -262,7 +262,12 @@ export function useImportWizard() {
       }))
       return null
     }
-  }, [state.archivePath, state.matchingConfig, state.conflictResolutions, user?.id])
+  }, [
+    state.archivePath,
+    state.matchingConfig,
+    state.conflictResolutions,
+    user?.id,
+  ])
 
   // ステップを戻る
   const goBack = useCallback(() => {


### PR DESCRIPTION
## 概要

Closes #292

Prettier/ESLintによるコードフォーマットの自動整形を適用しました。

## 変更内容

- `pdfCanvasRenderer.ts`: 長い行の折り返し
- `useImportWizard.ts`: useCallback依存配列のフォーマット統一

## 備考

機能的な変更はなく、コードスタイルの統一のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)