### PR TITLE
fix: appimg://プロトコルでWindows版の画像読み込みエラーを修正

### DIFF
--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -1,7 +1,9 @@
 import { app, net, protocol } from "electron"
+import * as path from "path"
 import { pathToFileURL } from "url"
 
 import { initializeApp } from "./appInitializer"
+import { getAbsolutePathFromData } from "./lib/dataManager"
 import { setupAllIPCHandlers } from "./ipc-handlers"
 import { startEmbeddedNextServer } from "./nextServerEmbedded"
 import { createMainWindow, setupWindowEvents } from "./windowManager"
@@ -69,6 +71,11 @@ app.on("ready", async () => {
         // Windowsの場合、先頭の/を削除（/C:/path → C:/path）
         if (process.platform === "win32" && filePath.startsWith("/")) {
           filePath = filePath.slice(1)
+        }
+
+        // 相対パスの場合はデータディレクトリからの絶対パスに変換
+        if (!path.isAbsolute(filePath)) {
+          filePath = getAbsolutePathFromData(filePath)
         }
 
         const fileUrl = pathToFileURL(filePath).href


### PR DESCRIPTION
## 概要

Closes #328

Windows版のコンパイル済みアプリで、模範解答や答案の画像読み込み時に発生していたエラーを修正。

## 変更内容

- `path.isAbsolute()` で相対パスかどうかを判定
- 相対パスの場合は `getAbsolutePathFromData()` で絶対パスに変換

## 原因

- DBに保存された相対パスを `pathToFileURL()` に直接渡していた
- `pathToFileURL()` は絶対パスを期待するが、相対パスが渡されていた
- 開発環境では偶然動作していたが、Windowsパッケージ版では失敗

## テスト方法

1. macOS開発環境で既存機能が壊れていないことを確認
2. Windows版をビルドして画像読み込みが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)