### PR TITLE
fix: PDF加工画面の無限再レンダリングループを修正

### DIFF
--- a/components/pdf-tools/PdfToolsMainView.tsx
+++ b/components/pdf-tools/PdfToolsMainView.tsx
@@ -43,9 +43,9 @@ export default function PdfToolsMainView() {
     )
   }
 
-  const handleOutputPagesChange = (pages: OutputPage[]) => {
+  const handleOutputPagesChange = useCallback((pages: OutputPage[]) => {
     setOutputPages(pages)
-  }
+  }, [])
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- `handleOutputPagesChange` を `useCallback` でメモ化し、`ExportPanel` の `useEffect` による無限ループを解消

Closes #363

## 変更内容
- `components/pdf-tools/PdfToolsMainView.tsx`: `handleOutputPagesChange` を `useCallback` でラップ

## 原因
メモ化されていないコールバック関数が `useEffect` の依存配列に含まれており、毎レンダリングで新しい関数参照 → エフェクト再実行 → 状態更新 → 再レンダリングの無限ループが発生していた。

## Test plan
- [ ] Windows版でPDF加工画面を開き、エラーが発生しないことを確認
- [ ] PDFファイルをインポートし、出力プレビューが正常に表示されることを確認
- [ ] エクスポートモード切り替え時にプレビューが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)