### PR TITLE
feat: 外部フォーマットインポート機能と小計グループ統合

### DIFF
--- a/__tests__/renderer/helpers/mockWizard.ts
+++ b/__tests__/renderer/helpers/mockWizard.ts
@@ -32,6 +32,8 @@ export function createMockWizard(
     setScoringConflictStrategy: vi.fn(),
     setScoringConflictResolution: vi.fn(),
     setAllScoringConflictResolutions: vi.fn(),
+    acceptHszDisclaimer: vi.fn().mockResolvedValue(true),
+    dismissHszDisclaimer: vi.fn(),
     goToNextStep: vi.fn(),
     goBack: vi.fn(),
     executeImport: vi.fn().mockResolvedValue({

--- a/components/import/HszDisclaimerModal.tsx
+++ b/components/import/HszDisclaimerModal.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+import { AlertTriangle, FileArchive, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
+
+/**
+ * 外部フォーマット別の表示情報
+ */
+const FORMAT_INFO = {
+  hsz: {
+    productName: "百問繚乱",
+    companyName: "株式会社シンプルエデュケーション",
+  },
+  dat: {
+    productName: "リアテンダント",
+    companyName: "大日本印刷株式会社",
+  },
+} as const
+
+interface HszDisclaimerModalProps {
+  wizard: UseImportWizardReturn
+}
+
+export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
+  const { state, acceptHszDisclaimer, dismissHszDisclaimer } = wizard
+  const [agreed, setAgreed] = useState(false)
+
+  const fileName = state.hszOriginalPath
+    ? (state.hszOriginalPath.split(/[/\\]/).pop() ?? "")
+    : ""
+
+  const formatKey = state.sourceFormat === "dat" ? "dat" : "hsz"
+  const { productName, companyName } = FORMAT_INFO[formatKey]
+
+  // モーダルが開くたびに同意状態をリセット
+  useEffect(() => {
+    if (state.showHszDisclaimer) {
+      setAgreed(false)
+    }
+  }, [state.showHszDisclaimer])
+
+  return (
+    <Dialog
+      open={state.showHszDisclaimer === true}
+      onOpenChange={(open) => {
+        if (!open && !state.isProcessing) {
+          dismissHszDisclaimer()
+        }
+      }}
+    >
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            他社フォーマットの変換
+          </DialogTitle>
+          <DialogDescription>
+            {productName}
+            のデータファイルを一括採点形式に変換します
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* ファイル名表示 */}
+          <div className="bg-muted flex items-center gap-3 rounded-lg p-3">
+            <FileArchive className="text-muted-foreground h-5 w-5 shrink-0" />
+            <span className="text-sm font-medium break-all">{fileName}</span>
+          </div>
+
+          {/* 変換に関する注意事項 */}
+          <div className="space-y-2 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+            <p className="text-sm font-medium">変換に関する注意事項</p>
+            <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
+              <li>
+                採点領域の座標は自動変換されますが、精度を保証するものではありません
+              </li>
+              <li>
+                変換後、テンプレート編集画面で各領域の位置を確認・調整してください
+              </li>
+              <li>
+                模範解答画像と採点領域のみがインポートされます（生徒・採点結果は含まれません）
+              </li>
+            </ul>
+          </div>
+
+          {/* 免責事項 */}
+          <div className="space-y-3 rounded-lg border p-4">
+            <p className="text-sm font-medium">免責事項</p>
+            <div className="text-muted-foreground space-y-2 text-xs leading-relaxed">
+              <p>
+                本ソフトウェアは、{companyName}
+                とは一切の関係がなく、同社からの承認・推奨・技術提供を受けたものではありません。
+              </p>
+              <p>
+                本ソフトウェアに含まれるファイル読み込み機能は、公開されているデータ形式をもとに独自に実装した変換機能であり、同社のソフトウェアの技術・ソースコード・ライセンスに依拠するものではありません。
+              </p>
+              <ul className="list-inside list-disc space-y-1.5 pl-1">
+                <li>
+                  <span className="font-medium">動作の保証について：</span>
+                  本機能による読み込み結果の正確性・完全性について、いかなる保証も行いません。読み込み後のデータについては、必ずご自身で内容をご確認ください。
+                </li>
+                <li>
+                  <span className="font-medium">データ形式の変更について：</span>
+                  ソフトウェアの更新等によりデータ形式が変更された場合、本機能が正常に動作しなくなる可能性があります。
+                </li>
+                <li>
+                  <span className="font-medium">データの利用について：</span>
+                  読み込むファイルに含まれるコンテンツ（問題文・解答等）の著作権は、その作成者または権利者に帰属します。ファイルの利用にあたっては、各コンテンツの利用条件を遵守してください。
+                </li>
+                <li>
+                  <span className="font-medium">免責：</span>
+                  本機能の使用により生じたいかなる損害についても、本ソフトウェアの開発者は一切の責任を負いません。
+                </li>
+              </ul>
+            </div>
+
+            {/* 商標表示 */}
+            <div className="text-muted-foreground border-t pt-2 text-[11px] leading-relaxed">
+              <p>
+                「百問繚乱」は、株式会社シンプルエデュケーションの登録商標または商標です。
+              </p>
+              <p>
+                「リアテンダント」は、大日本印刷株式会社の登録商標または商標です。
+              </p>
+              <p>
+                その他、本ソフトウェア内で使用されている会社名・製品名等は、各社の登録商標または商標です。
+              </p>
+            </div>
+          </div>
+
+          {/* 同意チェックボックス */}
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 select-none has-[:checked]:border-amber-400 has-[:checked]:bg-amber-50 dark:has-[:checked]:bg-amber-950/20">
+            <Checkbox
+              checked={agreed}
+              onCheckedChange={(checked) => setAgreed(checked === true)}
+              disabled={state.isProcessing}
+              className="mt-0.5"
+            />
+            <span className="text-sm">
+              上記の免責事項を確認し、同意のうえ変換を行います
+            </span>
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={dismissHszDisclaimer}
+            disabled={state.isProcessing}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={acceptHszDisclaimer}
+            disabled={state.isProcessing || !agreed}
+          >
+            {state.isProcessing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                変換中...
+              </>
+            ) : (
+              "変換して読み込む"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/import/ImportWizardModal.tsx
+++ b/components/import/ImportWizardModal.tsx
@@ -14,6 +14,7 @@ import { useImportWizard } from "@/hooks/import/useImportWizard"
 import { cn } from "@/lib/utils"
 import type { ImportWizardStep } from "@/types/projectArchive.types"
 
+import { HszDisclaimerModal } from "./HszDisclaimerModal"
 import { ExecuteStep } from "./steps/ExecuteStep"
 import { FileOverviewStep } from "./steps/FileOverviewStep"
 import { FileSelectStep } from "./steps/FileSelectStep"
@@ -69,135 +70,144 @@ export function ImportWizardModal({
   const currentStepIndex = STEP_ORDER.indexOf(state.currentStep)
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="flex max-h-[90vh] min-w-4xl flex-col gap-0 p-0">
-        {/* ヘッダー */}
-        <DialogHeader className="bg-muted/30 border-b px-6 py-4">
-          <div className="flex items-center justify-between">
-            <DialogTitle className="text-xl font-semibold">
-              プロジェクトインポート
-            </DialogTitle>
-          </div>
-
-          {/* ステップインジケーター */}
-          <div className="flex items-center justify-center pt-4">
-            {STEP_ORDER.map((step, index) => {
-              const isActive = step === state.currentStep
-              const isCompleted = index < currentStepIndex
-
-              return (
-                <div key={step} className="flex items-center">
-                  {index > 0 && (
-                    <div
-                      className={cn(
-                        "h-0.5 w-8 transition-colors",
-                        isCompleted ? "bg-primary" : "bg-muted-foreground/20"
-                      )}
-                    />
-                  )}
-                  <div className="flex w-20 flex-col items-center gap-y-2">
-                    <div
-                      className={cn(
-                        "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-all",
-                        isActive &&
-                          "bg-primary text-primary-foreground ring-primary/20 ring-4",
-                        isCompleted && "bg-primary text-primary-foreground",
-                        !isActive &&
-                          !isCompleted &&
-                          "bg-muted text-muted-foreground"
-                      )}
-                    >
-                      {isCompleted ? <Check className="h-4 w-4" /> : index + 1}
-                    </div>
-                    <span
-                      className={cn(
-                        "text-center text-xs font-medium",
-                        isActive && "text-primary",
-                        !isActive && "text-muted-foreground"
-                      )}
-                    >
-                      {STEP_TITLES[step]}
-                    </span>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        </DialogHeader>
-
-        {/* エラー表示 */}
-        {state.error && (
-          <div className="bg-destructive/10 border-destructive/20 mx-6 mt-4 rounded-lg border p-4">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
-              <div className="flex-1">
-                <p className="text-destructive text-sm font-medium">エラー</p>
-                <p className="text-destructive/80 mt-1 text-sm">
-                  {state.error}
-                </p>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={wizard.clearError}
-                className="text-destructive hover:text-destructive hover:bg-destructive/10 -mt-2 -mr-2"
-              >
-                <X className="h-4 w-4" />
-              </Button>
+    <>
+      <HszDisclaimerModal wizard={wizard} />
+      <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+        <DialogContent className="flex max-h-[90vh] min-w-4xl flex-col gap-0 p-0">
+          {/* ヘッダー */}
+          <DialogHeader className="bg-muted/30 border-b px-6 py-4">
+            <div className="flex items-center justify-between">
+              <DialogTitle className="text-xl font-semibold">
+                プロジェクトインポート
+              </DialogTitle>
             </div>
+
+            {/* ステップインジケーター */}
+            <div className="flex items-center justify-center pt-4">
+              {STEP_ORDER.map((step, index) => {
+                const isActive = step === state.currentStep
+                const isCompleted = index < currentStepIndex
+
+                return (
+                  <div key={step} className="flex items-center">
+                    {index > 0 && (
+                      <div
+                        className={cn(
+                          "h-0.5 w-8 transition-colors",
+                          isCompleted ? "bg-primary" : "bg-muted-foreground/20"
+                        )}
+                      />
+                    )}
+                    <div className="flex w-20 flex-col items-center gap-y-2">
+                      <div
+                        className={cn(
+                          "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-all",
+                          isActive &&
+                            "bg-primary text-primary-foreground ring-primary/20 ring-4",
+                          isCompleted && "bg-primary text-primary-foreground",
+                          !isActive &&
+                            !isCompleted &&
+                            "bg-muted text-muted-foreground"
+                        )}
+                      >
+                        {isCompleted ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          index + 1
+                        )}
+                      </div>
+                      <span
+                        className={cn(
+                          "text-center text-xs font-medium",
+                          isActive && "text-primary",
+                          !isActive && "text-muted-foreground"
+                        )}
+                      >
+                        {STEP_TITLES[step]}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </DialogHeader>
+
+          {/* エラー表示 */}
+          {state.error && (
+            <div className="bg-destructive/10 border-destructive/20 mx-6 mt-4 rounded-lg border p-4">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
+                <div className="flex-1">
+                  <p className="text-destructive text-sm font-medium">エラー</p>
+                  <p className="text-destructive/80 mt-1 text-sm">
+                    {state.error}
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={wizard.clearError}
+                  className="text-destructive hover:text-destructive hover:bg-destructive/10 -mt-2 -mr-2"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* ステップコンテンツ */}
+          <div className="min-h-100 flex-1 overflow-y-auto px-6 py-6">
+            {state.currentStep === "file_select" && (
+              <FileSelectStep wizard={wizard} />
+            )}
+            {state.currentStep === "file_overview" && (
+              <FileOverviewStep wizard={wizard} />
+            )}
+            {state.currentStep === "id_integration" && (
+              <IdIntegrationStep wizard={wizard} />
+            )}
+
+            {state.currentStep === "update_confirm" && (
+              <UpdateConfirmStep wizard={wizard} />
+            )}
+            {state.currentStep === "final_confirm" && (
+              <FinalConfirmStep
+                wizard={wizard}
+                onExecute={() => wizard.goToNextStep()}
+              />
+            )}
+            {state.currentStep === "execute" && (
+              <ExecuteStep
+                wizard={wizard}
+                onComplete={onComplete}
+                onClose={onClose}
+              />
+            )}
           </div>
-        )}
 
-        {/* ステップコンテンツ */}
-        <div className="min-h-100 flex-1 overflow-y-auto px-6 py-6">
-          {state.currentStep === "file_select" && (
-            <FileSelectStep wizard={wizard} />
-          )}
-          {state.currentStep === "file_overview" && (
-            <FileOverviewStep wizard={wizard} />
-          )}
-          {state.currentStep === "id_integration" && (
-            <IdIntegrationStep wizard={wizard} />
-          )}
-
-          {state.currentStep === "update_confirm" && (
-            <UpdateConfirmStep wizard={wizard} />
-          )}
-          {state.currentStep === "final_confirm" && (
-            <FinalConfirmStep
-              wizard={wizard}
-              onExecute={() => wizard.goToNextStep()}
-            />
-          )}
-          {state.currentStep === "execute" && (
-            <ExecuteStep
-              wizard={wizard}
-              onComplete={onComplete}
-              onClose={onClose}
-            />
-          )}
-        </div>
-
-        {/* フッター */}
-        <div className="bg-muted/30 flex items-center justify-between border-t px-6 py-4">
-          <Button
-            variant="ghost"
-            onClick={wizard.goBack}
-            disabled={state.currentStep === "file_select" || state.isProcessing}
-            className="gap-2"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            戻る
-          </Button>
-          <Button
-            variant="outline"
-            onClick={handleClose}
-            disabled={state.isProcessing}
-          >
-            キャンセル
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+          {/* フッター */}
+          <div className="bg-muted/30 flex items-center justify-between border-t px-6 py-4">
+            <Button
+              variant="ghost"
+              onClick={wizard.goBack}
+              disabled={
+                state.currentStep === "file_select" || state.isProcessing
+              }
+              className="gap-2"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              戻る
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleClose}
+              disabled={state.isProcessing}
+            >
+              キャンセル
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/components/import/steps/FileSelectStep.tsx
+++ b/components/import/steps/FileSelectStep.tsx
@@ -69,7 +69,23 @@ export function FileSelectStep({ wizard }: FileSelectStepProps) {
               <CheckCircle2 className="h-4 w-4 text-green-500" />
               一括採点プロジェクトデータ (.score)
             </li>
+            <li className="text-muted-foreground flex items-center gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              百問繚乱&trade;データ（採点情報のみ）(.hsz)
+            </li>
+            <li className="text-muted-foreground flex items-center gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              リアテンダント&trade;データ（採点情報のみ）(.dat)
+            </li>
           </ul>
+          <div className="text-muted-foreground/60 mt-3 text-[10px] leading-relaxed">
+            <p>
+              「百問繚乱」は、株式会社シンプルエデュケーションの登録商標または商標です。
+            </p>
+            <p>
+              「リアテンダント」は、大日本印刷株式会社の登録商標または商標です。
+            </p>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -17,6 +17,8 @@ import type {
 } from "../../types/projectArchive.types"
 import { exportProject } from "../lib/export/project-archive"
 import { generateExportFileName } from "../lib/export/project-archive/archiveCreator"
+import { convertHszToScore } from "../lib/import/external-formats/hsz"
+import { convertDatToScore } from "../lib/import/external-formats/reattendant"
 import {
   detectAllConflicts,
   detectScoringConflictsWithUserDecisions,
@@ -129,7 +131,23 @@ export function registerArchiveHandlers(): void {
       const result = await dialog.showOpenDialog({
         title: "プロジェクトをインポート",
         filters: [
-          { name: "一括採点プロジェクトデータ", extensions: ["score"] },
+          {
+            name: "対応ファイル (.score, .hsz, .dat)",
+            extensions: ["score", "hsz", "dat"],
+          },
+          {
+            name: "一括採点プロジェクトデータ (.score)",
+            extensions: ["score"],
+          },
+          {
+            name: "百問繚乱™データ（採点情報のみ）(.hsz)",
+            extensions: ["hsz"],
+          },
+          {
+            name: "リアテンダント™データ（採点情報のみ）(.dat)",
+            extensions: ["dat"],
+          },
+          { name: "すべてのファイル", extensions: ["*"] },
         ],
         properties: ["openFile"],
       })
@@ -138,7 +156,29 @@ export function registerArchiveHandlers(): void {
         return { success: true, canceled: true }
       }
 
-      return { success: true, filePath: result.filePaths[0] }
+      const filePath = result.filePaths[0]
+      const ext = path.extname(filePath).toLowerCase()
+
+      // .datファイルはリアテンダント形式かどうかをZIP内のファイルで判定
+      let sourceFormat: "score" | "hsz" | "dat" =
+        ext === ".hsz" ? "hsz" : "score"
+
+      if (ext === ".dat") {
+        try {
+          const AdmZip = (await import("adm-zip")).default
+          const zip = new AdmZip(filePath)
+          const hasVersion = zip
+            .getEntries()
+            .some((e) => e.entryName.endsWith("RealtendantAppVersion.txt"))
+          if (hasVersion) {
+            sourceFormat = "dat"
+          }
+        } catch {
+          // ZIPとして開けない場合は.score扱い（後段でエラーになる）
+        }
+      }
+
+      return { success: true, filePath, sourceFormat }
     } catch (error) {
       console.error("Error in archive:selectImportFile:", error)
       return {
@@ -150,6 +190,44 @@ export function registerArchiveHandlers(): void {
       }
     }
   })
+
+  // .hsz → .score 変換
+  ipcMain.handle(
+    "archive:convertHszToScore",
+    async (_event, options: { hszPath: string }) => {
+      try {
+        return await convertHszToScore(options.hszPath)
+      } catch (error) {
+        console.error("Error in archive:convertHszToScore:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : ".hsz ファイルの変換に失敗しました",
+        }
+      }
+    }
+  )
+
+  // .dat → .score 変換
+  ipcMain.handle(
+    "archive:convertDatToScore",
+    async (_event, options: { datPath: string }) => {
+      try {
+        return await convertDatToScore(options.datPath)
+      } catch (error) {
+        console.error("Error in archive:convertDatToScore:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : ".dat ファイルの変換に失敗しました",
+        }
+      }
+    }
+  )
 
   // アーカイブ解析（プレビュー用）
   ipcMain.handle(

--- a/electron-src/lib/import/external-formats/hsz/hszConverter.ts
+++ b/electron-src/lib/import/external-formats/hsz/hszConverter.ts
@@ -1,0 +1,617 @@
+/**
+ * 百問繚乱 .hsz → .score 変換ロジック
+ *
+ * .hszファイルを内部的に.score形式（テンプレートモード）に変換し、
+ * 既存のインポートパイプラインに乗せる。
+ *
+ * データマッピング:
+ *   rim.l / imageW → x (0-1 正規化座標)
+ *   rim.t / imageH → y (0-1 正規化座標)
+ *   rim.w / imageW → width (0-1 正規化座標)
+ *   rim.h / imageH → height (0-1 正規化座標)
+ *   part1+part2+part3 → label
+ *   allot          → points
+ *   kind           → type (HSZ_KIND_TO_CROP_TYPE経由)
+ *   page           → projectPageId (UUID経由)
+ *   correct_N.png  → master-images/ (模範解答画像)
+ */
+
+import AdmZip from "adm-zip"
+import * as crypto from "crypto"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import { CURRENT_VERSION } from "../../transformers/types"
+import type { HszDbInfo, HszSheetField } from "./types"
+import { HSZ_KIND_TO_CROP_TYPE, HSZ_SKIP_KINDS, HSZ_SUBJECT_MAP } from "./types"
+
+interface ConvertHszResult {
+  success: boolean
+  /** 変換後の.scoreファイルパス（一時ディレクトリ内） */
+  scorePath?: string
+  /** 元の試験タイトル */
+  originalTitle?: string
+  error?: string
+}
+
+/**
+ * .hszファイルを.score形式に変換
+ */
+export async function convertHszToScore(
+  hszPath: string
+): Promise<ConvertHszResult> {
+  try {
+    // 1. .hszをZIPとして開く
+    const hszZip = new AdmZip(hszPath)
+    const entries = hszZip.getEntries()
+
+    // 2. db_info.json を取得・パース
+    const dbInfoEntry = entries.find((e) => e.entryName === "db_info.json")
+    if (!dbInfoEntry) {
+      return { success: false, error: "db_info.json が見つかりません" }
+    }
+
+    const dbInfo: HszDbInfo = JSON.parse(dbInfoEntry.getData().toString("utf8"))
+    const { sheets, sheet_pages, sheet_fields } = dbInfo
+
+    // 3. UUID生成
+    const projectId = generateUuid()
+    const now = new Date().toISOString()
+
+    // ページ番号 → UUID マッピング
+    const pageUuidMap = new Map<number, string>()
+    for (const sp of sheet_pages) {
+      pageUuidMap.set(sp.page, generateUuid())
+    }
+
+    // 4. ProjectPages 生成
+    const projectPages = sheet_pages.map((sp) => ({
+      id: pageUuidMap.get(sp.page)!,
+      projectId,
+      pageNumber: sp.page + 1, // Score at Onceは1始まり
+      createdAt: now,
+      updatedAt: now,
+    }))
+
+    // 5. MasterImages 生成
+    const masterImages: Array<{
+      id: string
+      projectPageId: string
+      imagePath: string
+      createdAt: string
+      updatedAt: string
+    }> = []
+
+    for (const sp of sheet_pages) {
+      const imgFileName = `correct_${sp.page}.png`
+      const imgEntry = entries.find((e) => e.entryName === imgFileName)
+      if (imgEntry) {
+        masterImages.push({
+          id: generateUuid(),
+          projectPageId: pageUuidMap.get(sp.page)!,
+          imagePath: imgFileName,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+
+    // 6. CropRegions 生成（sheet_fields → cropRegions変換）
+    // ページ番号 → 画像サイズ マッピング（ピクセル→正規化座標変換用）
+    const pageImageSizeMap = new Map<number, { w: number; h: number }>()
+    for (const sp of sheet_pages) {
+      pageImageSizeMap.set(sp.page, sp.correct_image_size)
+    }
+
+    const {
+      regions: cropRegions,
+      part1ToCropIds,
+      regionToCropIds,
+      scorePCropIdByPart1,
+      scoreRCropIdByRegion,
+    } = convertFieldsToCropRegions(sheet_fields, pageUuidMap, pageImageSizeMap, now)
+
+    // 7. SubtotalGroup / Subtotal / CropSubtotal 生成
+    const subtotalData = generateHszSubtotalData(
+      part1ToCropIds,
+      regionToCropIds,
+      scorePCropIdByPart1,
+      scoreRCropIdByRegion,
+      projectId,
+      now
+    )
+
+    // 8. プロジェクトデータ構築
+    const subjectName =
+      HSZ_SUBJECT_MAP[sheets.subject_id] || `教科${sheets.subject_id}`
+
+    const projectData = {
+      project: {
+        id: projectId,
+        examName: sheets.title_name,
+        examDate: null,
+        subject: subjectName,
+        description: `百問繚乱からインポート（${sheets.course}）`,
+        createdAt: now,
+        updatedAt: now,
+      },
+      projectPages,
+      cropRegions,
+      pageImages: [], // v1.2.0以降は使用しない
+      masterImages,
+      studentAnswerImages: [],
+      projectStudents: [],
+      userProjects: [],
+      projectSubtotalGroups: subtotalData.projectSubtotalGroups,
+      projectClasses: [],
+      projectMarkingFormats: [],
+      projectExportSettings: null,
+      cropRegionMarkingOverrides: [],
+    }
+
+    // 9. manifest 生成
+    const manifest = {
+      version: CURRENT_VERSION,
+      schemaVersion: "hsz-import",
+      appVersion: "0.0.0",
+      exportedAt: now,
+      sourceDbId: `hsz:${sheets.id}`,
+      projectId,
+      projectName: sheets.title_name,
+      exportMode: "template_with_subtotals",
+      counts: {
+        students: 0,
+        classes: 0,
+        users: 0,
+        pages: projectPages.length,
+        regions: cropRegions.length,
+        scores: 0,
+        annotations: 0,
+        subtotalGroups: subtotalData.subtotalGroups.length,
+        masterImages: masterImages.length,
+        answerSheetImages: 0,
+      },
+    }
+
+    // 10. .score ZIP ファイルを生成
+    const scoreZip = new AdmZip()
+
+    // JSON ファイル追加
+    scoreZip.addFile(
+      "manifest.json",
+      Buffer.from(JSON.stringify(manifest, null, 2))
+    )
+    scoreZip.addFile(
+      "project.json",
+      Buffer.from(JSON.stringify(projectData, null, 2))
+    )
+    scoreZip.addFile(
+      "students.json",
+      Buffer.from(JSON.stringify({ students: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "classes.json",
+      Buffer.from(JSON.stringify({ classes: [], memberships: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "users.json",
+      Buffer.from(JSON.stringify({ users: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "subtotals.json",
+      Buffer.from(
+        JSON.stringify(
+          {
+            subtotalGroups: subtotalData.subtotalGroups,
+            subtotals: subtotalData.subtotals,
+            cropSubtotals: subtotalData.cropSubtotals,
+          },
+          null,
+          2
+        )
+      )
+    )
+    scoreZip.addFile(
+      "scores.json",
+      Buffer.from(
+        JSON.stringify({ questionScores: [], drawingAnnotations: [] }, null, 2)
+      )
+    )
+    scoreZip.addFile(
+      "subjects.json",
+      Buffer.from(
+        JSON.stringify({ subjects: [], subjectSubtotalGroups: [] }, null, 2)
+      )
+    )
+
+    // 模範解答画像をmaster-images/にコピー
+    for (const sp of sheet_pages) {
+      const imgFileName = `correct_${sp.page}.png`
+      const imgEntry = entries.find((e) => e.entryName === imgFileName)
+      if (imgEntry) {
+        scoreZip.addFile(`master-images/${imgFileName}`, imgEntry.getData())
+      }
+    }
+
+    // 一時ファイルに書き出し
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hsz-convert-"))
+    const scorePath = path.join(tempDir, "converted.score")
+    scoreZip.writeZip(scorePath)
+
+    return {
+      success: true,
+      scorePath,
+      originalTitle: sheets.title_name,
+    }
+  } catch (error) {
+    console.error("Error converting HSZ to Score:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : ".hsz ファイルの変換に失敗しました",
+    }
+  }
+}
+
+/** convertFieldsToCropRegions の結果 */
+interface HszCropRegionsResult {
+  regions: Array<{
+    id: string
+    projectPageId: string
+    label: string
+    type: string
+    x: number
+    y: number
+    width: number
+    height: number
+    points: number | null
+    orderIndex: number | null
+    createdAt: string
+    updatedAt: string
+  }>
+  /** part1 → QUESTION_ANSWER CropRegion ID（大問グループ紐付け用） */
+  part1ToCropIds: Map<string, string[]>
+  /** region → QUESTION_ANSWER CropRegion ID（観点グループ紐付け用） */
+  regionToCropIds: Map<string, string[]>
+  /** part1 → score_p CropRegion ID（小計表示エリア → 大問 SUBTOTAL_DEFINITION） */
+  scorePCropIdByPart1: Map<string, string>
+  /** region → score_r CropRegion ID（観点表示エリア → 観点 SUBTOTAL_DEFINITION） */
+  scoreRCropIdByRegion: Map<string, string>
+}
+
+/**
+ * sheet_fields → CropRegions 変換
+ *
+ * 百問繚乱のrim座標（ピクセル）をScore at Onceの正規化座標（0-1）に変換する
+ */
+function convertFieldsToCropRegions(
+  fields: HszSheetField[],
+  pageUuidMap: Map<number, string>,
+  pageImageSizeMap: Map<number, { w: number; h: number }>,
+  now: string
+): HszCropRegionsResult {
+  const regions: HszCropRegionsResult["regions"] = []
+  const part1ToCropIds = new Map<string, string[]>()
+  const regionToCropIds = new Map<string, string[]>()
+  const scorePCropIdByPart1 = new Map<string, string>()
+  const scoreRCropIdByRegion = new Map<string, string>()
+
+  let orderIndex = 0
+
+  for (const field of fields) {
+    // rimがnullまたはスキップ対象のkindはスキップ
+    if (!field.rim) continue
+    if (HSZ_SKIP_KINDS.has(field.kind)) continue
+
+    // kindからCropRegionタイプを決定
+    const cropType = HSZ_KIND_TO_CROP_TYPE[field.kind]
+    if (!cropType) continue
+
+    // ページのUUIDを取得
+    const projectPageId = pageUuidMap.get(field.page)
+    if (!projectPageId) continue
+
+    // ページの画像サイズを取得（正規化用）
+    const imageSize = pageImageSizeMap.get(field.page)
+    if (!imageSize || imageSize.w === 0 || imageSize.h === 0) continue
+
+    // ラベル生成
+    const label = buildLabel(field)
+
+    const id = generateUuid()
+
+    // ピクセル座標 → 正規化座標（0-1）に変換
+    regions.push({
+      id,
+      projectPageId,
+      label,
+      type: cropType,
+      x: field.rim.l / imageSize.w,
+      y: field.rim.t / imageSize.h,
+      width: field.rim.w / imageSize.w,
+      height: field.rim.h / imageSize.h,
+      points: field.allot ?? null,
+      orderIndex: cropType === "QUESTION_ANSWER" ? orderIndex++ : null,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // サブトータル紐付け用マッピングを記録
+    if (field.kind === "q") {
+      if (field.part1) {
+        const ids = part1ToCropIds.get(field.part1) || []
+        ids.push(id)
+        part1ToCropIds.set(field.part1, ids)
+      }
+      if (field.region) {
+        const ids = regionToCropIds.get(field.region) || []
+        ids.push(id)
+        regionToCropIds.set(field.region, ids)
+      }
+    } else if (field.kind === "score_p" && field.part1) {
+      scorePCropIdByPart1.set(field.part1, id)
+    } else if (field.kind === "score_r" && field.region) {
+      scoreRCropIdByRegion.set(field.region, id)
+    }
+  }
+
+  return {
+    regions,
+    part1ToCropIds,
+    regionToCropIds,
+    scorePCropIdByPart1,
+    scoreRCropIdByRegion,
+  }
+}
+
+/**
+ * フィールドのpart1/part2/part3からラベルを生成
+ *
+ * 例:
+ * - part1="1", part2="", part3="1" → "1(1)"
+ * - part1="1", part2=null, part3=null → "1"
+ * - kind="ssk_no" → "出席番号"
+ * - kind="name" → "氏名"
+ * - kind="score" → "合計"
+ * - kind="score_r", region="11" → "観点11"
+ * - kind="score_p", part1="1" → "小計1"
+ */
+function buildLabel(field: HszSheetField): string {
+  switch (field.kind) {
+    case "ssk_no":
+      return "出席番号"
+    case "name":
+      return "氏名"
+    case "score":
+      return "合計"
+    case "score_r":
+      return field.region ? `観点${field.region}` : "観点"
+    case "score_p":
+      return field.part1 ? `小計${field.part1}` : "小計"
+    case "q": {
+      const parts: string[] = []
+      if (field.part1) parts.push(field.part1)
+      if (field.part2) parts.push(field.part2)
+      if (field.part3) parts.push(field.part3)
+
+      if (parts.length === 0) return `問${field.sort_no}`
+      if (parts.length === 1) return parts[0]
+      // part1(part2) or part1(part3)
+      return `${parts[0]}(${parts.slice(1).join("-")})`
+    }
+    default:
+      return `field_${field.sort_no}`
+  }
+}
+
+/** SubtotalGroup/Subtotal/CropSubtotal/ProjectSubtotalGroup の生成結果 */
+interface HszSubtotalResult {
+  subtotalGroups: Array<{
+    id: string
+    name: string
+    createdAt: string
+    updatedAt: string
+  }>
+  subtotals: Array<{
+    id: string
+    name: string
+    subtotalGroupId: string
+    order: number
+    createdAt: string
+    updatedAt: string
+  }>
+  cropSubtotals: Array<{
+    id: string
+    cropRegionId: string
+    subtotalId: string
+    assignmentType: string
+    createdAt: string
+    updatedAt: string
+  }>
+  projectSubtotalGroups: Array<{
+    id: string
+    projectId: string
+    subtotalGroupId: string
+  }>
+}
+
+/**
+ * 百問繚乱のフィールドデータから SubtotalGroup/Subtotal/CropSubtotal を生成
+ *
+ * 2つのSubtotalGroupを作成:
+ * 1. 「大問」: part1（大問番号）でグループ化
+ *    - QUESTION_ASSIGNMENT: 各設問CropRegion → 対応する大問Subtotal
+ *    - SUBTOTAL_DEFINITION: score_p CropRegion → 対応する大問Subtotal
+ * 2. 「観点」: region（観点コード）でグループ化
+ *    - QUESTION_ASSIGNMENT: 各設問CropRegion → 対応する観点Subtotal
+ *    - SUBTOTAL_DEFINITION: score_r CropRegion → 対応する観点Subtotal
+ */
+function generateHszSubtotalData(
+  part1ToCropIds: Map<string, string[]>,
+  regionToCropIds: Map<string, string[]>,
+  scorePCropIdByPart1: Map<string, string>,
+  scoreRCropIdByRegion: Map<string, string>,
+  projectId: string,
+  now: string
+): HszSubtotalResult {
+  const subtotalGroups: HszSubtotalResult["subtotalGroups"] = []
+  const subtotals: HszSubtotalResult["subtotals"] = []
+  const cropSubtotals: HszSubtotalResult["cropSubtotals"] = []
+  const projectSubtotalGroups: HszSubtotalResult["projectSubtotalGroups"] = []
+
+  // ========================================
+  // 1. 「大問」SubtotalGroup
+  // ========================================
+
+  if (part1ToCropIds.size > 0) {
+    const daimonGroupId = generateUuid()
+    subtotalGroups.push({
+      id: daimonGroupId,
+      name: "大問",
+      createdAt: now,
+      updatedAt: now,
+    })
+    projectSubtotalGroups.push({
+      id: generateUuid(),
+      projectId,
+      subtotalGroupId: daimonGroupId,
+    })
+
+    // part1をソートしてSubtotalを作成
+    const sortedPart1s = Array.from(part1ToCropIds.keys()).sort(
+      (a, b) => parseInt(a, 10) - parseInt(b, 10)
+    )
+    const part1ToSubtotalId = new Map<string, string>()
+
+    for (let i = 0; i < sortedPart1s.length; i++) {
+      const part1 = sortedPart1s[i]
+      const subtotalId = generateUuid()
+      part1ToSubtotalId.set(part1, subtotalId)
+
+      subtotals.push({
+        id: subtotalId,
+        name: `大問${part1}`,
+        subtotalGroupId: daimonGroupId,
+        order: i,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // QUESTION_ASSIGNMENT: 各設問CropRegion → 大問Subtotal
+    for (const [part1, cropIds] of part1ToCropIds) {
+      const subtotalId = part1ToSubtotalId.get(part1)
+      if (!subtotalId) continue
+
+      for (const cropId of cropIds) {
+        cropSubtotals.push({
+          id: generateUuid(),
+          cropRegionId: cropId,
+          subtotalId,
+          assignmentType: "QUESTION_ASSIGNMENT",
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+
+    // SUBTOTAL_DEFINITION: score_p CropRegion → 大問Subtotal
+    for (const [part1, cropId] of scorePCropIdByPart1) {
+      const subtotalId = part1ToSubtotalId.get(part1)
+      if (!subtotalId) continue
+
+      cropSubtotals.push({
+        id: generateUuid(),
+        cropRegionId: cropId,
+        subtotalId,
+        assignmentType: "SUBTOTAL_DEFINITION",
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+  }
+
+  // ========================================
+  // 2. 「観点」SubtotalGroup
+  // ========================================
+
+  if (regionToCropIds.size > 0) {
+    const kantenGroupId = generateUuid()
+    subtotalGroups.push({
+      id: kantenGroupId,
+      name: "観点",
+      createdAt: now,
+      updatedAt: now,
+    })
+    projectSubtotalGroups.push({
+      id: generateUuid(),
+      projectId,
+      subtotalGroupId: kantenGroupId,
+    })
+
+    // regionをソートしてSubtotalを作成
+    const sortedRegions = Array.from(regionToCropIds.keys()).sort(
+      (a, b) => parseInt(a, 10) - parseInt(b, 10)
+    )
+    const regionToSubtotalId = new Map<string, string>()
+
+    for (let i = 0; i < sortedRegions.length; i++) {
+      const region = sortedRegions[i]
+      const subtotalId = generateUuid()
+      regionToSubtotalId.set(region, subtotalId)
+
+      subtotals.push({
+        id: subtotalId,
+        name: `観点${region}`,
+        subtotalGroupId: kantenGroupId,
+        order: i,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // QUESTION_ASSIGNMENT: 各設問CropRegion → 観点Subtotal
+    for (const [region, cropIds] of regionToCropIds) {
+      const subtotalId = regionToSubtotalId.get(region)
+      if (!subtotalId) continue
+
+      for (const cropId of cropIds) {
+        cropSubtotals.push({
+          id: generateUuid(),
+          cropRegionId: cropId,
+          subtotalId,
+          assignmentType: "QUESTION_ASSIGNMENT",
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+
+    // SUBTOTAL_DEFINITION: score_r CropRegion → 観点Subtotal
+    for (const [region, cropId] of scoreRCropIdByRegion) {
+      const subtotalId = regionToSubtotalId.get(region)
+      if (!subtotalId) continue
+
+      cropSubtotals.push({
+        id: generateUuid(),
+        cropRegionId: cropId,
+        subtotalId,
+        assignmentType: "SUBTOTAL_DEFINITION",
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+  }
+
+  return { subtotalGroups, subtotals, cropSubtotals, projectSubtotalGroups }
+}
+
+/**
+ * UUID v4 生成
+ */
+function generateUuid(): string {
+  return crypto.randomUUID()
+}

--- a/electron-src/lib/import/external-formats/hsz/index.ts
+++ b/electron-src/lib/import/external-formats/hsz/index.ts
@@ -1,0 +1,2 @@
+export { convertHszToScore } from "./hszConverter"
+export type { HszDbInfo, HszSheet, HszSheetField, HszSheetPage } from "./types"

--- a/electron-src/lib/import/external-formats/hsz/types.ts
+++ b/electron-src/lib/import/external-formats/hsz/types.ts
@@ -1,0 +1,239 @@
+/**
+ * 百問繚乱 .hsz ファイルの型定義
+ *
+ * .hszはZIPアーカイブで、以下を含む:
+ * - db_info.json: シート・フィールド定義
+ * - correct_N.png: 模範解答画像（ページ番号N）
+ * - correct_homography_info_N.json: OpenCV射影変換用特徴点データ（未使用）
+ */
+
+// =============================================================================
+// db_info.json のルート構造
+// =============================================================================
+
+export interface HszDbInfo {
+  sheets: HszSheet
+  sheet_pages: HszSheetPage[]
+  sheet_fields: HszSheetField[]
+}
+
+// =============================================================================
+// sheets: シート（試験）のメタ情報
+// =============================================================================
+
+export interface HszSheet {
+  id: number
+  /** 教科ID（HSZ_SUBJECT_MAP参照） */
+  subject_id: number
+  /** ページ数 */
+  page_count: number
+  /** 配点合計（nullの場合あり） */
+  allot: number | null
+  /** 試験タイトル（例: "Wプリント 評価プリント 東書 英語1 10回 1年 英語"） */
+  title_name: string
+  /** フィールド名設定完了フラグ */
+  field_names_completed: boolean
+  /** 模範解答画像設定完了フラグ */
+  corretct_image_completed: boolean // 原文ママ（typo）
+  /** フィールド位置設定完了フラグ */
+  field_positions_completed: boolean
+  /** コース名 */
+  course: string
+  /** 採点ルール有無 */
+  has_saiten_rule: boolean
+  created_at: string
+  updated_at: string
+  /** 学年コード（21=中1等） */
+  grade: number
+  /** 支社ID */
+  branch_id: string
+  /** 年度 */
+  nendo: number
+
+  // --- 以下は百問繚乱固有の設定（Score at Onceでは未使用） ---
+  /** マークサイズ（ピクセル） */
+  marking_size: number
+  /** 空矩形位置情報 */
+  position_config_info: { empry_rects: unknown[] } // 原文ママ（typo）
+  meta: Record<string, unknown>
+  /** フィールドマージン（ピクセル） */
+  field_margin: number
+  /** マーク形状（"n"=なし等） */
+  mark_shape: string
+  /** マーク位置（"center-front"等） */
+  marking_position: string
+  /** 出席番号OCR桁数（0=使用しない） */
+  syusseki_no_ocr_digit: number
+  /** 採点回数 */
+  saiten_count: number
+  src_id: string | null
+  position_configed_at: string | null
+  /** 同時採点数 */
+  douji_saiten_count: number
+  /** part3編集モード */
+  is_edit_part3: boolean
+}
+
+// =============================================================================
+// sheet_pages: ページ情報
+// =============================================================================
+
+export interface HszSheetPage {
+  id: number
+  sheet_id: number
+  /** 0始まりのページ番号 */
+  page: number
+  /** 補正位置情報 */
+  hosei_position: Record<string, unknown>
+  /** 模範解答画像サイズ（w, h ピクセル） */
+  correct_image_size: { w: number; h: number }
+  /** QRコード情報 */
+  qr: unknown | null
+  created_at: string
+  updated_at: string
+}
+
+// =============================================================================
+// sheet_fields: フィールド（設問・メタ領域）定義
+// =============================================================================
+
+export interface HszSheetField {
+  id: number
+  sheet_id: number
+  /**
+   * フィールド種別
+   * - "q": 設問（採点対象）
+   * - "ssk_no": 出席番号
+   * - "name": 氏名
+   * - "score": 合計点
+   * - "score_r": 観点別合計（region付き）
+   * - "score_p": 大問小計
+   * - "print_ssk_no": 印刷用出席番号
+   * - "print_datetime": 印刷日時
+   */
+  kind: HszFieldKind
+  /** 0始まりのページ番号 */
+  page: number
+  /** ソート順 */
+  sort_no: number
+  /** 大問番号（例: "1", "2"） */
+  part1: string | null
+  /** 中問番号（例: "1", ""） */
+  part2: string | null
+  /** 小問番号（例: "1", "2"） */
+  part3: string | null
+  /** 配点 */
+  allot: number | null
+  /** 観点コード（例: "11", "12"） */
+  region: string | null
+  /**
+   * 領域矩形（ピクセル座標）
+   * l=left, t=top, w=width, h=height
+   * nullの場合はスキップ対象
+   */
+  rim: HszFieldRim | null
+
+  // --- 以下は百問繚乱固有の設定（Score at Onceでは未使用） ---
+  /** 採点方式（"partial"=部分点あり等） */
+  saiten_kind: string | null
+  created_at: string
+  updated_at: string
+  /** マーク位置自動計算 */
+  marking_pos_auto: boolean | null
+  /** マーク位置オフセット */
+  marking_pos: { l: number; t: number } | null
+  /** マーク使用フラグ */
+  is_mark: boolean
+  /** マーク詳細情報 */
+  mark_info: Record<string, unknown>
+  /** OCR1文字モード */
+  is_ocr_one: boolean
+  ocr_one_kind: string | null
+  m_tangen_id: string | null
+  src_id: string | null
+  cbt_m_tangen_id: string | null
+  /** ランダム出題順 */
+  is_random_order: boolean
+  /** 完答方式 */
+  is_complete_answer: boolean
+  /** 正答 */
+  correct_answer: string | null
+  /** 採点方式詳細 */
+  saiten_houshiki: string | null
+}
+
+/**
+ * フィールドの矩形座標（ピクセル）
+ */
+export interface HszFieldRim {
+  /** left: X座標 */
+  l: number
+  /** top: Y座標 */
+  t: number
+  /** width: 幅 */
+  w: number
+  /** height: 高さ */
+  h: number
+}
+
+// =============================================================================
+// フィールド種別
+// =============================================================================
+
+export type HszFieldKind =
+  | "q" // 設問（採点対象）
+  | "ssk_no" // 出席番号
+  | "name" // 氏名
+  | "score" // 合計点
+  | "score_r" // 観点別合計
+  | "score_p" // 大問小計
+  | "print_ssk_no" // 印刷用出席番号
+  | "print_datetime" // 印刷日時
+
+// =============================================================================
+// マッピング定数
+// =============================================================================
+
+/**
+ * 百問繚乱の subject_id → 教科名マッピング
+ *
+ * 百問繚乱のsubject_idは以下の値を取る（推定）:
+ * 1=国語, 2=数学, 3=理科, 4=英語, 5=社会
+ */
+export const HSZ_SUBJECT_MAP: Record<number, string> = {
+  1: "国語",
+  2: "数学",
+  3: "理科",
+  4: "英語",
+  5: "社会",
+}
+
+/**
+ * Score at OnceのCropRegionタイプへのマッピング
+ *
+ * 百問繚乱のkind → Score at OnceのCropRegion.type (CropRegionAreaType):
+ * - "q" → "QUESTION_ANSWER": 設問（採点対象）
+ * - "ssk_no" → "STUDENT_ID": 出席番号
+ * - "name" → "STUDENT_NAME": 氏名
+ * - "score" → "TOTAL_SCORE": 合計点
+ * - "score_r" → "SUBTOTAL_SCORE": 観点別合計
+ * - "score_p" → "SUBTOTAL_SCORE": 大問小計
+ */
+export const HSZ_KIND_TO_CROP_TYPE: Partial<Record<HszFieldKind, string>> = {
+  q: "QUESTION_ANSWER",
+  ssk_no: "STUDENT_ID",
+  name: "STUDENT_NAME",
+  score: "TOTAL_SCORE",
+  score_r: "SUBTOTAL_SCORE",
+  score_p: "SUBTOTAL_SCORE",
+}
+
+/**
+ * スキップするフィールド種別
+ *
+ * これらのkindは印刷用メタ情報であり、採点領域として不要
+ */
+export const HSZ_SKIP_KINDS: Set<HszFieldKind> = new Set([
+  "print_ssk_no",
+  "print_datetime",
+])

--- a/electron-src/lib/import/external-formats/reattendant/datConverter.ts
+++ b/electron-src/lib/import/external-formats/reattendant/datConverter.ts
@@ -1,0 +1,937 @@
+/**
+ * リアテンダント .dat → .score 変換ロジック
+ *
+ * .datファイルを内部的に.score形式（テンプレートモード）に変換し、
+ * 既存のインポートパイプラインに乗せる。
+ *
+ * データマッピング:
+ *   AreaBlock[AREA_NO]               → type: STUDENT_ID, label: "出席番号"
+ *   AreaBlock[AREA_NAME]             → type: STUDENT_NAME, label: "氏名"
+ *   QuationBlock[FREE].PointArea     → type: QUESTION_ANSWER
+ *   QuationBlock[PARTIAL_MATCH]
+ *     .Completion[i].PointArea       → type: QUESTION_ANSWER, label: "QuizName(i+1)"
+ *   TotalScoreArea (abc_xml)         → type: TOTAL_SCORE, label: "合計"
+ *   LargeQuestionScoreArea (abc_xml) → type: SUBTOTAL_SCORE, label: "小計N"
+ *   AngleScoreArea (abc_xml)         → type: SUBTOTAL_SCORE, label: "観点"
+ *   座標正規化:
+ *     abcData JS座標 / (フル画像幅 × image_scale)
+ *     abc_xml座標 / フル画像サイズ（PageSize）
+ *   Correct/abc_m*.png               → master-images/
+ */
+
+import AdmZip from "adm-zip"
+import * as crypto from "crypto"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import { CURRENT_VERSION } from "../../transformers/types"
+import type {
+  DatAbcData,
+  DatAngle,
+  DatContents,
+  DatPageBlock,
+  DatQuationBlock,
+  DatQuestion,
+  DatQuestionAngle,
+  DatWorkbook,
+} from "./types"
+import {
+  DAT_AREA_TYPE_TO_CROP_TYPE,
+  DAT_AREA_TYPE_TO_LABEL,
+  DAT_SUBJECT_MAP,
+} from "./types"
+
+/** CropRegionデータ */
+interface CropRegionData {
+  id: string
+  projectPageId: string
+  label: string
+  type: string
+  x: number
+  y: number
+  width: number
+  height: number
+  points: number | null
+  orderIndex: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+interface ConvertDatResult {
+  success: boolean
+  /** 変換後の.scoreファイルパス（一時ディレクトリ内） */
+  scorePath?: string
+  /** 元の試験タイトル */
+  originalTitle?: string
+  error?: string
+}
+
+/**
+ * .datファイルを.score形式に変換
+ */
+export async function convertDatToScore(
+  datPath: string
+): Promise<ConvertDatResult> {
+  try {
+    // 1. .datをZIPとして開く
+    const datZip = new AdmZip(datPath)
+    const entries = datZip.getEntries()
+
+    // 2. RealtendantAppVersion.txt で検証
+    const versionEntry = entries.find((e) =>
+      e.entryName.endsWith("RealtendantAppVersion.txt")
+    )
+    if (!versionEntry) {
+      return {
+        success: false,
+        error:
+          "リアテンダントのデータファイルではありません（RealtendantAppVersion.txt が見つかりません）",
+      }
+    }
+
+    // 3. contents.json → image_scale取得
+    const contentsEntry = entries.find((e) =>
+      e.entryName.endsWith("contents.json")
+    )
+    if (!contentsEntry) {
+      return { success: false, error: "contents.json が見つかりません" }
+    }
+    const contentsArray: DatContents[] = JSON.parse(
+      contentsEntry.getData().toString("utf8")
+    )
+    const contents = contentsArray[0]
+    if (!contents) {
+      return { success: false, error: "contents.json が空です" }
+    }
+    const imageScale = contents.image_scale || 0.5
+
+    // 4. workbooks.json → プロジェクト名・教科取得
+    const workbooksEntry = entries.find((e) =>
+      e.entryName.endsWith("workbooks.json")
+    )
+    if (!workbooksEntry) {
+      return { success: false, error: "workbooks.json が見つかりません" }
+    }
+    const workbooks: DatWorkbook[] = JSON.parse(
+      workbooksEntry.getData().toString("utf8")
+    )
+    const workbook = workbooks[0]
+    if (!workbook) {
+      return { success: false, error: "workbooks.json が空です" }
+    }
+
+    // 5. .jsファイルを発見し、abcDataをパース
+    const jsEntry = entries.find(
+      (e) => e.entryName.endsWith(".js") && !e.entryName.endsWith("_answer.js")
+    )
+    if (!jsEntry) {
+      return {
+        success: false,
+        error: "座標データの .js ファイルが見つかりません",
+      }
+    }
+    const jsContent = jsEntry.getData().toString("utf8")
+    const jsonStr = jsContent.replace(/^var\s+abcData\s*=\s*/, "")
+    let abcData: DatAbcData
+    try {
+      abcData = JSON.parse(jsonStr)
+    } catch {
+      return { success: false, error: "座標データのパースに失敗しました" }
+    }
+
+    // 6. workbook_infoes.json → abc_xml（スコア印字エリア情報）
+    const workbookInfoEntry = entries.find((e) =>
+      e.entryName.endsWith("workbook_infoes.json")
+    )
+    let abcXml: string | null = null
+    if (workbookInfoEntry) {
+      try {
+        const infoes: Array<{ abc_xml?: string | null }> = JSON.parse(
+          workbookInfoEntry.getData().toString("utf8")
+        )
+        abcXml = infoes[0]?.abc_xml ?? null
+      } catch {
+        // パース失敗時はスコアエリア無しで続行
+      }
+    }
+
+    // 7. 模範解答画像を発見し、PNGヘッダーから画像サイズを取得
+    const masterImageEntries = entries
+      .filter(
+        (e) =>
+          e.entryName.includes("/Correct/abc_m") &&
+          e.entryName.endsWith(".png")
+      )
+      .sort((a, b) => a.entryName.localeCompare(b.entryName))
+
+    if (masterImageEntries.length === 0) {
+      return { success: false, error: "模範解答画像が見つかりません" }
+    }
+
+    // ページ番号 → 画像サイズ（フルスケール）
+    const pageImageSizes = new Map<number, { w: number; h: number }>()
+    for (let i = 0; i < masterImageEntries.length; i++) {
+      const imgBuffer = masterImageEntries[i].getData()
+      const width = imgBuffer.readUInt32BE(16)
+      const height = imgBuffer.readUInt32BE(20)
+      pageImageSizes.set(i + 1, { w: width, h: height })
+    }
+
+    // 8. UUID生成とプロジェクト構築
+    const projectId = generateUuid()
+    const now = new Date().toISOString()
+
+    // ページ番号 → UUID マッピング
+    const pageUuidMap = new Map<number, string>()
+    for (let pageNo = 1; pageNo <= abcData.PageMax; pageNo++) {
+      pageUuidMap.set(pageNo, generateUuid())
+    }
+
+    // ProjectPages 生成
+    const projectPages = Array.from(pageUuidMap.entries()).map(
+      ([pageNo, id]) => ({
+        id,
+        projectId,
+        pageNumber: pageNo,
+        createdAt: now,
+        updatedAt: now,
+      })
+    )
+
+    // MasterImages 生成
+    const masterImages: Array<{
+      id: string
+      projectPageId: string
+      imagePath: string
+      createdAt: string
+      updatedAt: string
+    }> = []
+    for (let i = 0; i < masterImageEntries.length; i++) {
+      const pageNo = i + 1
+      const pageId = pageUuidMap.get(pageNo)
+      if (pageId) {
+        masterImages.push({
+          id: generateUuid(),
+          projectPageId: pageId,
+          imagePath: `abc_m${String(pageNo).padStart(2, "0")}.png`,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+
+    // 9. questions.json, angles.json, question_angles.json 読み込み
+    const questionsEntry = entries.find((e) =>
+      e.entryName.endsWith("questions.json")
+    )
+    const questions: DatQuestion[] = questionsEntry
+      ? JSON.parse(questionsEntry.getData().toString("utf8"))
+      : []
+
+    const anglesEntry = entries.find((e) =>
+      e.entryName.endsWith("angles.json")
+    )
+    const angles: DatAngle[] = anglesEntry
+      ? JSON.parse(anglesEntry.getData().toString("utf8"))
+      : []
+
+    const questionAnglesEntry = entries.find((e) =>
+      e.entryName.endsWith("question_angles.json")
+    )
+    const questionAngles: DatQuestionAngle[] = questionAnglesEntry
+      ? JSON.parse(questionAnglesEntry.getData().toString("utf8"))
+      : []
+
+    // 10. CropRegions 生成（設問 + 出席番号/氏名）
+    const { regions: questionRegions, quizNameToCropIds } =
+      convertPageBlocksToCropRegions(
+        abcData.PageBlock,
+        pageUuidMap,
+        pageImageSizes,
+        imageScale,
+        now
+      )
+    const cropRegions = [...questionRegions]
+
+    // 11. abc_xml からスコア印字エリアを抽出してCropRegionsに追加
+    let largeQuestionToCropId = new Map<string, string>()
+    if (abcXml) {
+      const scoreAreaResult = extractScoreAreasFromAbcXml(
+        abcXml,
+        pageUuidMap,
+        pageImageSizes,
+        now
+      )
+      cropRegions.push(...scoreAreaResult.regions)
+      largeQuestionToCropId = scoreAreaResult.largeQuestionToCropId
+    }
+
+    // 12. SubtotalGroup / Subtotal / CropSubtotal 生成
+    const subtotalData = generateSubtotalData(
+      questions,
+      angles,
+      questionAngles,
+      quizNameToCropIds,
+      largeQuestionToCropId,
+      projectId,
+      now
+    )
+
+    // 13. プロジェクトデータ構築
+    const subjectName =
+      DAT_SUBJECT_MAP[workbook.subject_id] ||
+      `教科${workbook.subject_id}`
+    const projectTitle = `${contents.contents_name} ${workbook.workbook_name}`
+
+    const projectData = {
+      project: {
+        id: projectId,
+        examName: projectTitle,
+        examDate: null,
+        subject: subjectName,
+        description: `リアテンダントからインポート`,
+        createdAt: now,
+        updatedAt: now,
+      },
+      projectPages,
+      cropRegions,
+      pageImages: [],
+      masterImages,
+      studentAnswerImages: [],
+      projectStudents: [],
+      userProjects: [],
+      projectSubtotalGroups: subtotalData.projectSubtotalGroups,
+      projectClasses: [],
+      projectMarkingFormats: [],
+      projectExportSettings: null,
+      cropRegionMarkingOverrides: [],
+    }
+
+    // 14. manifest 生成
+    const manifest = {
+      version: CURRENT_VERSION,
+      schemaVersion: "dat-import",
+      appVersion: "0.0.0",
+      exportedAt: now,
+      sourceDbId: `dat:${contents.contents_uid}`,
+      projectId,
+      projectName: projectTitle,
+      exportMode: "template_with_subtotals",
+      counts: {
+        students: 0,
+        classes: 0,
+        users: 0,
+        pages: projectPages.length,
+        regions: cropRegions.length,
+        scores: 0,
+        annotations: 0,
+        subtotalGroups: subtotalData.subtotalGroups.length,
+        masterImages: masterImages.length,
+        answerSheetImages: 0,
+      },
+    }
+
+    // 15. .score ZIP ファイルを生成
+    const scoreZip = new AdmZip()
+
+    scoreZip.addFile(
+      "manifest.json",
+      Buffer.from(JSON.stringify(manifest, null, 2))
+    )
+    scoreZip.addFile(
+      "project.json",
+      Buffer.from(JSON.stringify(projectData, null, 2))
+    )
+    scoreZip.addFile(
+      "students.json",
+      Buffer.from(JSON.stringify({ students: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "classes.json",
+      Buffer.from(JSON.stringify({ classes: [], memberships: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "users.json",
+      Buffer.from(JSON.stringify({ users: [] }, null, 2))
+    )
+    scoreZip.addFile(
+      "subtotals.json",
+      Buffer.from(
+        JSON.stringify(
+          {
+            subtotalGroups: subtotalData.subtotalGroups,
+            subtotals: subtotalData.subtotals,
+            cropSubtotals: subtotalData.cropSubtotals,
+          },
+          null,
+          2
+        )
+      )
+    )
+    scoreZip.addFile(
+      "scores.json",
+      Buffer.from(
+        JSON.stringify({ questionScores: [], drawingAnnotations: [] }, null, 2)
+      )
+    )
+    scoreZip.addFile(
+      "subjects.json",
+      Buffer.from(
+        JSON.stringify({ subjects: [], subjectSubtotalGroups: [] }, null, 2)
+      )
+    )
+
+    // 模範解答画像をmaster-images/にコピー
+    for (let i = 0; i < masterImageEntries.length; i++) {
+      const fileName = `abc_m${String(i + 1).padStart(2, "0")}.png`
+      scoreZip.addFile(
+        `master-images/${fileName}`,
+        masterImageEntries[i].getData()
+      )
+    }
+
+    // 一時ファイルに書き出し
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dat-convert-"))
+    const scorePath = path.join(tempDir, "converted.score")
+    scoreZip.writeZip(scorePath)
+
+    return {
+      success: true,
+      scorePath,
+      originalTitle: projectTitle,
+    }
+  } catch (error) {
+    console.error("Error converting DAT to Score:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : ".dat ファイルの変換に失敗しました",
+    }
+  }
+}
+
+/** extractScoreAreasFromAbcXml の結果 */
+interface ScoreAreasResult {
+  regions: CropRegionData[]
+  /** LargeQuestionNumber → CropRegion ID（大問小計の紐付け用） */
+  largeQuestionToCropId: Map<string, string>
+}
+
+/**
+ * abc_xml (workbook_infoes.json内) からスコア印字エリアを抽出
+ *
+ * abc_xmlの<PointInfoBlock>/<AreaInfo>に以下が含まれる:
+ * - TotalScoreArea: 合計点印字位置（フルスケール座標）
+ * - LargeQuestionScoreArea: 大問小計印字位置（LargeQuestionNumber付き）
+ * - AngleScoreArea: 観点別得点印字位置
+ *
+ * 座標はフルスケール（PageSize基準）。正規化: 座標 / フル画像サイズ
+ */
+function extractScoreAreasFromAbcXml(
+  abcXml: string,
+  pageUuidMap: Map<number, string>,
+  pageImageSizes: Map<number, { w: number; h: number }>,
+  now: string
+): ScoreAreasResult {
+  const regions: CropRegionData[] = []
+  const largeQuestionToCropId = new Map<string, string>()
+
+  // 簡易XMLパース（DOMParser不要、正規表現で自己完結型要素を抽出）
+  // TotalScoreArea, LargeQuestionScoreArea, AngleScoreArea は全て自己閉じタグ
+
+  // TotalScoreArea
+  const totalMatches = abcXml.matchAll(
+    /<TotalScoreArea\s+([^/]*?)\/>/g
+  )
+  for (const match of totalMatches) {
+    const attrs = parseXmlAttributes(match[1])
+    const page = parseInt(attrs.Page || "1", 10)
+    const region = createScoreRegion(
+      attrs,
+      page,
+      "TOTAL_SCORE",
+      "合計",
+      pageUuidMap,
+      pageImageSizes,
+      now
+    )
+    if (region) regions.push(region)
+  }
+
+  // LargeQuestionScoreArea（大問小計）
+  const largeMatches = abcXml.matchAll(
+    /<LargeQuestionScoreArea\s+([^/]*?)\/>/g
+  )
+  for (const match of largeMatches) {
+    const attrs = parseXmlAttributes(match[1])
+    if (attrs.Visible === "false") continue
+    const page = parseInt(attrs.Page || "1", 10)
+    const lqNum = attrs.LargeQuestionNumber || "?"
+    const region = createScoreRegion(
+      attrs,
+      page,
+      "SUBTOTAL_SCORE",
+      `小計${lqNum}`,
+      pageUuidMap,
+      pageImageSizes,
+      now
+    )
+    if (region) {
+      regions.push(region)
+      largeQuestionToCropId.set(lqNum, region.id)
+    }
+  }
+
+  // AngleScoreArea（観点別得点）
+  const angleMatches = abcXml.matchAll(
+    /<AngleScoreArea\s+([^/]*?)\/>/g
+  )
+  let angleIndex = 0
+  for (const match of angleMatches) {
+    const attrs = parseXmlAttributes(match[1])
+    if (attrs.Visible === "false") continue
+    const page = parseInt(attrs.Page || "1", 10)
+    angleIndex++
+    const label = angleIndex === 1 ? "観点" : `観点${angleIndex}`
+    const region = createScoreRegion(
+      attrs,
+      page,
+      "SUBTOTAL_SCORE",
+      label,
+      pageUuidMap,
+      pageImageSizes,
+      now
+    )
+    if (region) regions.push(region)
+  }
+
+  return { regions, largeQuestionToCropId }
+}
+
+/**
+ * XML属性文字列をパースしてRecord<string,string>に変換
+ * 例: 'Page="1" X="901" Y="88"' → { Page: "1", X: "901", Y: "88" }
+ */
+function parseXmlAttributes(attrString: string): Record<string, string> {
+  const attrs: Record<string, string> = {}
+  const re = /(\w+)="([^"]*)"/g
+  let m
+  while ((m = re.exec(attrString)) !== null) {
+    attrs[m[1]] = m[2]
+  }
+  return attrs
+}
+
+/**
+ * スコアエリア属性からCropRegionDataを生成
+ *
+ * abc_xmlの座標はフルスケール（PageSize基準）
+ * 正規化: フル画像サイズで割る
+ */
+function createScoreRegion(
+  attrs: Record<string, string>,
+  page: number,
+  type: string,
+  label: string,
+  pageUuidMap: Map<number, string>,
+  pageImageSizes: Map<number, { w: number; h: number }>,
+  now: string
+): CropRegionData | null {
+  const projectPageId = pageUuidMap.get(page)
+  if (!projectPageId) return null
+
+  const imageSize = pageImageSizes.get(page)
+  if (!imageSize || imageSize.w === 0 || imageSize.h === 0) return null
+
+  const x = parseInt(attrs.X || "0", 10)
+  const y = parseInt(attrs.Y || "0", 10)
+  const w = parseInt(attrs.Width || "0", 10)
+  const h = parseInt(attrs.Height || "0", 10)
+
+  // フルスケール座標 → 正規化座標
+  return {
+    id: generateUuid(),
+    projectPageId,
+    label,
+    type,
+    x: x / imageSize.w,
+    y: y / imageSize.h,
+    width: w / imageSize.w,
+    height: h / imageSize.h,
+    points: null,
+    orderIndex: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/** convertPageBlocksToCropRegions の結果 */
+interface CropRegionsResult {
+  regions: CropRegionData[]
+  /** QuizName → CropRegion ID（小計グループ紐付け用） */
+  quizNameToCropIds: Map<string, string[]>
+}
+
+/**
+ * PageBlock[] → CropRegions 変換
+ *
+ * リアテンダントのJS座標（半スケール）をScore at Onceの正規化座標（0-1）に変換する。
+ * 正規化: JS座標 / (フル画像幅 × image_scale)
+ */
+function convertPageBlocksToCropRegions(
+  pageBlocks: DatPageBlock[],
+  pageUuidMap: Map<number, string>,
+  pageImageSizes: Map<number, { w: number; h: number }>,
+  imageScale: number,
+  now: string
+): CropRegionsResult {
+  const regions: CropRegionData[] = []
+  const quizNameToCropIds = new Map<string, string[]>()
+
+  // 全ページを通した設問の連番
+  let questionOrderIndex = 0
+
+  // まず全PageBlockのQuationBlockをSeqでソートして順序を確定
+  const allQuestions: Array<{
+    pageNo: number
+    question: DatQuationBlock
+  }> = []
+  for (const page of pageBlocks) {
+    for (const q of page.QuationBlock) {
+      allQuestions.push({ pageNo: page.PageNo, question: q })
+    }
+  }
+  allQuestions.sort((a, b) => a.question.Seq - b.question.Seq)
+
+  // Seq → orderIndex マッピング
+  const seqToOrderIndex = new Map<number, number>()
+  for (const { question } of allQuestions) {
+    if (question.QuizType === "PARTIAL_MATCH" && question.Completion) {
+      // PARTIAL_MATCH: 各Completionに個別orderIndex
+      for (let i = 0; i < question.Completion.length; i++) {
+        // Seq*1000+i で一意キー（Completion内の順番を区別）
+        seqToOrderIndex.set(question.Seq * 1000 + i, questionOrderIndex++)
+      }
+    } else {
+      seqToOrderIndex.set(question.Seq * 1000, questionOrderIndex++)
+    }
+  }
+
+  /** QuizName → CropRegion ID のヘルパー */
+  function trackQuizName(quizName: string, cropId: string) {
+    const ids = quizNameToCropIds.get(quizName) || []
+    ids.push(cropId)
+    quizNameToCropIds.set(quizName, ids)
+  }
+
+  for (const page of pageBlocks) {
+    const projectPageId = pageUuidMap.get(page.PageNo)
+    if (!projectPageId) continue
+
+    const imageSize = pageImageSizes.get(page.PageNo)
+    if (!imageSize || imageSize.w === 0 || imageSize.h === 0) continue
+
+    // 正規化用の分母: フル画像サイズ × image_scale
+    const normW = imageSize.w * imageScale
+    const normH = imageSize.h * imageScale
+
+    // AreaBlock → STUDENT_ID / STUDENT_NAME
+    for (const area of page.AreaBlock) {
+      const cropType = DAT_AREA_TYPE_TO_CROP_TYPE[area.Type]
+      if (!cropType) continue
+
+      regions.push({
+        id: generateUuid(),
+        projectPageId,
+        label: DAT_AREA_TYPE_TO_LABEL[area.Type] || area.Type,
+        type: cropType,
+        x: area.X / normW,
+        y: area.Y / normH,
+        width: area.Width / normW,
+        height: area.Height / normH,
+        points: null,
+        orderIndex: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // QuationBlock → QUESTION_ANSWER
+    for (const q of page.QuationBlock) {
+      if (q.QuizType === "PARTIAL_MATCH" && q.Completion) {
+        // PARTIAL_MATCH: 各Completionに個別CropRegion
+        for (let i = 0; i < q.Completion.length; i++) {
+          const completion = q.Completion[i]
+          const pointArea = completion.PointArea?.[0]
+          if (!pointArea) continue
+
+          const id = generateUuid()
+          regions.push({
+            id,
+            projectPageId,
+            label: `${q.QuizName}(${i + 1})`,
+            type: "QUESTION_ANSWER",
+            x: pointArea.X / normW,
+            y: pointArea.Y / normH,
+            width: pointArea.Width / normW,
+            height: pointArea.Height / normH,
+            points: q.Score,
+            orderIndex: seqToOrderIndex.get(q.Seq * 1000 + i) ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          trackQuizName(q.QuizName, id)
+        }
+      } else {
+        // FREE: PointArea[0] → 1つのCropRegion
+        const pointArea = q.PointArea?.[0]
+        if (!pointArea) continue
+
+        const id = generateUuid()
+        regions.push({
+          id,
+          projectPageId,
+          label: q.QuizName,
+          type: "QUESTION_ANSWER",
+          x: pointArea.X / normW,
+          y: pointArea.Y / normH,
+          width: pointArea.Width / normW,
+          height: pointArea.Height / normH,
+          points: q.Score,
+          orderIndex: seqToOrderIndex.get(q.Seq * 1000) ?? null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        trackQuizName(q.QuizName, id)
+      }
+    }
+  }
+
+  return { regions, quizNameToCropIds }
+}
+
+/** SubtotalGroup/Subtotal/CropSubtotal/ProjectSubtotalGroup の生成結果 */
+interface SubtotalGenerationResult {
+  subtotalGroups: Array<{
+    id: string
+    name: string
+    createdAt: string
+    updatedAt: string
+  }>
+  subtotals: Array<{
+    id: string
+    name: string
+    subtotalGroupId: string
+    order: number
+    createdAt: string
+    updatedAt: string
+  }>
+  cropSubtotals: Array<{
+    id: string
+    cropRegionId: string
+    subtotalId: string
+    assignmentType: string
+    createdAt: string
+    updatedAt: string
+  }>
+  projectSubtotalGroups: Array<{
+    id: string
+    projectId: string
+    subtotalGroupId: string
+  }>
+}
+
+/**
+ * リアテンダントのデータから SubtotalGroup/Subtotal/CropSubtotal を生成
+ *
+ * 2つのSubtotalGroupを作成:
+ * 1. 「大問」: QuizName のプレフィックス（"1-1"→"1"）でグループ化
+ *    - QUESTION_ASSIGNMENT: 各設問CropRegion → 対応する大問Subtotal
+ *    - SUBTOTAL_DEFINITION: 小計N CropRegion → 大問N Subtotal
+ * 2. 「観点」: angles.json の観点名（知識・技能, 思考・判断・表現）
+ *    - QUESTION_ASSIGNMENT: 各設問CropRegion → question_angles経由で対応する観点Subtotal
+ */
+function generateSubtotalData(
+  questions: DatQuestion[],
+  angles: DatAngle[],
+  questionAngles: DatQuestionAngle[],
+  quizNameToCropIds: Map<string, string[]>,
+  largeQuestionToCropId: Map<string, string>,
+  projectId: string,
+  now: string
+): SubtotalGenerationResult {
+  const subtotalGroups: SubtotalGenerationResult["subtotalGroups"] = []
+  const subtotals: SubtotalGenerationResult["subtotals"] = []
+  const cropSubtotals: SubtotalGenerationResult["cropSubtotals"] = []
+  const projectSubtotalGroups: SubtotalGenerationResult["projectSubtotalGroups"] =
+    []
+
+  // question_name → question_id マッピング
+  const questionNameToId = new Map<string, number>()
+  for (const q of questions) {
+    questionNameToId.set(q.question_name, q.id)
+  }
+
+  // question_id → angle_id マッピング
+  const questionIdToAngleId = new Map<number, number>()
+  for (const qa of questionAngles) {
+    questionIdToAngleId.set(qa.question_id, qa.angle_id)
+  }
+
+  // ========================================
+  // 1. 「大問」SubtotalGroup
+  // ========================================
+
+  // QuizName のプレフィックスを抽出（"1-1" → "1", "2-3" → "2"）
+  const prefixSet = new Set<string>()
+  for (const quizName of quizNameToCropIds.keys()) {
+    const prefix = quizName.split("-")[0]
+    if (prefix) prefixSet.add(prefix)
+  }
+
+  if (prefixSet.size > 0) {
+    const daimonGroupId = generateUuid()
+    subtotalGroups.push({
+      id: daimonGroupId,
+      name: "大問",
+      createdAt: now,
+      updatedAt: now,
+    })
+    projectSubtotalGroups.push({
+      id: generateUuid(),
+      projectId,
+      subtotalGroupId: daimonGroupId,
+    })
+
+    // プレフィックスをソートしてSubtotalを作成
+    const sortedPrefixes = Array.from(prefixSet).sort(
+      (a, b) => parseInt(a, 10) - parseInt(b, 10)
+    )
+    const prefixToSubtotalId = new Map<string, string>()
+
+    for (let i = 0; i < sortedPrefixes.length; i++) {
+      const prefix = sortedPrefixes[i]
+      const subtotalId = generateUuid()
+      prefixToSubtotalId.set(prefix, subtotalId)
+
+      subtotals.push({
+        id: subtotalId,
+        name: `大問${prefix}`,
+        subtotalGroupId: daimonGroupId,
+        order: i,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // QUESTION_ASSIGNMENT: 各設問CropRegion → 大問Subtotal
+    for (const [quizName, cropIds] of quizNameToCropIds) {
+      const prefix = quizName.split("-")[0]
+      const subtotalId = prefixToSubtotalId.get(prefix)
+      if (!subtotalId) continue
+
+      for (const cropId of cropIds) {
+        cropSubtotals.push({
+          id: generateUuid(),
+          cropRegionId: cropId,
+          subtotalId,
+          assignmentType: "QUESTION_ASSIGNMENT",
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+
+    // SUBTOTAL_DEFINITION: 小計N CropRegion → 大問N Subtotal
+    for (const [lqNum, cropId] of largeQuestionToCropId) {
+      const subtotalId = prefixToSubtotalId.get(lqNum)
+      if (!subtotalId) continue
+
+      cropSubtotals.push({
+        id: generateUuid(),
+        cropRegionId: cropId,
+        subtotalId,
+        assignmentType: "SUBTOTAL_DEFINITION",
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+  }
+
+  // ========================================
+  // 2. 「観点」SubtotalGroup
+  // ========================================
+
+  const activeAngles = angles
+    .filter((a) => !a.delete_flg)
+    .sort((a, b) => a.angle_sort_no - b.angle_sort_no)
+
+  if (activeAngles.length > 0 && questionAngles.length > 0) {
+    const kantenGroupId = generateUuid()
+    subtotalGroups.push({
+      id: kantenGroupId,
+      name: "観点",
+      createdAt: now,
+      updatedAt: now,
+    })
+    projectSubtotalGroups.push({
+      id: generateUuid(),
+      projectId,
+      subtotalGroupId: kantenGroupId,
+    })
+
+    // angle_id → Subtotal ID マッピング
+    const angleIdToSubtotalId = new Map<number, string>()
+
+    for (let i = 0; i < activeAngles.length; i++) {
+      const angle = activeAngles[i]
+      const subtotalId = generateUuid()
+      angleIdToSubtotalId.set(angle.id, subtotalId)
+
+      subtotals.push({
+        id: subtotalId,
+        name: angle.angle_name,
+        subtotalGroupId: kantenGroupId,
+        order: i,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // QUESTION_ASSIGNMENT: 各設問CropRegion → 観点Subtotal
+    // QuizName → question_id → angle_id → Subtotal
+    for (const [quizName, cropIds] of quizNameToCropIds) {
+      const questionId = questionNameToId.get(quizName)
+      if (questionId === undefined) continue
+
+      const angleId = questionIdToAngleId.get(questionId)
+      if (angleId === undefined) continue
+
+      const subtotalId = angleIdToSubtotalId.get(angleId)
+      if (!subtotalId) continue
+
+      for (const cropId of cropIds) {
+        cropSubtotals.push({
+          id: generateUuid(),
+          cropRegionId: cropId,
+          subtotalId,
+          assignmentType: "QUESTION_ASSIGNMENT",
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+  }
+
+  return { subtotalGroups, subtotals, cropSubtotals, projectSubtotalGroups }
+}
+
+/**
+ * UUID v4 生成
+ */
+function generateUuid(): string {
+  return crypto.randomUUID()
+}

--- a/electron-src/lib/import/external-formats/reattendant/index.ts
+++ b/electron-src/lib/import/external-formats/reattendant/index.ts
@@ -1,0 +1,8 @@
+export { convertDatToScore } from "./datConverter"
+export type {
+  DatAbcData,
+  DatContents,
+  DatPageBlock,
+  DatQuestion,
+  DatWorkbook,
+} from "./types"

--- a/electron-src/lib/import/external-formats/reattendant/types.ts
+++ b/electron-src/lib/import/external-formats/reattendant/types.ts
@@ -1,0 +1,173 @@
+/**
+ * リアテンダント .dat ファイルの型定義
+ *
+ * .datはZIPアーカイブで、以下を含む:
+ * - 1/RealtendantAppVersion.txt: バージョン情報（検出用）
+ * - 1/contents.json: コンテンツ情報（image_scale等）
+ * - 1/workbooks.json: テスト情報（名前、教科、満点）
+ * - 1/questions.json: 設問定義（question_name, score_allocation）
+ * - 1/angles.json: 観点（知識・技能, 思考・判断・表現）
+ * - 1/question_angles.json: 設問→観点紐付け
+ * - 1/{uid}@{ver}/1/Correct/abc_m*.png: 模範解答画像（フルスケール）
+ * - 1/{uid}@{ver}/1(html)/{wid}/json/{wid}.js: 座標データ (var abcData={...})
+ */
+
+// =============================================================================
+// contents.json
+// =============================================================================
+
+export interface DatContents {
+  id: number
+  contents_uid: string
+  contents_name: string
+  version: string
+  /** 座標スケール（通常 0.5） */
+  image_scale: number
+}
+
+// =============================================================================
+// workbooks.json
+// =============================================================================
+
+export interface DatWorkbook {
+  id: number
+  workbook_uid: string
+  workbook_name: string
+  workbook_display_name: string
+  /** 教科ID */
+  subject_id: number
+  /** 満点 */
+  full_score: number
+  /** 設問数 */
+  question_count: number
+  contents_id: number
+}
+
+// =============================================================================
+// questions.json
+// =============================================================================
+
+export interface DatQuestion {
+  id: number
+  no: number
+  question_seq: number
+  question_name: string
+  /**
+   * 設問タイプ
+   * 2 = 通常（FREE相当）
+   */
+  question_type: number
+  score_allocation: number
+  workbook_id: number
+}
+
+// =============================================================================
+// angles.json
+// =============================================================================
+
+export interface DatAngle {
+  id: number
+  angle_name: string
+  angle_short_name: string
+  subject_id: number
+  angle_sort_no: number
+  delete_flg: boolean
+}
+
+// =============================================================================
+// question_angles.json
+// =============================================================================
+
+export interface DatQuestionAngle {
+  question_id: number
+  angle_id: number
+}
+
+// =============================================================================
+// abcData (座標データ .js ファイル)
+// =============================================================================
+
+export interface DatAbcData {
+  PageBlock: DatPageBlock[]
+  PageMax: number
+  QuizUID: string
+  TestName: string
+}
+
+export interface DatPageBlock {
+  AreaBlock: DatAreaBlock[]
+  PageNo: number
+  QuationBlock: DatQuationBlock[]
+  /** ページ画像ファイル名（json/フォルダ内） */
+  QuizImage: string
+}
+
+export interface DatAreaBlock {
+  Height: number
+  /** "AREA_NO" = 出席番号, "AREA_NAME" = 氏名 */
+  Type: string
+  Width: number
+  X: number
+  Y: number
+}
+
+export interface DatQuationBlock {
+  No: number
+  /** 設問タイプ: "FREE" | "PARTIAL_MATCH" 等 */
+  QuizType: string
+  QuizName: string
+  Score: number
+  /** ソート順（全ページ通し） */
+  Seq: number
+  /** FREE設問の場合: 1つのPointArea */
+  PointArea: DatPointArea[]
+  /** PARTIAL_MATCH設問の場合: 個別の完答部分 */
+  Completion: DatCompletion[] | null
+}
+
+export interface DatPointArea {
+  Height: number
+  Type: string
+  Width: number
+  X: number
+  Y: number
+}
+
+export interface DatCompletion {
+  PointArea: DatPointArea[]
+}
+
+// =============================================================================
+// マッピング定数
+// =============================================================================
+
+/**
+ * AreaBlockのType → Score at OnceのCropRegion.type マッピング
+ */
+export const DAT_AREA_TYPE_TO_CROP_TYPE: Record<string, string> = {
+  AREA_NO: "STUDENT_ID",
+  AREA_NAME: "STUDENT_NAME",
+}
+
+/**
+ * AreaBlockのType → ラベル マッピング
+ */
+export const DAT_AREA_TYPE_TO_LABEL: Record<string, string> = {
+  AREA_NO: "出席番号",
+  AREA_NAME: "氏名",
+}
+
+/**
+ * リアテンダントの subject_id → 教科名マッピング（推定）
+ */
+export const DAT_SUBJECT_MAP: Record<number, string> = {
+  11: "国語",
+  12: "数学",
+  13: "理科",
+  14: "社会",
+  15: "音楽",
+  16: "美術",
+  17: "保健体育",
+  18: "英語",
+  19: "技術・家庭",
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -658,6 +658,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     selectImportFile: () => ipcRenderer.invoke("archive:selectImportFile"),
     convertHszToScore: (options: { hszPath: string }) =>
       ipcRenderer.invoke("archive:convertHszToScore", options),
+    convertDatToScore: (options: { datPath: string }) =>
+      ipcRenderer.invoke("archive:convertDatToScore", options),
   },
 
   // ProjectClass
@@ -1181,6 +1183,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
     convertToProject: (
       args: import("../types/answerSheetBuilder.types").ASBConvertToProjectArgs
     ) => ipcRenderer.invoke("asb:convert-to-project", args),
+    print: (
+      args: import("../types/answerSheetBuilder.types").ASBPrintArgs
+    ) => ipcRenderer.invoke("asb:print", args),
   },
 })
 

--- a/hooks/import/constants.ts
+++ b/hooks/import/constants.ts
@@ -36,6 +36,10 @@ export const initialState: ImportWizardState = {
   matchingSummaries: [],
   matchingDecisions: {},
   updateDecisions: {},
+  sourceFormat: undefined,
+  showHszDisclaimer: false,
+  hszOriginalPath: undefined,
+  hszOriginalTitle: undefined,
 }
 
 /**

--- a/hooks/import/useImportWizard.ts
+++ b/hooks/import/useImportWizard.ts
@@ -34,6 +34,54 @@ export function useImportWizard() {
   const { user } = useAuth()
   const [state, setState] = useState<ImportWizardState>(initialState)
 
+  // アーカイブ解析 → 事前照合 → file_overview遷移（共通処理）
+  const analyzeAndPreMatch = useCallback(async (archivePath: string) => {
+    setState((prev) => ({ ...prev, isProcessing: true, error: null }))
+
+    try {
+      // アーカイブを解析
+      const analyzeResult = await window.electronAPI.archive.analyzeArchive({
+        archivePath,
+      })
+
+      if (!analyzeResult.success) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          error: analyzeResult.error || "アーカイブの解析に失敗しました",
+        }))
+        return false
+      }
+
+      // 事前照合を実行
+      const preMatchResult = await window.electronAPI.archive.preMatch({
+        archivePath,
+      })
+
+      const fileOverviewData: FileOverviewData | null = preMatchResult.success
+        ? (preMatchResult.data ?? null)
+        : null
+
+      setState((prev) => ({
+        ...prev,
+        archivePath,
+        manifest: analyzeResult.manifest!,
+        fileOverviewData,
+        isProcessing: false,
+        currentStep: "file_overview",
+      }))
+
+      return true
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isProcessing: false,
+        error: error instanceof Error ? error.message : "エラーが発生しました",
+      }))
+      return false
+    }
+  }, [])
+
   // ファイル選択
   const selectFile = useCallback(async () => {
     setState((prev) => ({ ...prev, isProcessing: true, error: null }))
@@ -55,39 +103,20 @@ export function useImportWizard() {
         return false
       }
 
-      // アーカイブを解析
-      const analyzeResult = await window.electronAPI.archive.analyzeArchive({
-        archivePath: result.filePath!,
-      })
-
-      if (!analyzeResult.success) {
+      // .hsz/.datファイルの場合は免責事項モーダルを表示して停止
+      if (result.sourceFormat === "hsz" || result.sourceFormat === "dat") {
         setState((prev) => ({
           ...prev,
           isProcessing: false,
-          error: analyzeResult.error || "アーカイブの解析に失敗しました",
+          sourceFormat: result.sourceFormat as "hsz" | "dat",
+          showHszDisclaimer: true,
+          hszOriginalPath: result.filePath!,
         }))
-        return false
+        return true
       }
 
-      // 事前照合を実行
-      const preMatchResult = await window.electronAPI.archive.preMatch({
-        archivePath: result.filePath!,
-      })
-
-      const fileOverviewData: FileOverviewData | null = preMatchResult.success
-        ? (preMatchResult.data ?? null)
-        : null
-
-      setState((prev) => ({
-        ...prev,
-        archivePath: result.filePath!,
-        manifest: analyzeResult.manifest!,
-        fileOverviewData,
-        isProcessing: false,
-        currentStep: "file_overview",
-      }))
-
-      return true
+      // .scoreファイルの場合は従来通り解析→事前照合
+      return await analyzeAndPreMatch(result.filePath!)
     } catch (error) {
       setState((prev) => ({
         ...prev,
@@ -96,6 +125,65 @@ export function useImportWizard() {
       }))
       return false
     }
+  }, [analyzeAndPreMatch])
+
+  // .hsz免責事項を承認して変換開始
+  const acceptHszDisclaimer = useCallback(async () => {
+    const hszPath = state.hszOriginalPath
+    if (!hszPath) return false
+
+    setState((prev) => ({
+      ...prev,
+      isProcessing: true,
+      showHszDisclaimer: false,
+      error: null,
+    }))
+
+    try {
+      // 外部フォーマット → .score 変換
+      const convertResult =
+        state.sourceFormat === "dat"
+          ? await window.electronAPI.archive.convertDatToScore({
+              datPath: hszPath,
+            })
+          : await window.electronAPI.archive.convertHszToScore({ hszPath })
+
+      if (!convertResult.success || !convertResult.scorePath) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          error:
+            convertResult.error ||
+            `${state.sourceFormat === "dat" ? ".dat" : ".hsz"} ファイルの変換に失敗しました`,
+        }))
+        return false
+      }
+
+      setState((prev) => ({
+        ...prev,
+        hszOriginalTitle: convertResult.originalTitle,
+      }))
+
+      // 変換後の.scoreファイルで解析→事前照合
+      return await analyzeAndPreMatch(convertResult.scorePath)
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isProcessing: false,
+        error: error instanceof Error ? error.message : "エラーが発生しました",
+      }))
+      return false
+    }
+  }, [state.hszOriginalPath, state.sourceFormat, analyzeAndPreMatch])
+
+  // .hsz免責事項をキャンセル
+  const dismissHszDisclaimer = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      showHszDisclaimer: false,
+      sourceFormat: undefined,
+      hszOriginalPath: undefined,
+    }))
   }, [])
 
   // 事前照合を実行（Step 2で使用）
@@ -571,6 +659,8 @@ export function useImportWizard() {
     setScoringConflictStrategy,
     setScoringConflictResolution,
     setAllScoringConflictResolutions,
+    acceptHszDisclaimer,
+    dismissHszDisclaimer,
 
     goToNextStep,
     goBack,

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1341,7 +1341,7 @@ export interface MyAPI {
       filePath?: string
       canceled?: boolean
       /** ファイルの元形式 */
-      sourceFormat?: "score" | "hsz"
+      sourceFormat?: "score" | "hsz" | "dat"
       error?: string
     }>
 
@@ -1349,6 +1349,16 @@ export interface MyAPI {
      * .hszファイルを.score形式に変換
      */
     convertHszToScore: (options: { hszPath: string }) => Promise<{
+      success: boolean
+      scorePath?: string
+      originalTitle?: string
+      error?: string
+    }>
+
+    /**
+     * .datファイル（リアテンダント）を.score形式に変換
+     */
+    convertDatToScore: (options: { datPath: string }) => Promise<{
       success: boolean
       scorePath?: string
       originalTitle?: string
@@ -2208,6 +2218,9 @@ export interface MyAPI {
     convertToProject: (
       args: import("./answerSheetBuilder.types").ASBConvertToProjectArgs
     ) => Promise<import("./answerSheetBuilder.types").ASBConvertResult>
+    print: (
+      args: import("./answerSheetBuilder.types").ASBPrintArgs
+    ) => Promise<{ success: boolean; error?: string }>
   }
 }
 

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -892,6 +892,14 @@ export interface ImportWizardState {
   matchingDecisions: Record<string, MatchingDecisionType>
   /** ユーザーの更新判断（`${category}:${importId}` -> フィールドごとの戦略） */
   updateDecisions: UpdateDecisions
+  /** 外部フォーマットの種別（.hsz/.dat選択時に設定） */
+  sourceFormat?: "score" | "hsz" | "dat"
+  /** .hsz免責事項モーダル表示フラグ */
+  showHszDisclaimer?: boolean
+  /** .hszの元ファイルパス（変換前） */
+  hszOriginalPath?: string
+  /** .hszの元タイトル */
+  hszOriginalTitle?: string
 }
 
 /**
@@ -918,6 +926,10 @@ export const INITIAL_WIZARD_STATE: ImportWizardState = {
   matchingSummaries: [],
   matchingDecisions: {},
   updateDecisions: {},
+  sourceFormat: undefined,
+  showHszDisclaimer: false,
+  hszOriginalPath: undefined,
+  hszOriginalTitle: undefined,
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- 百問繚乱(.hsz)・リアテンダント(.dat)の採点設定データを.score形式に変換してインポート
- 両フォーマットで大問・観点のSubtotalGroup/Subtotal/CropSubtotalを自動生成
- 免責事項モーダルに商標表示・同意チェックボックスを追加

## 詳細

### リアテンダント(.dat)変換 — 新規
- ZIP内のJSON(contents/workbooks/questions/angles/question_angles)、JS座標データ(abcData)、XML(abc_xml)、PNG模範解答画像を解析
- 半スケール(JS)・フルスケール(XML)の2座標系を正規化
- TotalScoreArea / LargeQuestionScoreArea / AngleScoreArea の印字エリアを抽出

### 小計グループ統合 — 両フォーマット共通
| グループ | Subtotals | QUESTION_ASSIGNMENT | SUBTOTAL_DEFINITION |
|---------|-----------|--------------------|--------------------|
| 大問 | 大問1〜N | 各設問→大問 | 小計N→大問N |
| 観点 | 知識・技能 等(DAT) / 観点コード(HSZ) | 各設問→観点 | 観点表示→観点(DAT) |

### 免責事項モーダル (HszDisclaimerModal)
- `sourceFormat` で百問繚乱/リアテンダントの表示切替
- 株式会社シンプルエデュケーション / 大日本印刷株式会社の商標表示
- 同意チェックボックス必須（未同意時はボタン無効化）

## Test plan
- [ ] .datファイル選択 → 免責事項モーダルに「リアテンダント」表示を確認
- [ ] .hszファイル選択 → 免責事項モーダルに「百問繚乱」表示を確認
- [ ] 同意チェック前はボタン無効化、チェック後に有効化を確認
- [ ] 変換後、既存ウィザードフローに正常遷移を確認
- [ ] インポート後、模範解答画像と採点領域の位置・ラベル・配点を目視確認
- [ ] 小計グループ設定画面で大問・観点の自動割当を確認
- [ ] PARTIAL_MATCH設問が個別CropRegionに分割されていることを確認

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)