### PR TITLE
インポート時のユニーク制約違反エラーを修正

### DIFF
--- a/electron-src/lib/import/merge/dataMerger.ts
+++ b/electron-src/lib/import/merge/dataMerger.ts
@@ -20,9 +20,7 @@ import { performAllMatching } from "./matcher"
 import { resolveConflict } from "./conflictResolver"
 import { detectAllConflicts } from "./conflictDetector"
 
-/**
- * マージ操作のカウンター
- */
+/** マージ操作のカウンター */
 interface MergeCounts {
   created: ArchiveDataCounts
   updated: ArchiveDataCounts
@@ -47,10 +45,15 @@ function createEmptyCounts(): ArchiveDataCounts {
 /**
  * マージインポートを実行
  *
+ * 既存データとのマッチングを行い、競合解決設定に基づいてデータをマージする。
+ * ユニーク制約のあるフィールド（studentId, name, username）は
+ * マッチング方法に関わらず既存チェックを行い、重複を回避する。
+ *
  * @param data - 展開されたアーカイブデータ
  * @param config - マッチング設定
  * @param resolutions - 競合解決設定
  * @param currentUserId - 現在ログインしているユーザーID
+ * @returns マージインポート結果
  */
 export async function executeMergeImport(
   data: ExtractedArchiveData,
@@ -103,21 +106,34 @@ export async function executeMergeImport(
         const importStudent = result.importData
 
         if (!result.existingData) {
-          // 新規作成
-          const newId = randomUUID()
-          await tx.student.create({
-            data: {
-              id: newId,
-              studentId: importStudent.studentId,
-              lastName: importStudent.lastName,
-              firstName: importStudent.firstName,
-              lastNameKana: importStudent.lastNameKana,
-              firstNameKana: importStudent.firstNameKana,
-              enrollmentYear: importStudent.enrollmentYear,
-            },
+          // マッチングで見つからなかった場合でも、studentIdで既存チェック
+          const existingByStudentId = await tx.student.findUnique({
+            where: { studentId: importStudent.studentId },
           })
-          idMappings.student[importStudent.id] = newId
-          counts.created.students++
+
+          if (existingByStudentId) {
+            // studentIdで既存データが見つかった場合は再利用
+            idMappings.student[importStudent.id] = existingByStudentId.id
+            warnings.push(
+              `生徒「${importStudent.lastName} ${importStudent.firstName}」(studentId: ${importStudent.studentId}) は既存データを使用します`
+            )
+          } else {
+            // 新規作成
+            const newId = randomUUID()
+            await tx.student.create({
+              data: {
+                id: newId,
+                studentId: importStudent.studentId,
+                lastName: importStudent.lastName,
+                firstName: importStudent.firstName,
+                lastNameKana: importStudent.lastNameKana,
+                firstNameKana: importStudent.firstNameKana,
+                enrollmentYear: importStudent.enrollmentYear,
+              },
+            })
+            idMappings.student[importStudent.id] = newId
+            counts.created.students++
+          }
         } else {
           // 既存データとの競合チェック
           const conflictItem = conflictResult.results
@@ -158,18 +174,31 @@ export async function executeMergeImport(
         const importClass = result.importData
 
         if (!result.existingData) {
-          const newId = randomUUID()
-          await tx.class.create({
-            data: {
-              id: newId,
-              name: importClass.name,
-              classCode: importClass.classCode,
-              grade: importClass.grade,
-              description: importClass.description,
-            },
+          // マッチングで見つからなかった場合でも、nameで既存チェック
+          const existingByName = await tx.class.findUnique({
+            where: { name: importClass.name },
           })
-          idMappings.class[importClass.id] = newId
-          counts.created.classes++
+
+          if (existingByName) {
+            // nameで既存データが見つかった場合は再利用
+            idMappings.class[importClass.id] = existingByName.id
+            warnings.push(
+              `学級「${importClass.name}」は既存データを使用します`
+            )
+          } else {
+            const newId = randomUUID()
+            await tx.class.create({
+              data: {
+                id: newId,
+                name: importClass.name,
+                classCode: importClass.classCode,
+                grade: importClass.grade,
+                description: importClass.description,
+              },
+            })
+            idMappings.class[importClass.id] = newId
+            counts.created.classes++
+          }
         } else {
           const conflictItem = conflictResult.results
             .find((r) => r.category === "Class")
@@ -203,21 +232,34 @@ export async function executeMergeImport(
         const importUser = result.importData
 
         if (!result.existingData) {
-          const newId = randomUUID()
-          await tx.user.create({
-            data: {
-              id: newId,
-              username: importUser.username,
-              name: importUser.name,
-              role: importUser.role,
-              passcode: "",
-            },
+          // マッチングで見つからなかった場合でも、usernameで既存チェック
+          const existingByUsername = await tx.user.findUnique({
+            where: { username: importUser.username },
           })
-          idMappings.user[importUser.id] = newId
-          counts.created.users++
-          warnings.push(
-            `新規ユーザー "${importUser.name}" のパスコードは空です`
-          )
+
+          if (existingByUsername) {
+            // usernameで既存データが見つかった場合は再利用
+            idMappings.user[importUser.id] = existingByUsername.id
+            warnings.push(
+              `ユーザー "${importUser.name}" は既存データを使用します`
+            )
+          } else {
+            const newId = randomUUID()
+            await tx.user.create({
+              data: {
+                id: newId,
+                username: importUser.username,
+                name: importUser.name,
+                role: importUser.role,
+                passcode: "",
+              },
+            })
+            idMappings.user[importUser.id] = newId
+            counts.created.users++
+            warnings.push(
+              `新規ユーザー "${importUser.name}" のパスコードは空です`
+            )
+          }
         } else {
           // ユーザーは基本的に既存を維持
           idMappings.user[importUser.id] = result.existingData.id
@@ -515,7 +557,10 @@ export async function executeMergeImport(
 }
 
 /**
- * 画像ファイルをコピー
+ * 画像ファイルをプロジェクトディレクトリにコピー
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @param newProjectId - 新規プロジェクトID
  */
 async function copyMergeImages(
   data: ExtractedArchiveData,
@@ -550,8 +595,11 @@ async function copyMergeImages(
 /**
  * 画像レコードを作成（MasterImage / StudentAnswerImage）
  *
- * v1.2.0+: masterImages と studentAnswerImages を使用
- * v1.1.0以前: pageImages から変換
+ * - v1.2.0+: masterImages と studentAnswerImages を使用
+ * - v1.1.0以前: pageImages から変換（後方互換性）
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @param idMappings - IDマッピング
  */
 async function createMergeImageRecords(
   data: ExtractedArchiveData,

--- a/electron-src/lib/import/project-archive/dataCreator.ts
+++ b/electron-src/lib/import/project-archive/dataCreator.ts
@@ -6,12 +6,87 @@
 
 import * as fs from "fs"
 import * as path from "path"
+import type { PrismaClient } from "@prisma/client"
 import type { ArchiveDataCounts } from "../../../../types/projectArchive.types"
 import { getDataDirectory } from "../../dataManager"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "./archiveExtractor"
 import type { IdMappings } from "./idRemapper"
 import { remapId, remapIdRequired } from "./idRemapper"
+
+/** Prismaトランザクションクライアント型 */
+type TransactionClient = Omit<
+  PrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>
+
+/**
+ * 重複しないstudentIdを生成
+ *
+ * 既存のstudentIdがある場合は `_1`, `_2` のようなサフィックスを付与して
+ * 一意性を保証する
+ *
+ * @param tx - Prismaトランザクションクライアント
+ * @param originalStudentId - 元のstudentId
+ * @returns 一意なstudentId
+ */
+async function generateUniqueStudentId(
+  tx: TransactionClient,
+  originalStudentId: string
+): Promise<string> {
+  const existing = await tx.student.findUnique({
+    where: { studentId: originalStudentId },
+  })
+
+  if (!existing) {
+    return originalStudentId
+  }
+
+  // サフィックスを付けて重複を回避
+  let suffix = 1
+  let newStudentId = `${originalStudentId}_${suffix}`
+
+  while (await tx.student.findUnique({ where: { studentId: newStudentId } })) {
+    suffix++
+    newStudentId = `${originalStudentId}_${suffix}`
+  }
+
+  return newStudentId
+}
+
+/**
+ * 重複しない学級名を生成
+ *
+ * 既存の名前がある場合は `(2)`, `(3)` のようなサフィックスを付与して
+ * 一意性を保証する
+ *
+ * @param tx - Prismaトランザクションクライアント
+ * @param originalName - 元の学級名
+ * @returns 一意な学級名
+ */
+async function generateUniqueClassName(
+  tx: TransactionClient,
+  originalName: string
+): Promise<string> {
+  const existing = await tx.class.findUnique({
+    where: { name: originalName },
+  })
+
+  if (!existing) {
+    return originalName
+  }
+
+  // サフィックスを付けて重複を回避
+  let suffix = 2
+  let newName = `${originalName} (${suffix})`
+
+  while (await tx.class.findUnique({ where: { name: newName } })) {
+    suffix++
+    newName = `${originalName} (${suffix})`
+  }
+
+  return newName
+}
 
 /**
  * データ作成結果
@@ -49,12 +124,23 @@ export async function createImportedData(
   try {
     // トランザクションで全データを作成
     await prisma.$transaction(async (tx) => {
-      // 1. 生徒を作成
+      // 1. 生徒を作成（重複するstudentIdはサフィックスを付与）
       for (const student of data.studentsData.students) {
+        const uniqueStudentId = await generateUniqueStudentId(
+          tx,
+          student.studentId
+        )
+
+        if (uniqueStudentId !== student.studentId) {
+          warnings.push(
+            `生徒「${student.lastName} ${student.firstName}」のstudentIdを「${student.studentId}」から「${uniqueStudentId}」に変更しました`
+          )
+        }
+
         await tx.student.create({
           data: {
             id: remapIdRequired(student.id, mappings.student),
-            studentId: student.studentId,
+            studentId: uniqueStudentId,
             lastName: student.lastName,
             firstName: student.firstName,
             lastNameKana: student.lastNameKana,
@@ -64,12 +150,20 @@ export async function createImportedData(
         })
       }
 
-      // 2. 学級を作成
+      // 2. 学級を作成（重複する名前はサフィックスを付与）
       for (const cls of data.classesData.classes) {
+        const uniqueName = await generateUniqueClassName(tx, cls.name)
+
+        if (uniqueName !== cls.name) {
+          warnings.push(
+            `学級名を「${cls.name}」から「${uniqueName}」に変更しました`
+          )
+        }
+
         await tx.class.create({
           data: {
             id: remapIdRequired(cls.id, mappings.class),
-            name: cls.name,
+            name: uniqueName,
             classCode: cls.classCode,
             grade: cls.grade,
             description: cls.description,
@@ -346,6 +440,9 @@ export async function createImportedData(
 
 /**
  * 画像ファイルをプロジェクトディレクトリにコピー
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @param newProjectId - 新規プロジェクトID
  */
 async function copyImages(
   data: ExtractedArchiveData,
@@ -384,8 +481,12 @@ async function copyImages(
 /**
  * 画像レコードを作成（MasterImage / StudentAnswerImage）
  *
- * v1.2.0+: masterImages と studentAnswerImages を使用
- * v1.1.0以前: pageImages から変換
+ * - v1.2.0+: masterImages と studentAnswerImages を使用
+ * - v1.1.0以前: pageImages から変換（後方互換性）
+ *
+ * @param data - 展開されたアーカイブデータ
+ * @param mappings - IDマッピング
+ * @param newProjectId - 新規プロジェクトID
  */
 async function createImageRecords(
   data: ExtractedArchiveData,


### PR DESCRIPTION
## Summary

- インポート時のユニーク制約違反エラー（studentId重複等）を修正
- 統合モードと新規モードの両方で適切な重複処理を実装
- JSDocコメントの改善

Closes #298

## 変更内容

### 統合モード（dataMerger.ts）

| 対象 | ユニーク制約 | 修正内容 |
|------|-------------|----------|
| 生徒 | `studentId` | 既存があれば再利用 |
| 学級 | `name` | 既存があれば再利用 |
| ユーザー | `username` | 既存があれば再利用 |

### 新規モード（dataCreator.ts）

| 対象 | ユニーク制約 | 修正内容 |
|------|-------------|----------|
| 生徒 | `studentId` | サフィックス付与 (`_1`, `_2`...) |
| 学級 | `name` | サフィックス付与 (`(2)`, `(3)`...) |

## Test plan

- [ ] 型チェック: `npm run typecheck` ✓
- [ ] 統合モードで既存studentIdを持つ生徒をインポート → 既存データが再利用される
- [ ] 新規モードで既存studentIdを持つ生徒をインポート → サフィックス付きで作成される
- [ ] 警告メッセージがUIに正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)