### PR TITLE
style: dataMerger.tsのPrettierフォーマット修正

### DIFF
--- a/electron-src/lib/import/merge/dataMerger.ts
+++ b/electron-src/lib/import/merge/dataMerger.ts
@@ -182,9 +182,7 @@ export async function executeMergeImport(
           if (existingByName) {
             // nameで既存データが見つかった場合は再利用
             idMappings.class[importClass.id] = existingByName.id
-            warnings.push(
-              `学級「${importClass.name}」は既存データを使用します`
-            )
+            warnings.push(`学級「${importClass.name}」は既存データを使用します`)
           } else {
             const newId = randomUUID()
             await tx.class.create({


### PR DESCRIPTION
## Summary
- `dataMerger.ts`のPrettierフォーマット違反を修正

## 変更内容
- 警告文字列の不要な改行を削除し、1行に統一

## Test plan
- [x] `npm run check-all`でフォーマットチェックが通ることを確認済み

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)