### PR TITLE
PDF加工: 出力プレビューにページ削除機能を追加

### DIFF
--- a/components/pdf-tools/PdfToolsMainView.tsx
+++ b/components/pdf-tools/PdfToolsMainView.tsx
@@ -22,6 +22,8 @@ export default function PdfToolsMainView() {
     transforms: [],
   })
   const [isProcessing, setIsProcessing] = useState(false)
+  // 出力プレビューから除外されたページ（"fileId:pageNumber" のセット）
+  const [excludedPages, setExcludedPages] = useState<Set<string>>(new Set())
 
   // リサイズ関連の状態
   const [leftPanelWidth, setLeftPanelWidth] = useState(50) // パーセント
@@ -35,6 +37,14 @@ export default function PdfToolsMainView() {
   const handleFileRemoved = (fileId: string) => {
     setImportedFiles((prev) => prev.filter((f) => f.id !== fileId))
     setOutputPages((prev) => prev.filter((p) => p.sourceFileId !== fileId))
+    // ファイル削除時に対応する除外ページもクリア
+    setExcludedPages((prev) => {
+      const next = new Set<string>()
+      for (const key of prev) {
+        if (!key.startsWith(`${fileId}:`)) next.add(key)
+      }
+      return next
+    })
   }
 
   const handleFileUpdated = (updatedFile: ImportedFile) => {
@@ -45,6 +55,36 @@ export default function PdfToolsMainView() {
 
   const handleOutputPagesChange = useCallback((pages: OutputPage[]) => {
     setOutputPages(pages)
+  }, [])
+
+  /** 出力プレビューからページを除外（永続的） */
+  const handlePageExcluded = useCallback((page: OutputPage) => {
+    setExcludedPages((prev) => {
+      const next = new Set(prev)
+      if (page.isNUpCombined && page.combinedPages) {
+        for (const pn of page.combinedPages) {
+          next.add(`${page.sourceFileId}:${pn}`)
+        }
+      } else {
+        next.add(`${page.sourceFileId}:${page.sourcePageNumber}`)
+      }
+      return next
+    })
+  }, [])
+
+  /** 除外ページのリセット（ファイル指定 or 全体） */
+  const handleResetExcludedPages = useCallback((fileId?: string) => {
+    if (fileId) {
+      setExcludedPages((prev) => {
+        const next = new Set<string>()
+        for (const key of prev) {
+          if (!key.startsWith(`${fileId}:`)) next.add(key)
+        }
+        return next
+      })
+    } else {
+      setExcludedPages(new Set())
+    }
   }, [])
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -90,9 +130,11 @@ export default function PdfToolsMainView() {
       >
         <ImportPanel
           importedFiles={importedFiles}
+          excludedPages={excludedPages}
           onFilesImported={handleFilesImported}
           onFileRemoved={handleFileRemoved}
           onFileUpdated={handleFileUpdated}
+          onResetExcludedPages={handleResetExcludedPages}
           isProcessing={isProcessing}
         />
       </div>
@@ -112,12 +154,14 @@ export default function PdfToolsMainView() {
         <ExportPanel
           importedFiles={importedFiles}
           outputPages={outputPages}
+          excludedPages={excludedPages}
           exportMode={exportMode}
           interleaveConfig={interleaveConfig}
           isProcessing={isProcessing}
           onExportModeChange={setExportMode}
           onInterleaveConfigChange={setInterleaveConfig}
           onOutputPagesChange={handleOutputPagesChange}
+          onPageExcluded={handlePageExcluded}
           onProcessingChange={setIsProcessing}
         />
       </div>

--- a/components/pdf-tools/export-panel/ExportPanel.tsx
+++ b/components/pdf-tools/export-panel/ExportPanel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
 import type {
@@ -18,12 +18,14 @@ import OutputPreview from "./OutputPreview"
 interface ExportPanelProps {
   importedFiles: ImportedFile[]
   outputPages: OutputPage[]
+  excludedPages: Set<string>
   exportMode: ExportMode
   interleaveConfig: InterleaveConfig
   isProcessing: boolean
   onExportModeChange: (mode: ExportMode) => void
   onInterleaveConfigChange: (config: InterleaveConfig) => void
   onOutputPagesChange: (pages: OutputPage[]) => void
+  onPageExcluded: (page: OutputPage) => void
   onProcessingChange: (processing: boolean) => void
 }
 
@@ -35,22 +37,31 @@ interface ExportPanelProps {
 export default function ExportPanel({
   importedFiles,
   outputPages,
+  excludedPages,
   exportMode,
   interleaveConfig,
   isProcessing,
   onExportModeChange,
   onInterleaveConfigChange,
   onOutputPagesChange,
+  onPageExcluded,
   onProcessingChange,
 }: ExportPanelProps) {
-  // インポートファイルが変更されたら出力ページを更新
+  // excludedPages の最新値をrefで保持（useEffectの依存配列に入れず、再生成時のみ参照）
+  const excludedPagesRef = useRef(excludedPages)
+  excludedPagesRef.current = excludedPages
+
+  // インポートファイルが変更されたら出力ページを更新（除外ページを反映）
   useEffect(() => {
     const pages = generateOutputPages(
       importedFiles,
       exportMode,
       interleaveConfig
     )
-    onOutputPagesChange(pages)
+    const filtered = pages.filter(
+      (p) => !isPageExcluded(p, excludedPagesRef.current)
+    )
+    onOutputPagesChange(filtered)
   }, [importedFiles, exportMode, interleaveConfig, onOutputPagesChange])
 
   return (
@@ -85,6 +96,7 @@ export default function ExportPanel({
           <OutputPreview
             pages={outputPages}
             onPagesChange={onOutputPagesChange}
+            onDeletePage={onPageExcluded}
             disabled={isProcessing}
           />
         </ScrollArea>
@@ -99,6 +111,18 @@ export default function ExportPanel({
         />
       </div>
     </div>
+  )
+}
+
+/** 除外対象かどうかを判定 */
+function isPageExcluded(page: OutputPage, excludedPages: Set<string>): boolean {
+  if (page.isNUpCombined && page.combinedPages) {
+    return page.combinedPages.some((pn) =>
+      excludedPages.has(`${page.sourceFileId}:${pn}`)
+    )
+  }
+  return excludedPages.has(
+    `${page.sourceFileId}:${page.sourcePageNumber}`
   )
 }
 

--- a/components/pdf-tools/export-panel/OutputPreview.tsx
+++ b/components/pdf-tools/export-panel/OutputPreview.tsx
@@ -17,7 +17,7 @@ import {
   useSortable,
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { GripVertical } from "lucide-react"
+import { GripVertical, Trash2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import type { OutputPage } from "@/types/pdfTools.types"
@@ -25,12 +25,14 @@ import type { OutputPage } from "@/types/pdfTools.types"
 interface OutputPreviewProps {
   pages: OutputPage[]
   onPagesChange: (pages: OutputPage[]) => void
+  onDeletePage: (page: OutputPage) => void
   disabled: boolean
 }
 
 export default function OutputPreview({
   pages,
   onPagesChange,
+  onDeletePage,
   disabled,
 }: OutputPreviewProps) {
   const sensors = useSensors(
@@ -50,6 +52,13 @@ export default function OutputPreview({
     if (oldIndex !== -1 && newIndex !== -1) {
       onPagesChange(arrayMove(pages, oldIndex, newIndex))
     }
+  }
+
+  const handleDeletePage = (page: OutputPage) => {
+    // 即座に表示から除去（ドラッグ並び替えの順序を維持）
+    onPagesChange(pages.filter((p) => p.id !== page.id))
+    // 永続的に除外（設定変更による再生成時も反映）
+    onDeletePage(page)
   }
 
   if (pages.length === 0) {
@@ -77,6 +86,7 @@ export default function OutputPreview({
               page={page}
               index={index}
               disabled={disabled}
+              onDelete={() => handleDeletePage(page)}
             />
           ))}
         </div>
@@ -89,9 +99,10 @@ interface SortablePageItemProps {
   page: OutputPage
   index: number
   disabled: boolean
+  onDelete: () => void
 }
 
-function SortablePageItem({ page, index, disabled }: SortablePageItemProps) {
+function SortablePageItem({ page, index, disabled, onDelete }: SortablePageItemProps) {
   const {
     attributes,
     listeners,
@@ -145,6 +156,26 @@ function SortablePageItem({ page, index, disabled }: SortablePageItemProps) {
             </span>
           </div>
         )}
+      </div>
+
+      {/* ホバー時オーバーレイ（削除ボタン） */}
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity",
+          !disabled && "group-hover:opacity-100"
+        )}
+      >
+        <button
+          className="pointer-events-auto rounded-full bg-red-500 p-1.5 text-white shadow-md transition-colors hover:bg-red-600"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          title="削除"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
       </div>
 
       {/* ドラッグハンドル */}

--- a/components/pdf-tools/import-panel/ImportPanel.tsx
+++ b/components/pdf-tools/import-panel/ImportPanel.tsx
@@ -8,17 +8,21 @@ import ImportedFileList from "./ImportedFileList"
 
 interface ImportPanelProps {
   importedFiles: ImportedFile[]
+  excludedPages: Set<string>
   onFilesImported: (files: ImportedFile[]) => void
   onFileRemoved: (fileId: string) => void
   onFileUpdated: (file: ImportedFile) => void
+  onResetExcludedPages: (fileId?: string) => void
   isProcessing: boolean
 }
 
 export default function ImportPanel({
   importedFiles,
+  excludedPages,
   onFilesImported,
   onFileRemoved,
   onFileUpdated,
+  onResetExcludedPages,
   isProcessing,
 }: ImportPanelProps) {
   return (
@@ -38,8 +42,10 @@ export default function ImportPanel({
       <ScrollArea className="flex-1 px-4 pb-4">
         <ImportedFileList
           files={importedFiles}
+          excludedPages={excludedPages}
           onFileRemoved={onFileRemoved}
           onFileUpdated={onFileUpdated}
+          onResetExcludedPages={onResetExcludedPages}
           isProcessing={isProcessing}
         />
       </ScrollArea>

--- a/components/pdf-tools/import-panel/ImportedFileItem.tsx
+++ b/components/pdf-tools/import-panel/ImportedFileItem.tsx
@@ -4,11 +4,13 @@ import {
   ChevronDown,
   ChevronRight,
   FileText,
+  RotateCcw,
   RotateCw,
   Trash2,
 } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Collapsible,
@@ -31,18 +33,31 @@ import type {
 
 interface ImportedFileItemProps {
   file: ImportedFile
+  excludedPages: Set<string>
   onRemove: () => void
   onUpdate: (file: ImportedFile) => void
+  onResetExcluded: () => void
   isProcessing: boolean
 }
 
 export default function ImportedFileItem({
   file,
+  excludedPages,
   onRemove,
   onUpdate,
+  onResetExcluded,
   isProcessing,
 }: ImportedFileItemProps) {
   const [isOpen, setIsOpen] = useState(false)
+
+  // このファイルの除外ページ数を算出
+  const excludedCount = useMemo(() => {
+    let count = 0
+    for (const key of excludedPages) {
+      if (key.startsWith(`${file.id}:`)) count++
+    }
+    return count
+  }, [excludedPages, file.id])
 
   const handleNUpChange = (value: string) => {
     const enabled = value !== "1in1"
@@ -98,9 +113,33 @@ export default function ImportedFileItem({
             <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">{file.name}</p>
-              <p className="text-muted-foreground text-xs">
-                {selectedCount}/{file.pageCount}ページ選択
-              </p>
+              <div className="flex items-center gap-1.5">
+                <p className="text-muted-foreground text-xs">
+                  {selectedCount}/{file.pageCount}ページ選択
+                </p>
+                {excludedCount > 0 && (
+                  <div className="flex items-center gap-0.5">
+                    <Badge
+                      variant="destructive"
+                      className="h-4 px-1 py-0 text-[10px]"
+                    >
+                      削除 {excludedCount}ページ
+                    </Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onResetExcluded()
+                      }}
+                      title="削除をリセット"
+                    >
+                      <RotateCcw className="h-2.5 w-2.5" />
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
             <Button
               variant="ghost"

--- a/components/pdf-tools/import-panel/ImportedFileList.tsx
+++ b/components/pdf-tools/import-panel/ImportedFileList.tsx
@@ -6,15 +6,19 @@ import ImportedFileItem from "./ImportedFileItem"
 
 interface ImportedFileListProps {
   files: ImportedFile[]
+  excludedPages: Set<string>
   onFileRemoved: (fileId: string) => void
   onFileUpdated: (file: ImportedFile) => void
+  onResetExcludedPages: (fileId?: string) => void
   isProcessing: boolean
 }
 
 export default function ImportedFileList({
   files,
+  excludedPages,
   onFileRemoved,
   onFileUpdated,
+  onResetExcludedPages,
   isProcessing,
 }: ImportedFileListProps) {
   if (files.length === 0) {
@@ -31,8 +35,10 @@ export default function ImportedFileList({
         <ImportedFileItem
           key={file.id}
           file={file}
+          excludedPages={excludedPages}
           onRemove={() => onFileRemoved(file.id)}
           onUpdate={onFileUpdated}
+          onResetExcluded={() => onResetExcludedPages(file.id)}
           isProcessing={isProcessing}
         />
       ))}


### PR DESCRIPTION
## Summary

- 出力プレビューの各ページカードにホバー時削除ボタン（ゴミ箱アイコン）を追加
- `excludedPages` (Set<string>) による永続的な除外管理を実装し、設定変更による再生成でも削除状態を維持
- インポートパネルのファイル一覧に「削除 Nページ」バッジとリセットボタンを表示

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `PdfToolsMainView.tsx` | `excludedPages` state、除外/リセットハンドラー追加 |
| `ExportPanel.tsx` | 再生成時の除外フィルタリング、`onDeletePage` 中継 |
| `OutputPreview.tsx` | 削除ボタンUI、即座の表示除去+永続除外の二重処理 |
| `ImportPanel.tsx` | `excludedPages`・リセットハンドラーの受け渡し |
| `ImportedFileList.tsx` | props中継 |
| `ImportedFileItem.tsx` | 除外ページ数バッジ・リセットボタン表示 |

## Test plan

- [ ] 出力プレビューでページにホバーし、削除ボタンが表示されることを確認
- [ ] 削除ボタンクリックでページが即座に除去されることを確認
- [ ] エクスポートモード変更後も削除したページが復活しないことを確認
- [ ] インポートパネルに「削除 Nページ」バッジが表示されることを確認
- [ ] リセットボタンで削除状態が解除され、再生成時にページが復活することを確認
- [ ] ドラッグによるページ並び替えが引き続き正常に動作することを確認

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)