### PR TITLE
fix: 問題切替時にフィルター条件が適用されない問題を修正

### DIFF
--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
@@ -113,13 +113,7 @@ export function useScoringEffects(params: UseScoringEffectsParams): void {
     if (gradingMode === "grid") {
       // グリッドモード: 選択をリセット
       setSelectedPageImageIds(new Set())
-      const scheduleIncrement = () =>
-        setQuestionChangeVersion((version) => version + 1)
-      if (typeof queueMicrotask === "function") {
-        queueMicrotask(scheduleIncrement)
-      } else {
-        Promise.resolve().then(scheduleIncrement)
-      }
+      setQuestionChangeVersion((version) => version + 1)
     } else {
       // 個別モード: 現在選択中の生徒の新しい設問ページに対応するpageImageに更新
       const currentSelectedIds = selectedStudentAnswerImageIdsRef.current

--- a/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/components/projects/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -261,15 +261,7 @@ export function useScoringFilter({
       return
     }
 
-    const runUpdate = () => {
-      updateVisibleAnswers()
-    }
-
-    if (typeof queueMicrotask === "function") {
-      queueMicrotask(runUpdate)
-    } else {
-      Promise.resolve().then(runUpdate)
-    }
+    updateVisibleAnswers()
   }, [
     studentAnswerImages.length,
     cropRegions.length,


### PR DESCRIPTION
## Summary
- `useScoringFilter.ts`・`useScoringEffects.ts` 内の不要な `queueMicrotask` を削除
- `setState` を直接呼び出しに変更し、`useLayoutEffect` / `useEffect` 内での状態更新を同期化
- 問題切替時の `visibleAnswers` 更新と選択ロジックのタイミング不整合を解消

Closes #385

## Test plan
- [ ] 一括採点画面で問題を切り替えた際にフィルター条件が正しく適用される
- [ ] フィルターを「正解のみ」等に設定した状態で問題を切り替えても正しく動作する
- [ ] グリッドモード・個別モードの両方で問題切替が正常に動作する
- [ ] 採点済み答案の表示が問題切替後も正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)