### PR TITLE
fix: 部分点モーダル連続操作時のf/jキー無効化バグを修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
@@ -212,8 +212,9 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
     hasSelectedAnswers: false,
   })
 
-  // コマンドレジストリ（commandId -> CommandHandler）
-  const [commands, setCommands] = useState<Map<string, CommandHandler>>(
+  // コマンドレジストリ（commandId -> CommandHandler[]）
+  // 同一commandIdに異なるwhen句を持つ複数ハンドラーを共存させる
+  const [commands, setCommands] = useState<Map<string, CommandHandler[]>>(
     new Map()
   )
 
@@ -268,29 +269,36 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
   const registerCommand = useCallback((command: CommandHandler) => {
     setCommands((prev) => {
       const next = new Map(prev)
-
-      // 重複登録の警告（開発環境のみ）
-      if (
-        process.env.NODE_ENV === "development" &&
-        next.has(command.commandId)
-      ) {
-        console.warn(
-          `[ShortcutProvider] Command "${command.commandId}" is already registered. Overwriting.`
-        )
-      }
-
-      next.set(command.commandId, command)
+      const existing = next.get(command.commandId) || []
+      // 同じregistrationIdのハンドラーを置換、それ以外は保持
+      const filtered = existing.filter(
+        (h) => h.registrationId !== command.registrationId
+      )
+      next.set(command.commandId, [...filtered, command])
       return next
     })
   }, [])
 
-  const unregisterCommand = useCallback((commandId: string) => {
-    setCommands((prev) => {
-      const next = new Map(prev)
-      next.delete(commandId)
-      return next
-    })
-  }, [])
+  const unregisterCommand = useCallback(
+    (commandId: string, registrationId: string) => {
+      setCommands((prev) => {
+        const next = new Map(prev)
+        const existing = next.get(commandId)
+        if (existing) {
+          const filtered = existing.filter(
+            (h) => h.registrationId !== registrationId
+          )
+          if (filtered.length === 0) {
+            next.delete(commandId)
+          } else {
+            next.set(commandId, filtered)
+          }
+        }
+        return next
+      })
+    },
+    []
+  )
 
   // ============================================
   // キーバインディングの管理
@@ -332,7 +340,7 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
   // ============================================
 
   const getAllCommands = useCallback(() => {
-    return Array.from(commands.values())
+    return Array.from(commands.values()).flat()
   }, [commands])
 
   // ============================================
@@ -407,39 +415,36 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
       // ============================================
       // 重要: より具体的な条件を持つコマンドを優先
       // ============================================
+      // 全候補ハンドラーを収集（同一commandIdに複数ハンドラーが存在しうる）
+      const candidates: CommandHandler[] = []
+      for (const commandId of commandIds) {
+        const handlers = commands.get(commandId) || []
+        candidates.push(...handlers)
+      }
+
       // when句の複雑さ（&&の数）でソート（降順）
       // より複雑な条件 = より具体的な状況 = 優先度が高い
-      const sortedCommandIds = commandIds.sort((a, b) => {
-        const commandA = commands.get(a)
-        const commandB = commands.get(b)
-        if (!commandA || !commandB) return 0
-
-        const complexityA = (commandA.when.match(/&&/g) || []).length
-        const complexityB = (commandB.when.match(/&&/g) || []).length
-
-        return complexityB - complexityA // 降順（複雑な方が先）
+      candidates.sort((a, b) => {
+        const complexityA = (a.when.match(/&&/g) || []).length
+        const complexityB = (b.when.match(/&&/g) || []).length
+        return complexityB - complexityA
       })
 
-      // 複数のコマンドがある場合、when句が真になる最初のコマンドを実行
-      for (const commandId of sortedCommandIds) {
-        const command = commands.get(commandId)
-        if (!command) {
-          // コマンドが登録されていない（コンポーネントがアンマウント済み）
-          continue
-        }
-
-        // when句を評価
-        const shouldExecute = evaluateWhenClause(command.when, context)
+      // 複数のハンドラーがある場合、when句が真になる最初のものを実行
+      for (const candidate of candidates) {
+        const shouldExecute = evaluateWhenClause(candidate.when, context)
 
         if (shouldExecute) {
-          // 実行条件を満たす最初のコマンドを実行
           event.preventDefault()
           event.stopPropagation()
 
           try {
-            command.handler()
+            candidate.handler()
           } catch (error) {
-            console.error(`Failed to execute command "${commandId}":`, error)
+            console.error(
+              `Failed to execute command "${candidate.commandId}":`,
+              error
+            )
           }
 
           // 最初にマッチしたコマンドのみ実行（VSCodeと同じ動作）

--- a/components/projects/07-score-at-once/ScoringMain/contexts/shortcutContextTypes.ts
+++ b/components/projects/07-score-at-once/ScoringMain/contexts/shortcutContextTypes.ts
@@ -37,6 +37,9 @@ export interface CommandHandler {
   /** コマンドID（例: "scoring.correct"） */
   commandId: string
 
+  /** 各useCommand呼び出しを一意に識別するID */
+  registrationId: string
+
   /** コマンド実行時のハンドラー関数 */
   handler: () => void
 
@@ -87,7 +90,7 @@ export interface ShortcutContextValue {
   registerCommand: (command: CommandHandler) => void
 
   /** コマンドを解除する関数 */
-  unregisterCommand: (commandId: string) => void
+  unregisterCommand: (commandId: string, registrationId: string) => void
 
   /** 現在のキーバインディング */
   keyBindings: KeyBinding

--- a/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -50,6 +50,9 @@ export function usePartialScore({
       if (!showPartialScoreModal) {
         setPartialScoreInput("")
         setShowPartialScoreModal(true)
+        // useEffect遅延を回避するため同期的にコンテキストを更新
+        setContextValue("partialScoreModalOpen", true)
+        setContextValue("modalOpen", true)
       }
 
       const currentInput = partialScoreInput || ""
@@ -96,6 +99,7 @@ export function usePartialScore({
       partialScoreInput,
       showPartialScoreModal,
       showExceedsMaxPointsToast,
+      setContextValue,
     ]
   )
 
@@ -128,9 +132,11 @@ export function usePartialScore({
       // モーダルを閉じる
       setPartialScoreInput("")
       setShowPartialScoreModal(false)
+      // useEffect遅延を回避するため同期的にコンテキストを更新
+      setContextValue("partialScoreModalOpen", false)
+      setContextValue("modalOpen", false)
       blurActiveElement()
       setContextValue("inputFocus", false)
-
     },
     [
       showPartialScoreModal,
@@ -147,6 +153,9 @@ export function usePartialScore({
   const handlePartialScoreCancel = useCallback(() => {
     setPartialScoreInput("")
     setShowPartialScoreModal(false)
+    // useEffect遅延を回避するため同期的にコンテキストを更新
+    setContextValue("partialScoreModalOpen", false)
+    setContextValue("modalOpen", false)
     blurActiveElement()
     setContextValue("inputFocus", false)
   }, [blurActiveElement, setContextValue])

--- a/components/projects/07-score-at-once/hooks/useCommand.ts
+++ b/components/projects/07-score-at-once/hooks/useCommand.ts
@@ -15,7 +15,7 @@
  * ```
  */
 
-import { useCallback, useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useId, useMemo, useRef } from "react"
 
 import type {
   CommandHandler,
@@ -81,6 +81,10 @@ export function useCommand(
 ) {
   const { registerCommand, unregisterCommand } = useShortcutContext()
 
+  // 一意のregistrationIdを生成（useIdで安定化）
+  const reactId = useId()
+  const registrationIdRef = useRef(`${commandId}::${reactId}`)
+
   // handlerの最新版をrefで保持（無限ループ回避）
   const handlerRef = useRef(handler)
   useEffect(() => {
@@ -104,9 +108,12 @@ export function useCommand(
   const when = options.when || "true"
 
   useEffect(() => {
+    const registrationId = registrationIdRef.current
+
     // コマンドオブジェクトを作成
     const command: CommandHandler = {
       commandId,
+      registrationId,
       handler: stableHandler,
       when,
       metadata: stableMetadata,
@@ -117,7 +124,7 @@ export function useCommand(
 
     // アンマウント時に解除
     return () => {
-      unregisterCommand(commandId)
+      unregisterCommand(commandId, registrationId)
     }
   }, [
     commandId,


### PR DESCRIPTION
## Summary
- 同一コマンドIDに対する複数ハンドラーの共存を実現し、コマンド登録の上書き問題を解消
- モーダル開閉時のコンテキスト同期更新により、useEffect遅延による1フレームのタイミング問題を解消
- 素早い連続操作（数字キー→f/j→数字キー→f/j）でもf/jキーが正常に動作するよう修正

Closes #336

## 変更内容

### `shortcutContextTypes.ts`
- `CommandHandler` に `registrationId` フィールドを追加
- `unregisterCommand` の引数に `registrationId` を追加

### `ShortcutProvider.tsx`
- `commands` の型を `Map<string, CommandHandler>` から `Map<string, CommandHandler[]>` に変更
- `registerCommand`: 同一 `registrationId` は置換、異なる `registrationId` は追加する配列方式
- `unregisterCommand`: `registrationId` 指定で特定ハンドラーのみ削除
- keydownハンドラー: 全候補をフラットに収集してwhen句の複雑さでソート

### `useCommand.ts`
- `useId()` で一意の `registrationId` を生成
- cleanup関数でref値をローカル変数にコピー（lint警告対応）

### `usePartialScore.ts`
- モーダル開時・閉時・キャンセル時に `setContextValue` を直接呼び出して同期更新

## Test plan
- [ ] グリッドモードで答案を選択し、数字キー→f→数字キー→fの連続操作が正常に動作すること
- [ ] jキーでの確定も同様に連続操作が正常に動作すること
- [ ] 通常のf/j採点（モーダルなし）が引き続き動作すること
- [ ] Escapeでのモーダルキャンセルが正常に動作すること
- [ ] キーバインディング設定画面が正常に表示されること
- [ ] `npm run typecheck` で型エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)