### PR TITLE
fix: 答案再アップロード時の重複レコード問題を修正

### DIFF
--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -198,6 +198,7 @@ export function setupMiscHandlers(): void {
         buffer: ArrayBuffer
         studentId?: string
         pageNumber?: number
+        overwrite?: boolean
       }[]
     ) => {
       try {

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -91,10 +91,28 @@ async function changeStudentId(
     data: { studentId: target.newId },
   })
 
-  await tx.studentAnswerImage.updateMany({
+  // StudentAnswerImage: 重複を回避しつつstudentIdを更新
+  const existingAnswerImages = await tx.studentAnswerImage.findMany({
     where: { studentId: target.existingId },
-    data: { studentId: target.newId },
   })
+  for (const img of existingAnswerImages) {
+    // 移行先のstudentIdで同じprojectPageIdのレコードが既に存在するか確認
+    const duplicate = await tx.studentAnswerImage.findFirst({
+      where: {
+        projectPageId: img.projectPageId,
+        studentId: target.newId,
+      },
+    })
+    if (duplicate) {
+      // 重複する場合は古い方を削除
+      await tx.studentAnswerImage.delete({ where: { id: img.id } })
+    } else {
+      await tx.studentAnswerImage.update({
+        where: { id: img.id },
+        data: { studentId: target.newId },
+      })
+    }
+  }
 
   await tx.questionScore.updateMany({
     where: { studentId: target.existingId },

--- a/electron-src/lib/import/merge/mergeImageHandler.ts
+++ b/electron-src/lib/import/merge/mergeImageHandler.ts
@@ -119,6 +119,15 @@ async function createStudentAnswerImageRecords(
     const newStudentId = idMappings.student[img.studentId]
     if (!newProjectPageId || !newStudentId) continue
 
+    // 同一(projectPageId, studentId)の重複チェック
+    const existing = await prisma.studentAnswerImage.findFirst({
+      where: {
+        projectPageId: newProjectPageId,
+        studentId: newStudentId,
+      },
+    })
+    if (existing) continue
+
     const relativePath = img.imagePath.substring(
       img.imagePath.indexOf("answer-sheets") + "answer-sheets".length + 1
     )
@@ -166,6 +175,15 @@ async function createLegacyImageRecords(
     } else if (img.imageType === "STUDENT_ANSWER" && img.studentId) {
       const newStudentId = idMappings.student[img.studentId]
       if (!newStudentId) continue
+
+      // 同一(projectPageId, studentId)の重複チェック
+      const existing = await prisma.studentAnswerImage.findFirst({
+        where: {
+          projectPageId: newProjectPageId,
+          studentId: newStudentId,
+        },
+      })
+      if (existing) continue
 
       const relativePath = img.imagePath.substring(
         img.imagePath.indexOf("answer-sheets") + "answer-sheets".length + 1

--- a/electron-src/lib/import/project-archive/imageHandler.ts
+++ b/electron-src/lib/import/project-archive/imageHandler.ts
@@ -97,6 +97,15 @@ export async function createImageRecords(
       const newStudentId = remapId(img.studentId, mappings.student)
       if (!newProjectPageId || !newStudentId) continue
 
+      // 同一(projectPageId, studentId)の重複チェック
+      const existing = await prisma.studentAnswerImage.findFirst({
+        where: {
+          projectPageId: newProjectPageId,
+          studentId: newStudentId,
+        },
+      })
+      if (existing) continue
+
       const relativePath = img.imagePath.substring(
         img.imagePath.indexOf("answer-sheets") + "answer-sheets".length + 1
       )
@@ -139,6 +148,15 @@ export async function createImageRecords(
     } else if (img.imageType === "STUDENT_ANSWER" && img.studentId) {
       const newStudentId = remapId(img.studentId, mappings.student)
       if (!newStudentId) continue
+
+      // 同一(projectPageId, studentId)の重複チェック
+      const existing = await prisma.studentAnswerImage.findFirst({
+        where: {
+          projectPageId: newProjectPageId,
+          studentId: newStudentId,
+        },
+      })
+      if (existing) continue
 
       const relativePath = img.imagePath.substring(
         img.imagePath.indexOf("answer-sheets") + "answer-sheets".length + 1

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -538,6 +538,9 @@ CREATE UNIQUE INDEX "CropRegionMarkingOverride_cropRegionId_markType_key" ON "Cr
 CREATE INDEX "CropRegionMarkingOverride_cropRegionId_idx" ON "CropRegionMarkingOverride"("cropRegionId");
 
 -- CreateIndex (MasterImage/StudentAnswerImage)
+CREATE UNIQUE INDEX "StudentAnswerImage_projectPageId_studentId_key" ON "StudentAnswerImage"("projectPageId", "studentId");
+
+-- CreateIndex
 CREATE INDEX "StudentAnswerImage_projectPageId_idx" ON "StudentAnswerImage"("projectPageId");
 
 -- CreateIndex

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -6,6 +6,7 @@ import * as fs from "fs/promises"
 import * as path from "path"
 
 import {
+  getAbsolutePathFromData,
   getAnswerSheetsDirectory,
   getRelativePathFromData,
 } from "../../dataManager"
@@ -22,6 +23,7 @@ export async function uploadStudentAnswers(
     buffer: ArrayBuffer
     studentId?: string
     pageNumber?: number
+    overwrite?: boolean
   }[]
 ) {
   try {
@@ -33,17 +35,6 @@ export async function uploadStudentAnswers(
     const uploadedSheets = []
 
     for (const fileData of filesData) {
-      // ファイル名を正規化
-      const timestamp = Date.now()
-      const sanitizedName = fileData.name.replace(/[^a-zA-Z0-9\-_.]/g, "_")
-      const fileName = `${timestamp}_${sanitizedName}`
-      const filePath = path.join(projectDir, fileName)
-      const relativePath = getRelativePathFromData(filePath)
-
-      // ファイルを保存
-      const buffer = Buffer.from(fileData.buffer)
-      await fs.writeFile(filePath, buffer)
-
       // studentIdが必須
       if (!fileData.studentId) {
         throw new Error(`Student ID is required for file: ${fileData.name}`)
@@ -74,22 +65,56 @@ export async function uploadStudentAnswers(
         },
       })
 
-      // データベースに記録
-      const answerSheet = await prisma.studentAnswerImage.create({
-        data: {
-          projectPageId: projectPage.id,
-          studentId: fileData.studentId,
-          imagePath: relativePath,
-        },
-      })
+      // ファイル名を正規化
+      const timestamp = Date.now()
+      const sanitizedName = fileData.name.replace(/[^a-zA-Z0-9\-_.]/g, "_")
+      const fileName = `${timestamp}_${sanitizedName}`
+      const filePath = path.join(projectDir, fileName)
+      const relativePath = getRelativePathFromData(filePath)
 
-      // 上書きフラグを追加
-      const resultSheet = {
-        ...answerSheet,
-        isOverwrite: !!existingRecord,
+      if (existingRecord) {
+        if (fileData.overwrite) {
+          // ファイルを保存
+          const buffer = Buffer.from(fileData.buffer)
+          await fs.writeFile(filePath, buffer)
+
+          // 古いファイルを削除
+          try {
+            const oldFilePath = getAbsolutePathFromData(
+              existingRecord.imagePath
+            )
+            await fs.unlink(oldFilePath)
+          } catch {
+            // ファイルが存在しない場合は無視
+          }
+
+          // レコードを更新
+          const answerSheet = await prisma.studentAnswerImage.update({
+            where: { id: existingRecord.id },
+            data: { imagePath: relativePath },
+          })
+
+          uploadedSheets.push({ ...answerSheet, isOverwrite: true })
+        } else {
+          // 上書き無効: スキップ（既存レコードをそのまま返す）
+          uploadedSheets.push({ ...existingRecord, isOverwrite: false })
+        }
+      } else {
+        // ファイルを保存
+        const buffer = Buffer.from(fileData.buffer)
+        await fs.writeFile(filePath, buffer)
+
+        // 新規作成
+        const answerSheet = await prisma.studentAnswerImage.create({
+          data: {
+            projectPageId: projectPage.id,
+            studentId: fileData.studentId,
+            imagePath: relativePath,
+          },
+        })
+
+        uploadedSheets.push({ ...answerSheet, isOverwrite: false })
       }
-
-      uploadedSheets.push(resultSheet)
     }
 
     return { success: true, answerSheets: uploadedSheets }
@@ -130,7 +155,18 @@ export async function getStudentAnswersByProjectId(projectId: string) {
       orderBy: [{ studentId: "asc" }, { projectPage: { pageNumber: "asc" } }],
     })
 
-    return { success: true, studentAnswerImages }
+    // 重複除去フォールバック（@@unique制約適用前のデータ対策）
+    const seen = new Map<string, (typeof studentAnswerImages)[0]>()
+    for (const img of studentAnswerImages) {
+      const key = `${img.studentId}-${img.projectPageId}`
+      const existing = seen.get(key)
+      if (!existing || new Date(img.updatedAt) > new Date(existing.updatedAt)) {
+        seen.set(key, img)
+      }
+    }
+    const deduplicated = Array.from(seen.values())
+
+    return { success: true, studentAnswerImages: deduplicated }
   } catch (error) {
     console.error("Error fetching student answer images:", error)
     return {

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -84,6 +84,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       buffer: ArrayBuffer
       studentId?: string
       pageNumber?: number
+      overwrite?: boolean
     }[]
   ) => ipcRenderer.invoke("upload-answer-sheets", projectId, filesData),
   getStudentAnswersByProjectId: (projectId: string) =>

--- a/prisma/migrations/20260226000000_add_unique_student_answer_image/migration.sql
+++ b/prisma/migrations/20260226000000_add_unique_student_answer_image/migration.sql
@@ -1,0 +1,16 @@
+-- 重複レコードのクリーンアップ（最新のみ残す）
+DELETE FROM StudentAnswerImage
+WHERE id NOT IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY projectPageId, studentId
+      ORDER BY updatedAt DESC
+    ) as rn
+    FROM StudentAnswerImage
+  ) ranked
+  WHERE rn = 1
+);
+
+-- UNIQUE制約の追加
+CREATE UNIQUE INDEX "StudentAnswerImage_projectPageId_studentId_key"
+ON "StudentAnswerImage"("projectPageId", "studentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,7 @@ model StudentAnswerImage {
   projectPage   ProjectPage @relation(fields: [projectPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   student       Student     @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
+  @@unique([projectPageId, studentId])
   @@index([projectPageId])
   @@index([studentId])
 }


### PR DESCRIPTION
## Summary

Closes #381

- `StudentAnswerImage` に `@@unique([projectPageId, studentId])` 制約を追加
- `uploadStudentAnswers` を upsert パターンに変更（overwrite フラグ対応）
- `getStudentAnswersByProjectId` に重複除去フォールバックを追加
- インポート処理（imageHandler, mergeImageHandler, idChangeExecutor）に重複チェックを追加
- `databaseInitializer` の新規DB用SQLに UNIQUE INDEX を追加

## Test plan

- [ ] 答案を新規アップロード → 正常に登録される
- [ ] 同じ生徒の答案を「上書きオフ」で再アップロード → スキップされる
- [ ] 同じ生徒の答案を「上書きオン」で再アップロード → 古い画像が削除され新しい画像に置き換わる
- [ ] 一括採点画面で同一生徒が1回だけ表示される
- [ ] 配置済み答案確認で画像が正常に表示される
- [ ] 重複レコードを含む旧アーカイブのインポートが正常に完了する
- [ ] `npm run typecheck` パス
- [ ] `npm run lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)