### PR TITLE
fix: appimg://プロトコルのURLパースを修正し画像読み込みエラーを解消

### DIFF
--- a/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
+++ b/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
@@ -155,8 +155,8 @@ async function generateThumbnailsFromPath(
   pageCount: number
 ): Promise<string[]> {
   try {
-    // appimg:// プロトコルでローカルファイルを読み込み
-    const response = await fetch(`appimg://${filePath}`)
+    // appimg:/// プロトコルでローカルファイルを読み込み
+    const response = await fetch(`appimg:///${filePath}`)
     const arrayBuffer = await response.arrayBuffer()
 
     // ArrayBufferからFileオブジェクトを作成

--- a/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
+++ b/components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
@@ -59,7 +59,11 @@ export function useImageLoader({
         }))
       } else {
         // 単一ページ表示：ScoringDataのimageUrlを使用（Grid Viewと同じ）
-        const imagePath = currentScoringData.imageUrl.replace("appimg://", "")
+        // appimg:// または appimg:/// の両方に対応
+        const imagePath = currentScoringData.imageUrl.replace(
+          /^appimg:\/\/\/?/,
+          ""
+        )
         imagesToLoad = [{ path: imagePath, pageNumber: 1 }]
       }
 
@@ -77,12 +81,12 @@ export function useImageLoader({
             reject(error)
           }
 
-          // ファイル存在確認して読み込み（appimg://プロトコル使用）
+          // ファイル存在確認して読み込み（appimg:///プロトコル使用）
           window.electronAPI
             .checkFileExists(imageInfo.path)
             .then((result) => {
               if (result.success && result.exists) {
-                img.src = `appimg://${result.path}`
+                img.src = `appimg:///${result.path}`
               } else {
                 console.warn(`File does not exist: ${imageInfo.path}`)
                 reject(new Error(`File not found: ${imageInfo.path}`))
@@ -90,7 +94,7 @@ export function useImageLoader({
             })
             .catch((error) => {
               console.error("Error checking file existence:", error)
-              img.src = `appimg://${imageInfo.path}` // フォールバック
+              img.src = `appimg:///${imageInfo.path}` // フォールバック
             })
         })
       })

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -143,7 +143,7 @@ export function useScoringFilter({
             studentId: "",
             studentName: "不明",
             imageUrl: pageImage.imagePath
-              ? `appimg://${pageImage.imagePath}`
+              ? `appimg:///${pageImage.imagePath}`
               : "",
             currentScore: undefined,
             maxScore: currentCropRegion.points ?? 0,
@@ -164,7 +164,7 @@ export function useScoringFilter({
           studentId: pageImage.studentId,
           studentName: `${pageImage.student?.lastName ?? ""} ${pageImage.student?.firstName ?? ""}`,
           imageUrl: pageImage.imagePath
-            ? `appimg://${pageImage.imagePath}`
+            ? `appimg:///${pageImage.imagePath}`
             : "",
           currentScore:
             score?.partialScore !== undefined && score?.partialScore !== null
@@ -541,7 +541,7 @@ export function useScoringFilter({
       id: `master-${currentCropRegion.id}`,
       studentId: "MASTER",
       studentName: "模範解答",
-      imageUrl: masterImagePath ? `appimg://${masterImagePath}` : "",
+      imageUrl: masterImagePath ? `appimg:///${masterImagePath}` : "",
       maxScore: currentCropRegion.points || 0,
       status: "master",
       questionRegion: currentCropRegion,

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -64,14 +64,11 @@ app.on("ready", async () => {
     // appimg:///path/to/file → file:///path/to/file としてローカルファイルを読み込む
     protocol.handle("appimg", (request) => {
       try {
-        const url = new URL(request.url)
-        // pathnameをデコード（日本語やスペースを含むパス対応）
-        let filePath = decodeURIComponent(url.pathname)
-
-        // Windowsの場合、先頭の/を削除（/C:/path → C:/path）
-        if (process.platform === "win32" && filePath.startsWith("/")) {
-          filePath = filePath.slice(1)
-        }
+        // new URL() を使わず文字列操作でパスを抽出
+        // appimg://projects/... や appimg:///projects/... の両方に対応
+        let filePath = decodeURIComponent(
+          request.url.replace(/^appimg:\/\/\/?/, "")
+        )
 
         // 相対パスの場合はデータディレクトリからの絶対パスに変換
         if (!path.isAbsolute(filePath)) {

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -482,8 +482,9 @@ export function setupMiscHandlers(): void {
     async (_event, relativePath: string) => {
       try {
         // パスを適切にエンコード
+        // appimg:/// (スラッシュ3つ) にすることで、URLパース時にpathname全体が取得できる
         const encodedPath = encodeURI(relativePath)
-        const result = `appimg://${encodedPath}`
+        const result = `appimg:///${encodedPath}`
 
         return result
       } catch (err) {
@@ -683,8 +684,8 @@ export function setupMiscHandlers(): void {
 
       const fullPath = path.join(publicDir, assetPath)
 
-      // appimg:// プロトコルを使用してパスを返す（webSecurity有効時のローカルファイルアクセス用）
-      return { success: true, path: `appimg://${fullPath}` }
+      // appimg:/// プロトコルを使用してパスを返す（webSecurity有効時のローカルファイルアクセス用）
+      return { success: true, path: `appimg:///${fullPath}` }
     } catch (err) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Closes #330

- `protocol.handle` 内の `new URL()` パースを正規表現による直接抽出に変更
- 相対パスを `getAbsolutePathFromData()` で絶対パスに変換
- フロントエンド側のURL生成を `appimg:///` に統一

## 変更ファイル

- `electron-src/index.ts` - プロトコルハンドラーのURLパース修正
- `electron-src/ipc-handlers/miscHandlers.ts` - IPC URL生成を `appimg:///` に統一
- `components/pdf-tools/import-panel/hooks/useImportedFiles.ts` - URL生成修正
- `components/projects/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts` - URL生成・解析修正
- `components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts` - URL生成修正

## Test plan

- [x] macOS開発環境で模範解答画像が正常に表示されることを確認
- [ ] Windows版ビルドで画像読み込みが正常に動作することを確認
- [ ] Ubuntu版ビルドで画像読み込みが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)