### PR TITLE
個人成績表: 正答率修正・得点率追加・統計の受験状態フィルタ実装

### DIFF
--- a/components/projects/08-export/components/IndividualReportSettings.tsx
+++ b/components/projects/08-export/components/IndividualReportSettings.tsx
@@ -118,6 +118,47 @@ export function IndividualReportSettings({
             }}
           />
         </div>
+        {/* 統計に含める受験状態 */}
+        <div className="mt-2 flex flex-col gap-2">
+          <Label className="text-muted-foreground text-xs">
+            統計に含める受験状態
+          </Label>
+          <div className="flex flex-wrap gap-2">
+            <OptionCard
+              label="受験"
+              checked={options.boxPlotIncludeStatuses.participating}
+              onChange={(v) =>
+                updateOption("boxPlotIncludeStatuses", {
+                  ...options.boxPlotIncludeStatuses,
+                  participating: v,
+                })
+              }
+              variant="sub"
+            />
+            <OptionCard
+              label="見込"
+              checked={options.boxPlotIncludeStatuses.expected}
+              onChange={(v) =>
+                updateOption("boxPlotIncludeStatuses", {
+                  ...options.boxPlotIncludeStatuses,
+                  expected: v,
+                })
+              }
+              variant="sub"
+            />
+            <OptionCard
+              label="欠席"
+              checked={options.boxPlotIncludeStatuses.absent}
+              onChange={(v) =>
+                updateOption("boxPlotIncludeStatuses", {
+                  ...options.boxPlotIncludeStatuses,
+                  absent: v,
+                })
+              }
+              variant="sub"
+            />
+          </div>
+        </div>
       </Section>
 
       {/* 小計点関連 */}
@@ -211,47 +252,6 @@ export function IndividualReportSettings({
                     updateOption("boxPlotSubtotalGroupSelection", selection)
                   }
                 />
-                {/* 受験状態フィルタ */}
-                <div className="flex flex-col gap-2">
-                  <Label className="text-muted-foreground text-xs">
-                    統計に含める受験状態
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <OptionCard
-                      label="受験"
-                      checked={options.boxPlotIncludeStatuses.participating}
-                      onChange={(v) =>
-                        updateOption("boxPlotIncludeStatuses", {
-                          ...options.boxPlotIncludeStatuses,
-                          participating: v,
-                        })
-                      }
-                      variant="sub"
-                    />
-                    <OptionCard
-                      label="見込"
-                      checked={options.boxPlotIncludeStatuses.expected}
-                      onChange={(v) =>
-                        updateOption("boxPlotIncludeStatuses", {
-                          ...options.boxPlotIncludeStatuses,
-                          expected: v,
-                        })
-                      }
-                      variant="sub"
-                    />
-                    <OptionCard
-                      label="欠席"
-                      checked={options.boxPlotIncludeStatuses.absent}
-                      onChange={(v) =>
-                        updateOption("boxPlotIncludeStatuses", {
-                          ...options.boxPlotIncludeStatuses,
-                          absent: v,
-                        })
-                      }
-                      variant="sub"
-                    />
-                  </div>
-                </div>
                 <div className="flex flex-wrap gap-2">
                   <OptionCard
                     label="最小"
@@ -404,9 +404,15 @@ export function IndividualReportSettings({
                     variant="sub"
                   />
                   <OptionCard
-                    label="正答率表示"
+                    label="正答率"
                     checked={options.showCorrectRate}
                     onChange={(v) => updateOption("showCorrectRate", v)}
+                    variant="sub"
+                  />
+                  <OptionCard
+                    label="得点率"
+                    checked={options.showScoreRate ?? false}
+                    onChange={(v) => updateOption("showScoreRate", v)}
                     variant="sub"
                   />
                 </div>

--- a/components/projects/08-export/components/individual-report/IndividualReportPreview.tsx
+++ b/components/projects/08-export/components/individual-report/IndividualReportPreview.tsx
@@ -520,6 +520,7 @@ export function IndividualReportPreview({
 
 /**
  * 統計サマリーセクション
+ * rawTotalScoresから受験状態フィルタ付きで統計を再計算
  */
 function StatsSummary({
   report,
@@ -530,6 +531,79 @@ function StatsSummary({
   options: IndividualReportOptions
   fontScale: number
 }) {
+  // 受験状態フィルタ付きで統計を再計算（箱ひげ図と共通設定）
+  const filteredStats = useMemo(() => {
+    const statuses = options.boxPlotIncludeStatuses
+
+    const raw = report.statistics.rawTotalScores
+    if (!raw || raw.length === 0) return report.statistics
+
+    const includeAll =
+      statuses.participating && statuses.expected && statuses.absent
+    if (includeAll) return report.statistics
+
+    const filterByStatus = (entries: typeof raw) =>
+      entries.filter((e) => {
+        if (e.status === "participating") return statuses.participating
+        if (e.status === "expected") return statuses.expected
+        if (e.status === "absent") return statuses.absent
+        return true
+      })
+
+    const filteredAll = filterByStatus(raw)
+    const allScores = filteredAll.map((e) => e.totalScore)
+
+    // 学級フィルタ
+    const filteredClass = filteredAll.filter(
+      (e) =>
+        e.className === report.studentInfo.className &&
+        e.grade === report.studentInfo.grade
+    )
+    const classScores = filteredClass.map((e) => e.totalScore)
+
+    const avg = (arr: number[]) =>
+      arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
+    const stdDev = (arr: number[]) => {
+      if (arr.length === 0) return 0
+      const a = avg(arr)
+      return Math.sqrt(arr.reduce((s, v) => s + (v - a) ** 2, 0) / arr.length)
+    }
+    const rank = (score: number, scores: number[]) => {
+      const sorted = [...scores].sort((a, b) => b - a)
+      return sorted.findIndex((s) => s <= score) + 1
+    }
+
+    const overallAvg = avg(allScores)
+    const overallStd = stdDev(allScores)
+    const studentScore = report.scoringData.totalScore
+    const deviation =
+      overallStd === 0
+        ? 50
+        : Math.round(((studentScore - overallAvg) / overallStd) * 10 + 50)
+
+    return {
+      ...report.statistics,
+      overall: {
+        ...report.statistics.overall,
+        average: overallAvg,
+        stdDev: overallStd,
+        total: filteredAll.length,
+      },
+      class: {
+        ...report.statistics.class,
+        average: avg(classScores),
+        stdDev: stdDev(classScores),
+        total: filteredClass.length,
+      },
+      personal: {
+        ...report.statistics.personal,
+        deviation,
+        overallRank: rank(studentScore, allScores),
+        classRank: rank(studentScore, classScores),
+      },
+    }
+  }, [report, options.boxPlotIncludeStatuses])
+
   const items: { label: string; value: string }[] = []
 
   // 得点
@@ -545,13 +619,13 @@ function StatsSummary({
     if (options.showAverage === "class" || options.showAverage === "both") {
       items.push({
         label: "学級平均",
-        value: report.statistics.class.average.toFixed(1),
+        value: filteredStats.class.average.toFixed(1),
       })
     }
     if (options.showAverage === "overall" || options.showAverage === "both") {
       items.push({
         label: "全体平均",
-        value: report.statistics.overall.average.toFixed(1),
+        value: filteredStats.overall.average.toFixed(1),
       })
     }
   }
@@ -560,7 +634,7 @@ function StatsSummary({
   if (options.showDeviation) {
     items.push({
       label: "偏差値",
-      value: report.statistics.personal.deviation.toFixed(1),
+      value: filteredStats.personal.deviation.toFixed(1),
     })
   }
 
@@ -569,13 +643,13 @@ function StatsSummary({
     if (options.rankType === "class" || options.rankType === "both") {
       items.push({
         label: "学級順位",
-        value: `${report.statistics.personal.classRank} / ${report.statistics.class.total}`,
+        value: `${filteredStats.personal.classRank} / ${filteredStats.class.total}`,
       })
     }
     if (options.rankType === "overall" || options.rankType === "both") {
       items.push({
         label: "全体順位",
-        value: `${report.statistics.personal.overallRank} / ${report.statistics.overall.total}`,
+        value: `${filteredStats.personal.overallRank} / ${filteredStats.overall.total}`,
       })
     }
   }

--- a/components/projects/08-export/components/individual-report/ScoreTablePreview.tsx
+++ b/components/projects/08-export/components/individual-report/ScoreTablePreview.tsx
@@ -159,6 +159,17 @@ function SingleColumnTable({
                 正答率
               </th>
             )}
+            {options.showScoreRate && (
+              <th
+                style={{
+                  ...headerCellStyle,
+                  textAlign: "center",
+                  width: "15%",
+                }}
+              >
+                得点率
+              </th>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -170,6 +181,8 @@ function SingleColumnTable({
 
             const correctRate =
               report.statistics.questionCorrectRates[item.questionId] ?? 0
+            const scoreRate =
+              report.statistics.questionScoreRates?.[item.questionId] ?? 0
 
             const { mark, markColor } = getMarkInfo(item.status)
 
@@ -204,6 +217,11 @@ function SingleColumnTable({
                     {Math.round(correctRate)}%
                   </td>
                 )}
+                {options.showScoreRate && (
+                  <td style={{ ...cellStyle, textAlign: "center" }}>
+                    {Math.round(scoreRate)}%
+                  </td>
+                )}
               </tr>
             )
           })}
@@ -231,6 +249,17 @@ function SingleColumnTable({
               <td style={{ ...cellStyle, textAlign: "center" }}>-</td>
             )}
             {options.showCorrectRate && (
+              <td
+                style={{
+                  ...cellStyle,
+                  textAlign: "center",
+                  fontWeight: "bold",
+                }}
+              >
+                -
+              </td>
+            )}
+            {options.showScoreRate && (
               <td
                 style={{
                   ...cellStyle,
@@ -360,6 +389,17 @@ function MultiColumnTable({
                       正答率
                     </th>
                   )}
+                  {options.showScoreRate && (
+                    <th
+                      style={{
+                        ...headerCellStyle,
+                        textAlign: "center",
+                        width: "15%",
+                      }}
+                    >
+                      得点率
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -415,6 +455,16 @@ function MultiColumnTable({
                         <td style={{ ...cellStyle, textAlign: "center" }}>
                           {Math.round(
                             report.statistics.questionCorrectRates[
+                              item.questionId
+                            ] ?? 0
+                          )}
+                          %
+                        </td>
+                      )}
+                      {options.showScoreRate && (
+                        <td style={{ ...cellStyle, textAlign: "center" }}>
+                          {Math.round(
+                            report.statistics.questionScoreRates?.[
                               item.questionId
                             ] ?? 0
                           )}

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -16,6 +16,7 @@ import { fetchExportData } from "../excel/dataFetcher"
 import { generateLearningAdvice } from "./adviceGenerator"
 import {
   calculateQuestionCorrectRates,
+  calculateQuestionScoreRates,
   calculateStatisticsForStudent,
 } from "./statisticsCalculator"
 import type {
@@ -109,8 +110,9 @@ export async function fetchIndividualReportData(
       })
     )
 
-    // 設問別正答率を計算（全生徒データを使用）
+    // 設問別正答率・得点率を計算（全生徒データを使用）
     const questionCorrectRates = calculateQuestionCorrectRates(allScoringData)
+    const questionScoreRates = calculateQuestionScoreRates(allScoringData)
 
     // 各生徒のレポートデータを構築
     const reports: IndividualReportData[] = selectedScoringData.map(
@@ -138,7 +140,8 @@ export async function fetchIndividualReportData(
           scoringData.totalScore,
           allScoringData,
           classScoringData,
-          questionCorrectRates
+          questionCorrectRates,
+          questionScoreRates
         )
 
         // 学習アドバイス

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -5,6 +5,7 @@
 import type { ScoringData } from "../../shared/types/exportTypes"
 import type {
   BoxPlotData,
+  RawTotalScoreEntry,
   StatisticsData,
   SubtotalRawScores,
   SubtotalStatistics,
@@ -118,18 +119,42 @@ export function calculateQuestionCorrectRates(
         totalCount++
         if (score.status === "correct") {
           correctCount++
-        } else if (
-          score.status === "partial" &&
-          score.score !== null &&
-          score.maxScore > 0
-        ) {
-          // 部分点の場合は得点率を考慮
-          correctCount += score.score / score.maxScore
         }
       }
     }
 
     rates[questionId] = totalCount > 0 ? (correctCount / totalCount) * 100 : 0
+  }
+
+  return rates
+}
+
+/**
+ * 設問別得点率を計算
+ * 各生徒の得点/配点の平均（部分点を比例的に反映）
+ */
+export function calculateQuestionScoreRates(
+  allScoringData: ScoringData[]
+): Record<string, number> {
+  const rates: Record<string, number> = {}
+
+  if (allScoringData.length === 0) return rates
+
+  const questionIds = allScoringData[0].scores.map((s) => s.questionId)
+
+  for (const questionId of questionIds) {
+    let scoreSum = 0
+    let totalCount = 0
+
+    for (const data of allScoringData) {
+      const score = data.scores.find((s) => s.questionId === questionId)
+      if (score && score.status !== "unscored" && score.maxScore > 0) {
+        totalCount++
+        scoreSum += (score.score ?? 0) / score.maxScore
+      }
+    }
+
+    rates[questionId] = totalCount > 0 ? (scoreSum / totalCount) * 100 : 0
   }
 
   return rates
@@ -232,7 +257,8 @@ export function calculateStatisticsForStudent(
   studentScore: number,
   allScoringData: ScoringData[],
   classScoringData: ScoringData[],
-  questionCorrectRates: Record<string, number>
+  questionCorrectRates: Record<string, number>,
+  questionScoreRates: Record<string, number>
 ): StatisticsData {
   // 全体のスコア配列
   const allScores = allScoringData.map((d) => d.totalScore)
@@ -263,6 +289,15 @@ export function calculateStatisticsForStudent(
   // 小計別生スコア（renderer側でのbox plot再計算用）
   const subtotalRawScores = collectSubtotalRawScores(allScoringData)
 
+  // 全生徒の合計点データ（renderer側での統計再計算用）
+  const rawTotalScores: RawTotalScoreEntry[] = allScoringData.map((d) => ({
+    studentId: d.studentId,
+    totalScore: d.totalScore,
+    status: d.status || ("participating" as const),
+    className: d.className,
+    grade: d.grade,
+  }))
+
   return {
     overall: {
       average: overallAverage,
@@ -282,7 +317,9 @@ export function calculateStatisticsForStudent(
       classRank,
     },
     questionCorrectRates,
+    questionScoreRates,
     subtotalStatistics,
     subtotalRawScores,
+    rawTotalScores,
   }
 }

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -84,7 +84,7 @@ export interface IndividualReportOptions {
   boxPlotSubtotalGroupSelection: SubtotalGroupSelection // 箱ひげ図用グループ選択
   hideUnassignedSubtotals: boolean // 設問と関連付けのない小計点を非表示
   showGroupSubtotals: boolean // グループごとの合計を表示
-  /** 箱ひげ図に含める受験状態（チェックされた状態のみ統計に含める） */
+  /** 統計に含める受験状態（平均・偏差値・順位・箱ひげ図で共通） */
   boxPlotIncludeStatuses: {
     participating: boolean
     expected: boolean
@@ -96,6 +96,7 @@ export interface IndividualReportOptions {
   questionTableColumns: QuestionTableColumns
   questionTableFontSize: FontSizeOption
   showCorrectRate: boolean // 正答率を表示
+  showScoreRate: boolean // 得点率を表示
 
   // 学習アドバイス
   showLearningAdvice: boolean
@@ -149,6 +150,15 @@ export interface StudentSubtotalScore {
 export interface SubtotalRawScores {
   subtotalId: string
   scores: StudentSubtotalScore[]
+}
+
+/** 生徒ごとの合計点データ（renderer側での統計再計算用） */
+export interface RawTotalScoreEntry {
+  studentId: string
+  totalScore: number
+  status: "participating" | "expected" | "absent"
+  className?: string
+  grade?: string
 }
 
 /** 小計別統計データ */
@@ -207,11 +217,17 @@ export interface StatisticsData {
   // 設問別正答率
   questionCorrectRates: Record<string, number>
 
+  // 設問別得点率
+  questionScoreRates: Record<string, number>
+
   // 小計別統計
   subtotalStatistics: SubtotalStatistics[]
 
   // 小計別生スコア（renderer側でのbox plot再計算用）
   subtotalRawScores: SubtotalRawScores[]
+
+  // 全生徒の合計点データ（renderer側での統計再計算用）
+  rawTotalScores: RawTotalScoreEntry[]
 }
 
 /** 学習アドバイス用問題データ */
@@ -324,6 +340,7 @@ export const DEFAULT_INDIVIDUAL_REPORT_OPTIONS: IndividualReportOptions = {
   questionTableColumns: 1,
   questionTableFontSize: 10,
   showCorrectRate: true,
+  showScoreRate: false,
   showLearningAdvice: true,
   adviceOptions: DEFAULT_ADVICE_OPTIONS,
   showComment: false,


### PR DESCRIPTION
## Summary
- 正答率の計算を修正（部分点の比例加算を削除、correctのみカウント）
- 得点率（得点/配点の平均）を新規追加し、正答率と独立して表示可能に
- 統計（平均・偏差値・順位・箱ひげ図）に含める受験状態の選択チェックボックスを共通設定として追加

Closes #365

## Test plan
- [ ] 正答率が correct のみでカウントされることを確認
- [ ] 得点率が部分点を比例的に反映していることを確認
- [ ] 正答率・得点率を個別にON/OFF切り替えできることを確認
- [ ] 受験状態チェックボックスの変更が平均・偏差値・順位・箱ひげ図に即時反映されることを確認
- [ ] 欠席者を除外した場合の統計値が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)