### PR TITLE
fix: Excel正誤一覧表の無答記号を×から-に変更

### DIFF
--- a/electron-src/lib/shared/utilities/excelUtilities.ts
+++ b/electron-src/lib/shared/utilities/excelUtilities.ts
@@ -29,7 +29,7 @@ export function getStatusSymbol(status: string, score?: number): string {
     case "incorrect":
       return "×"
     case "no_answer":
-      return "×"
+      return "-"
     default:
       return "-"
   }


### PR DESCRIPTION
## Summary

- Excel正誤一覧表で無答(no_answer)の記号を「×」から「-」に変更
- 誤答(incorrect)との区別を明確化

Closes #373

## 変更内容

`getStatusSymbol`関数の`no_answer`ケースの返り値を`"×"`から`"-"`に修正。

## Test plan

- [ ] Excel出力で正誤一覧表を生成し、無答が「-」で表示されることを確認
- [ ] 誤答は引き続き「×」で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)