### PR TITLE
refactor: 個人成績表のプレビューとPDF出力を統合リファクタリング

### DIFF
--- a/components/projects/08-export/components/individual-report/BoxPlotChart.tsx
+++ b/components/projects/08-export/components/individual-report/BoxPlotChart.tsx
@@ -4,22 +4,28 @@
  * 箱ひげ図コンポーネント
  * SVGで描画し、印刷時もきれいにスケール
  * renderer側で欠席生徒の除外オプションに基づいて統計を再計算
+ *
+ * BoxPlotChart: hooks付きラッパー（プレビュー用）
+ * BoxPlotChartView: 純粋ビュー（プレビュー＋PDF出力共用）
  */
 import { useMemo } from "react"
 
 import type {
-  BoxPlotData,
   StatisticsData,
   SubtotalGroupSelection,
-  SubtotalRawScores,
 } from "@/electron-src/lib/export/individual-report/types"
 import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
 
-/** 受験状態フィルタ */
-interface BoxPlotIncludeStatuses {
-  participating: boolean
-  expected: boolean
-  absent: boolean
+import {
+  type BoxPlotIncludeStatuses,
+  type ComputedSubtotalStat,
+  computeFilteredSubtotalStats,
+} from "./computeReportData"
+
+const DEFAULT_INCLUDE_STATUSES: BoxPlotIncludeStatuses = {
+  participating: true,
+  expected: true,
+  absent: true,
 }
 
 interface BoxPlotChartProps {
@@ -41,130 +47,8 @@ interface BoxPlotChartProps {
 }
 
 /**
- * 配列の中央値を計算
+ * hooks付きラッパー（プレビュー用）
  */
-function calculateMedian(sortedValues: number[]): number {
-  const n = sortedValues.length
-  if (n === 0) return 0
-  if (n === 1) return sortedValues[0]
-
-  const mid = Math.floor(n / 2)
-  if (n % 2 === 0) {
-    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
-  } else {
-    return sortedValues[mid]
-  }
-}
-
-/**
- * 配列の平均値を計算
- */
-function calculateAverage(values: number[]): number {
-  if (values.length === 0) return 0
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}
-
-/**
- * 箱ひげ図データを計算（Tukey法）
- */
-function calculateBoxPlotData(values: number[]): BoxPlotData {
-  if (values.length === 0) {
-    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
-  }
-
-  const sorted = [...values].sort((a, b) => a - b)
-  const n = sorted.length
-
-  const min = sorted[0]
-  const max = sorted[n - 1]
-  const median = calculateMedian(sorted)
-
-  const midIndex = Math.floor(n / 2)
-  const lowerHalf = sorted.slice(0, midIndex)
-  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
-
-  const q1 = calculateMedian(lowerHalf)
-  const q3 = calculateMedian(upperHalf)
-
-  return { min, q1, median, q3, max }
-}
-
-/**
- * 小計ごとの統計データを計算（受験状態フィルタ対応）
- */
-interface ComputedSubtotalStat {
-  subtotalId: string
-  subtotalLabel: string
-  subtotalGroupId: string
-  boxPlot: BoxPlotData
-  average: number
-  maxScore: number
-}
-
-const DEFAULT_INCLUDE_STATUSES: BoxPlotIncludeStatuses = {
-  participating: true,
-  expected: true,
-  absent: true,
-}
-
-function computeSubtotalStats(
-  rawScores: SubtotalRawScores[],
-  subtotalStatistics: StatisticsData["subtotalStatistics"],
-  includeStatuses: BoxPlotIncludeStatuses
-): ComputedSubtotalStat[] {
-  // 全て含める場合は元の統計をそのまま使用
-  const includeAll =
-    includeStatuses.participating &&
-    includeStatuses.expected &&
-    includeStatuses.absent
-
-  return subtotalStatistics.map((stat) => {
-    const rawData = rawScores.find((r) => r.subtotalId === stat.subtotalId)
-
-    if (!rawData || includeAll) {
-      // 生データがないか、全て含める場合は元の統計をそのまま使用
-      return {
-        subtotalId: stat.subtotalId,
-        subtotalLabel: stat.subtotalLabel,
-        subtotalGroupId: stat.subtotalGroupId,
-        boxPlot: stat.boxPlot,
-        average: stat.average,
-        maxScore: stat.maxScore,
-      }
-    }
-
-    // 選択された受験状態のみでスコア配列を作成
-    const filteredScores = rawData.scores
-      .filter((s) => {
-        if (s.status === "participating") return includeStatuses.participating
-        if (s.status === "expected") return includeStatuses.expected
-        if (s.status === "absent") return includeStatuses.absent
-        return true
-      })
-      .map((s) => s.score)
-
-    if (filteredScores.length === 0) {
-      return {
-        subtotalId: stat.subtotalId,
-        subtotalLabel: stat.subtotalLabel,
-        subtotalGroupId: stat.subtotalGroupId,
-        boxPlot: { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
-        average: 0,
-        maxScore: stat.maxScore,
-      }
-    }
-
-    return {
-      subtotalId: stat.subtotalId,
-      subtotalLabel: stat.subtotalLabel,
-      subtotalGroupId: stat.subtotalGroupId,
-      boxPlot: calculateBoxPlotData(filteredScores),
-      average: calculateAverage(filteredScores),
-      maxScore: stat.maxScore,
-    }
-  })
-}
-
 export function BoxPlotChart({
   statistics,
   scoringData,
@@ -184,7 +68,7 @@ export function BoxPlotChart({
 }: BoxPlotChartProps) {
   // renderer側で統計を再計算（受験状態フィルタ対応）
   const computedStats = useMemo(() => {
-    return computeSubtotalStats(
+    return computeFilteredSubtotalStats(
       statistics.subtotalRawScores || [],
       statistics.subtotalStatistics,
       boxPlotIncludeStatuses
@@ -231,10 +115,71 @@ export function BoxPlotChart({
 
   if (subtotalStats.length === 0) return null
 
-  // チャート設定
-  // boxHeight: フォントサイズに基づく（fontSize * 1.8）
-  // itemSpacing: 項目間の間隔
-  // rowHeight: boxHeight + itemSpacing
+  // 各小計の得点を取得
+  const getStudentScore = (subtotalId: string): number => {
+    const subtotal = scoringData.subtotalScores.find(
+      (s) => s.subtotalId === subtotalId
+    )
+    return subtotal?.score ?? 0
+  }
+
+  return (
+    <BoxPlotChartView
+      subtotalStats={subtotalStats}
+      getStudentScore={getStudentScore}
+      fontScale={fontScale}
+      showMin={showMin}
+      showQ1={showQ1}
+      showMedian={showMedian}
+      showQ3={showQ3}
+      showMax={showMax}
+      showAverageLine={showAverageLine}
+      showStudentMarker={showStudentMarker}
+      boxPlotFontSize={boxPlotFontSize}
+      boxPlotItemHeight={boxPlotItemHeight}
+    />
+  )
+}
+
+// ============================
+// BoxPlotChartView（純粋ビュー）
+// ============================
+
+export interface BoxPlotChartViewProps {
+  subtotalStats: ComputedSubtotalStat[]
+  getStudentScore: (subtotalId: string) => number
+  fontScale: number
+  showMin: boolean
+  showQ1: boolean
+  showMedian: boolean
+  showQ3: boolean
+  showMax: boolean
+  showAverageLine: boolean
+  showStudentMarker: boolean
+  boxPlotFontSize: number
+  boxPlotItemHeight: number
+}
+
+/**
+ * 純粋ビューコンポーネント（hooks不使用）
+ * プレビューとPDF出力の両方で使用
+ */
+export function BoxPlotChartView({
+  subtotalStats,
+  getStudentScore,
+  fontScale,
+  showMin,
+  showQ1,
+  showMedian,
+  showQ3,
+  showMax,
+  showAverageLine,
+  showStudentMarker,
+  boxPlotFontSize,
+  boxPlotItemHeight,
+}: BoxPlotChartViewProps) {
+  if (subtotalStats.length === 0) return null
+
   const boxHeight = boxPlotFontSize * 1.8
   const itemSpacing = boxPlotItemHeight
   const rowHeight = boxHeight + itemSpacing
@@ -246,14 +191,6 @@ export function BoxPlotChart({
   const marginRight = 60
   const marginTop = 30
   const plotWidth = chartWidth - marginLeft - marginRight
-
-  // 各小計の得点を取得
-  const getStudentScore = (subtotalId: string): number => {
-    const subtotal = scoringData.subtotalScores.find(
-      (s) => s.subtotalId === subtotalId
-    )
-    return subtotal?.score ?? 0
-  }
 
   return (
     <svg
@@ -324,11 +261,8 @@ export function BoxPlotChart({
       {subtotalStats.map((stat, index) => {
         const y = marginTop + index * rowHeight
         const boxPlot = stat.boxPlot
-
-        // 最大得点 = boxPlot.max（全生徒の最高得点 = 満点の生徒がいれば満点）
         const maxScore = boxPlot.max || 100
 
-        // 得点率に変換
         const toPercent = (score: number) => (score / maxScore) * 100
         const toX = (percent: number) =>
           marginLeft + (percent / 100) * plotWidth
@@ -339,7 +273,6 @@ export function BoxPlotChart({
         const q3X = toX(toPercent(boxPlot.q3))
         const maxX = toX(toPercent(boxPlot.max))
 
-        // 生徒の得点位置
         const studentScore = getStudentScore(stat.subtotalId)
         const studentX = toX(toPercent(studentScore))
 
@@ -361,7 +294,6 @@ export function BoxPlotChart({
             {/* 最小から最も近い表示要素への水平線 */}
             {showMin &&
               (() => {
-                // 最小の次に表示される要素を探す
                 const targetX = showQ1
                   ? q1X
                   : showMedian
@@ -484,7 +416,6 @@ export function BoxPlotChart({
             {/* 最も近い表示要素から最大への水平線 */}
             {showMax &&
               (() => {
-                // 最大の手前に表示される要素を探す
                 const targetX = showQ3
                   ? q3X
                   : showMedian
@@ -551,14 +482,12 @@ export function BoxPlotChart({
           let xOffset = 0
           const legendFontSize = (boxPlotFontSize - 2) * fontScale
 
-          // 範囲ラベルを動的に生成
           const getRangeLabel = (): string | null => {
-            // 塗りつぶしが表示される条件に基づいてラベルを決定
             if (showQ1 && showMedian && showQ3) return "Q1-Q3範囲"
             if (showQ1 && showMedian && !showQ3) return "Q1-中央値範囲"
             if (!showQ1 && showMedian && showQ3) return "中央値-Q3範囲"
             if (showQ1 && !showMedian && showQ3) return "Q1-Q3範囲"
-            return null // 塗りつぶしなし
+            return null
           }
           const rangeLabel = getRangeLabel()
 

--- a/components/projects/08-export/components/individual-report/IndividualReportPreview.tsx
+++ b/components/projects/08-export/components/individual-report/IndividualReportPreview.tsx
@@ -15,7 +15,19 @@ import { cn } from "@/lib/utils"
 
 import { calculateLearningAdvice } from "../../utils/learningAdviceCalculator"
 import { BoxPlotChart } from "./BoxPlotChart"
+import {
+  buildStatsItems,
+  computeFilteredStats,
+  getVisibleSectionIndices,
+} from "./computeReportData"
 import { LearningAdvicePreview } from "./LearningAdvicePreview"
+import {
+  CommentSectionView,
+  HeaderView,
+  SignatureSectionView,
+  StatsSummaryView,
+  StudentInfoView,
+} from "./ReportSectionViews"
 import { ScoreTablePreview } from "./ScoreTablePreview"
 import { SubtotalTablePreview } from "./SubtotalTablePreview"
 
@@ -35,19 +47,12 @@ export interface PageAllocation {
 interface IndividualReportPreviewProps {
   report: IndividualReportData
   options: IndividualReportOptions
-  /** プレビュー表示用のスケール（0.5 = 50%縮小） */
   scale?: number
-  /** 追加のクラス名 */
   className?: string
-  /** 改ページプレビューを表示するか */
   showPageBreaks?: boolean
-  /** ページ振り分けが計算されたときのコールバック */
   onPagesCalculated?: (pages: PageAllocation[]) => void
 }
 
-/**
- * A4サイズの個人成績表プレビュー
- */
 export function IndividualReportPreview({
   report,
   options,
@@ -56,20 +61,16 @@ export function IndividualReportPreview({
   showPageBreaks = true,
   onPagesCalculated,
 }: IndividualReportPreviewProps) {
-  // フォントサイズのスケール（オプションに基づく）
-  const fontScale = getFontScale(options)
+  const fontScale = 1
 
-  // 各セクションのref
   const sectionRefs = useRef<(HTMLDivElement | null)[]>([])
   const [pages, setPages] = useState<PageAllocation[]>([
     { pageIndex: 0, sectionIndices: [] },
   ])
   const [measured, setMeasured] = useState(false)
 
-  // mm to px変換（96dpi基準: 1mm ≈ 3.7795px）
   const mmToPx = useCallback((mm: number) => mm * 3.7795275591, [])
 
-  // 学習アドバイスを動的に計算
   const learningAdvice = useMemo(() => {
     return calculateLearningAdvice(
       report.scoringData.scores,
@@ -82,26 +83,27 @@ export function IndividualReportPreview({
     options.adviceOptions,
   ])
 
-  // 表示されるセクションのインデックスリストを計算
-  const visibleSectionIndices = useMemo(() => {
-    const indices: number[] = [0, 1, 2] // ヘッダー、生徒情報、統計サマリーは常に表示
-    if (options.showSubtotalTable) indices.push(3)
-    if (options.graphOptions.showBoxPlot) indices.push(4)
-    if (options.showQuestionTable) indices.push(5)
-    if (options.showLearningAdvice) indices.push(6)
-    if (options.showComment) indices.push(7)
-    if (options.showSignature) indices.push(8)
-    return indices
-  }, [options])
+  const visibleSectionIndices = useMemo(
+    () => getVisibleSectionIndices(options),
+    [options]
+  )
 
-  // オプションやレポートが変更されたら再測定のためにリセット
+  // 統計サマリーの計算
+  const filteredStats = useMemo(
+    () => computeFilteredStats(report, options.boxPlotIncludeStatuses),
+    [report, options.boxPlotIncludeStatuses]
+  )
+
+  const statsItems = useMemo(
+    () => buildStatsItems(report, filteredStats, options),
+    [report, filteredStats, options]
+  )
+
   useEffect(() => {
     setMeasured(false)
   }, [options, report])
 
-  // セクションを測定してページに振り分け
   useEffect(() => {
-    // まだ測定用レンダリングが完了していない場合はスキップ
     if (measured) return
     if (!showPageBreaks) {
       setPages([{ pageIndex: 0, sectionIndices: [0, 1, 2, 3, 4, 5, 6, 7, 8] }])
@@ -115,20 +117,16 @@ export function IndividualReportPreview({
       let currentPage: PageAllocation = { pageIndex: 0, sectionIndices: [] }
       let currentPageHeight = 0
 
-      // 表示されるセクションのみを測定
       for (const index of visibleSectionIndices) {
         const ref = sectionRefs.current[index]
         if (!ref) continue
 
         const sectionHeight = ref.offsetHeight
 
-        // このセクションを現在のページに追加できるか？
         if (currentPageHeight + sectionHeight <= pageHeightPx) {
-          // 収まる場合は追加
           currentPage.sectionIndices.push(index)
           currentPageHeight += sectionHeight
         } else {
-          // 収まらない場合は新しいページを開始
           if (currentPage.sectionIndices.length > 0) {
             allocatedPages.push(currentPage)
           }
@@ -140,7 +138,6 @@ export function IndividualReportPreview({
         }
       }
 
-      // 最後のページを追加
       if (currentPage.sectionIndices.length > 0) {
         allocatedPages.push(currentPage)
       }
@@ -151,12 +148,9 @@ export function IndividualReportPreview({
           : [{ pageIndex: 0, sectionIndices: [] }]
       setPages(finalPages)
       setMeasured(true)
-
-      // コールバックで通知
       onPagesCalculated?.(finalPages)
     }
 
-    // 少し遅延させてDOMのレンダリング完了を待つ
     const timer = setTimeout(measureAndAllocate, 100)
     return () => clearTimeout(timer)
   }, [
@@ -167,7 +161,6 @@ export function IndividualReportPreview({
     visibleSectionIndices,
   ])
 
-  // セクションのref設定ヘルパー
   const setSectionRef = useCallback(
     (index: number) => (el: HTMLDivElement | null) => {
       sectionRefs.current[index] = el
@@ -175,125 +168,15 @@ export function IndividualReportPreview({
     []
   )
 
-  // 全セクションをレンダリング（測定用）
   const renderSection = (index: number) => {
     switch (index) {
-      case 0: // ヘッダー
-        return (
-          <header
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "flex-start",
-              marginBottom: "6mm",
-              paddingBottom: "4mm",
-              borderBottom: "2px solid #333",
-            }}
-          >
-            <div>
-              <h1
-                style={{
-                  fontSize: `${18 * fontScale}px`,
-                  fontWeight: "bold",
-                  margin: 0,
-                }}
-              >
-                {report.examInfo.examName}
-              </h1>
-              {report.examInfo.subject && (
-                <p
-                  style={{
-                    fontSize: `${12 * fontScale}px`,
-                    color: "#666",
-                    margin: "2mm 0 0 0",
-                  }}
-                >
-                  {report.examInfo.subject}
-                </p>
-              )}
-            </div>
-            <div style={{ textAlign: "right" }}>
-              {report.examInfo.examDate && (
-                <p
-                  style={{
-                    fontSize: `${12 * fontScale}px`,
-                    color: "#666",
-                    margin: 0,
-                  }}
-                >
-                  {formatDate(report.examInfo.examDate)}
-                </p>
-              )}
-              <p
-                style={{
-                  fontSize: `${14 * fontScale}px`,
-                  fontWeight: "bold",
-                  margin: "2mm 0 0 0",
-                }}
-              >
-                個人成績表
-              </p>
-            </div>
-          </header>
-        )
-      case 1: // 生徒情報
-        return (
-          <section
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              marginBottom: "6mm",
-              padding: "4mm",
-              backgroundColor: "#f5f5f5",
-              borderRadius: "2mm",
-            }}
-          >
-            <div>
-              <p
-                style={{
-                  fontSize: `${16 * fontScale}px`,
-                  fontWeight: "bold",
-                  margin: 0,
-                }}
-              >
-                {report.studentInfo.fullName}
-              </p>
-              <p
-                style={{
-                  fontSize: `${11 * fontScale}px`,
-                  color: "#666",
-                  margin: "1mm 0 0 0",
-                }}
-              >
-                {report.studentInfo.studentNumber}
-              </p>
-            </div>
-            <div style={{ textAlign: "right" }}>
-              <p
-                style={{
-                  fontSize: `${12 * fontScale}px`,
-                  margin: 0,
-                }}
-              >
-                {report.studentInfo.grade && `${report.studentInfo.grade}年`}
-                {report.studentInfo.className &&
-                  ` ${report.studentInfo.className}`}
-                {report.studentInfo.attendanceNumber != null &&
-                  ` ${report.studentInfo.attendanceNumber}番`}
-              </p>
-            </div>
-          </section>
-        )
-      case 2: // 統計サマリー
-        return (
-          <StatsSummary
-            report={report}
-            options={options}
-            fontScale={fontScale}
-          />
-        )
-      case 3: // 小計点テーブル
+      case 0:
+        return <HeaderView report={report} fontScale={fontScale} />
+      case 1:
+        return <StudentInfoView report={report} fontScale={fontScale} />
+      case 2:
+        return <StatsSummaryView items={statsItems} fontScale={fontScale} />
+      case 3:
         return options.showSubtotalTable ? (
           <SubtotalTablePreview
             report={report}
@@ -305,7 +188,7 @@ export function IndividualReportPreview({
             fontSize={options.subtotalTableFontSize}
           />
         ) : null
-      case 4: // 箱ひげ図
+      case 4:
         return options.graphOptions.showBoxPlot ? (
           <section style={{ marginBottom: "6mm" }}>
             <h2
@@ -338,7 +221,7 @@ export function IndividualReportPreview({
             />
           </section>
         ) : null
-      case 5: // 設問テーブル
+      case 5:
         return options.showQuestionTable ? (
           <ScoreTablePreview
             report={report}
@@ -346,7 +229,7 @@ export function IndividualReportPreview({
             fontScale={fontScale}
           />
         ) : null
-      case 6: // 学習アドバイス
+      case 6:
         return options.showLearningAdvice ? (
           <LearningAdvicePreview
             advice={learningAdvice}
@@ -354,80 +237,13 @@ export function IndividualReportPreview({
             fontScale={fontScale}
           />
         ) : null
-      case 7: // コメント欄
+      case 7:
         return options.showComment ? (
-          <section
-            style={{
-              marginTop: "6mm",
-              padding: "4mm",
-              border: "1px solid #ccc",
-              borderRadius: "2mm",
-            }}
-          >
-            <p
-              style={{
-                fontSize: `${11 * fontScale}px`,
-                fontWeight: "bold",
-                margin: "0 0 2mm 0",
-              }}
-            >
-              コメント:
-            </p>
-            <div
-              style={{
-                minHeight: "20mm",
-                borderBottom: "1px dotted #ccc",
-              }}
-            />
-          </section>
+          <CommentSectionView fontScale={fontScale} />
         ) : null
-      case 8: // 署名欄
+      case 8:
         return options.showSignature ? (
-          <section
-            style={{
-              display: "flex",
-              justifyContent: "flex-end",
-              gap: "10mm",
-              marginTop: "6mm",
-            }}
-          >
-            <div style={{ textAlign: "center" }}>
-              <p
-                style={{
-                  fontSize: `${10 * fontScale}px`,
-                  margin: "0 0 2mm 0",
-                }}
-              >
-                保護者印
-              </p>
-              <div
-                style={{
-                  width: "20mm",
-                  height: "20mm",
-                  border: "1px solid #ccc",
-                  borderRadius: "2mm",
-                }}
-              />
-            </div>
-            <div style={{ textAlign: "center" }}>
-              <p
-                style={{
-                  fontSize: `${10 * fontScale}px`,
-                  margin: "0 0 2mm 0",
-                }}
-              >
-                担任印
-              </p>
-              <div
-                style={{
-                  width: "20mm",
-                  height: "20mm",
-                  border: "1px solid #ccc",
-                  borderRadius: "2mm",
-                }}
-              />
-            </div>
-          </section>
+          <SignatureSectionView fontScale={fontScale} />
         ) : null
       default:
         return null
@@ -463,7 +279,6 @@ export function IndividualReportPreview({
               overflow: "hidden",
             }}
           >
-            {/* ページ番号表示 */}
             <div
               style={{
                 position: "absolute",
@@ -479,7 +294,6 @@ export function IndividualReportPreview({
               {pageIdx + 1} / {pages.length}
             </div>
 
-            {/* セクションをレンダリング */}
             {page.sectionIndices.map((sectionIdx) => (
               <div key={sectionIdx}>{renderSection(sectionIdx)}</div>
             ))}
@@ -508,7 +322,6 @@ export function IndividualReportPreview({
         position: "relative",
       }}
     >
-      {/* 測定用: 表示されるセクションのみを個別のdivでラップ */}
       {visibleSectionIndices.map((index) => (
         <div key={index} ref={setSectionRef(index)}>
           {renderSection(index)}
@@ -516,202 +329,4 @@ export function IndividualReportPreview({
       ))}
     </div>
   )
-}
-
-/**
- * 統計サマリーセクション
- * rawTotalScoresから受験状態フィルタ付きで統計を再計算
- */
-function StatsSummary({
-  report,
-  options,
-  fontScale,
-}: {
-  report: IndividualReportData
-  options: IndividualReportOptions
-  fontScale: number
-}) {
-  // 受験状態フィルタ付きで統計を再計算（箱ひげ図と共通設定）
-  const filteredStats = useMemo(() => {
-    const statuses = options.boxPlotIncludeStatuses
-
-    const raw = report.statistics.rawTotalScores
-    if (!raw || raw.length === 0) return report.statistics
-
-    const includeAll =
-      statuses.participating && statuses.expected && statuses.absent
-    if (includeAll) return report.statistics
-
-    const filterByStatus = (entries: typeof raw) =>
-      entries.filter((e) => {
-        if (e.status === "participating") return statuses.participating
-        if (e.status === "expected") return statuses.expected
-        if (e.status === "absent") return statuses.absent
-        return true
-      })
-
-    const filteredAll = filterByStatus(raw)
-    const allScores = filteredAll.map((e) => e.totalScore)
-
-    // 学級フィルタ
-    const filteredClass = filteredAll.filter(
-      (e) =>
-        e.className === report.studentInfo.className &&
-        e.grade === report.studentInfo.grade
-    )
-    const classScores = filteredClass.map((e) => e.totalScore)
-
-    const avg = (arr: number[]) =>
-      arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
-    const stdDev = (arr: number[]) => {
-      if (arr.length === 0) return 0
-      const a = avg(arr)
-      return Math.sqrt(arr.reduce((s, v) => s + (v - a) ** 2, 0) / arr.length)
-    }
-    const rank = (score: number, scores: number[]) => {
-      const sorted = [...scores].sort((a, b) => b - a)
-      return sorted.findIndex((s) => s <= score) + 1
-    }
-
-    const overallAvg = avg(allScores)
-    const overallStd = stdDev(allScores)
-    const studentScore = report.scoringData.totalScore
-    const deviation =
-      overallStd === 0
-        ? 50
-        : Math.round(((studentScore - overallAvg) / overallStd) * 10 + 50)
-
-    return {
-      ...report.statistics,
-      overall: {
-        ...report.statistics.overall,
-        average: overallAvg,
-        stdDev: overallStd,
-        total: filteredAll.length,
-      },
-      class: {
-        ...report.statistics.class,
-        average: avg(classScores),
-        stdDev: stdDev(classScores),
-        total: filteredClass.length,
-      },
-      personal: {
-        ...report.statistics.personal,
-        deviation,
-        overallRank: rank(studentScore, allScores),
-        classRank: rank(studentScore, classScores),
-      },
-    }
-  }, [report, options.boxPlotIncludeStatuses])
-
-  const items: { label: string; value: string }[] = []
-
-  // 得点
-  if (options.showScore) {
-    items.push({
-      label: "得点",
-      value: `${report.scoringData.totalScore} / ${report.scoringData.totalMaxScore}`,
-    })
-  }
-
-  // 平均点
-  if (options.showAverage !== "none") {
-    if (options.showAverage === "class" || options.showAverage === "both") {
-      items.push({
-        label: "学級平均",
-        value: filteredStats.class.average.toFixed(1),
-      })
-    }
-    if (options.showAverage === "overall" || options.showAverage === "both") {
-      items.push({
-        label: "全体平均",
-        value: filteredStats.overall.average.toFixed(1),
-      })
-    }
-  }
-
-  // 偏差値
-  if (options.showDeviation) {
-    items.push({
-      label: "偏差値",
-      value: filteredStats.personal.deviation.toFixed(1),
-    })
-  }
-
-  // 順位
-  if (options.showRank) {
-    if (options.rankType === "class" || options.rankType === "both") {
-      items.push({
-        label: "学級順位",
-        value: `${filteredStats.personal.classRank} / ${filteredStats.class.total}`,
-      })
-    }
-    if (options.rankType === "overall" || options.rankType === "both") {
-      items.push({
-        label: "全体順位",
-        value: `${filteredStats.personal.overallRank} / ${filteredStats.overall.total}`,
-      })
-    }
-  }
-
-  if (items.length === 0) return null
-
-  return (
-    <section
-      style={{
-        display: "flex",
-        gap: "3mm",
-        marginBottom: "6mm",
-      }}
-    >
-      {items.map((item, index) => (
-        <div
-          key={index}
-          style={{
-            flex: 1,
-            padding: "3mm 2mm",
-            backgroundColor: "#f0f7ff",
-            borderRadius: "2mm",
-            textAlign: "center",
-          }}
-        >
-          <p
-            style={{
-              fontSize: `${10 * fontScale}px`,
-              color: "#666",
-              margin: 0,
-            }}
-          >
-            {item.label}
-          </p>
-          <p
-            style={{
-              fontSize: `${16 * fontScale}px`,
-              fontWeight: "bold",
-              margin: "1mm 0 0 0",
-            }}
-          >
-            {item.value}
-          </p>
-        </div>
-      ))}
-    </section>
-  )
-}
-
-/**
- * フォントサイズのスケールを取得（将来的にオプションから取得）
- */
-function getFontScale(_options: IndividualReportOptions): number {
-  // TODO: オプションからフォントサイズ設定を取得
-  return 1
-}
-
-/**
- * 日付をフォーマット
- */
-function formatDate(date: Date | null): string {
-  if (!date) return ""
-  const d = new Date(date)
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
 }

--- a/components/projects/08-export/components/individual-report/ReportSectionViews.tsx
+++ b/components/projects/08-export/components/individual-report/ReportSectionViews.tsx
@@ -1,0 +1,286 @@
+/**
+ * 個人成績表の小さなセクション用純粋ビューコンポーネント
+ * hooks不使用 - プレビューとPDF出力（renderToStaticMarkup）の両方で使用可能
+ */
+import type { IndividualReportData } from "@/electron-src/lib/export/individual-report/types"
+
+import { formatDate } from "./computeReportData"
+
+// ============================
+// HeaderView
+// ============================
+
+interface HeaderViewProps {
+  report: IndividualReportData
+  fontScale: number
+}
+
+export function HeaderView({ report, fontScale }: HeaderViewProps) {
+  return (
+    <header
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "flex-start",
+        marginBottom: "6mm",
+        paddingBottom: "4mm",
+        borderBottom: "2px solid #333",
+      }}
+    >
+      <div>
+        <h1
+          style={{
+            fontSize: `${18 * fontScale}px`,
+            fontWeight: "bold",
+            margin: 0,
+          }}
+        >
+          {report.examInfo.examName}
+        </h1>
+        {report.examInfo.subject && (
+          <p
+            style={{
+              fontSize: `${12 * fontScale}px`,
+              color: "#666",
+              margin: "2mm 0 0 0",
+            }}
+          >
+            {report.examInfo.subject}
+          </p>
+        )}
+      </div>
+      <div style={{ textAlign: "right" }}>
+        {report.examInfo.examDate && (
+          <p
+            style={{
+              fontSize: `${12 * fontScale}px`,
+              color: "#666",
+              margin: 0,
+            }}
+          >
+            {formatDate(report.examInfo.examDate)}
+          </p>
+        )}
+        <p
+          style={{
+            fontSize: `${14 * fontScale}px`,
+            fontWeight: "bold",
+            margin: "2mm 0 0 0",
+          }}
+        >
+          個人成績表
+        </p>
+      </div>
+    </header>
+  )
+}
+
+// ============================
+// StudentInfoView
+// ============================
+
+interface StudentInfoViewProps {
+  report: IndividualReportData
+  fontScale: number
+}
+
+export function StudentInfoView({ report, fontScale }: StudentInfoViewProps) {
+  return (
+    <section
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: "6mm",
+        padding: "4mm",
+        backgroundColor: "#f5f5f5",
+        borderRadius: "2mm",
+      }}
+    >
+      <div>
+        <p
+          style={{
+            fontSize: `${16 * fontScale}px`,
+            fontWeight: "bold",
+            margin: 0,
+          }}
+        >
+          {report.studentInfo.fullName}
+        </p>
+        <p
+          style={{
+            fontSize: `${11 * fontScale}px`,
+            color: "#666",
+            margin: "1mm 0 0 0",
+          }}
+        >
+          {report.studentInfo.studentNumber}
+        </p>
+      </div>
+      <div style={{ textAlign: "right" }}>
+        <p
+          style={{
+            fontSize: `${12 * fontScale}px`,
+            margin: 0,
+          }}
+        >
+          {report.studentInfo.grade && `${report.studentInfo.grade}年`}
+          {report.studentInfo.className &&
+            ` ${report.studentInfo.className}`}
+          {report.studentInfo.attendanceNumber != null &&
+            ` ${report.studentInfo.attendanceNumber}番`}
+        </p>
+      </div>
+    </section>
+  )
+}
+
+// ============================
+// StatsSummaryView
+// ============================
+
+interface StatsSummaryViewProps {
+  items: { label: string; value: string }[]
+  fontScale: number
+}
+
+export function StatsSummaryView({ items, fontScale }: StatsSummaryViewProps) {
+  if (items.length === 0) return null
+
+  return (
+    <section
+      style={{
+        display: "flex",
+        gap: "3mm",
+        marginBottom: "6mm",
+      }}
+    >
+      {items.map((item, index) => (
+        <div
+          key={index}
+          style={{
+            flex: 1,
+            padding: "3mm 2mm",
+            backgroundColor: "#f0f7ff",
+            borderRadius: "2mm",
+            textAlign: "center",
+          }}
+        >
+          <p
+            style={{
+              fontSize: `${10 * fontScale}px`,
+              color: "#666",
+              margin: 0,
+            }}
+          >
+            {item.label}
+          </p>
+          <p
+            style={{
+              fontSize: `${16 * fontScale}px`,
+              fontWeight: "bold",
+              margin: "1mm 0 0 0",
+            }}
+          >
+            {item.value}
+          </p>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+// ============================
+// CommentSectionView
+// ============================
+
+interface CommentSectionViewProps {
+  fontScale: number
+}
+
+export function CommentSectionView({ fontScale }: CommentSectionViewProps) {
+  return (
+    <section
+      style={{
+        marginTop: "6mm",
+        padding: "4mm",
+        border: "1px solid #ccc",
+        borderRadius: "2mm",
+      }}
+    >
+      <p
+        style={{
+          fontSize: `${11 * fontScale}px`,
+          fontWeight: "bold",
+          margin: "0 0 2mm 0",
+        }}
+      >
+        コメント:
+      </p>
+      <div
+        style={{
+          minHeight: "20mm",
+          borderBottom: "1px dotted #ccc",
+        }}
+      />
+    </section>
+  )
+}
+
+// ============================
+// SignatureSectionView
+// ============================
+
+interface SignatureSectionViewProps {
+  fontScale: number
+}
+
+export function SignatureSectionView({ fontScale }: SignatureSectionViewProps) {
+  return (
+    <section
+      style={{
+        display: "flex",
+        justifyContent: "flex-end",
+        gap: "10mm",
+        marginTop: "6mm",
+      }}
+    >
+      <div style={{ textAlign: "center" }}>
+        <p
+          style={{
+            fontSize: `${10 * fontScale}px`,
+            margin: "0 0 2mm 0",
+          }}
+        >
+          保護者印
+        </p>
+        <div
+          style={{
+            width: "20mm",
+            height: "20mm",
+            border: "1px solid #ccc",
+            borderRadius: "2mm",
+          }}
+        />
+      </div>
+      <div style={{ textAlign: "center" }}>
+        <p
+          style={{
+            fontSize: `${10 * fontScale}px`,
+            margin: "0 0 2mm 0",
+          }}
+        >
+          担任印
+        </p>
+        <div
+          style={{
+            width: "20mm",
+            height: "20mm",
+            border: "1px solid #ccc",
+            borderRadius: "2mm",
+          }}
+        />
+      </div>
+    </section>
+  )
+}

--- a/components/projects/08-export/components/individual-report/SubtotalTablePreview.tsx
+++ b/components/projects/08-export/components/individual-report/SubtotalTablePreview.tsx
@@ -3,8 +3,9 @@
 /**
  * 小計点テーブルプレビューコンポーネント
  * ドント方式による列数配分とグループ別表示に対応
- * - 列数=1: グループを縦に積み重ね（横並びにしない）
- * - 列数>1: グループを横に並べ、ドント方式で列を配分
+ *
+ * SubtotalTablePreview: hooks付きラッパー（プレビュー用）
+ * SubtotalTableView: 純粋ビュー（プレビュー＋PDF出力共用）
  */
 import { Fragment, useMemo } from "react"
 
@@ -15,6 +16,13 @@ import type {
 } from "@/electron-src/lib/export/individual-report/types"
 import type { SubtotalScore } from "@/electron-src/lib/shared/types/exportTypes"
 
+import {
+  allocateColumnsDHondt,
+  filterSubtotalScores,
+  groupSubtotalData,
+  splitItemsIntoColumns,
+} from "./computeReportData"
+
 interface SubtotalTablePreviewProps {
   report: IndividualReportData
   fontScale: number
@@ -22,17 +30,7 @@ interface SubtotalTablePreviewProps {
   hideUnassignedSubtotals?: boolean
   columns?: SubtotalTableColumns
   showGroupSubtotals?: boolean
-  /** フォントサイズ（px）。指定がない場合は10 * fontScale */
   fontSize?: number
-}
-
-/** グループ化されたデータ構造 */
-interface GroupedSubtotals {
-  groupId: string
-  groupName: string
-  items: SubtotalScore[]
-  totalScore: number
-  totalMaxScore: number
 }
 
 /** グループごとの表示データ（列配分情報付き） */
@@ -40,9 +38,7 @@ interface GroupTableData {
   groupId: string
   groupName: string
   allocatedColumns: number
-  /** 各列のアイテム配列 */
   columnItems: SubtotalScore[][]
-  /** 最大行数（列間で揃えるため） */
   maxRows: number
   totalScore: number
   totalMaxScore: number
@@ -70,72 +66,8 @@ function ScoreDisplay({
 }
 
 /**
- * ドント方式で列数を各グループに配分
+ * hooks付きラッパー（プレビュー用）
  */
-function allocateColumnsDHondt(
-  groups: GroupedSubtotals[],
-  totalColumns: number
-): Map<string, number> {
-  const allocation = new Map<string, number>()
-
-  if (groups.length === 0) return allocation
-
-  // 全グループに最低1列を割り当て
-  for (const group of groups) {
-    allocation.set(group.groupId, 1)
-  }
-
-  // グループ数が列数以上の場合、各グループ1列で終了
-  if (groups.length >= totalColumns) {
-    return allocation
-  }
-
-  // 残りの列をドント方式で割り当て
-  let remainingColumns = totalColumns - groups.length
-
-  while (remainingColumns > 0) {
-    let maxQuotient = -1
-    let maxGroupId = ""
-
-    for (const group of groups) {
-      const currentAllocation = allocation.get(group.groupId)!
-      const quotient = group.items.length / (currentAllocation + 1)
-      if (quotient > maxQuotient) {
-        maxQuotient = quotient
-        maxGroupId = group.groupId
-      }
-    }
-
-    allocation.set(maxGroupId, allocation.get(maxGroupId)! + 1)
-    remainingColumns--
-  }
-
-  return allocation
-}
-
-/**
- * アイテムを指定列数に分割（縦方向に埋める）
- */
-function splitItemsIntoColumns(
-  items: SubtotalScore[],
-  columnCount: number
-): SubtotalScore[][] {
-  const result: SubtotalScore[][] = Array.from(
-    { length: columnCount },
-    () => []
-  )
-  const itemsPerColumn = Math.ceil(items.length / columnCount)
-
-  for (let i = 0; i < items.length; i++) {
-    const colIndex = Math.floor(i / itemsPerColumn)
-    if (colIndex < columnCount) {
-      result[colIndex].push(items[i])
-    }
-  }
-
-  return result
-}
-
 export function SubtotalTablePreview({
   report,
   fontScale,
@@ -145,69 +77,32 @@ export function SubtotalTablePreview({
   showGroupSubtotals = true,
   fontSize,
 }: SubtotalTablePreviewProps) {
-  // フィルタリング適用
-  const subtotalScores = useMemo(() => {
-    let scores = report.scoringData.subtotalScores
+  const subtotalScores = useMemo(
+    () =>
+      filterSubtotalScores(
+        report.scoringData.subtotalScores,
+        subtotalGroupSelection,
+        hideUnassignedSubtotals
+      ),
+    [report, subtotalGroupSelection, hideUnassignedSubtotals]
+  )
 
-    if (
-      subtotalGroupSelection?.enabled &&
-      subtotalGroupSelection.selectedGroupIds.length > 0
-    ) {
-      scores = scores.filter((score) =>
-        subtotalGroupSelection.selectedGroupIds.includes(score.subtotalGroupId)
-      )
-    }
+  const groupedData = useMemo(
+    () => groupSubtotalData(subtotalScores),
+    [subtotalScores]
+  )
 
-    if (hideUnassignedSubtotals) {
-      scores = scores.filter((score) => score.hasQuestionAssignments)
-    }
-
-    return scores
-  }, [report, subtotalGroupSelection, hideUnassignedSubtotals])
-
-  // グループごとにグルーピング
-  const groupedData = useMemo((): GroupedSubtotals[] => {
-    const groupMap = new Map<string, GroupedSubtotals>()
-
-    for (const score of subtotalScores) {
-      const groupId = score.subtotalGroupId
-      const existing = groupMap.get(groupId)
-      if (existing) {
-        existing.items.push(score)
-        existing.totalScore += score.score
-        existing.totalMaxScore += score.maxScore
-      } else {
-        groupMap.set(groupId, {
-          groupId,
-          groupName: score.subtotalGroupName,
-          items: [score],
-          totalScore: score.score,
-          totalMaxScore: score.maxScore,
-        })
-      }
-    }
-
-    return Array.from(groupMap.values())
-  }, [subtotalScores])
-
-  // 横並びか縦積みかを決定
-  // columns >= グループ数: 横並び（ドント方式で列配分）
-  // columns < グループ数: 縦積み（各グループに同じ列数を適用）
   const isHorizontalLayout = columns >= groupedData.length
 
-  // 各グループのテーブルデータを構築
   const groupTableDataList = useMemo((): GroupTableData[] => {
     if (groupedData.length === 0) return []
 
     if (isHorizontalLayout) {
-      // 横並び: ドント方式で列配分
       const allocation = allocateColumnsDHondt(groupedData, columns)
-
       return groupedData.map((group) => {
         const allocatedColumns = allocation.get(group.groupId) || 1
         const columnItems = splitItemsIntoColumns(group.items, allocatedColumns)
         const maxRows = Math.max(...columnItems.map((col) => col.length))
-
         return {
           groupId: group.groupId,
           groupName: group.groupName,
@@ -219,11 +114,9 @@ export function SubtotalTablePreview({
         }
       })
     } else {
-      // 縦積み: 各グループに指定された列数を適用
       return groupedData.map((group) => {
         const columnItems = splitItemsIntoColumns(group.items, columns)
         const maxRows = Math.max(...columnItems.map((col) => col.length))
-
         return {
           groupId: group.groupId,
           groupName: group.groupName,
@@ -237,7 +130,6 @@ export function SubtotalTablePreview({
     }
   }, [groupedData, columns, isHorizontalLayout])
 
-  // 全グループの合計列数（横並びの場合のみ使用）
   const totalAllocatedColumns = useMemo(() => {
     if (!isHorizontalLayout) return 1
     return groupTableDataList.reduce((sum, g) => sum + g.allocatedColumns, 0)
@@ -245,8 +137,54 @@ export function SubtotalTablePreview({
 
   if (subtotalScores.length === 0) return null
 
-  // フォントサイズ: fontSize prop があればそれを使用、なければ 10 * fontScale
   const baseFontSize = fontSize ?? 10 * fontScale
+
+  return (
+    <SubtotalTableView
+      groupTableDataList={groupTableDataList}
+      isHorizontalLayout={isHorizontalLayout}
+      totalAllocatedColumns={totalAllocatedColumns}
+      fontScale={fontScale}
+      baseFontSize={baseFontSize}
+      showGroupSubtotals={showGroupSubtotals}
+    />
+  )
+}
+
+// ============================
+// SubtotalTableView（純粋ビュー）
+// ============================
+
+export interface SubtotalTableViewProps {
+  groupTableDataList: {
+    groupId: string
+    groupName: string
+    allocatedColumns: number
+    columnItems: SubtotalScore[][]
+    maxRows: number
+    totalScore: number
+    totalMaxScore: number
+  }[]
+  isHorizontalLayout: boolean
+  totalAllocatedColumns: number
+  fontScale: number
+  baseFontSize: number
+  showGroupSubtotals: boolean
+}
+
+/**
+ * 純粋ビューコンポーネント（hooks不使用）
+ * プレビューとPDF出力の両方で使用
+ */
+export function SubtotalTableView({
+  groupTableDataList,
+  isHorizontalLayout,
+  totalAllocatedColumns,
+  fontScale,
+  baseFontSize,
+  showGroupSubtotals,
+}: SubtotalTableViewProps) {
+  if (groupTableDataList.length === 0) return null
 
   const cellStyle: React.CSSProperties = {
     padding: `${1.5 * fontScale}mm ${2 * fontScale}mm`,
@@ -289,12 +227,10 @@ export function SubtotalTablePreview({
         }}
       >
         {groupTableDataList.map((groupData, groupIndex) => {
-          // 横並びの場合はグループの幅を列配分比率で計算
           const groupWidth = isHorizontalLayout
             ? `${(groupData.allocatedColumns / totalAllocatedColumns) * 100}%`
             : "100%"
 
-          // 各列の幅を計算（ラベル60%、得点40%を列数で分割）
           const colWidthPercent = 100 / groupData.allocatedColumns
           const labelWidthPercent = colWidthPercent * 0.6
           const scoreWidthPercent = colWidthPercent * 0.4
@@ -319,7 +255,6 @@ export function SubtotalTablePreview({
                   tableLayout: "fixed",
                 }}
               >
-                {/* 列幅を明示的に定義 */}
                 <colgroup>
                   {Array.from({ length: groupData.allocatedColumns }).map(
                     (_, i) => (
@@ -330,7 +265,6 @@ export function SubtotalTablePreview({
                     )
                   )}
                 </colgroup>
-                {/* ヘッダー: グループ名（全列結合） */}
                 <thead>
                   <tr>
                     <th
@@ -342,7 +276,6 @@ export function SubtotalTablePreview({
                   </tr>
                 </thead>
                 <tbody>
-                  {/* 各行をレンダリング */}
                   {Array.from({ length: groupData.maxRows }).map(
                     (_, rowIndex) => {
                       const isAlt = rowIndex % 2 === 1
@@ -355,7 +288,6 @@ export function SubtotalTablePreview({
                           {groupData.columnItems.map((colItems, colIndex) => {
                             const item = colItems[rowIndex]
                             if (!item) {
-                              // 空セル
                               return (
                                 <Fragment key={colIndex}>
                                   <td style={cellStyle}></td>
@@ -393,7 +325,6 @@ export function SubtotalTablePreview({
                       )
                     }
                   )}
-                  {/* フッター: 小計（全列結合） */}
                   {showGroupSubtotals && (
                     <tr>
                       <td

--- a/components/projects/08-export/components/individual-report/computeReportData.ts
+++ b/components/projects/08-export/components/individual-report/computeReportData.ts
@@ -1,0 +1,416 @@
+/**
+ * 個人成績表の共通計算ロジック
+ * プレビュー（React）とPDF出力（renderToStaticMarkup）の両方で使用
+ */
+import type {
+  IndividualReportData,
+  IndividualReportOptions,
+  StatisticsData,
+  SubtotalRawScores,
+  SubtotalStatistics,
+} from "@/electron-src/lib/export/individual-report/types"
+import type { SubtotalScore } from "@/electron-src/lib/shared/types/exportTypes"
+
+/** 受験状態フィルタ */
+export interface BoxPlotIncludeStatuses {
+  participating: boolean
+  expected: boolean
+  absent: boolean
+}
+
+/** 計算済み小計統計データ */
+export interface ComputedSubtotalStat {
+  subtotalId: string
+  subtotalLabel: string
+  subtotalGroupId: string
+  boxPlot: { min: number; q1: number; median: number; q3: number; max: number }
+  average: number
+  maxScore: number
+}
+
+/** グループ化された小計データ */
+export interface GroupedSubtotalData {
+  groupId: string
+  groupName: string
+  items: SubtotalScore[]
+  totalScore: number
+  totalMaxScore: number
+}
+
+// ============================
+// 統計フィルタリング
+// ============================
+
+/**
+ * 受験状態フィルタ付きで統計を再計算
+ */
+export function computeFilteredStats(
+  report: IndividualReportData,
+  statuses: BoxPlotIncludeStatuses
+): StatisticsData {
+  const raw = report.statistics.rawTotalScores
+  if (!raw || raw.length === 0) return report.statistics
+
+  const includeAll =
+    statuses.participating && statuses.expected && statuses.absent
+  if (includeAll) return report.statistics
+
+  const filterByStatus = (entries: typeof raw) =>
+    entries.filter((e) => {
+      if (e.status === "participating") return statuses.participating
+      if (e.status === "expected") return statuses.expected
+      if (e.status === "absent") return statuses.absent
+      return true
+    })
+
+  const filteredAll = filterByStatus(raw)
+  const allScores = filteredAll.map((e) => e.totalScore)
+
+  const filteredClass = filteredAll.filter(
+    (e) =>
+      e.className === report.studentInfo.className &&
+      e.grade === report.studentInfo.grade
+  )
+  const classScores = filteredClass.map((e) => e.totalScore)
+
+  const avg = (arr: number[]) =>
+    arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
+  const stdDevFn = (arr: number[]) => {
+    if (arr.length === 0) return 0
+    const a = avg(arr)
+    return Math.sqrt(arr.reduce((s, v) => s + (v - a) ** 2, 0) / arr.length)
+  }
+  const rankFn = (score: number, scores: number[]) => {
+    const sorted = [...scores].sort((a, b) => b - a)
+    return sorted.findIndex((s) => s <= score) + 1
+  }
+
+  const overallAvg = avg(allScores)
+  const overallStd = stdDevFn(allScores)
+  const studentScore = report.scoringData.totalScore
+  const deviation =
+    overallStd === 0
+      ? 50
+      : Math.round(((studentScore - overallAvg) / overallStd) * 10 + 50)
+
+  return {
+    ...report.statistics,
+    overall: {
+      ...report.statistics.overall,
+      average: overallAvg,
+      stdDev: overallStd,
+      total: filteredAll.length,
+    },
+    class: {
+      ...report.statistics.class,
+      average: avg(classScores),
+      stdDev: stdDevFn(classScores),
+      total: filteredClass.length,
+    },
+    personal: {
+      ...report.statistics.personal,
+      deviation,
+      overallRank: rankFn(studentScore, allScores),
+      classRank: rankFn(studentScore, classScores),
+    },
+  }
+}
+
+// ============================
+// 箱ひげ図統計計算
+// ============================
+
+function calculateMedian(sortedValues: number[]): number {
+  const n = sortedValues.length
+  if (n === 0) return 0
+  if (n === 1) return sortedValues[0]
+  const mid = Math.floor(n / 2)
+  if (n % 2 === 0) {
+    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
+  }
+  return sortedValues[mid]
+}
+
+function calculateAverage(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}
+
+function calculateBoxPlotData(values: number[]) {
+  if (values.length === 0) {
+    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const n = sorted.length
+  const min = sorted[0]
+  const max = sorted[n - 1]
+  const median = calculateMedian(sorted)
+  const midIndex = Math.floor(n / 2)
+  const lowerHalf = sorted.slice(0, midIndex)
+  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
+  const q1 = calculateMedian(lowerHalf)
+  const q3 = calculateMedian(upperHalf)
+  return { min, q1, median, q3, max }
+}
+
+/**
+ * 小計点箱ひげ図の統計を受験状態フィルタ付きで再計算
+ */
+export function computeFilteredSubtotalStats(
+  rawScores: SubtotalRawScores[],
+  subtotalStatistics: SubtotalStatistics[],
+  includeStatuses: BoxPlotIncludeStatuses
+): ComputedSubtotalStat[] {
+  const includeAll =
+    includeStatuses.participating &&
+    includeStatuses.expected &&
+    includeStatuses.absent
+
+  return subtotalStatistics.map((stat) => {
+    const rawData = rawScores.find((r) => r.subtotalId === stat.subtotalId)
+
+    if (!rawData || includeAll) {
+      return {
+        subtotalId: stat.subtotalId,
+        subtotalLabel: stat.subtotalLabel,
+        subtotalGroupId: stat.subtotalGroupId,
+        boxPlot: stat.boxPlot,
+        average: stat.average,
+        maxScore: stat.maxScore,
+      }
+    }
+
+    const filteredScores = rawData.scores
+      .filter((s) => {
+        if (s.status === "participating") return includeStatuses.participating
+        if (s.status === "expected") return includeStatuses.expected
+        if (s.status === "absent") return includeStatuses.absent
+        return true
+      })
+      .map((s) => s.score)
+
+    if (filteredScores.length === 0) {
+      return {
+        subtotalId: stat.subtotalId,
+        subtotalLabel: stat.subtotalLabel,
+        subtotalGroupId: stat.subtotalGroupId,
+        boxPlot: { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
+        average: 0,
+        maxScore: stat.maxScore,
+      }
+    }
+
+    return {
+      subtotalId: stat.subtotalId,
+      subtotalLabel: stat.subtotalLabel,
+      subtotalGroupId: stat.subtotalGroupId,
+      boxPlot: calculateBoxPlotData(filteredScores),
+      average: calculateAverage(filteredScores),
+      maxScore: stat.maxScore,
+    }
+  })
+}
+
+// ============================
+// 小計点テーブル計算
+// ============================
+
+/**
+ * 小計点スコアをフィルタリング
+ */
+export function filterSubtotalScores(
+  subtotalScores: SubtotalScore[],
+  groupSelection?: { enabled: boolean; selectedGroupIds: string[] },
+  hideUnassigned?: boolean
+): SubtotalScore[] {
+  let scores = subtotalScores
+
+  if (
+    groupSelection?.enabled &&
+    groupSelection.selectedGroupIds.length > 0
+  ) {
+    scores = scores.filter((score) =>
+      groupSelection.selectedGroupIds.includes(score.subtotalGroupId)
+    )
+  }
+
+  if (hideUnassigned) {
+    scores = scores.filter((score) => score.hasQuestionAssignments)
+  }
+
+  return scores
+}
+
+/**
+ * 小計点スコアをグループ別にまとめる
+ */
+export function groupSubtotalData(
+  filteredScores: SubtotalScore[]
+): GroupedSubtotalData[] {
+  const groupMap = new Map<string, GroupedSubtotalData>()
+
+  for (const score of filteredScores) {
+    const groupId = score.subtotalGroupId
+    const existing = groupMap.get(groupId)
+    if (existing) {
+      existing.items.push(score)
+      existing.totalScore += score.score
+      existing.totalMaxScore += score.maxScore
+    } else {
+      groupMap.set(groupId, {
+        groupId,
+        groupName: score.subtotalGroupName,
+        items: [score],
+        totalScore: score.score,
+        totalMaxScore: score.maxScore,
+      })
+    }
+  }
+
+  return Array.from(groupMap.values())
+}
+
+/**
+ * ドント方式で列数を各グループに配分
+ */
+export function allocateColumnsDHondt(
+  groups: { groupId: string; items: { length: number } }[],
+  totalColumns: number
+): Map<string, number> {
+  const allocation = new Map<string, number>()
+  if (groups.length === 0) return allocation
+
+  for (const group of groups) {
+    allocation.set(group.groupId, 1)
+  }
+
+  if (groups.length >= totalColumns) {
+    return allocation
+  }
+
+  let remainingColumns = totalColumns - groups.length
+  while (remainingColumns > 0) {
+    let maxQuotient = -1
+    let maxGroupId = ""
+    for (const group of groups) {
+      const currentAllocation = allocation.get(group.groupId)!
+      const quotient = group.items.length / (currentAllocation + 1)
+      if (quotient > maxQuotient) {
+        maxQuotient = quotient
+        maxGroupId = group.groupId
+      }
+    }
+    allocation.set(maxGroupId, allocation.get(maxGroupId)! + 1)
+    remainingColumns--
+  }
+
+  return allocation
+}
+
+/**
+ * アイテムを指定列数に分割（縦方向に埋める）
+ */
+export function splitItemsIntoColumns<T>(
+  items: T[],
+  columnCount: number
+): T[][] {
+  const result: T[][] = Array.from({ length: columnCount }, () => [])
+  const itemsPerColumn = Math.ceil(items.length / columnCount)
+  for (let i = 0; i < items.length; i++) {
+    const colIndex = Math.floor(i / itemsPerColumn)
+    if (colIndex < columnCount) {
+      result[colIndex].push(items[i])
+    }
+  }
+  return result
+}
+
+// ============================
+// 表示制御
+// ============================
+
+/**
+ * 表示されるセクションのインデックスを取得
+ */
+export function getVisibleSectionIndices(
+  options: IndividualReportOptions
+): number[] {
+  const indices: number[] = [0, 1, 2] // ヘッダー、生徒情報、統計サマリーは常に表示
+  if (options.showSubtotalTable) indices.push(3)
+  if (options.graphOptions.showBoxPlot) indices.push(4)
+  if (options.showQuestionTable) indices.push(5)
+  if (options.showLearningAdvice) indices.push(6)
+  if (options.showComment) indices.push(7)
+  if (options.showSignature) indices.push(8)
+  return indices
+}
+
+/**
+ * 統計サマリーの表示アイテムを構築
+ */
+export function buildStatsItems(
+  report: IndividualReportData,
+  filteredStats: StatisticsData,
+  options: IndividualReportOptions
+): { label: string; value: string }[] {
+  const items: { label: string; value: string }[] = []
+
+  if (options.showScore) {
+    items.push({
+      label: "得点",
+      value: `${report.scoringData.totalScore} / ${report.scoringData.totalMaxScore}`,
+    })
+  }
+
+  if (options.showAverage !== "none") {
+    if (options.showAverage === "class" || options.showAverage === "both") {
+      items.push({
+        label: "学級平均",
+        value: filteredStats.class.average.toFixed(1),
+      })
+    }
+    if (options.showAverage === "overall" || options.showAverage === "both") {
+      items.push({
+        label: "全体平均",
+        value: filteredStats.overall.average.toFixed(1),
+      })
+    }
+  }
+
+  if (options.showDeviation) {
+    items.push({
+      label: "偏差値",
+      value: filteredStats.personal.deviation.toFixed(1),
+    })
+  }
+
+  if (options.showRank) {
+    if (options.rankType === "class" || options.rankType === "both") {
+      items.push({
+        label: "学級順位",
+        value: `${filteredStats.personal.classRank} / ${filteredStats.class.total}`,
+      })
+    }
+    if (options.rankType === "overall" || options.rankType === "both") {
+      items.push({
+        label: "全体順位",
+        value: `${filteredStats.personal.overallRank} / ${filteredStats.overall.total}`,
+      })
+    }
+  }
+
+  return items
+}
+
+// ============================
+// ユーティリティ
+// ============================
+
+/**
+ * 日付をフォーマット
+ */
+export function formatDate(date: Date | null): string {
+  if (!date) return ""
+  const d = new Date(date)
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
+}

--- a/components/projects/08-export/components/individual-report/generatePrintHtml.ts
+++ b/components/projects/08-export/components/individual-report/generatePrintHtml.ts
@@ -1,24 +1,37 @@
 /**
  * 個人成績表の印刷用HTMLを生成
- * プレビューコンポーネントと同じ構造のHTMLを生成し、
- * セクション単位での改ページとページ振り分けに対応
+ * renderToStaticMarkupを使い、プレビュー用Reactコンポーネントを再利用してHTML化
  */
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
 import type {
-  AdviceOptions,
   IndividualReportData,
   IndividualReportOptions,
-  StatisticsData,
-  SubtotalRawScores,
 } from "@/electron-src/lib/export/individual-report/types"
 
 import { calculateLearningAdvice } from "../../utils/learningAdviceCalculator"
-
-/** 受験状態フィルタ */
-interface BoxPlotIncludeStatuses {
-  participating: boolean
-  expected: boolean
-  absent: boolean
-}
+import { BoxPlotChartView } from "./BoxPlotChart"
+import {
+  allocateColumnsDHondt,
+  buildStatsItems,
+  computeFilteredStats,
+  computeFilteredSubtotalStats,
+  filterSubtotalScores,
+  getVisibleSectionIndices,
+  groupSubtotalData,
+  splitItemsIntoColumns,
+} from "./computeReportData"
+import { LearningAdvicePreview } from "./LearningAdvicePreview"
+import {
+  CommentSectionView,
+  HeaderView,
+  SignatureSectionView,
+  StatsSummaryView,
+  StudentInfoView,
+} from "./ReportSectionViews"
+import { ScoreTablePreview } from "./ScoreTablePreview"
+import { SubtotalTableView } from "./SubtotalTablePreview"
 
 /** ページ振り分け情報 */
 export interface PageAllocation {
@@ -28,9 +41,6 @@ export interface PageAllocation {
 
 /**
  * 複数の個人成績表を結合した印刷用HTMLを生成
- * @param reports 生徒ごとのレポートデータ
- * @param options 表示オプション
- * @param reportsPageAllocations 各レポートのページ振り分け情報（省略時はすべてのセクションを1ページに）
  */
 export function generatePrintHtml(
   reports: IndividualReportData[],
@@ -38,18 +48,14 @@ export function generatePrintHtml(
   reportsPageAllocations?: PageAllocation[][]
 ): string {
   const fontScale = 1
-
-  // 表示されるセクションのインデックスを計算
   const visibleSectionIndices = getVisibleSectionIndices(options)
 
-  // 各レポートのHTMLを生成
   const reportsHtml = reports
     .map((report, reportIndex) => {
       const pageAllocations = reportsPageAllocations?.[reportIndex]
       const isLastReport = reportIndex === reports.length - 1
 
-      // レポートのHTMLを生成
-      const reportHtml = generateSingleReportPrintHtml(
+      const reportHtml = generateSingleReportHtml(
         report,
         options,
         fontScale,
@@ -57,90 +63,69 @@ export function generatePrintHtml(
         pageAllocations
       )
 
-      // 最後のレポート以外は改ページを挿入
-      return `
-        <div class="student-report${isLastReport ? "" : " page-break-after"}">
-          ${reportHtml}
-        </div>
-      `
+      return `<div class="student-report${isLastReport ? "" : " page-break-after"}">${reportHtml}</div>`
     })
     .join("")
 
-  return `
-    <!DOCTYPE html>
-    <html lang="ja">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>個人成績表</title>
-      <style>
-        @page {
-          size: A4 portrait;
-          margin: 5mm;
-        }
-
-        * {
-          box-sizing: border-box;
-          margin: 0;
-          padding: 0;
-        }
-
-        body {
-          font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif;
-          font-size: 12px;
-          line-height: 1.5;
-          color: #1a1a1a;
-          background: white;
-          -webkit-print-color-adjust: exact;
-          print-color-adjust: exact;
-        }
-
-        .page-break-after {
-          page-break-after: always;
-        }
-
-        .page-break-before {
-          page-break-before: always;
-        }
-
-        .report-section {
-          page-break-inside: avoid;
-        }
-
-        table {
-          width: 100%;
-          border-collapse: collapse;
-        }
-
-        tr {
-          page-break-inside: avoid;
-        }
-      </style>
-    </head>
-    <body>
-      ${reportsHtml}
-    </body>
-    </html>
-  `
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>個人成績表</title>
+  <style>
+    @page {
+      size: A4 portrait;
+      margin: 5mm;
+    }
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #1a1a1a;
+      background: white;
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+    .page-break-after {
+      page-break-after: always;
+    }
+    .page-break-before {
+      page-break-before: always;
+    }
+    .report-section {
+      page-break-inside: avoid;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    tr {
+      page-break-inside: avoid;
+    }
+  </style>
+</head>
+<body>
+  ${reportsHtml}
+</body>
+</html>`
 }
 
 /**
  * 単一レポートの印刷用HTMLを生成
  */
-function generateSingleReportPrintHtml(
+function generateSingleReportHtml(
   report: IndividualReportData,
   options: IndividualReportOptions,
   fontScale: number,
   visibleSectionIndices: number[],
   pageAllocations?: PageAllocation[]
 ): string {
-  // 学習アドバイスを計算
-  const learningAdvice = calculateLearningAdvice(
-    report.scoringData.scores,
-    report.statistics.questionCorrectRates,
-    options.adviceOptions
-  )
-
   // 各ページの先頭セクションを特定
   const pageStartSections = new Set<number>()
   if (pageAllocations && pageAllocations.length > 1) {
@@ -151,1193 +136,213 @@ function generateSingleReportPrintHtml(
     })
   }
 
-  // 各セクションを生成
+  // 各セクションのReact要素を生成
   const sectionsHtml = visibleSectionIndices
     .map((sectionIndex) => {
-      const sectionHtml = generateSection(
+      const sectionElement = renderSectionElement(
         sectionIndex,
         report,
         options,
-        fontScale,
-        learningAdvice
+        fontScale
       )
-      if (!sectionHtml) return ""
+      if (!sectionElement) return ""
 
+      const html = renderToStaticMarkup(sectionElement)
       const pageBreak = pageStartSections.has(sectionIndex)
         ? "page-break-before"
         : ""
 
-      return `<div class="report-section ${pageBreak}">${sectionHtml}</div>`
+      return `<div class="report-section ${pageBreak}">${html}</div>`
     })
     .join("")
 
-  return `
-    <div class="individual-report-page" style="
-      width: 200mm;
-      min-height: 287mm;
-      padding: 0;
-      background-color: white;
-      font-family: 'Noto Sans JP', 'Hiragino Sans', sans-serif;
-      font-size: ${12 * fontScale}px;
-      line-height: 1.5;
-      color: #1a1a1a;
-      box-sizing: border-box;
-    ">
-      ${sectionsHtml}
-    </div>
-  `
+  return `<div class="individual-report-page" style="width:200mm;min-height:287mm;padding:0;background-color:white;font-family:'Noto Sans JP','Hiragino Sans',sans-serif;font-size:${12 * fontScale}px;line-height:1.5;color:#1a1a1a;box-sizing:border-box;">${sectionsHtml}</div>`
 }
 
 /**
- * 表示されるセクションのインデックスを取得
+ * セクションのReact要素を生成（renderToStaticMarkup用）
  */
-function getVisibleSectionIndices(options: IndividualReportOptions): number[] {
-  const indices: number[] = [0, 1, 2] // ヘッダー、生徒情報、統計サマリーは常に表示
-  if (options.showSubtotalTable) indices.push(3)
-  if (options.graphOptions.showBoxPlot) indices.push(4)
-  if (options.showQuestionTable) indices.push(5)
-  if (options.showLearningAdvice) indices.push(6)
-  if (options.showComment) indices.push(7)
-  if (options.showSignature) indices.push(8)
-  return indices
-}
-
-/**
- * セクションのHTMLを生成
- */
-function generateSection(
+function renderSectionElement(
   index: number,
   report: IndividualReportData,
   options: IndividualReportOptions,
-  fontScale: number,
-  learningAdvice: ReturnType<typeof calculateLearningAdvice>
-): string {
+  fontScale: number
+): React.ReactElement | null {
   switch (index) {
     case 0:
-      return generateHeader(report, fontScale)
+      return React.createElement(HeaderView, { report, fontScale })
+
     case 1:
-      return generateStudentInfo(report, fontScale)
-    case 2:
-      return generateStatsSummary(report, options, fontScale)
-    case 3:
-      return generateSubtotalTable(report, options, fontScale)
-    case 4:
-      return generateBoxPlot(report, options, fontScale)
+      return React.createElement(StudentInfoView, { report, fontScale })
+
+    case 2: {
+      const filteredStats = computeFilteredStats(
+        report,
+        options.boxPlotIncludeStatuses
+      )
+      const items = buildStatsItems(report, filteredStats, options)
+      if (items.length === 0) return null
+      return React.createElement(StatsSummaryView, { items, fontScale })
+    }
+
+    case 3: {
+      // 小計点テーブル
+      const subtotalScores = filterSubtotalScores(
+        report.scoringData.subtotalScores,
+        options.tableSubtotalGroupSelection,
+        options.hideUnassignedSubtotals
+      )
+      if (subtotalScores.length === 0) return null
+
+      const groupedData = groupSubtotalData(subtotalScores)
+      const columns = options.subtotalTableColumns || 1
+      const isHorizontalLayout = columns >= groupedData.length
+      const baseFontSize = options.subtotalTableFontSize || 10
+
+      const groupTableDataList = groupedData.map((group) => {
+        const allocatedColumns = isHorizontalLayout
+          ? (allocateColumnsDHondt(groupedData, columns).get(group.groupId) ||
+              1)
+          : columns
+        const columnItems = splitItemsIntoColumns(group.items, allocatedColumns)
+        const maxRows = Math.max(...columnItems.map((col) => col.length), 0)
+        return {
+          groupId: group.groupId,
+          groupName: group.groupName,
+          allocatedColumns,
+          columnItems,
+          maxRows,
+          totalScore: group.totalScore,
+          totalMaxScore: group.totalMaxScore,
+        }
+      })
+
+      const totalAllocatedColumns = isHorizontalLayout
+        ? groupTableDataList.reduce((sum, g) => sum + g.allocatedColumns, 0)
+        : 1
+
+      return React.createElement(SubtotalTableView, {
+        groupTableDataList,
+        isHorizontalLayout,
+        totalAllocatedColumns,
+        fontScale,
+        baseFontSize,
+        showGroupSubtotals: options.showGroupSubtotals,
+      })
+    }
+
+    case 4: {
+      // 箱ひげ図
+      const includeStatuses = options.boxPlotIncludeStatuses || {
+        participating: true,
+        expected: true,
+        absent: true,
+      }
+      const computedStats = computeFilteredSubtotalStats(
+        report.statistics.subtotalRawScores || [],
+        report.statistics.subtotalStatistics,
+        includeStatuses
+      )
+
+      let subtotalStats = computedStats
+
+      if (
+        options.boxPlotSubtotalGroupSelection?.enabled &&
+        options.boxPlotSubtotalGroupSelection.selectedGroupIds.length > 0
+      ) {
+        subtotalStats = subtotalStats.filter(
+          (s) =>
+            !s.subtotalGroupId ||
+            options.boxPlotSubtotalGroupSelection!.selectedGroupIds.includes(
+              s.subtotalGroupId
+            )
+        )
+      }
+
+      if (options.hideUnassignedSubtotals) {
+        const assignedSubtotalIds = new Set(
+          report.scoringData.subtotalScores
+            .filter((s) => s.hasQuestionAssignments)
+            .map((s) => s.subtotalId)
+        )
+        subtotalStats = subtotalStats.filter((s) =>
+          assignedSubtotalIds.has(s.subtotalId)
+        )
+      }
+
+      if (subtotalStats.length === 0) return null
+
+      const graphOptions = options.graphOptions
+      const getStudentScore = (subtotalId: string): number => {
+        const subtotal = report.scoringData.subtotalScores.find(
+          (s) => s.subtotalId === subtotalId
+        )
+        return subtotal?.score ?? 0
+      }
+
+      // セクションヘッダーと箱ひげ図をまとめる
+      return React.createElement(
+        "section",
+        { style: { marginBottom: "6mm" } },
+        React.createElement(
+          "h2",
+          {
+            style: {
+              fontSize: `${14 * fontScale}px`,
+              fontWeight: "bold",
+              marginBottom: "4mm",
+              paddingBottom: "2mm",
+              borderBottom: "1px solid #ddd",
+            },
+          },
+          "小計別分布"
+        ),
+        React.createElement(BoxPlotChartView, {
+          subtotalStats,
+          getStudentScore,
+          fontScale,
+          showMin: graphOptions.showBoxPlotMin,
+          showQ1: graphOptions.showBoxPlotQ1,
+          showMedian: graphOptions.showBoxPlotMedian,
+          showQ3: graphOptions.showBoxPlotQ3,
+          showMax: graphOptions.showBoxPlotMax,
+          showAverageLine: graphOptions.showAverageLine,
+          showStudentMarker: graphOptions.showStudentMarker,
+          boxPlotFontSize: graphOptions.boxPlotFontSize ?? 11,
+          boxPlotItemHeight: graphOptions.boxPlotItemHeight ?? 20,
+        })
+      )
+    }
+
     case 5:
-      return generateQuestionTable(report, options, fontScale)
-    case 6:
-      return generateLearningAdvice(
-        learningAdvice,
-        options.adviceOptions,
-        fontScale
+      // 設問テーブル（既にhooks不使用）
+      return React.createElement(ScoreTablePreview, {
+        report,
+        options,
+        fontScale,
+      })
+
+    case 6: {
+      // 学習アドバイス（既にhooks不使用）
+      const learningAdvice = calculateLearningAdvice(
+        report.scoringData.scores,
+        report.statistics.questionCorrectRates,
+        options.adviceOptions
       )
+      return React.createElement(LearningAdvicePreview, {
+        advice: learningAdvice,
+        options: options.adviceOptions,
+        fontScale,
+      })
+    }
+
     case 7:
-      return generateCommentSection(fontScale)
+      return React.createElement(CommentSectionView, { fontScale })
+
     case 8:
-      return generateSignatureSection(fontScale)
+      return React.createElement(SignatureSectionView, { fontScale })
+
     default:
-      return ""
+      return null
   }
-}
-
-// ヘッダー
-function generateHeader(
-  report: IndividualReportData,
-  fontScale: number
-): string {
-  const examDate = report.examInfo.examDate
-    ? formatDate(report.examInfo.examDate)
-    : ""
-
-  return `
-    <header style="
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 6mm;
-      padding-bottom: 4mm;
-      border-bottom: 2px solid #333;
-    ">
-      <div>
-        <h1 style="font-size: ${18 * fontScale}px; font-weight: bold; margin: 0;">
-          ${escapeHtml(report.examInfo.examName)}
-        </h1>
-        ${
-          report.examInfo.subject
-            ? `
-          <p style="font-size: ${12 * fontScale}px; color: #666; margin: 2mm 0 0 0;">
-            ${escapeHtml(report.examInfo.subject)}
-          </p>
-        `
-            : ""
-        }
-      </div>
-      <div style="text-align: right;">
-        ${
-          examDate
-            ? `
-          <p style="font-size: ${12 * fontScale}px; color: #666; margin: 0;">
-            ${examDate}
-          </p>
-        `
-            : ""
-        }
-        <p style="font-size: ${14 * fontScale}px; font-weight: bold; margin: 2mm 0 0 0;">
-          個人成績表
-        </p>
-      </div>
-    </header>
-  `
-}
-
-// 生徒情報
-function generateStudentInfo(
-  report: IndividualReportData,
-  fontScale: number
-): string {
-  const studentInfo = report.studentInfo
-  const classInfo = [
-    studentInfo.grade ? `${studentInfo.grade}年` : "",
-    studentInfo.className || "",
-    studentInfo.attendanceNumber != null
-      ? `${studentInfo.attendanceNumber}番`
-      : "",
-  ]
-    .filter(Boolean)
-    .join(" ")
-
-  return `
-    <section style="
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 6mm;
-      padding: 4mm;
-      background-color: #f5f5f5;
-      border-radius: 2mm;
-    ">
-      <div>
-        <p style="font-size: ${16 * fontScale}px; font-weight: bold; margin: 0;">
-          ${escapeHtml(studentInfo.fullName)}
-        </p>
-        <p style="font-size: ${11 * fontScale}px; color: #666; margin: 1mm 0 0 0;">
-          ${escapeHtml(studentInfo.studentNumber)}
-        </p>
-      </div>
-      <div style="text-align: right;">
-        <p style="font-size: ${12 * fontScale}px; margin: 0;">
-          ${escapeHtml(classInfo)}
-        </p>
-      </div>
-    </section>
-  `
-}
-
-// 統計サマリー
-function generateStatsSummary(
-  report: IndividualReportData,
-  options: IndividualReportOptions,
-  fontScale: number
-): string {
-  const items: { label: string; value: string }[] = []
-
-  if (options.showScore) {
-    items.push({
-      label: "得点",
-      value: `${report.scoringData.totalScore} / ${report.scoringData.totalMaxScore}`,
-    })
-  }
-
-  if (options.showAverage !== "none") {
-    if (options.showAverage === "class" || options.showAverage === "both") {
-      items.push({
-        label: "学級平均",
-        value: report.statistics.class.average.toFixed(1),
-      })
-    }
-    if (options.showAverage === "overall" || options.showAverage === "both") {
-      items.push({
-        label: "全体平均",
-        value: report.statistics.overall.average.toFixed(1),
-      })
-    }
-  }
-
-  if (options.showDeviation) {
-    items.push({
-      label: "偏差値",
-      value: report.statistics.personal.deviation.toFixed(1),
-    })
-  }
-
-  if (options.showRank) {
-    if (options.rankType === "class" || options.rankType === "both") {
-      items.push({
-        label: "学級順位",
-        value: `${report.statistics.personal.classRank} / ${report.statistics.class.total}`,
-      })
-    }
-    if (options.rankType === "overall" || options.rankType === "both") {
-      items.push({
-        label: "全体順位",
-        value: `${report.statistics.personal.overallRank} / ${report.statistics.overall.total}`,
-      })
-    }
-  }
-
-  if (items.length === 0) return ""
-
-  const itemsHtml = items
-    .map(
-      (item) => `
-    <div style="
-      flex: 1;
-      padding: 3mm 2mm;
-      background-color: #f0f7ff;
-      border-radius: 2mm;
-      text-align: center;
-    ">
-      <p style="font-size: ${10 * fontScale}px; color: #666; margin: 0;">
-        ${escapeHtml(item.label)}
-      </p>
-      <p style="font-size: ${16 * fontScale}px; font-weight: bold; margin: 1mm 0 0 0;">
-        ${escapeHtml(item.value)}
-      </p>
-    </div>
-  `
-    )
-    .join("")
-
-  return `
-    <section style="
-      display: flex;
-      gap: 3mm;
-      margin-bottom: 6mm;
-    ">
-      ${itemsHtml}
-    </section>
-  `
-}
-
-// 小計点テーブル（SubtotalTablePreview.tsxと同じロジック）
-function generateSubtotalTable(
-  report: IndividualReportData,
-  options: IndividualReportOptions,
-  fontScale: number
-): string {
-  let subtotalScores = report.scoringData.subtotalScores
-
-  // フィルタリング
-  if (
-    options.tableSubtotalGroupSelection?.enabled &&
-    options.tableSubtotalGroupSelection.selectedGroupIds.length > 0
-  ) {
-    subtotalScores = subtotalScores.filter((score) =>
-      options.tableSubtotalGroupSelection!.selectedGroupIds.includes(
-        score.subtotalGroupId
-      )
-    )
-  }
-
-  if (options.hideUnassignedSubtotals) {
-    subtotalScores = subtotalScores.filter(
-      (score) => score.hasQuestionAssignments
-    )
-  }
-
-  if (subtotalScores.length === 0) return ""
-
-  const baseFontSize = options.subtotalTableFontSize || 10
-
-  // グループごとにグルーピング
-  interface GroupedSubtotals {
-    groupId: string
-    groupName: string
-    items: typeof subtotalScores
-    totalScore: number
-    totalMaxScore: number
-  }
-
-  const groupMap = new Map<string, GroupedSubtotals>()
-
-  for (const score of subtotalScores) {
-    const groupId = score.subtotalGroupId
-    const existing = groupMap.get(groupId)
-    if (existing) {
-      existing.items.push(score)
-      existing.totalScore += score.score
-      existing.totalMaxScore += score.maxScore
-    } else {
-      groupMap.set(groupId, {
-        groupId,
-        groupName: score.subtotalGroupName,
-        items: [score],
-        totalScore: score.score,
-        totalMaxScore: score.maxScore,
-      })
-    }
-  }
-
-  const groups = Array.from(groupMap.values())
-  const columns = options.subtotalTableColumns || 1
-  const isHorizontalLayout = columns >= groups.length
-
-  // ドント方式で列数を各グループに配分
-  const allocateColumnsDHondt = (
-    grps: GroupedSubtotals[],
-    totalColumns: number
-  ): Map<string, number> => {
-    const allocation = new Map<string, number>()
-    if (grps.length === 0) return allocation
-    for (const group of grps) {
-      allocation.set(group.groupId, 1)
-    }
-    if (grps.length >= totalColumns) {
-      return allocation
-    }
-    let remainingColumns = totalColumns - grps.length
-    while (remainingColumns > 0) {
-      let maxQuotient = -1
-      let maxGroupId = ""
-      for (const group of grps) {
-        const currentAllocation = allocation.get(group.groupId)!
-        const quotient = group.items.length / (currentAllocation + 1)
-        if (quotient > maxQuotient) {
-          maxQuotient = quotient
-          maxGroupId = group.groupId
-        }
-      }
-      allocation.set(maxGroupId, allocation.get(maxGroupId)! + 1)
-      remainingColumns--
-    }
-    return allocation
-  }
-
-  // アイテムを指定列数に分割（縦方向に埋める）
-  const splitItemsIntoColumns = <T>(items: T[], columnCount: number): T[][] => {
-    const result: T[][] = Array.from({ length: columnCount }, () => [])
-    const itemsPerColumn = Math.ceil(items.length / columnCount)
-    for (let i = 0; i < items.length; i++) {
-      const colIndex = Math.floor(i / itemsPerColumn)
-      if (colIndex < columnCount) {
-        result[colIndex].push(items[i])
-      }
-    }
-    return result
-  }
-
-  // 各グループのテーブルデータを構築
-  interface GroupTableData {
-    groupId: string
-    groupName: string
-    allocatedColumns: number
-    columnItems: (typeof subtotalScores)[]
-    maxRows: number
-    totalScore: number
-    totalMaxScore: number
-  }
-
-  let groupTableDataList: GroupTableData[]
-  if (isHorizontalLayout) {
-    const allocation = allocateColumnsDHondt(groups, columns)
-    groupTableDataList = groups.map((group) => {
-      const allocatedColumns = allocation.get(group.groupId) || 1
-      const columnItems = splitItemsIntoColumns(group.items, allocatedColumns)
-      const maxRows = Math.max(...columnItems.map((col) => col.length), 0)
-      return {
-        groupId: group.groupId,
-        groupName: group.groupName,
-        allocatedColumns,
-        columnItems,
-        maxRows,
-        totalScore: group.totalScore,
-        totalMaxScore: group.totalMaxScore,
-      }
-    })
-  } else {
-    groupTableDataList = groups.map((group) => {
-      const columnItems = splitItemsIntoColumns(group.items, columns)
-      const maxRows = Math.max(...columnItems.map((col) => col.length), 0)
-      return {
-        groupId: group.groupId,
-        groupName: group.groupName,
-        allocatedColumns: columns,
-        columnItems,
-        maxRows,
-        totalScore: group.totalScore,
-        totalMaxScore: group.totalMaxScore,
-      }
-    })
-  }
-
-  const totalAllocatedColumns = isHorizontalLayout
-    ? groupTableDataList.reduce((sum, g) => sum + g.allocatedColumns, 0)
-    : 1
-
-  // HTMLを生成
-  const groupsHtml = groupTableDataList
-    .map((groupData, groupIndex) => {
-      const groupWidth = isHorizontalLayout
-        ? `${(groupData.allocatedColumns / totalAllocatedColumns) * 100}%`
-        : "100%"
-      const colWidthPercent = 100 / groupData.allocatedColumns
-      const labelWidthPercent = colWidthPercent * 0.6
-      const scoreWidthPercent = colWidthPercent * 0.4
-
-      // colgroup
-      const colgroupHtml = Array.from({ length: groupData.allocatedColumns })
-        .map(
-          () =>
-            `<col style="width: ${labelWidthPercent}%"/><col style="width: ${scoreWidthPercent}%"/>`
-        )
-        .join("")
-
-      // 行を生成
-      const rowsHtml = Array.from({ length: groupData.maxRows })
-        .map((_, rowIndex) => {
-          const isAlt = rowIndex % 2 === 1
-          const bgColor = isAlt ? "#fafafa" : "transparent"
-          const cellsHtml = groupData.columnItems
-            .map((colItems) => {
-              const item = colItems[rowIndex]
-              if (!item) {
-                return `<td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0;"></td><td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0;"></td>`
-              }
-              const shortLabel =
-                item.subtotalLabel.length > 10
-                  ? item.subtotalLabel.substring(0, 10) + "…"
-                  : item.subtotalLabel
-              return `
-                <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: left;">${escapeHtml(shortLabel)}</td>
-                <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: center;">
-                  ${item.score}<span style="font-size: ${baseFontSize * 0.8}px; color: #666;"> / ${item.maxScore}</span>
-                </td>
-              `
-            })
-            .join("")
-          return `<tr style="background-color: ${bgColor};">${cellsHtml}</tr>`
-        })
-        .join("")
-
-      const subtotalRow = options.showGroupSubtotals
-        ? `
-        <tr>
-          <td colspan="${groupData.allocatedColumns * 2 - 1}" style="padding: 1.5mm 2mm; background-color: #f0f7ff; font-weight: bold; text-align: right;">計</td>
-          <td style="padding: 1.5mm 2mm; background-color: #f0f7ff; font-weight: bold; text-align: center;">
-            ${groupData.totalScore}<span style="font-size: ${baseFontSize * 0.8}px; color: #666;"> / ${groupData.totalMaxScore}</span>
-          </td>
-        </tr>
-      `
-        : ""
-
-      return `
-        <div style="width: ${groupWidth}; ${!isHorizontalLayout && groupIndex < groupTableDataList.length - 1 ? "margin-bottom: 4mm;" : ""}">
-          <table style="width: 100%; border-collapse: collapse; font-size: ${baseFontSize}px; table-layout: fixed;">
-            <colgroup>${colgroupHtml}</colgroup>
-            <thead>
-              <tr>
-                <th colspan="${groupData.allocatedColumns * 2}" style="padding: 1.5mm 2mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center;">
-                  ${escapeHtml(groupData.groupName)}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              ${rowsHtml}
-              ${subtotalRow}
-            </tbody>
-          </table>
-        </div>
-      `
-    })
-    .join("")
-
-  return `
-    <section style="margin-bottom: 6mm;">
-      <h2 style="
-        font-size: ${14 * fontScale}px;
-        font-weight: bold;
-        margin-bottom: 4mm;
-        padding-bottom: 2mm;
-        border-bottom: 1px solid #ddd;
-      ">
-        小計別得点
-      </h2>
-      <div style="display: ${isHorizontalLayout ? "flex" : "block"}; gap: ${isHorizontalLayout ? "2mm" : "0"};">
-        ${groupsHtml}
-      </div>
-    </section>
-  `
-}
-
-// 箱ひげ図（SVG）
-function generateBoxPlot(
-  report: IndividualReportData,
-  options: IndividualReportOptions,
-  fontScale: number
-): string {
-  // 受験状態フィルタに基づいて統計を再計算（BoxPlotChartと同じロジック）
-  const includeStatuses =
-    options.boxPlotIncludeStatuses || DEFAULT_INCLUDE_STATUSES
-  const computedStats = computeSubtotalStats(
-    report.statistics.subtotalRawScores || [],
-    report.statistics.subtotalStatistics,
-    includeStatuses
-  )
-
-  let subtotalStats = computedStats
-
-  // グループ選択でフィルタリング
-  if (
-    options.boxPlotSubtotalGroupSelection?.enabled &&
-    options.boxPlotSubtotalGroupSelection.selectedGroupIds.length > 0
-  ) {
-    subtotalStats = subtotalStats.filter(
-      (s) =>
-        !s.subtotalGroupId ||
-        options.boxPlotSubtotalGroupSelection!.selectedGroupIds.includes(
-          s.subtotalGroupId
-        )
-    )
-  }
-
-  // 未割当小計を非表示
-  if (options.hideUnassignedSubtotals) {
-    const assignedSubtotalIds = new Set(
-      report.scoringData.subtotalScores
-        .filter((s) => s.hasQuestionAssignments)
-        .map((s) => s.subtotalId)
-    )
-    subtotalStats = subtotalStats.filter((s) =>
-      assignedSubtotalIds.has(s.subtotalId)
-    )
-  }
-
-  if (subtotalStats.length === 0) return ""
-
-  const graphOptions = options.graphOptions
-
-  // チャート設定（BoxPlotChartと同じロジック）
-  const boxPlotFontSize = graphOptions.boxPlotFontSize ?? 11
-  const boxPlotItemSpacing = graphOptions.boxPlotItemHeight ?? 20
-  const boxHeight = boxPlotFontSize * 1.8
-  const rowHeight = boxHeight + boxPlotItemSpacing
-
-  const chartWidth = 500
-  const legendHeight = 20 // 凡例用の高さ
-  const chartHeight = 40 + subtotalStats.length * rowHeight + legendHeight
-  const marginLeft = 100
-  const marginRight = 60
-  const marginTop = 30
-  const plotWidth = chartWidth - marginLeft - marginRight
-
-  const getStudentScore = (subtotalId: string): number => {
-    const subtotal = report.scoringData.subtotalScores.find(
-      (s) => s.subtotalId === subtotalId
-    )
-    return subtotal?.score ?? 0
-  }
-
-  const plotsHtml = subtotalStats
-    .map((stat, index) => {
-      const y = marginTop + index * rowHeight
-      const boxPlot = stat.boxPlot
-      const maxScore =
-        report.scoringData.subtotalScores.find(
-          (s) => s.subtotalId === stat.subtotalId
-        )?.maxScore || 100
-
-      const toPercent = (score: number) => (score / maxScore) * 100
-      const toX = (percent: number) => marginLeft + (percent / 100) * plotWidth
-
-      const minX = toX(toPercent(boxPlot.min))
-      const q1X = toX(toPercent(boxPlot.q1))
-      const medianX = toX(toPercent(boxPlot.median))
-      const q3X = toX(toPercent(boxPlot.q3))
-      const maxX = toX(toPercent(boxPlot.max))
-      const averageX = toX(toPercent(stat.average))
-      const studentScore = getStudentScore(stat.subtotalId)
-      const studentX = toX(toPercent(studentScore))
-      const markerRadius = Math.max(4, boxHeight / 4)
-
-      const truncatedLabel =
-        stat.subtotalLabel.length > 12
-          ? stat.subtotalLabel.substring(0, 12) + "..."
-          : stat.subtotalLabel
-
-      let svg = `<text x="${marginLeft - 8}" y="${y + boxHeight / 2 + 4}" font-size="${boxPlotFontSize * fontScale}" fill="#333" text-anchor="end">${escapeHtml(truncatedLabel)}</text>`
-
-      // ひげと箱
-      if (graphOptions.showBoxPlotMin && graphOptions.showBoxPlotQ1) {
-        svg += `<line x1="${minX}" y1="${y + boxHeight / 2}" x2="${q1X}" y2="${y + boxHeight / 2}" stroke="#666" stroke-width="1"/>`
-        svg += `<line x1="${minX}" y1="${y + 4}" x2="${minX}" y2="${y + boxHeight - 4}" stroke="#666" stroke-width="1"/>`
-      }
-      if (graphOptions.showBoxPlotQ1 && graphOptions.showBoxPlotQ3) {
-        svg += `<rect x="${q1X}" y="${y}" width="${Math.max(q3X - q1X, 1)}" height="${boxHeight}" fill="#e0e7ff" stroke="#6366f1"/>`
-      }
-      if (graphOptions.showBoxPlotMedian) {
-        svg += `<line x1="${medianX}" y1="${y}" x2="${medianX}" y2="${y + boxHeight}" stroke="#4f46e5" stroke-width="2"/>`
-      }
-      if (graphOptions.showBoxPlotMax && graphOptions.showBoxPlotQ3) {
-        svg += `<line x1="${q3X}" y1="${y + boxHeight / 2}" x2="${maxX}" y2="${y + boxHeight / 2}" stroke="#666" stroke-width="1"/>`
-        svg += `<line x1="${maxX}" y1="${y + 4}" x2="${maxX}" y2="${y + boxHeight - 4}" stroke="#666" stroke-width="1"/>`
-      }
-      if (graphOptions.showAverageLine) {
-        svg += `<line x1="${averageX}" y1="${y - 2}" x2="${averageX}" y2="${y + boxHeight + 2}" stroke="#f59e0b" stroke-width="2" stroke-dasharray="3 2"/>`
-      }
-      if (graphOptions.showStudentMarker) {
-        svg += `<circle cx="${studentX}" cy="${y + boxHeight / 2}" r="${markerRadius}" fill="#ef4444" stroke="#fff" stroke-width="2"/>`
-        svg += `<text x="${chartWidth - 10}" y="${y + boxHeight / 2 + 4}" font-size="${(boxPlotFontSize - 1) * fontScale}" fill="#333" text-anchor="end">${studentScore}点</text>`
-      }
-
-      return `<g>${svg}</g>`
-    })
-    .join("")
-
-  // 凡例を生成（BoxPlotChartと同じロジック）
-  const legendY = chartHeight - 8
-  let legendHtml = `<g transform="translate(${marginLeft}, ${legendY})">`
-  let xOffset = 0
-
-  // 範囲ラベルを動的に生成
-  const getRangeLabel = (): string | null => {
-    if (
-      graphOptions.showBoxPlotQ1 &&
-      graphOptions.showBoxPlotMedian &&
-      graphOptions.showBoxPlotQ3
-    )
-      return "Q1-Q3範囲"
-    if (
-      graphOptions.showBoxPlotQ1 &&
-      graphOptions.showBoxPlotMedian &&
-      !graphOptions.showBoxPlotQ3
-    )
-      return "Q1-中央値範囲"
-    if (
-      !graphOptions.showBoxPlotQ1 &&
-      graphOptions.showBoxPlotMedian &&
-      graphOptions.showBoxPlotQ3
-    )
-      return "中央値-Q3範囲"
-    if (
-      graphOptions.showBoxPlotQ1 &&
-      !graphOptions.showBoxPlotMedian &&
-      graphOptions.showBoxPlotQ3
-    )
-      return "Q1-Q3範囲"
-    return null
-  }
-  const rangeLabel = getRangeLabel()
-
-  const legendFontSize = (boxPlotFontSize - 2) * fontScale
-
-  if (graphOptions.showStudentMarker) {
-    legendHtml += `
-      <g transform="translate(${xOffset}, 0)">
-        <circle cx="0" cy="0" r="4" fill="#ef4444"/>
-        <text x="8" y="4" font-size="${legendFontSize}" fill="#666">あなたの得点</text>
-      </g>
-    `
-    xOffset += 80
-  }
-
-  if (rangeLabel) {
-    legendHtml += `
-      <g transform="translate(${xOffset}, 0)">
-        <rect x="0" y="-6" width="12" height="12" fill="#e0e7ff" stroke="#6366f1"/>
-        <text x="16" y="4" font-size="${legendFontSize}" fill="#666">${rangeLabel}</text>
-      </g>
-    `
-    xOffset += 80
-  }
-
-  if (graphOptions.showBoxPlotMedian) {
-    legendHtml += `
-      <g transform="translate(${xOffset}, 0)">
-        <line x1="0" y1="0" x2="10" y2="0" stroke="#4f46e5" stroke-width="2"/>
-        <text x="14" y="4" font-size="${legendFontSize}" fill="#666">中央値</text>
-      </g>
-    `
-    xOffset += 60
-  }
-
-  if (graphOptions.showAverageLine) {
-    legendHtml += `
-      <g transform="translate(${xOffset}, 0)">
-        <line x1="0" y1="0" x2="15" y2="0" stroke="#f59e0b" stroke-width="2" stroke-dasharray="3 2"/>
-        <text x="19" y="4" font-size="${legendFontSize}" fill="#666">平均</text>
-      </g>
-    `
-  }
-
-  legendHtml += `</g>`
-
-  return `
-    <section style="margin-bottom: 6mm;">
-      <h2 style="
-        font-size: ${14 * fontScale}px;
-        font-weight: bold;
-        margin-bottom: 4mm;
-        padding-bottom: 2mm;
-        border-bottom: 1px solid #ddd;
-      ">
-        小計別分布
-      </h2>
-      <svg viewBox="0 0 ${chartWidth} ${chartHeight}" style="width: 100%; height: auto;">
-        <text x="${marginLeft}" y="15" font-size="${10 * fontScale}" fill="#666" text-anchor="start">0%</text>
-        <text x="${marginLeft + plotWidth / 2}" y="15" font-size="${10 * fontScale}" fill="#666" text-anchor="middle">50%</text>
-        <text x="${marginLeft + plotWidth}" y="15" font-size="${10 * fontScale}" fill="#666" text-anchor="end">100%</text>
-        <line x1="${marginLeft}" y1="${marginTop}" x2="${marginLeft}" y2="${chartHeight - legendHeight - 10}" stroke="#e0e0e0" stroke-width="1"/>
-        <line x1="${marginLeft + plotWidth / 2}" y1="${marginTop}" x2="${marginLeft + plotWidth / 2}" y2="${chartHeight - legendHeight - 10}" stroke="#e0e0e0" stroke-width="1" stroke-dasharray="4 4"/>
-        <line x1="${marginLeft + plotWidth}" y1="${marginTop}" x2="${marginLeft + plotWidth}" y2="${chartHeight - legendHeight - 10}" stroke="#e0e0e0" stroke-width="1"/>
-        ${plotsHtml}
-        ${legendHtml}
-      </svg>
-    </section>
-  `
-}
-
-// 設問テーブル（ScoreTablePreview.tsxと同じロジック）
-function generateQuestionTable(
-  report: IndividualReportData,
-  options: IndividualReportOptions,
-  fontScale: number
-): string {
-  const data = report.scoringData.scores
-  if (data.length === 0) return ""
-
-  const columns = options.questionTableColumns || 1
-  const baseFontSize = options.questionTableFontSize || 10
-  const tableFontScale = fontScale * (baseFontSize / 11)
-
-  // マーク情報を取得
-  const getMarkInfo = (status: string): { mark: string; markColor: string } => {
-    switch (status) {
-      case "correct":
-        return { mark: "○", markColor: "#16a34a" }
-      case "incorrect":
-        return { mark: "×", markColor: "#dc2626" }
-      case "partial":
-        return { mark: "△", markColor: "#ca8a04" }
-      case "no_answer":
-        return { mark: "-", markColor: "#666" }
-      default:
-        return { mark: "", markColor: "#333" }
-    }
-  }
-
-  // 1列表示の場合
-  if (columns === 1) {
-    const rowsHtml = data
-      .map((item, index) => {
-        const isAlt = index % 2 === 1
-        const bgColor = isAlt ? "#fafafa" : "transparent"
-        const { mark, markColor } = getMarkInfo(item.status)
-        const correctRate =
-          report.statistics.questionCorrectRates[item.questionId] ?? 0
-
-        return `
-          <tr style="background-color: ${bgColor};">
-            <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: left;">
-              ${escapeHtml(item.questionLabel.length > 30 ? item.questionLabel.substring(0, 30) + "..." : item.questionLabel)}
-            </td>
-            <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center;">
-              ${item.score ?? "-"}<span style="font-size: ${baseFontSize * 0.8}px; color: #666;"> / ${item.maxScore}</span>
-            </td>
-            ${
-              options.showMarks
-                ? `
-              <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center; color: ${markColor}; font-weight: bold;">
-                ${mark}
-              </td>
-            `
-                : ""
-            }
-            ${
-              options.showCorrectRate
-                ? `
-              <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center;">
-                ${Math.round(correctRate)}%
-              </td>
-            `
-                : ""
-            }
-          </tr>
-        `
-      })
-      .join("")
-
-    const totalRow = `
-      <tr style="background-color: #e8f4fd; font-weight: bold;">
-        <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: left; font-weight: bold;">合計</td>
-        <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center; font-weight: bold;">
-          ${report.scoringData.totalScore}<span style="font-size: ${baseFontSize * 0.8}px; color: #666;"> / ${report.scoringData.totalMaxScore}</span>
-        </td>
-        ${options.showMarks ? `<td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center;">-</td>` : ""}
-        ${
-          options.showCorrectRate
-            ? `
-          <td style="padding: 2mm 3mm; border-bottom: 1px solid #e0e0e0; text-align: center; font-weight: bold;">
-            ${Math.round((report.scoringData.totalScore / report.scoringData.totalMaxScore) * 100)}%
-          </td>
-        `
-            : ""
-        }
-      </tr>
-    `
-
-    return `
-      <section style="margin-bottom: 6mm;">
-        <h2 style="font-size: ${14 * fontScale}px; font-weight: bold; margin-bottom: 4mm; padding-bottom: 2mm; border-bottom: 1px solid #ddd;">
-          設問別得点
-        </h2>
-        <table style="width: 100%; border-collapse: collapse; font-size: ${baseFontSize}px;">
-          <thead>
-            <tr>
-              <th style="padding: 2mm 3mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: left; width: 45%;">設問</th>
-              <th style="padding: 2mm 3mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 25%;">得点</th>
-              ${options.showMarks ? `<th style="padding: 2mm 3mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 10%;">評価</th>` : ""}
-              ${options.showCorrectRate ? `<th style="padding: 2mm 3mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 15%;">正答率</th>` : ""}
-            </tr>
-          </thead>
-          <tbody>
-            ${rowsHtml}
-            ${totalRow}
-          </tbody>
-        </table>
-      </section>
-    `
-  }
-
-  // 複数列表示の場合
-  const rowsPerColumn = Math.ceil(data.length / columns)
-  const columnData: (typeof data)[] = []
-  for (let i = 0; i < columns; i++) {
-    const start = i * rowsPerColumn
-    const end = Math.min(start + rowsPerColumn, data.length)
-    columnData.push(data.slice(start, end))
-  }
-
-  const multiFontSize = 10 * tableFontScale
-  const columnWidth = `${100 / columns}%`
-
-  const columnsHtml = columnData
-    .map((colData) => {
-      const rowsHtml = colData
-        .map((item, index) => {
-          const isAlt = index % 2 === 1
-          const bgColor = isAlt ? "#fafafa" : "transparent"
-          const { mark, markColor } = getMarkInfo(item.status)
-          const shortLabel =
-            item.questionLabel.length > 8
-              ? item.questionLabel.substring(0, 8) + "…"
-              : item.questionLabel
-
-          return `
-            <tr style="background-color: ${bgColor};">
-              <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 0;" title="${escapeHtml(item.questionLabel)}">
-                ${escapeHtml(shortLabel)}
-              </td>
-              <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: center;">
-                ${item.score ?? "-"}<span style="font-size: ${multiFontSize * 0.8}px; color: #666;"> / ${item.maxScore}</span>
-              </td>
-              ${
-                options.showMarks
-                  ? `
-                <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: center; color: ${markColor}; font-weight: bold;">
-                  ${mark}
-                </td>
-              `
-                  : ""
-              }
-              ${
-                options.showCorrectRate
-                  ? `
-                <td style="padding: 1.5mm 2mm; border-bottom: 1px solid #e0e0e0; text-align: center;">
-                  ${Math.round(report.statistics.questionCorrectRates[item.questionId] ?? 0)}%
-                </td>
-              `
-                  : ""
-              }
-            </tr>
-          `
-        })
-        .join("")
-
-      return `
-        <div style="width: ${columnWidth};">
-          <table style="width: 100%; border-collapse: collapse; font-size: ${multiFontSize}px;">
-            <thead>
-              <tr>
-                <th style="padding: 1.5mm 2mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: left; width: 45%;">設問</th>
-                <th style="padding: 1.5mm 2mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 30%;">得点</th>
-                ${options.showMarks ? `<th style="padding: 1.5mm 2mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 10%;">○×</th>` : ""}
-                ${options.showCorrectRate ? `<th style="padding: 1.5mm 2mm; background-color: #f5f5f5; font-weight: bold; border-bottom: 2px solid #ccc; text-align: center; width: 15%;">正答率</th>` : ""}
-              </tr>
-            </thead>
-            <tbody>
-              ${rowsHtml}
-            </tbody>
-          </table>
-        </div>
-      `
-    })
-    .join("")
-
-  // 合計行
-  const totalRowHtml = `
-    <div style="margin-top: 2mm; padding: 2mm 3mm; background-color: #e8f4fd; border-radius: 2mm; display: flex; justify-content: space-between; font-size: ${11 * fontScale}px; font-weight: bold;">
-      <span>合計</span>
-      <span>
-        ${report.scoringData.totalScore}<span style="font-size: ${11 * fontScale * 0.8}px; color: #666;"> / ${report.scoringData.totalMaxScore}</span>
-        (${Math.round((report.scoringData.totalScore / report.scoringData.totalMaxScore) * 100)}%)
-      </span>
-    </div>
-  `
-
-  return `
-    <section style="margin-bottom: 6mm;">
-      <h2 style="font-size: ${14 * fontScale}px; font-weight: bold; margin-bottom: 4mm; padding-bottom: 2mm; border-bottom: 1px solid #ddd;">
-        設問別得点
-      </h2>
-      <div style="display: flex; gap: 2mm;">
-        ${columnsHtml}
-      </div>
-      ${totalRowHtml}
-    </section>
-  `
-}
-
-// 学習アドバイス
-function generateLearningAdvice(
-  advice: ReturnType<typeof calculateLearningAdvice>,
-  options: AdviceOptions,
-  fontScale: number
-): string {
-  if (advice.reviewQuestions.length === 0) return ""
-
-  const conditionParts: string[] = []
-  if (options.reviewRateMin !== null && options.reviewRateMax !== null) {
-    conditionParts.push(
-      `正答率${options.reviewRateMin}%〜${options.reviewRateMax}%`
-    )
-  } else if (options.reviewRateMin !== null) {
-    conditionParts.push(`正答率${options.reviewRateMin}%以上`)
-  } else if (options.reviewRateMax !== null) {
-    conditionParts.push(`正答率${options.reviewRateMax}%以下`)
-  }
-  if (options.reviewQuestionCount !== null) {
-    conditionParts.push(`上位${options.reviewQuestionCount}問`)
-  }
-  const conditionText =
-    conditionParts.length > 0 ? `（${conditionParts.join("・")}）` : ""
-
-  const questionsHtml = advice.reviewQuestions
-    .map(
-      (q, i) =>
-        `${i > 0 ? "、" : ""}<strong>${escapeHtml(q.label)}</strong><span style="font-size: ${10 * fontScale}px; color: #a16207;">（正答率${Math.round(q.correctRate)}%）</span>`
-    )
-    .join("")
-
-  return `
-    <section style="margin-bottom: 6mm;">
-      <h2 style="
-        font-size: ${14 * fontScale}px;
-        font-weight: bold;
-        margin-bottom: 4mm;
-        padding-bottom: 2mm;
-        border-bottom: 1px solid #ddd;
-      ">
-        学習アドバイス
-      </h2>
-      <div style="
-        padding: 3mm 4mm;
-        background-color: #fef3c7;
-        border-radius: 2mm;
-        border-left: 3px solid #f59e0b;
-      ">
-        <p style="font-size: ${12 * fontScale}px; font-weight: bold; margin: 0 0 2mm 0; color: #92400e;">
-          復習しよう！${conditionText}
-        </p>
-        <p style="font-size: ${11 * fontScale}px; margin: 0; color: #78350f;">
-          ${questionsHtml}
-        </p>
-      </div>
-    </section>
-  `
-}
-
-// コメント欄
-function generateCommentSection(fontScale: number): string {
-  return `
-    <section style="
-      margin-top: 6mm;
-      padding: 4mm;
-      border: 1px solid #ccc;
-      border-radius: 2mm;
-    ">
-      <p style="font-size: ${11 * fontScale}px; font-weight: bold; margin: 0 0 2mm 0;">
-        コメント:
-      </p>
-      <div style="min-height: 20mm; border-bottom: 1px dotted #ccc;"></div>
-    </section>
-  `
-}
-
-// 署名欄
-function generateSignatureSection(fontScale: number): string {
-  return `
-    <section style="
-      display: flex;
-      justify-content: flex-end;
-      gap: 10mm;
-      margin-top: 6mm;
-    ">
-      <div style="text-align: center;">
-        <p style="font-size: ${10 * fontScale}px; margin: 0 0 2mm 0;">保護者印</p>
-        <div style="width: 20mm; height: 20mm; border: 1px solid #ccc; border-radius: 2mm;"></div>
-      </div>
-      <div style="text-align: center;">
-        <p style="font-size: ${10 * fontScale}px; margin: 0 0 2mm 0;">担任印</p>
-        <div style="width: 20mm; height: 20mm; border: 1px solid #ccc; border-radius: 2mm;"></div>
-      </div>
-    </section>
-  `
-}
-
-// ユーティリティ
-function formatDate(date: Date | null): string {
-  if (!date) return ""
-  const d = new Date(date)
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;")
-}
-
-// ============================================================
-// 箱ひげ図統計計算用ヘルパー関数（BoxPlotChart.tsxと同じロジック）
-// ============================================================
-
-interface BoxPlotData {
-  min: number
-  q1: number
-  median: number
-  q3: number
-  max: number
-}
-
-interface ComputedSubtotalStat {
-  subtotalId: string
-  subtotalLabel: string
-  subtotalGroupId: string
-  boxPlot: BoxPlotData
-  average: number
-  maxScore: number
-}
-
-const DEFAULT_INCLUDE_STATUSES: BoxPlotIncludeStatuses = {
-  participating: true,
-  expected: true,
-  absent: true,
-}
-
-function calculateMedian(sortedValues: number[]): number {
-  const n = sortedValues.length
-  if (n === 0) return 0
-  if (n === 1) return sortedValues[0]
-
-  const mid = Math.floor(n / 2)
-  if (n % 2 === 0) {
-    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
-  } else {
-    return sortedValues[mid]
-  }
-}
-
-function calculateAverage(values: number[]): number {
-  if (values.length === 0) return 0
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}
-
-function calculateBoxPlotData(values: number[]): BoxPlotData {
-  if (values.length === 0) {
-    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
-  }
-
-  const sorted = [...values].sort((a, b) => a - b)
-  const n = sorted.length
-
-  const min = sorted[0]
-  const max = sorted[n - 1]
-  const median = calculateMedian(sorted)
-
-  const midIndex = Math.floor(n / 2)
-  const lowerHalf = sorted.slice(0, midIndex)
-  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
-
-  const q1 = calculateMedian(lowerHalf)
-  const q3 = calculateMedian(upperHalf)
-
-  return { min, q1, median, q3, max }
-}
-
-function computeSubtotalStats(
-  rawScores: SubtotalRawScores[],
-  subtotalStatistics: StatisticsData["subtotalStatistics"],
-  includeStatuses: BoxPlotIncludeStatuses
-): ComputedSubtotalStat[] {
-  const includeAll =
-    includeStatuses.participating &&
-    includeStatuses.expected &&
-    includeStatuses.absent
-
-  return subtotalStatistics.map((stat) => {
-    const rawData = rawScores.find((r) => r.subtotalId === stat.subtotalId)
-
-    if (!rawData || includeAll) {
-      return {
-        subtotalId: stat.subtotalId,
-        subtotalLabel: stat.subtotalLabel,
-        subtotalGroupId: stat.subtotalGroupId,
-        boxPlot: stat.boxPlot,
-        average: stat.average,
-        maxScore: stat.maxScore,
-      }
-    }
-
-    const filteredScores = rawData.scores
-      .filter((s) => {
-        if (s.status === "participating") return includeStatuses.participating
-        if (s.status === "expected") return includeStatuses.expected
-        if (s.status === "absent") return includeStatuses.absent
-        return true
-      })
-      .map((s) => s.score)
-
-    if (filteredScores.length === 0) {
-      return {
-        subtotalId: stat.subtotalId,
-        subtotalLabel: stat.subtotalLabel,
-        subtotalGroupId: stat.subtotalGroupId,
-        boxPlot: { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
-        average: 0,
-        maxScore: stat.maxScore,
-      }
-    }
-
-    return {
-      subtotalId: stat.subtotalId,
-      subtotalLabel: stat.subtotalLabel,
-      subtotalGroupId: stat.subtotalGroupId,
-      boxPlot: calculateBoxPlotData(filteredScores),
-      average: calculateAverage(filteredScores),
-      maxScore: stat.maxScore,
-    }
-  })
 }


### PR DESCRIPTION
## Summary
- 個人成績表のプレビュー（React）とPDF出力（HTML文字列テンプレート）の重複コードを統合
- `renderToStaticMarkup`を使い、プレビュー用コンポーネントをPDF出力でも再利用
- `generatePrintHtml.ts`を1443行→348行に大幅削減（約920行の重複解消）

Closes #367

## 変更内容
- **computeReportData.ts** (新規): 共通計算ロジックを純粋関数として集約
- **ReportSectionViews.tsx** (新規): hooks不使用の純粋ビューコンポーネント
- **BoxPlotChart.tsx**: `BoxPlotChartView`（純粋ビュー）を分離エクスポート
- **SubtotalTablePreview.tsx**: `SubtotalTableView`（純粋ビュー）を分離エクスポート
- **IndividualReportPreview.tsx**: 共通関数+純粋ビューを使用
- **generatePrintHtml.ts**: `renderToStaticMarkup`で全面書き換え

## Test plan
- [ ] `npm run typecheck` 成功確認済み
- [ ] `npx eslint` 対象ディレクトリ エラーなし確認済み
- [ ] プレビュー表示が従来と同じであることの目視確認
- [ ] PDF出力して従来の出力とレイアウト比較
- [ ] 全オプションの組み合わせ（表示/非表示）でプレビュー・PDF両方を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)