### PR TITLE
fix: databaseInitializer の studentId → studentNumber 対応

### DIFF
--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -133,7 +133,7 @@ CREATE TABLE "classes" (
 -- CreateTable
 CREATE TABLE "Student" (
     "id" TEXT NOT NULL PRIMARY KEY,
-    "studentId" TEXT NOT NULL,
+    "studentNumber" TEXT NOT NULL,
     "lastName" TEXT NOT NULL,
     "firstName" TEXT NOT NULL,
     "lastNameKana" TEXT NOT NULL,
@@ -441,7 +441,7 @@ CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
 CREATE UNIQUE INDEX "classes_name_key" ON "classes"("name");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Student_studentId_key" ON "Student"("studentId");
+CREATE UNIQUE INDEX "Student_studentNumber_key" ON "Student"("studentNumber");
 
 -- CreateIndex
 CREATE INDEX "StudentClassMembership_studentId_idx" ON "StudentClassMembership"("studentId");


### PR DESCRIPTION
## Summary
- 初回起動時のスキーマ作成SQLを最新スキーマに対応

## 問題
databaseInitializer.ts に埋め込まれたスキーマ作成SQLが、
studentId → studentNumber のリネームに対応していなかった。

## 変更内容
- `Student` テーブル: `studentId` → `studentNumber`
- インデックス: `Student_studentId_key` → `Student_studentNumber_key`

## Test plan
- [ ] 新規データベース作成時に正しいスキーマが生成されること
- [ ] 型チェックがエラーなく通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)