### PR TITLE
fix: PDF出力の採点マーク位置設定修正と点数表示の3種類個別設定対応

### DIFF
--- a/components/projects/08-export/ExportMainView.tsx
+++ b/components/projects/08-export/ExportMainView.tsx
@@ -116,7 +116,6 @@ export default function ExportMainView() {
 
   /**
    * scoringMarkConfigをScoringMarkConfigForPdf形式に変換
-   * 常にpartialScoreオブジェクトから読み取る（UIが常にpartialScoreに保存するため）
    */
   const getScoringMarkConfigForPdf =
     useCallback((): ScoringMarkConfigForPdf => {
@@ -132,28 +131,45 @@ export default function ExportMainView() {
               offsetY: scoringMarkConfig.scoreOffsetY || 0,
             }
 
-      // 小計・合計点設定を取得（デフォルトは18px）
-      const summaryScoreSize = scoringMarkConfig.summaryScore?.size ?? 18
+      // 小計点設定を取得（subtotalScore → summaryScore → デフォルトの順でフォールバック）
+      const subtotalScoreConfig = scoringMarkConfig.subtotalScore ??
+        scoringMarkConfig.summaryScore ?? {
+          position: "middle-center",
+          size: 18,
+          offsetX: 0,
+          offsetY: 0,
+        }
 
-      console.log("[DEBUG] getScoringMarkConfigForPdf:", {
-        useSeparateScoreSettings: scoringMarkConfig.useSeparateScoreSettings,
-        partialScore: scoringMarkConfig.partialScore,
-        partialScoreConfig,
-        summaryScoreSize,
-      })
+      // 合計点設定を取得（totalScore → summaryScore → デフォルトの順でフォールバック）
+      const totalScoreConfig = scoringMarkConfig.totalScore ??
+        scoringMarkConfig.summaryScore ?? {
+          position: "middle-center",
+          size: 18,
+          offsetX: 0,
+          offsetY: 0,
+        }
 
       return {
         markPosition: scoringMarkConfig.markPosition,
         markSize: scoringMarkConfig.markSize,
         useTransparent: scoringMarkConfig.useTransparent,
-        showPartialScore: true, // 部分点を表示
+        showPartialScore: true,
         partialScorePosition: partialScoreConfig.position || "middle-center",
         partialScoreSize: partialScoreConfig.size || 14,
         partialScoreOffsetX: partialScoreConfig.offsetX || 0,
         partialScoreOffsetY: partialScoreConfig.offsetY || 0,
-        // 小計・合計点のサイズ設定
-        summaryScoreSize,
-        // ステータスごとの点数表示設定
+        // 小計点用設定
+        subtotalScorePosition: subtotalScoreConfig.position || "middle-center",
+        subtotalScoreSize: subtotalScoreConfig.size || 18,
+        subtotalScoreOffsetX: subtotalScoreConfig.offsetX || 0,
+        subtotalScoreOffsetY: subtotalScoreConfig.offsetY || 0,
+        // 合計点用設定
+        totalScorePosition: totalScoreConfig.position || "middle-center",
+        totalScoreSize: totalScoreConfig.size || 18,
+        totalScoreOffsetX: totalScoreConfig.offsetX || 0,
+        totalScoreOffsetY: totalScoreConfig.offsetY || 0,
+        // ステータスごとの表示設定
+        showMarkForStatus: scoringMarkConfig.showMarkForStatus,
         showScoreForStatus: scoringMarkConfig.showScoreForStatus,
       }
     }, [scoringMarkConfig])

--- a/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
+++ b/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
@@ -6,7 +6,9 @@ import { StatusDisplaySection } from "@/components/projects/08-export/components
 import {
   defaultConfig,
   defaultPartialScoreConfig,
+  defaultSubtotalScoreConfig,
   defaultSummaryScoreConfig,
+  defaultTotalScoreConfig,
   positionLabels,
 } from "@/components/projects/08-export/components/scoring-mark-settings/constants/scoringMarkConstants"
 import type {
@@ -42,8 +44,10 @@ export function ScoringMarkSettingsContainer({
 }: ScoringMarkSettingsContainerProps) {
   const partialScore: ScoreTextConfig =
     config.partialScore || defaultPartialScoreConfig
-  const summaryScore: ScoreTextConfig =
-    config.summaryScore || defaultSummaryScoreConfig
+  const subtotalScore: ScoreTextConfig =
+    config.subtotalScore || defaultSubtotalScoreConfig
+  const totalScore: ScoreTextConfig =
+    config.totalScore || defaultTotalScoreConfig
   const useSeparateSettings = config.useSeparateScoreSettings ?? false
 
   const updateConfig = (updates: Partial<ScoringMarkConfig>) => {
@@ -55,14 +59,20 @@ export function ScoringMarkSettingsContainer({
     updateConfig({ partialScore: { ...partialScore, ...updates } })
   }
 
-  const updateSummaryScore = (updates: Partial<ScoreTextConfig>) => {
-    updateConfig({ summaryScore: { ...summaryScore, ...updates } })
+  const updateSubtotalScore = (updates: Partial<ScoreTextConfig>) => {
+    updateConfig({ subtotalScore: { ...subtotalScore, ...updates } })
   }
 
-  const updateBothScores = (updates: Partial<ScoreTextConfig>) => {
+  const updateTotalScore = (updates: Partial<ScoreTextConfig>) => {
+    updateConfig({ totalScore: { ...totalScore, ...updates } })
+  }
+
+  const updateAllScores = (updates: Partial<ScoreTextConfig>) => {
     updateConfig({
       partialScore: { ...partialScore, ...updates },
-      summaryScore: { ...summaryScore, ...updates },
+      summaryScore: { ...partialScore, ...updates },
+      subtotalScore: { ...subtotalScore, ...updates },
+      totalScore: { ...totalScore, ...updates },
     })
   }
 
@@ -278,23 +288,29 @@ export function ScoringMarkSettingsContainer({
 
         {useSeparateSettings ? (
           <Tabs defaultValue="partial" className="w-full">
-            <TabsList className="grid h-8 w-full grid-cols-2">
+            <TabsList className="grid h-8 w-full grid-cols-3">
               <TabsTrigger value="partial" className="text-xs text-red-600">
-                部分点
+                設問部分点
               </TabsTrigger>
-              <TabsTrigger value="summary" className="text-xs text-blue-600">
-                小計・合計点
+              <TabsTrigger value="subtotal" className="text-xs text-blue-600">
+                小計点
+              </TabsTrigger>
+              <TabsTrigger value="total" className="text-xs text-blue-600">
+                合計点
               </TabsTrigger>
             </TabsList>
             <TabsContent value="partial" className="mt-2">
               {renderScoreSettings(partialScore, updatePartialScore)}
             </TabsContent>
-            <TabsContent value="summary" className="mt-2">
-              {renderScoreSettings(summaryScore, updateSummaryScore)}
+            <TabsContent value="subtotal" className="mt-2">
+              {renderScoreSettings(subtotalScore, updateSubtotalScore)}
+            </TabsContent>
+            <TabsContent value="total" className="mt-2">
+              {renderScoreSettings(totalScore, updateTotalScore)}
             </TabsContent>
           </Tabs>
         ) : (
-          renderScoreSettings(partialScore, updateBothScores)
+          renderScoreSettings(partialScore, updateAllScores)
         )}
       </div>
 

--- a/components/projects/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
+++ b/components/projects/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
@@ -14,12 +14,30 @@ export const defaultPartialScoreConfig: ScoreTextConfig = {
   alignment: "center",
 }
 
-// 小計・合計点用デフォルト設定
+// 小計・合計点用デフォルト設定（後方互換性のため維持）
 export const defaultSummaryScoreConfig: ScoreTextConfig = {
   position: "middle-center",
   offsetX: 0,
   offsetY: 0,
   size: 18, // 小計・合計点はやや大きめ
+  alignment: "center",
+}
+
+// 小計点用デフォルト設定
+export const defaultSubtotalScoreConfig: ScoreTextConfig = {
+  position: "middle-center",
+  offsetX: 0,
+  offsetY: 0,
+  size: 18,
+  alignment: "center",
+}
+
+// 合計点用デフォルト設定
+export const defaultTotalScoreConfig: ScoreTextConfig = {
+  position: "middle-center",
+  offsetX: 0,
+  offsetY: 0,
+  size: 18,
   alignment: "center",
 }
 
@@ -56,8 +74,12 @@ export const defaultConfig: ScoringMarkConfig = {
   useSeparateScoreSettings: false,
   // 部分点設定
   partialScore: { ...defaultPartialScoreConfig },
-  // 小計・合計点設定
+  // 小計・合計点設定（後方互換性のため維持）
   summaryScore: { ...defaultSummaryScoreConfig },
+  // 小計点設定
+  subtotalScore: { ...defaultSubtotalScoreConfig },
+  // 合計点設定
+  totalScore: { ...defaultTotalScoreConfig },
   useTransparent: false,
   // PDF設定
   pageSize: "A4",

--- a/components/projects/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
+++ b/components/projects/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
@@ -60,8 +60,14 @@ export interface ScoringMarkConfig {
   // 部分点（設問ごとの点数）用設定
   partialScore: ScoreTextConfig
 
-  // 小計・合計点用設定
+  // 小計・合計点用設定（後方互換性のため維持）
   summaryScore: ScoreTextConfig
+
+  // 小計点用設定
+  subtotalScore: ScoreTextConfig
+
+  // 合計点用設定
+  totalScore: ScoreTextConfig
 
   // 透明度設定
   useTransparent: boolean

--- a/components/projects/08-export/hooks/useExportPage.ts
+++ b/components/projects/08-export/hooks/useExportPage.ts
@@ -70,10 +70,20 @@ export function useExportPage() {
             )
           if (result.success && result.settings) {
             if (result.settings.scoringMarkConfig) {
-              setScoringMarkConfigState({
+              const saved = result.settings
+                .scoringMarkConfig as Partial<ScoringMarkConfig>
+              // 後方互換性: subtotalScore/totalScore がない場合、summaryScore からフォールバック
+              const mergedConfig: ScoringMarkConfig = {
                 ...defaultScoringMarkConfig,
-                ...result.settings.scoringMarkConfig,
-              })
+                ...saved,
+              }
+              if (!saved.subtotalScore && saved.summaryScore) {
+                mergedConfig.subtotalScore = { ...saved.summaryScore }
+              }
+              if (!saved.totalScore && saved.summaryScore) {
+                mergedConfig.totalScore = { ...saved.summaryScore }
+              }
+              setScoringMarkConfigState(mergedConfig)
             }
             if (result.settings.individualReportOptions) {
               setIndividualReportOptionsState({

--- a/components/projects/08-export/utils/pdfCanvasRenderer.ts
+++ b/components/projects/08-export/utils/pdfCanvasRenderer.ts
@@ -35,7 +35,7 @@ export interface ScoringDataForPdf {
  * 採点マーク設定
  */
 export interface ScoringMarkConfigForPdf {
-  markPosition: string // "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" etc.
+  markPosition: string
   markSize: number
   useTransparent: boolean
   showPartialScore: boolean
@@ -43,9 +43,18 @@ export interface ScoringMarkConfigForPdf {
   partialScoreSize: number
   partialScoreOffsetX: number
   partialScoreOffsetY: number
-  // 小計・合計点のサイズ設定
-  summaryScoreSize: number
-  // ステータスごとの点数表示設定
+  // 小計点用設定
+  subtotalScorePosition: string
+  subtotalScoreSize: number
+  subtotalScoreOffsetX: number
+  subtotalScoreOffsetY: number
+  // 合計点用設定
+  totalScorePosition: string
+  totalScoreSize: number
+  totalScoreOffsetX: number
+  totalScoreOffsetY: number
+  // ステータスごとの表示設定
+  showMarkForStatus?: Record<string, boolean>
   showScoreForStatus?: Record<string, boolean>
 }
 
@@ -444,24 +453,24 @@ function calculateMarkPosition(
   switch (position) {
     case "top-left":
       return { x: regionX + padding, y: regionY + padding }
-    case "top":
+    case "top-center":
       return { x: regionX + (regionWidth - markSize) / 2, y: regionY + padding }
     case "top-right":
       return {
         x: regionX + regionWidth - markSize - padding,
         y: regionY + padding,
       }
-    case "left":
+    case "middle-left":
       return {
         x: regionX + padding,
         y: regionY + (regionHeight - markSize) / 2,
       }
-    case "center":
+    case "middle-center":
       return {
         x: regionX + (regionWidth - markSize) / 2,
         y: regionY + (regionHeight - markSize) / 2,
       }
-    case "right":
+    case "middle-right":
       return {
         x: regionX + regionWidth - markSize - padding,
         y: regionY + (regionHeight - markSize) / 2,
@@ -471,7 +480,7 @@ function calculateMarkPosition(
         x: regionX + padding,
         y: regionY + regionHeight - markSize - padding,
       }
-    case "bottom":
+    case "bottom-center":
       return {
         x: regionX + (regionWidth - markSize) / 2,
         y: regionY + regionHeight - markSize - padding,
@@ -641,12 +650,18 @@ function drawSubtotalScoreText(
   const regionWidth = subtotalData.width * imageWidth
   const regionHeight = subtotalData.height * imageHeight
 
-  // 小計点領域の中央に表示
-  const x = regionX + regionWidth / 2
-  const y = regionY + regionHeight / 2
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.subtotalScorePosition,
+    config.subtotalScoreOffsetX,
+    config.subtotalScoreOffsetY
+  )
 
   ctx.save()
-  ctx.font = `bold ${config.summaryScoreSize}px sans-serif`
+  ctx.font = `bold ${config.subtotalScoreSize}px sans-serif`
   ctx.fillStyle = "#2563eb" // 小計点は青色
   ctx.textAlign = "center"
   ctx.textBaseline = "middle"
@@ -669,12 +684,18 @@ function drawTotalScoreText(
   const regionWidth = totalScoreData.width * imageWidth
   const regionHeight = totalScoreData.height * imageHeight
 
-  // 合計点領域の中央に表示
-  const x = regionX + regionWidth / 2
-  const y = regionY + regionHeight / 2
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.totalScorePosition,
+    config.totalScoreOffsetX,
+    config.totalScoreOffsetY
+  )
 
   ctx.save()
-  ctx.font = `bold ${config.summaryScoreSize}px sans-serif`
+  ctx.font = `bold ${config.totalScoreSize}px sans-serif`
   ctx.fillStyle = "#2563eb" // 合計点も青色
   ctx.textAlign = "center"
   ctx.textBaseline = "middle"
@@ -739,26 +760,32 @@ export async function renderAnswerSheetToCanvas(
 
   // 2. 各設問に対して採点マークと部分点を描画
   for (const scoringData of scoringDataList) {
-    if (scoringData.status === "unscored") continue
+    // ステータスごとのマーク表示判定
+    const shouldShowMark = config.showMarkForStatus
+      ? (config.showMarkForStatus[scoringData.status] ?? true)
+      : scoringData.status !== "unscored"
+    if (!shouldShowMark) {
+      // マークは非表示でも点数テキストは別途判定するため、マーク描画だけスキップ
+    } else {
+      // 採点マーク画像の取得
+      const markKey =
+        scoringData.status === "pending"
+          ? "hold"
+          : scoringData.status === "no_answer"
+            ? "incorrect"
+            : scoringData.status
+      const markImage = scoringMarkImages.get(markKey)
 
-    // 採点マーク画像の取得
-    const markKey =
-      scoringData.status === "pending"
-        ? "hold"
-        : scoringData.status === "no_answer"
-          ? "incorrect"
-          : scoringData.status
-    const markImage = scoringMarkImages.get(markKey)
-
-    if (markImage) {
-      drawScoringMark(
-        ctx,
-        markImage,
-        scoringData.cropRegion,
-        config,
-        imageWidth,
-        imageHeight
-      )
+      if (markImage) {
+        drawScoringMark(
+          ctx,
+          markImage,
+          scoringData.cropRegion,
+          config,
+          imageWidth,
+          imageHeight
+        )
+      }
     }
 
     // 点数テキストの描画


### PR DESCRIPTION
## Summary

- 採点マーク位置のswitch文の値不一致を修正（9方向中5方向が壊れていた）
- `showMarkForStatus`をPDF描画パイプラインに実装（「表示しない」設定が反映されるように）
- 設問部分点・小計点・合計点の3種類で個別に位置/サイズ/オフセットを設定可能に
- 既存設定からの後方互換性フォールバック対応

Closes #361

## Test plan

- [ ] 設定画面で採点マーク位置を「下」に変更 → PDF出力でマークが下部に表示される
- [ ] 正答の「マーク表示」をOFFに → PDF出力で正答マークが非表示になる
- [ ] 「別々に設定」ONで小計点と合計点に別々の位置を設定 → それぞれ独立して反映される
- [ ] 「別々に設定」OFFで位置変更 → 3種類とも同じ位置で表示される
- [ ] 既存の保存済み設定でアプリを起動 → 後方互換性で正常に読み込まれる
- [ ] `npm run typecheck` がエラー0件で通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)