### PR TITLE
採点画面のuserId不一致バグ修正とアーカイブv1.4.0対応

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/projects/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -32,11 +32,13 @@ import {
   ScoringLoadingState,
 } from "@/components/projects/07-score-at-once/ScoringMain/ScoringStates"
 import { ScoringSidePanel } from "@/components/projects/07-score-at-once/ScoringSidePanel/ScoringSidePanel"
+import { useAuth } from "@/contexts/AuthContext"
 
 /** 内部コンポーネント（ShortcutProvider内で使用） */
 function ScoringMainViewContent() {
   const params = useParams()
   const projectId = params.projectId as string
+  const { user: authUser } = useAuth()
   const { helpButton } = usePageHelp()
   const { keyBindings } = useShortcutContext()
 
@@ -52,7 +54,7 @@ function ScoringMainViewContent() {
 
   /** データローダーフック */
   const { loading, project, studentAnswerImages, cropRegions, currentUserId } =
-    useScoringDataLoader(projectId)
+    useScoringDataLoader(projectId, authUser?.id ?? null)
 
   /** 設定管理フック */
   const {

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
@@ -14,7 +14,8 @@ interface ScoringDataLoaderResult {
 }
 
 export function useScoringDataLoader(
-  projectId: string
+  projectId: string,
+  authUserId: string | null
 ): ScoringDataLoaderResult {
   const [loading, setLoading] = useState(true)
   const [project, setProject] = useState<ProjectWithDetails | null>(null)
@@ -62,13 +63,18 @@ export function useScoringDataLoader(
         // DBレベルでフィルタリング済みなので、順序を保持したまま設定
         setCropRegions(regionsResult as CropRegionWithProjectPage[])
 
-        // ユーザーIDの取得
-        const userData = await window.electronAPI.getCurrentUser()
-        if (userData && userData.id) {
-          setCurrentUserId(userData.id)
+        // ユーザーIDの設定（AuthContextから渡されたIDを優先）
+        if (authUserId) {
+          setCurrentUserId(authUserId)
         } else {
-          console.warn("ユーザーIDが取得できませんでした")
-          setCurrentUserId("default-user")
+          // フォールバック: electronAPI経由で取得
+          const userData = await window.electronAPI.getCurrentUser()
+          if (userData && userData.id) {
+            setCurrentUserId(userData.id)
+          } else {
+            console.warn("ユーザーIDが取得できませんでした")
+            setCurrentUserId("default-user")
+          }
         }
       } catch (error) {
         console.error("データの読み込みに失敗しました:", error)
@@ -81,7 +87,7 @@ export function useScoringDataLoader(
     if (projectId) {
       loadData()
     }
-  }, [projectId])
+  }, [projectId, authUserId])
 
   return {
     loading,

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -11,6 +11,7 @@ import { setupQuestionGroupHandlers } from "./questionGroupHandlers"
 import { setupScoringHandlers } from "./scoringHandlers"
 import { registerSettingsHandlers } from "./settingsHandlers"
 import { setupStudentHandlers } from "./studentHandlers"
+import { setupSubjectHandlers } from "./subjectHandlers"
 import { setupSubtotalGroupHandlers } from "./subtotalGroupHandlers"
 import { setupUserProjectHandlers } from "./userProjectHandlers"
 
@@ -30,4 +31,5 @@ export function setupAllIPCHandlers(): void {
   setupUserProjectHandlers()
   registerSettingsHandlers()
   setupPdfToolsHandlers()
+  setupSubjectHandlers()
 }

--- a/electron-src/ipc-handlers/subjectHandlers.ts
+++ b/electron-src/ipc-handlers/subjectHandlers.ts
@@ -1,0 +1,63 @@
+/**
+ * Subject/SubjectSubtotalGroup IPC ハンドラー
+ */
+
+import { ipcMain } from "electron"
+
+import {
+  createSubject,
+  deleteSubject,
+  getAllSubjects,
+  getSubjectById,
+  updateSubject,
+} from "../lib/prisma/subject"
+import {
+  createSubjectSubtotalGroup,
+  deleteSubjectSubtotalGroup,
+  getSubjectSubtotalGroups,
+} from "../lib/prisma/subjectSubtotalGroup"
+
+export function setupSubjectHandlers(): void {
+  // Subject CRUD
+  ipcMain.handle("subject:getAll", async () => {
+    return getAllSubjects()
+  })
+
+  ipcMain.handle("subject:getById", async (_event, id: string) => {
+    return getSubjectById(id)
+  })
+
+  ipcMain.handle("subject:create", async (_event, data: { name: string }) => {
+    return createSubject(data)
+  })
+
+  ipcMain.handle(
+    "subject:update",
+    async (_event, id: string, data: { name: string }) => {
+      return updateSubject(id, data)
+    }
+  )
+
+  ipcMain.handle("subject:delete", async (_event, id: string) => {
+    return deleteSubject(id)
+  })
+
+  // SubjectSubtotalGroup CRUD
+  ipcMain.handle(
+    "subjectSubtotalGroup:getBySubjectId",
+    async (_event, subjectId: string) => {
+      return getSubjectSubtotalGroups(subjectId)
+    }
+  )
+
+  ipcMain.handle(
+    "subjectSubtotalGroup:create",
+    async (_event, data: { subjectId: string; subtotalGroupId: string }) => {
+      return createSubjectSubtotalGroup(data)
+    }
+  )
+
+  ipcMain.handle("subjectSubtotalGroup:delete", async (_event, id: string) => {
+    return deleteSubjectSubtotalGroup(id)
+  })
+}

--- a/electron-src/lib/export/project-archive/archiveCreator.ts
+++ b/electron-src/lib/export/project-archive/archiveCreator.ts
@@ -173,6 +173,9 @@ export async function createArchive(
       archive.append(JSON.stringify(collectedData.scoresData, null, 2), {
         name: "scores.json",
       })
+      archive.append(JSON.stringify(collectedData.subjectsData, null, 2), {
+        name: "subjects.json",
+      })
 
       // 3. マスター画像を追加
       // 注意: relativePathはdataディレクトリからの相対パス（例: projects/{projectId}/master-answers/image.png）

--- a/electron-src/lib/export/project-archive/dataCollector.ts
+++ b/electron-src/lib/export/project-archive/dataCollector.ts
@@ -10,6 +10,7 @@ import type {
   ArchiveProjectData,
   ArchiveScoresData,
   ArchiveStudentsData,
+  ArchiveSubjectsData,
   ArchiveSubtotalsData,
   ArchiveUsersData,
 } from "../../../../types/projectArchive.types"
@@ -25,6 +26,7 @@ export interface CollectedData {
   usersData: ArchiveUsersData
   subtotalsData: ArchiveSubtotalsData
   scoresData: ArchiveScoresData
+  subjectsData: ArchiveSubjectsData
   counts: ArchiveDataCounts
   /** マスター画像の相対パス一覧 */
   masterImagePaths: string[]
@@ -134,6 +136,39 @@ export async function collectProjectData(
     const subtotalGroups = await prisma.subtotalGroup.findMany({
       where: { id: { in: Array.from(subtotalGroupIds) } },
       include: { subtotals: true },
+    })
+
+    // 7.5. ProjectMarkingFormatを取得
+    const projectMarkingFormats = await prisma.projectMarkingFormat.findMany({
+      where: { projectId },
+    })
+
+    // 7.6. ProjectExportSettingsを取得
+    const projectExportSettings = await prisma.projectExportSettings.findUnique(
+      {
+        where: { projectId },
+      }
+    )
+
+    // 7.7. CropRegionMarkingOverrideを取得
+    const cropRegionIds = project.projectPages.flatMap((page) =>
+      page.cropRegions.map((r) => r.id)
+    )
+    const cropRegionMarkingOverrides =
+      await prisma.cropRegionMarkingOverride.findMany({
+        where: { cropRegionId: { in: cropRegionIds } },
+      })
+
+    // 7.8. Subject/SubjectSubtotalGroupを取得（subtotalGroup経由）
+    const subtotalGroupIdArray = Array.from(subtotalGroupIds)
+    const subjectSubtotalGroups = await prisma.subjectSubtotalGroup.findMany({
+      where: { subtotalGroupId: { in: subtotalGroupIdArray } },
+    })
+    const subjectIds = [
+      ...new Set(subjectSubtotalGroups.map((ssg) => ssg.subjectId)),
+    ]
+    const subjects = await prisma.subject.findMany({
+      where: { id: { in: subjectIds } },
     })
 
     // CropSubtotalを収集
@@ -311,6 +346,37 @@ export async function collectProjectData(
         createdAt: pc.createdAt.toISOString(),
         updatedAt: pc.updatedAt.toISOString(),
       })),
+      // v1.4.0+
+      projectMarkingFormats: projectMarkingFormats.map((pmf) => ({
+        id: pmf.id,
+        projectId: pmf.projectId,
+        markType: pmf.markType,
+        symbol: pmf.symbol,
+        color: pmf.color,
+        fontSize: pmf.fontSize,
+        strokeWidth: pmf.strokeWidth,
+        createdAt: pmf.createdAt.toISOString(),
+        updatedAt: pmf.updatedAt.toISOString(),
+      })),
+      projectExportSettings: projectExportSettings
+        ? {
+            id: projectExportSettings.id,
+            projectId: projectExportSettings.projectId,
+            settingsJson: projectExportSettings.settingsJson,
+            createdAt: projectExportSettings.createdAt.toISOString(),
+            updatedAt: projectExportSettings.updatedAt.toISOString(),
+          }
+        : null,
+      cropRegionMarkingOverrides: cropRegionMarkingOverrides.map((crmo) => ({
+        id: crmo.id,
+        cropRegionId: crmo.cropRegionId,
+        markType: crmo.markType,
+        symbol: crmo.symbol,
+        color: crmo.color,
+        visible: crmo.visible,
+        createdAt: crmo.createdAt.toISOString(),
+        updatedAt: crmo.updatedAt.toISOString(),
+      })),
     }
 
     const studentsData: ArchiveStudentsData = {
@@ -394,6 +460,22 @@ export async function collectProjectData(
       drawingAnnotations,
     }
 
+    const subjectsData: ArchiveSubjectsData = {
+      subjects: subjects.map((s) => ({
+        id: s.id,
+        name: s.name,
+        createdAt: s.createdAt.toISOString(),
+        updatedAt: s.updatedAt.toISOString(),
+      })),
+      subjectSubtotalGroups: subjectSubtotalGroups.map((ssg) => ({
+        id: ssg.id,
+        subjectId: ssg.subjectId,
+        subtotalGroupId: ssg.subtotalGroupId,
+        createdAt: ssg.createdAt.toISOString(),
+        updatedAt: ssg.updatedAt.toISOString(),
+      })),
+    }
+
     // 11. 件数を集計
     const counts: ArchiveDataCounts = {
       students: students.length,
@@ -417,6 +499,7 @@ export async function collectProjectData(
         usersData,
         subtotalsData,
         scoresData,
+        subjectsData,
         counts,
         masterImagePaths,
         answerSheetPaths,

--- a/electron-src/lib/import/project-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/project-archive/archiveExtractor.ts
@@ -15,6 +15,7 @@ import type {
   ArchiveProjectData,
   ArchiveScoresData,
   ArchiveStudentsData,
+  ArchiveSubjectsData,
   ArchiveSubtotalsData,
   ArchiveUsersData,
 } from "../../../../types/projectArchive.types"
@@ -37,6 +38,8 @@ export interface ExtractedArchiveData {
   subtotalsData: ArchiveSubtotalsData
   /** 採点データ */
   scoresData: ArchiveScoresData
+  /** 教科データ (v1.4.0+) */
+  subjectsData: ArchiveSubjectsData
   /** 一時展開ディレクトリパス */
   tempDir: string
   /** マスター画像のパス一覧 (展開後のフルパス) */
@@ -102,6 +105,12 @@ export async function extractArchive(archivePath: string): Promise<{
     )
     const scoresData = readJsonFile<ArchiveScoresData>(tempDir, "scores.json")
 
+    // v1.4.0+: 教科データ（存在しない場合はデフォルト値）
+    const subjectsData = readJsonFile<ArchiveSubjectsData>(
+      tempDir,
+      "subjects.json"
+    ) ?? { subjects: [], subjectSubtotalGroups: [] }
+
     if (
       !projectData ||
       !studentsData ||
@@ -131,6 +140,7 @@ export async function extractArchive(archivePath: string): Promise<{
         usersData,
         subtotalsData,
         scoresData,
+        subjectsData,
         tempDir,
         masterImagePaths,
         answerSheetPaths,

--- a/electron-src/lib/import/project-archive/dataCreator.ts
+++ b/electron-src/lib/import/project-archive/dataCreator.ts
@@ -4,6 +4,8 @@
  * インポートデータをデータベースに作成
  */
 
+import { randomUUID } from "crypto"
+
 import type { ArchiveDataCounts } from "../../../../types/projectArchive.types"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "./archiveExtractor"
@@ -147,6 +149,63 @@ export async function createImportedData(
         })
       }
 
+      // 6.5. Subject/SubjectSubtotalGroupを作成 (v1.4.0+)
+      const subjectsData = data.subjectsData
+      if (subjectsData) {
+        for (const subject of subjectsData.subjects) {
+          await tx.subject.upsert({
+            where: { name: subject.name },
+            update: {},
+            create: {
+              id: remapIdRequired(subject.id, mappings.subject),
+              name: subject.name,
+            },
+          })
+        }
+
+        for (const ssg of subjectsData.subjectSubtotalGroups) {
+          const newSubjectId = remapId(ssg.subjectId, mappings.subject)
+          const newSubtotalGroupId = remapId(
+            ssg.subtotalGroupId,
+            mappings.subtotalGroup
+          )
+          if (newSubjectId && newSubtotalGroupId) {
+            // subjectのIDがupsertで変わっている可能性があるため、名前で実際のIDを取得
+            const originalSubject = subjectsData.subjects.find(
+              (s) => s.id === ssg.subjectId
+            )
+            if (originalSubject) {
+              const actualSubject = await tx.subject.findUnique({
+                where: { name: originalSubject.name },
+              })
+              if (actualSubject) {
+                // 重複チェック
+                const existing = await tx.subjectSubtotalGroup.findUnique({
+                  where: {
+                    subjectId_subtotalGroupId: {
+                      subjectId: actualSubject.id,
+                      subtotalGroupId: newSubtotalGroupId,
+                    },
+                  },
+                })
+                if (!existing) {
+                  await tx.subjectSubtotalGroup.create({
+                    data: {
+                      id: remapIdRequired(
+                        ssg.id,
+                        mappings.subjectSubtotalGroup
+                      ),
+                      subjectId: actualSubject.id,
+                      subtotalGroupId: newSubtotalGroupId,
+                    },
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
+
       // 7. プロジェクトを作成
       const project = data.projectData.project
       await tx.project.create({
@@ -161,8 +220,17 @@ export async function createImportedData(
 
       // 8. UserProjectを作成（現在のログインユーザーのみ）
       // v0.3.0以降: アーカイブ内のUserProjectは無視し、現在のユーザーをOWNERとして作成
+      // UserProjectのIDはuserProject mappingから取得、空の場合は新規UUID
+      const userProjectId =
+        data.projectData.userProjects.length > 0
+          ? remapIdRequired(
+              data.projectData.userProjects[0].id,
+              mappings.userProject
+            )
+          : randomUUID()
       await tx.userProject.create({
         data: {
+          id: userProjectId,
           userId: currentUserId,
           projectId: newProjectId,
           role: "OWNER",
@@ -170,6 +238,33 @@ export async function createImportedData(
           invitedBy: null,
         },
       })
+
+      // 8.5. ProjectMarkingFormatを作成 (v1.4.0+)
+      for (const pmf of data.projectData.projectMarkingFormats || []) {
+        await tx.projectMarkingFormat.create({
+          data: {
+            id: remapIdRequired(pmf.id, mappings.projectMarkingFormat),
+            projectId: newProjectId,
+            markType: pmf.markType,
+            symbol: pmf.symbol,
+            color: pmf.color,
+            fontSize: pmf.fontSize,
+            strokeWidth: pmf.strokeWidth,
+          },
+        })
+      }
+
+      // 8.6. ProjectExportSettingsを作成 (v1.4.0+)
+      const pes = data.projectData.projectExportSettings
+      if (pes) {
+        await tx.projectExportSettings.create({
+          data: {
+            id: remapIdRequired(pes.id, mappings.projectExportSettings),
+            projectId: newProjectId,
+            settingsJson: pes.settingsJson,
+          },
+        })
+      }
 
       // 9. ProjectSubtotalGroupを作成
       for (const psg of data.projectData.projectSubtotalGroups) {
@@ -251,6 +346,23 @@ export async function createImportedData(
             orderIndex: region.orderIndex,
           },
         })
+      }
+
+      // 12.5. CropRegionMarkingOverrideを作成 (v1.4.0+)
+      for (const crmo of data.projectData.cropRegionMarkingOverrides || []) {
+        const newCropRegionId = remapId(crmo.cropRegionId, mappings.cropRegion)
+        if (newCropRegionId) {
+          await tx.cropRegionMarkingOverride.create({
+            data: {
+              id: remapIdRequired(crmo.id, mappings.cropRegionMarkingOverride),
+              cropRegionId: newCropRegionId,
+              markType: crmo.markType,
+              symbol: crmo.symbol,
+              color: crmo.color,
+              visible: crmo.visible,
+            },
+          })
+        }
       }
 
       // 13. CropSubtotalを作成

--- a/electron-src/lib/import/project-archive/idRemapper.ts
+++ b/electron-src/lib/import/project-archive/idRemapper.ts
@@ -50,6 +50,16 @@ export interface IdMappings {
   questionScore: Record<string, string>
   /** DrawingAnnotation ID: 旧ID -> 新ID */
   drawingAnnotation: Record<string, string>
+  /** ProjectMarkingFormat ID: 旧ID -> 新ID (v1.4.0+) */
+  projectMarkingFormat: Record<string, string>
+  /** ProjectExportSettings ID: 旧ID -> 新ID (v1.4.0+) */
+  projectExportSettings: Record<string, string>
+  /** CropRegionMarkingOverride ID: 旧ID -> 新ID (v1.4.0+) */
+  cropRegionMarkingOverride: Record<string, string>
+  /** Subject ID: 旧ID -> 新ID (v1.4.0+) */
+  subject: Record<string, string>
+  /** SubjectSubtotalGroup ID: 旧ID -> 新ID (v1.4.0+) */
+  subjectSubtotalGroup: Record<string, string>
 }
 
 /**
@@ -81,6 +91,11 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     cropSubtotal: {},
     questionScore: {},
     drawingAnnotation: {},
+    projectMarkingFormat: {},
+    projectExportSettings: {},
+    cropRegionMarkingOverride: {},
+    subject: {},
+    subjectSubtotalGroup: {},
   }
 
   // プロジェクト
@@ -174,6 +189,35 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // DrawingAnnotation
   for (const da of data.scoresData.drawingAnnotations) {
     mappings.drawingAnnotation[da.id] = randomUUID()
+  }
+
+  // v1.4.0+: ProjectMarkingFormat
+  for (const pmf of data.projectData.projectMarkingFormats || []) {
+    mappings.projectMarkingFormat[pmf.id] = randomUUID()
+  }
+
+  // v1.4.0+: ProjectExportSettings
+  if (data.projectData.projectExportSettings) {
+    mappings.projectExportSettings[data.projectData.projectExportSettings.id] =
+      randomUUID()
+  }
+
+  // v1.4.0+: CropRegionMarkingOverride
+  for (const crmo of data.projectData.cropRegionMarkingOverrides || []) {
+    mappings.cropRegionMarkingOverride[crmo.id] = randomUUID()
+  }
+
+  // v1.4.0+: Subject
+  const subjectsData = data.subjectsData
+  if (subjectsData) {
+    for (const subject of subjectsData.subjects) {
+      mappings.subject[subject.id] = randomUUID()
+    }
+
+    // SubjectSubtotalGroup
+    for (const ssg of subjectsData.subjectSubtotalGroups) {
+      mappings.subjectSubtotalGroup[ssg.id] = randomUUID()
+    }
   }
 
   return mappings

--- a/electron-src/lib/import/transformers/V1_3_0_to_V1_4_0.ts
+++ b/electron-src/lib/import/transformers/V1_3_0_to_V1_4_0.ts
@@ -1,0 +1,53 @@
+/**
+ * v1.3.0 → v1.4.0 変換器
+ *
+ * 主な変更点:
+ * - ProjectMarkingFormat, ProjectExportSettings, CropRegionMarkingOverride をプロジェクトデータに追加
+ * - Subject, SubjectSubtotalGroup を教科データとして追加
+ *
+ * v1.3.0形式のアーカイブにはこれらのフィールドが存在しないため、
+ * デフォルト値（空配列/null）を設定する
+ */
+
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  TransformResult,
+  VersionTransformer,
+} from "./types"
+
+export class V1_3_0_to_V1_4_0_Transformer implements VersionTransformer {
+  readonly fromVersion: ArchiveVersion = "1.3.0"
+  readonly toVersion: ArchiveVersion = "1.4.0"
+
+  transform(data: ArchiveData): TransformResult {
+    const warnings: string[] = []
+
+    warnings.push(
+      `アーカイブはv0.5.x形式(archive v${this.fromVersion})で作成されています。` +
+        `採点マーク設定・エクスポート設定・設問別マークオーバーライド・教科データが追加されます。`
+    )
+
+    return {
+      data: {
+        ...data,
+        manifest: {
+          ...data.manifest,
+          version: this.toVersion,
+        },
+        projectData: {
+          ...data.projectData,
+          projectMarkingFormats: data.projectData.projectMarkingFormats ?? [],
+          projectExportSettings: data.projectData.projectExportSettings ?? null,
+          cropRegionMarkingOverrides:
+            data.projectData.cropRegionMarkingOverrides ?? [],
+        },
+        subjectsData: data.subjectsData ?? {
+          subjects: [],
+          subjectSubtotalGroups: [],
+        },
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/transformers/index.ts
+++ b/electron-src/lib/import/transformers/index.ts
@@ -16,6 +16,7 @@ import { CURRENT_VERSION, SUPPORTED_VERSIONS } from "./types"
 import { V1_0_0_to_V1_1_0_Transformer } from "./V1_0_0_to_V1_1_0"
 import { V1_1_0_to_V1_2_0_Transformer } from "./V1_1_0_to_V1_2_0"
 import { V1_2_0_to_V1_3_0_Transformer } from "./V1_2_0_to_V1_3_0"
+import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 
 // =============================================================================
 // Transformer Registry
@@ -30,6 +31,7 @@ const TRANSFORMERS: VersionTransformer[] = [
   new V1_0_0_to_V1_1_0_Transformer(),
   new V1_1_0_to_V1_2_0_Transformer(),
   new V1_2_0_to_V1_3_0_Transformer(),
+  new V1_3_0_to_V1_4_0_Transformer(),
 ]
 
 /**
@@ -230,3 +232,4 @@ export { CURRENT_VERSION, SUPPORTED_VERSIONS } from "./types"
 export { V1_0_0_to_V1_1_0_Transformer } from "./V1_0_0_to_V1_1_0"
 export { V1_1_0_to_V1_2_0_Transformer } from "./V1_1_0_to_V1_2_0"
 export { V1_2_0_to_V1_3_0_Transformer } from "./V1_2_0_to_V1_3_0"
+export { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -11,6 +11,7 @@ import type {
   ArchiveProjectData,
   ArchiveScoresData,
   ArchiveStudentsData,
+  ArchiveSubjectsData,
   ArchiveSubtotalsData,
   ArchiveUsersData,
 } from "../../../../types/projectArchive.types"
@@ -26,11 +27,12 @@ import type {
  * - 1.1.0: v0.3.x (UserProject完全対応, ProjectClass追加, PageImage使用)
  * - 1.2.0: v0.4.x (MasterImage/StudentAnswerImage分離, userId/studentId非NULL)
  * - 1.3.0: v0.5.x (Student.studentId → Student.studentNumber リネーム)
+ * - 1.4.0: v0.5.x (ProjectMarkingFormat, ProjectExportSettings, CropRegionMarkingOverride, Subject, SubjectSubtotalGroup追加)
  */
-export type ArchiveVersion = "1.0.0" | "1.1.0" | "1.2.0" | "1.3.0"
+export type ArchiveVersion = "1.0.0" | "1.1.0" | "1.2.0" | "1.3.0" | "1.4.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.3.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.4.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -38,6 +40,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.1.0",
   "1.2.0",
   "1.3.0",
+  "1.4.0",
 ] as const
 
 // =============================================================================
@@ -55,6 +58,8 @@ export interface ArchiveData {
   usersData: ArchiveUsersData
   subtotalsData: ArchiveSubtotalsData
   scoresData: ArchiveScoresData
+  /** v1.4.0+ 教科データ */
+  subjectsData?: ArchiveSubjectsData
 }
 
 /**

--- a/electron-src/lib/import/versionedImporter.ts
+++ b/electron-src/lib/import/versionedImporter.ts
@@ -12,6 +12,7 @@ import type {
   ArchiveProjectData,
   ArchiveScoresData,
   ArchiveStudentsData,
+  ArchiveSubjectsData,
   ArchiveSubtotalsData,
   ArchiveUsersData,
 } from "../../../types/projectArchive.types"
@@ -58,6 +59,8 @@ export interface ExtractedArchiveData {
   usersData: ArchiveUsersData
   subtotalsData: ArchiveSubtotalsData
   scoresData: ArchiveScoresData
+  /** 教科データ (v1.4.0+) */
+  subjectsData?: ArchiveSubjectsData
   tempDir: string
   /** マスター画像のパス一覧 (展開後のフルパス) */
   masterImagePaths: string[]
@@ -73,6 +76,8 @@ export interface TransformedArchiveData extends ExtractedArchiveData {
   originalVersion: ArchiveVersion | "unknown"
   /** 変換時の警告 */
   transformWarnings: string[]
+  /** 教科データ (v1.4.0+、変換後は必須) */
+  subjectsData: ArchiveSubjectsData
 }
 
 // =============================================================================
@@ -100,8 +105,10 @@ export function transformArchiveData(
         `Attempting to process as ${CURRENT_VERSION}.`
     )
 
+    const defaultSubjectsData = { subjects: [], subjectSubtotalGroups: [] }
     return {
       ...data,
+      subjectsData: data.subjectsData ?? defaultSubjectsData,
       originalVersion: "unknown",
       transformWarnings: [
         `アーカイブバージョン ${data.manifest.version} は認識できません。` +
@@ -112,8 +119,10 @@ export function transformArchiveData(
 
   // 変換不要の場合
   if (originalVersion === CURRENT_VERSION) {
+    const defaultSubjectsData = { subjects: [], subjectSubtotalGroups: [] }
     return {
       ...data,
+      subjectsData: data.subjectsData ?? defaultSubjectsData,
       originalVersion,
       transformWarnings: [],
     }
@@ -128,6 +137,7 @@ export function transformArchiveData(
     usersData: data.usersData,
     subtotalsData: data.subtotalsData,
     scoresData: data.scoresData,
+    subjectsData: data.subjectsData,
   }
 
   const result: ChainTransformResult = transformToLatest(archiveData)
@@ -148,6 +158,10 @@ export function transformArchiveData(
     usersData: result.data.usersData,
     subtotalsData: result.data.subtotalsData,
     scoresData: result.data.scoresData,
+    subjectsData: result.data.subjectsData ?? {
+      subjects: [],
+      subjectSubtotalGroups: [],
+    },
     tempDir: data.tempDir,
     masterImagePaths: data.masterImagePaths,
     answerSheetPaths: data.answerSheetPaths,

--- a/electron-src/lib/prisma/subject.ts
+++ b/electron-src/lib/prisma/subject.ts
@@ -1,0 +1,85 @@
+/**
+ * Subject（教科）のPrisma操作関数
+ */
+
+import prisma from "./client"
+
+/**
+ * 全教科を取得
+ */
+export async function getAllSubjects() {
+  return prisma.subject.findMany({
+    orderBy: { name: "asc" },
+  })
+}
+
+/**
+ * IDで教科を取得
+ */
+export async function getSubjectById(id: string) {
+  return prisma.subject.findUnique({
+    where: { id },
+  })
+}
+
+/**
+ * SubtotalGroup IDリストに関連するSubjectを取得
+ */
+export async function getSubjectsBySubtotalGroupIds(
+  subtotalGroupIds: string[]
+) {
+  return prisma.subject.findMany({
+    where: {
+      subjectSubtotalGroups: {
+        some: {
+          subtotalGroupId: { in: subtotalGroupIds },
+        },
+      },
+    },
+    include: {
+      subjectSubtotalGroups: true,
+    },
+  })
+}
+
+/**
+ * 教科を作成
+ */
+export async function createSubject(data: { name: string }) {
+  return prisma.subject.create({
+    data: { name: data.name },
+  })
+}
+
+/**
+ * 教科を更新
+ */
+export async function updateSubject(id: string, data: { name: string }) {
+  return prisma.subject.update({
+    where: { id },
+    data: { name: data.name },
+  })
+}
+
+/**
+ * 教科を削除
+ */
+export async function deleteSubject(id: string) {
+  return prisma.subject.delete({
+    where: { id },
+  })
+}
+
+/**
+ * 名前で検索、なければ作成
+ */
+export async function findOrCreateSubject(name: string) {
+  const existing = await prisma.subject.findUnique({
+    where: { name },
+  })
+  if (existing) return existing
+
+  return prisma.subject.create({
+    data: { name },
+  })
+}

--- a/electron-src/lib/prisma/subjectSubtotalGroup.ts
+++ b/electron-src/lib/prisma/subjectSubtotalGroup.ts
@@ -1,0 +1,60 @@
+/**
+ * SubjectSubtotalGroup（教科-小計グループ関連）のPrisma操作関数
+ */
+
+import prisma from "./client"
+
+/**
+ * 教科のSubtotalGroup関連を取得
+ */
+export async function getSubjectSubtotalGroups(subjectId: string) {
+  return prisma.subjectSubtotalGroup.findMany({
+    where: { subjectId },
+    include: {
+      subtotalGroup: true,
+    },
+  })
+}
+
+/**
+ * SubtotalGroup IDリストから関連を取得
+ */
+export async function getSubjectSubtotalGroupsBySubtotalGroupIds(
+  subtotalGroupIds: string[]
+) {
+  return prisma.subjectSubtotalGroup.findMany({
+    where: { subtotalGroupId: { in: subtotalGroupIds } },
+  })
+}
+
+/**
+ * 関連を作成
+ */
+export async function createSubjectSubtotalGroup(data: {
+  subjectId: string
+  subtotalGroupId: string
+}) {
+  return prisma.subjectSubtotalGroup.create({
+    data,
+  })
+}
+
+/**
+ * 関連を削除
+ */
+export async function deleteSubjectSubtotalGroup(id: string) {
+  return prisma.subjectSubtotalGroup.delete({
+    where: { id },
+  })
+}
+
+/**
+ * 教科の全関連を削除
+ */
+export async function deleteSubjectSubtotalGroupsBySubjectId(
+  subjectId: string
+) {
+  return prisma.subjectSubtotalGroup.deleteMany({
+    where: { subjectId },
+  })
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -918,6 +918,29 @@ contextBridge.exposeInMainWorld("electronAPI", {
     // ドラッグ&ドロップされたFileオブジェクトからパスを取得
     getPathForFile: (file: File) => webUtils.getPathForFile(file),
   },
+
+  // =============================================================================
+  // Subject（教科）
+  // =============================================================================
+  subjectGetAll: () => ipcRenderer.invoke("subject:getAll"),
+  subjectGetById: (id: string) => ipcRenderer.invoke("subject:getById", id),
+  subjectCreate: (data: { name: string }) =>
+    ipcRenderer.invoke("subject:create", data),
+  subjectUpdate: (id: string, data: { name: string }) =>
+    ipcRenderer.invoke("subject:update", id, data),
+  subjectDelete: (id: string) => ipcRenderer.invoke("subject:delete", id),
+
+  // =============================================================================
+  // SubjectSubtotalGroup（教科-小計グループ関連）
+  // =============================================================================
+  subjectSubtotalGroupGetBySubjectId: (subjectId: string) =>
+    ipcRenderer.invoke("subjectSubtotalGroup:getBySubjectId", subjectId),
+  subjectSubtotalGroupCreate: (data: {
+    subjectId: string
+    subtotalGroupId: string
+  }) => ipcRenderer.invoke("subjectSubtotalGroup:create", data),
+  subjectSubtotalGroupDelete: (id: string) =>
+    ipcRenderer.invoke("subjectSubtotalGroup:delete", id),
 })
 
 process.once("loaded", () => {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1706,6 +1706,53 @@ export interface MyAPI {
     /** ドラッグ&ドロップされたFileオブジェクトからパスを取得 */
     getPathForFile: (file: File) => string
   }
+
+  // =============================================================================
+  // Subject（教科）
+  // =============================================================================
+
+  subjectGetAll: () => Promise<
+    Array<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
+  >
+  subjectGetById: (id: string) => Promise<{
+    id: string
+    name: string
+    createdAt: Date
+    updatedAt: Date
+  } | null>
+  subjectCreate: (data: {
+    name: string
+  }) => Promise<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
+  subjectUpdate: (
+    id: string,
+    data: { name: string }
+  ) => Promise<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
+  subjectDelete: (id: string) => Promise<void>
+
+  // =============================================================================
+  // SubjectSubtotalGroup（教科-小計グループ関連）
+  // =============================================================================
+
+  subjectSubtotalGroupGetBySubjectId: (subjectId: string) => Promise<
+    Array<{
+      id: string
+      subjectId: string
+      subtotalGroupId: string
+      createdAt: Date
+      updatedAt: Date
+    }>
+  >
+  subjectSubtotalGroupCreate: (data: {
+    subjectId: string
+    subtotalGroupId: string
+  }) => Promise<{
+    id: string
+    subjectId: string
+    subtotalGroupId: string
+    createdAt: Date
+    updatedAt: Date
+  }>
+  subjectSubtotalGroupDelete: (id: string) => Promise<void>
 }
 
 // =============================================================================

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -605,6 +605,37 @@ export interface ArchiveProjectData {
     createdAt: string
     updatedAt: string
   }>
+  /** v1.4.0+ 採点マーク設定 */
+  projectMarkingFormats?: Array<{
+    id: string
+    projectId: string
+    markType: string
+    symbol: string
+    color: string
+    fontSize: number | null
+    strokeWidth: number | null
+    createdAt: string
+    updatedAt: string
+  }>
+  /** v1.4.0+ エクスポート設定 */
+  projectExportSettings?: {
+    id: string
+    projectId: string
+    settingsJson: string
+    createdAt: string
+    updatedAt: string
+  } | null
+  /** v1.4.0+ 設問別マークオーバーライド */
+  cropRegionMarkingOverrides?: Array<{
+    id: string
+    cropRegionId: string
+    markType: string
+    symbol: string | null
+    color: string | null
+    visible: boolean
+    createdAt: string
+    updatedAt: string
+  }>
 }
 
 /**
@@ -731,6 +762,25 @@ export interface ArchiveScoresData {
     displayX: number
     displayY: number
     userId: string
+    createdAt: string
+    updatedAt: string
+  }>
+}
+
+/**
+ * 教科データ (subjects.json) - v1.4.0+
+ */
+export interface ArchiveSubjectsData {
+  subjects: Array<{
+    id: string
+    name: string
+    createdAt: string
+    updatedAt: string
+  }>
+  subjectSubtotalGroups: Array<{
+    id: string
+    subjectId: string
+    subtotalGroupId: string
     createdAt: string
     updatedAt: string
   }>


### PR DESCRIPTION
## Summary
- 採点画面でインポートデータが未採点表示されるバグをAuthContext経由のuserId取得で修正
- アーカイブバージョンをv1.4.0にバンプし、5つの新規エンティティのエクスポート/インポートに対応
- Subject/SubjectSubtotalGroupのCRUD・IPCハンドラーを新規作成

Closes #348

## 変更内容

### 採点画面バグ修正
- `useScoringDataLoader`: AuthContextから`authUserId`を受け取り、`getCurrentUser()` IPC呼び出しの代わりに使用
- `ScoringMainView`: `useAuth()`で取得したuserIdを`useScoringDataLoader`に渡す

### アーカイブv1.4.0
- `ProjectMarkingFormat`, `ProjectExportSettings`, `CropRegionMarkingOverride`をproject.json内に追加
- `Subject`, `SubjectSubtotalGroup`をsubjects.jsonとして新規追加
- v1.3.0→v1.4.0変換器で後方互換性を維持
- IDリマッパーに5つの新マッピングを追加

### UserProject ID修正
- `dataCreator.ts`でUserProject作成時にidフィールドを明示指定

## Test plan
- [ ] Mac devでエクスポート → インポート → 採点画面で採点済みデータが正しく表示される
- [ ] ProjectMarkingFormat/ExportSettings/CropRegionMarkingOverrideがインポート後に保持される
- [ ] v1.3.0形式のアーカイブがv1.4.0でも正常にインポートできる
- [ ] `npm run typecheck` エラー0件 ✅
- [ ] `npm run lint` エラー0件 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)