### PR TITLE
chore: Prettier/ESLintによるコードフォーマット統一

### DIFF
--- a/app/mathjax-svg-explanation/page.tsx
+++ b/app/mathjax-svg-explanation/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef,useState } from "react"
+import { useRef, useState } from "react"
 
 /**
  * ステップ結果の型定義
@@ -35,7 +35,7 @@ interface StepResult {
   canvas?: HTMLCanvasElement
   completed?: boolean
 }
-import { ArrowRight,Code, Info, Play } from "lucide-react"
+import { ArrowRight, Code, Info, Play } from "lucide-react"
 
 // Tabs components are available for future use
 // import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"

--- a/app/projects/[projectId]/06-student-answers/page.tsx
+++ b/app/projects/[projectId]/06-student-answers/page.tsx
@@ -16,7 +16,7 @@ import {
   StudentAnswersTabsNavigation,
   type StudentAnswerTab,
 } from "./components"
-import { usePendingChanges,useStudentAnswersData } from "./hooks"
+import { usePendingChanges, useStudentAnswersData } from "./hooks"
 
 /**
  * StudentAnswersPage - Main page component for student answer management

--- a/app/test/grid-layout-debug/page.tsx
+++ b/app/test/grid-layout-debug/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback,useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 type LayoutDirection = "right-down" | "left-down" | "down-right" | "down-left"
 

--- a/components/auth/PasscodeEditModal.tsx
+++ b/components/auth/PasscodeEditModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect,useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {

--- a/components/auth/UserEditModal.tsx
+++ b/components/auth/UserEditModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect,useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {

--- a/components/drawing/hooks/useCanvasMouseEvents.ts
+++ b/components/drawing/hooks/useCanvasMouseEvents.ts
@@ -3,7 +3,7 @@
  * @description マウスダウン、移動、アップイベントの処理を行う
  */
 
-import { useCallback, useRef,useState } from "react"
+import { useCallback, useRef, useState } from "react"
 
 import type { DrawingTool } from "@/hooks/useDrawingAnnotations"
 import type {

--- a/components/drawing/utils/canvasRenderer.ts
+++ b/components/drawing/utils/canvasRenderer.ts
@@ -12,7 +12,7 @@ import type {
 } from "@/types/drawingAnnotation.types"
 
 import { getAbsoluteCoordinates } from "./coordinateUtils"
-import { drawArrowHead,drawWaveLine, drawZigzagLine } from "./lineRendering"
+import { drawArrowHead, drawWaveLine, drawZigzagLine } from "./lineRendering"
 
 /**
  * キャンバス描画パラメータ

--- a/components/drawing/utils/index.ts
+++ b/components/drawing/utils/index.ts
@@ -2,10 +2,10 @@
  * @fileoverview 描画ユーティリティのエクスポート
  */
 
-export { type CanvasDrawParams,redrawCanvas } from "./canvasRenderer"
+export { type CanvasDrawParams, redrawCanvas } from "./canvasRenderer"
 export {
   getAbsoluteCoordinates,
   getRelativeCoordinates,
 } from "./coordinateUtils"
 export { isPointInAnnotation } from "./hitDetection"
-export { drawArrowHead,drawWaveLine, drawZigzagLine } from "./lineRendering"
+export { drawArrowHead, drawWaveLine, drawZigzagLine } from "./lineRendering"

--- a/components/import/steps/FinalConfirmStep.tsx
+++ b/components/import/steps/FinalConfirmStep.tsx
@@ -77,7 +77,10 @@ function calculateCategorySummary(
     for (const match of preMatch.byStudentNumber) {
       const decision = getDecision(match.importId)
 
-      if (config.strategy === "by_student_number" || config.strategy === "by_name") {
+      if (
+        config.strategy === "by_student_number" ||
+        config.strategy === "by_name"
+      ) {
         // デフォルトはsame_person
         if (!decision || decision.decisionType === "same_person") {
           linked++
@@ -310,8 +313,9 @@ export function FinalConfirmStep({ wizard, onExecute }: FinalConfirmStepProps) {
                             情報を更新: {classSummary.updated}クラス
                           </span>
                         )}
-                        {classSummary.updated > 0 &&
-                          classSummary.kept > 0 && <span>/</span>}
+                        {classSummary.updated > 0 && classSummary.kept > 0 && (
+                          <span>/</span>
+                        )}
                         {classSummary.kept > 0 && (
                           <span className="text-gray-500">
                             既存を維持: {classSummary.kept}クラス

--- a/components/import/steps/ScoringConflictStep.tsx
+++ b/components/import/steps/ScoringConflictStep.tsx
@@ -92,7 +92,9 @@ export function ScoringConflictStep({ wizard }: ScoringConflictStepProps) {
       {/* 解決方針の選択 */}
       <Card className="mb-6">
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">どちらの採点を使いますか？</CardTitle>
+          <CardTitle className="text-base">
+            どちらの採点を使いますか？
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <RadioGroup
@@ -195,8 +197,11 @@ function ManualResolutionPanel({
   wizard,
   conflicts,
 }: ManualResolutionPanelProps) {
-  const { setScoringConflictResolution, setAllScoringConflictResolutions, state } =
-    wizard
+  const {
+    setScoringConflictResolution,
+    setAllScoringConflictResolutions,
+    state,
+  } = wizard
   const { manualResolutions } = state.scoringConflictConfig
 
   // ページネーション
@@ -229,7 +234,9 @@ function ManualResolutionPanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setAllScoringConflictResolutions(allIds, "existing")}
+              onClick={() =>
+                setAllScoringConflictResolutions(allIds, "existing")
+              }
             >
               全てこのPC
             </Button>
@@ -237,7 +244,7 @@ function ManualResolutionPanel({
         </div>
       </CardHeader>
       <CardContent>
-        <ScrollArea className="h-[300px]">
+        <ScrollArea className="h-75">
           <div className="space-y-3">
             {currentConflicts.map((conflict) => (
               <ConflictCard
@@ -245,7 +252,10 @@ function ManualResolutionPanel({
                 conflict={conflict}
                 resolution={manualResolutions[conflict.importScoreId]}
                 onResolutionChange={(resolution) =>
-                  setScoringConflictResolution(conflict.importScoreId, resolution)
+                  setScoringConflictResolution(
+                    conflict.importScoreId,
+                    resolution
+                  )
                 }
               />
             ))}
@@ -269,7 +279,9 @@ function ManualResolutionPanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              onClick={() =>
+                setCurrentPage((p) => Math.min(totalPages - 1, p + 1))
+              }
               disabled={currentPage === totalPages - 1}
             >
               <ChevronRight className="h-4 w-4" />
@@ -295,8 +307,13 @@ function ConflictCard({
   resolution,
   onResolutionChange,
 }: ConflictCardProps) {
-  const formatScore = (status: string, partialScore: number | null, maxPoints: number | null) => {
-    if (status === "CORRECT") return `正解${maxPoints ? `（${maxPoints}点）` : ""}`
+  const formatScore = (
+    status: string,
+    partialScore: number | null,
+    maxPoints: number | null
+  ) => {
+    if (status === "CORRECT")
+      return `正解${maxPoints ? `（${maxPoints}点）` : ""}`
     if (status === "INCORRECT") return "不正解（0点）"
     if (status === "PARTIAL" && partialScore !== null)
       return `部分点（${partialScore}点）`

--- a/components/import/steps/UpdateConfirmStep.tsx
+++ b/components/import/steps/UpdateConfirmStep.tsx
@@ -197,12 +197,8 @@ function extractUpdateableItems(
  * 「現在の情報 → インポート後」を視覚的に表示
  */
 export function UpdateConfirmStep({ wizard }: UpdateConfirmStepProps) {
-  const {
-    state,
-    setUpdateDecision,
-    setAllUpdateDecisions,
-    goToNextStep,
-  } = wizard
+  const { state, setUpdateDecision, setAllUpdateDecisions, goToNextStep } =
+    wizard
   const { fileOverviewData, idIntegrationConfig, updateDecisions } = state
 
   // 更新が必要なアイテムを抽出

--- a/components/pdf-tools/PdfToolsMainView.tsx
+++ b/components/pdf-tools/PdfToolsMainView.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { GripVertical } from "lucide-react"
-import { useCallback, useEffect,useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import type {
   ExportMode,

--- a/components/pdf-tools/import-panel/FileDropzone.tsx
+++ b/components/pdf-tools/import-panel/FileDropzone.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { FileUp, Loader2 } from "lucide-react"
-import { type DragEvent,useCallback, useState } from "react"
+import { type DragEvent, useCallback, useState } from "react"
 import { toast } from "sonner"
 
 import { cn } from "@/lib/utils"

--- a/components/projects/02-template/components/DetectedRectOverlay.tsx
+++ b/components/projects/02-template/components/DetectedRectOverlay.tsx
@@ -5,7 +5,7 @@
 
 "use client"
 
-import { memo, useCallback,useState } from "react"
+import { memo, useCallback, useState } from "react"
 
 import { OVERLAY_STYLES } from "../constants/detection"
 import { DetectedRect, ImageDimensions } from "../types"

--- a/components/projects/02-template/components/PageNavigation.tsx
+++ b/components/projects/02-template/components/PageNavigation.tsx
@@ -90,7 +90,7 @@ export function PageNavigation({
           onValueChange={onImageChange}
           disabled={isLoading || isSaving}
         >
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger className="w-50">
             <SelectValue placeholder="ページを選択" />
           </SelectTrigger>
           <SelectContent>

--- a/components/projects/02-template/constants/detection.ts
+++ b/components/projects/02-template/constants/detection.ts
@@ -2,7 +2,7 @@
  * 採点枠自動認識機能の定数
  */
 
-import { DetectionMode,DetectionSettings } from "../types"
+import { DetectionMode, DetectionSettings } from "../types"
 
 /**
  * デフォルトの検出設定（シンプル版）

--- a/components/projects/02-template/hooks/useFrameDetection.ts
+++ b/components/projects/02-template/hooks/useFrameDetection.ts
@@ -2,7 +2,7 @@
  * 採点枠検出フック
  */
 
-import { useCallback, useRef,useState } from "react"
+import { useCallback, useRef, useState } from "react"
 
 import {
   DEFAULT_DETECTION_MODE,

--- a/components/projects/04-question-group/components/QuestionAssignmentMatrixWithFillHandle.tsx
+++ b/components/projects/04-question-group/components/QuestionAssignmentMatrixWithFillHandle.tsx
@@ -20,7 +20,7 @@ import {
   SubtotalGroupWithItems,
 } from "@/types/electron"
 
-import { type FillUpdate,useFillHandleDrag } from "../hooks/useFillHandleDrag"
+import { type FillUpdate, useFillHandleDrag } from "../hooks/useFillHandleDrag"
 import { CheckboxCellWithFillHandle } from "./CheckboxCellWithFillHandle"
 
 interface QuestionAssignmentMatrixWithFillHandleProps {

--- a/components/projects/04-question-group/components/SubtotalAssignmentMatrixWithFillHandle.tsx
+++ b/components/projects/04-question-group/components/SubtotalAssignmentMatrixWithFillHandle.tsx
@@ -20,7 +20,7 @@ import {
   SubtotalGroupWithItems,
 } from "@/types/electron"
 
-import { type FillUpdate,useFillHandleDrag } from "../hooks/useFillHandleDrag"
+import { type FillUpdate, useFillHandleDrag } from "../hooks/useFillHandleDrag"
 import { CheckboxCellWithFillHandle } from "./CheckboxCellWithFillHandle"
 
 interface SubtotalAssignmentMatrixWithFillHandleProps {

--- a/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
+++ b/components/projects/04-question-group/components/SubtotalGroupSelector.tsx
@@ -2,7 +2,7 @@
 
 import { Calculator, Plus, Search, Trash2 } from "lucide-react"
 import Link from "next/link"
-import { useEffect,useState } from "react"
+import { useEffect, useState } from "react"
 
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 import type { SubtotalGroup } from "@/components/subtotal-groups/types/subtotalGroupTypes"

--- a/components/projects/05-students/components/sortable-student-table/components/TableHeaderRow.tsx
+++ b/components/projects/05-students/components/sortable-student-table/components/TableHeaderRow.tsx
@@ -20,7 +20,7 @@ export function TableHeaderRow({
   return (
     <TableHeader className="bg-background sticky top-0 z-10">
       <TableRow>
-        <TableHead className="w-[100px]">
+        <TableHead className="w-25">
           <div className="flex items-center gap-2">
             <GripVertical className="text-muted-foreground h-4 w-4" />
             <Checkbox
@@ -32,8 +32,8 @@ export function TableHeaderRow({
             />
           </div>
         </TableHead>
-        <TableHead className="w-[80px]">出席番号</TableHead>
-        <TableHead className="w-[100px]">学籍番号</TableHead>
+        <TableHead className="w-20">出席番号</TableHead>
+        <TableHead className="w-25">学籍番号</TableHead>
         <TableHead>氏名</TableHead>
         <TableHead>ふりがな</TableHead>
         <TableHead>学級</TableHead>

--- a/components/projects/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/components/projects/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -1,4 +1,4 @@
-import { rectSortingStrategy,SortableContext } from "@dnd-kit/sortable"
+import { rectSortingStrategy, SortableContext } from "@dnd-kit/sortable"
 
 import { EmptyTableCell } from "@/components/projects/06-student-answers/student-answer-table/components/EmptyTableCell"
 import { FilePreviewCell } from "@/components/projects/06-student-answers/student-answer-table/components/FilePreviewCell"

--- a/components/projects/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
+++ b/components/projects/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useEffect, useMemo,useRef } from "react"
+import { RefObject, useCallback, useEffect, useMemo, useRef } from "react"
 
 interface UseAutoScrollProps {
   selectedAnswers: Set<string>

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/interaction/useCanvasInteraction.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/interaction/useCanvasInteraction.ts
@@ -13,7 +13,7 @@ import type {
 
 import { useDrawingCreation } from "./useDrawingCreation"
 import { useElementMovement } from "./useElementMovement"
-import { type ResizeOriginalBounds,useElementResize } from "./useElementResize"
+import { type ResizeOriginalBounds, useElementResize } from "./useElementResize"
 import { useElementSelection } from "./useElementSelection"
 import { useRectangleSelection } from "./useRectangleSelection"
 

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
@@ -3,7 +3,7 @@
  * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
  */
 
-import { useCallback, useEffect, useRef,useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
 

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
@@ -3,7 +3,7 @@
  * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
  */
 
-import { useCallback, useEffect, useRef,useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
 

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
@@ -3,7 +3,7 @@
  * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
  */
 
-import { useCallback, useEffect, useRef,useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
 

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
@@ -3,7 +3,7 @@
  * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
  */
 
-import { useCallback, useEffect, useRef,useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import type { LayoutDirection } from "@/components/projects/07-score-at-once/types"
 import { useAuth } from "@/contexts/AuthContext"

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { CropRegionWithProjectPage } from "@/components/projects/07-score-at-once/types"
-import { isValidProject,ProjectWithDetails } from "@/types/common.types"
+import { isValidProject, ProjectWithDetails } from "@/types/common.types"
 import { StudentAnswerImageWithDetails } from "@/types/prismaExtensions"
 
 interface ScoringDataLoaderResult {

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
@@ -3,7 +3,7 @@
  * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
  */
 
-import { useCallback, useEffect, useRef,useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
 

--- a/components/projects/list/ProjectList.tsx
+++ b/components/projects/list/ProjectList.tsx
@@ -44,8 +44,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { SortDirection,useTableSort } from "@/hooks/useTableSort"
-import { isValidProject,ProjectWithDetails } from "@/types/common.types"
+import { SortDirection, useTableSort } from "@/hooks/useTableSort"
+import { isValidProject, ProjectWithDetails } from "@/types/common.types"
 import { getProjectStatus } from "@/utils/projectStatus"
 
 interface ProjectSortable {

--- a/components/subtotal-groups/SubtotalGroupsPageContainer.tsx
+++ b/components/subtotal-groups/SubtotalGroupsPageContainer.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Plus, Search } from "lucide-react"
-import { useCallback,useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 import { SubtotalGroupCard } from "@/components/subtotal-groups/components/SubtotalGroupCard"

--- a/components/subtotal-groups/components/SubtotalGroupCard.tsx
+++ b/components/subtotal-groups/components/SubtotalGroupCard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Calculator,Edit, Trash2 } from "lucide-react"
+import { Calculator, Edit, Trash2 } from "lucide-react"
 
 import type { SubtotalGroup } from "@/components/subtotal-groups/types/subtotalGroupTypes"
 import { Badge } from "@/components/ui/badge"

--- a/components/subtotal-groups/components/SubtotalGroupModal.tsx
+++ b/components/subtotal-groups/components/SubtotalGroupModal.tsx
@@ -17,8 +17,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { GripVertical,Plus, Trash2 } from "lucide-react"
-import { useEffect,useState } from "react"
+import { GripVertical, Plus, Trash2 } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import type {
   SubtotalGroup,

--- a/components/ui/SortableTableHead.tsx
+++ b/components/ui/SortableTableHead.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronDown, ChevronsUpDown,ChevronUp } from "lucide-react"
+import { ChevronDown, ChevronsUpDown, ChevronUp } from "lucide-react"
 import * as React from "react"
 
 import type { SortDirection } from "@/hooks/useTableSort"

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -58,4 +58,4 @@ const AlertDescription = React.forwardRef<
 ))
 AlertDescription.displayName = "AlertDescription"
 
-export { Alert, AlertDescription,AlertTitle }
+export { Alert, AlertDescription, AlertTitle }

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -8,4 +8,4 @@ const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
 
 const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
 
-export { Collapsible, CollapsibleContent,CollapsibleTrigger }
+export { Collapsible, CollapsibleContent, CollapsibleTrigger }

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -45,7 +45,7 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent className="overflow-hidden p-0">
-        <Command className="**:[[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:[[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3">
           {children}
         </Command>
       </DialogContent>

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -72,4 +72,4 @@ function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
   )
 }
 
-export { InputOTP, InputOTPGroup, InputOTPSeparator,InputOTPSlot }
+export { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot }

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -43,4 +43,4 @@ function PopoverAnchor({
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
-export { Popover, PopoverAnchor,PopoverContent, PopoverTrigger }
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger }

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot"
-import { cva,VariantProps } from "class-variance-authority"
+import { cva, VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 import * as React from "react"
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -61,4 +61,4 @@ function TabsContent({
   )
 }
 
-export { Tabs, TabsContent,TabsList, TabsTrigger }
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -60,4 +60,4 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipContent, TooltipProvider,TooltipTrigger }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -41,7 +41,7 @@ npm run format      # Prettier --write のみ
 {
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
-    "source.organizeImports": "never"  // ESLintに統一、競合回避
+    "source.organizeImports": "never" // ESLintに統一、競合回避
   },
   "editor.formatOnSave": true
 }
@@ -99,27 +99,27 @@ npx @tailwindcss/upgrade --force
 ```typescript
 // ✅ 良い例: 役割が明確
 const studentCount = students.length
-const isLoading = status === 'loading'
+const isLoading = status === "loading"
 function calculateTotalScore(scores: number[]): number
 
 // ❌ 悪い例: 意味が不明確
 const cnt = students.length
-const flag = status === 'loading'
+const flag = status === "loading"
 function calc(arr: number[]): number
 ```
 
 ### 関数名
 
-| 接頭辞 | 用途 | 例 |
-| ------ | ---- | --- |
-| `get` | 値を取得 | `getStudentById`, `getProjectList` |
-| `set` | 値を設定 | `setCurrentPage`, `setFilter` |
-| `is` / `has` / `can` | 真偽値を返す | `isValid`, `hasPermission`, `canEdit` |
-| `create` | 新規作成 | `createProject`, `createStudent` |
-| `update` | 更新 | `updateScore`, `updateStatus` |
-| `delete` / `remove` | 削除 | `deleteProject`, `removeStudent` |
-| `handle` | イベントハンドラ | `handleClick`, `handleSubmit` |
-| `fetch` | 非同期でデータ取得 | `fetchProjects`, `fetchUserData` |
+| 接頭辞               | 用途               | 例                                    |
+| -------------------- | ------------------ | ------------------------------------- |
+| `get`                | 値を取得           | `getStudentById`, `getProjectList`    |
+| `set`                | 値を設定           | `setCurrentPage`, `setFilter`         |
+| `is` / `has` / `can` | 真偽値を返す       | `isValid`, `hasPermission`, `canEdit` |
+| `create`             | 新規作成           | `createProject`, `createStudent`      |
+| `update`             | 更新               | `updateScore`, `updateStatus`         |
+| `delete` / `remove`  | 削除               | `deleteProject`, `removeStudent`      |
+| `handle`             | イベントハンドラ   | `handleClick`, `handleSubmit`         |
+| `fetch`              | 非同期でデータ取得 | `fetchProjects`, `fetchUserData`      |
 
 ### 変数名
 
@@ -201,8 +201,7 @@ npm run lint:strict
 - ✅ 外部ライブラリとのインターフェース
 - ✅ 汎用的なユーティリティ関数
 
-```typescript
-// トップレベル配置の例
+```
 /hooks/useProject.ts       // 複数画面で使用されるプロジェクト管理
 /types/common.types.ts     // ProjectData, StudentDataなど全体共通型
 /lib/utils.ts              // 日付フォーマット、バリデーション等の汎用関数
@@ -245,12 +244,12 @@ npm run lint:strict
 
 データに関する型は以下の優先順位で選択する。**上位を使えるなら上位を使う。**
 
-| 優先度 | 型の種類 | 説明 | 例 |
-| :---: | -------- | ---- | --- |
-| 1 | **Prisma型** | `@prisma/client` が生成する基本型 | `Student`, `Project`, `CropRegion` |
-| 2 | **Prisma拡張型** | `include` 等で生まれるペイロード型 | `Prisma.StudentGetPayload<{ include: { memberships: true } }>` |
-| 3 | **シリアライズ型** | Decimal→number等、やむを得ず一部を再定義する型 | `SerializedQuestionScore` |
-| 4 | **独自定義型** | 上記で対応できない場合のみ | UI専用の中間状態など |
+| 優先度 | 型の種類           | 説明                                           | 例                                                             |
+| :----: | ------------------ | ---------------------------------------------- | -------------------------------------------------------------- |
+|   1    | **Prisma型**       | `@prisma/client` が生成する基本型              | `Student`, `Project`, `CropRegion`                             |
+|   2    | **Prisma拡張型**   | `include` 等で生まれるペイロード型             | `Prisma.StudentGetPayload<{ include: { memberships: true } }>` |
+|   3    | **シリアライズ型** | Decimal→number等、やむを得ず一部を再定義する型 | `SerializedQuestionScore`                                      |
+|   4    | **独自定義型**     | 上記で対応できない場合のみ                     | UI専用の中間状態など                                           |
 
 ### 独自定義型を使ってよい条件
 
@@ -289,11 +288,11 @@ interface StudentData {
 
 Main process（electron-src）と Renderer process（components, hooks）間のIPC通信では、**同一の型定義を参照すること**。
 
-| 型の種類 | 参照元 |
-| -------- | ------ |
-| Prisma基本型 | `@prisma/client` から直接 import |
+| 型の種類     | 参照元                                   |
+| ------------ | ---------------------------------------- |
+| Prisma基本型 | `@prisma/client` から直接 import         |
 | Prisma拡張型 | `/types/prismaExtensions.ts` から import |
-| 共通型 | `/types/common.types.ts` から import |
+| 共通型       | `/types/common.types.ts` から import     |
 
 ```typescript
 // ✅ OK: Main/Renderer両方で同じ型を参照
@@ -317,11 +316,11 @@ interface ProjectData { ... }  // Renderer独自（微妙に違う可能性）
 
 ### 型定義の配置ルール
 
-| スコープ | 配置場所 | 例 |
-| -------- | -------- | --- |
-| 単一ファイル | ファイル内で宣言 | Props型、ローカルな状態型 |
-| 機能内で共有 | 機能ディレクトリの `types.ts` | `components/projects/07-score-at-once/types.ts` |
-| アプリ全体で共有 | `/types/` ディレクトリ | `types/common.types.ts`, `types/prismaExtensions.ts` |
+| スコープ         | 配置場所                      | 例                                                   |
+| ---------------- | ----------------------------- | ---------------------------------------------------- |
+| 単一ファイル     | ファイル内で宣言              | Props型、ローカルな状態型                            |
+| 機能内で共有     | 機能ディレクトリの `types.ts` | `components/projects/07-score-at-once/types.ts`      |
+| アプリ全体で共有 | `/types/` ディレクトリ        | `types/common.types.ts`, `types/prismaExtensions.ts` |
 
 ### Prisma拡張型の管理
 
@@ -392,11 +391,11 @@ DBに保存しないデータ or どうしても必要？ → Yes → 独自定�
 
 ### 分割対象の基準
 
-| 行数       | 対応         |
-| ---------- | ------------ |
-| 200行未満  | 分割不要     |
-| 200行以上  | 分割を検討   |
-| 500行以上  | 分割を強く推奨 |
+| 行数      | 対応           |
+| --------- | -------------- |
+| 200行未満 | 分割不要       |
+| 200行以上 | 分割を検討     |
+| 500行以上 | 分割を強く推奨 |
 
 ### その他の分割判断基準
 
@@ -455,11 +454,11 @@ function UserProfile() {
 
 ### コンポーネントの分類
 
-| 種類             | 責務                       | 例                          |
-| ---------------- | -------------------------- | --------------------------- |
-| Container        | データ取得・状態管理       | `UserProfileContainer.tsx`  |
-| Presentational   | UI表示のみ                 | `UserProfileView.tsx`       |
-| Hook             | ロジックの再利用           | `useUser.ts`                |
+| 種類           | 責務                 | 例                         |
+| -------------- | -------------------- | -------------------------- |
+| Container      | データ取得・状態管理 | `UserProfileContainer.tsx` |
+| Presentational | UI表示のみ           | `UserProfileView.tsx`      |
+| Hook           | ロジックの再利用     | `useUser.ts`               |
 
 ### Props設計
 
@@ -468,7 +467,7 @@ function UserProfile() {
 interface ButtonProps {
   label: string
   onClick: () => void
-  variant?: 'primary' | 'secondary'
+  variant?: "primary" | "secondary"
   disabled?: boolean
 }
 
@@ -493,7 +492,7 @@ interface ButtonProps {
 // 状態は必要最小限に
 // ✅ 派生値は計算で求める
 const [items, setItems] = useState<Item[]>([])
-const completedCount = items.filter(i => i.completed).length
+const completedCount = items.filter((i) => i.completed).length
 
 // ❌ 派生値を別の状態として持たない
 const [items, setItems] = useState<Item[]>([])
@@ -515,39 +514,39 @@ npm run lint:fix    # 保存時も自動実行される
 ソート後のイメージ：
 
 ```typescript
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react"
 
-import { clsx } from 'clsx'
-import { useForm } from 'react-hook-form'
+import { clsx } from "clsx"
+import { useForm } from "react-hook-form"
 
-import { Button } from '@/components/ui/button'
-import { useProject } from '@/hooks/useProject'
-import type { ProjectData } from '@/types/common.types'
+import { Button } from "@/components/ui/button"
+import { useProject } from "@/hooks/useProject"
+import type { ProjectData } from "@/types/common.types"
 
-import { FeatureHeader } from './components/FeatureHeader'
-import { useFeature } from './hooks/useFeature'
-import type { FeatureProps } from './types'
+import { FeatureHeader } from "./components/FeatureHeader"
+import { useFeature } from "./hooks/useFeature"
+import type { FeatureProps } from "./types"
 ```
 
 > **Note**: グループ間の空行は ESLint が自動挿入する。
 
 ### パスの使い分け
 
-| パス種類   | 使用場面                                 |
-| ---------- | ---------------------------------------- |
-| `@/`       | トップレベルモジュール、別機能からの参照 |
-| `./`       | 同一機能内の参照                         |
-| `../`      | 親ディレクトリへの参照（2階層まで）      |
+| パス種類 | 使用場面                                 |
+| -------- | ---------------------------------------- |
+| `@/`     | トップレベルモジュール、別機能からの参照 |
+| `./`     | 同一機能内の参照                         |
+| `../`    | 親ディレクトリへの参照（2階層まで）      |
 
 ```typescript
 // ✅ トップレベルは絶対パス
-import { useProject } from '@/hooks/useProject'
+import { useProject } from "@/hooks/useProject"
 
 // ✅ 機能内は相対パス
-import { useFeature } from './hooks/useFeature'
+import { useFeature } from "./hooks/useFeature"
 
 // ⚠️ 深い相対パスは避ける
-import { something } from '../../../shared/utils' // → @/を使用
+import { something } from "../../../shared/utils" // → @/を使用
 ```
 
 ### type import
@@ -556,14 +555,14 @@ import { something } from '../../../shared/utils' // → @/を使用
 
 ```typescript
 // ✅ 型のみのインポート
-import type { ProjectData } from '@/types/common.types'
+import type { ProjectData } from "@/types/common.types"
 
 // ✅ 値と型の混在
-import { useProject } from '@/hooks/useProject'
-import type { ProjectData } from '@/types/common.types'
+import { useProject } from "@/hooks/useProject"
+import type { ProjectData } from "@/types/common.types"
 
 // または
-import { useProject, type ProjectData } from '@/hooks/useProject'
+import { useProject, type ProjectData } from "@/hooks/useProject"
 ```
 
 ---
@@ -638,12 +637,12 @@ export async function exportToExcel(
 
 ## 更新履歴
 
-| 日付       | 内容           |
-| ---------- | -------------- |
-| 2025-01-12 | 初版作成       |
-| 2025-01-12 | 型管理方針を改訂（優先順位の明確化、後方互換性の方針追加） |
-| 2025-01-12 | IPC通信における型の一貫性ルールを追加 |
-| 2025-01-12 | フォーマッター・リンターセクションを追加 |
-| 2025-01-12 | eslint-plugin-simple-import-sort を導入 |
-| 2025-01-12 | 命名規則・不要コード削除のセクションを追加 |
+| 日付       | 内容                                                             |
+| ---------- | ---------------------------------------------------------------- |
+| 2025-01-12 | 初版作成                                                         |
+| 2025-01-12 | 型管理方針を改訂（優先順位の明確化、後方互換性の方針追加）       |
+| 2025-01-12 | IPC通信における型の一貫性ルールを追加                            |
+| 2025-01-12 | フォーマッター・リンターセクションを追加                         |
+| 2025-01-12 | eslint-plugin-simple-import-sort を導入                          |
+| 2025-01-12 | 命名規則・不要コード削除のセクションを追加                       |
 | 2025-01-12 | ESLint設定との整合性確認・修正、Tailwind CSSマイグレーション追加 |

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -1,4 +1,4 @@
-import { app, net,protocol } from "electron"
+import { app, net, protocol } from "electron"
 import { pathToFileURL } from "url"
 
 import { initializeApp } from "./appInitializer"

--- a/electron-src/ipc-handlers/pdfToolsHandlers.ts
+++ b/electron-src/ipc-handlers/pdfToolsHandlers.ts
@@ -12,7 +12,7 @@ import type {
   RotationDegree,
 } from "@/types/pdfTools.types"
 
-import { type MergePageInput,mergePdfs } from "../lib/pdf-tools/pdfMerger"
+import { type MergePageInput, mergePdfs } from "../lib/pdf-tools/pdfMerger"
 import { applyNUp } from "../lib/pdf-tools/pdfNUp"
 import {
   type RotatePageInput,

--- a/electron-src/lib/authStore.ts
+++ b/electron-src/lib/authStore.ts
@@ -1,5 +1,5 @@
 import { app } from "electron"
-import { existsSync, readFileSync, unlinkSync,writeFileSync } from "fs"
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs"
 import { join } from "path"
 
 interface AuthData {

--- a/electron-src/lib/import/merge/conflictDetector.ts
+++ b/electron-src/lib/import/merge/conflictDetector.ts
@@ -16,7 +16,7 @@ import type {
   MatchingSummary,
 } from "../../../../types/projectArchive.types"
 import type { ExtractedArchiveData } from "../project-archive/archiveExtractor"
-import { type MatchResult,performAllMatching } from "./matcher"
+import { type MatchResult, performAllMatching } from "./matcher"
 
 // =============================================================================
 // フィールドラベルマッピング（先生向けUI表示用）

--- a/electron-src/lib/pdf-tools/pdfMerger.ts
+++ b/electron-src/lib/pdf-tools/pdfMerger.ts
@@ -4,9 +4,9 @@
  */
 import * as fs from "fs"
 import * as path from "path"
-import { degrees,PDFDocument } from "pdf-lib"
+import { degrees, PDFDocument } from "pdf-lib"
 
-import type { NUpLayout,RotationDegree } from "@/types/pdfTools.types"
+import type { NUpLayout, RotationDegree } from "@/types/pdfTools.types"
 
 // A4サイズ (ポイント単位: 1pt = 1/72 inch)
 const A4_WIDTH = 595.28 // 210mm

--- a/electron-src/lib/pdf-tools/pdfRotator.ts
+++ b/electron-src/lib/pdf-tools/pdfRotator.ts
@@ -2,7 +2,7 @@
  * ページ回転ユーティリティ
  */
 import * as fs from "fs"
-import { degrees,PDFDocument } from "pdf-lib"
+import { degrees, PDFDocument } from "pdf-lib"
 
 import type { RotationDegree } from "@/types/pdfTools.types"
 

--- a/electron-src/lib/prisma/cropSubtotal.ts
+++ b/electron-src/lib/prisma/cropSubtotal.ts
@@ -1,4 +1,4 @@
-import type { CropSubtotal,Prisma } from "@prisma/client"
+import type { CropSubtotal, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -1,4 +1,4 @@
-import { MasterImage, Prisma,ProjectPage } from "@prisma/client"
+import { MasterImage, Prisma, ProjectPage } from "@prisma/client"
 import fs from "fs/promises"
 import path from "path"
 

--- a/electron-src/lib/prisma/projectPage.ts
+++ b/electron-src/lib/prisma/projectPage.ts
@@ -1,4 +1,4 @@
-import type { Prisma,ProjectPage } from "@prisma/client"
+import type { Prisma, ProjectPage } from "@prisma/client"
 
 import prisma from "./client"
 

--- a/electron-src/lib/prisma/questionSubtotalAssignment.ts
+++ b/electron-src/lib/prisma/questionSubtotalAssignment.ts
@@ -1,4 +1,4 @@
-import type { CropSubtotal,Prisma } from "@prisma/client"
+import type { CropSubtotal, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 

--- a/hooks/useFileUpload.ts
+++ b/hooks/useFileUpload.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback,useState } from "react"
+import { useCallback, useState } from "react"
 import { toast } from "sonner"
 
 export interface FileUploadOptions {

--- a/hooks/useProject.ts
+++ b/hooks/useProject.ts
@@ -1,7 +1,7 @@
 "use client"
 
-import { CropRegion, MasterImage, Prisma,Project } from "@prisma/client"
-import { useCallback, useEffect,useState } from "react"
+import { CropRegion, MasterImage, Prisma, Project } from "@prisma/client"
+import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
 export type ProjectWithDetails = Project & {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { type ClassValue,clsx } from "clsx"
+import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {


### PR DESCRIPTION
## Summary
- コードベース全体にPrettier/ESLintを適用しフォーマットを統一
- 57ファイルの軽微なフォーマット修正
- docs/coding-style.mdのMarkdownテーブル整形

## Test plan
- [x] `npm run typecheck` 成功確認
- [x] `npm run lint` 成功確認（警告1件のみ）
- [x] `prettier --check .` 成功確認

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)