### PR TITLE
PageImage→StudentAnswerImage型統一とプロトコル重複登録修正

### DIFF
--- a/app/projects/[projectId]/06-student-answers/hooks/index.tsx
+++ b/app/projects/[projectId]/06-student-answers/hooks/index.tsx
@@ -81,8 +81,33 @@ export function useStudentAnswersData(projectId: string) {
       // Load student answers
       const studentAnswersResult =
         await window.electronAPI.getStudentAnswersByProjectId(projectId)
-      if (studentAnswersResult.success && studentAnswersResult.studentAnswers) {
-        setStudentAnswers(studentAnswersResult.studentAnswers)
+      if (
+        studentAnswersResult.success &&
+        studentAnswersResult.studentAnswerImages
+      ) {
+        // Convert Prisma型をProcessedStudentAnswer型に変換
+        const processedAnswers: ProcessedStudentAnswer[] =
+          studentAnswersResult.studentAnswerImages.map((img) => ({
+            id: img.id,
+            studentId: img.studentId,
+            pageNumber: img.projectPage.pageNumber,
+            originalImagePath: img.imagePath,
+            isAbsent:
+              img.student?.projectStudents?.[0]?.status === "ABSENT" || false,
+            student: img.student
+              ? {
+                  id: img.student.id,
+                  lastName: img.student.lastName,
+                  firstName: img.student.firstName,
+                  lastNameKana: img.student.lastNameKana,
+                  firstNameKana: img.student.firstNameKana,
+                  studentId: img.student.studentId,
+                }
+              : null,
+            projectId: img.projectPage.projectId,
+            status: "ready" as const,
+          }))
+        setStudentAnswers(processedAnswers)
       }
 
       // Load model answer count

--- a/components/projects/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/components/projects/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -1,7 +1,7 @@
 // import { checkForAutoFinalization } from "@/components/projects/07-score-at-once/hooks/scoring-data/utils/auto-finalization"
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
@@ -10,7 +10,7 @@ import { useCallback } from "react"
 import { toast } from "sonner"
 
 interface UseBatchScoringProps {
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithProjectStudents[]
   cropRegions: CropRegionWithProjectPage[]
   currentCropRegionId: string | null
   currentUserId: string | null
@@ -20,7 +20,7 @@ interface UseBatchScoringProps {
 }
 
 export function useBatchScoring({
-  pageImages,
+  studentAnswerImages,
   cropRegions,
   currentCropRegionId,
   currentUserId,
@@ -88,14 +88,16 @@ export function useBatchScoring({
       if (!currentCropRegion) return
 
       for (const answerId of ids) {
-        const pageImage = pageImages.find((image) => image.id === answerId)
-        if (!pageImage) continue
+        const studentAnswerImage = studentAnswerImages.find(
+          (image) => image.id === answerId
+        )
+        if (!studentAnswerImage) continue
 
-        if (!pageImage.studentId) continue // studentIdがnullの場合はスキップ
+        if (!studentAnswerImage.studentId) continue // studentIdがnullの場合はスキップ
 
         const currentScore = findQuestionScore(
           questionScores,
-          pageImage.studentId,
+          studentAnswerImage.studentId,
           currentCropRegion.id
         )
 
@@ -174,7 +176,7 @@ export function useBatchScoring({
           } else {
             // Create new score
             const scoreData = {
-              studentId: pageImage.studentId,
+              studentId: studentAnswerImage.studentId,
               cropRegionId: currentCropRegion.id,
               partialScore: newScore !== null ? newScore : undefined,
               status: scoringStatus,
@@ -202,9 +204,9 @@ export function useBatchScoring({
 
           // TODO: Check for auto-finalization in collaborative mode
           // Temporarily disabled during QuestionScore array migration
-          // if (scoringStatus === "pending" && pageImage.studentId) {
+          // if (scoringStatus === "pending" && studentAnswerImage.studentId) {
           //   await checkForAutoFinalization(
-          //     pageImage.studentId,
+          //     studentAnswerImage.studentId,
           //     currentCropRegion.id,
           //     currentUserId,
           //     setQuestionScores,
@@ -220,7 +222,7 @@ export function useBatchScoring({
         } catch (error) {
           console.error("Error in batch scoring:", error)
           toast.error(
-            `採点中にエラーが発生しました: ${pageImage.student?.lastName || "不明な生徒"}`
+            `採点中にエラーが発生しました: ${studentAnswerImage.student?.lastName || "不明な生徒"}`
           )
         }
       }
@@ -230,7 +232,7 @@ export function useBatchScoring({
       cropRegions,
       setCurrentUserId,
       currentCropRegionId,
-      pageImages,
+      studentAnswerImages,
       questionScores,
       setQuestionScores,
     ]

--- a/components/projects/07-score-at-once/ScoringData/types/scoringDataTypes.ts
+++ b/components/projects/07-score-at-once/ScoringData/types/scoringDataTypes.ts
@@ -1,6 +1,6 @@
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
@@ -36,7 +36,7 @@ export interface ScoreCreateData {
 
 export type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringStatus,
 }

--- a/components/projects/07-score-at-once/ScoringData/utils/progressCalculator.ts
+++ b/components/projects/07-score-at-once/ScoringData/utils/progressCalculator.ts
@@ -1,6 +1,6 @@
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionProgress,
 } from "@/components/projects/07-score-at-once/ScoringData/types/scoringDataTypes"
 import {
@@ -13,7 +13,7 @@ import {
  */
 export function calculateQuestionProgress(
   cropRegions: CropRegionWithProjectPage[],
-  pageImages: PageImageWithProjectStudents[],
+  pageImages: StudentAnswerImageWithProjectStudents[],
   questionScores: QuestionScore[]
 ): QuestionProgress {
   const progress: QuestionProgress = {}

--- a/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -24,7 +24,7 @@ export default function AnswerIndividualView({
   scoringDatas,
   currentScoringDataId,
   currentCropRegion,
-  pageImages,
+  studentAnswerImages,
   showMultiplePages = true, // 常に複数ページ表示
   pageSpacing = 20,
   onTextInputStateChange,
@@ -90,7 +90,7 @@ export default function AnswerIndividualView({
   } = useImageCanvas({
     currentScoringData,
     currentCropRegion,
-    pageImages,
+    studentAnswerImages,
     zoom,
     position,
     drawingElements: drawingState.drawingElements,

--- a/components/projects/07-score-at-once/ScoringIndividual/IndividualModePanel.tsx
+++ b/components/projects/07-score-at-once/ScoringIndividual/IndividualModePanel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { PageImageWithProjectStudents } from "@/components/projects/07-score-at-once/types"
+import type { StudentAnswerImageWithProjectStudents } from "@/components/projects/07-score-at-once/types"
 import { useMemo } from "react"
 import {
   ScoringBehaviorSelector,
@@ -19,7 +19,7 @@ interface Student {
 interface IndividualModePanelProps {
   students: Student[]
   selectedAnswers?: Set<string> // TODO: selectedPageImageIdsに統一予定
-  pageImages?: PageImageWithProjectStudents[]
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[]
   onStudentChange: (studentId: string) => void
   scoringBehavior: ScoringBehavior
   onScoringBehaviorChange: (behavior: ScoringBehavior) => void
@@ -28,7 +28,7 @@ interface IndividualModePanelProps {
 export function IndividualModePanel({
   students,
   selectedAnswers,
-  pageImages,
+  studentAnswerImages,
   onStudentChange,
   scoringBehavior,
   onScoringBehaviorChange,
@@ -37,11 +37,13 @@ export function IndividualModePanel({
   const currentStudentId = useMemo(() => {
     if (selectedAnswers && selectedAnswers.size > 0) {
       const selectedAnswerId = Array.from(selectedAnswers)[0]
-      const selectedAnswer = pageImages?.find((a) => a.id === selectedAnswerId)
+      const selectedAnswer = studentAnswerImages?.find(
+        (a) => a.id === selectedAnswerId
+      )
       return selectedAnswer?.student?.id || ""
     }
     return ""
-  }, [selectedAnswers, pageImages])
+  }, [selectedAnswers, studentAnswerImages])
   return (
     <>
       <StudentAnswerPanel

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/types.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/types.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/components/projects/07-score-at-once/ScoringIndividual/types/answerIndividualTypes"
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
@@ -18,7 +18,7 @@ import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotati
 export interface UseImageCanvasProps {
   currentScoringData: ScoringData | null
   currentCropRegion?: CropRegionWithProjectPage | null
-  pageImages?: PageImageWithProjectStudents[]
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[]
   zoom: number
   position: { x: number; y: number }
   drawingElements: DrawingElement[]

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
@@ -23,7 +23,7 @@ import { useScoringMarks } from "./useScoringMarks"
 export function useImageCanvas({
   currentScoringData,
   currentCropRegion,
-  pageImages,
+  studentAnswerImages,
   zoom,
   drawingElements,
   isDrawing,
@@ -51,7 +51,7 @@ export function useImageCanvas({
   // 画像読み込み
   const { imageLoaded, loadedImages } = useImageLoader({
     currentScoringData,
-    pageImages,
+    studentAnswerImages,
     showMultiplePages,
     imageRef,
   })

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
@@ -5,7 +5,7 @@
  * - ファイル存在確認
  */
 import type {
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
 import { useEffect, useState } from "react"
@@ -13,7 +13,7 @@ import type { ImageLoaderReturn } from "./types"
 
 interface UseImageLoaderProps {
   currentScoringData: ScoringData | null
-  pageImages?: PageImageWithProjectStudents[]
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[]
   showMultiplePages?: boolean
   imageRef: React.RefObject<HTMLImageElement | null>
 }
@@ -23,7 +23,7 @@ interface UseImageLoaderProps {
  */
 export function useImageLoader({
   currentScoringData,
-  pageImages,
+  studentAnswerImages,
   showMultiplePages,
   imageRef,
 }: UseImageLoaderProps): ImageLoaderReturn {
@@ -41,9 +41,9 @@ export function useImageLoader({
 
       let imagesToLoad: { path: string; pageNumber: number }[] = []
 
-      if (showMultiplePages && pageImages) {
+      if (showMultiplePages && studentAnswerImages) {
         // 複数ページ表示：同一生徒の全ページを取得
-        const studentAnswerSheets = pageImages
+        const studentAnswerSheets = studentAnswerImages
           .filter((sheet) => sheet.studentId === currentScoringData.studentId)
           .sort(
             (a, b) =>
@@ -132,7 +132,7 @@ export function useImageLoader({
     if (currentScoringData) {
       loadAnswerImages()
     }
-  }, [currentScoringData, pageImages, showMultiplePages, imageRef])
+  }, [currentScoringData, studentAnswerImages, showMultiplePages, imageRef])
 
   return {
     imageLoaded,

--- a/components/projects/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -1,7 +1,7 @@
 // Prisma型をインポート
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
@@ -86,7 +86,7 @@ export interface AnswerIndividualViewProps {
   onQuestionScoreCreated?: () => void
 
   // Individual表示固有設定
-  pageImages?: PageImageWithProjectStudents[] // 全答案データ
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[] // 全答案データ
   showMultiplePages?: boolean // 複数画像の縦並び表示設定
   pageSpacing?: number // ページ間の余白（ピクセル）
 

--- a/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -7,7 +7,7 @@ import type {
   GradingMode,
   LayoutDirection,
   MasterGridItem,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringData,
 } from "@/components/projects/07-score-at-once/types"
@@ -36,7 +36,7 @@ interface ScoringContentAreaProps {
   expandMargin?: number
 
   /** IndividualView設定 */
-  pageImages?: PageImageWithProjectStudents[]
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[]
 
   /** テキスト入力状態変更のコールバック（ショートカット制御用） */
   onTextInputStateChange?: (showTextInput: boolean) => void
@@ -66,7 +66,7 @@ export function ScoringContentArea({
   autoScroll,
   showStudentNames,
   expandMargin,
-  pageImages,
+  studentAnswerImages,
   onTextInputStateChange,
   currentStudentId,
   currentUserId,
@@ -90,7 +90,7 @@ export function ScoringContentArea({
       scoringDatas={allScoringData}
       currentScoringDataId={currentScoringDataId}
       currentCropRegion={currentCropRegion}
-      pageImages={pageImages}
+      studentAnswerImages={studentAnswerImages}
       onTextInputStateChange={onTextInputStateChange}
       currentStudentId={currentStudentId}
       currentUserId={currentUserId}

--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -50,7 +50,7 @@ function ScoringMainViewContent() {
   )
 
   /** データローダーフック */
-  const { loading, project, pageImages, cropRegions, currentUserId } =
+  const { loading, project, studentAnswerImages, cropRegions, currentUserId } =
     useScoringDataLoader(projectId)
 
   /** 設定管理フック */
@@ -77,7 +77,7 @@ function ScoringMainViewContent() {
   const {
     /** 個別の状態 */
     gradingMode,
-    selectedPageImageIds,
+    selectedStudentAnswerImageIds,
     currentStudentIndex,
     currentCropRegionId,
     showKeyboardHelp,
@@ -100,12 +100,20 @@ function ScoringMainViewContent() {
 
   /** 現在の答案と設問 */
   const currentAnswerSheet = useMemo(() => {
-    if (gradingMode === "individual" && selectedPageImageIds.size > 0) {
-      const selectedAnswerId = Array.from(selectedPageImageIds)[0]
-      return pageImages.find((sheet) => sheet.id === selectedAnswerId)
+    if (
+      gradingMode === "individual" &&
+      selectedStudentAnswerImageIds.size > 0
+    ) {
+      const selectedAnswerId = Array.from(selectedStudentAnswerImageIds)[0]
+      return studentAnswerImages.find((sheet) => sheet.id === selectedAnswerId)
     }
-    return pageImages[currentStudentIndex]
-  }, [gradingMode, selectedPageImageIds, pageImages, currentStudentIndex])
+    return studentAnswerImages[currentStudentIndex]
+  }, [
+    gradingMode,
+    selectedStudentAnswerImageIds,
+    studentAnswerImages,
+    currentStudentIndex,
+  ])
 
   const currentCropRegion = cropRegions.find(
     (r) => r.id === currentCropRegionId
@@ -114,8 +122,8 @@ function ScoringMainViewContent() {
   /** Effect処理フック */
   useScoringEffects({
     gradingMode,
-    selectedPageImageIds,
-    pageImages,
+    selectedStudentAnswerImageIds,
+    studentAnswerImages,
     cropRegions,
     currentCropRegionId,
     setSelectedPageImageIds,
@@ -126,8 +134,8 @@ function ScoringMainViewContent() {
   /** 生徒・答案管理フック */
   const { students, handleStudentChange, handleIndividualNextStudent } =
     useStudentAnswerManagement({
-      pageImages,
-      selectedPageImageIds,
+      studentAnswerImages,
+      selectedStudentAnswerImageIds,
       gradingMode,
       currentCropRegion,
       setSelectedPageImageIds,
@@ -145,7 +153,7 @@ function ScoringMainViewContent() {
     currentUserId,
     setCurrentUserId: () => {},
     currentCropRegionId,
-    pageImages,
+    studentAnswerImages,
     cropRegions,
   })
 
@@ -171,11 +179,11 @@ function ScoringMainViewContent() {
     handleRefreshFilter,
     handleToggleFilter,
   } = useScoringFilter({
-    pageImages,
+    studentAnswerImages,
     cropRegions,
     currentCropRegionId: currentCropRegionId,
     questionScores,
-    selectedPageImageIds: selectedPageImageIds,
+    selectedStudentAnswerImageIds: selectedStudentAnswerImageIds,
     setSelectedPageImageIds: setSelectedPageImageIds,
     project,
     gradingMode,
@@ -198,10 +206,10 @@ function ScoringMainViewContent() {
     handleResetZoom,
     handleGridNavigation,
   } = useScoringNavigation({
-    answerSheetsLength: pageImages.length,
+    answerSheetsLength: studentAnswerImages.length,
     currentCropRegionId: currentCropRegionId,
     setCurrentCropRegionId: setCurrentCropRegionId,
-    selectedPageImageIds: selectedPageImageIds,
+    selectedStudentAnswerImageIds: selectedStudentAnswerImageIds,
     setSelectedPageImageIds: setSelectedPageImageIds,
     layoutDirection: layoutDirection,
     getGridAnswerData,
@@ -211,7 +219,7 @@ function ScoringMainViewContent() {
 
   const { handleBatchScoreWithProgress, handleAutoAdvance } =
     useBatchScoringWithProgress({
-      selectedAnswers: selectedPageImageIds,
+      selectedAnswers: selectedStudentAnswerImageIds,
       gradingMode: gradingMode,
       scoringBehavior: scoringBehavior,
       setRecentlyScoredAnswers,
@@ -249,7 +257,7 @@ function ScoringMainViewContent() {
     handlePartialScoreBackspace,
     handlePartialScoreChange,
   } = usePartialScore({
-    selectedAnswers: selectedPageImageIds,
+    selectedAnswers: selectedStudentAnswerImageIds,
     currentCropRegion,
     onBatchScore: handleBatchScoreWithProgress,
     onAutoAdvance: handleAutoAdvance,
@@ -257,7 +265,7 @@ function ScoringMainViewContent() {
 
   /** コンテキスト値の設定 */
   useContextValue("gradingMode", gradingMode)
-  useContextValue("hasSelectedAnswers", selectedPageImageIds.size > 0)
+  useContextValue("hasSelectedAnswers", selectedStudentAnswerImageIds.size > 0)
   useContextValue("sidePanelVisible", showSidePanel)
   useContextValue("partialScoreModalOpen", showPartialScoreModal)
   useContextValue("modalOpen", showPartialScoreModal || showScoreComparison)
@@ -282,13 +290,15 @@ function ScoringMainViewContent() {
   })
 
   const currentStudentId = useMemo(() => {
-    if (selectedPageImageIds.size > 0) {
-      const selectedAnswerId = Array.from(selectedPageImageIds)[0]
-      const selectedAnswer = pageImages.find((a) => a.id === selectedAnswerId)
+    if (selectedStudentAnswerImageIds.size > 0) {
+      const selectedAnswerId = Array.from(selectedStudentAnswerImageIds)[0]
+      const selectedAnswer = studentAnswerImages.find(
+        (a) => a.id === selectedAnswerId
+      )
       return selectedAnswer?.student?.id || ""
     }
     return ""
-  }, [selectedPageImageIds, pageImages])
+  }, [selectedStudentAnswerImageIds, studentAnswerImages])
 
   const questionProgress = calculateQuestionProgress()
 
@@ -296,11 +306,15 @@ function ScoringMainViewContent() {
     return <ScoringLoadingState />
   }
 
-  if (!project || pageImages.length === 0 || cropRegions.length === 0) {
+  if (
+    !project ||
+    studentAnswerImages.length === 0 ||
+    cropRegions.length === 0
+  ) {
     return (
       <ScoringErrorState
         project={project}
-        answerSheetsLength={pageImages.length}
+        answerSheetsLength={studentAnswerImages.length}
         cropRegionsLength={cropRegions.length}
         projectId={projectId}
       />
@@ -342,9 +356,9 @@ function ScoringMainViewContent() {
           filteredScoringDataIds={filteredScoringDataIds}
           selectedScoringDataIds={selectedScoringDataIds}
           currentCropRegion={currentCropRegion}
-          pageImages={pageImages}
+          studentAnswerImages={studentAnswerImages}
           onScoringDataSelect={(dataId, isSelected) =>
-            handleAnswerSelect(dataId, isSelected, pageImages)
+            handleAnswerSelect(dataId, isSelected, studentAnswerImages)
           }
           onScoringDataReplace={handleReplaceSelection}
           layoutDirection={layoutDirection}
@@ -370,8 +384,8 @@ function ScoringMainViewContent() {
             onPrevQuestion={handlePrevQuestion}
             onNextQuestion={handleNextQuestion}
             questionProgress={questionProgress}
-            selectedPageImageIds={selectedPageImageIds}
-            selectedAnswersCount={selectedPageImageIds.size}
+            selectedStudentAnswerImageIds={selectedStudentAnswerImageIds}
+            selectedAnswersCount={selectedStudentAnswerImageIds.size}
             filterSettings={filterSettings}
             onScore={handleBatchScoreWithProgress}
             onToggleFilter={handleToggleFilter}
@@ -379,7 +393,7 @@ function ScoringMainViewContent() {
             partialScoreInput={partialScoreInput}
             layoutDirection={layoutDirection}
             visibleAnswersCount={visibleAnswers.length}
-            totalAnswersCount={pageImages.length}
+            totalAnswersCount={studentAnswerImages.length}
             onLayoutDirectionChange={setLayoutDirection}
             onGridNavigation={handleGridNavigation}
             onRefreshView={handleRefreshFilter}
@@ -392,7 +406,7 @@ function ScoringMainViewContent() {
             onExpandMarginChange={setExpandMargin}
             students={students}
             onStudentChange={handleStudentChange}
-            pageImages={pageImages}
+            studentAnswerImages={studentAnswerImages}
             scoringBehavior={scoringBehavior}
             onScoringBehaviorChange={(behavior) => setScoringBehavior(behavior)}
           />

--- a/components/projects/07-score-at-once/ScoringMain/ScoringModals.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringModals.tsx
@@ -4,7 +4,7 @@ import PartialScoreModal from "@/components/projects/07-score-at-once/ScoringMai
 import ScoreComparisonModal from "@/components/projects/07-score-at-once/ScoringMain/ScoreComparisonModal"
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/types"
 
 /** キーバインディングの型 */
@@ -27,7 +27,7 @@ interface ScoringModalsProps {
   // Score Comparison Modal props
   showScoreComparison: boolean
   onScoreComparisonClose: () => void
-  currentAnswerSheet?: PageImageWithProjectStudents
+  currentAnswerSheet?: StudentAnswerImageWithProjectStudents
 }
 
 export function ScoringModals({

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringData.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringData.ts
@@ -1,7 +1,7 @@
 import { useBatchScoring } from "@/components/projects/07-score-at-once/ScoringData/hooks/useBatchScoring"
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/ScoringData/types/scoringDataTypes"
 import { loadQuestionScores } from "@/components/projects/07-score-at-once/ScoringData/utils/dataLoader"
 import { calculateQuestionProgress } from "@/components/projects/07-score-at-once/ScoringData/utils/progressCalculator"
@@ -12,7 +12,7 @@ interface UseScoringDataProps {
   currentUserId: string | null
   setCurrentUserId: (userId: string) => void
   currentCropRegionId: string | null
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithProjectStudents[]
   cropRegions: CropRegionWithProjectPage[]
 }
 
@@ -20,14 +20,14 @@ export function useScoringData({
   currentUserId,
   setCurrentUserId,
   currentCropRegionId,
-  pageImages,
+  studentAnswerImages,
   cropRegions,
 }: UseScoringDataProps) {
   const [questionScores, setQuestionScores] = useState<QuestionScore[]>([])
 
   // Batch scoring hook
   const { handleBatchScore } = useBatchScoring({
-    pageImages,
+    studentAnswerImages,
     cropRegions,
     currentCropRegionId,
     currentUserId,
@@ -47,8 +47,12 @@ export function useScoringData({
 
   // Progress calculation function
   const calculateQuestionProgressCallback = useCallback(() => {
-    return calculateQuestionProgress(cropRegions, pageImages, questionScores)
-  }, [pageImages, cropRegions, questionScores])
+    return calculateQuestionProgress(
+      cropRegions,
+      studentAnswerImages,
+      questionScores
+    )
+  }, [studentAnswerImages, cropRegions, questionScores])
 
   return {
     questionScores,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
@@ -1,15 +1,13 @@
-import {
-  CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
-} from "@/components/projects/07-score-at-once/types"
+import { CropRegionWithProjectPage } from "@/components/projects/07-score-at-once/types"
 import { ProjectWithDetails, isValidProject } from "@/types/common.types"
+import { StudentAnswerImageWithDetails } from "@/types/prismaExtensions"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 interface ScoringDataLoaderResult {
   loading: boolean
   project: ProjectWithDetails | null
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithDetails[]
   cropRegions: CropRegionWithProjectPage[]
   currentUserId: string | null
 }
@@ -19,9 +17,9 @@ export function useScoringDataLoader(
 ): ScoringDataLoaderResult {
   const [loading, setLoading] = useState(true)
   const [project, setProject] = useState<ProjectWithDetails | null>(null)
-  const [pageImages, setPageImages] = useState<PageImageWithProjectStudents[]>(
-    []
-  )
+  const [studentAnswerImages, setStudentAnswerImages] = useState<
+    StudentAnswerImageWithDetails[]
+  >([])
   const [cropRegions, setCropRegions] = useState<CropRegionWithProjectPage[]>(
     []
   )
@@ -49,10 +47,7 @@ export function useScoringDataLoader(
           throw new Error("答案データの読み込みに失敗しました")
         }
 
-        const pageImagesData = (answersResult.studentAnswers ||
-          []) as unknown as PageImageWithProjectStudents[]
-
-        setPageImages(pageImagesData)
+        setStudentAnswerImages(answersResult.studentAnswerImages ?? [])
 
         // 設問領域データの読み込み
         const regionsResult =
@@ -90,7 +85,7 @@ export function useScoringDataLoader(
   return {
     loading,
     project,
-    pageImages,
+    studentAnswerImages,
     cropRegions,
     currentUserId,
   }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
@@ -10,7 +10,7 @@
 import type {
   CropRegionWithProjectPage,
   GradingMode,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/types"
 import { useEffect, useLayoutEffect, useRef } from "react"
 
@@ -21,9 +21,9 @@ interface UseScoringEffectsParams {
   /** 現在の採点モード */
   gradingMode: GradingMode
   /** 選択中のページ画像ID集合 */
-  selectedPageImageIds: Set<string>
+  selectedStudentAnswerImageIds: Set<string>
   /** ページ画像一覧 */
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithProjectStudents[]
   /** 採点領域一覧 */
   cropRegions: CropRegionWithProjectPage[]
   /** 現在選択中の採点領域ID */
@@ -44,8 +44,8 @@ interface UseScoringEffectsParams {
 export function useScoringEffects(params: UseScoringEffectsParams): void {
   const {
     gradingMode,
-    selectedPageImageIds,
-    pageImages,
+    selectedStudentAnswerImageIds,
+    studentAnswerImages,
     cropRegions,
     currentCropRegionId,
     setSelectedPageImageIds,
@@ -57,14 +57,14 @@ export function useScoringEffects(params: UseScoringEffectsParams): void {
   const previousCropRegionIdRef = useRef<string | null>(currentCropRegionId)
 
   // 設問変更時のeffectで使用するためのrefs（依存配列の問題を回避）
-  const pageImagesRef = useRef(pageImages)
-  const selectedPageImageIdsRef = useRef(selectedPageImageIds)
+  const studentAnswerImagesRef = useRef(studentAnswerImages)
+  const selectedStudentAnswerImageIdsRef = useRef(selectedStudentAnswerImageIds)
   const cropRegionsRef = useRef(cropRegions)
 
   // refsを常に最新の値で更新
   useLayoutEffect(() => {
-    pageImagesRef.current = pageImages
-    selectedPageImageIdsRef.current = selectedPageImageIds
+    studentAnswerImagesRef.current = studentAnswerImages
+    selectedStudentAnswerImageIdsRef.current = selectedStudentAnswerImageIds
     cropRegionsRef.current = cropRegions
   })
 
@@ -72,11 +72,14 @@ export function useScoringEffects(params: UseScoringEffectsParams): void {
    * 個別表示モードでは単一選択を維持
    */
   useEffect(() => {
-    if (gradingMode === "individual" && selectedPageImageIds.size > 1) {
-      const firstSelected = Array.from(selectedPageImageIds)[0]
+    if (
+      gradingMode === "individual" &&
+      selectedStudentAnswerImageIds.size > 1
+    ) {
+      const firstSelected = Array.from(selectedStudentAnswerImageIds)[0]
       setSelectedPageImageIds(new Set([firstSelected]))
     }
-  }, [gradingMode, selectedPageImageIds, setSelectedPageImageIds])
+  }, [gradingMode, selectedStudentAnswerImageIds, setSelectedPageImageIds])
 
   /**
    * 設問未選択時は最初の設問を自動選択
@@ -118,8 +121,8 @@ export function useScoringEffects(params: UseScoringEffectsParams): void {
       }
     } else {
       // 個別モード: 現在選択中の生徒の新しい設問ページに対応するpageImageに更新
-      const currentSelectedIds = selectedPageImageIdsRef.current
-      const currentPageImages = pageImagesRef.current
+      const currentSelectedIds = selectedStudentAnswerImageIdsRef.current
+      const currentPageImages = studentAnswerImagesRef.current
       const currentCropRegions = cropRegionsRef.current
 
       if (currentSelectedIds.size > 0) {

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -2,7 +2,7 @@ import type {
   CropRegionWithProjectPage,
   GradingMode,
   MasterGridItem,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringData,
   ScoringStatus,
@@ -40,11 +40,11 @@ interface FilterSettings {
 }
 
 interface UseScoringFilterProps {
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithProjectStudents[]
   cropRegions: CropRegionWithProjectPage[]
   currentCropRegionId: string | null
   questionScores: QuestionScore[]
-  selectedPageImageIds: Set<string>
+  selectedStudentAnswerImageIds: Set<string>
   setSelectedPageImageIds: (answers: Set<string>) => void
   project: ProjectWithDetails | null
   gradingMode: GradingMode
@@ -53,11 +53,11 @@ interface UseScoringFilterProps {
 }
 
 export function useScoringFilter({
-  pageImages,
+  studentAnswerImages,
   cropRegions,
   currentCropRegionId,
   questionScores,
-  selectedPageImageIds,
+  selectedStudentAnswerImageIds,
   setSelectedPageImageIds,
   project,
   gradingMode,
@@ -109,7 +109,7 @@ export function useScoringFilter({
   const allScoringData = useMemo((): ScoringData[] => {
     if (!currentCropRegion) return []
 
-    const pageFilteredSheets = pageImages.filter(
+    const pageFilteredSheets = studentAnswerImages.filter(
       (pageImage) => pageImage.projectPageId === currentCropRegion.projectPageId
     )
 
@@ -179,7 +179,7 @@ export function useScoringFilter({
     )
 
     return studentScoringData
-  }, [currentCropRegion, pageImages, questionScores])
+  }, [currentCropRegion, studentAnswerImages, questionScores])
 
   const updateVisibleAnswers = useCallback(
     (customFilterSettings?: FilterSettings) => {
@@ -204,7 +204,7 @@ export function useScoringFilter({
 
       const selectedIdsSet = questionVersionChanged
         ? new Set<string>()
-        : new Set(selectedPageImageIds)
+        : new Set(selectedStudentAnswerImageIds)
 
       for (const scoringData of allScoringData) {
         const status = scoringData.status
@@ -250,13 +250,13 @@ export function useScoringFilter({
       currentCropRegion,
       allScoringData,
       recentlyScoredAnswers,
-      selectedPageImageIds,
+      selectedStudentAnswerImageIds,
       questionChangeVersion,
     ]
   )
 
   useLayoutEffect(() => {
-    if (pageImages.length === 0 || cropRegions.length === 0) {
+    if (studentAnswerImages.length === 0 || cropRegions.length === 0) {
       return
     }
 
@@ -270,7 +270,7 @@ export function useScoringFilter({
       Promise.resolve().then(runUpdate)
     }
   }, [
-    pageImages.length,
+    studentAnswerImages.length,
     cropRegions.length,
     currentCropRegionId,
     updateVisibleAnswers,
@@ -308,7 +308,7 @@ export function useScoringFilter({
       return
     }
 
-    if (selectedPageImageIds.size > 1) {
+    if (selectedStudentAnswerImageIds.size > 1) {
       pendingGridSelectionRef.current = false
       return
     }
@@ -353,7 +353,7 @@ export function useScoringFilter({
     const filteredSelection =
       hasFreshSnapshot && snapshot?.filteredSelection
         ? snapshot.filteredSelection
-        : Array.from(selectedPageImageIds).filter(
+        : Array.from(selectedStudentAnswerImageIds).filter(
             (id) => visibleIds.has(id) && !id.startsWith("master-")
           )
     const firstStudentAnswerId =
@@ -371,7 +371,7 @@ export function useScoringFilter({
       if (shouldApplySelection) {
         if (cropRegionChanged) {
           if (visibleAnswers.length === 0 || !firstStudentAnswerId) {
-            if (selectedPageImageIds.size > 0) {
+            if (selectedStudentAnswerImageIds.size > 0) {
               setSelectedPageImageIds(new Set())
             }
             pendingGridSelectionRef.current = false
@@ -379,8 +379,8 @@ export function useScoringFilter({
           }
 
           if (
-            selectedPageImageIds.size !== 1 ||
-            !selectedPageImageIds.has(firstStudentAnswerId)
+            selectedStudentAnswerImageIds.size !== 1 ||
+            !selectedStudentAnswerImageIds.has(firstStudentAnswerId)
           ) {
             setSelectedPageImageIds(new Set([firstStudentAnswerId]))
           }
@@ -394,7 +394,7 @@ export function useScoringFilter({
             : filteredSelection.length > 0
 
         if (hasVisibleSelection) {
-          if (filteredSelection.length !== selectedPageImageIds.size) {
+          if (filteredSelection.length !== selectedStudentAnswerImageIds.size) {
             setSelectedPageImageIds(new Set(filteredSelection))
           }
           pendingGridSelectionRef.current = false
@@ -405,7 +405,7 @@ export function useScoringFilter({
         }
 
         if (visibleAnswers.length === 0 || !firstStudentAnswerId) {
-          if (selectedPageImageIds.size > 0) {
+          if (selectedStudentAnswerImageIds.size > 0) {
             setSelectedPageImageIds(new Set())
           }
           if (visibleAnswers.length > 0) {
@@ -418,8 +418,8 @@ export function useScoringFilter({
         }
 
         if (
-          selectedPageImageIds.size !== 1 ||
-          !selectedPageImageIds.has(firstStudentAnswerId)
+          selectedStudentAnswerImageIds.size !== 1 ||
+          !selectedStudentAnswerImageIds.has(firstStudentAnswerId)
         ) {
           setSelectedPageImageIds(new Set([firstStudentAnswerId]))
         }
@@ -433,7 +433,7 @@ export function useScoringFilter({
   }, [
     currentCropRegionId,
     gradingMode,
-    selectedPageImageIds,
+    selectedStudentAnswerImageIds,
     setSelectedPageImageIds,
     visibleAnswers,
     manualSelectionVersion,
@@ -458,7 +458,7 @@ export function useScoringFilter({
       return
     }
 
-    if (selectedPageImageIds.size === 0) {
+    if (selectedStudentAnswerImageIds.size === 0) {
       return
     }
 
@@ -473,7 +473,9 @@ export function useScoringFilter({
         : undefined
     const firstVisibleSelected = firstCandidateId
       ? firstCandidateId
-      : Array.from(selectedPageImageIds).find((id) => visibleIds.has(id))
+      : Array.from(selectedStudentAnswerImageIds).find((id) =>
+          visibleIds.has(id)
+        )
 
     if (!firstVisibleSelected) {
       return
@@ -486,7 +488,7 @@ export function useScoringFilter({
         })
       )
     }
-  }, [gradingMode, selectedPageImageIds, visibleAnswers])
+  }, [gradingMode, selectedStudentAnswerImageIds, visibleAnswers])
 
   // 設問変更時の選択処理用のref
   const questionChangeVersionForSelectionRef = useRef(questionChangeVersion)
@@ -550,9 +552,9 @@ export function useScoringFilter({
   const getAllGridAnswerData = useMemo(() => {
     return allScoringData.map((data) => ({
       ...data,
-      isSelected: selectedPageImageIds.has(data.id),
+      isSelected: selectedStudentAnswerImageIds.has(data.id),
     }))
-  }, [allScoringData, selectedPageImageIds])
+  }, [allScoringData, selectedStudentAnswerImageIds])
 
   const getGridAnswerData = useCallback((): (ScoringData & {
     isSelected: boolean
@@ -594,7 +596,7 @@ export function useScoringFilter({
     allScoringData,
     masterAnswerData,
     filteredScoringDataIds: visibleAnswers,
-    selectedScoringDataIds: selectedPageImageIds,
+    selectedScoringDataIds: selectedStudentAnswerImageIds,
 
     filterSettings,
     visibleAnswers,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
@@ -1,6 +1,6 @@
 import type {
   GradingMode,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/types"
 import { getModifierKeyLabel } from "@/lib/platformUtils"
 import { useCallback, useRef, useState } from "react"
@@ -9,9 +9,9 @@ export function useScoringMainState() {
   /** 採点モード状態 */
   const [gradingMode, setGradingMode] = useState<GradingMode>("grid")
   /** 選択中の答案ID集合 */
-  const [selectedPageImageIds, setSelectedPageImageIds] = useState<Set<string>>(
-    new Set()
-  )
+  const [selectedStudentAnswerImageIds, setSelectedPageImageIds] = useState<
+    Set<string>
+  >(new Set())
   const [manualSelectionVersion, setManualSelectionVersion] = useState(0)
   const suppressSelectionUpdateRef = useRef(false)
   /** 現在選択中の生徒インデックス */
@@ -36,7 +36,7 @@ export function useScoringMainState() {
     (
       answerId: string,
       isSelected: boolean,
-      pageImages: PageImageWithProjectStudents[]
+      studentAnswerImages: StudentAnswerImageWithProjectStudents[]
     ) => {
       if (suppressSelectionUpdateRef.current) {
         return
@@ -45,7 +45,9 @@ export function useScoringMainState() {
         return
       }
 
-      const answerExists = pageImages.some((sheet) => sheet.id === answerId)
+      const answerExists = studentAnswerImages.some(
+        (sheet) => sheet.id === answerId
+      )
       if (!answerExists) {
         return
       }
@@ -78,7 +80,7 @@ export function useScoringMainState() {
   return {
     /** 個別の状態 */
     gradingMode,
-    selectedPageImageIds,
+    selectedStudentAnswerImageIds,
     currentStudentIndex,
     currentCropRegionId,
     showKeyboardHelp,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
@@ -12,7 +12,7 @@ interface UseScoringNavigationProps {
   answerSheetsLength: number
   currentCropRegionId: string | null
   setCurrentCropRegionId: (id: string | null) => void
-  selectedPageImageIds: Set<string>
+  selectedStudentAnswerImageIds: Set<string>
   setSelectedPageImageIds: (answers: Set<string>) => void
   layoutDirection: LayoutDirection
   getGridAnswerData: () => ScoringDataWithSelection[]
@@ -24,7 +24,7 @@ export function useScoringNavigation({
   answerSheetsLength,
   currentCropRegionId,
   setCurrentCropRegionId,
-  selectedPageImageIds,
+  selectedStudentAnswerImageIds,
   setSelectedPageImageIds,
   layoutDirection,
   getGridAnswerData,
@@ -110,8 +110,8 @@ export function useScoringNavigation({
 
       // 現在選択されている答案のインデックスを取得
       let currentIndex = -1
-      if (selectedPageImageIds.size >= 1) {
-        const selectedId = Array.from(selectedPageImageIds)[0]
+      if (selectedStudentAnswerImageIds.size >= 1) {
+        const selectedId = Array.from(selectedStudentAnswerImageIds)[0]
         currentIndex = gridAnswers.findIndex(
           (answer) => answer.id === selectedId
         )
@@ -259,7 +259,7 @@ export function useScoringNavigation({
     [
       answerSheetsLength,
       getGridAnswerData,
-      selectedPageImageIds,
+      selectedStudentAnswerImageIds,
       setSelectedPageImageIds,
       layoutDirection,
       findNextValidAnswer,

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
@@ -8,7 +8,7 @@
 import type {
   CropRegionWithProjectPage,
   GradingMode,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
 } from "@/components/projects/07-score-at-once/types"
 import { useCallback, useEffect, useMemo } from "react"
 
@@ -33,9 +33,9 @@ export interface StudentData {
  */
 interface UseStudentAnswerManagementParams {
   /** ページ画像一覧 */
-  pageImages: PageImageWithProjectStudents[]
+  studentAnswerImages: StudentAnswerImageWithProjectStudents[]
   /** 選択中のページ画像ID集合 */
-  selectedPageImageIds: Set<string>
+  selectedStudentAnswerImageIds: Set<string>
   /** 現在の採点モード */
   gradingMode: GradingMode
   /** 現在の採点領域（ナビゲーション用） */
@@ -68,8 +68,8 @@ export function useStudentAnswerManagement(
   params: UseStudentAnswerManagementParams
 ): UseStudentAnswerManagementReturn {
   const {
-    pageImages,
-    selectedPageImageIds,
+    studentAnswerImages,
+    selectedStudentAnswerImageIds,
     gradingMode,
     currentCropRegion,
     setSelectedPageImageIds,
@@ -77,14 +77,14 @@ export function useStudentAnswerManagement(
   } = params
 
   /**
-   * 個別表示用の生徒データ（pageImagesから抽出、useMemoで安定化）
+   * 個別表示用の生徒データ（studentAnswerImagesから抽出、useMemoで安定化）
    */
   const students = useMemo(() => {
-    if (!pageImages || pageImages.length === 0) return []
+    if (!studentAnswerImages || studentAnswerImages.length === 0) return []
 
     const uniqueStudents = new Map<string, StudentData>()
 
-    pageImages.forEach((sheet) => {
+    studentAnswerImages.forEach((sheet) => {
       if (sheet.student && !uniqueStudents.has(sheet.student.id)) {
         const studentData: StudentData = {
           id: sheet.student.id,
@@ -101,14 +101,14 @@ export function useStudentAnswerManagement(
       (a, b) => a.customOrder - b.customOrder
     )
     return sortedStudents
-  }, [pageImages])
+  }, [studentAnswerImages])
 
   /**
    * 個別表示用のナビゲーション関数
    */
   const handleStudentChange = useCallback(
     (studentId: string) => {
-      const studentSheets = pageImages.filter(
+      const studentSheets = studentAnswerImages.filter(
         (sheet) => sheet.student?.id === studentId
       )
       if (studentSheets.length > 0) {
@@ -123,7 +123,7 @@ export function useStudentAnswerManagement(
         const targetSheet = currentPageSheet || studentSheets[0]
         setSelectedPageImageIds(new Set([targetSheet.id]))
 
-        const studentIndex = pageImages.findIndex(
+        const studentIndex = studentAnswerImages.findIndex(
           (sheet) => sheet.id === targetSheet.id
         )
         if (studentIndex !== -1) {
@@ -132,7 +132,7 @@ export function useStudentAnswerManagement(
       }
     },
     [
-      pageImages,
+      studentAnswerImages,
       setSelectedPageImageIds,
       setCurrentStudentIndex,
       currentCropRegion,
@@ -146,23 +146,30 @@ export function useStudentAnswerManagement(
     if (
       gradingMode === "individual" &&
       students.length > 0 &&
-      selectedPageImageIds.size === 0
+      selectedStudentAnswerImageIds.size === 0
     ) {
       const sortedStudents = [...students].sort(
         (a, b) => a.customOrder - b.customOrder
       )
       handleStudentChange(sortedStudents[0].id)
     }
-  }, [gradingMode, students, selectedPageImageIds.size, handleStudentChange])
+  }, [
+    gradingMode,
+    students,
+    selectedStudentAnswerImageIds.size,
+    handleStudentChange,
+  ])
 
   /**
    * 次の生徒へ移動（個別表示用）
    */
   const handleIndividualNextStudent = useCallback(() => {
-    if (selectedPageImageIds.size === 0) return
+    if (selectedStudentAnswerImageIds.size === 0) return
 
-    const currentAnswerId = Array.from(selectedPageImageIds)[0]
-    const currentAnswer = pageImages.find((a) => a.id === currentAnswerId)
+    const currentAnswerId = Array.from(selectedStudentAnswerImageIds)[0]
+    const currentAnswer = studentAnswerImages.find(
+      (a) => a.id === currentAnswerId
+    )
     if (!currentAnswer) return
 
     const sortedStudents = [...students].sort(
@@ -174,7 +181,7 @@ export function useStudentAnswerManagement(
     if (currentIndex < sortedStudents.length - 1) {
       const nextStudent = sortedStudents[currentIndex + 1]
       // 現在の設問ページに対応するpageImageを優先選択
-      const nextStudentSheets = pageImages.filter(
+      const nextStudentSheets = studentAnswerImages.filter(
         (a) => a.student?.id === nextStudent.id
       )
       const nextStudentAnswer = currentCropRegion
@@ -188,8 +195,8 @@ export function useStudentAnswerManagement(
     }
   }, [
     students,
-    selectedPageImageIds,
-    pageImages,
+    selectedStudentAnswerImageIds,
+    studentAnswerImages,
     setSelectedPageImageIds,
     currentCropRegion,
   ])

--- a/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -9,7 +9,7 @@ import { QuestionProgress } from "@/components/projects/07-score-at-once/Scoring
 import type {
   CropRegionWithProjectPage,
   LayoutDirection,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
 import { Separator } from "@/components/ui/separator"
@@ -66,8 +66,8 @@ interface ScoringSidePanelProps {
     customOrder: number
   }[]
   onStudentChange?: (studentId: string) => void
-  selectedPageImageIds?: Set<string>
-  pageImages?: PageImageWithProjectStudents[]
+  selectedStudentAnswerImageIds?: Set<string>
+  studentAnswerImages?: StudentAnswerImageWithProjectStudents[]
   scoringBehavior?: "next-student" | "next-question" | "stay"
   onScoringBehaviorChange?: (
     behavior: "next-student" | "next-question" | "stay"
@@ -103,8 +103,8 @@ export function ScoringSidePanel({
   onExpandMarginChange,
   students,
   onStudentChange,
-  selectedPageImageIds,
-  pageImages,
+  selectedStudentAnswerImageIds,
+  studentAnswerImages,
   scoringBehavior,
   onScoringBehaviorChange,
 }: ScoringSidePanelProps) {
@@ -144,8 +144,8 @@ export function ScoringSidePanel({
             <Separator />
             <IndividualModePanel
               students={students}
-              selectedAnswers={selectedPageImageIds}
-              pageImages={pageImages}
+              selectedAnswers={selectedStudentAnswerImageIds}
+              studentAnswerImages={studentAnswerImages}
               onStudentChange={onStudentChange}
               scoringBehavior={scoringBehavior}
               onScoringBehaviorChange={onScoringBehaviorChange}

--- a/components/projects/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
+++ b/components/projects/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
@@ -1,6 +1,6 @@
 import type {
   CropRegionWithProjectPage,
-  PageImageWithProjectStudents,
+  StudentAnswerImageWithProjectStudents,
   QuestionScore,
   ScoringStatus,
 } from "@/components/projects/07-score-at-once/types"
@@ -9,7 +9,7 @@ import { useCallback } from "react"
 import { toast } from "sonner"
 
 interface UseBatchScoringProps {
-  pageImages: PageImageWithProjectStudents[]
+  pageImages: StudentAnswerImageWithProjectStudents[]
   cropRegions: CropRegionWithProjectPage[]
   currentCropRegionId: string | null
   currentUserId: string | null

--- a/components/projects/07-score-at-once/types/index.ts
+++ b/components/projects/07-score-at-once/types/index.ts
@@ -6,6 +6,10 @@
 /** Prismaから基本型とPayload型をインポート */
 import type { Prisma, QuestionScore } from "@prisma/client"
 
+/** Prisma拡張型をprismaExtensions.tsからインポート・再エクスポート */
+import type { StudentAnswerImageWithDetails } from "@/types/prismaExtensions"
+export type { StudentAnswerImageWithDetails } from "@/types/prismaExtensions"
+
 /** Prisma基本型をエクスポート */
 export type {
   CropRegion,
@@ -27,25 +31,12 @@ export type ScoringStatus =
   | "no_answer"
 
 /**
- * StudentAnswerImageを学生とProjectStudents情報で拡張したPrisma生成型
+ * StudentAnswerImageを学生とProjectStudents情報で拡張した型
+ * StudentAnswerImageWithDetailsのエイリアス（型統一のため）
  * 変数名: studentAnswerImage, studentAnswerImages
  */
 export type StudentAnswerImageWithProjectStudents =
-  Prisma.StudentAnswerImageGetPayload<{
-    include: {
-      student: {
-        include: {
-          projectStudents: true
-        }
-      }
-      projectPage: true
-    }
-  }>
-
-/**
- * @deprecated Use StudentAnswerImageWithProjectStudents instead
- */
-export type PageImageWithProjectStudents = StudentAnswerImageWithProjectStudents
+  StudentAnswerImageWithDetails
 
 /**
  * CropRegionをProjectPage情報で拡張したPrisma生成型
@@ -117,11 +108,11 @@ export function calculateActualScore(
 
 /**
  * 採点データの基本インターフェース
- * QuestionScore + Student + CropRegion + PageImage の結合データから変換されたもの
+ * QuestionScore + Student + CropRegion + StudentAnswerImage の結合データから変換されたもの
  * 注意: 学生データのみを管理し、模範解答は別途管理する
  */
 export interface ScoringData {
-  /** PageImage.id */
+  /** StudentAnswerImage.id */
   id: string
   /** Student.id (UUID) */
   studentId: string

--- a/electron-src/appInitializer.ts
+++ b/electron-src/appInitializer.ts
@@ -1,9 +1,4 @@
-import { net, protocol } from "electron"
-import { format } from "url"
-import {
-  getAbsolutePathFromData,
-  initializeDataDirectory,
-} from "./lib/dataManager"
+import { initializeDataDirectory } from "./lib/dataManager"
 import { optimizeDatabaseForSharedDrive } from "./lib/prisma/databaseInitializer"
 
 export async function initializeApp(): Promise<void> {
@@ -49,52 +44,4 @@ export async function initializeApp(): Promise<void> {
     const errorMessage = error instanceof Error ? error.message : String(error)
     throw new Error(`Application initialization failed: ${errorMessage}`)
   }
-
-  // カスタムプロトコルの設定
-  protocol.handle("appimg", async (request) => {
-    try {
-      const relativePathInData = request.url.substring("appimg://".length)
-
-      // より確実なデコード処理
-      let decodedRelativePath
-      try {
-        // まずdecodeURIComponentを試す
-        decodedRelativePath = decodeURIComponent(relativePathInData)
-      } catch {
-        try {
-          // 失敗したらdecodeURIを試す
-          decodedRelativePath = decodeURI(relativePathInData)
-        } catch {
-          // 両方失敗したら生のパスを使用
-          decodedRelativePath = relativePathInData
-        }
-      }
-
-      const absolutePath = getAbsolutePathFromData(decodedRelativePath)
-
-      // ファイル存在確認
-      const fs = await import("fs/promises")
-      try {
-        await fs.access(absolutePath)
-      } catch {
-        return new Response("File not found", { status: 404 })
-      }
-
-      const fileURL = format({
-        pathname: absolutePath,
-        protocol: "file:",
-        slashes: true,
-      })
-
-      const response = await net.fetch(fileURL)
-      return response
-    } catch (error) {
-      console.error(
-        `Failed to handle 'appimg' protocol request ${request.url}:`,
-        error
-      )
-
-      return new Response("File not found", { status: 404 })
-    }
-  })
 }

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -216,14 +216,12 @@ export function setupMiscHandlers(): void {
         if (!result.success) {
           return { success: false, error: result.error }
         }
-        const serializedStudentAnswers = (result.answerSheets || []).map(
-          (answer) => ({
-            ...answer,
-          })
-        )
-        return { success: true, studentAnswers: serializedStudentAnswers }
+        return {
+          success: true,
+          studentAnswerImages: result.studentAnswerImages ?? [],
+        }
       } catch (err) {
-        console.error("Error fetching answer sheets:", err)
+        console.error("Error fetching student answer images:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "Unknown error",

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -162,11 +162,37 @@ export async function getPdfExportData(options: {
 
     // 答案画像を取得
     const studentAnswersResult = await getStudentAnswersByProjectId(projectId)
-    if (!studentAnswersResult.success || !studentAnswersResult.answerSheets) {
+    if (
+      !studentAnswersResult.success ||
+      !studentAnswersResult.studentAnswerImages
+    ) {
       return { success: false, error: "答案画像の取得に失敗しました" }
     }
+    // Prisma型をStudentAnswerData型に変換
     const studentAnswers: StudentAnswerData[] =
-      studentAnswersResult.answerSheets
+      studentAnswersResult.studentAnswerImages.map((img) => ({
+        id: img.id,
+        studentId: img.studentId,
+        pageNumber: img.projectPage.pageNumber,
+        projectPageId: img.projectPageId,
+        imagePath: img.imagePath,
+        originalImagePath: img.imagePath,
+        isAbsent:
+          img.student?.projectStudents?.[0]?.status === "ABSENT" || false,
+        student: img.student
+          ? {
+              id: img.student.id,
+              lastName: img.student.lastName,
+              firstName: img.student.firstName,
+              lastNameKana: img.student.lastNameKana,
+              firstNameKana: img.student.firstNameKana,
+              studentId: img.student.studentId,
+              projectStudents: img.student.projectStudents,
+            }
+          : null,
+        projectId: img.projectPage.projectId,
+        status: "ready" as const,
+      }))
 
     // 選択された生徒のみフィルタリング
     const selectedStudents = allStudents.filter((s) =>

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -106,10 +106,11 @@ export async function uploadStudentAnswers(
 
 /**
  * プロジェクトの答案一覧を取得
+ * Prismaの型をそのまま返す（StudentAnswerImageWithProjectStudents互換）
  */
 export async function getStudentAnswersByProjectId(projectId: string) {
   try {
-    const answerSheets = await prisma.studentAnswerImage.findMany({
+    const studentAnswerImages = await prisma.studentAnswerImage.findMany({
       where: {
         projectPage: {
           projectId: projectId,
@@ -120,52 +121,17 @@ export async function getStudentAnswersByProjectId(projectId: string) {
           include: {
             projectStudents: {
               where: { projectId },
-              select: { customOrder: true, status: true },
             },
           },
         },
-        projectPage: {
-          include: {
-            project: true,
-          },
-        },
+        projectPage: true,
       },
       orderBy: [{ studentId: "asc" }, { projectPage: { pageNumber: "asc" } }],
     })
 
-    // Transform StudentAnswerImage data for backward compatibility
-    const processedAnswerSheets = answerSheets.map((sheet) => {
-      // Get ProjectStudent status to determine if absent
-      const projectStudent = sheet.student?.projectStudents?.[0]
-      const isAbsent = projectStudent?.status === "ABSENT"
-
-      return {
-        id: sheet.id,
-        studentId: sheet.studentId,
-        pageNumber: sheet.projectPage.pageNumber,
-        projectPageId: sheet.projectPage.id,
-        imagePath: sheet.imagePath,
-        originalImagePath: sheet.imagePath,
-        isAbsent: isAbsent,
-        student: sheet.student
-          ? {
-              id: sheet.student.id,
-              lastName: sheet.student.lastName,
-              firstName: sheet.student.firstName,
-              lastNameKana: sheet.student.lastNameKana,
-              firstNameKana: sheet.student.firstNameKana,
-              studentId: sheet.student.studentId,
-              projectStudents: sheet.student.projectStudents,
-            }
-          : null,
-        projectId: sheet.projectPage.project.id,
-        status: "ready" as const,
-      }
-    })
-
-    return { success: true, answerSheets: processedAnswerSheets }
+    return { success: true, studentAnswerImages }
   } catch (error) {
-    console.error("Error fetching answer sheets:", error)
+    console.error("Error fetching student answer images:", error)
     return {
       success: false,
       error:

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -286,23 +286,7 @@ export interface MyAPI {
   }>
   getStudentAnswersByProjectId: (projectId: string) => Promise<{
     success: boolean
-    studentAnswers?: Array<{
-      id: string
-      studentId: string | null
-      pageNumber: number
-      originalImagePath: string | null
-      isAbsent: boolean
-      student: {
-        id: string
-        lastName: string
-        firstName: string
-        lastNameKana: string
-        firstNameKana: string
-        studentId: string
-      } | null
-      projectId: string
-      status: "ready"
-    }>
+    studentAnswerImages?: StudentAnswerImageWithDetails[]
     error?: string
   }>
   deleteStudentAnswer: (studentAnswerId: string) => Promise<{

--- a/types/prismaExtensions.ts
+++ b/types/prismaExtensions.ts
@@ -223,19 +223,19 @@ export type MasterImageWithDetails = Prisma.MasterImageGetPayload<{
 
 /**
  * 詳細情報を含むStudentAnswerImage型
+ * 採点機能で使用する際はprojectStudentsも含む
  */
 export type StudentAnswerImageWithDetails =
   Prisma.StudentAnswerImageGetPayload<{
     include: {
-      projectPage: { include: { project: true } }
-      student: true
+      projectPage: true
+      student: {
+        include: {
+          projectStudents: true
+        }
+      }
     }
   }>
-
-/**
- * @deprecated Use MasterImageWithDetails or StudentAnswerImageWithDetails instead
- */
-export type PageImageWithDetails = StudentAnswerImageWithDetails
 
 // =============================================================================
 // UserProject/ProjectSubtotalGroup関連型


### PR DESCRIPTION
## 概要

Closes #296

データベーススキーマ変更（PageImage→StudentAnswerImage/MasterImage分割）の影響を正しく対処し、型安全性を向上させる。

## 変更内容

### 1. 変数名の統一
- `pageImages` → `studentAnswerImages`
- `selectedPageImageIds` → `selectedStudentAnswerImageIds`
- `pageImage` → `studentAnswerImage`

### 2. 非推奨型の削除
- `PageImageWithDetails` エイリアスを削除
- `PageImageWithProjectStudents` エイリアスを削除

### 3. 型定義の統一
- `StudentAnswerImageWithDetails` をPrisma型として統一（`projectStudents`を含む）
- IPC戻り値型をPrisma生成型に変更
- 危険な `as unknown as` 型キャストを排除

### 4. プロトコル重複登録の修正
- `appInitializer.ts` から `appimg://` プロトコル登録を削除（重複起動エラー解消）

## テスト計画

- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [ ] 採点画面での動作確認
- [ ] アプリ起動時にプロトコルエラーが発生しないことを確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)