### PR TITLE
fix: フォーム要素にアクセシビリティ用title属性を追加

### DIFF
--- a/components/drawing/DrawingToolbar.tsx
+++ b/components/drawing/DrawingToolbar.tsx
@@ -176,6 +176,7 @@ export const DrawingToolbar: React.FC<DrawingToolbarProps> = ({
             value={drawingColor}
             onChange={(e) => onColorChange(e.target.value)}
             disabled={readOnly}
+            title="カスタム色を選択"
             className="h-6 w-8 cursor-pointer rounded border border-gray-300 disabled:cursor-not-allowed"
           />
         </div>

--- a/components/projects/02-template/components/DetectionSettingsPanel.tsx
+++ b/components/projects/02-template/components/DetectionSettingsPanel.tsx
@@ -70,6 +70,7 @@ export const DetectionSettingsPanel = memo(function DetectionSettingsPanel({
               onChange={(e) =>
                 handleChange("lineExtension", parseInt(e.target.value))
               }
+              title="線の延長"
               className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
             />
           </div>
@@ -91,6 +92,7 @@ export const DetectionSettingsPanel = memo(function DetectionSettingsPanel({
               onChange={(e) =>
                 handleChange("minWidth", parseFloat(e.target.value))
               }
+              title="最小幅"
               className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
             />
           </div>
@@ -112,6 +114,7 @@ export const DetectionSettingsPanel = memo(function DetectionSettingsPanel({
               onChange={(e) =>
                 handleChange("minHeight", parseFloat(e.target.value))
               }
+              title="最小高さ"
               className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 accent-blue-600"
             />
           </div>


### PR DESCRIPTION
## 概要

Closes #320

axeによるアクセシビリティ警告（フォーム要素にラベルが必要）を修正。

## 変更内容

### DrawingToolbar.tsx
- `<input type="color">` に `title="カスタム色を選択"` を追加

### DetectionSettingsPanel.tsx
- 線の延長スライダーに `title="線の延長"` を追加
- 最小幅スライダーに `title="最小幅"` を追加
- 最小高さスライダーに `title="最小高さ"` を追加

## テスト

- axeアクセシビリティ警告が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)