### PR TITLE
feat: プロジェクト一括書き出し機能とエクスポートモード選択を追加

### DIFF
--- a/__tests__/import-export/integration/bulkExportProjects.test.ts
+++ b/__tests__/import-export/integration/bulkExportProjects.test.ts
@@ -1,0 +1,274 @@
+/**
+ * 一括エクスポート (executeBulkExport) の統合テスト
+ *
+ * テスト対象: electron-src/ipc-handlers/archiveHandlers.ts の executeBulkExport
+ * 実際のSQLiteテスト用DBを使用し、複数プロジェクトの順次エクスポートを検証する
+ */
+
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+
+import {
+  cleanupTestDatabase,
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+import { createFullTestProject } from "../../helpers/testProjectBuilder"
+
+// electronモック
+vi.mock("electron", () => ({
+  app: {
+    getVersion: () => "0.5.0-test",
+    getAppPath: () => process.cwd(),
+  },
+  dialog: {
+    showSaveDialog: vi.fn(),
+    showOpenDialog: vi.fn(),
+  },
+  ipcMain: { handle: vi.fn() },
+}))
+
+// Prismaクライアントのモック
+vi.mock("../../../electron-src/lib/prisma/client", () => {
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+let tmpDir: string
+vi.mock("../../../electron-src/lib/dataManager", () => ({
+  getDataDirectory: () => tmpDir || "/tmp/test-data",
+}))
+
+import { executeBulkExport } from "../../../electron-src/ipc-handlers/archiveHandlers"
+
+const prisma = getTestPrismaClient()
+
+describe("executeBulkExport", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bulk-export-"))
+  })
+
+  afterEach(() => {
+    if (tmpDir && fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  // BE-1: 複数プロジェクトの一括エクスポートが成功する
+  it("BE-1: 複数プロジェクトを順次エクスポートし全て成功する", async () => {
+    // 2つのプロジェクトを作成
+    const project1 = await createFullTestProject(prisma, {
+      examName: "数学テスト",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+    const project2 = await createFullTestProject(prisma, {
+      examName: "英語テスト",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      [project1.project.id, project2.project.id],
+      project1.user.id,
+      outputDir
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.results).toHaveLength(2)
+    expect(result.results[0].success).toBe(true)
+    expect(result.results[0].projectName).toBe("数学テスト")
+    expect(result.results[1].success).toBe(true)
+    expect(result.results[1].projectName).toBe("英語テスト")
+    expect(result.outputDirectory).toBe(outputDir)
+
+    // .scoreファイルが実際に作成されている
+    const files = fs.readdirSync(outputDir)
+    const scoreFiles = files.filter((f) => f.endsWith(".score"))
+    expect(scoreFiles).toHaveLength(2)
+    expect(scoreFiles.some((f) => f.startsWith("数学テスト-"))).toBe(true)
+    expect(scoreFiles.some((f) => f.startsWith("英語テスト-"))).toBe(true)
+  })
+
+  // BE-2: 存在しないプロジェクトIDが含まれる場合、そのプロジェクトのみ失敗し他は続行する
+  it("BE-2: 存在しないプロジェクトIDは失敗し残りは続行する", async () => {
+    const project1 = await createFullTestProject(prisma, {
+      examName: "成功テスト",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      ["non-existent-id", project1.project.id],
+      project1.user.id,
+      outputDir
+    )
+
+    // 1つ成功しているのでsuccess=true
+    expect(result.success).toBe(true)
+    expect(result.results).toHaveLength(2)
+
+    // 最初のプロジェクトは失敗
+    expect(result.results[0].success).toBe(false)
+    expect(result.results[0].projectId).toBe("non-existent-id")
+    expect(result.results[0].error).toContain("プロジェクトが見つかりません")
+
+    // 2番目のプロジェクトは成功
+    expect(result.results[1].success).toBe(true)
+    expect(result.results[1].projectName).toBe("成功テスト")
+
+    // 成功した分のファイルのみ作成される
+    const scoreFiles = fs
+      .readdirSync(outputDir)
+      .filter((f) => f.endsWith(".score"))
+    expect(scoreFiles).toHaveLength(1)
+  })
+
+  // BE-3: 全て失敗した場合success=false
+  it("BE-3: 全プロジェクトが失敗した場合はsuccess=falseになる", async () => {
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      ["non-existent-1", "non-existent-2"],
+      "dummy-user-id",
+      outputDir
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.results).toHaveLength(2)
+    expect(result.results.every((r) => !r.success)).toBe(true)
+  })
+
+  // BE-4: 単一プロジェクトの一括エクスポート
+  it("BE-4: 単一プロジェクトでも正常に動作する", async () => {
+    const project = await createFullTestProject(prisma, {
+      examName: "単一テスト",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      [project.project.id],
+      project.user.id,
+      outputDir
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].success).toBe(true)
+    expect(result.results[0].outputPath).toBeDefined()
+    expect(result.results[0].outputPath!).toContain("単一テスト-")
+    expect(result.results[0].outputPath!).toContain(".score")
+  })
+
+  // BE-5: 空の配列を渡した場合
+  it("BE-5: 空のプロジェクト配列ではsuccess=falseで結果も空", async () => {
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport([], "dummy-user-id", outputDir)
+
+    // results.some(r => r.success)がfalseを返す（空配列）
+    expect(result.success).toBe(false)
+    expect(result.results).toHaveLength(0)
+  })
+
+  // BE-6: 出力ファイルパスが各プロジェクトで正しいディレクトリ内に作成される
+  it("BE-6: 出力パスが指定ディレクトリ内の正しいファイル名で構成される", async () => {
+    const project = await createFullTestProject(prisma, {
+      examName: "パス確認テスト",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+
+    const outputDir = path.join(tmpDir, "deep", "nested", "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      [project.project.id],
+      project.user.id,
+      outputDir
+    )
+
+    expect(result.success).toBe(true)
+    const outputPath = result.results[0].outputPath!
+
+    // 指定ディレクトリ内にある
+    expect(path.dirname(outputPath)).toBe(outputDir)
+
+    // ファイル名が正しい形式
+    const fileName = path.basename(outputPath)
+    expect(fileName).toMatch(
+      /^パス確認テスト-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.score$/
+    )
+  })
+
+  // BE-7: エクスポートされた.scoreファイルが有効なアーカイブである
+  it("BE-7: 生成された.scoreファイルが有効なZIPアーカイブである", async () => {
+    const project = await createFullTestProject(prisma, {
+      examName: "アーカイブ検証",
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      studentCount: 1,
+    })
+
+    const outputDir = path.join(tmpDir, "output")
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    const result = await executeBulkExport(
+      [project.project.id],
+      project.user.id,
+      outputDir
+    )
+
+    expect(result.success).toBe(true)
+
+    // ファイルが存在し、サイズ > 0
+    const outputPath = result.results[0].outputPath!
+    expect(fs.existsSync(outputPath)).toBe(true)
+    const stat = fs.statSync(outputPath)
+    expect(stat.size).toBeGreaterThan(0)
+
+    // ZIPマジックナンバーの確認 (PK\x03\x04)
+    const fd = fs.openSync(outputPath, "r")
+    const buf = Buffer.alloc(4)
+    fs.readSync(fd, buf, 0, 4, 0)
+    fs.closeSync(fd)
+    expect(buf[0]).toBe(0x50) // P
+    expect(buf[1]).toBe(0x4b) // K
+    expect(buf[2]).toBe(0x03)
+    expect(buf[3]).toBe(0x04)
+  })
+})

--- a/__tests__/import-export/integration/collectProjectDataExportMode.test.ts
+++ b/__tests__/import-export/integration/collectProjectDataExportMode.test.ts
@@ -1,0 +1,407 @@
+/**
+ * collectProjectData のエクスポートモード統合テスト
+ *
+ * テスト対象: electron-src/lib/export/project-archive/dataCollector.ts
+ * 各エクスポートモード（full, template, template_with_subtotals）で
+ * 正しいデータが収集/除外されることを検証する
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  cleanupTestDatabase,
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+import {
+  createFullTestProject,
+  type FullTestProject,
+} from "../../helpers/testProjectBuilder"
+
+// Prismaクライアントのモック: Electron依存を回避
+vi.mock("../../../electron-src/lib/prisma/client", () => {
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+// dataManagerのモック
+vi.mock("../../../electron-src/lib/dataManager", () => {
+  return {
+    getDataDirectory: () => "/tmp/test-data",
+  }
+})
+
+import { collectProjectData } from "../../../electron-src/lib/export/project-archive/dataCollector"
+
+describe("collectProjectData - エクスポートモード", () => {
+  let testProject: FullTestProject
+
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+    testProject = await createFullTestProject(getTestPrismaClient(), {
+      pageCount: 2,
+      cropRegionsPerPage: 2,
+      studentCount: 3,
+      includeV140Data: true,
+      includeScores: true,
+      includeMasterImages: true,
+      includeStudentAnswerImages: true,
+    })
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  // ==========================================================================
+  // fullモード（デフォルト）
+  // ==========================================================================
+
+  describe("fullモード", () => {
+    it("EM-F1: デフォルト（引数なし）はfullモードと同じ結果を返す", async () => {
+      const defaultResult = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id
+      )
+      const fullResult = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "full"
+      )
+
+      expect(defaultResult.success).toBe(true)
+      expect(fullResult.success).toBe(true)
+
+      const d = defaultResult.data!
+      const f = fullResult.data!
+
+      // 主要フィールドの件数が一致
+      expect(d.studentsData.students.length).toBe(
+        f.studentsData.students.length
+      )
+      expect(d.classesData.classes.length).toBe(f.classesData.classes.length)
+      expect(d.scoresData.questionScores.length).toBe(
+        f.scoresData.questionScores.length
+      )
+      expect(d.subtotalsData.subtotalGroups.length).toBe(
+        f.subtotalsData.subtotalGroups.length
+      )
+      expect(d.answerSheetPaths.length).toBe(f.answerSheetPaths.length)
+    })
+
+    it("EM-F2: fullモードは全データを含む", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "full"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.studentsData.students.length).toBe(3)
+      expect(data.classesData.classes.length).toBeGreaterThanOrEqual(1)
+      expect(data.classesData.memberships.length).toBe(3)
+      expect(data.scoresData.questionScores.length).toBe(12) // 4 regions × 3 students
+      expect(data.subtotalsData.subtotalGroups.length).toBe(1)
+      expect(data.subtotalsData.subtotals.length).toBe(2)
+      expect(data.masterImagePaths.length).toBe(2)
+      expect(data.answerSheetPaths.length).toBe(6) // 3 students × 2 pages
+      expect(data.projectData.projectStudents.length).toBe(3)
+      expect(data.projectData.projectClasses.length).toBeGreaterThanOrEqual(1)
+      expect(data.projectData.projectSubtotalGroups.length).toBe(1)
+      expect(data.subjectsData.subjects.length).toBeGreaterThan(0)
+    })
+  })
+
+  // ==========================================================================
+  // templateモード
+  // ==========================================================================
+
+  describe("templateモード", () => {
+    it("EM-T1: 生徒データが空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.studentsData.students).toEqual([])
+      expect(data.projectData.projectStudents).toEqual([])
+      expect(data.counts.students).toBe(0)
+    })
+
+    it("EM-T2: 学級データが空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.classesData.classes).toEqual([])
+      expect(data.classesData.memberships).toEqual([])
+      expect(data.projectData.projectClasses).toEqual([])
+      expect(data.counts.classes).toBe(0)
+    })
+
+    it("EM-T3: 採点データが空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.scoresData.questionScores).toEqual([])
+      expect(data.scoresData.drawingAnnotations).toEqual([])
+      expect(data.counts.scores).toBe(0)
+      expect(data.counts.annotations).toBe(0)
+    })
+
+    it("EM-T4: 答案画像が空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.projectData.studentAnswerImages).toEqual([])
+      expect(data.answerSheetPaths).toEqual([])
+      expect(data.counts.answerSheetImages).toBe(0)
+    })
+
+    it("EM-T5: 小計データが空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.subtotalsData.subtotalGroups).toEqual([])
+      expect(data.subtotalsData.subtotals).toEqual([])
+      expect(data.subtotalsData.cropSubtotals).toEqual([])
+      expect(data.projectData.projectSubtotalGroups).toEqual([])
+      expect(data.counts.subtotalGroups).toBe(0)
+    })
+
+    it("EM-T6: Subject/SubjectSubtotalGroupが空になる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.subjectsData.subjects).toEqual([])
+      expect(data.subjectsData.subjectSubtotalGroups).toEqual([])
+    })
+
+    it("EM-T7: プロジェクト基本データ・ページ・領域・模範解答画像は保持される", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      // プロジェクト基本情報
+      expect(data.projectData.project.id).toBe(testProject.project.id)
+      expect(data.projectData.project.examName).toBe(
+        testProject.project.examName
+      )
+
+      // ページと領域
+      expect(data.projectData.projectPages.length).toBe(2)
+      expect(data.projectData.cropRegions.length).toBe(4)
+
+      // 模範解答画像
+      expect(data.masterImagePaths.length).toBe(2)
+      expect(data.counts.masterImages).toBe(2)
+    })
+
+    it("EM-T8: マーク設定（v1.4.0+）は保持される", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.projectData.projectMarkingFormats).toBeDefined()
+      expect(data.projectData.projectMarkingFormats!.length).toBeGreaterThan(0)
+      expect(data.projectData.cropRegionMarkingOverrides).toBeDefined()
+    })
+
+    it("EM-T9: ユーザーデータは保持される", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.usersData.users.length).toBe(1)
+      expect(data.counts.users).toBe(1)
+    })
+  })
+
+  // ==========================================================================
+  // template_with_subtotalsモード
+  // ==========================================================================
+
+  describe("template_with_subtotalsモード", () => {
+    it("EM-S1: 生徒・学級・採点・答案が空になる（templateと同じ）", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.studentsData.students).toEqual([])
+      expect(data.classesData.classes).toEqual([])
+      expect(data.classesData.memberships).toEqual([])
+      expect(data.scoresData.questionScores).toEqual([])
+      expect(data.scoresData.drawingAnnotations).toEqual([])
+      expect(data.projectData.studentAnswerImages).toEqual([])
+      expect(data.answerSheetPaths).toEqual([])
+      expect(data.projectData.projectStudents).toEqual([])
+      expect(data.projectData.projectClasses).toEqual([])
+    })
+
+    it("EM-S2: 小計データが含まれる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.subtotalsData.subtotalGroups.length).toBe(1)
+      expect(data.subtotalsData.subtotals.length).toBe(2)
+      expect(data.projectData.projectSubtotalGroups.length).toBe(1)
+      expect(data.counts.subtotalGroups).toBe(1)
+    })
+
+    it("EM-S3: Subject/SubjectSubtotalGroupが含まれる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.subjectsData.subjects.length).toBeGreaterThan(0)
+      expect(data.subjectsData.subjectSubtotalGroups.length).toBeGreaterThan(0)
+    })
+
+    it("EM-S4: プロジェクト基本データ・ページ・領域・模範解答画像は保持される", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.projectData.project.id).toBe(testProject.project.id)
+      expect(data.projectData.projectPages.length).toBe(2)
+      expect(data.projectData.cropRegions.length).toBe(4)
+      expect(data.masterImagePaths.length).toBe(2)
+    })
+
+    it("EM-S5: CropSubtotalが含まれる", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      // includeV140Dataでcropsubtotalが作成されている場合
+      expect(data.subtotalsData.cropSubtotals.length).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  // ==========================================================================
+  // countsの整合性
+  // ==========================================================================
+
+  describe("countsの整合性", () => {
+    it("EM-C1: templateモードのcountsが実データ長と一致する", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.counts.students).toBe(data.studentsData.students.length)
+      expect(data.counts.classes).toBe(data.classesData.classes.length)
+      expect(data.counts.scores).toBe(data.scoresData.questionScores.length)
+      expect(data.counts.annotations).toBe(
+        data.scoresData.drawingAnnotations.length
+      )
+      expect(data.counts.subtotalGroups).toBe(
+        data.subtotalsData.subtotalGroups.length
+      )
+      expect(data.counts.masterImages).toBe(data.masterImagePaths.length)
+      expect(data.counts.answerSheetImages).toBe(data.answerSheetPaths.length)
+    })
+
+    it("EM-C2: template_with_subtotalsモードのcountsが実データ長と一致する", async () => {
+      const result = await collectProjectData(
+        testProject.project.id,
+        testProject.user.id,
+        "template_with_subtotals"
+      )
+
+      expect(result.success).toBe(true)
+      const data = result.data!
+
+      expect(data.counts.students).toBe(data.studentsData.students.length)
+      expect(data.counts.classes).toBe(data.classesData.classes.length)
+      expect(data.counts.scores).toBe(data.scoresData.questionScores.length)
+      expect(data.counts.subtotalGroups).toBe(
+        data.subtotalsData.subtotalGroups.length
+      )
+      expect(data.counts.masterImages).toBe(data.masterImagePaths.length)
+      expect(data.counts.answerSheetImages).toBe(data.answerSheetPaths.length)
+    })
+  })
+})

--- a/__tests__/import-export/unit/exportMode.test.ts
+++ b/__tests__/import-export/unit/exportMode.test.ts
@@ -1,0 +1,73 @@
+/**
+ * エクスポートモード関連のユニットテスト
+ *
+ * テスト対象:
+ * - generateExportFileName のモード別サフィックス
+ * - ExportMode 型の定義
+ */
+
+import { describe, expect, test } from "vitest"
+
+import { generateExportFileName } from "../../../electron-src/lib/export/project-archive/archiveCreator"
+import type { ExportMode } from "../../../types/projectArchive.types"
+
+describe("generateExportFileName - エクスポートモード対応", () => {
+  // EM-1: fullモード（デフォルト）はサフィックスなし
+  test("EM-1: fullモードではサフィックスが付かない", () => {
+    const fileName = generateExportFileName("期末テスト", "full")
+    expect(fileName).toMatch(
+      /^期末テスト-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.score$/
+    )
+    expect(fileName).not.toContain("template")
+  })
+
+  // EM-2: exportMode未指定（デフォルト）もサフィックスなし
+  test("EM-2: exportMode未指定ではサフィックスが付かない", () => {
+    const fileName = generateExportFileName("期末テスト")
+    expect(fileName).toMatch(
+      /^期末テスト-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.score$/
+    )
+    expect(fileName).not.toContain("template")
+  })
+
+  // EM-3: templateモードで-templateサフィックス
+  test("EM-3: templateモードで-templateサフィックスが付く", () => {
+    const fileName = generateExportFileName("期末テスト", "template")
+    expect(fileName).toMatch(
+      /^期末テスト-template-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.score$/
+    )
+  })
+
+  // EM-4: template_with_subtotalsモードで-template-subtotalsサフィックス
+  test("EM-4: template_with_subtotalsモードで-template-subtotalsサフィックスが付く", () => {
+    const fileName = generateExportFileName(
+      "期末テスト",
+      "template_with_subtotals"
+    )
+    expect(fileName).toMatch(
+      /^期末テスト-template-subtotals-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.score$/
+    )
+  })
+
+  // EM-5: 特殊文字のサニタイズとモードサフィックスが両立する
+  test("EM-5: 特殊文字のサニタイズとモードサフィックスが両立する", () => {
+    const fileName = generateExportFileName('テスト"名前', "template")
+    expect(fileName).not.toContain('"')
+    expect(fileName).toContain("-template-")
+    expect(fileName.endsWith(".score")).toBe(true)
+  })
+
+  // EM-6: 拡張子は常に.score
+  test("EM-6: 拡張子は全モードで.score", () => {
+    const modes: (ExportMode | undefined)[] = [
+      "full",
+      "template",
+      "template_with_subtotals",
+      undefined,
+    ]
+    for (const mode of modes) {
+      const fileName = generateExportFileName("テスト", mode)
+      expect(fileName.endsWith(".score")).toBe(true)
+    }
+  })
+})

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -7,6 +7,7 @@ import { useState } from "react"
 import { toast } from "sonner"
 
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
+import ExportModeModal from "@/components/projects/detail/ExportModeModal"
 import { useWorkflowData } from "@/components/projects/detail/hooks/useWorkflowData"
 import OverallProgress from "@/components/projects/detail/OverallProgress"
 import PhaseCard from "@/components/projects/detail/PhaseCard"
@@ -16,6 +17,7 @@ import EditProjectWindow from "@/components/projects/forms/EditProjectWindow"
 import DeleteProjectModal from "@/components/projects/shared/DeleteProjectModal"
 import { useAuth } from "@/contexts/AuthContext"
 import { useProjectDetail } from "@/hooks/useProjectDetail"
+import type { ExportMode } from "@/types/projectArchive.types"
 
 export default function ProjectDetailPage() {
   const params = useParams()
@@ -25,6 +27,7 @@ export default function ProjectDetailPage() {
 
   const [showEditModal, setShowEditModal] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [showExportModal, setShowExportModal] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
 
   const {
@@ -65,7 +68,7 @@ export default function ProjectDetailPage() {
     router.push("/projects")
   }
 
-  const handleExport = async () => {
+  const handleExport = async (exportMode: ExportMode) => {
     if (isExporting) return
 
     if (!user?.id) {
@@ -84,16 +87,20 @@ export default function ProjectDetailPage() {
       const result = await window.electronAPI.archive.exportProject({
         projectId,
         userId: user.id,
+        exportMode,
       })
 
       if (result.success) {
+        setShowExportModal(false)
         toast.success("エクスポート完了", {
           description: `${result.outputPath} に保存しました。`,
         })
       } else {
-        toast.error("エクスポート失敗", {
-          description: result.error || "エクスポートに失敗しました。",
-        })
+        if (result.error !== "キャンセルされました") {
+          toast.error("エクスポート失敗", {
+            description: result.error || "エクスポートに失敗しました。",
+          })
+        }
       }
     } catch (error) {
       toast.error("エクスポート失敗", {
@@ -149,7 +156,7 @@ export default function ProjectDetailPage() {
             project={project}
             onEdit={() => setShowEditModal(true)}
             onDelete={() => setShowDeleteModal(true)}
-            onExport={handleExport}
+            onExport={() => setShowExportModal(true)}
           />
 
           <OverallProgress
@@ -175,6 +182,12 @@ export default function ProjectDetailPage() {
           </div>
 
           {/* Modals */}
+          <ExportModeModal
+            open={showExportModal}
+            onOpenChange={setShowExportModal}
+            onExport={handleExport}
+            isExporting={isExporting}
+          />
           {project && showEditModal && (
             <EditProjectWindow
               projectToEdit={project}

--- a/components/projects/08-export/components/ExcelPreview.tsx
+++ b/components/projects/08-export/components/ExcelPreview.tsx
@@ -5,6 +5,8 @@ import { useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import type { ExcelPreviewData } from "../hooks/useExcelPreview"
+import { useItemAnalysis } from "../hooks/useItemAnalysis"
+import { ItemAnalysisPreview } from "./ItemAnalysisPreview"
 
 function getStatusSymbol(status: string, score?: number | null): string {
   switch (status) {
@@ -43,7 +45,10 @@ interface ExcelPreviewProps {
 }
 
 export function ExcelPreview({ data }: ExcelPreviewProps) {
-  const [sheetTab, setSheetTab] = useState<"scores" | "results">("scores")
+  const [sheetTab, setSheetTab] = useState<
+    "scores" | "results" | "item-analysis"
+  >("scores")
+  const itemAnalysisData = useItemAnalysis(data)
 
   const hasSubtotals = data.headers.subtotalLabels.length > 0
 
@@ -54,12 +59,15 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
         onValueChange={(v) => setSheetTab(v as "scores" | "results")}
         className="flex flex-1 flex-col"
       >
-        <TabsList className="mb-1 grid w-full grid-cols-2">
+        <TabsList className="mb-1 grid w-full grid-cols-3">
           <TabsTrigger value="scores" className="text-xs">
             点数一覧
           </TabsTrigger>
           <TabsTrigger value="results" className="text-xs">
             正誤一覧
+          </TabsTrigger>
+          <TabsTrigger value="item-analysis" className="text-xs">
+            問題分析
           </TabsTrigger>
         </TabsList>
 
@@ -183,6 +191,19 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
               ))}
             </tbody>
           </table>
+        </TabsContent>
+
+        <TabsContent
+          value="item-analysis"
+          className="mt-0 flex-1 overflow-auto"
+        >
+          {itemAnalysisData ? (
+            <ItemAnalysisPreview data={itemAnalysisData} />
+          ) : (
+            <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+              データがありません
+            </div>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/components/projects/detail/ExportModeModal.tsx
+++ b/components/projects/detail/ExportModeModal.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useState } from "react"
+
+import BaseModal from "@/components/common/BaseModal"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import type { ExportMode } from "@/types/projectArchive.types"
+
+interface ExportModeModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onExport: (mode: ExportMode) => void
+  isExporting: boolean
+}
+
+const EXPORT_MODES: Array<{
+  value: ExportMode
+  label: string
+  description: string
+}> = [
+  {
+    value: "full",
+    label: "すべてのデータ",
+    description: "生徒・採点・答案を含む完全データ",
+  },
+  {
+    value: "template",
+    label: "模範解答＋領域情報",
+    description: "採点テンプレートのみ（生徒・採点・答案・小計を除外）",
+  },
+  {
+    value: "template_with_subtotals",
+    label: "模範解答＋領域情報＋小計",
+    description: "テンプレートと小計設定（生徒・採点・答案を除外）",
+  },
+]
+
+export default function ExportModeModal({
+  open,
+  onOpenChange,
+  onExport,
+  isExporting,
+}: ExportModeModalProps) {
+  const [selectedMode, setSelectedMode] = useState<ExportMode>("full")
+
+  return (
+    <BaseModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="エクスポート"
+      description="エクスポートするデータの範囲を選択してください。"
+      variant="default"
+      size="md"
+      actions={{
+        cancel: { label: "キャンセル" },
+        primary: {
+          label: "エクスポート",
+          onClick: () => onExport(selectedMode),
+          loading: isExporting,
+          disabled: isExporting,
+        },
+      }}
+    >
+      <RadioGroup
+        value={selectedMode}
+        onValueChange={(value) => setSelectedMode(value as ExportMode)}
+        className="space-y-3"
+      >
+        {EXPORT_MODES.map((mode) => (
+          <div
+            key={mode.value}
+            className="flex items-start space-x-3 rounded-md border p-3"
+          >
+            <RadioGroupItem
+              value={mode.value}
+              id={`export-mode-${mode.value}`}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor={`export-mode-${mode.value}`}
+              className="flex cursor-pointer flex-col gap-1"
+            >
+              <span className="font-medium">{mode.label}</span>
+              <span className="text-muted-foreground text-sm">
+                {mode.description}
+              </span>
+            </Label>
+          </div>
+        ))}
+      </RadioGroup>
+    </BaseModal>
+  )
+}

--- a/components/projects/list/ProjectList.tsx
+++ b/components/projects/list/ProjectList.tsx
@@ -12,6 +12,7 @@ import {
   Eye,
   FileImage,
   FolderInput,
+  FolderOutput,
   PlayCircle,
   PlusCircle,
   Settings,
@@ -20,14 +21,16 @@ import {
   Users,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useMemo } from "react"
-import { useState } from "react"
+import { useCallback, useMemo, useState } from "react"
+import { toast } from "sonner"
 
 import { useFileActions } from "@/components/hooks/useFileActions"
 import { useProjects } from "@/components/hooks/useProjects"
 import { ImportWizardModal } from "@/components/import/ImportWizardModal"
+import ExportModeModal from "@/components/projects/detail/ExportModeModal"
 import CreateProjectWindow from "@/components/projects/forms/CreateProjectWindow"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -44,8 +47,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { useAuth } from "@/contexts/AuthContext"
 import { SortDirection, useTableSort } from "@/hooks/useTableSort"
 import { isValidProject, ProjectWithDetails } from "@/types/common.types"
+import type { ExportMode } from "@/types/projectArchive.types"
 import { getProjectStatus } from "@/utils/projectStatus"
 
 interface ProjectSortable {
@@ -84,7 +89,13 @@ const SORT_OPTIONS = [
 
 const File = () => {
   const { projects, loadProjects } = useProjects()
+  const { user } = useAuth()
   const [showImportModal, setShowImportModal] = useState(false)
+  const [selectedProjectIds, setSelectedProjectIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [isBulkExporting, setIsBulkExporting] = useState(false)
+  const [showBulkExportModal, setShowBulkExportModal] = useState(false)
 
   const { createProjectModal } = useFileActions()
   const router = useRouter()
@@ -139,6 +150,77 @@ const File = () => {
     router.push(`/projects/${projectId}`)
   }
 
+  const handleToggleSelect = useCallback((projectId: string) => {
+    setSelectedProjectIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(projectId)) {
+        next.delete(projectId)
+      } else {
+        next.add(projectId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleToggleSelectAll = useCallback(() => {
+    setSelectedProjectIds((prev) => {
+      if (prev.size === sortedData.length) {
+        return new Set()
+      }
+      return new Set(sortedData.map((d) => d.id))
+    })
+  }, [sortedData])
+
+  const handleBulkExport = useCallback(
+    async (exportMode: ExportMode) => {
+      if (!user || selectedProjectIds.size === 0) return
+
+      setIsBulkExporting(true)
+      toast("書き出し中...", {
+        description: `${selectedProjectIds.size}件のプロジェクトを書き出しています。`,
+      })
+
+      try {
+        const result = await window.electronAPI.archive.bulkExportProjects({
+          projectIds: Array.from(selectedProjectIds),
+          userId: user.id,
+          exportMode,
+        })
+
+        if (result.error === "canceled") {
+          // フォルダ選択キャンセル時はtoast表示なし
+          return
+        }
+
+        const successCount = result.results.filter((r) => r.success).length
+        const failCount = result.results.filter((r) => !r.success).length
+
+        if (failCount === 0) {
+          toast.success("書き出し完了", {
+            description: `${successCount}件のプロジェクトを書き出しました。`,
+          })
+        } else {
+          toast.warning("一部書き出しに失敗", {
+            description: `${successCount}件成功、${failCount}件失敗`,
+          })
+        }
+
+        setSelectedProjectIds(new Set())
+        setShowBulkExportModal(false)
+      } catch (error) {
+        toast.error("書き出しに失敗しました", {
+          description:
+            error instanceof Error
+              ? error.message
+              : "予期しないエラーが発生しました",
+        })
+      } finally {
+        setIsBulkExporting(false)
+      }
+    },
+    [user, selectedProjectIds]
+  )
+
   return (
     <>
       {createProjectModal.isOpen && (
@@ -151,6 +233,12 @@ const File = () => {
         isOpen={showImportModal}
         onClose={() => setShowImportModal(false)}
         onComplete={handleImportComplete}
+      />
+      <ExportModeModal
+        open={showBulkExportModal}
+        onOpenChange={setShowBulkExportModal}
+        onExport={handleBulkExport}
+        isExporting={isBulkExporting}
       />
       <div className="flex h-full min-w-full flex-col">
         <div className="flex items-center justify-between border-b px-4 py-3">
@@ -171,6 +259,22 @@ const File = () => {
               <FolderInput className="mr-2 h-4 w-4" />
               インポート
             </Button>
+            {selectedProjectIds.size > 0 && (
+              <>
+                <span className="text-muted-foreground ml-2 text-sm">
+                  {selectedProjectIds.size}件選択中
+                </span>
+                <Button
+                  onClick={() => setShowBulkExportModal(true)}
+                  variant="outline"
+                  className="rounded-lg"
+                  disabled={isBulkExporting}
+                >
+                  <FolderOutput className="mr-2 h-4 w-4" />
+                  一括書き出し
+                </Button>
+              </>
+            )}
           </div>
 
           {/* ソート選択 */}
@@ -213,6 +317,16 @@ const File = () => {
             <Table wrapperClassName="h-full">
               <TableHeader className="bg-card sticky top-0 z-10">
                 <TableRow className="hover:bg-transparent">
+                  <TableHead className="w-10 text-center">
+                    <Checkbox
+                      checked={
+                        sortedData.length > 0 &&
+                        selectedProjectIds.size === sortedData.length
+                      }
+                      onCheckedChange={handleToggleSelectAll}
+                      aria-label="全選択"
+                    />
+                  </TableHead>
                   <TableHead>プロジェクト名</TableHead>
                   <TableHead className="w-32 text-center">詳細</TableHead>
                   <TableHead className="w-40 text-center">
@@ -226,6 +340,13 @@ const File = () => {
 
                   return (
                     <TableRow key={project.id} className="group">
+                      <TableCell className="text-center">
+                        <Checkbox
+                          checked={selectedProjectIds.has(project.id)}
+                          onCheckedChange={() => handleToggleSelect(project.id)}
+                          aria-label={`${project.examName}を選択`}
+                        />
+                      </TableCell>
                       <TableCell>
                         <div>
                           <div className="font-medium">{project.examName}</div>

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -3,8 +3,12 @@
  */
 
 import { dialog, ipcMain } from "electron"
+import * as path from "path"
 
 import type {
+  BulkExportProjectResult,
+  BulkExportProjectsResult,
+  ExportMode,
   FileOverviewData,
   IdIntegrationConfig,
   MatchingConfig,
@@ -12,6 +16,7 @@ import type {
   UpdateDecisions,
 } from "../../types/projectArchive.types"
 import { exportProject } from "../lib/export/project-archive"
+import { generateExportFileName } from "../lib/export/project-archive/archiveCreator"
 import {
   detectAllConflicts,
   detectScoringConflictsWithUserDecisions,
@@ -23,6 +28,69 @@ import {
   cleanupTempDir,
   extractArchive,
 } from "../lib/import/project-archive"
+import { getProjectById } from "../lib/prisma/project"
+
+/**
+ * 一括エクスポートのコアロジック
+ *
+ * ダイアログを含まず、指定されたディレクトリに順次エクスポートする
+ */
+export async function executeBulkExport(
+  projectIds: string[],
+  userId: string,
+  outputDirectory: string,
+  exportMode?: ExportMode
+): Promise<BulkExportProjectsResult> {
+  const results: BulkExportProjectResult[] = []
+
+  // 順次処理（SQLite同時書き込み制限のため）
+  for (const projectId of projectIds) {
+    try {
+      const project = await getProjectById(projectId)
+      if (!project) {
+        results.push({
+          projectId,
+          projectName: projectId,
+          success: false,
+          error: "プロジェクトが見つかりません",
+        })
+        continue
+      }
+
+      const fileName = generateExportFileName(project.examName, exportMode)
+      const outputPath = path.join(outputDirectory, fileName)
+
+      const exportResult = await exportProject({
+        projectId,
+        userId,
+        outputPath,
+        exportMode,
+      })
+
+      results.push({
+        projectId,
+        projectName: project.examName,
+        success: exportResult.success,
+        outputPath: exportResult.outputPath,
+        error: exportResult.error,
+      })
+    } catch (error) {
+      results.push({
+        projectId,
+        projectName: projectId,
+        success: false,
+        error:
+          error instanceof Error ? error.message : "エクスポートに失敗しました",
+      })
+    }
+  }
+
+  return {
+    success: results.some((r) => r.success),
+    results,
+    outputDirectory,
+  }
+}
 
 /**
  * アーカイブ関連のIPCハンドラーを登録
@@ -33,7 +101,12 @@ export function registerArchiveHandlers(): void {
     "archive:exportProject",
     async (
       _event,
-      options: { projectId: string; userId: string; outputPath?: string }
+      options: {
+        projectId: string
+        userId: string
+        outputPath?: string
+        exportMode?: import("../../types/projectArchive.types").ExportMode
+      }
     ) => {
       try {
         return await exportProject(options)
@@ -261,6 +334,48 @@ export function registerArchiveHandlers(): void {
       } finally {
         if (tempDir) {
           cleanupTempDir(tempDir)
+        }
+      }
+    }
+  )
+
+  // 一括エクスポート
+  ipcMain.handle(
+    "archive:bulkExportProjects",
+    async (
+      _event,
+      options: {
+        projectIds: string[]
+        userId: string
+        exportMode?: ExportMode
+      }
+    ): Promise<BulkExportProjectsResult> => {
+      try {
+        // フォルダ選択ダイアログを表示
+        const dialogResult = await dialog.showOpenDialog({
+          title: "一括書き出し先フォルダを選択",
+          properties: ["openDirectory", "createDirectory"],
+        })
+
+        if (dialogResult.canceled || dialogResult.filePaths.length === 0) {
+          return { success: false, results: [], error: "canceled" }
+        }
+
+        return await executeBulkExport(
+          options.projectIds,
+          options.userId,
+          dialogResult.filePaths[0],
+          options.exportMode
+        )
+      } catch (error) {
+        console.error("Error in archive:bulkExportProjects:", error)
+        return {
+          success: false,
+          results: [],
+          error:
+            error instanceof Error
+              ? error.message
+              : "一括エクスポートに失敗しました",
         }
       }
     }

--- a/electron-src/lib/export/project-archive/archiveCreator.ts
+++ b/electron-src/lib/export/project-archive/archiveCreator.ts
@@ -9,7 +9,10 @@ import { app } from "electron"
 import * as fs from "fs"
 import * as path from "path"
 
-import type { ArchiveManifest } from "../../../../types/projectArchive.types"
+import type {
+  ArchiveManifest,
+  ExportMode,
+} from "../../../../types/projectArchive.types"
 import { getDataDirectory } from "../../dataManager"
 import { CURRENT_VERSION } from "../../import/transformers/types"
 import type { CollectedData } from "./dataCollector"
@@ -39,6 +42,8 @@ interface CreateArchiveOptions {
   outputPath: string
   /** エクスポートしたユーザー名 */
   exportedBy?: string
+  /** エクスポートモード */
+  exportMode?: ExportMode
 }
 
 /**
@@ -71,7 +76,8 @@ function createManifest(
   projectId: string,
   projectName: string,
   counts: CollectedData["counts"],
-  exportedBy?: string
+  exportedBy?: string,
+  exportMode?: ExportMode
 ): ArchiveManifest {
   return {
     version: CURRENT_VERSION,
@@ -82,6 +88,7 @@ function createManifest(
     projectName,
     exportedBy,
     counts,
+    ...(exportMode && exportMode !== "full" ? { exportMode } : {}),
   }
 }
 
@@ -104,8 +111,14 @@ function getDataDir(): string {
 export async function createArchive(
   options: CreateArchiveOptions
 ): Promise<{ success: boolean; outputPath?: string; error?: string }> {
-  const { collectedData, projectName, projectId, outputPath, exportedBy } =
-    options
+  const {
+    collectedData,
+    projectName,
+    projectId,
+    outputPath,
+    exportedBy,
+    exportMode,
+  } = options
 
   return new Promise((resolve) => {
     try {
@@ -148,7 +161,8 @@ export async function createArchive(
         projectId,
         projectName,
         collectedData.counts,
-        exportedBy
+        exportedBy,
+        exportMode
       )
       archive.append(JSON.stringify(manifest, null, 2), {
         name: "manifest.json",
@@ -224,7 +238,10 @@ export async function createArchive(
  *
  * フォーマット: {projectName}-yyyy-MM-dd-hh-mm-ss.score
  */
-export function generateExportFileName(projectName: string): string {
+export function generateExportFileName(
+  projectName: string,
+  exportMode?: ExportMode
+): string {
   const sanitizedName = projectName.replace(/[<>:"/\\|?*]/g, "_")
   const now = new Date()
   const timestamp = [
@@ -235,5 +252,13 @@ export function generateExportFileName(projectName: string): string {
     String(now.getMinutes()).padStart(2, "0"),
     String(now.getSeconds()).padStart(2, "0"),
   ].join("-")
-  return `${sanitizedName}-${timestamp}.score`
+
+  const modeSuffix =
+    exportMode === "template"
+      ? "-template"
+      : exportMode === "template_with_subtotals"
+        ? "-template-subtotals"
+        : ""
+
+  return `${sanitizedName}${modeSuffix}-${timestamp}.score`
 }

--- a/electron-src/lib/export/project-archive/dataCollector.ts
+++ b/electron-src/lib/export/project-archive/dataCollector.ts
@@ -13,6 +13,7 @@ import type {
   ArchiveSubjectsData,
   ArchiveSubtotalsData,
   ArchiveUsersData,
+  ExportMode,
 } from "../../../../types/projectArchive.types"
 import prisma from "../../prisma/client"
 
@@ -39,14 +40,20 @@ export interface CollectedData {
  *
  * @param projectId - 対象プロジェクトID
  * @param userId - ログインユーザーID（このユーザーのデータのみ収集）
+ * @param exportMode - エクスポートモード（デフォルト: full）
  * @returns 収集されたデータ
  */
 export async function collectProjectData(
   projectId: string,
-  userId: string
+  userId: string,
+  exportMode: ExportMode = "full"
 ): Promise<{ success: boolean; data?: CollectedData; error?: string }> {
   try {
+    const isTemplate =
+      exportMode === "template" || exportMode === "template_with_subtotals"
+
     // 1. プロジェクト基本データを取得
+    // クエリは常にフルで取得し、データ整形段階でモードに応じてフィルタリングする
     const project = await prisma.project.findUnique({
       where: { id: projectId },
       include: {
@@ -78,36 +85,44 @@ export async function collectProjectData(
       return { success: false, error: "プロジェクトが見つかりません" }
     }
 
-    // 2. 関連する生徒IDを収集
+    // 2. 関連する生徒IDを収集（templateモードではスキップ）
     const studentIds = new Set<string>()
-    for (const ps of project.projectStudents) {
-      studentIds.add(ps.studentId)
-    }
-    for (const page of project.projectPages) {
-      for (const img of page.studentAnswerImages) {
-        studentIds.add(img.studentId)
+    if (!isTemplate) {
+      for (const ps of project.projectStudents) {
+        studentIds.add(ps.studentId)
       }
-      for (const region of page.cropRegions) {
-        for (const score of region.questionScores) {
-          studentIds.add(score.studentId)
+      for (const page of project.projectPages) {
+        for (const img of page.studentAnswerImages) {
+          studentIds.add(img.studentId)
+        }
+        for (const region of page.cropRegions) {
+          for (const score of region.questionScores) {
+            studentIds.add(score.studentId)
+          }
         }
       }
     }
 
-    // 3. 生徒データを取得
-    const students = await prisma.student.findMany({
-      where: { id: { in: Array.from(studentIds) } },
-    })
+    // 3. 生徒データを取得（templateモードでは空）
+    const students = isTemplate
+      ? []
+      : await prisma.student.findMany({
+          where: { id: { in: Array.from(studentIds) } },
+        })
 
-    // 4. 関連する学級と所属を取得
-    const memberships = await prisma.studentClassMembership.findMany({
-      where: { studentId: { in: Array.from(studentIds) } },
-    })
+    // 4. 関連する学級と所属を取得（templateモードでは空）
+    const memberships = isTemplate
+      ? []
+      : await prisma.studentClassMembership.findMany({
+          where: { studentId: { in: Array.from(studentIds) } },
+        })
 
     const classIds = new Set(memberships.map((m) => m.classId))
-    const classes = await prisma.class.findMany({
-      where: { id: { in: Array.from(classIds) } },
-    })
+    const classes = isTemplate
+      ? []
+      : await prisma.class.findMany({
+          where: { id: { in: Array.from(classIds) } },
+        })
 
     // 5. 現在のユーザーのみを取得（パスコードは除外）
     // v0.3.0以降: ログインユーザーのデータのみをエクスポート
@@ -129,14 +144,19 @@ export async function collectProjectData(
 
     const users = [currentUser]
 
-    // 7. 小計グループと小計を取得
+    // 7. 小計グループと小計を取得（templateモードでは空）
+    const includeSubtotals = exportMode !== "template"
     const subtotalGroupIds = new Set(
-      project.projectSubtotalGroups.map((psg) => psg.subtotalGroupId)
+      includeSubtotals
+        ? project.projectSubtotalGroups.map((psg) => psg.subtotalGroupId)
+        : []
     )
-    const subtotalGroups = await prisma.subtotalGroup.findMany({
-      where: { id: { in: Array.from(subtotalGroupIds) } },
-      include: { subtotals: true },
-    })
+    const subtotalGroups = includeSubtotals
+      ? await prisma.subtotalGroup.findMany({
+          where: { id: { in: Array.from(subtotalGroupIds) } },
+          include: { subtotals: true },
+        })
+      : []
 
     // 7.5. ProjectMarkingFormatを取得
     const projectMarkingFormats = await prisma.projectMarkingFormat.findMany({
@@ -159,19 +179,23 @@ export async function collectProjectData(
         where: { cropRegionId: { in: cropRegionIds } },
       })
 
-    // 7.8. Subject/SubjectSubtotalGroupを取得（subtotalGroup経由）
+    // 7.8. Subject/SubjectSubtotalGroupを取得（subtotalGroup経由、templateモードでは空）
     const subtotalGroupIdArray = Array.from(subtotalGroupIds)
-    const subjectSubtotalGroups = await prisma.subjectSubtotalGroup.findMany({
-      where: { subtotalGroupId: { in: subtotalGroupIdArray } },
-    })
+    const subjectSubtotalGroups = includeSubtotals
+      ? await prisma.subjectSubtotalGroup.findMany({
+          where: { subtotalGroupId: { in: subtotalGroupIdArray } },
+        })
+      : []
     const subjectIds = [
       ...new Set(subjectSubtotalGroups.map((ssg) => ssg.subjectId)),
     ]
-    const subjects = await prisma.subject.findMany({
-      where: { id: { in: subjectIds } },
-    })
+    const subjects = includeSubtotals
+      ? await prisma.subject.findMany({
+          where: { id: { in: subjectIds } },
+        })
+      : []
 
-    // CropSubtotalを収集
+    // CropSubtotalを収集（templateモードでは空）
     const cropSubtotals: Array<{
       id: string
       cropRegionId: string
@@ -180,15 +204,17 @@ export async function collectProjectData(
       createdAt: Date
       updatedAt: Date
     }> = []
-    for (const page of project.projectPages) {
-      for (const region of page.cropRegions) {
-        for (const cs of region.cropSubtotals) {
-          cropSubtotals.push(cs)
+    if (includeSubtotals) {
+      for (const page of project.projectPages) {
+        for (const region of page.cropRegions) {
+          for (const cs of region.cropSubtotals) {
+            cropSubtotals.push(cs)
+          }
         }
       }
     }
 
-    // 8. 画像パスを収集
+    // 8. 画像パスを収集（templateモードでは答案画像は空）
     const masterImagePaths: string[] = []
     const answerSheetPaths: string[] = []
 
@@ -196,67 +222,71 @@ export async function collectProjectData(
       for (const img of page.masterImages) {
         masterImagePaths.push(img.imagePath)
       }
-      for (const img of page.studentAnswerImages) {
-        answerSheetPaths.push(img.imagePath)
+      if (!isTemplate) {
+        for (const img of page.studentAnswerImages) {
+          answerSheetPaths.push(img.imagePath)
+        }
       }
     }
 
-    // 9. QuestionScoreとDrawingAnnotationを収集
+    // 9. QuestionScoreとDrawingAnnotationを収集（templateモードでは空）
     // v0.3.0以降: ログインユーザーのデータのみをエクスポート
     const questionScores: ArchiveScoresData["questionScores"] = []
     const drawingAnnotations: ArchiveScoresData["drawingAnnotations"] = []
 
-    for (const page of project.projectPages) {
-      for (const region of page.cropRegions) {
-        for (const score of region.questionScores) {
-          // ログインユーザーの採点データのみを収集
-          if (score.userId !== userId) {
-            continue
-          }
-
-          questionScores.push({
-            id: score.id,
-            cropRegionId: score.cropRegionId,
-            studentId: score.studentId,
-            partialScore: score.partialScore?.toString() ?? null,
-            status: score.status,
-            userId: score.userId,
-            createdAt: score.createdAt.toISOString(),
-            updatedAt: score.updatedAt.toISOString(),
-          })
-
-          for (const ann of score.drawingAnnotations) {
-            // ログインユーザーのアノテーションのみを収集
-            if (ann.userId !== userId) {
+    if (!isTemplate) {
+      for (const page of project.projectPages) {
+        for (const region of page.cropRegions) {
+          for (const score of region.questionScores) {
+            // ログインユーザーの採点データのみを収集
+            if (score.userId !== userId) {
               continue
             }
 
-            drawingAnnotations.push({
-              id: ann.id,
-              questionScoreId: ann.questionScoreId,
-              type: ann.type,
-              x: ann.x,
-              y: ann.y,
-              color: ann.color,
-              strokeWidth: ann.strokeWidth,
-              width: ann.width,
-              height: ann.height,
-              endX: ann.endX,
-              endY: ann.endY,
-              lineStyle: ann.lineStyle,
-              text: ann.text,
-              fontSize: ann.fontSize,
-              textBoxWidth: ann.textBoxWidth,
-              textBoxHeight: ann.textBoxHeight,
-              horizontalAlign: ann.horizontalAlign,
-              verticalAlign: ann.verticalAlign,
-              anchorDirection: ann.anchorDirection,
-              displayX: ann.displayX,
-              displayY: ann.displayY,
-              userId: ann.userId,
-              createdAt: ann.createdAt.toISOString(),
-              updatedAt: ann.updatedAt.toISOString(),
+            questionScores.push({
+              id: score.id,
+              cropRegionId: score.cropRegionId,
+              studentId: score.studentId,
+              partialScore: score.partialScore?.toString() ?? null,
+              status: score.status,
+              userId: score.userId,
+              createdAt: score.createdAt.toISOString(),
+              updatedAt: score.updatedAt.toISOString(),
             })
+
+            for (const ann of score.drawingAnnotations) {
+              // ログインユーザーのアノテーションのみを収集
+              if (ann.userId !== userId) {
+                continue
+              }
+
+              drawingAnnotations.push({
+                id: ann.id,
+                questionScoreId: ann.questionScoreId,
+                type: ann.type,
+                x: ann.x,
+                y: ann.y,
+                color: ann.color,
+                strokeWidth: ann.strokeWidth,
+                width: ann.width,
+                height: ann.height,
+                endX: ann.endX,
+                endY: ann.endY,
+                lineStyle: ann.lineStyle,
+                text: ann.text,
+                fontSize: ann.fontSize,
+                textBoxWidth: ann.textBoxWidth,
+                textBoxHeight: ann.textBoxHeight,
+                horizontalAlign: ann.horizontalAlign,
+                verticalAlign: ann.verticalAlign,
+                anchorDirection: ann.anchorDirection,
+                displayX: ann.displayX,
+                displayY: ann.displayY,
+                userId: ann.userId,
+                createdAt: ann.createdAt.toISOString(),
+                updatedAt: ann.updatedAt.toISOString(),
+              })
+            }
           }
         }
       }
@@ -308,44 +338,52 @@ export async function collectProjectData(
           updatedAt: img.updatedAt.toISOString(),
         }))
       ),
-      studentAnswerImages: project.projectPages.flatMap((page) =>
-        page.studentAnswerImages.map((img) => ({
-          id: img.id,
-          projectPageId: img.projectPageId,
-          studentId: img.studentId,
-          imagePath: img.imagePath,
-          createdAt: img.createdAt.toISOString(),
-          updatedAt: img.updatedAt.toISOString(),
-        }))
-      ),
-      projectStudents: project.projectStudents.map((ps) => ({
-        id: ps.id,
-        projectId: ps.projectId,
-        studentId: ps.studentId,
-        status: ps.status,
-        customOrder: ps.customOrder,
-        createdAt: ps.createdAt.toISOString(),
-        updatedAt: ps.updatedAt.toISOString(),
-      })),
+      studentAnswerImages: isTemplate
+        ? []
+        : project.projectPages.flatMap((page) =>
+            page.studentAnswerImages.map((img) => ({
+              id: img.id,
+              projectPageId: img.projectPageId,
+              studentId: img.studentId,
+              imagePath: img.imagePath,
+              createdAt: img.createdAt.toISOString(),
+              updatedAt: img.updatedAt.toISOString(),
+            }))
+          ),
+      projectStudents: isTemplate
+        ? []
+        : project.projectStudents.map((ps) => ({
+            id: ps.id,
+            projectId: ps.projectId,
+            studentId: ps.studentId,
+            status: ps.status,
+            customOrder: ps.customOrder,
+            createdAt: ps.createdAt.toISOString(),
+            updatedAt: ps.updatedAt.toISOString(),
+          })),
       // v0.3.0以降: UserProjectは無視（インポート時に現在のユーザーで作成）
       userProjects: [],
-      projectSubtotalGroups: project.projectSubtotalGroups.map((psg) => ({
-        id: psg.id,
-        projectId: psg.projectId,
-        subtotalGroupId: psg.subtotalGroupId,
-        createdAt: psg.createdAt.toISOString(),
-        updatedAt: psg.updatedAt.toISOString(),
-      })),
-      projectClasses: project.projectClasses.map((pc) => ({
-        id: pc.id,
-        projectId: pc.projectId,
-        classId: pc.classId,
-        administered: pc.administered,
-        statistics: pc.statistics,
-        order: pc.order,
-        createdAt: pc.createdAt.toISOString(),
-        updatedAt: pc.updatedAt.toISOString(),
-      })),
+      projectSubtotalGroups: includeSubtotals
+        ? project.projectSubtotalGroups.map((psg) => ({
+            id: psg.id,
+            projectId: psg.projectId,
+            subtotalGroupId: psg.subtotalGroupId,
+            createdAt: psg.createdAt.toISOString(),
+            updatedAt: psg.updatedAt.toISOString(),
+          }))
+        : [],
+      projectClasses: isTemplate
+        ? []
+        : project.projectClasses.map((pc) => ({
+            id: pc.id,
+            projectId: pc.projectId,
+            classId: pc.classId,
+            administered: pc.administered,
+            statistics: pc.statistics,
+            order: pc.order,
+            createdAt: pc.createdAt.toISOString(),
+            updatedAt: pc.updatedAt.toISOString(),
+          })),
       // v1.4.0+
       projectMarkingFormats: projectMarkingFormats.map((pmf) => ({
         id: pmf.id,

--- a/electron-src/lib/export/project-archive/index.ts
+++ b/electron-src/lib/export/project-archive/index.ts
@@ -23,7 +23,7 @@ import { collectProjectData } from "./dataCollector"
 export async function exportProject(
   options: ExportProjectOptions
 ): Promise<ExportProjectResult> {
-  const { projectId, userId, outputPath } = options
+  const { projectId, userId, outputPath, exportMode = "full" } = options
 
   try {
     // 1. プロジェクト情報を取得
@@ -32,8 +32,12 @@ export async function exportProject(
       return { success: false, error: "プロジェクトが見つかりません" }
     }
 
-    // 2. データを収集（ログインユーザーのデータのみ）
-    const collectResult = await collectProjectData(projectId, userId)
+    // 2. データを収集（ログインユーザーのデータのみ、モードに応じて部分収集）
+    const collectResult = await collectProjectData(
+      projectId,
+      userId,
+      exportMode
+    )
     if (!collectResult.success || !collectResult.data) {
       return { success: false, error: collectResult.error }
     }
@@ -41,7 +45,10 @@ export async function exportProject(
     // 3. 出力先を決定
     let finalOutputPath = outputPath
     if (!finalOutputPath) {
-      const defaultFileName = generateExportFileName(project.examName)
+      const defaultFileName = generateExportFileName(
+        project.examName,
+        exportMode
+      )
       const result = await dialog.showSaveDialog({
         title: "プロジェクトをエクスポート",
         defaultPath: defaultFileName,
@@ -62,6 +69,7 @@ export async function exportProject(
       projectName: project.examName,
       projectId,
       outputPath: finalOutputPath,
+      exportMode,
     })
 
     if (!archiveResult.success) {

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -627,6 +627,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       projectId: string
       userId: string
       outputPath?: string
+      exportMode?: import("../types/projectArchive.types").ExportMode
     }) => ipcRenderer.invoke("archive:exportProject", options),
     analyzeArchive: (options: { archivePath: string }) =>
       ipcRenderer.invoke("archive:analyzeArchive", options),
@@ -649,6 +650,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
       preMatchResult: import("../types/projectArchive.types").FileOverviewData
       integrationConfig: import("../types/projectArchive.types").IdIntegrationConfig
     }) => ipcRenderer.invoke("archive:detectScoringConflicts", options),
+    bulkExportProjects: (options: {
+      projectIds: string[]
+      userId: string
+      exportMode?: import("../types/projectArchive.types").ExportMode
+    }) => ipcRenderer.invoke("archive:bulkExportProjects", options),
     selectImportFile: () => ipcRenderer.invoke("archive:selectImportFile"),
   },
 

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1251,9 +1251,12 @@ export interface MyAPI {
     /**
      * プロジェクトをZIPアーカイブとしてエクスポート
      */
-    exportProject: (
-      options: import("./projectArchive.types").ExportProjectOptions
-    ) => Promise<import("./projectArchive.types").ExportProjectResult>
+    exportProject: (options: {
+      projectId: string
+      userId: string
+      outputPath?: string
+      exportMode?: import("./projectArchive.types").ExportMode
+    }) => Promise<import("./projectArchive.types").ExportProjectResult>
 
     /**
      * アーカイブファイルを解析してプレビュー情報を取得
@@ -1321,6 +1324,14 @@ export interface MyAPI {
       data?: import("./projectArchive.types").ScoringConflictData
       error?: string
     }>
+
+    /**
+     * 複数プロジェクトを一括エクスポート
+     * フォルダ選択ダイアログを表示し、各プロジェクトを個別の.scoreファイルとして保存
+     */
+    bulkExportProjects: (
+      options: import("./projectArchive.types").BulkExportProjectsOptions
+    ) => Promise<import("./projectArchive.types").BulkExportProjectsResult>
 
     /**
      * インポートファイル選択ダイアログ

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -28,6 +28,8 @@ export interface ArchiveManifest {
   exportedBy?: string
   /** データ件数サマリー */
   counts: ArchiveDataCounts
+  /** エクスポートモード（部分エクスポート時に記録） */
+  exportMode?: ExportMode
 }
 
 /**
@@ -450,8 +452,52 @@ export interface ImportOptions {
 }
 
 // =============================================================================
+// Export Mode
+// =============================================================================
+
+/**
+ * エクスポートモード
+ *
+ * - full: 全データ（現行動作）
+ * - template: 模範解答＋領域情報のみ（採点テンプレート）
+ * - template_with_subtotals: テンプレート＋小計設定
+ */
+export type ExportMode = "full" | "template" | "template_with_subtotals"
+
+// =============================================================================
 // IPC API Types
 // =============================================================================
+
+/**
+ * 一括エクスポートオプション
+ */
+export interface BulkExportProjectsOptions {
+  projectIds: string[]
+  userId: string
+  /** エクスポートモード（デフォルト: full） */
+  exportMode?: ExportMode
+}
+
+/**
+ * 一括エクスポートの個別プロジェクト結果
+ */
+export interface BulkExportProjectResult {
+  projectId: string
+  projectName: string
+  success: boolean
+  outputPath?: string
+  error?: string
+}
+
+/**
+ * 一括エクスポート全体の結果
+ */
+export interface BulkExportProjectsResult {
+  success: boolean
+  results: BulkExportProjectResult[]
+  outputDirectory?: string
+  error?: string
+}
 
 /**
  * エクスポートオプション
@@ -461,6 +507,8 @@ export interface ExportProjectOptions {
   /** ログインユーザーID（このユーザーのデータのみエクスポート） */
   userId: string
   outputPath?: string
+  /** エクスポートモード（デフォルト: full） */
+  exportMode?: ExportMode
 }
 
 /**


### PR DESCRIPTION
## Summary
- プロジェクト一覧から複数プロジェクトを選択して一括`.score`書き出しを可能にした
- エクスポート時にモード（全データ/テンプレート/テンプレート+小計設定）を選択できるようにした
- 統合テスト・ユニットテストを追加（計3ファイル）

Closes #387

## Test plan
- [ ] プロジェクト一覧で2〜3件のプロジェクトをチェックボックスで選択
- [ ] 「一括書き出し」ボタンをクリックしモード選択モーダルが表示されることを確認
- [ ] フォルダ選択ダイアログで保存先を選択し各プロジェクトの`.score`ファイルが作成されることを確認
- [ ] 完了toastが表示されることを確認
- [ ] 全選択/全解除が正しく動作することを確認
- [ ] プロジェクト詳細ページの既存エクスポートでもモード選択が機能することを確認
- [ ] `npx vitest run __tests__/import-export/integration/bulkExportProjects.test.ts` が全パスすることを確認
- [ ] `npm run typecheck` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)