### PR TITLE
chore: TypeScript 6/7 対応のため baseUrl を削除

### DIFF
--- a/electron-src/tsconfig.json
+++ b/electron-src/tsconfig.json
@@ -19,9 +19,8 @@
     "strict": true,
     "target": "ES2022",
     "outDir": "../main",
-    "baseUrl": "../",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["../*"]
     }
   },
   "exclude": ["node_modules", "../node_modules"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./*"]
     },


### PR DESCRIPTION
## Summary

- TypeScript 6.0/7.0 で廃止される `baseUrl` を両方の tsconfig から削除
- 公式ツール `ts5to6` を使用した安全な移行

Closes #398

## 変更内容

| ファイル | 変更 |
|---|---|
| `tsconfig.json` | `baseUrl: "./"` を削除 |
| `electron-src/tsconfig.json` | `baseUrl: "../"` を削除、`paths` を `"../*"` に調整 |

## Test plan

- [x] `ts5to6` ツールで依存なしを確認
- [x] コードベース全体のインポート調査（ベアインポート 0件）
- [x] `tsc --noEmit` パス（既存OMRエラーのみ、本変更と無関係）
- [x] Vitest 全403テスト パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)