### PR TITLE
fix: 採点競合検出をID統合ステップ後に実行するよう修正

### DIFF
--- a/components/import/steps/IdIntegrationStep.tsx
+++ b/components/import/steps/IdIntegrationStep.tsx
@@ -1,0 +1,1100 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
+import type {
+  ClassMatchingStrategy,
+  IdChoice,
+  MatchedItem,
+  StudentMatchingStrategy,
+  SubtotalGroupMatchingStrategy,
+} from "@/types/projectArchive.types"
+import { Layers, Loader2, School, Settings, Users } from "lucide-react"
+import { useState } from "react"
+
+interface IdIntegrationStepProps {
+  wizard: UseImportWizardReturn
+}
+
+type CategoryType = "student" | "class" | "subtotalGroup"
+
+/**
+ * ID統合ステップ (Step 3)
+ *
+ * レコードのIDをどうするか決める。
+ * - 紐づけ方法の選択
+ * - 同一人物の場合のID選択（このPCに合わせる / 書き出したPCに合わせる）
+ */
+export function IdIntegrationStep({ wizard }: IdIntegrationStepProps) {
+  const { state, detectScoringConflicts, updateIdIntegrationConfig } = wizard
+  const [activeTab, setActiveTab] = useState<CategoryType>("student")
+  const [isProcessing, setIsProcessing] = useState(false)
+
+  // 判断が必要なデータがあるかチェック
+  const hasStudentDecisions =
+    state.fileOverviewData &&
+    state.fileOverviewData.student.byId.length <
+      (state.manifest?.counts.students ?? 0)
+  const hasClassDecisions =
+    state.fileOverviewData &&
+    state.fileOverviewData.class.byId.length <
+      (state.manifest?.counts.classes ?? 0)
+  const hasSubtotalGroupDecisions =
+    state.fileOverviewData &&
+    state.fileOverviewData.subtotalGroup.byId.length <
+      (state.manifest?.counts.subtotalGroups ?? 0)
+
+  // 何も判断が必要ない場合はスキップ可能
+  const canSkip =
+    !hasStudentDecisions && !hasClassDecisions && !hasSubtotalGroupDecisions
+
+  const handleNext = async () => {
+    setIsProcessing(true)
+    // 採点競合検出を実行してscoring_conflictステップへ進む
+    await detectScoringConflicts()
+    setIsProcessing(false)
+  }
+
+  if (canSkip) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center">
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-green-100 dark:bg-green-900/20">
+          <Settings className="h-10 w-10 text-green-600 dark:text-green-400" />
+        </div>
+        <h3 className="mb-2 text-xl font-semibold">
+          すべてのデータが自動で紐づきました
+        </h3>
+        <p className="text-muted-foreground mb-8 max-w-md text-center">
+          同じパソコンで作成されたデータのため、
+          すべての生徒・学級・小計グループが自動的に紐づけられました。
+        </p>
+        <Button onClick={handleNext} size="lg" className="px-8">
+          次へ
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* ヘッダー */}
+      <div className="mb-6 text-center">
+        <div className="bg-primary/10 mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-2xl">
+          <Settings className="text-primary h-10 w-10" />
+        </div>
+        <h3 className="mb-2 text-xl font-semibold">データの紐づけ</h3>
+        <p className="text-muted-foreground max-w-lg">
+          判断が必要なデータについて、どうやって既存のデータと紐づけるか選んでください。
+        </p>
+      </div>
+
+      {/* タブ形式でカテゴリ別に設定 */}
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as CategoryType)}
+        className="flex-1"
+      >
+        <TabsList className="mb-4 grid w-full grid-cols-3">
+          <TabsTrigger value="student" className="gap-2">
+            <Users className="h-4 w-4" />
+            生徒
+            {hasStudentDecisions && (
+              <span className="ml-1 rounded-full bg-amber-500 px-1.5 text-xs text-white">
+                !
+              </span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="class" className="gap-2">
+            <School className="h-4 w-4" />
+            学級
+            {hasClassDecisions && (
+              <span className="ml-1 rounded-full bg-amber-500 px-1.5 text-xs text-white">
+                !
+              </span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="subtotalGroup" className="gap-2">
+            <Layers className="h-4 w-4" />
+            小計グループ
+            {hasSubtotalGroupDecisions && (
+              <span className="ml-1 rounded-full bg-amber-500 px-1.5 text-xs text-white">
+                !
+              </span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* 生徒タブ */}
+        <TabsContent value="student" className="mt-0">
+          <StudentIntegrationPanel
+            wizard={wizard}
+            onStrategyChange={(strategy) =>
+              updateIdIntegrationConfig("student", { strategy, decisions: [] })
+            }
+          />
+        </TabsContent>
+
+        {/* 学級タブ */}
+        <TabsContent value="class" className="mt-0">
+          <ClassIntegrationPanel
+            wizard={wizard}
+            onStrategyChange={(strategy) =>
+              updateIdIntegrationConfig("class", { strategy, decisions: [] })
+            }
+          />
+        </TabsContent>
+
+        {/* 小計グループタブ */}
+        <TabsContent value="subtotalGroup" className="mt-0">
+          <SubtotalGroupIntegrationPanel
+            wizard={wizard}
+            onStrategyChange={(strategy) =>
+              updateIdIntegrationConfig("subtotalGroup", {
+                strategy,
+                decisions: [],
+              })
+            }
+          />
+        </TabsContent>
+      </Tabs>
+
+      {/* 次へボタン */}
+      <div className="mt-6 flex justify-center">
+        <Button
+          onClick={handleNext}
+          disabled={isProcessing}
+          size="lg"
+          className="gap-2 px-8"
+        >
+          {isProcessing ? (
+            <>
+              <Loader2 className="h-5 w-5 animate-spin" />
+              処理中...
+            </>
+          ) : (
+            "次へ"
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 生徒の統合パネル
+ */
+interface StudentIntegrationPanelProps {
+  wizard: UseImportWizardReturn
+  onStrategyChange: (strategy: StudentMatchingStrategy) => void
+}
+
+function StudentIntegrationPanel({
+  wizard,
+  onStrategyChange,
+}: StudentIntegrationPanelProps) {
+  const { state } = wizard
+  const overview = state.fileOverviewData?.student
+  const strategy = state.idIntegrationConfig.student
+    .strategy as StudentMatchingStrategy
+
+  if (!overview) return null
+
+  const byStudentNumberCount = overview.byStudentNumber?.length ?? 0
+  const byNameCount = overview.byName?.length ?? 0
+  const noMatchCount = overview.noMatch.length
+  const needsDecisionCount = byStudentNumberCount + byNameCount + noMatchCount
+
+  if (needsDecisionCount === 0) {
+    return (
+      <Card className="border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20">
+        <CardContent className="p-4 text-center">
+          <p className="text-green-700 dark:text-green-300">
+            すべての生徒が自動で紐づきました
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">
+            判断が必要な生徒が{needsDecisionCount}名います
+          </CardTitle>
+          <p className="text-muted-foreground text-sm">
+            どうやって既存の生徒と紐づけますか？
+          </p>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={strategy}
+            onValueChange={(v) =>
+              onStrategyChange(v as StudentMatchingStrategy)
+            }
+          >
+            <div className="space-y-3">
+              <StrategyOption
+                value="by_student_number"
+                id="student-by-number"
+                label={`学籍番号で紐づける (${byStudentNumberCount}名が一致)`}
+                description="学籍番号が同じ生徒と紐づけます"
+                recommended={byStudentNumberCount > 0}
+              />
+              <StrategyOption
+                value="by_name"
+                id="student-by-name"
+                label={`氏名で紐づける (${byNameCount}名が一致)`}
+                description="姓と名が同じ生徒と紐づけます"
+              />
+              <StrategyOption
+                value="individual"
+                id="student-individual"
+                label="1人ずつ設定する"
+                description="各生徒について個別に設定します"
+              />
+              <StrategyOption
+                value="all_new"
+                id="student-all-new"
+                label="全員を新しい生徒として追加する"
+                description="既存の生徒とは紐づけません"
+              />
+            </div>
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {/* 紐づけ方法選択後の詳細UI */}
+      {(strategy === "by_student_number" ||
+        strategy === "by_name" ||
+        strategy === "individual") && (
+        <StudentDetailPanel
+          wizard={wizard}
+          strategy={strategy}
+          byStudentNumber={overview.byStudentNumber ?? []}
+          byName={overview.byName ?? []}
+          noMatch={overview.noMatch}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * 学級の統合パネル
+ */
+interface ClassIntegrationPanelProps {
+  wizard: UseImportWizardReturn
+  onStrategyChange: (strategy: ClassMatchingStrategy) => void
+}
+
+function ClassIntegrationPanel({
+  wizard,
+  onStrategyChange,
+}: ClassIntegrationPanelProps) {
+  const { state } = wizard
+  const overview = state.fileOverviewData?.class
+  const strategy = state.idIntegrationConfig.class
+    .strategy as ClassMatchingStrategy
+
+  if (!overview) return null
+
+  const byNameCount = overview.byName?.length ?? 0
+  const noMatchCount = overview.noMatch.length
+  const needsDecisionCount = byNameCount + noMatchCount
+
+  if (needsDecisionCount === 0) {
+    return (
+      <Card className="border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20">
+        <CardContent className="p-4 text-center">
+          <p className="text-green-700 dark:text-green-300">
+            すべての学級が自動で紐づきました
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">
+            判断が必要な学級が{needsDecisionCount}クラスあります
+          </CardTitle>
+          <p className="text-muted-foreground text-sm">
+            どうやって既存の学級と紐づけますか？
+          </p>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={strategy}
+            onValueChange={(v) => onStrategyChange(v as ClassMatchingStrategy)}
+          >
+            <div className="space-y-3">
+              <StrategyOption
+                value="by_name"
+                id="class-by-name"
+                label={`学級名で紐づける (${byNameCount}クラスが一致)`}
+                description="学級名が同じ学級と紐づけます"
+                recommended={byNameCount > 0}
+              />
+              <StrategyOption
+                value="individual"
+                id="class-individual"
+                label="1つずつ設定する"
+                description="各学級について個別に設定します"
+              />
+              <StrategyOption
+                value="all_new"
+                id="class-all-new"
+                label="全て新しい学級として追加する"
+                description="既存の学級とは紐づけません"
+              />
+            </div>
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {/* 紐づけ方法選択後の詳細UI */}
+      {(strategy === "by_name" || strategy === "individual") && (
+        <ClassDetailPanel
+          wizard={wizard}
+          strategy={strategy}
+          byName={overview.byName ?? []}
+          noMatch={overview.noMatch}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * 小計グループの統合パネル
+ */
+interface SubtotalGroupIntegrationPanelProps {
+  wizard: UseImportWizardReturn
+  onStrategyChange: (strategy: SubtotalGroupMatchingStrategy) => void
+}
+
+function SubtotalGroupIntegrationPanel({
+  wizard,
+  onStrategyChange,
+}: SubtotalGroupIntegrationPanelProps) {
+  const { state } = wizard
+  const overview = state.fileOverviewData?.subtotalGroup
+  const strategy = state.idIntegrationConfig.subtotalGroup
+    .strategy as SubtotalGroupMatchingStrategy
+
+  if (!overview) return null
+
+  const byNameCount = overview.byName?.length ?? 0
+  const noMatchCount = overview.noMatch.length
+  const needsDecisionCount = byNameCount + noMatchCount
+
+  if (needsDecisionCount === 0) {
+    return (
+      <Card className="border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20">
+        <CardContent className="p-4 text-center">
+          <p className="text-green-700 dark:text-green-300">
+            すべての小計グループが自動で紐づきました
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">
+            判断が必要な小計グループが{needsDecisionCount}グループあります
+          </CardTitle>
+          <p className="text-muted-foreground text-sm">
+            どうやって既存の小計グループと紐づけますか？
+          </p>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={strategy}
+            onValueChange={(v) =>
+              onStrategyChange(v as SubtotalGroupMatchingStrategy)
+            }
+          >
+            <div className="space-y-3">
+              <StrategyOption
+                value="by_name"
+                id="subtotal-by-name"
+                label={`グループ名で紐づける (${byNameCount}グループが一致)`}
+                description="グループ名が同じ小計グループと紐づけます"
+                recommended={byNameCount > 0}
+              />
+              <StrategyOption
+                value="individual"
+                id="subtotal-individual"
+                label="1つずつ設定する"
+                description="各グループについて個別に設定します"
+              />
+              <StrategyOption
+                value="all_new"
+                id="subtotal-all-new"
+                label="全て新しいグループとして追加する"
+                description="既存のグループとは紐づけません"
+              />
+            </div>
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {/* 紐づけ方法選択後の詳細UI */}
+      {(strategy === "by_name" || strategy === "individual") && (
+        <SubtotalGroupDetailPanel
+          wizard={wizard}
+          strategy={strategy}
+          byName={overview.byName ?? []}
+          noMatch={overview.noMatch}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * 方針選択オプション
+ */
+interface StrategyOptionProps {
+  value: string
+  id: string
+  label: string
+  description: string
+  recommended?: boolean
+}
+
+function StrategyOption({
+  value,
+  id,
+  label,
+  description,
+  recommended,
+}: StrategyOptionProps) {
+  return (
+    <div className="flex items-start space-x-3">
+      <RadioGroupItem value={value} id={id} />
+      <div className="flex-1">
+        <Label htmlFor={id} className="cursor-pointer font-medium">
+          {label}
+          {recommended && (
+            <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+              推奨
+            </span>
+          )}
+        </Label>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 生徒の詳細パネル（紐づけ確認UI）
+ */
+interface StudentDetailPanelProps {
+  wizard: UseImportWizardReturn
+  strategy: StudentMatchingStrategy
+  byStudentNumber: MatchedItem[]
+  byName: MatchedItem[]
+  noMatch: Array<{ importId: string; displayLabel: string }>
+}
+
+function StudentDetailPanel({
+  wizard,
+  strategy,
+  byStudentNumber,
+  byName,
+  noMatch,
+}: StudentDetailPanelProps) {
+  const { updateIdIntegrationDecision } = wizard
+
+  // 表示するアイテムを決定
+  const items =
+    strategy === "by_student_number"
+      ? byStudentNumber
+      : strategy === "by_name"
+        ? byName
+        : [...byStudentNumber, ...byName]
+
+  if (items.length === 0 && noMatch.length === 0) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">生徒の紐づけ確認</CardTitle>
+        <p className="text-muted-foreground text-sm">
+          {strategy === "individual"
+            ? "各生徒についてどうするか選んでください"
+            : "照合結果です。必要に応じて変更できます。"}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {/* マッチしたアイテム */}
+          {items.map((item) => (
+            <MatchedItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision, idChoice) =>
+                updateIdIntegrationDecision("student", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                  existingId: item.existingId,
+                  idChoice,
+                })
+              }
+            />
+          ))}
+
+          {/* マッチしなかったアイテム */}
+          {noMatch.map((item) => (
+            <NoMatchItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision) =>
+                updateIdIntegrationDecision("student", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                })
+              }
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * マッチしたアイテムの行
+ */
+interface MatchedItemRowProps {
+  item: MatchedItem
+  onDecisionChange: (
+    decision: "same_person" | "create_new" | "skip",
+    idChoice?: IdChoice
+  ) => void
+}
+
+function MatchedItemRow({ item, onDecisionChange }: MatchedItemRowProps) {
+  const [decision, setDecision] = useState<
+    "same_person" | "create_new" | "skip"
+  >("same_person")
+  const [idChoice, setIdChoice] = useState<IdChoice>("use_existing_id")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "same_person" | "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(
+      newDecision,
+      newDecision === "same_person" ? idChoice : undefined
+    )
+  }
+
+  const handleIdChoiceChange = (value: string) => {
+    const newIdChoice = value as IdChoice
+    setIdChoice(newIdChoice)
+    onDecisionChange(decision, newIdChoice)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          {item.matchReason}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Select value={decision} onValueChange={handleDecisionChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="same_person">
+              このPCの生徒と同じ人として扱う
+            </SelectItem>
+            <SelectItem value="create_new">新しい生徒として登録する</SelectItem>
+            <SelectItem value="skip">取り込まない</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* 同じ人の場合のID選択 */}
+        {decision === "same_person" && (
+          <div className="mt-1 ml-4">
+            <p className="text-muted-foreground mb-1 text-xs">
+              どちらに合わせる？
+            </p>
+            <Select value={idChoice} onValueChange={handleIdChoiceChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="use_existing_id">
+                  このPCに合わせる
+                </SelectItem>
+                <SelectItem value="use_import_id">
+                  書き出したPCに合わせる
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * マッチしなかったアイテムの行
+ */
+interface NoMatchItemRowProps {
+  item: { importId: string; displayLabel: string }
+  onDecisionChange: (decision: "create_new" | "skip") => void
+}
+
+function NoMatchItemRow({ item, onDecisionChange }: NoMatchItemRowProps) {
+  const [decision, setDecision] = useState<"create_new" | "skip">("create_new")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(newDecision)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          このPCに同じデータなし
+        </span>
+      </div>
+      <Select value={decision} onValueChange={handleDecisionChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="create_new">新しく登録する</SelectItem>
+          <SelectItem value="skip">取り込まない</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/**
+ * 学級の詳細パネル（紐づけ確認UI）
+ */
+interface ClassDetailPanelProps {
+  wizard: UseImportWizardReturn
+  strategy: ClassMatchingStrategy
+  byName: MatchedItem[]
+  noMatch: Array<{ importId: string; displayLabel: string }>
+}
+
+function ClassDetailPanel({
+  wizard,
+  strategy,
+  byName,
+  noMatch,
+}: ClassDetailPanelProps) {
+  const { updateIdIntegrationDecision } = wizard
+
+  // 表示するアイテムを決定
+  const items = strategy === "by_name" ? byName : byName
+
+  if (items.length === 0 && noMatch.length === 0) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">学級の紐づけ確認</CardTitle>
+        <p className="text-muted-foreground text-sm">
+          {strategy === "individual"
+            ? "各学級についてどうするか選んでください"
+            : "照合結果です。必要に応じて変更できます。"}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {/* マッチしたアイテム */}
+          {items.map((item) => (
+            <ClassMatchedItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision, idChoice) =>
+                updateIdIntegrationDecision("class", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                  existingId: item.existingId,
+                  idChoice,
+                })
+              }
+            />
+          ))}
+
+          {/* マッチしなかったアイテム */}
+          {noMatch.map((item) => (
+            <ClassNoMatchItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision) =>
+                updateIdIntegrationDecision("class", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                })
+              }
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * 学級のマッチしたアイテムの行
+ */
+interface ClassMatchedItemRowProps {
+  item: MatchedItem
+  onDecisionChange: (
+    decision: "same_person" | "create_new" | "skip",
+    idChoice?: IdChoice
+  ) => void
+}
+
+function ClassMatchedItemRow({
+  item,
+  onDecisionChange,
+}: ClassMatchedItemRowProps) {
+  const [decision, setDecision] = useState<
+    "same_person" | "create_new" | "skip"
+  >("same_person")
+  const [idChoice, setIdChoice] = useState<IdChoice>("use_existing_id")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "same_person" | "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(
+      newDecision,
+      newDecision === "same_person" ? idChoice : undefined
+    )
+  }
+
+  const handleIdChoiceChange = (value: string) => {
+    const newIdChoice = value as IdChoice
+    setIdChoice(newIdChoice)
+    onDecisionChange(decision, newIdChoice)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          {item.matchReason}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Select value={decision} onValueChange={handleDecisionChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="same_person">
+              このPCの学級と同じものとして扱う
+            </SelectItem>
+            <SelectItem value="create_new">新しい学級として登録する</SelectItem>
+            <SelectItem value="skip">取り込まない</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* 同じ学級の場合のID選択 */}
+        {decision === "same_person" && (
+          <div className="mt-1 ml-4">
+            <p className="text-muted-foreground mb-1 text-xs">
+              どちらに合わせる？
+            </p>
+            <Select value={idChoice} onValueChange={handleIdChoiceChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="use_existing_id">
+                  このPCに合わせる
+                </SelectItem>
+                <SelectItem value="use_import_id">
+                  書き出したPCに合わせる
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 学級のマッチしなかったアイテムの行
+ */
+interface ClassNoMatchItemRowProps {
+  item: { importId: string; displayLabel: string }
+  onDecisionChange: (decision: "create_new" | "skip") => void
+}
+
+function ClassNoMatchItemRow({
+  item,
+  onDecisionChange,
+}: ClassNoMatchItemRowProps) {
+  const [decision, setDecision] = useState<"create_new" | "skip">("create_new")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(newDecision)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          このPCに同じデータなし
+        </span>
+      </div>
+      <Select value={decision} onValueChange={handleDecisionChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="create_new">新しく登録する</SelectItem>
+          <SelectItem value="skip">取り込まない</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/**
+ * 小計グループの詳細パネル（紐づけ確認UI）
+ */
+interface SubtotalGroupDetailPanelProps {
+  wizard: UseImportWizardReturn
+  strategy: SubtotalGroupMatchingStrategy
+  byName: MatchedItem[]
+  noMatch: Array<{ importId: string; displayLabel: string }>
+}
+
+function SubtotalGroupDetailPanel({
+  wizard,
+  strategy,
+  byName,
+  noMatch,
+}: SubtotalGroupDetailPanelProps) {
+  const { updateIdIntegrationDecision } = wizard
+
+  // 表示するアイテムを決定
+  const items = strategy === "by_name" ? byName : byName
+
+  if (items.length === 0 && noMatch.length === 0) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">小計グループの紐づけ確認</CardTitle>
+        <p className="text-muted-foreground text-sm">
+          {strategy === "individual"
+            ? "各グループについてどうするか選んでください"
+            : "照合結果です。必要に応じて変更できます。"}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {/* マッチしたアイテム */}
+          {items.map((item) => (
+            <SubtotalGroupMatchedItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision, idChoice) =>
+                updateIdIntegrationDecision("subtotalGroup", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                  existingId: item.existingId,
+                  idChoice,
+                })
+              }
+            />
+          ))}
+
+          {/* マッチしなかったアイテム */}
+          {noMatch.map((item) => (
+            <SubtotalGroupNoMatchItemRow
+              key={item.importId}
+              item={item}
+              onDecisionChange={(decision) =>
+                updateIdIntegrationDecision("subtotalGroup", item.importId, {
+                  importId: item.importId,
+                  decisionType: decision,
+                })
+              }
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * 小計グループのマッチしたアイテムの行
+ */
+interface SubtotalGroupMatchedItemRowProps {
+  item: MatchedItem
+  onDecisionChange: (
+    decision: "same_person" | "create_new" | "skip",
+    idChoice?: IdChoice
+  ) => void
+}
+
+function SubtotalGroupMatchedItemRow({
+  item,
+  onDecisionChange,
+}: SubtotalGroupMatchedItemRowProps) {
+  const [decision, setDecision] = useState<
+    "same_person" | "create_new" | "skip"
+  >("same_person")
+  const [idChoice, setIdChoice] = useState<IdChoice>("use_existing_id")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "same_person" | "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(
+      newDecision,
+      newDecision === "same_person" ? idChoice : undefined
+    )
+  }
+
+  const handleIdChoiceChange = (value: string) => {
+    const newIdChoice = value as IdChoice
+    setIdChoice(newIdChoice)
+    onDecisionChange(decision, newIdChoice)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          {item.matchReason}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Select value={decision} onValueChange={handleDecisionChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="same_person">
+              このPCのグループと同じものとして扱う
+            </SelectItem>
+            <SelectItem value="create_new">
+              新しいグループとして登録する
+            </SelectItem>
+            <SelectItem value="skip">取り込まない</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* 同じグループの場合のID選択 */}
+        {decision === "same_person" && (
+          <div className="mt-1 ml-4">
+            <p className="text-muted-foreground mb-1 text-xs">
+              どちらに合わせる？
+            </p>
+            <Select value={idChoice} onValueChange={handleIdChoiceChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="use_existing_id">
+                  このPCに合わせる
+                </SelectItem>
+                <SelectItem value="use_import_id">
+                  書き出したPCに合わせる
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * 小計グループのマッチしなかったアイテムの行
+ */
+interface SubtotalGroupNoMatchItemRowProps {
+  item: { importId: string; displayLabel: string }
+  onDecisionChange: (decision: "create_new" | "skip") => void
+}
+
+function SubtotalGroupNoMatchItemRow({
+  item,
+  onDecisionChange,
+}: SubtotalGroupNoMatchItemRowProps) {
+  const [decision, setDecision] = useState<"create_new" | "skip">("create_new")
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as "create_new" | "skip"
+    setDecision(newDecision)
+    onDecisionChange(newDecision)
+  }
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium">{item.displayLabel}</span>
+        <span className="text-muted-foreground text-xs">
+          このPCに同じデータなし
+        </span>
+      </div>
+      <Select value={decision} onValueChange={handleDecisionChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="create_new">新しく登録する</SelectItem>
+          <SelectItem value="skip">取り込まない</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -5,13 +5,22 @@
 import { dialog, ipcMain } from "electron"
 import type {
   ConflictResolutions,
+  FileOverviewData,
+  IdIntegrationConfig,
   MatchingConfig,
+  ScoringConflictConfig,
 } from "../../types/projectArchive.types"
 import {
   exportProject,
   selectExportSavePath,
 } from "../lib/export/project-archive"
-import { detectAllConflicts, executeMergeImport } from "../lib/import/merge"
+import {
+  detectAllConflicts,
+  detectScoringConflictsWithUserDecisions,
+  executeIdIntegrationImport,
+  executeMergeImport,
+  performPreMatching,
+} from "../lib/import/merge"
 import {
   analyzeArchive,
   cleanupTempDir,
@@ -128,6 +137,39 @@ export function registerArchiveHandlers(): void {
     }
   )
 
+  // 事前照合（Step 2: ファイル概要表示用）
+  ipcMain.handle(
+    "archive:preMatch",
+    async (_event, options: { archivePath: string }) => {
+      let tempDir: string | null = null
+
+      try {
+        // アーカイブを展開
+        const extractResult = await extractArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+
+        // 事前照合を実行
+        const fileOverviewData = await performPreMatching(extractResult.data)
+
+        return { success: true, data: fileOverviewData }
+      } catch (error) {
+        console.error("Error in archive:preMatch:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "事前照合に失敗しました",
+        }
+      } finally {
+        if (tempDir) {
+          cleanupTempDir(tempDir)
+        }
+      }
+    }
+  )
+
   // 競合検出
   ipcMain.handle(
     "archive:detectConflicts",
@@ -207,6 +249,100 @@ export function registerArchiveHandlers(): void {
             error instanceof Error
               ? error.message
               : "マージインポートに失敗しました",
+        }
+      } finally {
+        if (tempDir) {
+          cleanupTempDir(tempDir)
+        }
+      }
+    }
+  )
+
+  // 採点競合検出（ユーザーの判断に基づく）
+  ipcMain.handle(
+    "archive:detectScoringConflicts",
+    async (
+      _event,
+      options: {
+        archivePath: string
+        preMatchResult: FileOverviewData
+        integrationConfig: IdIntegrationConfig
+      }
+    ) => {
+      let tempDir: string | null = null
+
+      try {
+        // アーカイブを展開
+        const extractResult = await extractArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+
+        // 採点競合を検出
+        const scoringConflicts = await detectScoringConflictsWithUserDecisions(
+          extractResult.data,
+          options.preMatchResult,
+          options.integrationConfig
+        )
+
+        return { success: true, data: scoringConflicts }
+      } catch (error) {
+        console.error("Error in archive:detectScoringConflicts:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "採点競合の検出に失敗しました",
+        }
+      } finally {
+        if (tempDir) {
+          cleanupTempDir(tempDir)
+        }
+      }
+    }
+  )
+
+  // ID統合インポート（新しいフロー）
+  ipcMain.handle(
+    "archive:idIntegrationImport",
+    async (
+      _event,
+      options: {
+        archivePath: string
+        preMatchResult: FileOverviewData
+        integrationConfig: IdIntegrationConfig
+        currentUserId: string
+        scoringConflictConfig?: ScoringConflictConfig
+      }
+    ) => {
+      let tempDir: string | null = null
+
+      try {
+        // アーカイブを展開
+        const extractResult = await extractArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+
+        // ID統合インポートを実行
+        const result = await executeIdIntegrationImport(
+          extractResult.data,
+          options.preMatchResult,
+          options.integrationConfig,
+          options.currentUserId,
+          options.scoringConflictConfig
+        )
+
+        return result
+      } catch (error) {
+        console.error("Error in archive:idIntegrationImport:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "インポートに失敗しました",
         }
       } finally {
         if (tempDir) {

--- a/electron-src/lib/import/merge/matcher.ts
+++ b/electron-src/lib/import/merge/matcher.ts
@@ -4,14 +4,22 @@
  * インポートデータと既存データのマッチングを行う
  */
 
-import prisma from "../../prisma/client"
 import type {
-  MatchingConfig,
-  StudentMatchingMethod,
   ClassMatchingMethod,
-  UserMatchingMethod,
+  FileOverviewData,
+  IdIntegrationConfig,
+  ImportItem,
+  MatchedItem,
+  MatchingConfig,
+  PreMatchingResult,
+  ProjectPreMatchingResult,
+  ScoringConflict,
+  ScoringConflictData,
+  StudentMatchingMethod,
   SubtotalGroupMatchingMethod,
+  UserMatchingMethod,
 } from "../../../../types/projectArchive.types"
+import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "../project-archive/archiveExtractor"
 
 /**
@@ -39,7 +47,7 @@ export interface AllMatchResults {
 // 内部型定義
 interface StudentData {
   id: string
-  studentId: string
+  studentNumber: string
   lastName: string
   firstName: string
   lastNameKana: string
@@ -73,6 +81,13 @@ interface SubtotalGroupData {
 
 /**
  * 生徒データのマッチングを実行
+ *
+ * 照合の流れ:
+ * 1. まずUUIDで照合（同じPCでエクスポート/インポートした場合に一致）
+ * 2. UUIDが一致しない場合、methodで指定された二次照合を実行
+ *    - "none": 二次照合しない（新規として扱う）
+ *    - "studentNumber": 学籍番号で照合
+ *    - "name": 氏名で照合
  */
 export async function matchStudents(
   importData: ExtractedArchiveData,
@@ -85,34 +100,40 @@ export async function matchStudents(
 
   for (const importStudent of importData.studentsData.students) {
     let matchedStudent: (typeof existingStudents)[0] | null = null
+    let isExactMatch = false
 
-    switch (method) {
-      case "uuid":
-        matchedStudent =
-          existingStudents.find((s) => s.id === importStudent.id) ?? null
-        break
+    // Step 1: UUIDで照合
+    const uuidMatch = existingStudents.find((s) => s.id === importStudent.id)
+    if (uuidMatch) {
+      matchedStudent = uuidMatch
+      isExactMatch = true
+    }
 
-      case "studentId":
-        matchedStudent =
-          existingStudents.find(
-            (s) => s.studentId === importStudent.studentId
-          ) ?? null
-        break
+    // Step 2: UUIDが一致しない場合、二次照合を実行
+    if (!matchedStudent && method !== "none") {
+      switch (method) {
+        case "studentNumber":
+          matchedStudent =
+            existingStudents.find(
+              (s) => s.studentNumber === importStudent.studentNumber
+            ) ?? null
+          break
 
-      case "name":
-        matchedStudent =
-          existingStudents.find(
-            (s) =>
-              s.lastName === importStudent.lastName &&
-              s.firstName === importStudent.firstName
-          ) ?? null
-        break
+        case "name":
+          matchedStudent =
+            existingStudents.find(
+              (s) =>
+                s.lastName === importStudent.lastName &&
+                s.firstName === importStudent.firstName
+            ) ?? null
+          break
+      }
     }
 
     results.push({
       importData: {
         id: importStudent.id,
-        studentId: importStudent.studentId,
+        studentNumber: importStudent.studentNumber,
         lastName: importStudent.lastName,
         firstName: importStudent.firstName,
         lastNameKana: importStudent.lastNameKana,
@@ -123,7 +144,7 @@ export async function matchStudents(
       existingData: matchedStudent
         ? {
             id: matchedStudent.id,
-            studentId: matchedStudent.studentId,
+            studentNumber: matchedStudent.studentNumber,
             lastName: matchedStudent.lastName,
             firstName: matchedStudent.firstName,
             lastNameKana: matchedStudent.lastNameKana,
@@ -132,11 +153,7 @@ export async function matchStudents(
             updatedAt: matchedStudent.updatedAt,
           }
         : null,
-      matchType: matchedStudent
-        ? matchedStudent.id === importStudent.id
-          ? "exact"
-          : "fuzzy"
-        : "new",
+      matchType: matchedStudent ? (isExactMatch ? "exact" : "fuzzy") : "new",
     })
   }
 
@@ -145,6 +162,10 @@ export async function matchStudents(
 
 /**
  * 学級データのマッチングを実行
+ *
+ * 照合の流れ:
+ * 1. まずUUIDで照合
+ * 2. UUIDが一致しない場合、methodで指定された二次照合を実行
  */
 export async function matchClasses(
   importData: ExtractedArchiveData,
@@ -156,17 +177,23 @@ export async function matchClasses(
 
   for (const importClass of importData.classesData.classes) {
     let matchedClass: (typeof existingClasses)[0] | null = null
+    let isExactMatch = false
 
-    switch (method) {
-      case "uuid":
-        matchedClass =
-          existingClasses.find((c) => c.id === importClass.id) ?? null
-        break
+    // Step 1: UUIDで照合
+    const uuidMatch = existingClasses.find((c) => c.id === importClass.id)
+    if (uuidMatch) {
+      matchedClass = uuidMatch
+      isExactMatch = true
+    }
 
-      case "name":
-        matchedClass =
-          existingClasses.find((c) => c.name === importClass.name) ?? null
-        break
+    // Step 2: UUIDが一致しない場合、二次照合を実行
+    if (!matchedClass && method !== "none") {
+      switch (method) {
+        case "name":
+          matchedClass =
+            existingClasses.find((c) => c.name === importClass.name) ?? null
+          break
+      }
     }
 
     results.push({
@@ -188,11 +215,7 @@ export async function matchClasses(
             updatedAt: matchedClass.updatedAt,
           }
         : null,
-      matchType: matchedClass
-        ? matchedClass.id === importClass.id
-          ? "exact"
-          : "fuzzy"
-        : "new",
+      matchType: matchedClass ? (isExactMatch ? "exact" : "fuzzy") : "new",
     })
   }
 
@@ -201,6 +224,10 @@ export async function matchClasses(
 
 /**
  * ユーザーデータのマッチングを実行
+ *
+ * 照合の流れ:
+ * 1. まずUUIDで照合
+ * 2. UUIDが一致しない場合、methodで指定された二次照合を実行
  */
 export async function matchUsers(
   importData: ExtractedArchiveData,
@@ -212,16 +239,24 @@ export async function matchUsers(
 
   for (const importUser of importData.usersData.users) {
     let matchedUser: (typeof existingUsers)[0] | null = null
+    let isExactMatch = false
 
-    switch (method) {
-      case "uuid":
-        matchedUser = existingUsers.find((u) => u.id === importUser.id) ?? null
-        break
+    // Step 1: UUIDで照合
+    const uuidMatch = existingUsers.find((u) => u.id === importUser.id)
+    if (uuidMatch) {
+      matchedUser = uuidMatch
+      isExactMatch = true
+    }
 
-      case "username":
-        matchedUser =
-          existingUsers.find((u) => u.username === importUser.username) ?? null
-        break
+    // Step 2: UUIDが一致しない場合、二次照合を実行
+    if (!matchedUser && method !== "none") {
+      switch (method) {
+        case "username":
+          matchedUser =
+            existingUsers.find((u) => u.username === importUser.username) ??
+            null
+          break
+      }
     }
 
     results.push({
@@ -241,11 +276,7 @@ export async function matchUsers(
             updatedAt: matchedUser.updatedAt,
           }
         : null,
-      matchType: matchedUser
-        ? matchedUser.id === importUser.id
-          ? "exact"
-          : "fuzzy"
-        : "new",
+      matchType: matchedUser ? (isExactMatch ? "exact" : "fuzzy") : "new",
     })
   }
 
@@ -254,6 +285,10 @@ export async function matchUsers(
 
 /**
  * 小計グループデータのマッチングを実行
+ *
+ * 照合の流れ:
+ * 1. まずUUIDで照合
+ * 2. UUIDが一致しない場合、methodで指定された二次照合を実行
  */
 export async function matchSubtotalGroups(
   importData: ExtractedArchiveData,
@@ -265,17 +300,23 @@ export async function matchSubtotalGroups(
 
   for (const importGroup of importData.subtotalsData.subtotalGroups) {
     let matchedGroup: (typeof existingGroups)[0] | null = null
+    let isExactMatch = false
 
-    switch (method) {
-      case "uuid":
-        matchedGroup =
-          existingGroups.find((g) => g.id === importGroup.id) ?? null
-        break
+    // Step 1: UUIDで照合
+    const uuidMatch = existingGroups.find((g) => g.id === importGroup.id)
+    if (uuidMatch) {
+      matchedGroup = uuidMatch
+      isExactMatch = true
+    }
 
-      case "name":
-        matchedGroup =
-          existingGroups.find((g) => g.name === importGroup.name) ?? null
-        break
+    // Step 2: UUIDが一致しない場合、二次照合を実行
+    if (!matchedGroup && method !== "none") {
+      switch (method) {
+        case "name":
+          matchedGroup =
+            existingGroups.find((g) => g.name === importGroup.name) ?? null
+          break
+      }
     }
 
     results.push({
@@ -291,11 +332,7 @@ export async function matchSubtotalGroups(
             updatedAt: matchedGroup.updatedAt,
           }
         : null,
-      matchType: matchedGroup
-        ? matchedGroup.id === importGroup.id
-          ? "exact"
-          : "fuzzy"
-        : "new",
+      matchType: matchedGroup ? (isExactMatch ? "exact" : "fuzzy") : "new",
     })
   }
 
@@ -372,4 +409,506 @@ export function buildIdMappings(matchResults: AllMatchResults): {
     user: userMapping,
     subtotalGroup: subtotalGroupMapping,
   }
+}
+
+// =============================================================================
+// 事前照合（Step 2: ファイル概要表示用）
+// =============================================================================
+
+/**
+ * 事前照合を実行し、FileOverviewData形式で返す
+ *
+ * 全ての照合方法（ID、学籍番号、氏名、名前）で照合を実行し、
+ * ID一致と不一致を分類する。Step 2で概要表示に使用。
+ *
+ * 注意: 採点競合検出はここでは行わない。
+ * ユーザーがid_integrationで判断した後に、別途detectScoringConflictsWithUserDecisionsを呼ぶ。
+ */
+export async function performPreMatching(
+  importData: ExtractedArchiveData
+): Promise<FileOverviewData> {
+  const [studentResult, classResult, subtotalGroupResult, projectResult] =
+    await Promise.all([
+      preMatchStudents(importData),
+      preMatchClasses(importData),
+      preMatchSubtotalGroups(importData),
+      preMatchProject(importData),
+    ])
+
+  return {
+    student: studentResult,
+    class: classResult,
+    subtotalGroup: subtotalGroupResult,
+    project: projectResult,
+  }
+}
+
+/**
+ * プロジェクトの事前照合
+ *
+ * プロジェクトIDが既存データベースに存在するかチェック。
+ * ID一致 = 同じPCでエクスポートしたデータ → マージ可能
+ */
+async function preMatchProject(
+  importData: ExtractedArchiveData
+): Promise<ProjectPreMatchingResult> {
+  const importProject = importData.projectData.project
+
+  // ID照合
+  const existingProject = await prisma.project.findUnique({
+    where: { id: importProject.id },
+  })
+
+  if (existingProject) {
+    return {
+      isIdMatch: true,
+      importProjectId: importProject.id,
+      existingProjectId: existingProject.id,
+      importData: importProject as unknown as Record<string, unknown>,
+      existingData: existingProject as unknown as Record<string, unknown>,
+      displayLabel: importProject.examName,
+    }
+  }
+
+  return {
+    isIdMatch: false,
+    importProjectId: importProject.id,
+    importData: importProject as unknown as Record<string, unknown>,
+    displayLabel: importProject.examName,
+  }
+}
+
+/**
+ * 生徒の事前照合
+ */
+async function preMatchStudents(
+  importData: ExtractedArchiveData
+): Promise<PreMatchingResult> {
+  const existingStudents = await prisma.student.findMany()
+
+  const byId: MatchedItem[] = []
+  const byStudentNumber: MatchedItem[] = []
+  const byName: MatchedItem[] = []
+  const noMatch: ImportItem[] = []
+
+  // 既存データをID別、学籍番号別、氏名別にインデックス化
+  const existingById = new Map(existingStudents.map((s) => [s.id, s]))
+  const existingByStudentNumber = new Map(
+    existingStudents.map((s) => [s.studentNumber, s])
+  )
+  // 氏名は重複がありうるので、最初に見つかったものを使用
+  const existingByName = new Map<string, (typeof existingStudents)[0]>()
+  for (const s of existingStudents) {
+    const key = `${s.lastName}|${s.firstName}`
+    if (!existingByName.has(key)) {
+      existingByName.set(key, s)
+    }
+  }
+
+  for (const importStudent of importData.studentsData.students) {
+    const displayLabel = `${importStudent.lastName}${importStudent.firstName}（${importStudent.studentNumber}）`
+    const importItem: ImportItem = {
+      importId: importStudent.id,
+      importData: importStudent as unknown as Record<string, unknown>,
+      displayLabel,
+    }
+
+    // ID照合
+    const idMatch = existingById.get(importStudent.id)
+    if (idMatch) {
+      byId.push({
+        importId: importStudent.id,
+        existingId: idMatch.id,
+        importData: importStudent as unknown as Record<string, unknown>,
+        existingData: idMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "同じパソコンで作成されたデータ",
+      })
+      continue
+    }
+
+    // 学籍番号照合（ID不一致の場合のみ）
+    const studentNumberMatch = existingByStudentNumber.get(
+      importStudent.studentNumber
+    )
+    if (studentNumberMatch) {
+      byStudentNumber.push({
+        importId: importStudent.id,
+        existingId: studentNumberMatch.id,
+        importData: importStudent as unknown as Record<string, unknown>,
+        existingData: studentNumberMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "学籍番号が一致",
+      })
+      continue
+    }
+
+    // 氏名照合（ID、学籍番号不一致の場合のみ）
+    const nameKey = `${importStudent.lastName}|${importStudent.firstName}`
+    const nameMatch = existingByName.get(nameKey)
+    if (nameMatch) {
+      byName.push({
+        importId: importStudent.id,
+        existingId: nameMatch.id,
+        importData: importStudent as unknown as Record<string, unknown>,
+        existingData: nameMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "氏名が一致",
+      })
+      continue
+    }
+
+    // どれにも一致しない
+    noMatch.push(importItem)
+  }
+
+  return {
+    byId,
+    byStudentNumber,
+    byName,
+    noMatch,
+  }
+}
+
+/**
+ * 学級の事前照合
+ */
+async function preMatchClasses(
+  importData: ExtractedArchiveData
+): Promise<PreMatchingResult> {
+  const existingClasses = await prisma.class.findMany()
+
+  const byId: MatchedItem[] = []
+  const byName: MatchedItem[] = []
+  const noMatch: ImportItem[] = []
+
+  const existingById = new Map(existingClasses.map((c) => [c.id, c]))
+  const existingByName = new Map(existingClasses.map((c) => [c.name, c]))
+
+  for (const importClass of importData.classesData.classes) {
+    const displayLabel = importClass.name
+    const importItem: ImportItem = {
+      importId: importClass.id,
+      importData: importClass as unknown as Record<string, unknown>,
+      displayLabel,
+    }
+
+    // ID照合
+    const idMatch = existingById.get(importClass.id)
+    if (idMatch) {
+      byId.push({
+        importId: importClass.id,
+        existingId: idMatch.id,
+        importData: importClass as unknown as Record<string, unknown>,
+        existingData: idMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "同じパソコンで作成されたデータ",
+      })
+      continue
+    }
+
+    // 名前照合
+    const nameMatch = existingByName.get(importClass.name)
+    if (nameMatch) {
+      byName.push({
+        importId: importClass.id,
+        existingId: nameMatch.id,
+        importData: importClass as unknown as Record<string, unknown>,
+        existingData: nameMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "学級名が一致",
+      })
+      continue
+    }
+
+    noMatch.push(importItem)
+  }
+
+  return {
+    byId,
+    byName,
+    noMatch,
+  }
+}
+
+/**
+ * 小計グループの事前照合
+ */
+async function preMatchSubtotalGroups(
+  importData: ExtractedArchiveData
+): Promise<PreMatchingResult> {
+  const existingGroups = await prisma.subtotalGroup.findMany()
+
+  const byId: MatchedItem[] = []
+  const byName: MatchedItem[] = []
+  const noMatch: ImportItem[] = []
+
+  const existingById = new Map(existingGroups.map((g) => [g.id, g]))
+  const existingByName = new Map(existingGroups.map((g) => [g.name, g]))
+
+  for (const importGroup of importData.subtotalsData.subtotalGroups) {
+    const displayLabel = importGroup.name
+    const importItem: ImportItem = {
+      importId: importGroup.id,
+      importData: importGroup as unknown as Record<string, unknown>,
+      displayLabel,
+    }
+
+    // ID照合
+    const idMatch = existingById.get(importGroup.id)
+    if (idMatch) {
+      byId.push({
+        importId: importGroup.id,
+        existingId: idMatch.id,
+        importData: importGroup as unknown as Record<string, unknown>,
+        existingData: idMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "同じパソコンで作成されたデータ",
+      })
+      continue
+    }
+
+    // 名前照合
+    const nameMatch = existingByName.get(importGroup.name)
+    if (nameMatch) {
+      byName.push({
+        importId: importGroup.id,
+        existingId: nameMatch.id,
+        importData: importGroup as unknown as Record<string, unknown>,
+        existingData: nameMatch as unknown as Record<string, unknown>,
+        displayLabel,
+        matchReason: "グループ名が一致",
+      })
+      continue
+    }
+
+    noMatch.push(importItem)
+  }
+
+  return {
+    byId,
+    byName,
+    noMatch,
+  }
+}
+
+// =============================================================================
+// 採点結果の競合検出（Step 3.5: 採点結果の競合解決用）
+// =============================================================================
+
+/**
+ * 採点結果の競合を検出
+ *
+ * 既存DBにある採点結果と、インポートデータの採点結果を比較し、
+ * 同じ生徒×設問で異なる採点がある場合に競合として検出する。
+ *
+ * @param importData - 展開されたアーカイブデータ
+ * @param studentIdMapping - 生徒IDのマッピング（インポートID → 既存ID）
+ * @param cropRegionIdMapping - CropRegion IDのマッピング（インポートID → 既存ID）
+ * @returns 採点競合データ
+ */
+export async function detectScoringConflicts(
+  importData: ExtractedArchiveData,
+  studentIdMapping: Record<string, string>,
+  cropRegionIdMapping: Record<string, string>
+): Promise<ScoringConflictData> {
+  const conflicts: ScoringConflict[] = []
+  let newCount = 0
+
+  // マッピングされた既存のCropRegion IDリスト
+  const existingCropRegionIds = Object.values(cropRegionIdMapping)
+  if (existingCropRegionIds.length === 0) {
+    // 全て新規プロジェクトの場合、競合なし
+    return {
+      conflictCount: 0,
+      newCount: importData.scoresData.questionScores.length,
+      conflicts: [],
+    }
+  }
+
+  // 既存のQuestionScoreを取得（関連するCropRegionのみ）
+  const existingScores = await prisma.questionScore.findMany({
+    where: {
+      cropRegionId: { in: existingCropRegionIds },
+    },
+    include: {
+      cropRegion: true,
+      student: true,
+    },
+  })
+
+  // 既存スコアをキー（studentId + cropRegionId）でインデックス化
+  const existingScoreMap = new Map<string, (typeof existingScores)[0]>()
+  for (const score of existingScores) {
+    const key = `${score.studentId}:${score.cropRegionId}`
+    existingScoreMap.set(key, score)
+  }
+
+  // CropRegionのラベル・配点を取得
+  const cropRegions = await prisma.cropRegion.findMany({
+    where: { id: { in: existingCropRegionIds } },
+  })
+  const cropRegionMap = new Map(cropRegions.map((r) => [r.id, r]))
+
+  // 生徒情報を取得
+  const studentIds = Object.values(studentIdMapping)
+  const students = await prisma.student.findMany({
+    where: { id: { in: studentIds } },
+  })
+  const studentMap = new Map(students.map((s) => [s.id, s]))
+
+  // インポートデータの各QuestionScoreについて競合をチェック
+  for (const importScore of importData.scoresData.questionScores) {
+    const mappedStudentId = importScore.studentId
+      ? studentIdMapping[importScore.studentId]
+      : null
+    const mappedCropRegionId = cropRegionIdMapping[importScore.cropRegionId]
+
+    if (!mappedStudentId || !mappedCropRegionId) {
+      // マッピングがない場合は新規
+      newCount++
+      continue
+    }
+
+    const key = `${mappedStudentId}:${mappedCropRegionId}`
+    const existingScore = existingScoreMap.get(key)
+
+    if (!existingScore) {
+      // 既存に存在しない場合は新規
+      newCount++
+      continue
+    }
+
+    // 既存と値が異なる場合は競合
+    const importPartialScore = importScore.partialScore
+      ? parseFloat(importScore.partialScore)
+      : null
+    const existingPartialScore = existingScore.partialScore
+      ? Number(existingScore.partialScore)
+      : null
+
+    if (
+      importScore.status !== existingScore.status ||
+      importPartialScore !== existingPartialScore
+    ) {
+      const student = studentMap.get(mappedStudentId)
+      const cropRegion = cropRegionMap.get(mappedCropRegionId)
+
+      conflicts.push({
+        importScoreId: importScore.id,
+        existingScoreId: existingScore.id,
+        studentName: student
+          ? `${student.lastName}${student.firstName}`
+          : "不明",
+        studentId: mappedStudentId,
+        questionLabel: cropRegion?.label ?? "不明",
+        cropRegionId: mappedCropRegionId,
+        importScore: {
+          status: importScore.status,
+          partialScore: importPartialScore,
+          updatedAt: importScore.updatedAt,
+        },
+        existingScore: {
+          status: existingScore.status,
+          partialScore: existingPartialScore,
+          updatedAt: existingScore.updatedAt.toISOString(),
+        },
+        maxPoints: cropRegion?.points ?? null,
+      })
+    }
+    // 値が同じ場合は競合なし（既存を維持）
+  }
+
+  return {
+    conflictCount: conflicts.length,
+    newCount,
+    conflicts,
+  }
+}
+
+/**
+ * ユーザーの判断に基づいて採点結果の競合を検出
+ *
+ * id_integrationステップでユーザーが「同じ人」と判断した生徒を含めて
+ * 採点競合を検出する。
+ *
+ * @param importData - 展開されたアーカイブデータ
+ * @param preMatchResult - 事前照合結果
+ * @param integrationConfig - ユーザーのID統合設定
+ * @returns 採点競合データ
+ */
+export async function detectScoringConflictsWithUserDecisions(
+  importData: ExtractedArchiveData,
+  preMatchResult: FileOverviewData,
+  integrationConfig: IdIntegrationConfig
+): Promise<ScoringConflictData> {
+  // プロジェクトIDが一致しない場合、競合なし
+  if (!preMatchResult.project?.isIdMatch) {
+    return {
+      conflictCount: 0,
+      newCount: importData.scoresData.questionScores.length,
+      conflicts: [],
+    }
+  }
+
+  // 生徒IDマッピングを構築（ユーザーの判断を反映）
+  const studentIdMapping: Record<string, string> = {}
+
+  // 1. ID一致の生徒（自動でマッピング）
+  for (const match of preMatchResult.student.byId) {
+    studentIdMapping[match.importId] = match.existingId
+  }
+
+  // 2. ユーザーが「同じ人」と判断した生徒
+  const studentConfig = integrationConfig.student
+
+  // strategyに基づくデフォルトマッピング
+  if (studentConfig.strategy === "by_student_number") {
+    // 学籍番号一致のものをマッピング
+    for (const match of preMatchResult.student.byStudentNumber ?? []) {
+      if (!studentIdMapping[match.importId]) {
+        studentIdMapping[match.importId] = match.existingId
+      }
+    }
+  } else if (studentConfig.strategy === "by_name") {
+    // 氏名一致のものをマッピング
+    for (const match of preMatchResult.student.byName ?? []) {
+      if (!studentIdMapping[match.importId]) {
+        studentIdMapping[match.importId] = match.existingId
+      }
+    }
+  }
+
+  // 3. 個別のdecisionsでオーバーライド
+  for (const decision of studentConfig.decisions) {
+    if (decision.decisionType === "same_person" && decision.existingId) {
+      studentIdMapping[decision.importId] = decision.existingId
+    } else if (
+      decision.decisionType === "create_new" ||
+      decision.decisionType === "skip"
+    ) {
+      // 「新規作成」または「スキップ」の場合、マッピングから削除
+      delete studentIdMapping[decision.importId]
+    }
+  }
+
+  // CropRegionマッピングを構築（プロジェクトID一致時はID一致でマッピング）
+  const cropRegionIdMapping: Record<string, string> = {}
+  const existingCropRegions = await prisma.cropRegion.findMany({
+    where: {
+      projectPage: {
+        projectId: preMatchResult.project.existingProjectId!,
+      },
+    },
+  })
+  const existingCropRegionIds = new Set(existingCropRegions.map((r) => r.id))
+
+  for (const region of importData.projectData.cropRegions) {
+    if (existingCropRegionIds.has(region.id)) {
+      cropRegionIdMapping[region.id] = region.id
+    }
+  }
+
+  // 競合を検出
+  return detectScoringConflicts(importData, studentIdMapping, cropRegionIdMapping)
 }

--- a/hooks/import/useImportWizard.ts
+++ b/hooks/import/useImportWizard.ts
@@ -1,39 +1,80 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useAuth } from "@/contexts/AuthContext"
 import type {
+  CategoryIdIntegrationConfig,
+  CategoryMatchingSummary,
+  FileOverviewData,
+  IdIntegrationConfig,
+  IdIntegrationDecision,
   ImportWizardState,
   ImportWizardStep,
-  ImportMode,
   MatchingConfig,
-  ConflictResolutions,
-  CategoryConflictResolution,
-  ConflictCategory,
+  MatchingDecisionType,
+  ScoringConflictConfig,
+  ScoringConflictResolutionStrategy,
 } from "@/types/projectArchive.types"
-import { useAuth } from "@/contexts/AuthContext"
+import { useCallback, useState } from "react"
+
+/**
+ * インポートウィザードの初期状態
+ */
+const initialState: ImportWizardState = {
+  currentStep: "file_select",
+  archivePath: null,
+  manifest: null,
+  fileOverviewData: null,
+  idIntegrationConfig: {
+    student: { strategy: "by_student_number", decisions: [] },
+    class: { strategy: "by_name", decisions: [] },
+    subtotalGroup: { strategy: "by_name", decisions: [] },
+  },
+  scoringConflictConfig: {
+    strategy: "newer_wins",
+    manualResolutions: {},
+  },
+  matchingConfig: {
+    student: "studentNumber",
+    class: "name",
+    user: "username",
+    project: "always_new",
+    subtotalGroup: "name",
+  },
+  isProcessing: false,
+  error: null,
+  matchingSummaries: [],
+  matchingDecisions: {},
+  updateDecisions: {},
+}
+
+/**
+ * ステップの順序
+ * file_select → file_overview → id_integration → scoring_conflict → update_confirm → final_confirm → execute
+ */
+const STEP_ORDER: ImportWizardStep[] = [
+  "file_select",
+  "file_overview",
+  "id_integration",
+  "scoring_conflict",
+  "update_confirm",
+  "final_confirm",
+  "execute",
+]
 
 /**
  * インポートウィザードの状態管理フック
+ *
+ * フロー:
+ * Step 1 (file_select): ファイル選択
+ * Step 2 (file_overview): ファイル概要説明（ID一致数、判断必要数を表示）
+ * Step 3 (id_integration): データの統合（レコードのIDをどうするか決める）
+ * Step 4 (update_confirm): データの更新（ID以外のカラムをどうするか決める）
+ * Step 5 (final_confirm): 最終確認
+ * Step 6 (execute): 実行
  */
 export function useImportWizard() {
   const { user } = useAuth()
-  const [state, setState] = useState<ImportWizardState>({
-    currentStep: "file_select",
-    archivePath: null,
-    manifest: null,
-    mode: null,
-    matchingConfig: {
-      student: "studentId",
-      class: "name",
-      user: "username",
-      project: "always_new",
-      subtotalGroup: "name",
-    },
-    conflictDetectionResult: null,
-    conflictResolutions: {},
-    isProcessing: false,
-    error: null,
-  })
+  const [state, setState] = useState<ImportWizardState>(initialState)
 
   // ファイル選択
   const selectFile = useCallback(async () => {
@@ -70,12 +111,22 @@ export function useImportWizard() {
         return false
       }
 
+      // 事前照合を実行
+      const preMatchResult = await window.electronAPI.archive.preMatch({
+        archivePath: result.filePath!,
+      })
+
+      const fileOverviewData: FileOverviewData | null = preMatchResult.success
+        ? (preMatchResult.data ?? null)
+        : null
+
       setState((prev) => ({
         ...prev,
         archivePath: result.filePath!,
         manifest: analyzeResult.manifest!,
+        fileOverviewData,
         isProcessing: false,
-        currentStep: "mode_select",
+        currentStep: "file_overview",
       }))
 
       return true
@@ -89,16 +140,88 @@ export function useImportWizard() {
     }
   }, [])
 
-  // モード選択
-  const selectMode = useCallback((mode: ImportMode) => {
-    setState((prev) => ({
-      ...prev,
-      mode,
-      currentStep: mode === "new" ? "execute" : "matching_config",
-    }))
-  }, [])
+  // 事前照合を実行（Step 2で使用）
+  const performPreMatching = useCallback(async () => {
+    if (!state.archivePath) return false
 
-  // マッチング設定更新
+    setState((prev) => ({ ...prev, isProcessing: true, error: null }))
+
+    try {
+      const result = await window.electronAPI.archive.preMatch({
+        archivePath: state.archivePath,
+      })
+
+      if (!result.success) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          error: result.error || "事前照合に失敗しました",
+        }))
+        return false
+      }
+
+      setState((prev) => ({
+        ...prev,
+        fileOverviewData: result.data ?? null,
+        isProcessing: false,
+      }))
+
+      return true
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isProcessing: false,
+        error: error instanceof Error ? error.message : "エラーが発生しました",
+      }))
+      return false
+    }
+  }, [state.archivePath])
+
+  // ID統合設定を更新
+  const updateIdIntegrationConfig = useCallback(
+    <K extends keyof IdIntegrationConfig>(
+      category: K,
+      config: CategoryIdIntegrationConfig
+    ) => {
+      setState((prev) => ({
+        ...prev,
+        idIntegrationConfig: {
+          ...prev.idIntegrationConfig,
+          [category]: config,
+        },
+      }))
+    },
+    []
+  )
+
+  // 個別のID統合決定を更新
+  const updateIdIntegrationDecision = useCallback(
+    (
+      category: keyof IdIntegrationConfig,
+      importId: string,
+      decision: IdIntegrationDecision
+    ) => {
+      setState((prev) => {
+        const currentConfig = prev.idIntegrationConfig[category]
+        const existingDecisions = currentConfig.decisions.filter(
+          (d) => d.importId !== importId
+        )
+        return {
+          ...prev,
+          idIntegrationConfig: {
+            ...prev.idIntegrationConfig,
+            [category]: {
+              ...currentConfig,
+              decisions: [...existingDecisions, decision],
+            },
+          },
+        }
+      })
+    },
+    []
+  )
+
+  // マッチング設定更新（後方互換用）
   const updateMatchingConfig = useCallback(
     <K extends keyof MatchingConfig>(key: K, value: MatchingConfig[K]) => {
       setState((prev) => ({
@@ -112,8 +235,8 @@ export function useImportWizard() {
     []
   )
 
-  // 競合検出
-  const detectConflicts = useCallback(async () => {
+  // 照合を実行してdata_matchingへ進む（後方互換用）
+  const performMatching = useCallback(async () => {
     if (!state.archivePath) return false
 
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
@@ -128,28 +251,47 @@ export function useImportWizard() {
         setState((prev) => ({
           ...prev,
           isProcessing: false,
-          error: result.error || "競合検出に失敗しました",
+          error: result.error || "照合に失敗しました",
         }))
         return false
       }
 
-      // デフォルトの競合解決設定を生成
-      const defaultResolutions: ConflictResolutions = {}
-      for (const categoryResult of result.results || []) {
-        if (categoryResult.conflictItems.length > 0) {
-          const category = categoryResult.category as ConflictCategory
-          defaultResolutions[category] = {
-            policy: "timestamp",
-          }
+      // 結果をCategoryMatchingSummary形式に変換
+      const summaries: CategoryMatchingSummary[] = (result.results || []).map(
+        (categoryResult) => ({
+          category: categoryResult.category,
+          autoMatched: categoryResult.summary.matched,
+          newItems: categoryResult.summary.newItems,
+          needsConfirmation: categoryResult.summary.conflicts,
+          hasConflict: 0,
+          autoMatchedItems: [],
+          newItemsList: [],
+          confirmationItems: categoryResult.conflictItems.map((item) => ({
+            ...item,
+            fieldChanges: [],
+            isImportNewer: false,
+            importUpdatedAt: "",
+            existingUpdatedAt: "",
+            matchReason: "データが一致",
+          })),
+          conflictItems: [],
+        })
+      )
+
+      // デフォルトの照合判断を設定（全て「同じ人」）
+      const defaultDecisions: Record<string, MatchingDecisionType> = {}
+      for (const summary of summaries) {
+        for (const item of summary.confirmationItems) {
+          defaultDecisions[item.id] = "same_person"
         }
       }
 
       setState((prev) => ({
         ...prev,
-        conflictDetectionResult: result,
-        conflictResolutions: defaultResolutions,
+        matchingSummaries: summaries,
+        matchingDecisions: defaultDecisions,
         isProcessing: false,
-        currentStep: "conflict_resolve",
+        currentStep: "id_integration",
       }))
 
       return true
@@ -163,67 +305,185 @@ export function useImportWizard() {
     }
   }, [state.archivePath, state.matchingConfig])
 
-  // 競合解決設定更新
-  const updateConflictResolution = useCallback(
-    (category: ConflictCategory, resolution: CategoryConflictResolution) => {
+  // 照合判断を設定
+  const setMatchingDecision = useCallback(
+    (itemId: string, decision: MatchingDecisionType) => {
       setState((prev) => ({
         ...prev,
-        conflictResolutions: {
-          ...prev.conflictResolutions,
-          [category]: resolution,
+        matchingDecisions: {
+          ...prev.matchingDecisions,
+          [itemId]: decision,
         },
       }))
     },
     []
   )
 
-  // 実行へ進む
-  const proceedToExecute = useCallback(() => {
-    setState((prev) => ({ ...prev, currentStep: "execute" }))
-  }, [])
+  // 複数の照合判断を一括設定
+  const setAllMatchingDecisions = useCallback(
+    (itemIds: string[], decision: MatchingDecisionType) => {
+      setState((prev) => {
+        const newDecisions = { ...prev.matchingDecisions }
+        for (const itemId of itemIds) {
+          newDecisions[itemId] = decision
+        }
+        return {
+          ...prev,
+          matchingDecisions: newDecisions,
+        }
+      })
+    },
+    []
+  )
 
-  // インポート実行（新規作成モード）
-  const executeImportAsNew = useCallback(async () => {
-    if (!state.archivePath) return null
-    if (!user?.id) {
+  // 更新判断を設定
+  const setUpdateDecision = useCallback(
+    (itemId: string, shouldUpdate: boolean) => {
       setState((prev) => ({
         ...prev,
-        error: "ログインが必要です",
+        updateDecisions: {
+          ...prev.updateDecisions,
+          [itemId]: shouldUpdate,
+        },
       }))
-      return null
-    }
+    },
+    []
+  )
+
+  // 複数の更新判断を一括設定
+  const setAllUpdateDecisions = useCallback(
+    (itemIds: string[], shouldUpdate: boolean) => {
+      setState((prev) => {
+        const newDecisions = { ...prev.updateDecisions }
+        for (const itemId of itemIds) {
+          newDecisions[itemId] = shouldUpdate
+        }
+        return {
+          ...prev,
+          updateDecisions: newDecisions,
+        }
+      })
+    },
+    []
+  )
+
+  // 採点競合解決の方針を設定
+  const setScoringConflictStrategy = useCallback(
+    (strategy: ScoringConflictResolutionStrategy) => {
+      setState((prev) => ({
+        ...prev,
+        scoringConflictConfig: {
+          ...prev.scoringConflictConfig,
+          strategy,
+        },
+      }))
+    },
+    []
+  )
+
+  // 採点競合の個別解決を設定
+  const setScoringConflictResolution = useCallback(
+    (conflictId: string, resolution: "import" | "existing") => {
+      setState((prev) => ({
+        ...prev,
+        scoringConflictConfig: {
+          ...prev.scoringConflictConfig,
+          manualResolutions: {
+            ...prev.scoringConflictConfig.manualResolutions,
+            [conflictId]: resolution,
+          },
+        },
+      }))
+    },
+    []
+  )
+
+  // 複数の採点競合を一括解決
+  const setAllScoringConflictResolutions = useCallback(
+    (conflictIds: string[], resolution: "import" | "existing") => {
+      setState((prev) => {
+        const newResolutions = { ...prev.scoringConflictConfig.manualResolutions }
+        for (const id of conflictIds) {
+          newResolutions[id] = resolution
+        }
+        return {
+          ...prev,
+          scoringConflictConfig: {
+            ...prev.scoringConflictConfig,
+            manualResolutions: newResolutions,
+          },
+        }
+      })
+    },
+    []
+  )
+
+  // 採点競合を検出（id_integrationからscoring_conflictへの遷移時に呼び出す）
+  const detectScoringConflicts = useCallback(async () => {
+    if (!state.archivePath || !state.fileOverviewData) return false
 
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
 
     try {
-      const result = await window.electronAPI.archive.importAsNew({
+      const result = await window.electronAPI.archive.detectScoringConflicts({
         archivePath: state.archivePath,
-        currentUserId: user.id,
+        preMatchResult: state.fileOverviewData,
+        integrationConfig: state.idIntegrationConfig,
       })
-
-      setState((prev) => ({ ...prev, isProcessing: false }))
 
       if (!result.success) {
         setState((prev) => ({
           ...prev,
-          error: result.error || "インポートに失敗しました",
+          isProcessing: false,
+          error: result.error || "採点競合の検出に失敗しました",
         }))
-        return null
+        return false
       }
 
-      return result
+      // 検出結果をfileOverviewDataに保存してステップを進める
+      setState((prev) => ({
+        ...prev,
+        fileOverviewData: prev.fileOverviewData
+          ? {
+              ...prev.fileOverviewData,
+              scoringConflicts: result.data,
+            }
+          : null,
+        isProcessing: false,
+        currentStep: "scoring_conflict",
+      }))
+
+      return true
     } catch (error) {
       setState((prev) => ({
         ...prev,
         isProcessing: false,
         error: error instanceof Error ? error.message : "エラーが発生しました",
       }))
-      return null
+      return false
     }
-  }, [state.archivePath, user?.id])
+  }, [state.archivePath, state.fileOverviewData, state.idIntegrationConfig])
 
-  // インポート実行（マージモード）
-  const executeMergeImport = useCallback(async () => {
+  // 次のステップへ進む
+  const goToNextStep = useCallback(() => {
+    setState((prev) => {
+      const currentIndex = STEP_ORDER.indexOf(prev.currentStep)
+      if (currentIndex < 0 || currentIndex >= STEP_ORDER.length - 1) return prev
+      return { ...prev, currentStep: STEP_ORDER[currentIndex + 1] }
+    })
+  }, [])
+
+  // ステップを戻る
+  const goBack = useCallback(() => {
+    setState((prev) => {
+      const currentIndex = STEP_ORDER.indexOf(prev.currentStep)
+      if (currentIndex <= 0) return prev
+      return { ...prev, currentStep: STEP_ORDER[currentIndex - 1] }
+    })
+  }, [])
+
+  // インポート実行
+  const executeImport = useCallback(async () => {
     if (!state.archivePath) return null
     if (!user?.id) {
       setState((prev) => ({
@@ -232,15 +492,24 @@ export function useImportWizard() {
       }))
       return null
     }
+    if (!state.fileOverviewData) {
+      setState((prev) => ({
+        ...prev,
+        error: "事前照合データがありません",
+      }))
+      return null
+    }
 
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
 
     try {
-      const result = await window.electronAPI.archive.mergeImport({
+      // ID統合インポートを実行
+      const result = await window.electronAPI.archive.idIntegrationImport({
         archivePath: state.archivePath,
-        matchingConfig: state.matchingConfig,
-        conflictResolutions: state.conflictResolutions,
+        preMatchResult: state.fileOverviewData,
+        integrationConfig: state.idIntegrationConfig,
         currentUserId: user.id,
+        scoringConflictConfig: state.scoringConflictConfig,
       })
 
       setState((prev) => ({ ...prev, isProcessing: false }))
@@ -264,53 +533,14 @@ export function useImportWizard() {
     }
   }, [
     state.archivePath,
-    state.matchingConfig,
-    state.conflictResolutions,
+    state.fileOverviewData,
+    state.idIntegrationConfig,
     user?.id,
   ])
 
-  // ステップを戻る
-  const goBack = useCallback(() => {
-    setState((prev) => {
-      const stepOrder: ImportWizardStep[] = [
-        "file_select",
-        "mode_select",
-        "matching_config",
-        "conflict_resolve",
-        "execute",
-      ]
-      const currentIndex = stepOrder.indexOf(prev.currentStep)
-
-      if (currentIndex <= 0) return prev
-
-      // 新規作成モードの場合、mode_selectに戻る
-      if (prev.mode === "new" && prev.currentStep === "execute") {
-        return { ...prev, currentStep: "mode_select" }
-      }
-
-      return { ...prev, currentStep: stepOrder[currentIndex - 1] }
-    })
-  }, [])
-
   // リセット
   const reset = useCallback(() => {
-    setState({
-      currentStep: "file_select",
-      archivePath: null,
-      manifest: null,
-      mode: null,
-      matchingConfig: {
-        student: "studentId",
-        class: "name",
-        user: "username",
-        project: "always_new",
-        subtotalGroup: "name",
-      },
-      conflictDetectionResult: null,
-      conflictResolutions: {},
-      isProcessing: false,
-      error: null,
-    })
+    setState(initialState)
   }, [])
 
   // エラーをクリア
@@ -321,14 +551,22 @@ export function useImportWizard() {
   return {
     state,
     selectFile,
-    selectMode,
+    performPreMatching,
+    updateIdIntegrationConfig,
+    updateIdIntegrationDecision,
     updateMatchingConfig,
-    detectConflicts,
-    updateConflictResolution,
-    proceedToExecute,
-    executeImportAsNew,
-    executeMergeImport,
+    performMatching,
+    setMatchingDecision,
+    setAllMatchingDecisions,
+    setUpdateDecision,
+    setAllUpdateDecisions,
+    setScoringConflictStrategy,
+    setScoringConflictResolution,
+    setAllScoringConflictResolutions,
+    detectScoringConflicts,
+    goToNextStep,
     goBack,
+    executeImport,
     reset,
     clearError,
   }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1182,36 +1182,87 @@ export interface MyAPI {
      * プロジェクトをZIPアーカイブとしてエクスポート
      */
     exportProject: (
-      options: import("./project-archive.types").ExportProjectOptions
-    ) => Promise<import("./project-archive.types").ExportProjectResult>
+      options: import("./projectArchive.types").ExportProjectOptions
+    ) => Promise<import("./projectArchive.types").ExportProjectResult>
 
     /**
      * アーカイブファイルを解析してプレビュー情報を取得
      */
     analyzeArchive: (
-      options: import("./project-archive.types").AnalyzeArchiveOptions
-    ) => Promise<import("./project-archive.types").AnalyzeArchiveResult>
+      options: import("./projectArchive.types").AnalyzeArchiveOptions
+    ) => Promise<import("./projectArchive.types").AnalyzeArchiveResult>
 
     /**
      * アーカイブを新規プロジェクトとしてインポート
      */
     importAsNew: (
-      options: import("./project-archive.types").ImportAsNewOptions
-    ) => Promise<import("./project-archive.types").ImportAsNewResult>
+      options: import("./projectArchive.types").ImportAsNewOptions
+    ) => Promise<import("./projectArchive.types").ImportAsNewResult>
+
+    /**
+     * 事前照合を実行（Step 2: ファイル概要表示用）
+     * 全照合方法（ID、学籍番号、氏名、名前）で照合し、結果を返す
+     */
+    preMatch: (options: { archivePath: string }) => Promise<{
+      success: boolean
+      data?: import("./projectArchive.types").FileOverviewData
+      error?: string
+    }>
 
     /**
      * 競合を検出（マージインポート用ドライラン）
      */
     detectConflicts: (
-      options: import("./project-archive.types").DetectConflictsOptions
-    ) => Promise<import("./project-archive.types").ConflictDetectionResult>
+      options: import("./projectArchive.types").DetectConflictsOptions
+    ) => Promise<import("./projectArchive.types").ConflictDetectionResult>
 
     /**
      * マージインポートを実行
      */
     mergeImport: (
-      options: import("./project-archive.types").MergeImportOptions
-    ) => Promise<import("./project-archive.types").MergeImportResult>
+      options: import("./projectArchive.types").MergeImportOptions
+    ) => Promise<import("./projectArchive.types").MergeImportResult>
+
+    /**
+     * ID統合インポートを実行（新しいフロー）
+     *
+     * Step 3で設定したID統合設定を使ってインポートを実行
+     * 2段階処理: マッピング → ID変更
+     * Step 3.5で設定した採点競合解決設定も適用
+     */
+    idIntegrationImport: (options: {
+      archivePath: string
+      preMatchResult: import("./projectArchive.types").FileOverviewData
+      integrationConfig: import("./projectArchive.types").IdIntegrationConfig
+      currentUserId: string
+      scoringConflictConfig?: import("./projectArchive.types").ScoringConflictConfig
+    }) => Promise<{
+      success: boolean
+      projectId?: string
+      summary?: {
+        created: import("./projectArchive.types").ArchiveDataCounts
+        updated: import("./projectArchive.types").ArchiveDataCounts
+        skipped: import("./projectArchive.types").ArchiveDataCounts
+      }
+      warnings?: string[]
+      error?: string
+    }>
+
+    /**
+     * 採点競合を検出（ユーザーの判断に基づく）
+     *
+     * id_integrationステップでユーザーが「同じ人」と判断した生徒を含めて
+     * 採点競合を検出する。scoring_conflictステップ遷移時に呼び出す。
+     */
+    detectScoringConflicts: (options: {
+      archivePath: string
+      preMatchResult: import("./projectArchive.types").FileOverviewData
+      integrationConfig: import("./projectArchive.types").IdIntegrationConfig
+    }) => Promise<{
+      success: boolean
+      data?: import("./projectArchive.types").ScoringConflictData
+      error?: string
+    }>
 
     /**
      * エクスポート保存先選択ダイアログ


### PR DESCRIPTION
## Summary
- 採点競合検出のタイミングをID統合ステップ後に移動
- ユーザーの紐づけ決定を反映した競合検出を実装

## 変更内容
- `detectScoringConflictsWithUserDecisions`関数を追加（ユーザーの決定を反映）
- `archive:detectScoringConflicts` IPCハンドラを追加
- `useImportWizard`に`detectScoringConflicts`関数を追加
- `IdIntegrationStep`で「次へ」時に採点競合検出を実行

Closes #304

## Test plan
- [ ] 学籍番号で紐づけた生徒の採点競合が検出されること
- [ ] 氏名で紐づけた生徒の採点競合が検出されること
- [ ] 新規登録を選んだ生徒は競合検出されないこと
- [ ] 型チェックがエラーなく通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)