### PR TITLE
fix: UserScoringPreferenceの初期読み込みとユーザー切り替え時の問題を修正

### DIFF
--- a/app/settings/components/DisplaySettingsTab.tsx
+++ b/app/settings/components/DisplaySettingsTab.tsx
@@ -34,7 +34,7 @@ const SELECTION_BORDER_PRESETS = [
 export function DisplaySettingsTab() {
   const { user } = useAuth()
   const userId = user?.id
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   // 選択枠色の状態
   const [selectionBorderColor, setSelectionBorderColor] = useState(
@@ -51,8 +51,14 @@ export function DisplaySettingsTab() {
 
   // 初期値をロード（カラム別）
   useEffect(() => {
-    if (initializedRef.current || !userId) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) return
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
 
     const loadSettings = async () => {
       if (window.electronAPI?.settings) {

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
@@ -15,15 +15,23 @@ export function useSelectionBorder(): string {
   const { user } = useAuth()
   const userId = user?.id
   const [color, setColor] = useState(DEFAULT_SELECTION_BORDER_COLOR)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   // 設定を読み込む（カラム別）
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
 
     const loadColor = async () => {
-      if (userId && window.electronAPI?.settings) {
+      if (window.electronAPI?.settings) {
         try {
           const result =
             await window.electronAPI.settings.getScoringPreferenceColumn(

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
@@ -22,14 +22,24 @@ export function useAutoScroll() {
   const [autoScroll, setAutoScrollState] =
     useState<boolean>(DEFAULT_AUTO_SCROLL)
   const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
 
     const load = async () => {
-      if (!userId || !window.electronAPI?.settings) {
+      if (!window.electronAPI?.settings) {
         setIsLoading(false)
         return
       }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
@@ -24,14 +24,24 @@ export function useExpandMargin() {
     DEFAULT_EXPAND_MARGIN
   )
   const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
 
     const load = async () => {
-      if (!userId || !window.electronAPI?.settings) {
+      if (!window.electronAPI?.settings) {
         setIsLoading(false)
         return
       }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
@@ -23,15 +23,25 @@ export function useItemsPerLine() {
     DEFAULT_ITEMS_PER_LINE
   )
   const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   // 初期読み込み
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
 
     const load = async () => {
-      if (!userId || !window.electronAPI?.settings) {
+      if (!window.electronAPI?.settings) {
         setIsLoading(false)
         return
       }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
@@ -24,14 +24,24 @@ export function useLayoutDirection() {
     DEFAULT_LAYOUT_DIRECTION
   )
   const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
 
     const load = async () => {
-      if (!userId || !window.electronAPI?.settings) {
+      if (!window.electronAPI?.settings) {
         setIsLoading(false)
         return
       }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
@@ -23,14 +23,24 @@ export function useShowStudentNames() {
     DEFAULT_SHOW_STUDENT_NAMES
   )
   const [isLoading, setIsLoading] = useState(true)
-  const initializedRef = useRef(false)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    if (initializedRef.current) return
-    initializedRef.current = true
+    // 同じユーザーで既に初期化済みならスキップ
+    if (initializedUserIdRef.current === userId) return
+
+    // userIdがundefinedの場合は待機（refは更新しない）
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    // 新しいユーザーとして初期化
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
 
     const load = async () => {
-      if (!userId || !window.electronAPI?.settings) {
+      if (!window.electronAPI?.settings) {
         setIsLoading(false)
         return
       }


### PR DESCRIPTION
## 概要

Closes #294

UserScoringPreferenceに関連する設定フックで、`initializedRef`の実装に起因する初期読み込みおよびユーザー切り替え時の問題を修正しました。

## 変更内容

### Before
```typescript
const initializedRef = useRef(false)

useEffect(() => {
  if (initializedRef.current) return
  initializedRef.current = true
  // ...
}, [userId])
```

### After
```typescript
const initializedUserIdRef = useRef<string | undefined>(undefined)

useEffect(() => {
  // 同じユーザーで既に初期化済みならスキップ
  if (initializedUserIdRef.current === userId) return

  // userIdがundefinedの場合は待機（refは更新しない）
  if (!userId) {
    setIsLoading(false)
    return
  }

  // 新しいユーザーとして初期化
  initializedUserIdRef.current = userId
  setIsLoading(true)
  // ...
}, [userId])
```

## 修正の効果

1. `userId`が最初に`undefined`で後から取得される場合も正しく読み込まれる
2. ユーザー切り替え時に新しいユーザーの設定が読み込まれる
3. 同じユーザーでの重複読み込みは防止される

## 影響ファイル

- `useShowStudentNames.ts`
- `useAutoScroll.ts`
- `useItemsPerLine.ts`
- `useLayoutDirection.ts`
- `useExpandMargin.ts`
- `useSelectionBorder.ts`
- `DisplaySettingsTab.tsx`

## テスト計画

- [ ] 採点画面で設定が正しく読み込まれることを確認
- [ ] 設定変更後、楽観的更新が正しく動作することを確認
- [ ] ユーザー切り替え時に設定が正しく切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)