### PR TITLE
fix: 答案プレビュー・上書き・配置交換のバグ修正

### DIFF
--- a/components/projects/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
+++ b/components/projects/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
@@ -58,34 +58,33 @@ export function FilePreviewCell({
    *
    * DB保存済みの画像をElectron API経由でBase64として取得し表示する。
    * 依存配列にはfile.idとfile.imagePathのみを含め、fileオブジェクト全体は含めない。
+   * isImageLoadingは依存配列に含めない（含めるとstate変更→cleanup→cancelled=trueで読み込みが完了しない）。
    */
   useEffect(() => {
+    let mounted = true
     const currentFile = fileRef.current
-    if (!imagePreview && currentFile.imagePath && !isImageLoading) {
-      let cancelled = false
-      const frame = requestAnimationFrame(() => {
-        if (cancelled) return
 
-        setIsImageLoading(true)
-        loadStudentAnswerImage(currentFile)
-          .then((dataUrl) => {
-            if (cancelled) return
-            setImagePreview(dataUrl)
-            setIsImageLoading(false)
-          })
-          .catch((error) => {
-            if (cancelled) return
-            console.error("画像読み込みエラー:", error)
-            setIsImageLoading(false)
-          })
-      })
-
-      return () => {
-        cancelled = true
-        cancelAnimationFrame(frame)
-      }
+    if (!imagePreview && currentFile.imagePath) {
+      setIsImageLoading(true)
+      loadStudentAnswerImage(currentFile)
+        .then((dataUrl) => {
+          if (!mounted) return
+          setImagePreview(dataUrl)
+        })
+        .catch((error) => {
+          if (!mounted) return
+          console.error("画像読み込みエラー:", error)
+        })
+        .finally(() => {
+          if (!mounted) return
+          setIsImageLoading(false)
+        })
     }
-  }, [file.id, file.imagePath, imagePreview, isImageLoading])
+
+    return () => {
+      mounted = false
+    }
+  }, [file.id, file.imagePath, imagePreview])
 
   /**
    * 氏名欄プレビューの生成

--- a/components/projects/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/components/projects/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
 
 import { useDisabledState } from "@/components/projects/06-student-answers/student-answer-table/hooks/useDisabledState"
 import { useDragDrop } from "@/components/projects/06-student-answers/student-answer-table/hooks/useDragDrop"
@@ -104,18 +105,17 @@ export function useStudentAnswerTableLogic({
         const result = await window.electronAPI.deleteStudentAnswer(fileId)
 
         if (result.success) {
-          // 削除成功時はデータを再読み込み
           if (onReloadData) {
-            onReloadData()
+            await onReloadData()
           }
-          // TODO: 成功通知を追加
+          toast.success("答案画像を削除しました")
         } else {
           console.error("答案削除エラー:", result.error)
-          // TODO: エラー通知を追加
+          toast.error(result.error || "答案削除に失敗しました")
         }
       } catch (error) {
         console.error("答案削除例外:", error)
-        // TODO: エラー通知を追加
+        toast.error("答案削除に失敗しました")
       }
     },
     [onReloadData]
@@ -163,7 +163,7 @@ export function useStudentAnswerTableLogic({
             buffer: cell.file.buffer,
             studentId: cell.student.id,
             pageNumber: cell.pageNumber,
-            overwrite: false,
+            overwrite: allowOverwrite,
           })
         }
       })

--- a/electron-src/lib/prisma/studentAnswer/batch.ts
+++ b/electron-src/lib/prisma/studentAnswer/batch.ts
@@ -88,7 +88,21 @@ export async function batchUpdateStudentAnswerPlacements(
         })
       }
 
-      // 各答案を最終位置に移動
+      // @@unique([projectPageId, studentId])制約回避のため2段階更新
+      // Step 1: 全ての対象を一時IDに設定（制約衝突を回避）
+      const tempPrefix = `__TEMP_BATCH_${Date.now()}_`
+      await Promise.all(
+        updateMoves.map((move, index) =>
+          tx.studentAnswerImage.update({
+            where: { id: move.fileId },
+            data: {
+              studentId: `${tempPrefix}${index}`,
+            },
+          })
+        )
+      )
+
+      // Step 2: 最終位置に移動
       await Promise.all(
         updateMoves.map((move) =>
           tx.studentAnswerImage.update({
@@ -194,16 +208,25 @@ export async function swapStudentAnswerPlacementsWithScoring(
       ])
 
       // StudentAnswerImageのstudentIdを交換
-      // 一時的に新しいstudentIdを設定できないため、2段階で更新
-      // ユニーク制約がないので直接交換可能
+      // @@unique([projectPageId, studentId])制約回避のため一時ID方式で3段階更新
+      const tempStudentId = `__TEMP_SWAP_${Date.now()}`
+
+      // Step 1: file_1 → 一時ID
       await tx.studentAnswerImage.update({
         where: { id: answerSheetId1 },
-        data: { studentId: answerSheet2.studentId },
+        data: { studentId: tempStudentId },
       })
 
+      // Step 2: file_2 → file_1の元のstudentId
       await tx.studentAnswerImage.update({
         where: { id: answerSheetId2 },
         data: { studentId: answerSheet1.studentId },
+      })
+
+      // Step 3: file_1（一時ID） → file_2の元のstudentId
+      await tx.studentAnswerImage.update({
+        where: { id: answerSheetId1 },
+        data: { studentId: answerSheet2.studentId },
       })
 
       // 採点データを入れ替えて復元

--- a/electron-src/lib/prisma/studentAnswer/placement.ts
+++ b/electron-src/lib/prisma/studentAnswer/placement.ts
@@ -115,14 +115,25 @@ export async function swapStudentAnswerPlacements(
       }
 
       // StudentAnswerImageのstudentIdを交換
+      // @@unique([projectPageId, studentId])制約回避のため一時ID方式で3段階更新
+      const tempStudentId = `__TEMP_SWAP_${Date.now()}`
+
+      // Step 1: file_1 → 一時ID（制約衝突を回避）
       await tx.studentAnswerImage.update({
         where: { id: answerSheetId1 },
-        data: { studentId: answerSheet2.studentId },
+        data: { studentId: tempStudentId },
       })
 
+      // Step 2: file_2 → file_1の元のstudentId
       await tx.studentAnswerImage.update({
         where: { id: answerSheetId2 },
         data: { studentId: answerSheet1.studentId },
+      })
+
+      // Step 3: file_1（一時ID） → file_2の元のstudentId
+      await tx.studentAnswerImage.update({
+        where: { id: answerSheetId1 },
+        data: { studentId: answerSheet2.studentId },
       })
 
       // 更新後の答案情報を取得


### PR DESCRIPTION
## Summary
- FilePreviewCellのuseEffectレース条件を修正し、配置済み答案のプレビュー画像が正しく表示されるようにした
- 上書きフラグ(`allowOverwrite`)がアップロードデータに正しく伝達されるよう修正
- `@@unique([projectPageId, studentId])`制約に対応し、答案の配置交換・一括更新を一時ID方式に変更

Closes #383

## Test plan
- [ ] 配置済み答案の確認画面で画像が正しく表示される（スピナーが止まらない問題が解消）
- [ ] 「上書き許可」トグルONで既存答案の再アップロードが正しく上書きされる
- [ ] 「上書き許可」トグルOFFで既存答案がスキップされる
- [ ] 答案の削除操作後にtoast通知が表示される
- [ ] 答案の配置交換（ドラッグ&ドロップ）がエラーなく動作する
- [ ] 答案の一括配置変更がエラーなく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)