### PR TITLE
fix: Excel小計点のSubtotalGroup方式統一 & 全設問未採点時の空欄化

### DIFF
--- a/__tests__/calculations/computeReportData.test.ts
+++ b/__tests__/calculations/computeReportData.test.ts
@@ -1,0 +1,275 @@
+/**
+ * computeReportData のnull score対応テスト
+ *
+ * テスト対象:
+ * - computeFilteredStats: totalScore が null の場合の統計再計算
+ * - groupSubtotalData: subtotalScore.score が null の場合のグループ集計
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+  computeFilteredStats,
+  groupSubtotalData,
+} from "@/components/projects/08-export/components/individual-report/computeReportData"
+import type {
+  IndividualReportData,
+  StatisticsData,
+} from "@/electron-src/lib/export/individual-report/types"
+import type { SubtotalScore } from "@/electron-src/lib/shared/types/exportTypes"
+
+// ================== ヘルパー ==================
+
+function createMinimalStats(): StatisticsData {
+  return {
+    overall: {
+      average: 70,
+      stdDev: 10,
+      boxPlot: { min: 50, q1: 60, median: 70, q3: 80, max: 90 },
+      total: 3,
+    },
+    class: {
+      average: 70,
+      stdDev: 10,
+      boxPlot: { min: 50, q1: 60, median: 70, q3: 80, max: 90 },
+      total: 3,
+    },
+    personal: {
+      deviation: 50,
+      overallRank: 1,
+      classRank: 1,
+    },
+    questionCorrectRates: {},
+    questionScoreRates: {},
+    subtotalStatistics: [],
+    subtotalRawScores: [],
+    rawTotalScores: [],
+  }
+}
+
+function createMinimalReport(
+  overrides: {
+    totalScore?: number | null
+    rawTotalScores?: StatisticsData["rawTotalScores"]
+  } = {}
+): IndividualReportData {
+  return {
+    studentInfo: {
+      id: "s1",
+      fullName: "テスト太郎",
+      studentNumber: "001",
+      grade: "1",
+      className: "A",
+      attendanceNumber: 1,
+    },
+    examInfo: {
+      examName: "テスト試験",
+      examDate: null,
+      subject: null,
+    },
+    scoringData: {
+      studentId: "s1",
+      studentName: "テスト太郎",
+      studentNumber: "001",
+      grade: "1",
+      className: "A",
+      scores: [],
+      totalScore: "totalScore" in overrides ? overrides.totalScore! : 80,
+      totalMaxScore: 100,
+      subtotalScores: [],
+    },
+    statistics: {
+      ...createMinimalStats(),
+      rawTotalScores: overrides.rawTotalScores ?? [
+        {
+          studentId: "s1",
+          totalScore: 80,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+        {
+          studentId: "s2",
+          totalScore: 60,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+        {
+          studentId: "s3",
+          totalScore: 90,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+      ],
+    },
+    learningAdvice: { reviewQuestions: [] },
+  }
+}
+
+// ================== computeFilteredStats ==================
+
+describe("computeFilteredStats", () => {
+  const allStatuses = {
+    participating: true,
+    expected: true,
+    absent: true,
+  }
+
+  it("totalScore が null の生徒が rawTotalScores に含まれていても統計から除外される", () => {
+    const report = createMinimalReport({
+      totalScore: 80,
+      rawTotalScores: [
+        {
+          studentId: "s1",
+          totalScore: 80,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+        {
+          studentId: "s2",
+          totalScore: null,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+        {
+          studentId: "s3",
+          totalScore: 60,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+      ],
+    })
+
+    // absent=false でフィルタリングをトリガー
+    const statuses = { participating: true, expected: true, absent: false }
+    const result = computeFilteredStats(report, statuses)
+
+    // s2(null)除外、s1(80)+s3(60) → 平均70
+    expect(result.overall.average).toBe(70)
+  })
+
+  it("自分の totalScore が null の場合、偏差値0・順位0", () => {
+    const report = createMinimalReport({
+      totalScore: null,
+      rawTotalScores: [
+        {
+          studentId: "s1",
+          totalScore: null,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+        {
+          studentId: "s2",
+          totalScore: 80,
+          status: "participating",
+          className: "A",
+          grade: "1",
+        },
+      ],
+    })
+
+    const statuses = { participating: true, expected: true, absent: false }
+    const result = computeFilteredStats(report, statuses)
+
+    expect(result.personal.deviation).toBe(0)
+    expect(result.personal.overallRank).toBe(0)
+    expect(result.personal.classRank).toBe(0)
+  })
+
+  it("全ステータス有効時はフィルタリングせず元の統計を返す", () => {
+    const report = createMinimalReport()
+    const result = computeFilteredStats(report, allStatuses)
+
+    // 元のstatisticsがそのまま返される
+    expect(result).toBe(report.statistics)
+  })
+})
+
+// ================== groupSubtotalData ==================
+
+describe("groupSubtotalData", () => {
+  it("score が null の小計はグループ合計に0として加算される", () => {
+    const scores: SubtotalScore[] = [
+      {
+        subtotalId: "sub1",
+        subtotalGroupId: "g1",
+        subtotalGroupName: "国語",
+        subtotalLabel: "漢字",
+        score: 30,
+        maxScore: 50,
+        hasQuestionAssignments: true,
+      },
+      {
+        subtotalId: "sub2",
+        subtotalGroupId: "g1",
+        subtotalGroupName: "国語",
+        subtotalLabel: "読解",
+        score: null,
+        maxScore: 50,
+        hasQuestionAssignments: true,
+      },
+    ]
+
+    const result = groupSubtotalData(scores)
+    expect(result).toHaveLength(1)
+    expect(result[0].groupName).toBe("国語")
+    // null → 0 として加算: 30 + 0 = 30
+    expect(result[0].totalScore).toBe(30)
+    expect(result[0].totalMaxScore).toBe(100)
+    expect(result[0].items).toHaveLength(2)
+  })
+
+  it("全 score が null でもグループは作成される（合計0）", () => {
+    const scores: SubtotalScore[] = [
+      {
+        subtotalId: "sub1",
+        subtotalGroupId: "g1",
+        subtotalGroupName: "数学",
+        subtotalLabel: "計算",
+        score: null,
+        maxScore: 50,
+        hasQuestionAssignments: true,
+      },
+    ]
+
+    const result = groupSubtotalData(scores)
+    expect(result).toHaveLength(1)
+    expect(result[0].totalScore).toBe(0)
+  })
+
+  it("複数グループを正しく分離する", () => {
+    const scores: SubtotalScore[] = [
+      {
+        subtotalId: "sub1",
+        subtotalGroupId: "g1",
+        subtotalGroupName: "国語",
+        subtotalLabel: "漢字",
+        score: 30,
+        maxScore: 50,
+        hasQuestionAssignments: true,
+      },
+      {
+        subtotalId: "sub2",
+        subtotalGroupId: "g2",
+        subtotalGroupName: "数学",
+        subtotalLabel: "計算",
+        score: null,
+        maxScore: 50,
+        hasQuestionAssignments: true,
+      },
+    ]
+
+    const result = groupSubtotalData(scores)
+    expect(result).toHaveLength(2)
+
+    const kokugo = result.find((g) => g.groupName === "国語")
+    const sugaku = result.find((g) => g.groupName === "数学")
+    expect(kokugo?.totalScore).toBe(30)
+    expect(sugaku?.totalScore).toBe(0)
+  })
+})

--- a/__tests__/calculations/statisticsCalculator.test.ts
+++ b/__tests__/calculations/statisticsCalculator.test.ts
@@ -1,0 +1,321 @@
+/**
+ * statisticsCalculator のnull score対応テスト
+ *
+ * テスト対象:
+ * - calculateSubtotalStatistics: subtotalScore.score が null の場合に統計から除外
+ * - collectSubtotalRawScores: subtotalScore.score が null の場合に除外
+ * - calculateStatisticsForStudent: totalScore が null の場合の統計処理
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+  calculateStatisticsForStudent,
+  calculateSubtotalStatistics,
+  collectSubtotalRawScores,
+} from "@/electron-src/lib/export/individual-report/statisticsCalculator"
+import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
+
+// ================== ヘルパー ==================
+
+function createScoringData(
+  overrides: Partial<ScoringData> & { studentId: string }
+): ScoringData {
+  return {
+    studentName: "テスト生徒",
+    studentNumber: "001",
+    scores: [],
+    totalScore: 80,
+    totalMaxScore: 100,
+    subtotalScores: [],
+    ...overrides,
+  }
+}
+
+// ================== calculateSubtotalStatistics ==================
+
+describe("calculateSubtotalStatistics", () => {
+  it("score が null の生徒を統計から除外する", () => {
+    const data: ScoringData[] = [
+      createScoringData({
+        studentId: "s1",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 30,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+      createScoringData({
+        studentId: "s2",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: null, // 全設問未採点
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+      createScoringData({
+        studentId: "s3",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 50,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+    ]
+
+    const result = calculateSubtotalStatistics(data)
+    expect(result).toHaveLength(1)
+    // s2(null)は除外され、s1(30) と s3(50) のみで平均 = 40
+    expect(result[0].average).toBe(40)
+  })
+
+  it("全員 null の場合は空配列で統計計算（平均0）", () => {
+    const data: ScoringData[] = [
+      createScoringData({
+        studentId: "s1",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: null,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+      createScoringData({
+        studentId: "s2",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: null,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+    ]
+
+    const result = calculateSubtotalStatistics(data)
+    expect(result).toHaveLength(1)
+    expect(result[0].average).toBe(0)
+    expect(result[0].stdDev).toBe(0)
+  })
+
+  it("0点の生徒は統計に含まれる", () => {
+    const data: ScoringData[] = [
+      createScoringData({
+        studentId: "s1",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 0, // 全問不正解
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+      createScoringData({
+        studentId: "s2",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 100,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+    ]
+
+    const result = calculateSubtotalStatistics(data)
+    // 0点と100点の平均 = 50
+    expect(result[0].average).toBe(50)
+  })
+})
+
+// ================== collectSubtotalRawScores ==================
+
+describe("collectSubtotalRawScores", () => {
+  it("score が null の生徒を除外する", () => {
+    const data: ScoringData[] = [
+      createScoringData({
+        studentId: "s1",
+        status: "participating",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 30,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+      createScoringData({
+        studentId: "s2",
+        status: "participating",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: null,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+    ]
+
+    const result = collectSubtotalRawScores(data)
+    expect(result).toHaveLength(1)
+    expect(result[0].scores).toHaveLength(1) // s2 は除外
+    expect(result[0].scores[0].studentId).toBe("s1")
+    expect(result[0].scores[0].score).toBe(30)
+  })
+
+  it("0点は除外されない", () => {
+    const data: ScoringData[] = [
+      createScoringData({
+        studentId: "s1",
+        status: "participating",
+        subtotalScores: [
+          {
+            subtotalId: "sub1",
+            subtotalGroupId: "g1",
+            subtotalGroupName: "G1",
+            subtotalLabel: "小計1",
+            score: 0,
+            maxScore: 50,
+            hasQuestionAssignments: true,
+          },
+        ],
+      }),
+    ]
+
+    const result = collectSubtotalRawScores(data)
+    expect(result[0].scores).toHaveLength(1)
+    expect(result[0].scores[0].score).toBe(0)
+  })
+})
+
+// ================== calculateStatisticsForStudent ==================
+
+describe("calculateStatisticsForStudent", () => {
+  const emptyRates: Record<string, number> = {}
+
+  it("totalScore が null の生徒は偏差値0・順位0", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: 80 }),
+      createScoringData({ studentId: "s2", totalScore: null }),
+      createScoringData({ studentId: "s3", totalScore: 60 }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s2",
+      null,
+      allData,
+      allData,
+      emptyRates,
+      emptyRates
+    )
+
+    expect(result.personal.deviation).toBe(0)
+    expect(result.personal.overallRank).toBe(0)
+    expect(result.personal.classRank).toBe(0)
+  })
+
+  it("totalScore が null の生徒は全体・学級統計から除外される", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: 80 }),
+      createScoringData({ studentId: "s2", totalScore: null }),
+      createScoringData({ studentId: "s3", totalScore: 60 }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s1",
+      80,
+      allData,
+      allData,
+      emptyRates,
+      emptyRates
+    )
+
+    // s2(null)を除外して s1(80) と s3(60) のみで平均 = 70
+    expect(result.overall.average).toBe(70)
+  })
+
+  it("全員 null の場合は平均0・標準偏差0", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: null }),
+      createScoringData({ studentId: "s2", totalScore: null }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s1",
+      null,
+      allData,
+      allData,
+      emptyRates,
+      emptyRates
+    )
+
+    expect(result.overall.average).toBe(0)
+    expect(result.overall.stdDev).toBe(0)
+    expect(result.personal.deviation).toBe(0)
+    expect(result.personal.overallRank).toBe(0)
+  })
+
+  it("0点の生徒は統計に含まれる（nullとは区別される）", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: 0 }),
+      createScoringData({ studentId: "s2", totalScore: 100 }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s1",
+      0,
+      allData,
+      allData,
+      emptyRates,
+      emptyRates
+    )
+
+    // 0点と100点の平均 = 50
+    expect(result.overall.average).toBe(50)
+    // 0点の生徒は順位2位
+    expect(result.personal.overallRank).toBe(2)
+  })
+})

--- a/__tests__/calculations/subtotalCalculator.test.ts
+++ b/__tests__/calculations/subtotalCalculator.test.ts
@@ -1,0 +1,325 @@
+/**
+ * subtotalCalculator のnull score対応テスト
+ *
+ * テスト対象:
+ * - calculateSubtotalScoreBySubtotalId: hasScoredQuestion パターン
+ * - calculateSubtotalScoreForStudent: hasScoredQuestion パターン
+ *
+ * DB関数（getCropSubtotals*）と calculateActualScore をモックして
+ * 純粋なロジックのみを検証する
+ */
+import type { CropRegion } from "@prisma/client"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// モック設定（import前に定義）
+const mockGetCropSubtotalsByCropRegionId = vi.fn()
+const mockGetCropSubtotalsBySubtotalId = vi.fn()
+const mockCalculateActualScore = vi.fn()
+
+vi.mock("@/electron-src/lib/prisma/cropSubtotal", () => ({
+  getCropSubtotalsByCropRegionId: (...args: unknown[]) =>
+    mockGetCropSubtotalsByCropRegionId(...args),
+  getCropSubtotalsBySubtotalId: (...args: unknown[]) =>
+    mockGetCropSubtotalsBySubtotalId(...args),
+}))
+
+vi.mock("@/electron-src/lib/prisma/questionScore", () => ({
+  calculateActualScore: (...args: unknown[]) =>
+    mockCalculateActualScore(...args),
+}))
+
+import {
+  calculateSubtotalScoreBySubtotalId,
+  calculateSubtotalScoreForStudent,
+  type QuestionScoreData,
+} from "@/electron-src/lib/shared/calculations/subtotalCalculator"
+
+// ================== ヘルパー ==================
+
+/** 最小限のCropRegion（テスト用） */
+function createCropRegion(
+  overrides: Partial<CropRegion> & { id: string }
+): CropRegion {
+  return {
+    label: "問1",
+    type: "QUESTION_ANSWER",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 50,
+    projectPageId: "page1",
+    orderIndex: 0,
+    points: 10,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    daimon: null,
+    shomon: null,
+    shimon: null,
+    ...overrides,
+  } as CropRegion
+}
+
+function createQuestionScore(
+  studentId: string,
+  cropRegionId: string,
+  status: string,
+  partialScore: number | null = null
+): QuestionScoreData {
+  return { studentId, cropRegionId, status, partialScore }
+}
+
+// ================== calculateSubtotalScoreBySubtotalId ==================
+
+describe("calculateSubtotalScoreBySubtotalId", () => {
+  const cropRegions = [
+    createCropRegion({ id: "q1", points: 10 }),
+    createCropRegion({ id: "q2", points: 20 }),
+    createCropRegion({ id: "q3", points: 30 }),
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // デフォルト: subtotal は q1, q2, q3 の3設問に紐付け
+    mockGetCropSubtotalsBySubtotalId.mockResolvedValue([
+      {
+        cropRegionId: "q1",
+        subtotalId: "sub1",
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+      {
+        cropRegionId: "q2",
+        subtotalId: "sub1",
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+      {
+        cropRegionId: "q3",
+        subtotalId: "sub1",
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+    ])
+  })
+
+  it("全設問採点済み → score に合計点を返す", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "correct"),
+      createQuestionScore("s1", "q2", "incorrect"),
+      createQuestionScore("s1", "q3", "partial", 15),
+    ]
+    // correct→10, incorrect→0, partial→15
+    mockCalculateActualScore
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(15)
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBe(25)
+    expect(result.maxScore).toBe(60)
+    expect(result.hasQuestionAssignments).toBe(true)
+  })
+
+  it("全設問未採点 → score が null", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "unscored"),
+      createQuestionScore("s1", "q2", "unscored"),
+      createQuestionScore("s1", "q3", "unscored"),
+    ]
+    // unscored→null
+    mockCalculateActualScore.mockReturnValue(null)
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBeNull()
+    expect(result.maxScore).toBe(60)
+    expect(result.hasQuestionAssignments).toBe(true)
+  })
+
+  it("一部未採点 → 採点済み分のみの合計を返す", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "correct"),
+      createQuestionScore("s1", "q2", "unscored"),
+      createQuestionScore("s1", "q3", "correct"),
+    ]
+    // correct→10, unscored→null, correct→30
+    mockCalculateActualScore
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(30)
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBe(40) // 10 + 30
+    expect(result.hasQuestionAssignments).toBe(true)
+  })
+
+  it("全問不正解（0点） → score が 0（null ではない）", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "incorrect"),
+      createQuestionScore("s1", "q2", "incorrect"),
+      createQuestionScore("s1", "q3", "incorrect"),
+    ]
+    mockCalculateActualScore.mockReturnValue(0)
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBe(0)
+    expect(result.hasQuestionAssignments).toBe(true)
+  })
+
+  it("QUESTION_ASSIGNMENT が無い → null, hasQuestionAssignments=false", async () => {
+    mockGetCropSubtotalsBySubtotalId.mockResolvedValue([])
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      [],
+      cropRegions
+    )
+
+    expect(result.score).toBeNull()
+    expect(result.hasQuestionAssignments).toBe(false)
+  })
+
+  it("採点データが存在しない設問は加算されない", async () => {
+    // s1 は q1 のみ採点済み、q2,q3 は採点データ自体が無い
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "correct"),
+    ]
+    mockCalculateActualScore.mockReturnValueOnce(10)
+
+    const result = await calculateSubtotalScoreBySubtotalId(
+      "s1",
+      "sub1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBe(10)
+    expect(result.maxScore).toBe(60) // q1+q2+q3 の配点合計
+  })
+})
+
+// ================== calculateSubtotalScoreForStudent ==================
+
+describe("calculateSubtotalScoreForStudent", () => {
+  const cropRegions = [
+    createCropRegion({ id: "q1", points: 10 }),
+    createCropRegion({ id: "q2", points: 20 }),
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // CropRegion(SUBTOTAL_SCORE) → CropSubtotal → Subtotal のチェーン
+    mockGetCropSubtotalsByCropRegionId.mockResolvedValue([
+      {
+        subtotalId: "item1",
+        cropRegionId: "subtotal-region-1",
+        assignmentType: "SUBTOTAL_SCORE",
+        subtotal: { subtotalGroupId: "group1" },
+      },
+    ])
+    // group1 → item1 → q1, q2
+    mockGetCropSubtotalsBySubtotalId.mockResolvedValue([
+      {
+        cropRegionId: "q1",
+        subtotalId: "item1",
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+      {
+        cropRegionId: "q2",
+        subtotalId: "item1",
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+    ])
+  })
+
+  it("全設問採点済み → score に合計点", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "correct"),
+      createQuestionScore("s1", "q2", "correct"),
+    ]
+    mockCalculateActualScore.mockReturnValueOnce(10).mockReturnValueOnce(20)
+
+    const result = await calculateSubtotalScoreForStudent(
+      "s1",
+      "subtotal-region-1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBe(30)
+    expect(result.hasQuestionAssignments).toBe(true)
+  })
+
+  it("全設問未採点 → score が null", async () => {
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "unscored"),
+      createQuestionScore("s1", "q2", "unscored"),
+    ]
+    mockCalculateActualScore.mockReturnValue(null)
+
+    const result = await calculateSubtotalScoreForStudent(
+      "s1",
+      "subtotal-region-1",
+      scores,
+      cropRegions
+    )
+
+    expect(result.score).toBeNull()
+  })
+
+  it("グループ定義が無い場合のフォールバックでも null 対応", async () => {
+    mockGetCropSubtotalsByCropRegionId.mockResolvedValue([])
+
+    const scores: QuestionScoreData[] = [
+      createQuestionScore("s1", "q1", "unscored"),
+      createQuestionScore("s1", "q2", "unscored"),
+    ]
+    mockCalculateActualScore.mockReturnValue(null)
+
+    const result = await calculateSubtotalScoreForStudent(
+      "s1",
+      "subtotal-region-1",
+      scores,
+      cropRegions
+    )
+
+    // フォールバック（calculateStudentTotalScoreWithMax）でもnull
+    expect(result.score).toBeNull()
+  })
+
+  it("エラー時 → score が null", async () => {
+    mockGetCropSubtotalsByCropRegionId.mockRejectedValue(new Error("DB error"))
+
+    const result = await calculateSubtotalScoreForStudent(
+      "s1",
+      "subtotal-region-1",
+      [],
+      cropRegions
+    )
+
+    expect(result.score).toBeNull()
+    expect(result.hasQuestionAssignments).toBe(false)
+  })
+})

--- a/__tests__/renderer/components/ImportWizardModal.test.tsx
+++ b/__tests__/renderer/components/ImportWizardModal.test.tsx
@@ -3,19 +3,18 @@
  * ImportWizardModal コンポーネントのテスト
  */
 
+// setup.ts を適用
+import "../setup"
+
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { useImportWizard } from "@/hooks/import/useImportWizard"
-import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
 import { ImportWizardModal } from "@/components/import/ImportWizardModal"
-import { initialState } from "@/hooks/import/constants"
+import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
+import { useImportWizard } from "@/hooks/import/useImportWizard"
 
 import { createMockWizard } from "../helpers/mockWizard"
-
-// setup.ts を適用
-import "../setup"
 
 // useImportWizard をモック
 vi.mock("@/hooks/import/useImportWizard", () => ({
@@ -123,7 +122,7 @@ describe("ImportWizardModal", () => {
   })
 
   it("IM-8: 処理中にキャンセルボタンクリックでonCloseが呼ばれない", async () => {
-    const user = userEvent.setup()
+    userEvent.setup()
     const onClose = vi.fn()
     mockWizard = createMockWizard({ isProcessing: true })
     mockUseImportWizard.mockReturnValue(mockWizard)

--- a/__tests__/renderer/components/steps/ExecuteStep.test.tsx
+++ b/__tests__/renderer/components/steps/ExecuteStep.test.tsx
@@ -3,6 +3,9 @@
  * ExecuteStep コンポーネントのテスト
  */
 
+// setup.ts を適用
+import "../../setup"
+
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -10,9 +13,6 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { ExecuteStep } from "@/components/import/steps/ExecuteStep"
 
 import { createMockWizard } from "../../helpers/mockWizard"
-
-// setup.ts を適用
-import "../../setup"
 
 describe("ExecuteStep", () => {
   afterEach(() => {

--- a/__tests__/renderer/components/steps/FileOverviewStep.test.tsx
+++ b/__tests__/renderer/components/steps/FileOverviewStep.test.tsx
@@ -3,20 +3,20 @@
  * FileOverviewStep コンポーネントのテスト
  */
 
+// setup.ts を適用
+import "../../setup"
+
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { FileOverviewStep } from "@/components/import/steps/FileOverviewStep"
 
-import { createMockWizard } from "../../helpers/mockWizard"
 import {
   createMockFileOverviewData,
   createMockManifest,
 } from "../../helpers/mockData"
-
-// setup.ts を適用
-import "../../setup"
+import { createMockWizard } from "../../helpers/mockWizard"
 
 describe("FileOverviewStep", () => {
   afterEach(() => {

--- a/__tests__/renderer/components/steps/FileSelectStep.test.tsx
+++ b/__tests__/renderer/components/steps/FileSelectStep.test.tsx
@@ -3,16 +3,16 @@
  * FileSelectStep コンポーネントのテスト
  */
 
+// setup.ts を適用
+import "../../setup"
+
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { FileSelectStep } from "@/components/import/steps/FileSelectStep"
 
 import { createMockWizard } from "../../helpers/mockWizard"
-
-// setup.ts を適用
-import "../../setup"
 
 describe("FileSelectStep", () => {
   afterEach(() => {

--- a/__tests__/renderer/helpers/mockWizard.ts
+++ b/__tests__/renderer/helpers/mockWizard.ts
@@ -6,8 +6,8 @@
 
 import { vi } from "vitest"
 
-import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
 import { initialState } from "@/hooks/import/constants"
+import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
 import type { ImportWizardState } from "@/types/projectArchive.types"
 
 /**

--- a/__tests__/renderer/hooks/useImportWizard.test.ts
+++ b/__tests__/renderer/hooks/useImportWizard.test.ts
@@ -9,19 +9,18 @@ import { act, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useAuth } from "@/contexts/AuthContext"
-import { useImportWizard } from "@/hooks/import/useImportWizard"
 import { initialState } from "@/hooks/import/constants"
+import { useImportWizard } from "@/hooks/import/useImportWizard"
 
+import {
+  createMockFileOverviewData,
+  createMockScoringConflictData,
+} from "../helpers/mockData"
 import {
   cleanupMockElectronAPI,
   createMockElectronAPI,
   type MockArchive,
 } from "../helpers/mockElectronAPI"
-import {
-  createMockFileOverviewData,
-  createMockManifest,
-  createMockScoringConflictData,
-} from "../helpers/mockData"
 
 // useAuth モック
 vi.mock("@/contexts/AuthContext", () => ({
@@ -756,7 +755,6 @@ describe("useImportWizard", () => {
 
     it("IW-75: 正常実行時にresultを返す", async () => {
       const { result } = renderHook(() => useImportWizard())
-      const hookResult = { result }
       await setupForExecute({ result })
 
       let importResult: unknown

--- a/__tests__/renderer/setup.ts
+++ b/__tests__/renderer/setup.ts
@@ -5,6 +5,7 @@
  */
 
 import "@testing-library/jest-dom/vitest"
+
 import { cleanup } from "@testing-library/react"
 import { afterEach, vi } from "vitest"
 

--- a/components/projects/08-export/components/individual-report/ReportSectionViews.tsx
+++ b/components/projects/08-export/components/individual-report/ReportSectionViews.tsx
@@ -125,8 +125,7 @@ export function StudentInfoView({ report, fontScale }: StudentInfoViewProps) {
           }}
         >
           {report.studentInfo.grade && `${report.studentInfo.grade}年`}
-          {report.studentInfo.className &&
-            ` ${report.studentInfo.className}`}
+          {report.studentInfo.className && ` ${report.studentInfo.className}`}
           {report.studentInfo.attendanceNumber != null &&
             ` ${report.studentInfo.attendanceNumber}番`}
         </p>

--- a/components/projects/08-export/components/individual-report/ScoreTablePreview.tsx
+++ b/components/projects/08-export/components/individual-report/ScoreTablePreview.tsx
@@ -267,12 +267,13 @@ function SingleColumnTable({
                   fontWeight: "bold",
                 }}
               >
-                {Math.round(
-                  (report.scoringData.totalScore /
-                    report.scoringData.totalMaxScore) *
-                    100
-                )}
-                %
+                {report.scoringData.totalScore !== null
+                  ? `${Math.round(
+                      (report.scoringData.totalScore /
+                        report.scoringData.totalMaxScore) *
+                        100
+                    )}%`
+                  : "-"}
               </td>
             )}
           </tr>
@@ -495,7 +496,7 @@ function MultiColumnTable({
       >
         <span>合計</span>
         <span>
-          {report.scoringData.totalScore}
+          {report.scoringData.totalScore ?? "-"}
           <span
             style={{ fontSize: `${11 * fontScale * 0.8}px`, color: "#666" }}
           >
@@ -503,11 +504,14 @@ function MultiColumnTable({
             / {report.scoringData.totalMaxScore}
           </span>{" "}
           (
-          {Math.round(
-            (report.scoringData.totalScore / report.scoringData.totalMaxScore) *
-              100
-          )}
-          %)
+          {report.scoringData.totalScore !== null
+            ? `${Math.round(
+                (report.scoringData.totalScore /
+                  report.scoringData.totalMaxScore) *
+                  100
+              )}%`
+            : "-"}
+          )
         </span>
       </div>
     </section>

--- a/components/projects/08-export/components/individual-report/computeReportData.ts
+++ b/components/projects/08-export/components/individual-report/computeReportData.ts
@@ -64,14 +64,18 @@ export function computeFilteredStats(
     })
 
   const filteredAll = filterByStatus(raw)
-  const allScores = filteredAll.map((e) => e.totalScore)
+  const allScores = filteredAll
+    .map((e) => e.totalScore)
+    .filter((s): s is number => s !== null)
 
   const filteredClass = filteredAll.filter(
     (e) =>
       e.className === report.studentInfo.className &&
       e.grade === report.studentInfo.grade
   )
-  const classScores = filteredClass.map((e) => e.totalScore)
+  const classScores = filteredClass
+    .map((e) => e.totalScore)
+    .filter((s): s is number => s !== null)
 
   const avg = (arr: number[]) =>
     arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
@@ -89,8 +93,10 @@ export function computeFilteredStats(
   const overallStd = stdDevFn(allScores)
   const studentScore = report.scoringData.totalScore
   const deviation =
-    overallStd === 0
-      ? 50
+    studentScore === null || overallStd === 0
+      ? studentScore === null
+        ? 0
+        : 50
       : Math.round(((studentScore - overallAvg) / overallStd) * 10 + 50)
 
   return {
@@ -110,8 +116,8 @@ export function computeFilteredStats(
     personal: {
       ...report.statistics.personal,
       deviation,
-      overallRank: rankFn(studentScore, allScores),
-      classRank: rankFn(studentScore, classScores),
+      overallRank: studentScore !== null ? rankFn(studentScore, allScores) : 0,
+      classRank: studentScore !== null ? rankFn(studentScore, classScores) : 0,
     },
   }
 }
@@ -188,6 +194,7 @@ export function computeFilteredSubtotalStats(
         return true
       })
       .map((s) => s.score)
+      .filter((s): s is number => s !== null)
 
     if (filteredScores.length === 0) {
       return {
@@ -225,10 +232,7 @@ export function filterSubtotalScores(
 ): SubtotalScore[] {
   let scores = subtotalScores
 
-  if (
-    groupSelection?.enabled &&
-    groupSelection.selectedGroupIds.length > 0
-  ) {
+  if (groupSelection?.enabled && groupSelection.selectedGroupIds.length > 0) {
     scores = scores.filter((score) =>
       groupSelection.selectedGroupIds.includes(score.subtotalGroupId)
     )
@@ -254,14 +258,14 @@ export function groupSubtotalData(
     const existing = groupMap.get(groupId)
     if (existing) {
       existing.items.push(score)
-      existing.totalScore += score.score
+      existing.totalScore += score.score ?? 0
       existing.totalMaxScore += score.maxScore
     } else {
       groupMap.set(groupId, {
         groupId,
         groupName: score.subtotalGroupName,
         items: [score],
-        totalScore: score.score,
+        totalScore: score.score ?? 0,
         totalMaxScore: score.maxScore,
       })
     }

--- a/components/projects/08-export/components/individual-report/generatePrintHtml.ts
+++ b/components/projects/08-export/components/individual-report/generatePrintHtml.ts
@@ -201,8 +201,7 @@ function renderSectionElement(
 
       const groupTableDataList = groupedData.map((group) => {
         const allocatedColumns = isHorizontalLayout
-          ? (allocateColumnsDHondt(groupedData, columns).get(group.groupId) ||
-              1)
+          ? allocateColumnsDHondt(groupedData, columns).get(group.groupId) || 1
           : columns
         const columnItems = splitItemsIntoColumns(group.items, allocatedColumns)
         const maxRows = Math.max(...columnItems.map((col) => col.length), 0)

--- a/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
+++ b/components/projects/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
@@ -7,7 +7,6 @@ import {
   defaultConfig,
   defaultPartialScoreConfig,
   defaultSubtotalScoreConfig,
-  defaultSummaryScoreConfig,
   defaultTotalScoreConfig,
   positionLabels,
 } from "@/components/projects/08-export/components/scoring-mark-settings/constants/scoringMarkConstants"

--- a/components/projects/08-export/utils/reportCanvasRenderer.ts
+++ b/components/projects/08-export/utils/reportCanvasRenderer.ts
@@ -484,7 +484,7 @@ function drawCharts(
       )
       return {
         label: st.subtotalLabel,
-        value: st.score,
+        value: st.score ?? 0,
         maxValue: st.maxScore,
         average: stats?.average,
       }
@@ -532,7 +532,7 @@ function drawCharts(
     drawBoxPlot(
       ctx,
       reportData.statistics.overall.boxPlot,
-      reportData.scoringData.totalScore,
+      reportData.scoringData.totalScore ?? 0,
       reportData.scoringData.totalMaxScore,
       chartX,
       y,

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -24,6 +24,12 @@ import {
   SubtotalScore,
 } from "../../shared/types/exportTypes"
 
+/** SubtotalGroupから構築した小計列情報（Excel出力用） */
+export interface SubtotalColumn {
+  subtotalId: string
+  label: string
+}
+
 /** SubtotalGroup情報（Excel出力用） */
 interface SubtotalGroupData {
   groupId: string
@@ -45,6 +51,7 @@ export interface ExportDataResult {
   selectedStudents?: (Student & { projectStudent?: ProjectStudent })[]
   questionRegions?: CropRegion[]
   subtotalRegions?: CropRegion[]
+  subtotalColumns?: SubtotalColumn[]
   scoringData?: ScoringData[]
 }
 
@@ -153,6 +160,12 @@ export async function fetchExportData(
           }))
         : []
 
+    // SubtotalGroupから小計列情報を構築
+    const subtotalColumns: SubtotalColumn[] = subtotalGroupsData.flatMap(
+      (group) =>
+        group.subtotals.map((s) => ({ subtotalId: s.id, label: s.name }))
+    )
+
     // 採点データの構造化
     const scoringData = await buildScoringData(
       selectedStudents,
@@ -167,6 +180,7 @@ export async function fetchExportData(
       selectedStudents,
       questionRegions,
       subtotalRegions,
+      subtotalColumns,
       scoringData,
     }
   } catch (error) {
@@ -216,10 +230,10 @@ async function buildScoringData(
         questionScores.scores || []
       )
 
-      const totalScore = scores.reduce(
-        (sum, score) => sum + (score.score || 0),
-        0
-      )
+      const allUnscored = scores.every((s) => s.status === "unscored")
+      const totalScore = allUnscored
+        ? null
+        : scores.reduce((sum, score) => sum + (score.score ?? 0), 0)
       const totalMaxScore = scores.reduce(
         (sum, score) => sum + score.maxScore,
         0

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -30,7 +30,7 @@ export async function exportGradingDataExcel(
     // データが正常に取得できているかチェック
     if (
       !dataResult.questionRegions ||
-      !dataResult.subtotalRegions ||
+      !dataResult.subtotalColumns ||
       !dataResult.scoringData
     ) {
       return { success: false, error: "必要なデータの取得に失敗しました" }
@@ -56,7 +56,7 @@ export async function exportGradingDataExcel(
     await createScoreSheet(
       workbook,
       dataResult.questionRegions,
-      dataResult.subtotalRegions,
+      dataResult.subtotalColumns,
       dataResult.scoringData
     )
 
@@ -64,7 +64,7 @@ export async function exportGradingDataExcel(
     await createResultSheet(
       workbook,
       dataResult.questionRegions,
-      dataResult.subtotalRegions,
+      dataResult.subtotalColumns,
       dataResult.scoringData
     )
 

--- a/electron-src/lib/export/excel/headerCreators.ts
+++ b/electron-src/lib/export/excel/headerCreators.ts
@@ -2,18 +2,19 @@ import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
 import { applyCellStyle } from "../../shared/utilities/excelUtilities"
+import type { SubtotalColumn } from "./dataFetcher"
 
 /**
  * シートのヘッダー行を作成する
  *
  * @param worksheet - 対象のワークシート
  * @param questionRegions - 設問領域配列
- * @param subtotalRegions - 小計領域配列
+ * @param subtotalColumns - 小計列情報配列（SubtotalGroupから構築）
  */
 export async function createSheetHeaders(
   worksheet: ExcelJS.Worksheet,
   questionRegions: CropRegion[],
-  subtotalRegions: CropRegion[]
+  subtotalColumns: SubtotalColumn[]
 ) {
   const row = worksheet.addRow([
     "受験状態",
@@ -24,10 +25,7 @@ export async function createSheetHeaders(
     "学籍番号",
     "氏名",
     "合計点",
-    ...subtotalRegions.map(
-      (region: CropRegion) =>
-        region.label || `小計${(region.orderIndex ?? 0) + 1}`
-    ),
+    ...subtotalColumns.map((col) => col.label),
     ...questionRegions.map(
       (region: CropRegion) =>
         region.label || `問${(region.orderIndex ?? 0) + 1}`

--- a/electron-src/lib/export/excel/rowCreators.ts
+++ b/electron-src/lib/export/excel/rowCreators.ts
@@ -1,23 +1,13 @@
-import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
-import { SubtotalTargetMap } from "../../shared/calculations/subtotalCalculator"
 import { ScoringData } from "../../shared/types/exportTypes"
 import {
   applyCellStyle,
   getExcelColumnLetter,
   getStatusSymbol,
 } from "../../shared/utilities/excelUtilities"
+import type { SubtotalColumn } from "./dataFetcher"
 
-/**
- * データ行を作成する
- *
- * @param worksheet - 対象のワークシート
- * @param scoringData - 採点データ配列
- * @param subtotalRegions - 小計領域配列
- * @param subtotalTargetMap - 小計対象設問マップ
- * @param isScoreSheet - 点数一覧シートかどうか（true: 点数一覧、false: 正誤一覧）
- */
 /**
  * 順位付きの採点データ型
  */
@@ -26,14 +16,21 @@ type ScoringDataWithRank = ScoringData & {
   rank: number
 }
 
+/**
+ * データ行を作成する
+ *
+ * @param worksheet - 対象のワークシート
+ * @param scoringData - 採点データ配列
+ * @param subtotalColumns - 小計列情報配列（SubtotalGroupから構築）
+ * @param isScoreSheet - 点数一覧シートかどうか（true: 点数一覧、false: 正誤一覧）
+ */
 export async function createDataRows(
   worksheet: ExcelJS.Worksheet,
   scoringData: ScoringData[],
-  subtotalRegions: CropRegion[],
-  subtotalTargetMap: SubtotalTargetMap,
+  subtotalColumns: SubtotalColumn[],
   isScoreSheet: boolean
 ) {
-  // 事前に順位を計算（総合点の降順でソート）
+  // 事前に順位を計算（総合点の降順でソート、null は最下位扱い）
   const scoringDataWithRank: ScoringDataWithRank[] = scoringData
     .map(
       (student, index): ScoringDataWithRank => ({
@@ -42,11 +39,11 @@ export async function createDataRows(
         rank: 0, // 仮の値、後で正しい順位に更新
       })
     )
-    .sort((a, b) => b.totalScore - a.totalScore)
+    .sort((a, b) => (b.totalScore ?? -1) - (a.totalScore ?? -1))
     .map(
       (student, rank): ScoringDataWithRank => ({
         ...student,
-        rank: rank + 1,
+        rank: student.totalScore !== null ? rank + 1 : 0,
       })
     )
     // 元の順序に戻す
@@ -54,14 +51,13 @@ export async function createDataRows(
 
   for (let i = 0; i < scoringDataWithRank.length; i++) {
     const student = scoringDataWithRank[i]
-    const rowIndex = i + 2 // ヘッダー行を考慮
 
     // 受験状態を最左列（A列）に設定
     const statusText = getStatusText(student.status)
 
     const row = worksheet.addRow([
       statusText, // 受験状態（A列）
-      student.rank, // 順位（B列）- 事前に計算済みの順位を使用
+      student.rank > 0 ? student.rank : "", // 順位（B列）- null totalScore → 空欄
       student.grade || "",
       student.className || "",
       student.attendanceNumber || "",
@@ -69,31 +65,21 @@ export async function createDataRows(
       student.studentName,
     ])
 
-    // 合計点の計算（Excel関数使用）
-    const questionStartColIndex = 9 + subtotalRegions.length // 1つ右にシフト
-    const questionEndColIndex =
-      questionStartColIndex + student.scores.length - 1
-    const questionStartCol = getExcelColumnLetter(questionStartColIndex)
-    const questionEndCol = getExcelColumnLetter(questionEndColIndex)
-    const totalCell = row.getCell("H") // G列からH列に変更
-    totalCell.value = {
-      formula: `SUM(${questionStartCol}${rowIndex}:${questionEndCol}${rowIndex})`,
+    // 合計点の設定（計算済み値を直接出力、null → 空欄）
+    const totalCell = row.getCell("H")
+    if (student.totalScore !== null) {
+      totalCell.value = student.totalScore
+    } else {
+      totalCell.value = ""
     }
     // 合計点を赤色に設定
     totalCell.font = { color: { argb: "FFFF0000" } }
 
-    // 小計点の設定
-    await setSubtotalCells(
-      row,
-      student,
-      subtotalRegions,
-      subtotalTargetMap,
-      rowIndex,
-      isScoreSheet
-    )
+    // 小計点の設定（SubtotalColumn ID紐付け方式）
+    setSubtotalCells(row, student, subtotalColumns, isScoreSheet)
 
     // 設問別データの設定
-    setQuestionCells(row, student, subtotalRegions.length, isScoreSheet)
+    setQuestionCells(row, student, subtotalColumns.length, isScoreSheet)
 
     // 行スタイルの適用
     row.eachCell((cell) => applyCellStyle(cell, "data"))
@@ -101,69 +87,49 @@ export async function createDataRows(
 }
 
 /**
- * 小計点セルを設定する
+ * 小計点セルを設定する（SubtotalColumn ID紐付け方式）
  *
  * @param row - 対象の行
  * @param student - 生徒の採点データ（計算済み小計点を含む）
- * @param subtotalRegions - 小計領域配列
- * @param subtotalTargetMap - 小計対象設問マップ（正誤一覧シートでのみ使用、非推奨）
- * @param rowIndex - 行インデックス（1ベース）
- * @param isScoreSheet - 点数一覧シートかどうか（true: 点数一覧、false: 正誤一覧）
- *
- * 注意: 点数一覧では計算済みの小計点を直接使用、正誤一覧では従来のExcel関数を使用
+ * @param subtotalColumns - 小計列情報配列
+ * @param isScoreSheet - 点数一覧シートかどうか
  */
-async function setSubtotalCells(
+function setSubtotalCells(
   row: ExcelJS.Row,
   student: ScoringData,
-  subtotalRegions: CropRegion[],
-  subtotalTargetMap: SubtotalTargetMap,
-  rowIndex: number,
+  subtotalColumns: SubtotalColumn[],
   isScoreSheet: boolean
 ) {
-  let subtotalColIndex = 9 // 1つ右にシフト
-  const questionStartColIndex = 9 + subtotalRegions.length // 1つ右にシフト
+  let subtotalColIndex = 9
 
-  for (let i = 0; i < subtotalRegions.length; i++) {
+  for (const column of subtotalColumns) {
     const col = getExcelColumnLetter(subtotalColIndex)
-    const subtotalScore = student.subtotalScores[i]
+    const subtotalScore = student.subtotalScores.find(
+      (s) => s.subtotalId === column.subtotalId
+    )
 
-    if (subtotalScore) {
-      if (isScoreSheet) {
-        // 点数一覧：計算済みの小計点を直接使用
-        if (subtotalScore.score !== null && subtotalScore.score !== undefined) {
-          // 採点済みデータがあれば0点でも表示
-          row.getCell(col).value = subtotalScore.score
-        } else {
-          // データがない場合は空欄
-          row.getCell(col).value = ""
-        }
+    if (isScoreSheet) {
+      // 点数一覧：計算済みの小計点を直接使用
+      if (
+        subtotalScore &&
+        subtotalScore.score !== null &&
+        subtotalScore.score !== undefined
+      ) {
+        row.getCell(col).value = subtotalScore.score
       } else {
-        // 正誤一覧：従来のロジックを使用（Excel関数が必要）
-        // NOTE: buildSubtotalTargetMapは非推奨で空のマップを返すため、このロジックは機能しない
-        const targetQuestionIndices =
-          subtotalTargetMap[subtotalScore.subtotalId] || []
-
-        if (targetQuestionIndices.length > 0) {
-          const targetCells = targetQuestionIndices.map((index) => {
-            const questionCol = getExcelColumnLetter(
-              questionStartColIndex + index
-            )
-            return `${questionCol}${rowIndex}`
-          })
-
-          // 正誤一覧：対象設問の正答数
-          const formula = targetCells
-            .map((cell) => `IF(${cell}="○",1,0)`)
-            .join("+")
-          row.getCell(col).value = { formula }
-        } else {
-          // 正誤一覧で対象設問が不明な場合は空欄
-          row.getCell(col).value = ""
-        }
+        row.getCell(col).value = ""
       }
     } else {
-      // データがない場合は空欄
-      row.getCell(col).value = ""
+      // 正誤一覧：計算済みの小計点を直接使用（旧Excel関数方式を廃止）
+      if (
+        subtotalScore &&
+        subtotalScore.score !== null &&
+        subtotalScore.score !== undefined
+      ) {
+        row.getCell(col).value = subtotalScore.score
+      } else {
+        row.getCell(col).value = ""
+      }
     }
     subtotalColIndex++
   }

--- a/electron-src/lib/export/excel/sheetCreators.ts
+++ b/electron-src/lib/export/excel/sheetCreators.ts
@@ -1,9 +1,9 @@
 import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
-import { buildSubtotalTargetMap } from "../../shared/calculations/subtotalCalculator"
 import { ScoringData } from "../../shared/types/exportTypes"
 import { autoFitColumns } from "../../shared/utilities/excelUtilities"
+import type { SubtotalColumn } from "./dataFetcher"
 import { createSheetHeaders } from "./headerCreators"
 import { createDataRows } from "./rowCreators"
 
@@ -11,37 +11,24 @@ import { createDataRows } from "./rowCreators"
  * 点数一覧シートを作成する
  *
  * @param workbook - Excelワークブック
- * @param project - プロジェクト情報
  * @param questionRegions - 設問領域配列
- * @param subtotalRegions - 小計領域配列
+ * @param subtotalColumns - 小計列情報配列（SubtotalGroupから構築）
  * @param scoringData - 採点データ配列
  * @returns 作成されたワークシート
  */
 export async function createScoreSheet(
   workbook: ExcelJS.Workbook,
   questionRegions: CropRegion[],
-  subtotalRegions: CropRegion[],
+  subtotalColumns: SubtotalColumn[],
   scoringData: ScoringData[]
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("点数一覧")
 
   // ヘッダー行の作成
-  await createSheetHeaders(worksheet, questionRegions, subtotalRegions)
-
-  // 小計点の対象設問マップを事前に構築
-  const subtotalTargetMap = await buildSubtotalTargetMap(
-    subtotalRegions,
-    questionRegions
-  )
+  await createSheetHeaders(worksheet, questionRegions, subtotalColumns)
 
   // データ行の作成
-  await createDataRows(
-    worksheet,
-    scoringData,
-    subtotalRegions,
-    subtotalTargetMap,
-    true
-  )
+  await createDataRows(worksheet, scoringData, subtotalColumns, true)
 
   // スタイル適用
   autoFitColumns(worksheet)
@@ -53,37 +40,24 @@ export async function createScoreSheet(
  * 正誤一覧シートを作成する
  *
  * @param workbook - Excelワークブック
- * @param project - プロジェクト情報
  * @param questionRegions - 設問領域配列
- * @param subtotalRegions - 小計領域配列
+ * @param subtotalColumns - 小計列情報配列（SubtotalGroupから構築）
  * @param scoringData - 採点データ配列
  * @returns 作成されたワークシート
  */
 export async function createResultSheet(
   workbook: ExcelJS.Workbook,
   questionRegions: CropRegion[],
-  subtotalRegions: CropRegion[],
+  subtotalColumns: SubtotalColumn[],
   scoringData: ScoringData[]
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("正誤一覧")
 
   // ヘッダー行の作成
-  await createSheetHeaders(worksheet, questionRegions, subtotalRegions)
-
-  // 小計点の対象設問マップを事前に構築
-  const subtotalTargetMap = await buildSubtotalTargetMap(
-    subtotalRegions,
-    questionRegions
-  )
+  await createSheetHeaders(worksheet, questionRegions, subtotalColumns)
 
   // データ行の作成
-  await createDataRows(
-    worksheet,
-    scoringData,
-    subtotalRegions,
-    subtotalTargetMap,
-    false
-  )
+  await createDataRows(worksheet, scoringData, subtotalColumns, false)
 
   // スタイル適用
   autoFitColumns(worksheet)

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -184,7 +184,7 @@ export function calculateSubtotalStatistics(
       const subtotal = data.subtotalScores.find(
         (s) => s.subtotalId === template.subtotalId
       )
-      if (subtotal) {
+      if (subtotal && subtotal.score !== null) {
         scores.push(subtotal.score)
       }
     }
@@ -225,7 +225,7 @@ export function collectSubtotalRawScores(
         const subtotal = data.subtotalScores.find(
           (s) => s.subtotalId === template.subtotalId
         )
-        if (!subtotal) return null
+        if (!subtotal || subtotal.score === null) return null
         return {
           studentId: data.studentId,
           score: subtotal.score,
@@ -254,15 +254,19 @@ export function collectSubtotalRawScores(
  */
 export function calculateStatisticsForStudent(
   studentId: string,
-  studentScore: number,
+  studentScore: number | null,
   allScoringData: ScoringData[],
   classScoringData: ScoringData[],
   questionCorrectRates: Record<string, number>,
   questionScoreRates: Record<string, number>
 ): StatisticsData {
-  // 全体のスコア配列
-  const allScores = allScoringData.map((d) => d.totalScore)
-  const classScores = classScoringData.map((d) => d.totalScore)
+  // 全体のスコア配列（null を除外）
+  const allScores = allScoringData
+    .map((d) => d.totalScore)
+    .filter((s): s is number => s !== null)
+  const classScores = classScoringData
+    .map((d) => d.totalScore)
+    .filter((s): s is number => s !== null)
 
   // 全体統計
   const overallAverage = calculateAverage(allScores)
@@ -274,14 +278,15 @@ export function calculateStatisticsForStudent(
   const classStdDev = calculateStdDev(classScores)
   const classBoxPlot = calculateBoxPlotData(classScores)
 
-  // 個人統計
-  const deviation = calculateDeviation(
-    studentScore,
-    overallAverage,
-    overallStdDev
-  )
-  const overallRank = calculateRank(studentScore, allScores)
-  const classRank = calculateRank(studentScore, classScores)
+  // 個人統計（studentScore === null の場合は deviation=0, rank=0）
+  const deviation =
+    studentScore !== null
+      ? calculateDeviation(studentScore, overallAverage, overallStdDev)
+      : 0
+  const overallRank =
+    studentScore !== null ? calculateRank(studentScore, allScores) : 0
+  const classRank =
+    studentScore !== null ? calculateRank(studentScore, classScores) : 0
 
   // 小計別統計（SubtotalScoreから直接グループ情報を取得）
   const subtotalStatistics = calculateSubtotalStatistics(allScoringData)

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -142,7 +142,7 @@ export interface BoxPlotData {
 /** 生徒ごとの小計点データ（renderer側計算用） */
 export interface StudentSubtotalScore {
   studentId: string
-  score: number
+  score: number | null
   status: "participating" | "expected" | "absent"
 }
 
@@ -155,7 +155,7 @@ export interface SubtotalRawScores {
 /** 生徒ごとの合計点データ（renderer側での統計再計算用） */
 export interface RawTotalScoreEntry {
   studentId: string
-  totalScore: number
+  totalScore: number | null
   status: "participating" | "expected" | "absent"
   className?: string
   grade?: string

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -83,7 +83,7 @@ export interface PdfExportPageData {
   subtotalData: Array<{
     regionId: string
     label: string
-    score: number
+    score: number | null
     x: number
     y: number
     width: number
@@ -93,7 +93,7 @@ export interface PdfExportPageData {
   // 合計点領域データ
   totalScoreData: Array<{
     regionId: string
-    score: number
+    score: number | null
     maxScore: number
     x: number
     y: number
@@ -354,6 +354,7 @@ export async function getPdfExportData(options: {
         )
         let totalScore = 0
         let totalMaxScore = 0
+        let hasScoredQuestion = false
         for (const region of questionRegions) {
           const score = allScores.find(
             (s) => s.cropRegionId === region.id && s.studentId === student.id
@@ -371,7 +372,10 @@ export async function getPdfExportData(options: {
               },
               maxScore
             )
-            totalScore += actualScore ?? 0
+            if (actualScore !== null) {
+              hasScoredQuestion = true
+              totalScore += actualScore
+            }
           }
         }
 
@@ -381,13 +385,14 @@ export async function getPdfExportData(options: {
         )
 
         // 合計点領域データを構築
+        const finalTotalScore = hasScoredQuestion ? totalScore : null
         const totalScoreData: PdfExportPageData["totalScoreData"] = []
         for (const totalRegion of totalScoreRegions) {
           if (!totalRegion.projectPage) continue
 
           totalScoreData.push({
             regionId: totalRegion.id,
-            score: totalScore,
+            score: finalTotalScore,
             maxScore: totalMaxScore,
             x: totalRegion.x,
             y: totalRegion.y,
@@ -406,7 +411,7 @@ export async function getPdfExportData(options: {
           scoringData,
           subtotalData,
           totalScoreData,
-          totalScore,
+          totalScore: finalTotalScore,
           totalMaxScore,
           annotations,
         })

--- a/electron-src/lib/shared/calculations/subtotalCalculator.ts
+++ b/electron-src/lib/shared/calculations/subtotalCalculator.ts
@@ -25,7 +25,7 @@ export interface QuestionScoreData {
 }
 
 export interface SubtotalScoreResult {
-  score: number
+  score: number | null
   maxScore: number
   /** QUESTION_ASSIGNMENTが存在するか */
   hasQuestionAssignments: boolean
@@ -138,6 +138,7 @@ export async function calculateSubtotalScoreForStudent(
     // scoreDataがある設問のみを対象にする（scoreと同じ設問）
     let totalScore = 0
     let totalMaxScore = 0
+    let hasScoredQuestion = false
 
     for (const questionId of finalQuestionIds) {
       const scoreData = studentScores.find((s) => s.cropRegionId === questionId)
@@ -146,12 +147,15 @@ export async function calculateSubtotalScoreForStudent(
         const questionMaxScore = cropRegion?.points || 0
         totalMaxScore += questionMaxScore
         const actualScore = calculateActualScore(scoreData, questionMaxScore)
-        totalScore += actualScore || 0
+        if (actualScore !== null) {
+          hasScoredQuestion = true
+          totalScore += actualScore
+        }
       }
     }
 
     return {
-      score: totalScore,
+      score: hasScoredQuestion ? totalScore : null,
       maxScore: totalMaxScore,
       hasQuestionAssignments: true,
     }
@@ -160,7 +164,7 @@ export async function calculateSubtotalScoreForStudent(
       `Error calculating subtotal score for student ${studentId}, region ${subtotalRegionId}:`,
       error
     )
-    return { score: 0, maxScore: 0, hasQuestionAssignments: false }
+    return { score: null, maxScore: 0, hasQuestionAssignments: false }
   }
 }
 
@@ -178,6 +182,7 @@ function calculateStudentTotalScoreWithMax(
 
   let totalScore = 0
   let totalMaxScore = 0
+  let hasScoredQuestion = false
 
   // 全設問領域から最大点を計算（採点データの有無に関わらず）
   for (const region of cropRegions) {
@@ -192,12 +197,15 @@ function calculateStudentTotalScoreWithMax(
     if (cropRegion && cropRegion.type === "QUESTION_ANSWER") {
       const maxScore = cropRegion.points || 10
       const actualScore = calculateActualScore(scoreData, maxScore)
-      totalScore += actualScore || 0
+      if (actualScore !== null) {
+        hasScoredQuestion = true
+        totalScore += actualScore
+      }
     }
   }
 
   return {
-    score: totalScore,
+    score: hasScoredQuestion ? totalScore : null,
     maxScore: totalMaxScore,
     hasQuestionAssignments: true,
   }
@@ -243,7 +251,7 @@ export async function calculateSubtotalScoreBySubtotalId(
     const hasQuestionAssignments = questionAssignments.length > 0
 
     if (!hasQuestionAssignments) {
-      return { score: 0, maxScore: 0, hasQuestionAssignments: false }
+      return { score: null, maxScore: 0, hasQuestionAssignments: false }
     }
 
     // 関連するQUESTION_ANSWER CropRegion IDを取得
@@ -254,6 +262,7 @@ export async function calculateSubtotalScoreBySubtotalId(
     // 該当する設問の点数と最大点を合計
     let totalScore = 0
     let totalMaxScore = 0
+    let hasScoredQuestion = false
 
     for (const questionId of questionCropRegionIds) {
       const cropRegion = cropRegions.find((r) => r.id === questionId)
@@ -265,12 +274,15 @@ export async function calculateSubtotalScoreBySubtotalId(
       const scoreData = studentScores.find((s) => s.cropRegionId === questionId)
       if (scoreData) {
         const actualScore = calculateActualScore(scoreData, questionMaxScore)
-        totalScore += actualScore || 0
+        if (actualScore !== null) {
+          hasScoredQuestion = true
+          totalScore += actualScore
+        }
       }
     }
 
     return {
-      score: totalScore,
+      score: hasScoredQuestion ? totalScore : null,
       maxScore: totalMaxScore,
       hasQuestionAssignments: true,
     }
@@ -279,7 +291,7 @@ export async function calculateSubtotalScoreBySubtotalId(
       `Error calculating subtotal score for student ${studentId}, subtotal ${subtotalId}:`,
       error
     )
-    return { score: 0, maxScore: 0, hasQuestionAssignments: false }
+    return { score: null, maxScore: 0, hasQuestionAssignments: false }
   }
 }
 

--- a/electron-src/lib/shared/types/exportTypes.ts
+++ b/electron-src/lib/shared/types/exportTypes.ts
@@ -16,7 +16,7 @@ export interface ScoringData {
   attendanceNumber?: number | null
   status?: "participating" | "expected" | "absent"
   scores: ScoreDetail[]
-  totalScore: number
+  totalScore: number | null
   totalMaxScore: number
   subtotalScores: SubtotalScore[]
 }
@@ -30,8 +30,8 @@ export interface SubtotalScore {
   subtotalGroupName: string
   /** 小計点ラベル（Subtotal.name） */
   subtotalLabel: string
-  /** 得点 */
-  score: number
+  /** 得点（全設問unscoredの場合はnull） */
+  score: number | null
   /** 最大点 */
   maxScore: number
   /** QUESTION_ASSIGNMENTが存在するか（設問と関連付けられているか） */


### PR DESCRIPTION
## Summary
- Excel小計点の紐付けをCropRegionインデックスからSubtotalGroup IDベースに統一
- 全設問未採点の生徒の合計点・小計点・順位を空欄表示に変更（0点との区別）
- 25件の新規vitestテストを追加

Closes #369

## 変更内容

### 修正A: SubtotalGroup方式統一
- `SubtotalColumn` 型を導入（`dataFetcher.ts`）
- ヘッダーを `SubtotalColumn.label` から生成（`headerCreators.ts`）
- 小計セルを `subtotalId` でfind紐付け（`rowCreators.ts`）
- `buildSubtotalTargetMap` 依存を廃止（`sheetCreators.ts`）

### 修正B: 全設問unscored時の空欄化
- `SubtotalScoreResult.score`: `number` → `number | null`
- 3計算関数に `hasScoredQuestion` フラグ追加
- `ScoringData.totalScore`, `SubtotalScore.score` を nullable に
- Excel合計点をSUM数式→計算済み値に変更
- PDF出力・統計計算のnull対応
- フロントエンド型エラー修正

### テスト
- `subtotalCalculator.test.ts` (10テスト): モック付きhasScoredQuestionパターン
- `statisticsCalculator.test.ts` (9テスト): null除外の統計計算
- `computeReportData.test.ts` (6テスト): フロントエンドnull対応

## Test plan
- [x] `npm run typecheck` - エラーなし
- [x] `npm run lint` - 新規エラーなし
- [x] `npx vitest run` - 全262テストパス（25件新規追加）
- [ ] 手動テスト: 小計点の値が個人成績表と一致すること
- [ ] 手動テスト: 全設問未採点の生徒 → 合計点・小計点・順位が空欄
- [ ] 手動テスト: 全問不正解（0点）の生徒 → 合計点が0、順位あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)