### PR TITLE
VSCode設定をリポジトリ管理対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ build/
 *.pem
 
 # IDE設定
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,40 @@
+{
+  "eslint.workingDirectories": ["."],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
+  },
+  "eslint.format.enable": false,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.lintTask.enable": true,
+  "eslint.run": "onType",
+  "problems.decorations.enabled": true,
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.lineNumbers": "on",
+  "editor.wordWrap": "on",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "prisma.pinToPrisma6": true,
+  "prisma.schemaPath": "prisma/schema.prisma",
+  "files.exclude": {
+    "docs/schema-history/*.prisma": true
+  }
+}


### PR DESCRIPTION
## 概要

VSCodeのプロジェクト固有設定をリポジトリに含めることで、チーム全体で一貫した開発環境を共有できるようにします。

Closes #302

## 変更内容

### .gitignore の修正
```diff
# IDE設定
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
```

### .vscode/settings.json の追加
- ESLint/Prettierの設定
- TypeScriptワークスペース設定
- Prisma拡張機能の設定（`prisma.schemaPath`の明示指定）

## 期待される効果

1. **新規開発者のオンボーディング改善**: 正しい設定で即座に開発を始められる
2. **Prismaエラーの解消**: `docs/schema-history/`配下の履歴スキーマファイルでの重複名エラーを回避
3. **一貫した開発環境**: チーム全体で同じフォーマット・Lint設定を使用

## テスト計画

- [x] `.vscode/settings.json`が正しくリポジトリに含まれることを確認
- [x] Prisma拡張機能がメインスキーマのみを対象とすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)