### PR TITLE
fix: グリッドモードの「下→左」レイアウト方向が「下→右」と同一になるバグを修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -206,6 +206,8 @@ export default function AnswerGridView({
             ? "minmax(200px, max-content)"
             : undefined,
           gridAutoFlow: isColumnLayout ? "column" : "row",
+          direction:
+            layoutDirection === "down-left" ? "rtl" : "ltr",
           width: isColumnLayout ? "max-content" : "100%",
           // 列レイアウト時は高さを100%にして、行ごとに均等分割
           height: isColumnLayout ? "100%" : "max-content",

--- a/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/projects/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -101,6 +101,9 @@ export function GridCell({
       maxHeight: calculatedCellHeight,
       overflow: "hidden",
     }),
+    ...(layoutDirection === "down-left" && {
+      direction: "ltr" as const,
+    }),
     ...cellBgStyle,
   }
 


### PR DESCRIPTION
## Summary

- グリッドモードの「下→左」レイアウト方向が「下→右」と同一動作になるバグを修正
- CSS `direction: rtl` でグリッドコンテナの列配置順を右→左に反転
- 子要素に `direction: ltr` を設定しテキスト方向を維持

Closes #334

## 変更ファイル

- `AnswerGridView.tsx`: グリッドコンテナに `direction` プロパティを追加
- `GridCell.tsx`: `down-left` 時にセル内の `direction: ltr` を設定

## Test plan

- [ ] 「下→右」レイアウトで列が左→右に並ぶことを確認
- [ ] 「下→左」レイアウトで列が右→左に並ぶことを確認
- [ ] 「下→左」でWASD操作・採点後の自動進行が正常動作することを確認
- [ ] 「右→下」「左→下」レイアウトに影響がないことを確認
- [ ] `npm run typecheck` で型エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)