### PR TITLE
fix: 部分点モーダル確定後の二重ナビゲーションを修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -218,8 +218,7 @@ function ScoringMainViewContent() {
     cropRegions: cropRegions,
   })
 
-  const { handleBatchScoreWithProgress, handleAutoAdvance } =
-    useBatchScoringWithProgress({
+  const { handleBatchScoreWithProgress } = useBatchScoringWithProgress({
       selectedAnswers: selectedStudentAnswerImageIds,
       gradingMode: gradingMode,
       scoringBehavior: scoringBehavior,
@@ -227,7 +226,6 @@ function ScoringMainViewContent() {
       handleBatchScore,
       getGridAnswerData,
       setSelectedAnswers: setSelectedPageImageIds,
-      handleGridNavigation,
       handleNextStudent: handleIndividualNextStudent,
       handleNextQuestion,
     })
@@ -261,7 +259,6 @@ function ScoringMainViewContent() {
     selectedAnswers: selectedStudentAnswerImageIds,
     currentCropRegion,
     onBatchScore: handleBatchScoreWithProgress,
-    onAutoAdvance: handleAutoAdvance,
   })
 
   /** コンテキスト値の設定 */

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
@@ -25,7 +25,6 @@ interface UseBatchScoringWithProgressParams {
   ) => Promise<void>
   getGridAnswerData: () => ScoringDataWithSelection[]
   setSelectedAnswers: (answers: Set<string>) => void
-  handleGridNavigation: (direction: string) => void
   handleNextStudent: () => void
   handleNextQuestion: () => void
 }
@@ -38,7 +37,6 @@ export function useBatchScoringWithProgress({
   handleBatchScore,
   getGridAnswerData,
   setSelectedAnswers,
-  handleGridNavigation,
   handleNextStudent,
   handleNextQuestion,
 }: UseBatchScoringWithProgressParams) {
@@ -133,30 +131,7 @@ export function useBatchScoringWithProgress({
     ]
   )
 
-  // 自動進行関数
-  const handleAutoAdvance = useCallback(() => {
-    if (gradingMode === "grid") {
-      // グリッドモードでは次の答案に移動
-      handleGridNavigation("d")
-    } else {
-      // 個別モードではscoringBehaviorに従って移動
-      if (scoringBehavior === "next-student") {
-        handleNextStudent()
-      } else if (scoringBehavior === "next-question") {
-        handleNextQuestion()
-      }
-      // "stay"の場合は何もしない
-    }
-  }, [
-    gradingMode,
-    scoringBehavior,
-    handleGridNavigation,
-    handleNextStudent,
-    handleNextQuestion,
-  ])
-
   return {
     handleBatchScoreWithProgress,
-    handleAutoAdvance,
   }
 }

--- a/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -17,14 +17,12 @@ interface UsePartialScoreProps {
     partialScore?: number | null,
     selectedAnswers?: Set<string>
   ) => void
-  onAutoAdvance?: () => void // 自動進行コールバック
 }
 
 export function usePartialScore({
   selectedAnswers,
   currentCropRegion,
   onBatchScore,
-  onAutoAdvance,
 }: UsePartialScoreProps) {
   const { setContextValue } = useShortcutContext()
   // 部分点入力モーダル用状態
@@ -133,12 +131,6 @@ export function usePartialScore({
       blurActiveElement()
       setContextValue("inputFocus", false)
 
-      // 自動進行（300ms後に実行）
-      if (onAutoAdvance) {
-        setTimeout(() => {
-          onAutoAdvance()
-        }, 300)
-      }
     },
     [
       showPartialScoreModal,
@@ -146,7 +138,6 @@ export function usePartialScore({
       partialScoreInput,
       currentCropRegion,
       onBatchScore,
-      onAutoAdvance,
       blurActiveElement,
       setContextValue,
     ]


### PR DESCRIPTION
## Summary

- 部分点確定時の二重ナビゲーション（`handleBatchScoreWithProgress` + `onAutoAdvance`）を解消
- `handleBatchScoreWithProgress` のインデックスベース自動進行に一本化
- 不要になった `handleAutoAdvance` 関数と `onAutoAdvance` プロップを削除

Closes #332

## Test plan

- [ ] グリッドモードで部分点モーダルを開き、Fキーで確定 → 次の答案に正しく移動することを確認
- [ ] Jキー（保留確定）でも同様に確認
- [ ] 通常の採点（E/Q/Oキー等）でも自動進行が正常に動作することを確認
- [ ] 個別モードでも部分点確定後の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)