### PR TITLE
feat: エクスポートプレビュー機能追加・印刷バグ修正・PDF自動用紙設定

### DIFF
--- a/components/grade-projects/07-export/ExportContainer.tsx
+++ b/components/grade-projects/07-export/ExportContainer.tsx
@@ -110,10 +110,7 @@ export function ExportContainer({ gradeProjectId }: ExportContainerProps) {
               )
             })
             .catch((error: unknown) => {
-              console.error(
-                "成績算出エクスポート設定の保存に失敗:",
-                error
-              )
+              console.error("成績算出エクスポート設定の保存に失敗:", error)
             })
         }
 

--- a/components/grade-projects/07-export/IndividualReportTab.tsx
+++ b/components/grade-projects/07-export/IndividualReportTab.tsx
@@ -259,7 +259,7 @@ export function IndividualReportTab({
       <Section title="フッター">
         <div className="flex flex-col gap-2">
           <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="text-xs w-6 shrink-0">左</Label>
+            <Label className="w-6 shrink-0 text-xs">左</Label>
             <Input
               value={options.footer.left}
               onChange={(e) =>
@@ -272,7 +272,7 @@ export function IndividualReportTab({
             />
           </div>
           <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="text-xs w-6 shrink-0">中</Label>
+            <Label className="w-6 shrink-0 text-xs">中</Label>
             <Input
               value={options.footer.center}
               onChange={(e) =>
@@ -285,7 +285,7 @@ export function IndividualReportTab({
             />
           </div>
           <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="text-xs w-6 shrink-0">右</Label>
+            <Label className="w-6 shrink-0 text-xs">右</Label>
             <Input
               value={options.footer.right}
               onChange={(e) =>

--- a/components/grade-projects/07-export/PreviewPane.tsx
+++ b/components/grade-projects/07-export/PreviewPane.tsx
@@ -74,9 +74,7 @@ export function PreviewPane({ html }: PreviewPaneProps) {
             parseFloat(cs.paddingLeft) -
             parseFloat(cs.paddingRight)
           if (availableWidth > 0 && contentSizeRef.current.width > 0) {
-            setScale(
-              Math.min(availableWidth / contentSizeRef.current.width, 1)
-            )
+            setScale(Math.min(availableWidth / contentSizeRef.current.width, 1))
             initializedRef.current = true
           }
         }

--- a/components/projects/08-export/ExportMainView.tsx
+++ b/components/projects/08-export/ExportMainView.tsx
@@ -21,8 +21,10 @@ import {
   type PdfExportPageData,
 } from "@/components/projects/08-export/components/PdfCanvasRenderer"
 import { StudentSelectionCard } from "@/components/projects/08-export/components/StudentSelectionCard"
+import { useExcelPreview } from "@/components/projects/08-export/hooks/useExcelPreview"
 import { useExportPage } from "@/components/projects/08-export/hooks/useExportPage"
 import { useIndividualReportPreview } from "@/components/projects/08-export/hooks/useIndividualReportPreview"
+import { useScoredAnswerPreview } from "@/components/projects/08-export/hooks/useScoredAnswerPreview"
 import type { ScoringMarkConfigForPdf } from "@/components/projects/08-export/utils/pdfCanvasRenderer"
 
 export default function ExportMainView() {
@@ -104,6 +106,20 @@ export default function ExportMainView() {
     enabled: !!project?.id && selectedStudents.size > 0,
   })
 
+  // Excelプレビュー
+  const {
+    previewData: excelPreviewData,
+    isLoading: isExcelPreviewLoading,
+    error: excelPreviewError,
+  } = useExcelPreview({
+    projectId: project?.id || "",
+    selectedStudentIds,
+    enabled:
+      !!project?.id &&
+      selectedStudents.size > 0 &&
+      exportTab === "grading-data",
+  })
+
   // プレビュー用の生徒リスト
   const previewStudentList = useMemo(() => {
     return students
@@ -173,6 +189,29 @@ export default function ExportMainView() {
         showScoreForStatus: scoringMarkConfig.showScoreForStatus,
       }
     }, [scoringMarkConfig])
+
+  // プレビュー用にmemoized configを用意（毎レンダーで新オブジェクト生成→無限ループ防止）
+  const scoringMarkConfigForPdf = useMemo(
+    () => getScoringMarkConfigForPdf(),
+    [getScoringMarkConfigForPdf]
+  )
+
+  // 採点済み答案プレビュー（getScoringMarkConfigForPdfの後に配置）
+  const {
+    previewImageUrls: scoredAnswerPreviewUrls,
+    isLoading: isScoredAnswerPreviewLoading,
+    error: scoredAnswerPreviewError,
+    previewStudentId: scoredAnswerPreviewStudentId,
+    setPreviewStudentId: setScoredAnswerPreviewStudentId,
+  } = useScoredAnswerPreview({
+    projectId: project?.id || "",
+    selectedStudentIds,
+    scoringMarkConfig: scoringMarkConfigForPdf,
+    enabled:
+      !!project?.id &&
+      selectedStudents.size > 0 &&
+      exportTab === "scored-answers",
+  })
 
   /**
    * Canvas描画ベースのPDF出力（ストリーミング処理フロー）
@@ -675,6 +714,18 @@ export default function ExportMainView() {
               onPreviewStudentChange={setPreviewStudentId}
               previewStudentList={previewStudentList}
               individualReportOptions={individualReportOptions}
+              // 採点済み答案プレビュー
+              scoredAnswerPreviewUrls={scoredAnswerPreviewUrls}
+              isScoredAnswerPreviewLoading={isScoredAnswerPreviewLoading}
+              scoredAnswerPreviewError={scoredAnswerPreviewError}
+              scoredAnswerPreviewStudentId={scoredAnswerPreviewStudentId}
+              onScoredAnswerPreviewStudentChange={
+                setScoredAnswerPreviewStudentId
+              }
+              // Excelプレビュー
+              excelPreviewData={excelPreviewData}
+              isExcelPreviewLoading={isExcelPreviewLoading}
+              excelPreviewError={excelPreviewError}
             />
           </div>
 

--- a/components/projects/08-export/components/ExcelPreview.tsx
+++ b/components/projects/08-export/components/ExcelPreview.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import { useState } from "react"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+import type { ExcelPreviewData } from "../hooks/useExcelPreview"
+
+function getStatusSymbol(status: string, score?: number | null): string {
+  switch (status) {
+    case "correct":
+      return "○"
+    case "partial":
+    case "hold":
+      return score != null ? `△${score}` : "△NULL"
+    case "incorrect":
+      return "×"
+    case "no_answer":
+      return "-"
+    default:
+      return "-"
+  }
+}
+
+function getStatusColor(status: string): string {
+  switch (status) {
+    case "correct":
+      return "text-blue-600"
+    case "partial":
+    case "hold":
+      return "text-amber-600"
+    case "incorrect":
+      return "text-red-600"
+    case "no_answer":
+      return "text-gray-400"
+    default:
+      return "text-gray-400"
+  }
+}
+
+interface ExcelPreviewProps {
+  data: ExcelPreviewData
+}
+
+export function ExcelPreview({ data }: ExcelPreviewProps) {
+  const [sheetTab, setSheetTab] = useState<"scores" | "results">("scores")
+
+  const hasSubtotals = data.headers.subtotalLabels.length > 0
+
+  return (
+    <div className="flex h-full flex-col">
+      <Tabs
+        value={sheetTab}
+        onValueChange={(v) => setSheetTab(v as "scores" | "results")}
+        className="flex flex-1 flex-col"
+      >
+        <TabsList className="mb-1 grid w-full grid-cols-2">
+          <TabsTrigger value="scores" className="text-xs">
+            点数一覧
+          </TabsTrigger>
+          <TabsTrigger value="results" className="text-xs">
+            正誤一覧
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="scores" className="mt-0 flex-1 overflow-auto">
+          <table className="w-full border-collapse text-[10px]">
+            <thead className="bg-muted sticky top-0">
+              <tr>
+                <th className="border px-1 py-0.5 text-left">#</th>
+                <th className="border px-1 py-0.5 text-left">氏名</th>
+                <th className="border px-1 py-0.5 text-right">合計</th>
+                {hasSubtotals &&
+                  data.headers.subtotalLabels.map((label, i) => (
+                    <th
+                      key={`sub-${i}`}
+                      className="border px-1 py-0.5 text-right"
+                    >
+                      {label}
+                    </th>
+                  ))}
+                {data.headers.questionLabels.map((label, i) => (
+                  <th key={i} className="border px-1 py-0.5 text-right">
+                    <div>{label}</div>
+                    <div className="text-muted-foreground font-normal">
+                      ({data.headers.questionMaxScores[i]})
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, rowIdx) => (
+                <tr key={row.studentId} className="hover:bg-muted/50">
+                  <td className="border px-1 py-0.5 text-center">
+                    {rowIdx + 1}
+                  </td>
+                  <td className="border px-1 py-0.5 whitespace-nowrap">
+                    {row.studentName}
+                  </td>
+                  <td className="border px-1 py-0.5 text-right font-medium">
+                    {row.totalScore ?? "-"}
+                  </td>
+                  {hasSubtotals &&
+                    data.headers.subtotalLabels.map((_, i) => {
+                      const sub = row.subtotalScores[i]
+                      return (
+                        <td
+                          key={`sub-${i}`}
+                          className="border px-1 py-0.5 text-right"
+                        >
+                          {sub?.score ?? "-"}
+                        </td>
+                      )
+                    })}
+                  {row.scores.map((score, i) => (
+                    <td key={i} className="border px-1 py-0.5 text-right">
+                      {score.score ?? "-"}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TabsContent>
+
+        <TabsContent value="results" className="mt-0 flex-1 overflow-auto">
+          <table className="w-full border-collapse text-[10px]">
+            <thead className="bg-muted sticky top-0">
+              <tr>
+                <th className="border px-1 py-0.5 text-left">#</th>
+                <th className="border px-1 py-0.5 text-left">氏名</th>
+                <th className="border px-1 py-0.5 text-right">合計</th>
+                {hasSubtotals &&
+                  data.headers.subtotalLabels.map((label, i) => (
+                    <th
+                      key={`sub-${i}`}
+                      className="border px-1 py-0.5 text-right"
+                    >
+                      {label}
+                    </th>
+                  ))}
+                {data.headers.questionLabels.map((label, i) => (
+                  <th key={i} className="border px-1 py-0.5 text-center">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, rowIdx) => (
+                <tr key={row.studentId} className="hover:bg-muted/50">
+                  <td className="border px-1 py-0.5 text-center">
+                    {rowIdx + 1}
+                  </td>
+                  <td className="border px-1 py-0.5 whitespace-nowrap">
+                    {row.studentName}
+                  </td>
+                  <td className="border px-1 py-0.5 text-right font-medium">
+                    {row.totalScore ?? "-"}
+                  </td>
+                  {hasSubtotals &&
+                    data.headers.subtotalLabels.map((_, i) => {
+                      const sub = row.subtotalScores[i]
+                      return (
+                        <td
+                          key={`sub-${i}`}
+                          className="border px-1 py-0.5 text-right"
+                        >
+                          {sub?.score ?? "-"}
+                        </td>
+                      )
+                    })}
+                  {row.scores.map((score, i) => (
+                    <td
+                      key={i}
+                      className={`border px-1 py-0.5 text-center ${getStatusColor(score.status)}`}
+                    >
+                      {getStatusSymbol(score.status, score.score)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/components/projects/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/projects/08-export/components/PdfCanvasRenderer.tsx
@@ -45,7 +45,7 @@ export interface PdfExportPageData {
   subtotalData?: Array<{
     regionId: string
     label: string
-    score: number
+    score: number | null
     x: number
     y: number
     width: number
@@ -55,7 +55,7 @@ export interface PdfExportPageData {
   // 合計点領域データ
   totalScoreData?: Array<{
     regionId: string
-    score: number
+    score: number | null
     maxScore: number
     x: number
     y: number
@@ -297,31 +297,33 @@ export function PdfCanvasRenderer({
         userId: a.userId,
       }))
 
-      const subtotalDataForPdf: SubtotalDataForPdf[] = (
-        page.subtotalData || []
-      ).map((st) => ({
-        regionId: st.regionId,
-        label: st.label,
-        score: st.score,
-        x: st.x,
-        y: st.y,
-        width: st.width,
-        height: st.height,
-        pageNumber: st.pageNumber,
-      }))
+      const subtotalDataForPdf: SubtotalDataForPdf[] = (page.subtotalData || [])
+        .filter((st): st is typeof st & { score: number } => st.score != null)
+        .map((st) => ({
+          regionId: st.regionId,
+          label: st.label,
+          score: st.score,
+          x: st.x,
+          y: st.y,
+          width: st.width,
+          height: st.height,
+          pageNumber: st.pageNumber,
+        }))
 
       const totalScoreDataForPdf: TotalScoreDataForPdf[] = (
         page.totalScoreData || []
-      ).map((ts) => ({
-        regionId: ts.regionId,
-        score: ts.score,
-        maxScore: ts.maxScore,
-        x: ts.x,
-        y: ts.y,
-        width: ts.width,
-        height: ts.height,
-        pageNumber: ts.pageNumber,
-      }))
+      )
+        .filter((ts): ts is typeof ts & { score: number } => ts.score != null)
+        .map((ts) => ({
+          regionId: ts.regionId,
+          score: ts.score,
+          maxScore: ts.maxScore,
+          x: ts.x,
+          y: ts.y,
+          width: ts.width,
+          height: ts.height,
+          pageNumber: ts.pageNumber,
+        }))
 
       const blob = await renderAnswerSheetToCanvas(
         canvas,

--- a/components/projects/08-export/components/ScoredAnswerPreview.tsx
+++ b/components/projects/08-export/components/ScoredAnswerPreview.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+interface ScoredAnswerPreviewProps {
+  imageUrls: string[]
+  isLoading: boolean
+  error: string | null
+}
+
+export function ScoredAnswerPreview({
+  imageUrls,
+  isLoading,
+  error,
+}: ScoredAnswerPreviewProps) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-muted-foreground text-sm">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-destructive text-sm">{error}</p>
+      </div>
+    )
+  }
+
+  if (imageUrls.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-muted-foreground text-sm">
+          プレビューする生徒を選択してください
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {imageUrls.map((url, index) => (
+        <img
+          key={index}
+          src={url}
+          alt={`採点済み答案 ページ${index + 1}`}
+          className="w-full rounded shadow-sm"
+          style={{ maxWidth: "100%" }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/components/projects/08-export/components/StudentSelectionCard.tsx
+++ b/components/projects/08-export/components/StudentSelectionCard.tsx
@@ -35,8 +35,11 @@ import type {
   IndividualReportOptions,
 } from "@/electron-src/lib/export/individual-report/types"
 
+import type { ExcelPreviewData } from "../hooks/useExcelPreview"
+import { ExcelPreview } from "./ExcelPreview"
 import type { ExportTabType } from "./ExportOptionsCard"
 import { IndividualReportPreview } from "./individual-report/IndividualReportPreview"
+import { ScoredAnswerPreview } from "./ScoredAnswerPreview"
 
 interface StudentSelectionCardProps {
   students: Student[]
@@ -58,6 +61,16 @@ interface StudentSelectionCardProps {
   onPreviewStudentChange?: (studentId: string) => void
   previewStudentList?: Array<{ id: string; name: string }>
   individualReportOptions?: IndividualReportOptions
+  // 採点済み答案プレビュー
+  scoredAnswerPreviewUrls?: string[]
+  isScoredAnswerPreviewLoading?: boolean
+  scoredAnswerPreviewError?: string | null
+  scoredAnswerPreviewStudentId?: string | null
+  onScoredAnswerPreviewStudentChange?: (studentId: string) => void
+  // Excelプレビュー
+  excelPreviewData?: ExcelPreviewData | null
+  isExcelPreviewLoading?: boolean
+  excelPreviewError?: string | null
 }
 
 export function StudentSelectionCard({
@@ -79,6 +92,14 @@ export function StudentSelectionCard({
   onPreviewStudentChange,
   previewStudentList,
   individualReportOptions,
+  scoredAnswerPreviewUrls,
+  isScoredAnswerPreviewLoading,
+  scoredAnswerPreviewError,
+  scoredAnswerPreviewStudentId,
+  onScoredAnswerPreviewStudentChange,
+  excelPreviewData,
+  isExcelPreviewLoading,
+  excelPreviewError,
 }: StudentSelectionCardProps) {
   const [activeTab, setActiveTab] = useState<"selection" | "preview">(
     "selection"
@@ -306,15 +327,24 @@ export function StudentSelectionCard({
         value="preview"
         className="mt-0 flex min-h-0 flex-1 flex-col"
       >
-        {/* 個人成績表の場合のみ生徒選択を表示 */}
-        {previewType === "individual-report" &&
+        {/* 個人成績表・採点済み答案の場合は生徒選択を表示 */}
+        {(previewType === "individual-report" ||
+          previewType === "scored-answers") &&
           previewStudentList &&
           previewStudentList.length > 0 && (
             <div className="mb-2 flex items-center gap-2">
               <Label className="text-sm whitespace-nowrap">生徒:</Label>
               <Select
-                value={previewStudentId || ""}
-                onValueChange={(v) => onPreviewStudentChange?.(v)}
+                value={
+                  previewType === "scored-answers"
+                    ? scoredAnswerPreviewStudentId || ""
+                    : previewStudentId || ""
+                }
+                onValueChange={(v) =>
+                  previewType === "scored-answers"
+                    ? onScoredAnswerPreviewStudentChange?.(v)
+                    : onPreviewStudentChange?.(v)
+                }
               >
                 <SelectTrigger className="h-8 flex-1">
                   <SelectValue placeholder="選択" />
@@ -359,16 +389,35 @@ export function StudentSelectionCard({
                 </p>
               </div>
             )
-          ) : (
-            // 採点済み答案 / Excel は準備中
-            <div className="flex flex-1 items-center justify-center">
-              <p className="text-muted-foreground text-sm">
-                {previewType === "scored-answers"
-                  ? "採点済み答案プレビューは準備中です"
-                  : "Excelプレビューは準備中です"}
-              </p>
-            </div>
-          )}
+          ) : previewType === "scored-answers" ? (
+            // 採点済み答案プレビュー
+            <ScoredAnswerPreview
+              imageUrls={scoredAnswerPreviewUrls || []}
+              isLoading={isScoredAnswerPreviewLoading || false}
+              error={scoredAnswerPreviewError || null}
+            />
+          ) : previewType === "excel" ? (
+            // Excelプレビュー
+            isExcelPreviewLoading ? (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="text-muted-foreground text-sm">読み込み中...</p>
+              </div>
+            ) : excelPreviewError ? (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="text-destructive text-sm">{excelPreviewError}</p>
+              </div>
+            ) : excelPreviewData ? (
+              <ExcelPreview data={excelPreviewData} />
+            ) : (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="text-muted-foreground text-sm">
+                  {selectedStudents.size === 0
+                    ? "生徒を選択してください"
+                    : "データの取得中..."}
+                </p>
+              </div>
+            )
+          ) : null}
         </div>
       </TabsContent>
     </Tabs>

--- a/components/projects/08-export/hooks/useExcelPreview.ts
+++ b/components/projects/08-export/hooks/useExcelPreview.ts
@@ -1,0 +1,144 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+interface ExcelPreviewScore {
+  questionId: string
+  questionLabel: string
+  score: number | null
+  maxScore: number
+  status:
+    | "unscored"
+    | "correct"
+    | "partial"
+    | "hold"
+    | "incorrect"
+    | "no_answer"
+}
+
+interface ExcelPreviewSubtotalScore {
+  subtotalId: string
+  subtotalLabel: string
+  score: number | null
+  maxScore: number
+}
+
+export interface ExcelPreviewRow {
+  studentId: string
+  studentName: string
+  studentNumber: string
+  grade?: string
+  className?: string
+  attendanceNumber?: number | null
+  status?: "participating" | "expected" | "absent"
+  scores: ExcelPreviewScore[]
+  totalScore: number | null
+  totalMaxScore: number
+  subtotalScores: ExcelPreviewSubtotalScore[]
+}
+
+export interface ExcelPreviewHeader {
+  questionLabels: string[]
+  questionMaxScores: number[]
+  subtotalLabels: string[]
+}
+
+export interface ExcelPreviewData {
+  headers: ExcelPreviewHeader
+  rows: ExcelPreviewRow[]
+}
+
+interface UseExcelPreviewProps {
+  projectId: string
+  selectedStudentIds: string[]
+  enabled: boolean
+}
+
+export function useExcelPreview({
+  projectId,
+  selectedStudentIds,
+  enabled,
+}: UseExcelPreviewProps) {
+  const [previewData, setPreviewData] = useState<ExcelPreviewData | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // selectedStudentIdsのJSON文字列でオブジェクト参照変化を無視
+  const selectedStudentIdsKey = JSON.stringify(selectedStudentIds)
+
+  useEffect(() => {
+    if (!enabled || !projectId || selectedStudentIds.length === 0) {
+      setPreviewData(null)
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
+    // デバウンス: 生徒選択変更時に300ms待機
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current)
+    }
+
+    setIsLoading(true)
+
+    debounceTimerRef.current = setTimeout(async () => {
+      setError(null)
+
+      try {
+        const result = await window.electronAPI.export.getExcelPreviewData({
+          projectId,
+          selectedStudentIds,
+        })
+
+        if (!result.success || !result.scoringData) {
+          setError(result.error || "データの取得に失敗しました")
+          setPreviewData(null)
+          return
+        }
+
+        const headers: ExcelPreviewHeader = {
+          questionLabels:
+            result.questionRegions?.map(
+              (r) => r.label || `問${(r.orderIndex ?? 0) + 1}`
+            ) || [],
+          questionMaxScores:
+            result.questionRegions?.map((r) => r.points ?? 0) || [],
+          subtotalLabels: result.subtotalColumns?.map((c) => c.label) || [],
+        }
+
+        const rows: ExcelPreviewRow[] = result.scoringData.map((data) => ({
+          studentId: data.studentId,
+          studentName: data.studentName,
+          studentNumber: data.studentNumber,
+          grade: data.grade,
+          className: data.className,
+          attendanceNumber: data.attendanceNumber,
+          status: data.status,
+          scores: data.scores,
+          totalScore: data.totalScore,
+          totalMaxScore: data.totalMaxScore,
+          subtotalScores: data.subtotalScores,
+        }))
+
+        setPreviewData({ headers, rows })
+      } catch (err) {
+        console.error("Excel preview data fetch error:", err)
+        setError(
+          err instanceof Error ? err.message : "データの取得に失敗しました"
+        )
+        setPreviewData(null)
+      } finally {
+        setIsLoading(false)
+      }
+    }, 300)
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, selectedStudentIdsKey, enabled])
+
+  return { previewData, isLoading, error }
+}

--- a/components/projects/08-export/hooks/useExportPage.ts
+++ b/components/projects/08-export/hooks/useExportPage.ts
@@ -171,6 +171,41 @@ export function useExportPage() {
     [projectId, individualReportOptions]
   )
 
+  // マスター画像の縦横比からPDF用紙の向きを自動設定
+  const orientationInitializedRef = useRef(false)
+  useEffect(() => {
+    if (orientationInitializedRef.current || !projectId) return
+
+    const detectOrientation = async () => {
+      try {
+        const masterImages =
+          await window.electronAPI.getMasterImagesByProjectId(projectId)
+        if (!masterImages || masterImages.length === 0) return
+
+        const firstImage = masterImages[0]
+        const imageUrl = await window.electronAPI.resolveFileProtocolPath(
+          firstImage.imagePath
+        )
+
+        const img = new Image()
+        img.src = imageUrl
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve()
+          img.onerror = () => reject(new Error("画像の読み込みに失敗"))
+        })
+
+        orientationInitializedRef.current = true
+        if (img.naturalWidth > img.naturalHeight) {
+          setExportOptions((prev) => ({ ...prev, pdfOrientation: "landscape" }))
+        }
+      } catch (error) {
+        console.error("用紙方向の自動検出に失敗しました:", error)
+      }
+    }
+
+    detectOrientation()
+  }, [projectId])
+
   // プログレス状態
   const [showProgressModal, setShowProgressModal] = useState(false)
   const [exportProgress, setExportProgress] = useState(0)

--- a/components/projects/08-export/hooks/useScoredAnswerPreview.ts
+++ b/components/projects/08-export/hooks/useScoredAnswerPreview.ts
@@ -1,0 +1,239 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+
+import type {
+  ScoringMarkConfigForPdf,
+  SubtotalDataForPdf,
+  TotalScoreDataForPdf,
+} from "../utils/pdfCanvasRenderer"
+import {
+  preloadScoringMarkImages,
+  renderAnswerSheetToCanvas,
+} from "../utils/pdfCanvasRenderer"
+
+interface UseScoredAnswerPreviewProps {
+  projectId: string
+  selectedStudentIds: string[]
+  scoringMarkConfig: ScoringMarkConfigForPdf
+  enabled: boolean
+}
+
+export function useScoredAnswerPreview({
+  projectId,
+  selectedStudentIds,
+  scoringMarkConfig,
+  enabled,
+}: UseScoredAnswerPreviewProps) {
+  const [previewImageUrls, setPreviewImageUrls] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [previewStudentId, setPreviewStudentId] = useState<string | null>(null)
+  const scoringMarkImagesRef = useRef<Map<string, HTMLImageElement> | null>(
+    null
+  )
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  // refでconfigを保持し、useEffect依存配列にオブジェクト直接を入れない
+  const scoringMarkConfigRef = useRef(scoringMarkConfig)
+  scoringMarkConfigRef.current = scoringMarkConfig
+
+  // 選択生徒が変更されたときにpreviewStudentIdを初期化
+  useEffect(() => {
+    if (selectedStudentIds.length > 0) {
+      if (!previewStudentId || !selectedStudentIds.includes(previewStudentId)) {
+        setPreviewStudentId(selectedStudentIds[0])
+      }
+    } else {
+      setPreviewStudentId(null)
+      setPreviewImageUrls([])
+    }
+  }, [selectedStudentIds, previewStudentId])
+
+  // enabled が false になったらリセット
+  useEffect(() => {
+    if (!enabled) {
+      setPreviewImageUrls([])
+      setError(null)
+      setIsLoading(false)
+    }
+  }, [enabled])
+
+  // previewStudentId変更時にCanvas描画
+  useEffect(() => {
+    if (!enabled || !projectId || !previewStudentId) {
+      return
+    }
+
+    let cancelled = false
+
+    const render = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        // 1. データ取得
+        const dataResult = await window.electronAPI.export.getPdfExportData({
+          projectId,
+          selectedStudentIds: [previewStudentId],
+        })
+
+        if (cancelled) return
+
+        if (!dataResult.success || !dataResult.pages) {
+          setError(dataResult.error || "データの取得に失敗しました")
+          setPreviewImageUrls([])
+          return
+        }
+
+        if (dataResult.pages.length === 0) {
+          setError("この生徒の答案データがありません")
+          setPreviewImageUrls([])
+          return
+        }
+
+        // 2. 採点マーク画像のプリロード
+        const config = scoringMarkConfigRef.current
+        if (!scoringMarkImagesRef.current) {
+          scoringMarkImagesRef.current = await preloadScoringMarkImages(
+            config.useTransparent
+          )
+        }
+
+        if (cancelled) return
+
+        // 3. Canvas要素の作成（非表示）
+        if (!canvasRef.current) {
+          canvasRef.current = document.createElement("canvas")
+        }
+        const canvas = canvasRef.current
+
+        // 4. 各ページを描画してdata URLに変換
+        const urls: string[] = []
+        for (const page of dataResult.pages) {
+          // 画像の読み込み
+          const img = new Image()
+          img.crossOrigin = "anonymous"
+          img.src = page.imageUrl
+
+          await new Promise<void>((resolve, reject) => {
+            img.onload = () => resolve()
+            img.onerror = () => reject(new Error("画像の読み込みに失敗"))
+          })
+
+          if (cancelled) return
+
+          // scoringDataをScoringDataForPdf形式に変換
+          const scoringDataForPdf = page.scoringData.map((sd) => ({
+            questionScoreId: sd.questionScoreId,
+            status: sd.status,
+            partialScore: sd.partialScore,
+            cropRegion: {
+              id: sd.cropRegion.id,
+              x: sd.cropRegion.x,
+              y: sd.cropRegion.y,
+              width: sd.cropRegion.width,
+              height: sd.cropRegion.height,
+              label: sd.cropRegion.label,
+              maxScore: sd.cropRegion.maxScore,
+              projectPage: {
+                pageNumber: sd.cropRegion.pageNumber,
+              },
+            },
+          }))
+
+          // subtotalDataをSubtotalDataForPdf形式に変換
+          const subtotalDataForPdf: SubtotalDataForPdf[] = (
+            page.subtotalData || []
+          )
+            .filter(
+              (sd): sd is typeof sd & { score: number } => sd.score != null
+            )
+            .map((sd) => ({
+              regionId: sd.regionId,
+              label: sd.label,
+              score: sd.score,
+              x: sd.x,
+              y: sd.y,
+              width: sd.width,
+              height: sd.height,
+              pageNumber: sd.pageNumber,
+            }))
+
+          // totalScoreDataをTotalScoreDataForPdf形式に変換
+          const totalScoreDataForPdf: TotalScoreDataForPdf[] = (
+            page.totalScoreData || []
+          )
+            .filter(
+              (td): td is typeof td & { score: number } => td.score != null
+            )
+            .map((td) => ({
+              regionId: td.regionId,
+              score: td.score,
+              maxScore: td.maxScore,
+              x: td.x,
+              y: td.y,
+              width: td.width,
+              height: td.height,
+              pageNumber: td.pageNumber,
+            }))
+
+          // annotationsをDrawingAnnotation形式にキャスト
+          // IPC経由のデータは一部フィールドが欠落しているが、
+          // renderAnswerSheetToCanvasが使用するフィールドは全て含まれている
+          const annotations = page.annotations as unknown as DrawingAnnotation[]
+
+          // Canvas描画
+          await renderAnswerSheetToCanvas(
+            canvas,
+            img,
+            scoringDataForPdf,
+            annotations,
+            config,
+            scoringMarkImagesRef.current!,
+            subtotalDataForPdf,
+            totalScoreDataForPdf,
+            page.pageNumber
+          )
+
+          if (cancelled) return
+
+          // data URLに変換
+          urls.push(canvas.toDataURL("image/png"))
+        }
+
+        setPreviewImageUrls(urls)
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Scored answer preview error:", err)
+          setError(
+            err instanceof Error
+              ? err.message
+              : "プレビューの生成に失敗しました"
+          )
+          setPreviewImageUrls([])
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    render()
+
+    return () => {
+      cancelled = true
+    }
+    // scoringMarkConfigはrefで参照するため依存配列に含めない
+  }, [projectId, previewStudentId, enabled])
+
+  return {
+    previewImageUrls,
+    isLoading,
+    error,
+    previewStudentId,
+    setPreviewStudentId,
+  }
+}

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, dialog, ipcMain } from "electron"
 
+import { fetchExportData } from "../lib/export/excel/dataFetcher"
 import type { GetIndividualReportDataOptions } from "../lib/export/individual-report"
 import {
   fetchIndividualReportData,
@@ -31,6 +32,75 @@ export function setupExportHandlers(): void {
         return await exportGradingDataExcel(options)
       } catch (err) {
         console.error("Error exporting grading data Excel:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    }
+  )
+
+  // Excelプレビュー用データ取得
+  ipcMain.handle(
+    "export:getExcelPreviewData",
+    async (
+      _event,
+      options: {
+        projectId: string
+        selectedStudentIds: string[]
+      }
+    ) => {
+      try {
+        const result = await fetchExportData(
+          options.projectId,
+          options.selectedStudentIds
+        )
+        if (!result.success) {
+          return { success: false, error: result.error }
+        }
+        // Prismaの Decimal/Date 型はIPC経由でcloneできないため、
+        // プレーンなJSオブジェクトに変換して返す
+        const questionRegions = result.questionRegions?.map((r) => ({
+          id: r.id,
+          label: r.label,
+          points: r.points != null ? Number(r.points) : null,
+          orderIndex: r.orderIndex != null ? Number(r.orderIndex) : null,
+        }))
+
+        const scoringData = result.scoringData?.map((sd) => ({
+          studentId: sd.studentId,
+          studentName: sd.studentName,
+          studentNumber: sd.studentNumber,
+          grade: sd.grade,
+          className: sd.className,
+          attendanceNumber:
+            sd.attendanceNumber != null ? Number(sd.attendanceNumber) : null,
+          status: sd.status,
+          scores: sd.scores.map((s) => ({
+            questionId: s.questionId,
+            questionLabel: s.questionLabel,
+            score: s.score != null ? Number(s.score) : null,
+            maxScore: Number(s.maxScore),
+            status: s.status,
+          })),
+          totalScore: sd.totalScore != null ? Number(sd.totalScore) : null,
+          totalMaxScore: Number(sd.totalMaxScore),
+          subtotalScores: sd.subtotalScores.map((ss) => ({
+            subtotalId: ss.subtotalId,
+            subtotalLabel: ss.subtotalLabel,
+            score: ss.score != null ? Number(ss.score) : null,
+            maxScore: Number(ss.maxScore),
+          })),
+        }))
+
+        return {
+          success: true,
+          questionRegions,
+          subtotalColumns: result.subtotalColumns,
+          scoringData,
+        }
+      } catch (err) {
+        console.error("Error getting Excel preview data:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "Unknown error occurred",
@@ -620,17 +690,17 @@ export function setupExportHandlers(): void {
         // レンダリング完了を待つ
         await new Promise((resolve) => setTimeout(resolve, 500))
 
-        // PDFを生成（マージンはインチ単位、5mm ≈ 0.2インチ）
+        // PDFを生成（マージンはCSSの@page marginに任せるため0に設定）
         const pdfBuffer = await win.webContents.printToPDF({
           pageSize: "A4",
           landscape: false,
           printBackground: true,
           margins: {
             marginType: "custom",
-            top: 0.2,
-            bottom: 0.2,
-            left: 0.2,
-            right: 0.2,
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
           },
         })
 

--- a/electron-src/ipc-handlers/gradeProjectHandlers.ts
+++ b/electron-src/ipc-handlers/gradeProjectHandlers.ts
@@ -116,8 +116,7 @@ export function setupGradeProjectHandlers(): void {
     "grade-project:getExportSettings",
     async (_event, gradeProjectId: string) => {
       try {
-        const settings =
-          await getGradeProjectExportSettings(gradeProjectId)
+        const settings = await getGradeProjectExportSettings(gradeProjectId)
         return { success: true, settings }
       } catch (error) {
         return {

--- a/electron-src/lib/prisma/gradeProject.ts
+++ b/electron-src/lib/prisma/gradeProject.ts
@@ -233,9 +233,7 @@ export async function deleteGradeProject(id: string) {
 // GradeProjectExportSettings（エクスポート設定）
 // =============================================================================
 
-export async function getGradeProjectExportSettings(
-  gradeProjectId: string
-) {
+export async function getGradeProjectExportSettings(gradeProjectId: string) {
   const settings = await prisma.gradeProjectExportSettings.findUnique({
     where: { gradeProjectId },
   })

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -536,6 +536,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
       pageSize?: "A4" | "Letter"
       landscape?: boolean
     }) => ipcRenderer.invoke("export:printMultipleHtmlToPdf", options),
+    // Excelプレビューデータ取得
+    getExcelPreviewData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+    }) => ipcRenderer.invoke("export:getExcelPreviewData", options),
     // 印刷ダイアログを開く
     openPrintDialog: (options: { html: string; title?: string }) =>
       ipcRenderer.invoke("export:openPrintDialog", options),

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -975,6 +975,28 @@ export interface MyAPI {
             pageNumber: number
           }
         }>
+        subtotalData: Array<{
+          regionId: string
+          label: string
+          score: number | null
+          x: number
+          y: number
+          width: number
+          height: number
+          pageNumber: number
+        }>
+        totalScoreData: Array<{
+          regionId: string
+          score: number | null
+          maxScore: number
+          x: number
+          y: number
+          width: number
+          height: number
+          pageNumber: number
+        }>
+        totalScore: number | null
+        totalMaxScore: number | null
         annotations: Array<{
           id: string
           questionScoreId: string
@@ -1138,6 +1160,55 @@ export interface MyAPI {
       landscape?: boolean
     }) => Promise<{
       success: boolean
+      error?: string
+    }>
+
+    // Excelプレビューデータ取得
+    getExcelPreviewData: (options: {
+      projectId: string
+      selectedStudentIds: string[]
+    }) => Promise<{
+      success: boolean
+      questionRegions?: Array<{
+        id: string
+        label: string | null
+        points: number | null
+        orderIndex: number | null
+      }>
+      subtotalColumns?: Array<{
+        subtotalId: string
+        label: string
+      }>
+      scoringData?: Array<{
+        studentId: string
+        studentName: string
+        studentNumber: string
+        grade?: string
+        className?: string
+        attendanceNumber?: number | null
+        status?: "participating" | "expected" | "absent"
+        scores: Array<{
+          questionId: string
+          questionLabel: string
+          score: number | null
+          maxScore: number
+          status:
+            | "unscored"
+            | "correct"
+            | "partial"
+            | "hold"
+            | "incorrect"
+            | "no_answer"
+        }>
+        totalScore: number | null
+        totalMaxScore: number
+        subtotalScores: Array<{
+          subtotalId: string
+          subtotalLabel: string
+          score: number | null
+          maxScore: number
+        }>
+      }>
       error?: string
     }>
 


### PR DESCRIPTION
## Summary
- 採点済み答案プレビュー: Canvas描画によるリアルタイムプレビュー表示を実装
- Excelプレビュー: 点数一覧/正誤一覧の2タブ切替テーブル表示を実装（全件表示）
- 印刷バグ修正: printToPDFマージン二重適用を解消
- PDF自動用紙設定: マスター画像の縦横比からlandscape/portrait自動選択
- IPC Decimal/Date型シリアライズ問題を修正
- PdfCanvasRenderer: subtotalData/totalScoreDataの型をnullable対応

Closes #379

## Test plan
- [ ] 生徒を選択 → プレビュータブ → 採点済み答案PDFタブ → 採点マーク付き答案画像が表示されることを確認
- [ ] 生徒を選択 → プレビュータブ → 採点データExcelタブ → 点数一覧/正誤一覧テーブルが全件表示されることを確認
- [ ] 個人成績表を1ページ設定で出力 → プレビュー.appで1ページに収まることを確認
- [ ] 横長の模範解答を持つプロジェクトでエクスポートページを開き → landscape が自動選択されることを確認
- [ ] `npm run check-all` で型チェックとlintが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)