### PR TITLE
feat: Mark2 OMR（光学マーク認識）エンジンを解答用紙ビルダーに統合

### DIFF
--- a/__tests__/omr/unit/coordinateTransform.test.ts
+++ b/__tests__/omr/unit/coordinateTransform.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createTransform,
+  normalizedRectToPixelRect,
+  normalizedToPixel,
+} from "../../../electron-src/lib/omr/coordinateTransform"
+import type { Point } from "../../../types/omr.types"
+
+describe("coordinateTransform", () => {
+  // 完全に歪みなしの場合（検出コーナー = 期待コーナー * 画像サイズ）
+  const imageWidth = 2480
+  const imageHeight = 3508
+
+  // OMRマーカーの0-1正規化中心座標
+  // sizeMm=5, offsetMm=3, A4 portrait (210x297mm)
+  // TL: (3+2.5)/210, (3+2.5)/297 → 0.02619, 0.01852
+  // TR: (210-3-2.5)/210, (3+2.5)/297 → 0.97381, 0.01852
+  // BL: (3+2.5)/210, (297-3-2.5)/297 → 0.02619, 0.98148
+  // BR: (210-3-2.5)/210, (297-3-2.5)/297 → 0.97381, 0.98148
+  const expectedCorners: [Point, Point, Point, Point] = [
+    { x: 0.02619, y: 0.01852 },
+    { x: 0.97381, y: 0.01852 },
+    { x: 0.02619, y: 0.98148 },
+    { x: 0.97381, y: 0.98148 },
+  ]
+
+  describe("歪みなし（理想的な場合）", () => {
+    // 検出コーナー = 正規化座標 * 画像サイズ
+    const detectedCorners: [Point, Point, Point, Point] = expectedCorners.map(
+      (c) => ({
+        x: c.x * imageWidth,
+        y: c.y * imageHeight,
+      })
+    ) as [Point, Point, Point, Point]
+
+    const transform = createTransform(
+      detectedCorners,
+      expectedCorners,
+      imageWidth,
+      imageHeight
+    )
+
+    it("正規化座標0,0を正しく変換できる", () => {
+      const p = normalizedToPixel(0, 0, transform)
+      expect(p.x).toBeCloseTo(0, 0)
+      expect(p.y).toBeCloseTo(0, 0)
+    })
+
+    it("正規化座標1,1を正しく変換できる", () => {
+      const p = normalizedToPixel(1, 1, transform)
+      expect(p.x).toBeCloseTo(imageWidth, 0)
+      expect(p.y).toBeCloseTo(imageHeight, 0)
+    })
+
+    it("正規化座標0.5,0.5を正しく変換できる（中心）", () => {
+      const p = normalizedToPixel(0.5, 0.5, transform)
+      expect(p.x).toBeCloseTo(imageWidth / 2, 0)
+      expect(p.y).toBeCloseTo(imageHeight / 2, 0)
+    })
+
+    it("任意の正規化座標を誤差2px以内で変換できる", () => {
+      const testPoints = [
+        { nx: 0.1, ny: 0.1 },
+        { nx: 0.3, ny: 0.7 },
+        { nx: 0.9, ny: 0.2 },
+        { nx: 0.5, ny: 0.95 },
+      ]
+
+      for (const { nx, ny } of testPoints) {
+        const p = normalizedToPixel(nx, ny, transform)
+        const expectedX = nx * imageWidth
+        const expectedY = ny * imageHeight
+        expect(Math.abs(p.x - expectedX)).toBeLessThan(2)
+        expect(Math.abs(p.y - expectedY)).toBeLessThan(2)
+      }
+    })
+  })
+
+  describe("歪みあり（スキャン傾き）", () => {
+    // スキャン時に少し回転した場合のシミュレーション
+    // 左上が少し右にずれ、右上が少し下にずれた場合
+    const skewedCorners: [Point, Point, Point, Point] = [
+      { x: 70, y: 60 }, // TL: 少し右にずれ
+      { x: 2415, y: 75 }, // TR: 少し下にずれ
+      { x: 60, y: 3445 }, // BL: 少し左にずれ
+      { x: 2420, y: 3440 }, // BR: 正常
+    ]
+
+    const transform = createTransform(
+      skewedCorners,
+      expectedCorners,
+      imageWidth,
+      imageHeight
+    )
+
+    it("変換結果が検出コーナー付近に収まる", () => {
+      // 期待コーナーの正規化座標を変換すると、検出コーナーに近い値になるべき
+      for (let i = 0; i < 4; i++) {
+        const p = normalizedToPixel(
+          expectedCorners[i].x,
+          expectedCorners[i].y,
+          transform
+        )
+        expect(Math.abs(p.x - skewedCorners[i].x)).toBeLessThan(2)
+        expect(Math.abs(p.y - skewedCorners[i].y)).toBeLessThan(2)
+      }
+    })
+
+    it("中心付近の座標も妥当な範囲にある", () => {
+      const center = normalizedToPixel(0.5, 0.5, transform)
+      // 中心は画像中心の近く（歪みにより多少ずれる）
+      expect(center.x).toBeGreaterThan(imageWidth * 0.4)
+      expect(center.x).toBeLessThan(imageWidth * 0.6)
+      expect(center.y).toBeGreaterThan(imageHeight * 0.4)
+      expect(center.y).toBeLessThan(imageHeight * 0.6)
+    })
+  })
+
+  describe("normalizedRectToPixelRect", () => {
+    const detectedCorners: [Point, Point, Point, Point] = expectedCorners.map(
+      (c) => ({
+        x: c.x * imageWidth,
+        y: c.y * imageHeight,
+      })
+    ) as [Point, Point, Point, Point]
+
+    const transform = createTransform(
+      detectedCorners,
+      expectedCorners,
+      imageWidth,
+      imageHeight
+    )
+
+    it("矩形を正しくピクセル座標に変換できる", () => {
+      const rect = normalizedRectToPixelRect(0.1, 0.2, 0.3, 0.15, transform)
+
+      expect(Math.abs(rect.x - imageWidth * 0.1)).toBeLessThan(2)
+      expect(Math.abs(rect.y - imageHeight * 0.2)).toBeLessThan(2)
+      expect(Math.abs(rect.width - imageWidth * 0.3)).toBeLessThan(4)
+      expect(Math.abs(rect.height - imageHeight * 0.15)).toBeLessThan(4)
+    })
+
+    it("矩形の幅と高さが正の値を返す", () => {
+      const rect = normalizedRectToPixelRect(0.5, 0.5, 0.2, 0.1, transform)
+      expect(rect.width).toBeGreaterThan(0)
+      expect(rect.height).toBeGreaterThan(0)
+    })
+  })
+})

--- a/__tests__/omr/unit/cornerMarkerDetector.test.ts
+++ b/__tests__/omr/unit/cornerMarkerDetector.test.ts
@@ -1,0 +1,217 @@
+import sharp from "sharp"
+import { describe, expect, it } from "vitest"
+
+import { detectCornerMarkers } from "../../../electron-src/lib/omr/cornerMarkerDetector"
+
+/**
+ * テスト用画像を動的生成
+ * 白背景に4隅に黒正方形マーカーを配置
+ */
+async function createTestImage(
+  width: number,
+  height: number,
+  markerSize: number,
+  markerOffset: number
+): Promise<string> {
+  // 白背景のRGBバッファ
+  const channels = 3
+  const buf = Buffer.alloc(width * height * channels, 255)
+
+  // 4隅にマーカーを描画
+  const corners = [
+    { x: markerOffset, y: markerOffset }, // TL
+    { x: width - markerOffset - markerSize, y: markerOffset }, // TR
+    { x: markerOffset, y: height - markerOffset - markerSize }, // BL
+    {
+      x: width - markerOffset - markerSize,
+      y: height - markerOffset - markerSize,
+    }, // BR
+  ]
+
+  for (const corner of corners) {
+    for (let dy = 0; dy < markerSize; dy++) {
+      for (let dx = 0; dx < markerSize; dx++) {
+        const px = corner.x + dx
+        const py = corner.y + dy
+        if (px >= 0 && px < width && py >= 0 && py < height) {
+          const idx = (py * width + px) * channels
+          buf[idx] = 0 // R
+          buf[idx + 1] = 0 // G
+          buf[idx + 2] = 0 // B
+        }
+      }
+    }
+  }
+
+  // tmpファイルに保存
+  const tmpPath = `/tmp/omr-test-markers-${Date.now()}.png`
+  await sharp(buf, { raw: { width, height, channels } }).png().toFile(tmpPath)
+
+  return tmpPath
+}
+
+/**
+ * マーカーが3つしかない画像を生成（BRなし）
+ */
+async function createPartialMarkerImage(
+  width: number,
+  height: number,
+  markerSize: number,
+  markerOffset: number
+): Promise<string> {
+  const channels = 3
+  const buf = Buffer.alloc(width * height * channels, 255)
+
+  // 3隅のみマーカーを描画（BRなし）
+  const corners = [
+    { x: markerOffset, y: markerOffset },
+    { x: width - markerOffset - markerSize, y: markerOffset },
+    { x: markerOffset, y: height - markerOffset - markerSize },
+  ]
+
+  for (const corner of corners) {
+    for (let dy = 0; dy < markerSize; dy++) {
+      for (let dx = 0; dx < markerSize; dx++) {
+        const px = corner.x + dx
+        const py = corner.y + dy
+        if (px >= 0 && px < width && py >= 0 && py < height) {
+          const idx = (py * width + px) * channels
+          buf[idx] = 0
+          buf[idx + 1] = 0
+          buf[idx + 2] = 0
+        }
+      }
+    }
+  }
+
+  const tmpPath = `/tmp/omr-test-partial-${Date.now()}.png`
+  await sharp(buf, { raw: { width, height, channels } }).png().toFile(tmpPath)
+
+  return tmpPath
+}
+
+describe("cornerMarkerDetector", () => {
+  it("4隅のマーカーを全て検出できる", async () => {
+    const width = 2480 // A4 300dpi相当
+    const height = 3508
+    const markerSize = 40 // ~3.4mm
+    const markerOffset = 25 // ~2.1mm
+
+    const imagePath = await createTestImage(
+      width,
+      height,
+      markerSize,
+      markerOffset
+    )
+    const result = await detectCornerMarkers(imagePath, 128)
+
+    expect(result.success).toBe(true)
+    expect(result.markers).toHaveLength(4)
+    expect(result.imageWidth).toBe(width)
+    expect(result.imageHeight).toBe(height)
+
+    // 各コーナーが検出されている
+    const corners = result.markers.map((m) => m.corner).sort()
+    expect(corners).toEqual(["BL", "BR", "TL", "TR"])
+  })
+
+  it("検出座標がマーカー中心付近にある（誤差5px以内）", async () => {
+    const width = 2480
+    const height = 3508
+    const markerSize = 40
+    const markerOffset = 25
+
+    const imagePath = await createTestImage(
+      width,
+      height,
+      markerSize,
+      markerOffset
+    )
+    const result = await detectCornerMarkers(imagePath, 128)
+
+    expect(result.success).toBe(true)
+
+    // 期待される中心座標
+    const expected = {
+      TL: {
+        x: markerOffset + markerSize / 2,
+        y: markerOffset + markerSize / 2,
+      },
+      TR: {
+        x: width - markerOffset - markerSize / 2,
+        y: markerOffset + markerSize / 2,
+      },
+      BL: {
+        x: markerOffset + markerSize / 2,
+        y: height - markerOffset - markerSize / 2,
+      },
+      BR: {
+        x: width - markerOffset - markerSize / 2,
+        y: height - markerOffset - markerSize / 2,
+      },
+    }
+
+    for (const marker of result.markers) {
+      const exp = expected[marker.corner]
+      expect(Math.abs(marker.centerX - exp.x)).toBeLessThanOrEqual(5)
+      expect(Math.abs(marker.centerY - exp.y)).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it("マーカーが不足している場合はsuccess=falseを返す", async () => {
+    const width = 2480
+    const height = 3508
+    const markerSize = 40
+    const markerOffset = 25
+
+    const imagePath = await createPartialMarkerImage(
+      width,
+      height,
+      markerSize,
+      markerOffset
+    )
+    const result = await detectCornerMarkers(imagePath, 128)
+
+    expect(result.success).toBe(false)
+    expect(result.markers.length).toBeLessThan(4)
+    expect(result.error).toBeDefined()
+  })
+
+  it("信頼度が正方形マーカーに対して高い値を返す", async () => {
+    const width = 2480
+    const height = 3508
+    const markerSize = 40
+    const markerOffset = 25
+
+    const imagePath = await createTestImage(
+      width,
+      height,
+      markerSize,
+      markerOffset
+    )
+    const result = await detectCornerMarkers(imagePath, 128)
+
+    expect(result.success).toBe(true)
+    for (const marker of result.markers) {
+      expect(marker.confidence).toBeGreaterThanOrEqual(0.75)
+    }
+  })
+
+  it("小さい画像でも検出できる", async () => {
+    const width = 800
+    const height = 1100
+    const markerSize = 15
+    const markerOffset = 10
+
+    const imagePath = await createTestImage(
+      width,
+      height,
+      markerSize,
+      markerOffset
+    )
+    const result = await detectCornerMarkers(imagePath, 128)
+
+    expect(result.success).toBe(true)
+    expect(result.markers).toHaveLength(4)
+  })
+})

--- a/__tests__/omr/unit/digitRecognizer.test.ts
+++ b/__tests__/omr/unit/digitRecognizer.test.ts
@@ -1,0 +1,234 @@
+/**
+ * 手書き数字認識エンジン テスト
+ *
+ * ONNX Runtime / MNISTモデルが利用可能な場合のみ認識テストを実行。
+ * モデル不在時はグレースフルフォールバックの動作を検証。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { recognizeDigitCell } from "../../../electron-src/lib/omr/digitRecognizer"
+import type { ComputedCell } from "../../../types/answerSheetBuilder.types"
+import type {
+  CoordinateTransform,
+  OMRRecognitionParams,
+  RawImageData,
+} from "../../../types/omr.types"
+
+// テスト用の単純な座標変換（歪みなし: 0-1座標 → ピクセル座標）
+function createIdentityTransform(
+  width: number,
+  height: number
+): CoordinateTransform {
+  return {
+    detectedCorners: [
+      { x: 0, y: 0 },
+      { x: width, y: 0 },
+      { x: 0, y: height },
+      { x: width, y: height },
+    ],
+    expectedCorners: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ],
+    imageWidth: width,
+    imageHeight: height,
+  }
+}
+
+const DEFAULT_PARAMS: OMRRecognitionParams = {
+  colorThreshold: 25,
+  areaThreshold: 0.4,
+}
+
+describe("digitRecognizer", () => {
+  it("モデル不在時: 空の認識結果が返る（graceful fallback）", async () => {
+    // MNISTモデルが存在しない環境でも例外を投げずに動作する
+    const width = 200
+    const height = 100
+    const channels = 3
+
+    // 白い画像を作成
+    const data = Buffer.alloc(width * height * channels, 255)
+    const rawImage: RawImageData = { data, width, height, channels }
+    const transform = createIdentityTransform(width, height)
+
+    const cell: ComputedCell = {
+      questionPath: [0, 0],
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+      normalizedX: 10 / width,
+      normalizedY: 10 / height,
+      normalizedW: 80 / width,
+      normalizedH: 40 / height,
+      label: "1-1",
+      points: 5,
+      textElements: [],
+      modelAnswer: undefined,
+      cellType: "answer",
+      pageIndex: 0,
+      omrDigitBoxes: [
+        {
+          normalizedX: 0.1,
+          normalizedY: 0.15,
+          normalizedW: 0.3,
+          normalizedH: 0.7,
+          digitIndex: 0,
+        },
+      ],
+    }
+
+    const result = await recognizeDigitCell(
+      cell,
+      rawImage,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result).toBeDefined()
+    expect(result.label).toBe("1-1")
+    expect(result.questionPath).toEqual([0, 0])
+    // モデルが存在しない場合は空の結果
+    // (CI環境ではモデルがないためこの分岐になる)
+    expect(Array.isArray(result.recognizedValues)).toBe(true)
+  })
+
+  it("omrDigitBoxes未設定のセルは no_answer を返す", async () => {
+    const width = 200
+    const height = 100
+    const channels = 3
+    const data = Buffer.alloc(width * height * channels, 255)
+    const rawImage: RawImageData = { data, width, height, channels }
+    const transform = createIdentityTransform(width, height)
+
+    const cell: ComputedCell = {
+      questionPath: [0, 0],
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+      normalizedX: 10 / width,
+      normalizedY: 10 / height,
+      normalizedW: 80 / width,
+      normalizedH: 40 / height,
+      label: "1-1",
+      points: 5,
+      textElements: [],
+      modelAnswer: undefined,
+      cellType: "answer",
+      pageIndex: 0,
+      // omrDigitBoxes なし
+    }
+
+    const result = await recognizeDigitCell(
+      cell,
+      rawImage,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("no_answer")
+    expect(result.recognizedValues).toEqual([])
+    expect(result.confidence).toBe(0)
+  })
+
+  it("空白領域（白い画像）は空文字を返す", async () => {
+    const width = 200
+    const height = 100
+    const channels = 3
+
+    // 完全に白い画像
+    const data = Buffer.alloc(width * height * channels, 255)
+    const rawImage: RawImageData = { data, width, height, channels }
+    const transform = createIdentityTransform(width, height)
+
+    const cell: ComputedCell = {
+      questionPath: [0, 0],
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+      normalizedX: 10 / width,
+      normalizedY: 10 / height,
+      normalizedW: 80 / width,
+      normalizedH: 40 / height,
+      label: "1-1",
+      points: 5,
+      textElements: [],
+      modelAnswer: undefined,
+      cellType: "answer",
+      pageIndex: 0,
+      omrDigitBoxes: [
+        {
+          normalizedX: 0.1,
+          normalizedY: 0.15,
+          normalizedW: 0.3,
+          normalizedH: 0.7,
+          digitIndex: 0,
+        },
+      ],
+    }
+
+    const result = await recognizeDigitCell(
+      cell,
+      rawImage,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    // モデルが利用可能でも白い画像は空欄として検出されるはず
+    // モデル不在でも空結果
+    expect(result).toBeDefined()
+    expect(result.label).toBe("1-1")
+  })
+
+  it("prepareDigitInput: 領域が画像範囲外の場合でもクラッシュしない", async () => {
+    const width = 50
+    const height = 50
+    const channels = 3
+    const data = Buffer.alloc(width * height * channels, 128)
+    const rawImage: RawImageData = { data, width, height, channels }
+    const transform = createIdentityTransform(width, height)
+
+    const cell: ComputedCell = {
+      questionPath: [0, 0],
+      x: 0,
+      y: 0,
+      width: 50,
+      height: 50,
+      normalizedX: 0,
+      normalizedY: 0,
+      normalizedW: 1,
+      normalizedH: 1,
+      label: "1-1",
+      points: 5,
+      textElements: [],
+      modelAnswer: undefined,
+      cellType: "answer",
+      pageIndex: 0,
+      omrDigitBoxes: [
+        {
+          // 画像の右端を超える領域
+          normalizedX: 0.9,
+          normalizedY: 0.1,
+          normalizedW: 0.2,
+          normalizedH: 0.8,
+          digitIndex: 0,
+        },
+      ],
+    }
+
+    // 例外が投げられないことを確認
+    const result = await recognizeDigitCell(
+      cell,
+      rawImage,
+      transform,
+      DEFAULT_PARAMS
+    )
+    expect(result).toBeDefined()
+  })
+})

--- a/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -1,84 +1,172 @@
 "use client"
 
-import { Trash2 } from "lucide-react"
+import { ChevronDown, ChevronUp, Settings2, Trash2 } from "lucide-react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import type { BranchQuestion } from "@/types/answerSheetBuilder.types"
 
 import { ModelAnswerEditor } from "./ModelAnswerEditor"
+import { OMRCellConfigForm } from "./OMRCellConfigForm"
 import { TextElementEditor } from "./TextElementEditor"
 
 interface BranchQuestionFormProps {
   branch: BranchQuestion
+  branchIndex: number
+  totalBranchCount: number
+  isHorizontal?: boolean
+  showPoints?: boolean
   onUpdate: (data: Partial<BranchQuestion>) => void
   onDelete: () => void
+  onMoveUp?: () => void
+  onMoveDown?: () => void
 }
 
 export function BranchQuestionForm({
   branch,
+  isHorizontal,
+  showPoints = true,
   onUpdate,
   onDelete,
+  onMoveUp,
+  onMoveDown,
 }: BranchQuestionFormProps) {
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const hasDetailContent =
+    !!branch.modelAnswer || branch.textElements.length > 0
+
   return (
-    <div className="space-y-1 py-1 pl-8">
+    <div className="border-muted-foreground/20 ml-4 space-y-1 border-l-2 py-1 pl-4">
       {/* 基本設定行 */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        <Input
-          className="h-7 w-16 text-xs"
-          value={branch.label}
-          onChange={(e) => onUpdate({ label: e.target.value })}
-          placeholder="ラベル"
-        />
-        <div className="flex items-center gap-1">
-          <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-            高さ×
-          </Label>
-          <Input
-            type="number"
-            className="h-7 w-14 text-xs"
-            value={branch.heightMultiplier}
-            min={1}
-            max={10}
-            step={0.5}
-            onChange={(e) =>
-              onUpdate({ heightMultiplier: Number(e.target.value) })
-            }
-          />
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex h-7 items-center divide-x overflow-hidden rounded-md border text-xs">
+          <div className="flex items-center gap-0.5 px-1.5">
+            <span className="text-muted-foreground">番号</span>
+            <input
+              className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
+              value={branch.label}
+              onChange={(e) => onUpdate({ label: e.target.value })}
+              placeholder=""
+            />
+          </div>
+          {showPoints && (
+            <div className="flex items-center gap-0.5 px-1.5">
+              <span className="text-muted-foreground">配点</span>
+              <input
+                type="number"
+                className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                value={branch.points}
+                min={0}
+                max={100}
+                onChange={(e) => onUpdate({ points: Number(e.target.value) })}
+                onBlur={(e) => {
+                  e.target.value = String(Number(e.target.value))
+                }}
+              />
+            </div>
+          )}
+          <div className="flex items-center gap-0.5 px-1.5">
+            <span className="text-muted-foreground">高さ</span>
+            <input
+              type="number"
+              className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              value={branch.heightMultiplier}
+              min={1}
+              max={10}
+              step={0.5}
+              onChange={(e) =>
+                onUpdate({ heightMultiplier: Number(e.target.value) })
+              }
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
+            />
+          </div>
+          {isHorizontal && (
+            <div className="flex items-center gap-0.5 px-1.5">
+              <span className="text-muted-foreground">幅</span>
+              <input
+                type="number"
+                className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                value={branch.colSpan ?? 1}
+                min={1}
+                max={10}
+                step={1}
+                onChange={(e) =>
+                  onUpdate({ colSpan: Number(e.target.value) || 1 })
+                }
+                onBlur={(e) => {
+                  e.target.value = String(Number(e.target.value) || 1)
+                }}
+              />
+            </div>
+          )}
         </div>
-        <div className="flex items-center gap-1">
-          <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-            配点
-          </Label>
-          <Input
-            type="number"
-            className="h-7 w-14 text-xs"
-            value={branch.points}
-            min={0}
-            max={100}
-            onChange={(e) => onUpdate({ points: Number(e.target.value) })}
-          />
+        <div className="ml-auto flex items-center gap-1.5">
+          <div className="inline-flex items-center rounded-md border">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground h-7 w-7 rounded-r-none"
+              onClick={onMoveUp}
+              disabled={!onMoveUp}
+              title="上へ移動"
+            >
+              <ChevronUp className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground h-7 w-7 rounded-l-none border-l"
+              onClick={onMoveDown}
+              disabled={!onMoveDown}
+              title="下へ移動"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`relative h-7 w-7 ${detailOpen ? "text-primary" : "text-muted-foreground"}`}
+            onClick={() => setDetailOpen(!detailOpen)}
+            title="詳細設定"
+          >
+            <Settings2 className="h-3.5 w-3.5" />
+            {hasDetailContent && (
+              <span className="bg-primary absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:text-destructive h-7 w-7"
+            onClick={onDelete}
+            title="枝問を削除"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground hover:text-destructive h-6 w-6"
-          onClick={onDelete}
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
       </div>
 
-      {/* 詳細設定 */}
-      <ModelAnswerEditor
-        value={branch.modelAnswer}
-        onChange={(v) => onUpdate({ modelAnswer: v })}
-      />
-      <TextElementEditor
-        textElements={branch.textElements}
-        onUpdate={(elements) => onUpdate({ textElements: elements })}
-      />
+      {/* 詳細設定（展開コンテンツ） */}
+      {detailOpen && (
+        <div className="space-y-2 pt-1">
+          <ModelAnswerEditor
+            value={branch.modelAnswer}
+            onChange={(v) => onUpdate({ modelAnswer: v })}
+          />
+          <TextElementEditor
+            textElements={branch.textElements}
+            onUpdate={(elements) => onUpdate({ textElements: elements })}
+          />
+          <OMRCellConfigForm
+            config={branch.omrConfig}
+            onChange={(config) => onUpdate({ omrConfig: config })}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
+++ b/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import { Scan } from "lucide-react"
+import { useCallback } from "react"
+
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import type { OMRCellConfig, OMRChoiceConfig } from "@/types/omr.types"
+
+/** 選択肢ラベルプリセット */
+const CHOICE_LABEL_PRESETS: { value: string; labels: string[] }[] = [
+  {
+    value: "katakana",
+    labels: ["ア", "イ", "ウ", "エ", "オ", "カ", "キ", "ク", "ケ", "コ"],
+  },
+  {
+    value: "alphabet",
+    labels: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"],
+  },
+  {
+    value: "circled",
+    labels: ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩"],
+  },
+  {
+    value: "number",
+    labels: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+  },
+]
+
+interface OMRCellConfigFormProps {
+  config?: OMRCellConfig
+  onChange: (config: OMRCellConfig | undefined) => void
+}
+
+export function OMRCellConfigForm({
+  config,
+  onChange,
+}: OMRCellConfigFormProps) {
+  const enabled = !!config
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        onChange({
+          type: "choice",
+          numChoices: 4,
+          labels: CHOICE_LABEL_PRESETS[0].labels.slice(0, 4),
+          correctAnswers: [],
+          layout: "horizontal",
+        })
+      } else {
+        onChange(undefined)
+      }
+    },
+    [onChange]
+  )
+
+  const handleTypeChange = useCallback(
+    (type: string) => {
+      if (type === "choice") {
+        onChange({
+          type: "choice",
+          numChoices: 4,
+          labels: CHOICE_LABEL_PRESETS[0].labels.slice(0, 4),
+          correctAnswers:
+            config?.type === "choice" ? config.correctAnswers : [],
+          layout: "horizontal",
+        })
+      } else {
+        onChange({
+          type: "handwritten-digit",
+          numDigits: 2,
+          correctAnswer:
+            config?.type === "handwritten-digit"
+              ? config.correctAnswer
+              : undefined,
+        })
+      }
+    },
+    [config, onChange]
+  )
+
+  const choiceConfig = config?.type === "choice" ? config : null
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Scan className="text-muted-foreground h-3.5 w-3.5" />
+          <Label className="text-muted-foreground text-xs">OMR自動認識</Label>
+        </div>
+        <Switch
+          className="scale-75"
+          checked={enabled}
+          onCheckedChange={handleToggle}
+        />
+      </div>
+
+      {enabled && config && (
+        <div className="border-muted ml-2 space-y-1.5 border-l-2 pl-3">
+          {/* 認識タイプ */}
+          <div className="flex items-center gap-1.5">
+            <Label className="text-muted-foreground min-w-[3rem] text-xs">
+              種類
+            </Label>
+            <Select value={config.type} onValueChange={handleTypeChange}>
+              <SelectTrigger className="h-7 w-32 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="choice">選択式</SelectItem>
+                <SelectItem value="handwritten-digit">手書き数字</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 選択式設定 */}
+          {choiceConfig && (
+            <ChoiceConfigFields config={choiceConfig} onChange={onChange} />
+          )}
+
+          {/* 手書き数字設定 */}
+          {config.type === "handwritten-digit" && (
+            <DigitConfigFields config={config} onChange={onChange} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ChoiceConfigFields({
+  config,
+  onChange,
+}: {
+  config: OMRChoiceConfig
+  onChange: (config: OMRCellConfig) => void
+}) {
+  return (
+    <>
+      {/* 選択肢数 */}
+      <div className="flex items-center gap-1.5">
+        <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          選択肢数
+        </Label>
+        <input
+          type="number"
+          className="border-input h-7 w-14 [appearance:textfield] rounded border px-1.5 text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          value={config.numChoices}
+          min={2}
+          max={10}
+          onChange={(e) => {
+            const n = Math.max(2, Math.min(10, Number(e.target.value) || 4))
+            const currentPreset = CHOICE_LABEL_PRESETS.find(
+              (p) => p.labels[0] === config.labels[0]
+            )
+            const labels = (
+              currentPreset?.labels ?? CHOICE_LABEL_PRESETS[0].labels
+            ).slice(0, n)
+            onChange({
+              ...config,
+              numChoices: n,
+              labels,
+              correctAnswers: config.correctAnswers.filter((i) => i < n),
+            })
+          }}
+        />
+      </div>
+
+      {/* ラベルプリセット */}
+      <div className="flex items-center gap-1.5">
+        <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          ラベル
+        </Label>
+        <Select
+          value={
+            CHOICE_LABEL_PRESETS.find((p) => p.labels[0] === config.labels[0])
+              ?.value ?? "katakana"
+          }
+          onValueChange={(preset) => {
+            const p = CHOICE_LABEL_PRESETS.find((pr) => pr.value === preset)
+            if (p) {
+              onChange({
+                ...config,
+                labels: p.labels.slice(0, config.numChoices),
+              })
+            }
+          }}
+        >
+          <SelectTrigger className="h-7 w-32 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CHOICE_LABEL_PRESETS.map((p) => (
+              <SelectItem key={p.value} value={p.value}>
+                {p.labels.slice(0, 4).join(",")}...
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 配置方向 */}
+      <div className="flex items-center gap-1.5">
+        <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          配置
+        </Label>
+        <Select
+          value={config.layout}
+          onValueChange={(v: "horizontal" | "vertical") =>
+            onChange({ ...config, layout: v })
+          }
+        >
+          <SelectTrigger className="h-7 w-32 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="horizontal">横</SelectItem>
+            <SelectItem value="vertical">縦</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 正解選択 */}
+      <div className="flex items-start gap-1.5">
+        <Label className="text-muted-foreground mt-1 min-w-[3rem] text-xs">
+          正解
+        </Label>
+        <div className="flex flex-wrap gap-1">
+          {config.labels.map((label, idx) => {
+            const isSelected = config.correctAnswers.includes(idx)
+            return (
+              <button
+                key={idx}
+                type="button"
+                className={`h-6 min-w-[1.5rem] rounded border px-1 text-xs ${
+                  isSelected
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-muted text-muted-foreground hover:border-primary/50"
+                }`}
+                onClick={() => {
+                  const next = isSelected
+                    ? config.correctAnswers.filter((i) => i !== idx)
+                    : [...config.correctAnswers, idx]
+                  onChange({ ...config, correctAnswers: next })
+                }}
+              >
+                {label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function DigitConfigFields({
+  config,
+  onChange,
+}: {
+  config: OMRCellConfig & { type: "handwritten-digit" }
+  onChange: (config: OMRCellConfig) => void
+}) {
+  return (
+    <>
+      <div className="flex items-center gap-1.5">
+        <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          桁数
+        </Label>
+        <input
+          type="number"
+          className="border-input h-7 w-14 [appearance:textfield] rounded border px-1.5 text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          value={config.numDigits}
+          min={1}
+          max={5}
+          onChange={(e) =>
+            onChange({
+              ...config,
+              numDigits: Math.max(1, Math.min(5, Number(e.target.value) || 2)),
+            })
+          }
+        />
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          正解
+        </Label>
+        <input
+          className="border-input h-7 w-20 rounded border px-1.5 text-center text-xs"
+          value={config.correctAnswer ?? ""}
+          placeholder="42"
+          onChange={(e) =>
+            onChange({
+              ...config,
+              correctAnswer: e.target.value || undefined,
+            })
+          }
+        />
+      </div>
+    </>
+  )
+}

--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -1,10 +1,18 @@
 "use client"
 
-import { GitBranch, Trash2 } from "lucide-react"
+import {
+  ChevronDown,
+  ChevronUp,
+  GitBranch,
+  Settings2,
+  Trash2,
+} from "lucide-react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import type {
   BranchQuestion,
   SubQuestion,
@@ -13,117 +21,193 @@ import type {
 import { BranchQuestionForm } from "./BranchQuestionForm"
 import { ManuscriptPaperSettings } from "./ManuscriptPaperSettings"
 import { ModelAnswerEditor } from "./ModelAnswerEditor"
+import { OMRCellConfigForm } from "./OMRCellConfigForm"
 import { TextElementEditor } from "./TextElementEditor"
 
 interface SubQuestionFormProps {
   sub: SubQuestion
   majorIndex: number
   subIndex: number
-  isHorizontalLayout?: boolean
+  totalSubCount: number
+  isHorizontal?: boolean
   onUpdate: (data: Partial<SubQuestion>) => void
   onDelete: () => void
+  onMoveUp?: () => void
+  onMoveDown?: () => void
   onAddBranch: () => void
   onUpdateBranch: (branchIndex: number, data: Partial<BranchQuestion>) => void
   onDeleteBranch: (branchIndex: number) => void
+  onReorderBranch: (fromIndex: number, toIndex: number) => void
 }
 
 export function SubQuestionForm({
   sub,
-  isHorizontalLayout,
+  isHorizontal,
   onUpdate,
   onDelete,
+  onMoveUp,
+  onMoveDown,
   onAddBranch,
   onUpdateBranch,
   onDeleteBranch,
+  onReorderBranch,
 }: SubQuestionFormProps) {
   const hasBranches = sub.branchQuestions.length > 0
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const hasDetailContent =
+    !!sub.modelAnswer ||
+    sub.textElements.length > 0 ||
+    !!sub.manuscriptPaper?.enabled
 
   return (
-    <div className="border-muted space-y-1 border-l-2 pl-4">
+    <div className="border-primary/30 space-y-1 border-l-2 pl-4">
       {/* 小問ヘッダー */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        <Input
-          className="h-7 w-14 text-xs"
-          value={sub.label}
-          onChange={(e) => onUpdate({ label: e.target.value })}
-          placeholder="ラベル"
-        />
-        {!hasBranches && (
-          <>
-            <div className="flex items-center gap-1">
-              <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-                高さ×
-              </Label>
-              <Input
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex h-7 items-center divide-x overflow-hidden rounded-md border text-xs">
+          <div className="flex items-center gap-0.5 px-1.5">
+            <span className="text-muted-foreground">番号</span>
+            <input
+              className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
+              value={sub.label}
+              onChange={(e) => onUpdate({ label: e.target.value })}
+              placeholder=""
+            />
+          </div>
+          {/* 配点: 枝問なし or 完答モード(usesBranchPoints=false)の時に表示 */}
+          {(!hasBranches || sub.usesBranchPoints === false) && (
+            <div className="flex items-center gap-0.5 px-1.5">
+              <span className="text-muted-foreground">配点</span>
+              <input
                 type="number"
-                className="h-7 w-12 text-xs"
-                value={sub.heightMultiplier}
-                min={1}
-                max={10}
-                step={0.5}
-                onChange={(e) =>
-                  onUpdate({ heightMultiplier: Number(e.target.value) })
-                }
-              />
-            </div>
-            {isHorizontalLayout && (
-              <div className="flex items-center gap-1">
-                <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-                  列幅×
-                </Label>
-                <Input
-                  type="number"
-                  className="h-7 w-12 text-xs"
-                  value={sub.colSpan ?? 1}
-                  min={1}
-                  max={10}
-                  step={1}
-                  onChange={(e) =>
-                    onUpdate({ colSpan: Number(e.target.value) || 1 })
-                  }
-                />
-              </div>
-            )}
-            <div className="flex items-center gap-1">
-              <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-                配点
-              </Label>
-              <Input
-                type="number"
-                className="h-7 w-12 text-xs"
+                className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 value={sub.points}
                 min={0}
                 max={100}
                 onChange={(e) => onUpdate({ points: Number(e.target.value) })}
+                onBlur={(e) => {
+                  e.target.value = String(Number(e.target.value))
+                }}
               />
             </div>
-          </>
+          )}
+          {!hasBranches && (
+            <>
+              <div className="flex items-center gap-0.5 px-1.5">
+                <span className="text-muted-foreground">高さ</span>
+                <input
+                  type="number"
+                  className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  value={sub.heightMultiplier}
+                  min={1}
+                  max={10}
+                  step={0.5}
+                  onChange={(e) =>
+                    onUpdate({ heightMultiplier: Number(e.target.value) })
+                  }
+                  onBlur={(e) => {
+                    e.target.value = String(Number(e.target.value))
+                  }}
+                />
+              </div>
+              {isHorizontal && (
+                <div className="flex items-center gap-0.5 px-1.5">
+                  <span className="text-muted-foreground">幅</span>
+                  <input
+                    type="number"
+                    className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    value={sub.colSpan ?? 1}
+                    min={1}
+                    max={10}
+                    step={1}
+                    onChange={(e) =>
+                      onUpdate({ colSpan: Number(e.target.value) || 1 })
+                    }
+                    onBlur={(e) => {
+                      e.target.value = String(Number(e.target.value) || 1)
+                    }}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* 枝問配点スイッチ（枝問がある場合のみ） */}
+        {hasBranches && (
+          <div className="flex items-center gap-1">
+            <span className="text-muted-foreground text-xs whitespace-nowrap">
+              枝問配点
+            </span>
+            <Switch
+              className="scale-75"
+              checked={sub.usesBranchPoints !== false}
+              onCheckedChange={(v) => onUpdate({ usesBranchPoints: v })}
+            />
+          </div>
         )}
-        <div className="flex gap-0.5">
-          {!isHorizontalLayout && (
+
+        {/* アクションボタン */}
+        <div className="ml-auto flex items-center gap-1.5">
+          <div className="inline-flex items-center rounded-md border">
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-primary h-6 w-6"
-              onClick={onAddBranch}
-              title="枝問を追加"
+              className="text-muted-foreground h-7 w-7 rounded-r-none"
+              onClick={onMoveUp}
+              disabled={!onMoveUp}
+              title="上へ移動"
             >
-              <GitBranch className="h-3 w-3" />
+              <ChevronUp className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground h-7 w-7 rounded-l-none border-l"
+              onClick={onMoveDown}
+              disabled={!onMoveDown}
+              title="下へ移動"
+            >
+              <ChevronDown className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          {!hasBranches && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={`relative h-7 w-7 ${detailOpen ? "text-primary" : "text-muted-foreground"}`}
+              onClick={() => setDetailOpen(!detailOpen)}
+              title="詳細設定"
+            >
+              <Settings2 className="h-3.5 w-3.5" />
+              {hasDetailContent && (
+                <span className="bg-primary absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full" />
+              )}
             </Button>
           )}
           <Button
             variant="ghost"
             size="icon"
-            className="text-muted-foreground hover:text-destructive h-6 w-6"
-            onClick={onDelete}
+            className="text-muted-foreground hover:text-primary h-7 w-7"
+            onClick={onAddBranch}
+            title="枝問を追加"
           >
-            <Trash2 className="h-3 w-3" />
+            <GitBranch className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:text-destructive h-7 w-7"
+            onClick={onDelete}
+            title="小問を削除"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
           </Button>
         </div>
       </div>
 
-      {/* 枝問なし: 詳細設定 */}
-      {!hasBranches && (
+      {/* 枝問なし: 詳細設定（展開コンテンツ） */}
+      {!hasBranches && detailOpen && (
         <div className="space-y-2 pt-1">
           <ModelAnswerEditor
             value={sub.modelAnswer}
@@ -137,6 +221,40 @@ export function SubQuestionForm({
             config={sub.manuscriptPaper}
             onUpdate={(config) => onUpdate({ manuscriptPaper: config })}
           />
+          <OMRCellConfigForm
+            config={sub.omrConfig}
+            onChange={(config) => onUpdate({ omrConfig: config })}
+          />
+        </div>
+      )}
+
+      {/* 枝問横配置設定 */}
+      {hasBranches && (
+        <div className="flex items-center gap-1.5 pl-1">
+          <Label className="text-muted-foreground text-xs whitespace-nowrap">
+            枝問横配置
+          </Label>
+          <Input
+            className="h-7 w-24 text-xs"
+            value={sub.branchHorizontalColumnsPerRow?.join(",") ?? ""}
+            onChange={(e) => {
+              const val = e.target.value.trim()
+              if (val === "") {
+                onUpdate({ branchHorizontalColumnsPerRow: undefined })
+              } else {
+                const nums = val
+                  .split(",")
+                  .map((s) => parseInt(s.trim(), 10))
+                  .filter((n) => !isNaN(n) && n > 0)
+                onUpdate({
+                  branchHorizontalColumnsPerRow:
+                    nums.length > 0 ? nums : undefined,
+                })
+              }
+            }}
+            placeholder="空欄=縦"
+            title="枝問の横配置列数をコンマ区切りで指定。例:「3」→3列1行。空欄→全て縦配置。"
+          />
         </div>
       )}
 
@@ -147,8 +265,18 @@ export function SubQuestionForm({
             <BranchQuestionForm
               key={branch.id}
               branch={branch}
+              branchIndex={bi}
+              totalBranchCount={sub.branchQuestions.length}
+              isHorizontal={!!sub.branchHorizontalColumnsPerRow?.length}
+              showPoints={sub.usesBranchPoints !== false}
               onUpdate={(data) => onUpdateBranch(bi, data)}
               onDelete={() => onDeleteBranch(bi)}
+              onMoveUp={bi > 0 ? () => onReorderBranch(bi, bi - 1) : undefined}
+              onMoveDown={
+                bi < sub.branchQuestions.length - 1
+                  ? () => onReorderBranch(bi, bi + 1)
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -2,6 +2,7 @@
 
 import type {
   ComputedLayout,
+  ComputedPageLayout,
   DragInfo,
   LineStyle,
   RenderMode,
@@ -9,19 +10,41 @@ import type {
 
 interface AnswerSheetSVGRendererProps {
   layout: ComputedLayout
+  /** 単一ページデータ（指定時はlayoutのcells/lines等より優先） */
+  pageLayout?: ComputedPageLayout
   renderMode: RenderMode
   interactive?: boolean
   hoveredDragInfo?: DragInfo | null
 }
 
-function getStrokeDashArray(style: LineStyle): string | undefined {
+function getDashProps(
+  style: LineStyle,
+  strokeWidth: number,
+  lineLength: number
+): {
+  strokeDasharray?: string
+  strokeDashoffset?: number
+  strokeLinecap?: "round" | "butt"
+} {
+  let dash: number, gap: number
   switch (style) {
     case "dashed":
-      return "4 2"
+      dash = strokeWidth * 3
+      gap = strokeWidth * 1
+      break
     case "dotted":
-      return "1 2"
+      dash = 0.01
+      gap = strokeWidth * 2
+      break
     default:
-      return undefined
+      return {}
+  }
+  const period = dash + gap
+  const offset = ((lineLength / 2) % period) - dash / 2
+  return {
+    strokeDasharray: `${dash} ${gap}`,
+    strokeDashoffset: offset,
+    strokeLinecap: "round",
   }
 }
 
@@ -50,18 +73,18 @@ function isDragInfoEqual(
 
 export function AnswerSheetSVGRenderer({
   layout,
+  pageLayout,
   renderMode,
   interactive,
   hoveredDragInfo,
 }: AnswerSheetSVGRendererProps) {
-  const {
-    pageWidthMm,
-    pageHeightMm,
-    cells,
-    lines,
-    numberLabels,
-    omrMarkerPositions,
-  } = layout
+  const { pageWidthMm, pageHeightMm } = layout
+  // pageLayoutが指定されている場合はそちらのデータを使用
+  const cells = pageLayout?.cells ?? layout.cells
+  const lines = pageLayout?.lines ?? layout.lines
+  const numberLabels = pageLayout?.numberLabels ?? layout.numberLabels
+  const omrMarkerPositions =
+    pageLayout?.omrMarkerPositions ?? layout.omrMarkerPositions
 
   return (
     <>
@@ -84,6 +107,9 @@ export function AnswerSheetSVGRenderer({
       {lines.map((line, i) => {
         const isHovered =
           interactive && isDragInfoEqual(line.dragInfo, hoveredDragInfo)
+        const sw = line.strokeWidth ?? (line.lineType === "outer" ? 0.7 : 0.4)
+        const len = Math.hypot(line.x2 - line.x1, line.y2 - line.y1)
+        const dashProps = getDashProps(line.style, sw, len)
         return (
           <g key={`line-${i}`}>
             <line
@@ -92,10 +118,8 @@ export function AnswerSheetSVGRenderer({
               x2={line.x2}
               y2={line.y2}
               stroke={isHovered ? "#3b82f6" : "black"}
-              strokeWidth={
-                isHovered ? 1 : line.lineType === "outer" ? 0.7 : 0.4
-              }
-              strokeDasharray={getStrokeDashArray(line.style)}
+              strokeWidth={isHovered ? 1 : sw}
+              {...dashProps}
             />
             {/* インタラクティブモードのヒットエリア */}
             {interactive && line.dragInfo && (
@@ -131,7 +155,10 @@ export function AnswerSheetSVGRenderer({
       {/* 番号ラベル */}
       {numberLabels.map((label, i) => {
         // 横配置時の小問ラベル: セル内左側に配置
-        if (label.displayMode === "sub-horizontal") {
+        if (
+          label.displayMode === "sub-horizontal" ||
+          label.displayMode === "branch-horizontal"
+        ) {
           return (
             <text
               key={`label-${i}`}
@@ -213,6 +240,12 @@ export function AnswerSheetSVGRenderer({
                 y={ty}
                 fontSize={te.fontSize}
                 fontWeight={te.fontWeight}
+                fontStyle={te.fontStyle === "italic" ? "italic" : undefined}
+                textDecoration={
+                  te.textDecoration === "line-through"
+                    ? "line-through"
+                    : undefined
+                }
                 fontFamily="'Noto Sans JP', sans-serif"
                 textAnchor={anchor}
                 dominantBaseline="central"
@@ -224,8 +257,103 @@ export function AnswerSheetSVGRenderer({
           })
         )}
 
-      {/* 溢れ警告 */}
-      {layout.overflow && (
+      {/* OMRバブル */}
+      {cells
+        .filter((c) => c.cellType === "answer" && c.omrBubbles?.length)
+        .flatMap((cell) =>
+          cell.omrBubbles!.map((bubble, bi) => {
+            const cx = bubble.normalizedCx * pageWidthMm
+            const cy = bubble.normalizedCy * pageHeightMm
+            const r = bubble.normalizedRadius * pageWidthMm
+            return (
+              <g key={`omr-bubble-${cell.label}-${bi}`}>
+                <circle
+                  cx={cx}
+                  cy={cy}
+                  r={r}
+                  fill="none"
+                  stroke="black"
+                  strokeWidth={0.3}
+                />
+                <text
+                  x={cx}
+                  y={cy + r + 2}
+                  fontSize={2.5}
+                  fontFamily="'Noto Sans JP', sans-serif"
+                  textAnchor="middle"
+                  dominantBaseline="hanging"
+                  fill="#333"
+                >
+                  {bubble.label}
+                </text>
+              </g>
+            )
+          })
+        )}
+
+      {/* OMR数字欄 */}
+      {cells
+        .filter((c) => c.cellType === "answer" && c.omrDigitBoxes?.length)
+        .flatMap((cell) =>
+          cell.omrDigitBoxes!.map((box, di) => {
+            const x = box.normalizedX * pageWidthMm
+            const y = box.normalizedY * pageHeightMm
+            const w = box.normalizedW * pageWidthMm
+            const h = box.normalizedH * pageHeightMm
+            return (
+              <rect
+                key={`omr-digit-${cell.label}-${di}`}
+                x={x}
+                y={y}
+                width={w}
+                height={h}
+                fill="none"
+                stroke="#666"
+                strokeWidth={0.3}
+              />
+            )
+          })
+        )}
+
+      {/* 原稿用紙グリッド */}
+      {cells
+        .filter((c) => c.cellType === "answer" && c.manuscriptGrid)
+        .map((cell) => {
+          const g = cell.manuscriptGrid!
+          const gridLines: React.ReactNode[] = []
+          for (let col = 1; col < g.columns; col++) {
+            const x = g.gridX + col * g.cellSizeMm
+            gridLines.push(
+              <line
+                key={`mg-v-${cell.label}-${col}`}
+                x1={x}
+                y1={g.gridY}
+                x2={x}
+                y2={g.gridY + g.gridHeight}
+                stroke="#ccc"
+                strokeWidth={0.2}
+              />
+            )
+          }
+          for (let row = 1; row < g.rows; row++) {
+            const y = g.gridY + row * g.cellSizeMm
+            gridLines.push(
+              <line
+                key={`mg-h-${cell.label}-${row}`}
+                x1={g.gridX}
+                y1={y}
+                x2={g.gridX + g.gridWidth}
+                y2={y}
+                stroke="#ccc"
+                strokeWidth={0.2}
+              />
+            )
+          }
+          return <g key={`mg-${cell.label}`}>{gridLines}</g>
+        })}
+
+      {/* 溢れ警告（単一ページモード時のみ表示） */}
+      {!pageLayout && layout.overflow && (
         <g>
           <rect
             x={pageWidthMm / 2 - 40}

--- a/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
@@ -10,18 +10,49 @@ import { useMemo } from "react"
 
 import type {
   AnswerSheetDefinition,
+  BorderConfig,
+  BranchLayoutRow,
+  BranchQuestion,
   ComputedCell,
   ComputedLayout,
   ComputedLine,
+  ComputedMultiPageLayout,
   ComputedNumberLabel,
   ComputedOMRMarker,
+  ComputedPageLayout,
   GlobalSettings,
+  LayoutRow,
   LineStyle,
   MajorQuestion,
+  ManuscriptGrid,
   SubQuestion,
 } from "@/types/answerSheetBuilder.types"
+import type {
+  ComputedOMRBubble,
+  ComputedOMRDigitBox,
+  OMRCellConfig,
+} from "@/types/omr.types"
 
 import { PAPER_SIZES } from "../constants"
+
+/** lineType から BorderConfig の線幅を取得するヘルパー */
+function getLineWidth(lineType: string, borderConfig: BorderConfig): number {
+  switch (lineType) {
+    case "outer":
+      return borderConfig.outerBorderWidth ?? 0.7
+    case "major":
+      return borderConfig.majorDividerWidth ?? 0.5
+    case "sub":
+    case "subHorizontalDivider":
+      return borderConfig.subDividerWidth ?? 0.4
+    case "branch":
+      return borderConfig.branchDividerWidth ?? 0.3
+    case "numberColumn":
+      return borderConfig.numberColumnDividerWidth ?? 0.4
+    default:
+      return 0.4
+  }
+}
 
 function getPaperDimensions(settings: GlobalSettings) {
   const base = PAPER_SIZES[settings.paperSize] ?? PAPER_SIZES.A4
@@ -31,85 +62,337 @@ function getPaperDimensions(settings: GlobalSettings) {
   return { width: base.width, height: base.height }
 }
 
-interface HorizontalRowAssignment {
-  subs: { sub: SubQuestion; subIndex: number; colStart: number; span: number }[]
-  columns: number
-}
-
-function assignSubsToRows(
+function buildLayoutRows(
   subQuestions: SubQuestion[],
   columnsPerRow: number[] | undefined
-): HorizontalRowAssignment[] {
-  const rows: HorizontalRowAssignment[] = []
-  let rowIdx = 0
-  let usedCols = 0
-  const defaultCols = subQuestions.length
+): LayoutRow[] {
+  if (!columnsPerRow || columnsPerRow.length === 0) {
+    return subQuestions.map((sub, si) => ({
+      type: "vertical-sub" as const,
+      sub,
+      subIndex: si,
+    }))
+  }
 
-  for (let si = 0; si < subQuestions.length; si++) {
-    const sub = subQuestions[si]
-    const span = sub.colSpan ?? 1
-    const maxCols =
-      columnsPerRow && columnsPerRow.length > 0
-        ? (columnsPerRow[rowIdx] ??
-          columnsPerRow[columnsPerRow.length - 1] ??
-          defaultCols)
-        : defaultCols
+  const rows: LayoutRow[] = []
+  let si = 0
+  let specIdx = 0
 
-    if (!rows[rowIdx]) {
-      rows[rowIdx] = { subs: [], columns: maxCols }
+  while (si < subQuestions.length && specIdx < columnsPerRow.length) {
+    const rowSpec = columnsPerRow[specIdx]
+    specIdx++
+
+    let consumed = 0
+    let batch: {
+      sub: SubQuestion
+      subIndex: number
+      colStart: number
+      span: number
+    }[] = []
+    let batchCols = 0
+
+    const flushBatch = () => {
+      if (batch.length > 0) {
+        rows.push({ type: "horizontal", subs: batch, columns: batchCols })
+        batch = []
+        batchCols = 0
+      }
     }
 
-    if (usedCols + span > maxCols && usedCols > 0) {
-      rowIdx++
-      usedCols = 0
-      const nextMaxCols =
-        columnsPerRow && columnsPerRow.length > 0
-          ? (columnsPerRow[rowIdx] ??
-            columnsPerRow[columnsPerRow.length - 1] ??
-            defaultCols)
-          : defaultCols
-      rows[rowIdx] = { subs: [], columns: nextMaxCols }
+    while (consumed < rowSpec && si < subQuestions.length) {
+      const sub = subQuestions[si]
+      const span = sub.colSpan ?? 1
+
+      if (sub.branchQuestions.length >= 2) {
+        flushBatch()
+        rows.push({ type: "vertical-sub", sub, subIndex: si })
+        si++
+        consumed += span
+        continue
+      }
+
+      batch.push({ sub, subIndex: si, colStart: batchCols, span })
+      batchCols += span
+      si++
+      consumed += span
     }
 
-    rows[rowIdx].subs.push({ sub, subIndex: si, colStart: usedCols, span })
-    usedCols += span
+    flushBatch()
+  }
 
-    const currentMaxCols = rows[rowIdx].columns
-    if (usedCols >= currentMaxCols) {
-      rowIdx++
-      usedCols = 0
-    }
+  while (si < subQuestions.length) {
+    rows.push({
+      type: "vertical-sub",
+      sub: subQuestions[si],
+      subIndex: si,
+    })
+    si++
   }
 
   return rows
+}
+
+function buildBranchLayoutRows(
+  branchQuestions: BranchQuestion[],
+  columnsPerRow: number[] | undefined
+): BranchLayoutRow[] {
+  if (!columnsPerRow || columnsPerRow.length === 0) {
+    return branchQuestions.map((branch, bi) => ({
+      type: "vertical-branch" as const,
+      branch,
+      branchIndex: bi,
+    }))
+  }
+
+  const rows: BranchLayoutRow[] = []
+  let bi = 0
+  let specIdx = 0
+
+  while (bi < branchQuestions.length && specIdx < columnsPerRow.length) {
+    const rowSpec = columnsPerRow[specIdx]
+    specIdx++
+
+    let consumed = 0
+    const batch: {
+      branch: BranchQuestion
+      branchIndex: number
+      colStart: number
+      span: number
+    }[] = []
+    let batchCols = 0
+
+    while (consumed < rowSpec && bi < branchQuestions.length) {
+      const branch = branchQuestions[bi]
+      const span = branch.colSpan ?? 1
+      batch.push({ branch, branchIndex: bi, colStart: batchCols, span })
+      batchCols += span
+      bi++
+      consumed += span
+    }
+
+    if (batch.length > 0) {
+      rows.push({ type: "horizontal", branches: batch, columns: batchCols })
+    }
+  }
+
+  while (bi < branchQuestions.length) {
+    rows.push({
+      type: "vertical-branch",
+      branch: branchQuestions[bi],
+      branchIndex: bi,
+    })
+    bi++
+  }
+
+  return rows
+}
+
+function computeSubHeight(sub: SubQuestion, baseRowHeight: number): number {
+  if (sub.branchQuestions.length > 0) {
+    const branchRows = buildBranchLayoutRows(
+      sub.branchQuestions,
+      sub.branchHorizontalColumnsPerRow
+    )
+    return branchRows.reduce((sum, row) => {
+      if (row.type === "horizontal") {
+        const maxH = Math.max(
+          ...row.branches.map((b) => b.branch.heightMultiplier),
+          1
+        )
+        return sum + maxH * baseRowHeight
+      }
+      return sum + row.branch.heightMultiplier * baseRowHeight
+    }, 0)
+  }
+  if (sub.manuscriptPaper?.enabled) {
+    return sub.manuscriptPaper.rows * sub.manuscriptPaper.cellSizeMm
+  }
+  return sub.heightMultiplier * baseRowHeight
+}
+
+/**
+ * OMR choiceセルのバブル位置を計算（0-1正規化座標）
+ */
+function computeOMRBubbles(
+  cellX: number,
+  cellY: number,
+  cellWidth: number,
+  cellHeight: number,
+  paperWidth: number,
+  paperHeight: number,
+  config: OMRCellConfig & { type: "choice" }
+): ComputedOMRBubble[] {
+  const bubbles: ComputedOMRBubble[] = []
+  const n = config.numChoices
+
+  const maxRadiusMm = Math.min(cellHeight * 0.25, cellWidth / (n * 2.5 + 1))
+  const radiusMm = Math.max(1.5, maxRadiusMm)
+
+  if (config.layout === "horizontal") {
+    const spacing = cellWidth / (n + 1)
+    const cy = cellY + cellHeight / 2
+
+    for (let i = 0; i < n; i++) {
+      const cx = cellX + spacing * (i + 1)
+      bubbles.push({
+        normalizedCx: cx / paperWidth,
+        normalizedCy: cy / paperHeight,
+        normalizedRadius: radiusMm / paperWidth,
+        choiceIndex: i,
+        label: config.labels[i] ?? String(i + 1),
+      })
+    }
+  } else {
+    const spacing = cellHeight / (n + 1)
+    const cx = cellX + cellWidth / 2
+
+    for (let i = 0; i < n; i++) {
+      const cy = cellY + spacing * (i + 1)
+      bubbles.push({
+        normalizedCx: cx / paperWidth,
+        normalizedCy: cy / paperHeight,
+        normalizedRadius: radiusMm / paperWidth,
+        choiceIndex: i,
+        label: config.labels[i] ?? String(i + 1),
+      })
+    }
+  }
+
+  return bubbles
+}
+
+/**
+ * OMR handwritten-digitセルの数字欄位置を計算（0-1正規化座標）
+ */
+function computeOMRDigitBoxes(
+  cellX: number,
+  cellY: number,
+  cellWidth: number,
+  cellHeight: number,
+  paperWidth: number,
+  paperHeight: number,
+  config: OMRCellConfig & { type: "handwritten-digit" }
+): ComputedOMRDigitBox[] {
+  const boxes: ComputedOMRDigitBox[] = []
+  const n = config.numDigits
+
+  const boxHeight = cellHeight * 0.8
+  const boxWidth = Math.min(boxHeight, cellWidth / (n + 0.5))
+  const totalWidth = boxWidth * n
+  const startX = cellX + (cellWidth - totalWidth) / 2
+  const startY = cellY + (cellHeight - boxHeight) / 2
+
+  for (let i = 0; i < n; i++) {
+    boxes.push({
+      normalizedX: (startX + boxWidth * i) / paperWidth,
+      normalizedY: startY / paperHeight,
+      normalizedW: boxWidth / paperWidth,
+      normalizedH: boxHeight / paperHeight,
+      digitIndex: i,
+    })
+  }
+
+  return boxes
+}
+
+/**
+ * セルを作成しOMRバブル/数字欄があれば計算する
+ */
+function createCell(
+  questionPath: number[],
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  paper: { width: number; height: number },
+  label: string,
+  points: number,
+  textElements: ComputedCell["textElements"],
+  modelAnswer: string | undefined,
+  cellType: ComputedCell["cellType"],
+  pageIndex: number = 0,
+  manuscriptGrid?: ManuscriptGrid,
+  omrConfig?: OMRCellConfig
+): ComputedCell {
+  const cell: ComputedCell = {
+    questionPath,
+    x,
+    y,
+    width,
+    height,
+    normalizedX: x / paper.width,
+    normalizedY: y / paper.height,
+    normalizedW: width / paper.width,
+    normalizedH: height / paper.height,
+    label,
+    points,
+    textElements,
+    modelAnswer,
+    cellType,
+    pageIndex,
+    ...(manuscriptGrid ? { manuscriptGrid } : {}),
+  }
+
+  if (omrConfig?.type === "choice") {
+    cell.omrBubbles = computeOMRBubbles(
+      x,
+      y,
+      width,
+      height,
+      paper.width,
+      paper.height,
+      omrConfig
+    )
+  } else if (omrConfig?.type === "handwritten-digit") {
+    cell.omrDigitBoxes = computeOMRDigitBoxes(
+      x,
+      y,
+      width,
+      height,
+      paper.width,
+      paper.height,
+      omrConfig
+    )
+  }
+
+  return cell
+}
+
+function computeManuscriptGrid(
+  sub: SubQuestion,
+  cellX: number,
+  cellY: number,
+  cellWidth: number
+): ManuscriptGrid | undefined {
+  if (!sub.manuscriptPaper?.enabled) return undefined
+  const { columns, rows, cellSizeMm } = sub.manuscriptPaper
+  const gridWidth = columns * cellSizeMm
+  const gridHeight = rows * cellSizeMm
+  return {
+    columns,
+    rows,
+    cellSizeMm,
+    gridX: cellX + (cellWidth - gridWidth) / 2,
+    gridY: cellY,
+    gridWidth,
+    gridHeight,
+  }
 }
 
 function computeMajorHeight(
   major: MajorQuestion,
   baseRowHeight: number
 ): number {
-  const layout = major.subQuestionLayout ?? "vertical"
-  if (layout === "horizontal") {
-    const rows = assignSubsToRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
-    return rows.reduce((sum, row) => {
+  const layoutRows = buildLayoutRows(
+    major.subQuestions,
+    major.horizontalColumnsPerRow
+  )
+  return layoutRows.reduce((sum, row) => {
+    if (row.type === "horizontal") {
       const maxH = Math.max(...row.subs.map((s) => s.sub.heightMultiplier), 1)
       return sum + maxH * baseRowHeight
-    }, 0)
-  }
-  return major.subQuestions.reduce((sum, sub) => {
-    if (sub.branchQuestions.length > 0) {
-      return (
-        sum +
-        sub.branchQuestions.reduce(
-          (bSum, bq) => bSum + bq.heightMultiplier * baseRowHeight,
-          0
-        )
-      )
     }
-    return sum + sub.heightMultiplier * baseRowHeight
+    return sum + computeSubHeight(row.sub, baseRowHeight)
   }, 0)
 }
 
@@ -144,7 +427,7 @@ function computeLayoutFromDefinition(
   let currentY = margins.top + spacing.headerHeight
 
   majorQuestions.forEach((major, mi) => {
-    if (major.spacingBefore && mi > 0) {
+    if (mi > 0) {
       currentY += spacing.majorQuestionSpacing
     }
 
@@ -157,25 +440,20 @@ function computeLayoutFromDefinition(
       y: majorStartY,
       width: majorNumWidth,
       height:
-        major.numberDisplayMode === "multirow" ? majorHeight : baseRowHeight,
+        settings.numberDisplayMode === "multirow" ? majorHeight : baseRowHeight,
       fontSize: settings.fonts.numberSize,
-      displayMode: major.numberDisplayMode,
+      displayMode: settings.numberDisplayMode,
     })
 
-    const isHorizontal =
-      (major.subQuestionLayout ?? "vertical") === "horizontal"
+    const layoutRows = buildLayoutRows(
+      major.subQuestions,
+      major.horizontalColumnsPerRow
+    )
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
 
-    if (isHorizontal) {
-      // 横配置: 大問番号列の右端から用紙右マージンまでが利用可能幅
-      const horizontalAreaX = majorNumX + majorNumWidth
-      const horizontalAreaWidth = contentRight - horizontalAreaX
-
-      const rows = assignSubsToRows(
-        major.subQuestions,
-        major.horizontalColumnsPerRow
-      )
-
-      rows.forEach((row, ri) => {
+    layoutRows.forEach((row, ri) => {
+      if (row.type === "horizontal") {
         const rowMaxH = Math.max(
           ...row.subs.map((s) => s.sub.heightMultiplier),
           1
@@ -187,7 +465,6 @@ function computeLayoutFromDefinition(
           const cellX = horizontalAreaX + entry.colStart * unitWidth
           const cellWidth = entry.span * unitWidth
 
-          // 横配置時は小問ラベルをセル内左側に配置
           numberLabels.push({
             text: entry.sub.label,
             x: cellX,
@@ -198,24 +475,25 @@ function computeLayoutFromDefinition(
             displayMode: "sub-horizontal",
           })
 
-          cells.push({
-            questionPath: [mi, entry.subIndex],
-            x: cellX,
-            y: currentY,
-            width: cellWidth,
-            height: rowHeight,
-            normalizedX: cellX / paper.width,
-            normalizedY: currentY / paper.height,
-            normalizedW: cellWidth / paper.width,
-            normalizedH: rowHeight / paper.height,
-            label: `${major.label}-${entry.sub.label}`,
-            points: entry.sub.points,
-            textElements: entry.sub.textElements,
-            modelAnswer: entry.sub.modelAnswer,
-            cellType: "answer",
-          })
+          cells.push(
+            createCell(
+              [mi, entry.subIndex],
+              cellX,
+              currentY,
+              cellWidth,
+              rowHeight,
+              paper,
+              `${major.label}-${entry.sub.label}`,
+              entry.sub.points,
+              entry.sub.textElements,
+              entry.sub.modelAnswer,
+              "answer",
+              0,
+              computeManuscriptGrid(entry.sub, cellX, currentY, cellWidth),
+              entry.sub.omrConfig
+            )
+          )
 
-          // 列間の垂直区切り線（セル右端が領域右端でない場合）
           const cellRight = cellX + cellWidth
           if (Math.abs(cellRight - contentRight) > 0.01) {
             lines.push({
@@ -225,35 +503,22 @@ function computeLayoutFromDefinition(
               y2: currentY + rowHeight,
               style: settings.borderConfig.subDivider,
               lineType: "subHorizontalDivider",
+              strokeWidth: getLineWidth(
+                "subHorizontalDivider",
+                settings.borderConfig
+              ),
             })
           }
         })
 
         currentY += rowHeight
-
-        // 行間の水平区切り線（最後の行以外）
-        if (ri < rows.length - 1) {
-          lines.push({
-            x1: horizontalAreaX,
-            y1: currentY,
-            x2: contentRight,
-            y2: currentY,
-            style: settings.borderConfig.subDivider,
-            lineType: "subHorizontalDivider",
-          })
-        }
-      })
-    } else {
-      // 縦配置: 既存ロジック
-      major.subQuestions.forEach((sub, si) => {
+      } else {
+        // vertical-sub
+        const sub = row.sub
+        const si = row.subIndex
         const subStartY = currentY
         const hasBranches = sub.branchQuestions.length > 0
-        const subHeight = hasBranches
-          ? sub.branchQuestions.reduce(
-              (sum, bq) => sum + bq.heightMultiplier * baseRowHeight,
-              0
-            )
-          : sub.heightMultiplier * baseRowHeight
+        const subHeight = computeSubHeight(sub, baseRowHeight)
 
         numberLabels.push({
           text: sub.label,
@@ -266,83 +531,196 @@ function computeLayoutFromDefinition(
         })
 
         if (hasBranches) {
+          const branchRows = buildBranchLayoutRows(
+            sub.branchQuestions,
+            sub.branchHorizontalColumnsPerRow
+          )
+          const branchAreaX = subNumX + subNumWidth
+          const branchAreaWidth = contentRight - branchAreaX
           let branchY = subStartY
-          sub.branchQuestions.forEach((branch, bi) => {
-            const branchHeight = branch.heightMultiplier * baseRowHeight
 
-            numberLabels.push({
-              text: branch.label,
-              x: branchNumX,
-              y: branchY,
-              width: branchNumWidth,
-              height: branchHeight,
-              fontSize: settings.fonts.numberSize - 1,
-              displayMode: "branch",
-            })
+          branchRows.forEach((bRow, bri) => {
+            if (bRow.type === "horizontal") {
+              const rowMaxH = Math.max(
+                ...bRow.branches.map((b) => b.branch.heightMultiplier),
+                1
+              )
+              const bRowHeight = rowMaxH * baseRowHeight
+              const unitWidth = branchAreaWidth / bRow.columns
 
-            cells.push({
-              questionPath: [mi, si, bi],
-              x: answerX,
-              y: branchY,
-              width: answerWidth,
-              height: branchHeight,
-              normalizedX: answerX / paper.width,
-              normalizedY: branchY / paper.height,
-              normalizedW: answerWidth / paper.width,
-              normalizedH: branchHeight / paper.height,
-              label: `${major.label}-${sub.label}-${branch.label}`,
-              points: branch.points,
-              textElements: branch.textElements,
-              modelAnswer: branch.modelAnswer,
-              cellType: "answer",
-            })
+              bRow.branches.forEach((entry) => {
+                const cellX = branchAreaX + entry.colStart * unitWidth
+                const cellWidth = entry.span * unitWidth
 
-            if (bi < sub.branchQuestions.length - 1) {
-              lines.push({
-                x1: branchNumX,
-                y1: branchY + branchHeight,
-                x2: contentRight,
-                y2: branchY + branchHeight,
-                style: settings.borderConfig.branchDivider,
-                lineType: "branch",
-                dragInfo: {
-                  axis: "horizontal",
-                  target: {
-                    type: "heightMultiplier",
-                    majorIndex: mi,
-                    subIndex: si,
-                    branchIndex: bi,
-                  },
-                  currentValueMm: branchHeight,
-                  minMm: baseRowHeight * 0.5,
-                },
+                numberLabels.push({
+                  text: entry.branch.label,
+                  x: cellX,
+                  y: branchY,
+                  width: cellWidth,
+                  height: bRowHeight,
+                  fontSize: settings.fonts.numberSize - 1,
+                  displayMode: "branch-horizontal",
+                })
+
+                cells.push(
+                  createCell(
+                    [mi, si, entry.branchIndex],
+                    cellX,
+                    branchY,
+                    cellWidth,
+                    bRowHeight,
+                    paper,
+                    `${major.label}-${sub.label}-${entry.branch.label}`,
+                    entry.branch.points,
+                    entry.branch.textElements,
+                    entry.branch.modelAnswer,
+                    "answer",
+                    0,
+                    undefined,
+                    entry.branch.omrConfig
+                  )
+                )
+
+                const cellRight = cellX + cellWidth
+                if (Math.abs(cellRight - contentRight) > 0.01) {
+                  lines.push({
+                    x1: cellRight,
+                    y1: branchY,
+                    x2: cellRight,
+                    y2: branchY + bRowHeight,
+                    style: settings.borderConfig.branchDivider,
+                    lineType: "branch",
+                    strokeWidth: getLineWidth("branch", settings.borderConfig),
+                  })
+                }
               })
+
+              branchY += bRowHeight
+            } else {
+              const branch = bRow.branch
+              const branchHeight = branch.heightMultiplier * baseRowHeight
+
+              numberLabels.push({
+                text: branch.label,
+                x: branchNumX,
+                y: branchY,
+                width: branchNumWidth,
+                height: branchHeight,
+                fontSize: settings.fonts.numberSize - 1,
+                displayMode: "branch",
+              })
+
+              cells.push(
+                createCell(
+                  [mi, si, bRow.branchIndex],
+                  answerX,
+                  branchY,
+                  answerWidth,
+                  branchHeight,
+                  paper,
+                  `${major.label}-${sub.label}-${branch.label}`,
+                  branch.points,
+                  branch.textElements,
+                  branch.modelAnswer,
+                  "answer",
+                  0,
+                  undefined,
+                  branch.omrConfig
+                )
+              )
+
+              if (bri < branchRows.length - 1) {
+                lines.push({
+                  x1: branchNumX,
+                  y1: branchY + branchHeight,
+                  x2: contentRight,
+                  y2: branchY + branchHeight,
+                  style: settings.borderConfig.branchDivider,
+                  lineType: "branch",
+                  strokeWidth: getLineWidth("branch", settings.borderConfig),
+                  dragInfo: {
+                    axis: "horizontal",
+                    target: {
+                      type: "heightMultiplier",
+                      majorIndex: mi,
+                      subIndex: si,
+                      branchIndex: bRow.branchIndex,
+                    },
+                    currentValueMm: branchHeight,
+                    minMm: baseRowHeight * 0.5,
+                  },
+                })
+              }
+
+              branchY += branchHeight
             }
 
-            branchY += branchHeight
+            // 枝問行間の区切り線（横配置行が関わる場合）
+            if (
+              bri < branchRows.length - 1 &&
+              (bRow.type === "horizontal" ||
+                branchRows[bri + 1].type === "horizontal")
+            ) {
+              const nextBRow = branchRows[bri + 1]
+              const lineX =
+                bRow.type === "horizontal" || nextBRow.type === "horizontal"
+                  ? branchAreaX
+                  : branchNumX
+              lines.push({
+                x1: lineX,
+                y1: branchY,
+                x2: contentRight,
+                y2: branchY,
+                style: settings.borderConfig.branchDivider,
+                lineType: "branch",
+                strokeWidth: getLineWidth("branch", settings.borderConfig),
+              })
+            }
           })
         } else {
-          cells.push({
-            questionPath: [mi, si],
-            x: answerX,
-            y: subStartY,
-            width: answerWidth,
-            height: subHeight,
-            normalizedX: answerX / paper.width,
-            normalizedY: subStartY / paper.height,
-            normalizedW: answerWidth / paper.width,
-            normalizedH: subHeight / paper.height,
-            label: `${major.label}-${sub.label}`,
-            points: sub.points,
-            textElements: sub.textElements,
-            modelAnswer: sub.modelAnswer,
-            cellType: "answer",
-          })
+          cells.push(
+            createCell(
+              [mi, si],
+              answerX,
+              subStartY,
+              answerWidth,
+              subHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              0,
+              computeManuscriptGrid(sub, answerX, subStartY, answerWidth),
+              sub.omrConfig
+            )
+          )
         }
 
         currentY += subHeight
+      }
 
-        if (si < major.subQuestions.length - 1) {
+      // 行間の区切り線（最後の行以外）
+      if (ri < layoutRows.length - 1) {
+        const nextRow = layoutRows[ri + 1]
+        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+          lines.push({
+            x1: horizontalAreaX,
+            y1: currentY,
+            x2: contentRight,
+            y2: currentY,
+            style: settings.borderConfig.subDivider,
+            lineType: "subHorizontalDivider",
+            strokeWidth: getLineWidth(
+              "subHorizontalDivider",
+              settings.borderConfig
+            ),
+          })
+        } else if (row.type === "vertical-sub") {
+          const sub = row.sub
+          const si = row.subIndex
+          const hasBranches = sub.branchQuestions.length > 0
           lines.push({
             x1: subNumX,
             y1: currentY,
@@ -350,6 +728,7 @@ function computeLayoutFromDefinition(
             y2: currentY,
             style: settings.borderConfig.subDivider,
             lineType: "sub",
+            strokeWidth: getLineWidth("sub", settings.borderConfig),
             dragInfo: {
               axis: "horizontal",
               target: {
@@ -366,9 +745,19 @@ function computeLayoutFromDefinition(
               minMm: baseRowHeight * 0.5,
             },
           })
+        } else {
+          lines.push({
+            x1: horizontalAreaX,
+            y1: currentY,
+            x2: contentRight,
+            y2: currentY,
+            style: settings.borderConfig.subDivider,
+            lineType: "sub",
+            strokeWidth: getLineWidth("sub", settings.borderConfig),
+          })
         }
-      })
-    }
+      }
+    })
 
     if (mi < majorQuestions.length - 1) {
       lines.push({
@@ -378,6 +767,7 @@ function computeLayoutFromDefinition(
         y2: currentY,
         style: settings.borderConfig.majorDivider,
         lineType: "major",
+        strokeWidth: getLineWidth("major", settings.borderConfig),
       })
     }
   })
@@ -392,26 +782,72 @@ function computeLayoutFromDefinition(
     contentTop,
     contentRight,
     contentBottom,
-    settings.borderConfig.outerBorder
+    settings.borderConfig.outerBorder,
+    settings.borderConfig
   )
 
-  // 縦配置の大問のY範囲を収集（番号列セグメント化用）
+  // vertical-sub 行のY範囲を収集（小問番号列セグメント化用）
+  // branchVerticalRanges: vertical-branch行のY範囲（枝問番号列用）
   const verticalRanges: { top: number; bottom: number }[] = []
+  const branchVerticalRanges: { top: number; bottom: number }[] = []
   {
     let trackY = margins.top + spacing.headerHeight
-    majorQuestions.forEach((mq, mi) => {
-      if (mq.spacingBefore && mi > 0) {
+    for (let mi2 = 0; mi2 < majorQuestions.length; mi2++) {
+      const mq = majorQuestions[mi2]
+      if (mi2 > 0) {
         trackY += spacing.majorQuestionSpacing
       }
-      const mh = computeMajorHeight(mq, baseRowHeight)
-      if ((mq.subQuestionLayout ?? "vertical") === "vertical") {
-        verticalRanges.push({ top: trackY, bottom: trackY + mh })
+      const rows = buildLayoutRows(mq.subQuestions, mq.horizontalColumnsPerRow)
+      let segStart: number | null = null
+      for (const r of rows) {
+        if (r.type === "vertical-sub") {
+          if (segStart === null) segStart = trackY
+          // 枝問番号列のセグメント: vertical-branch行のみ
+          if (r.sub.branchQuestions.length > 0) {
+            const bRows = buildBranchLayoutRows(
+              r.sub.branchQuestions,
+              r.sub.branchHorizontalColumnsPerRow
+            )
+            let bTrackY = trackY
+            let bSegStart: number | null = null
+            for (const br of bRows) {
+              if (br.type === "vertical-branch") {
+                if (bSegStart === null) bSegStart = bTrackY
+                bTrackY += br.branch.heightMultiplier * baseRowHeight
+              } else {
+                if (bSegStart !== null) {
+                  branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
+                  bSegStart = null
+                }
+                const maxH = Math.max(
+                  ...br.branches.map((b) => b.branch.heightMultiplier),
+                  1
+                )
+                bTrackY += maxH * baseRowHeight
+              }
+            }
+            if (bSegStart !== null) {
+              branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
+            }
+          }
+          trackY += computeSubHeight(r.sub, baseRowHeight)
+        } else {
+          if (segStart !== null) {
+            verticalRanges.push({ top: segStart, bottom: trackY })
+            segStart = null
+          }
+          const maxH = Math.max(...r.subs.map((s) => s.sub.heightMultiplier), 1)
+          trackY += maxH * baseRowHeight
+        }
       }
-      trackY += mh
-    })
+      if (segStart !== null) {
+        verticalRanges.push({ top: segStart, bottom: trackY })
+      }
+    }
   }
 
   // 大問番号列の縦線 → 全高（従来通り）
+  const ncSw = getLineWidth("numberColumn", settings.borderConfig)
   lines.push({
     x1: majorNumX + majorNumWidth,
     y1: contentTop,
@@ -419,6 +855,7 @@ function computeLayoutFromDefinition(
     y2: contentBottom,
     style: settings.borderConfig.numberColumnDivider,
     lineType: "numberColumn",
+    strokeWidth: ncSw,
     dragInfo: {
       axis: "vertical",
       target: { type: "columnWidth", column: "majorNumber" },
@@ -427,7 +864,7 @@ function computeLayoutFromDefinition(
     },
   })
 
-  // 小問/枝問番号列の縦線 → 縦配置のセグメントのみ
+  // 小問番号列の縦線 → 縦配置のセグメントのみ
   for (const range of verticalRanges) {
     lines.push({
       x1: subNumX + subNumWidth,
@@ -436,6 +873,7 @@ function computeLayoutFromDefinition(
       y2: range.bottom,
       style: settings.borderConfig.numberColumnDivider,
       lineType: "numberColumn",
+      strokeWidth: ncSw,
       dragInfo: {
         axis: "vertical",
         target: { type: "columnWidth", column: "subNumber" },
@@ -443,7 +881,11 @@ function computeLayoutFromDefinition(
         minMm: 5,
       },
     })
-    if (hasBranch) {
+  }
+
+  // 枝問番号列の縦線 → vertical-branchセグメントのみ
+  if (hasBranch) {
+    for (const range of branchVerticalRanges) {
       lines.push({
         x1: branchNumX + branchNumWidth,
         y1: range.top,
@@ -451,6 +893,7 @@ function computeLayoutFromDefinition(
         y2: range.bottom,
         style: settings.borderConfig.numberColumnDivider,
         lineType: "numberColumn",
+        strokeWidth: ncSw,
         dragInfo: {
           axis: "vertical",
           target: { type: "columnWidth", column: "branchNumber" },
@@ -482,12 +925,46 @@ function addBorderLines(
   t: number,
   r: number,
   b: number,
-  style: LineStyle
+  style: LineStyle,
+  borderConfig: BorderConfig
 ) {
-  lines.push({ x1: l, y1: t, x2: r, y2: t, style, lineType: "outer" })
-  lines.push({ x1: l, y1: b, x2: r, y2: b, style, lineType: "outer" })
-  lines.push({ x1: l, y1: t, x2: l, y2: b, style, lineType: "outer" })
-  lines.push({ x1: r, y1: t, x2: r, y2: b, style, lineType: "outer" })
+  const sw = getLineWidth("outer", borderConfig)
+  lines.push({
+    x1: l,
+    y1: t,
+    x2: r,
+    y2: t,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+  lines.push({
+    x1: l,
+    y1: b,
+    x2: r,
+    y2: b,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+  lines.push({
+    x1: l,
+    y1: t,
+    x2: l,
+    y2: b,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+  lines.push({
+    x1: r,
+    y1: t,
+    x2: r,
+    y2: b,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
 }
 
 function computeOMRMarkers(
@@ -508,8 +985,512 @@ function computeOMRMarkers(
   ]
 }
 
+function computeMultiPageLayoutFromDefinition(
+  definition: AnswerSheetDefinition
+): ComputedMultiPageLayout {
+  const { settings, majorQuestions } = definition
+  const paper = getPaperDimensions(settings)
+  const { margins, baseRowHeight, columnWidths, spacing } = settings
+
+  const contentLeft = margins.left
+  const contentRight = paper.width - margins.right
+  const contentTop = margins.top + spacing.headerHeight
+  const contentMaxY = paper.height - margins.bottom
+
+  const majorNumX = contentLeft
+  const majorNumWidth = columnWidths.majorNumber
+  const subNumX = majorNumX + majorNumWidth
+  const subNumWidth = columnWidths.subNumber
+
+  const hasBranch = majorQuestions.some((mq) =>
+    mq.subQuestions.some((sq) => sq.branchQuestions.length > 0)
+  )
+  const branchNumX = subNumX + subNumWidth
+  const branchNumWidth = hasBranch ? columnWidths.branchNumber : 0
+  const answerX = branchNumX + branchNumWidth
+  const answerWidth = contentRight - answerX
+
+  interface PageData {
+    cells: ComputedCell[]
+    lines: ComputedLine[]
+    numberLabels: ComputedNumberLabel[]
+    verticalRanges: { top: number; bottom: number }[]
+    branchVerticalRanges: { top: number; bottom: number }[]
+    contentBottomY: number
+  }
+
+  function newPageData(): PageData {
+    return {
+      cells: [],
+      lines: [],
+      numberLabels: [],
+      verticalRanges: [],
+      branchVerticalRanges: [],
+      contentBottomY: contentTop,
+    }
+  }
+
+  const pagesData: PageData[] = [newPageData()]
+  let currentPageIdx = 0
+  let currentY = contentTop
+
+  function layoutMajorOnPage(
+    page: PageData,
+    major: MajorQuestion,
+    mi: number,
+    startY: number,
+    pageIdx: number
+  ): number {
+    let localY = startY
+    const majorStartY = localY
+    const majorHeight = computeMajorHeight(major, baseRowHeight)
+
+    // 大問番号ラベル
+    page.numberLabels.push({
+      text: major.label,
+      x: majorNumX,
+      y: majorStartY,
+      width: majorNumWidth,
+      height:
+        settings.numberDisplayMode === "multirow" ? majorHeight : baseRowHeight,
+      fontSize: settings.fonts.numberSize,
+      displayMode: settings.numberDisplayMode,
+    })
+
+    const layoutRows = buildLayoutRows(
+      major.subQuestions,
+      major.horizontalColumnsPerRow
+    )
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
+
+    let vertSegStart: number | null = null
+
+    layoutRows.forEach((row, ri) => {
+      if (row.type === "horizontal") {
+        if (vertSegStart !== null) {
+          page.verticalRanges.push({ top: vertSegStart, bottom: localY })
+          vertSegStart = null
+        }
+
+        const rowMaxH = Math.max(
+          ...row.subs.map((s) => s.sub.heightMultiplier),
+          1
+        )
+        const rowHeight = rowMaxH * baseRowHeight
+        const unitWidth = horizontalAreaWidth / row.columns
+
+        row.subs.forEach((entry) => {
+          const cellX = horizontalAreaX + entry.colStart * unitWidth
+          const cellWidth = entry.span * unitWidth
+
+          page.numberLabels.push({
+            text: entry.sub.label,
+            x: cellX,
+            y: localY,
+            width: cellWidth,
+            height: rowHeight,
+            fontSize: settings.fonts.numberSize,
+            displayMode: "sub-horizontal",
+          })
+
+          page.cells.push(
+            createCell(
+              [mi, entry.subIndex],
+              cellX,
+              localY,
+              cellWidth,
+              rowHeight,
+              paper,
+              `${major.label}-${entry.sub.label}`,
+              entry.sub.points,
+              entry.sub.textElements,
+              entry.sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(entry.sub, cellX, localY, cellWidth),
+              entry.sub.omrConfig
+            )
+          )
+
+          const cellRight = cellX + cellWidth
+          if (Math.abs(cellRight - contentRight) > 0.01) {
+            page.lines.push({
+              x1: cellRight,
+              y1: localY,
+              x2: cellRight,
+              y2: localY + rowHeight,
+              style: settings.borderConfig.subDivider,
+              lineType: "subHorizontalDivider",
+              strokeWidth: getLineWidth(
+                "subHorizontalDivider",
+                settings.borderConfig
+              ),
+            })
+          }
+        })
+
+        localY += rowHeight
+      } else {
+        if (vertSegStart === null) vertSegStart = localY
+
+        const sub = row.sub
+        const si = row.subIndex
+        const subStartY = localY
+        const hasBranches = sub.branchQuestions.length > 0
+        const subHeight = computeSubHeight(sub, baseRowHeight)
+
+        page.numberLabels.push({
+          text: sub.label,
+          x: subNumX,
+          y: subStartY,
+          width: subNumWidth,
+          height: subHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub",
+        })
+
+        if (hasBranches) {
+          const branchRows = buildBranchLayoutRows(
+            sub.branchQuestions,
+            sub.branchHorizontalColumnsPerRow
+          )
+          const branchAreaX = subNumX + subNumWidth
+          const branchAreaWidth = contentRight - branchAreaX
+          let branchY = subStartY
+          let bVertSegStart: number | null = null
+
+          branchRows.forEach((bRow, bri) => {
+            if (bRow.type === "horizontal") {
+              if (bVertSegStart !== null) {
+                page.branchVerticalRanges.push({
+                  top: bVertSegStart,
+                  bottom: branchY,
+                })
+                bVertSegStart = null
+              }
+
+              const rowMaxH = Math.max(
+                ...bRow.branches.map((b) => b.branch.heightMultiplier),
+                1
+              )
+              const bRowHeight = rowMaxH * baseRowHeight
+              const unitWidth = branchAreaWidth / bRow.columns
+
+              bRow.branches.forEach((entry) => {
+                const cellX = branchAreaX + entry.colStart * unitWidth
+                const cellWidth = entry.span * unitWidth
+
+                page.numberLabels.push({
+                  text: entry.branch.label,
+                  x: cellX,
+                  y: branchY,
+                  width: cellWidth,
+                  height: bRowHeight,
+                  fontSize: settings.fonts.numberSize - 1,
+                  displayMode: "branch-horizontal",
+                })
+
+                page.cells.push(
+                  createCell(
+                    [mi, si, entry.branchIndex],
+                    cellX,
+                    branchY,
+                    cellWidth,
+                    bRowHeight,
+                    paper,
+                    `${major.label}-${sub.label}-${entry.branch.label}`,
+                    entry.branch.points,
+                    entry.branch.textElements,
+                    entry.branch.modelAnswer,
+                    "answer",
+                    pageIdx,
+                    undefined,
+                    entry.branch.omrConfig
+                  )
+                )
+
+                const cellRight = cellX + cellWidth
+                if (Math.abs(cellRight - contentRight) > 0.01) {
+                  page.lines.push({
+                    x1: cellRight,
+                    y1: branchY,
+                    x2: cellRight,
+                    y2: branchY + bRowHeight,
+                    style: settings.borderConfig.branchDivider,
+                    lineType: "branch",
+                    strokeWidth: getLineWidth("branch", settings.borderConfig),
+                  })
+                }
+              })
+
+              branchY += bRowHeight
+            } else {
+              if (bVertSegStart === null) bVertSegStart = branchY
+
+              const branch = bRow.branch
+              const branchHeight = branch.heightMultiplier * baseRowHeight
+
+              page.numberLabels.push({
+                text: branch.label,
+                x: branchNumX,
+                y: branchY,
+                width: branchNumWidth,
+                height: branchHeight,
+                fontSize: settings.fonts.numberSize - 1,
+                displayMode: "branch",
+              })
+
+              page.cells.push(
+                createCell(
+                  [mi, si, bRow.branchIndex],
+                  answerX,
+                  branchY,
+                  answerWidth,
+                  branchHeight,
+                  paper,
+                  `${major.label}-${sub.label}-${branch.label}`,
+                  branch.points,
+                  branch.textElements,
+                  branch.modelAnswer,
+                  "answer",
+                  pageIdx,
+                  undefined,
+                  branch.omrConfig
+                )
+              )
+
+              branchY += branchHeight
+            }
+
+            // 枝問行間の区切り線
+            if (bri < branchRows.length - 1) {
+              const nextBRow = branchRows[bri + 1]
+              const lineX =
+                bRow.type === "horizontal" || nextBRow.type === "horizontal"
+                  ? branchAreaX
+                  : branchNumX
+              page.lines.push({
+                x1: lineX,
+                y1: branchY,
+                x2: contentRight,
+                y2: branchY,
+                style: settings.borderConfig.branchDivider,
+                lineType: "branch",
+                strokeWidth: getLineWidth("branch", settings.borderConfig),
+              })
+            }
+          })
+
+          if (bVertSegStart !== null) {
+            page.branchVerticalRanges.push({
+              top: bVertSegStart,
+              bottom: branchY,
+            })
+          }
+        } else {
+          page.cells.push(
+            createCell(
+              [mi, si],
+              answerX,
+              subStartY,
+              answerWidth,
+              subHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(sub, answerX, subStartY, answerWidth),
+              sub.omrConfig
+            )
+          )
+        }
+
+        localY += subHeight
+      }
+
+      // 行間の区切り線（最後の行以外）
+      if (ri < layoutRows.length - 1) {
+        const nextRow = layoutRows[ri + 1]
+        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+          page.lines.push({
+            x1: horizontalAreaX,
+            y1: localY,
+            x2: contentRight,
+            y2: localY,
+            style: settings.borderConfig.subDivider,
+            lineType: "subHorizontalDivider",
+            strokeWidth: getLineWidth(
+              "subHorizontalDivider",
+              settings.borderConfig
+            ),
+          })
+        } else {
+          page.lines.push({
+            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            y1: localY,
+            x2: contentRight,
+            y2: localY,
+            style: settings.borderConfig.subDivider,
+            lineType: "sub",
+            strokeWidth: getLineWidth("sub", settings.borderConfig),
+          })
+        }
+      }
+    })
+
+    if (vertSegStart !== null) {
+      page.verticalRanges.push({ top: vertSegStart, bottom: localY })
+    }
+
+    return localY
+  }
+
+  // 大問を順番に配置
+  for (let mi = 0; mi < majorQuestions.length; mi++) {
+    const major = majorQuestions[mi]
+    const majorHeight = computeMajorHeight(major, baseRowHeight)
+    const spacingHeight =
+      mi > 0 && currentY > contentTop ? spacing.majorQuestionSpacing : 0
+
+    if (
+      currentY + spacingHeight + majorHeight > contentMaxY &&
+      currentY > contentTop
+    ) {
+      pagesData[currentPageIdx].contentBottomY = currentY
+      currentPageIdx++
+      pagesData.push(newPageData())
+      currentY = contentTop
+    } else {
+      currentY += spacingHeight
+    }
+
+    currentY = layoutMajorOnPage(
+      pagesData[currentPageIdx],
+      major,
+      mi,
+      currentY,
+      currentPageIdx
+    )
+
+    if (mi < majorQuestions.length - 1) {
+      pagesData[currentPageIdx].lines.push({
+        x1: contentLeft,
+        y1: currentY,
+        x2: contentRight,
+        y2: currentY,
+        style: settings.borderConfig.majorDivider,
+        lineType: "major",
+        strokeWidth: getLineWidth("major", settings.borderConfig),
+      })
+    }
+  }
+
+  pagesData[currentPageIdx].contentBottomY = currentY
+
+  // ページごとにborder線・番号列線・OMRマーカーを追加
+  const pages: ComputedPageLayout[] = pagesData.map((pd, idx) => {
+    const pageContentBottom = pd.contentBottomY
+
+    // ページ末尾の大問区切り線を削除
+    const lastLine = pd.lines[pd.lines.length - 1]
+    if (
+      lastLine &&
+      lastLine.lineType === "major" &&
+      Math.abs(lastLine.y1 - pageContentBottom) < 0.01
+    ) {
+      pd.lines.pop()
+    }
+
+    // 外枠線
+    addBorderLines(
+      pd.lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      pageContentBottom,
+      settings.borderConfig.outerBorder,
+      settings.borderConfig
+    )
+
+    // 番号列の縦線
+    const ncSwPage = getLineWidth("numberColumn", settings.borderConfig)
+
+    // 大問番号列の縦線
+    pd.lines.push({
+      x1: majorNumX + majorNumWidth,
+      y1: contentTop,
+      x2: majorNumX + majorNumWidth,
+      y2: pageContentBottom,
+      style: settings.borderConfig.numberColumnDivider,
+      lineType: "numberColumn",
+      strokeWidth: ncSwPage,
+    })
+
+    // 小問番号列の縦線（縦配置セグメントのみ）
+    for (const range of pd.verticalRanges) {
+      pd.lines.push({
+        x1: subNumX + subNumWidth,
+        y1: range.top,
+        x2: subNumX + subNumWidth,
+        y2: range.bottom,
+        style: settings.borderConfig.numberColumnDivider,
+        lineType: "numberColumn",
+        strokeWidth: ncSwPage,
+      })
+    }
+
+    // 枝問番号列の縦線（vertical-branchセグメントのみ）
+    if (hasBranch) {
+      for (const range of pd.branchVerticalRanges) {
+        pd.lines.push({
+          x1: branchNumX + branchNumWidth,
+          y1: range.top,
+          x2: branchNumX + branchNumWidth,
+          y2: range.bottom,
+          style: settings.borderConfig.numberColumnDivider,
+          lineType: "numberColumn",
+          strokeWidth: ncSwPage,
+        })
+      }
+    }
+
+    const omrMarkerPositions = computeOMRMarkers(settings, paper)
+
+    return {
+      pageIndex: idx,
+      cells: pd.cells,
+      lines: pd.lines,
+      numberLabels: pd.numberLabels,
+      omrMarkerPositions,
+      contentHeightMm: pageContentBottom - margins.top,
+    }
+  })
+
+  return {
+    pages,
+    totalPages: pages.length,
+    pageWidthMm: paper.width,
+    pageHeightMm: paper.height,
+  }
+}
+
+/** 単一ページレイアウト（後方互換） */
 export function useAnswerSheetLayout(
   definition: AnswerSheetDefinition
 ): ComputedLayout {
   return useMemo(() => computeLayoutFromDefinition(definition), [definition])
+}
+
+/** 複数ページレイアウト */
+export function useMultiPageLayout(
+  definition: AnswerSheetDefinition
+): ComputedMultiPageLayout {
+  return useMemo(
+    () => computeMultiPageLayoutFromDefinition(definition),
+    [definition]
+  )
 }

--- a/components/projects/07-score-at-once/OMRRecognition/OMRCellDetail.tsx
+++ b/components/projects/07-score-at-once/OMRRecognition/OMRCellDetail.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { OMRCellResult } from "@/types/omr.types"
+
+interface OMRCellDetailProps {
+  cellResult: OMRCellResult
+  studentId?: string
+  onUpdate: (updatedValues: string[]) => void
+  onClose: () => void
+}
+
+export function OMRCellDetail({
+  cellResult,
+  studentId,
+  onUpdate,
+  onClose,
+}: OMRCellDetailProps) {
+  const [editValue, setEditValue] = useState(
+    cellResult.recognizedValues.join(", ")
+  )
+
+  function handleSave() {
+    const values = editValue
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v !== "")
+    onUpdate(values)
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">
+          セル詳細: {cellResult.label}
+          {studentId && (
+            <span className="text-muted-foreground ml-2">({studentId})</span>
+          )}
+        </h4>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          閉じる
+        </Button>
+      </div>
+
+      {/* 認識結果 */}
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <Label className="text-muted-foreground text-xs">認識結果</Label>
+          <div className="mt-0.5">
+            {cellResult.recognizedValues.length > 0
+              ? cellResult.recognizedValues.join(", ")
+              : "（空）"}
+          </div>
+        </div>
+        <div>
+          <Label className="text-muted-foreground text-xs">信頼度</Label>
+          <div className="mt-0.5">
+            {(cellResult.confidence * 100).toFixed(1)}%
+          </div>
+        </div>
+        {cellResult.fillRatios && (
+          <div className="col-span-2">
+            <Label className="text-muted-foreground text-xs">
+              塗りつぶし率
+            </Label>
+            <div className="mt-0.5 flex gap-2">
+              {cellResult.fillRatios.map((r, i) => (
+                <span
+                  key={i}
+                  className={`rounded px-1.5 py-0.5 text-xs ${
+                    r >= 0.4
+                      ? "bg-primary/10 text-primary font-medium"
+                      : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {(r * 100).toFixed(0)}%
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 手動修正 */}
+      <div className="space-y-1.5">
+        <Label className="text-xs">手動修正</Label>
+        <div className="flex gap-2">
+          <Input
+            className="h-8 text-sm"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            placeholder="認識値を入力"
+          />
+          <Button size="sm" className="h-8" onClick={handleSave}>
+            適用
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/projects/07-score-at-once/OMRRecognition/OMRRecognitionPanel.tsx
+++ b/components/projects/07-score-at-once/OMRRecognition/OMRRecognitionPanel.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { Play, RotateCcw, Settings2 } from "lucide-react"
+import { useCallback, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
+import { Slider } from "@/components/ui/slider"
+import type { ComputedCell } from "@/types/answerSheetBuilder.types"
+import type { OMRCellConfig, OMRCellResult, Point } from "@/types/omr.types"
+
+import { useOMRRecognition } from "./hooks/useOMRRecognition"
+import { OMRCellDetail } from "./OMRCellDetail"
+import { OMRResultsTable } from "./OMRResultsTable"
+
+interface OMRRecognitionPanelProps {
+  /** レイアウトエンジンが計算したセル一覧 */
+  cells: ComputedCell[]
+  /** セルごとのOMR設定（キー: questionPath.join("-")） */
+  cellConfigs: Record<string, OMRCellConfig>
+  /** OMRマーカーの期待位置（0-1正規化座標） */
+  expectedCorners: [Point, Point, Point, Point]
+  /** 認識対象の答案画像パスリスト */
+  answerEntries: {
+    path: string
+    studentId?: string
+    studentName?: string
+  }[]
+  /** ページインデックス */
+  pageIndex?: number
+}
+
+export function OMRRecognitionPanel({
+  cells,
+  cellConfigs,
+  expectedCorners,
+  answerEntries,
+  pageIndex,
+}: OMRRecognitionPanelProps) {
+  const {
+    isRecognizing,
+    progress,
+    sheetResults,
+    error,
+    recognizeBatch,
+    clearResults,
+    updateParams,
+    currentParams,
+  } = useOMRRecognition({
+    cells,
+    cellConfigs,
+    expectedCorners,
+    pageIndex,
+  })
+
+  const [showSettings, setShowSettings] = useState(false)
+  const [selectedCell, setSelectedCell] = useState<{
+    studentId?: string
+    cellResult: OMRCellResult
+  } | null>(null)
+
+  const handleRunRecognition = useCallback(() => {
+    recognizeBatch(answerEntries)
+  }, [recognizeBatch, answerEntries])
+
+  const handleCellClick = useCallback(
+    (studentId: string | undefined, cellResult: OMRCellResult) => {
+      setSelectedCell({ studentId, cellResult })
+    },
+    []
+  )
+
+  const handleCellUpdate = useCallback(
+    (updatedValues: string[]) => {
+      // 結果テーブル上での手動修正（将来的にQuestionScoreへの書き込みに接続）
+      if (selectedCell) {
+        setSelectedCell({
+          ...selectedCell,
+          cellResult: {
+            ...selectedCell.cellResult,
+            recognizedValues: updatedValues,
+          },
+        })
+      }
+    },
+    [selectedCell]
+  )
+
+  const progressPercent =
+    progress && progress.total > 0
+      ? (progress.processed / progress.total) * 100
+      : 0
+
+  return (
+    <div className="space-y-4">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">OMR自動認識</h3>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1"
+            onClick={() => setShowSettings(!showSettings)}
+          >
+            <Settings2 className="h-3.5 w-3.5" />
+            設定
+          </Button>
+          {sheetResults.length > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1"
+              onClick={clearResults}
+              disabled={isRecognizing}
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              クリア
+            </Button>
+          )}
+          <Button
+            size="sm"
+            className="h-7 gap-1"
+            onClick={handleRunRecognition}
+            disabled={isRecognizing || answerEntries.length === 0}
+          >
+            <Play className="h-3.5 w-3.5" />
+            {isRecognizing
+              ? "認識中..."
+              : `認識実行 (${answerEntries.length}件)`}
+          </Button>
+        </div>
+      </div>
+
+      {/* パラメータ設定 */}
+      {showSettings && (
+        <div className="space-y-3 rounded-lg border p-3">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">
+                暗さ閾値: {currentParams.colorThreshold}
+              </Label>
+            </div>
+            <Slider
+              min={5}
+              max={100}
+              step={5}
+              value={[currentParams.colorThreshold]}
+              onValueChange={([v]) => updateParams({ colorThreshold: v })}
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">
+                塗りつぶし閾値: {(currentParams.areaThreshold * 100).toFixed(0)}
+                %
+              </Label>
+            </div>
+            <Slider
+              min={10}
+              max={90}
+              step={5}
+              value={[currentParams.areaThreshold * 100]}
+              onValueChange={([v]) => updateParams({ areaThreshold: v / 100 })}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* プログレスバー */}
+      {isRecognizing && progress && (
+        <div className="space-y-1">
+          <div className="text-muted-foreground flex items-center justify-between text-xs">
+            <span>
+              {progress.currentStudentName
+                ? `処理中: ${progress.currentStudentName}`
+                : "処理中..."}
+            </span>
+            <span>
+              {progress.processed}/{progress.total}
+            </span>
+          </div>
+          <Progress value={progressPercent} className="h-2" />
+        </div>
+      )}
+
+      {/* エラー表示 */}
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      {/* 結果サマリ */}
+      {!isRecognizing && progress && progress.processed > 0 && (
+        <div className="text-muted-foreground flex gap-4 text-xs">
+          <span>合計: {progress.total}件</span>
+          <span className="text-green-600">成功: {progress.succeeded}件</span>
+          <span className="text-red-600">失敗: {progress.failed}件</span>
+        </div>
+      )}
+
+      {/* 結果テーブル */}
+      <OMRResultsTable
+        sheetResults={sheetResults}
+        onCellClick={handleCellClick}
+      />
+
+      {/* セル詳細 */}
+      {selectedCell && (
+        <OMRCellDetail
+          cellResult={selectedCell.cellResult}
+          studentId={selectedCell.studentId}
+          onUpdate={handleCellUpdate}
+          onClose={() => setSelectedCell(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/components/projects/07-score-at-once/OMRRecognition/OMRResultsTable.tsx
+++ b/components/projects/07-score-at-once/OMRRecognition/OMRResultsTable.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { AlertTriangle, CheckCircle2, MinusCircle, XCircle } from "lucide-react"
+
+import type { OMRCellResult, OMRSheetResult } from "@/types/omr.types"
+
+interface OMRResultsTableProps {
+  sheetResults: OMRSheetResult[]
+  /** セル行クリック時のコールバック */
+  onCellClick?: (
+    studentId: string | undefined,
+    cellResult: OMRCellResult
+  ) => void
+}
+
+function StatusIcon({ status }: { status: OMRCellResult["autoScoreStatus"] }) {
+  switch (status) {
+    case "correct":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />
+    case "incorrect":
+      return <XCircle className="h-4 w-4 text-red-500" />
+    case "ambiguous":
+      return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+    case "no_answer":
+      return <MinusCircle className="text-muted-foreground h-4 w-4" />
+    default:
+      return null
+  }
+}
+
+function confidenceColor(confidence: number): string {
+  if (confidence >= 0.8) return "text-green-600"
+  if (confidence >= 0.5) return "text-yellow-600"
+  return "text-red-600"
+}
+
+export function OMRResultsTable({
+  sheetResults,
+  onCellClick,
+}: OMRResultsTableProps) {
+  if (sheetResults.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+        認識結果がありません。認識を実行してください。
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-h-[500px] overflow-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50 sticky top-0">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">生徒</th>
+            <th className="px-3 py-2 text-left font-medium">設問</th>
+            <th className="px-3 py-2 text-left font-medium">認識結果</th>
+            <th className="px-3 py-2 text-center font-medium">信頼度</th>
+            <th className="px-3 py-2 text-center font-medium">判定</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {sheetResults.map((sheet, si) => {
+            if (!sheet.success) {
+              return (
+                <tr key={si} className="bg-red-50/50">
+                  <td className="px-3 py-1.5">
+                    {sheet.studentId ?? `答案 ${si + 1}`}
+                  </td>
+                  <td colSpan={4} className="px-3 py-1.5 text-red-600">
+                    {sheet.error ?? "認識に失敗しました"}
+                  </td>
+                </tr>
+              )
+            }
+
+            return sheet.cellResults.map((cell, ci) => (
+              <tr
+                key={`${si}-${ci}`}
+                className="hover:bg-muted/30 cursor-pointer transition-colors"
+                onClick={() => onCellClick?.(sheet.studentId, cell)}
+              >
+                {ci === 0 ? (
+                  <td
+                    className="px-3 py-1.5 font-medium"
+                    rowSpan={sheet.cellResults.length}
+                  >
+                    {sheet.studentId ?? `答案 ${si + 1}`}
+                  </td>
+                ) : null}
+                <td className="px-3 py-1.5">{cell.label}</td>
+                <td className="px-3 py-1.5">
+                  {cell.recognizedValues.length > 0
+                    ? cell.recognizedValues.join(", ")
+                    : "-"}
+                </td>
+                <td className="px-3 py-1.5 text-center">
+                  <span className={confidenceColor(cell.confidence)}>
+                    {(cell.confidence * 100).toFixed(0)}%
+                  </span>
+                </td>
+                <td className="px-3 py-1.5">
+                  <div className="flex items-center justify-center">
+                    <StatusIcon status={cell.autoScoreStatus} />
+                  </div>
+                </td>
+              </tr>
+            ))
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/components/projects/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
+++ b/components/projects/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
@@ -1,0 +1,241 @@
+/**
+ * OMR認識実行フック
+ *
+ * バッチ認識の実行・進捗管理・結果保持を行う。
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { ComputedCell } from "@/types/answerSheetBuilder.types"
+import type {
+  OMRBatchProgress,
+  OMRCellConfig,
+  OMRCellResult,
+  OMRRecognitionParams,
+  OMRSheetResult,
+  Point,
+} from "@/types/omr.types"
+
+interface OMRRecognitionState {
+  /** 認識中フラグ */
+  isRecognizing: boolean
+  /** バッチ進捗 */
+  progress: OMRBatchProgress | null
+  /** シートごとの認識結果 */
+  sheetResults: OMRSheetResult[]
+  /** 全セル結果のフラットリスト */
+  allCellResults: Array<OMRCellResult & { studentId?: string }>
+  /** エラーメッセージ */
+  error: string | null
+}
+
+interface UseOMRRecognitionOptions {
+  cells: ComputedCell[]
+  cellConfigs: Record<string, OMRCellConfig>
+  expectedCorners: [Point, Point, Point, Point]
+  params?: OMRRecognitionParams
+  pageIndex?: number
+}
+
+interface UseOMRRecognitionReturn extends OMRRecognitionState {
+  /** 単一画像の認識を実行 */
+  recognizeSingle: (
+    imagePath: string,
+    studentId?: string
+  ) => Promise<OMRSheetResult | null>
+  /** バッチ認識を実行 */
+  recognizeBatch: (
+    entries: { path: string; studentId?: string; studentName?: string }[]
+  ) => Promise<void>
+  /** 結果をクリア */
+  clearResults: () => void
+  /** パラメータ変更 */
+  updateParams: (params: Partial<OMRRecognitionParams>) => void
+  /** 現在のパラメータ */
+  currentParams: OMRRecognitionParams
+}
+
+const DEFAULT_PARAMS: OMRRecognitionParams = {
+  colorThreshold: 25,
+  areaThreshold: 0.4,
+}
+
+export function useOMRRecognition(
+  options: UseOMRRecognitionOptions
+): UseOMRRecognitionReturn {
+  const { cells, cellConfigs, expectedCorners, pageIndex } = options
+
+  const [state, setState] = useState<OMRRecognitionState>({
+    isRecognizing: false,
+    progress: null,
+    sheetResults: [],
+    allCellResults: [],
+    error: null,
+  })
+
+  const [currentParams, setCurrentParams] = useState<OMRRecognitionParams>(
+    options.params ?? DEFAULT_PARAMS
+  )
+
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  // プログレスリスナー登録
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.electronAPI?.omr) return
+
+    const cleanup = window.electronAPI.omr.onBatchProgress((progress) => {
+      setState((prev) => ({ ...prev, progress }))
+    })
+    cleanupRef.current = cleanup
+
+    return () => {
+      cleanup()
+      cleanupRef.current = null
+    }
+  }, [])
+
+  const recognizeSingle = useCallback(
+    async (
+      imagePath: string,
+      studentId?: string
+    ): Promise<OMRSheetResult | null> => {
+      if (!window.electronAPI?.omr) {
+        setState((prev) => ({
+          ...prev,
+          error: "OMR APIが利用できません",
+        }))
+        return null
+      }
+
+      setState((prev) => ({
+        ...prev,
+        isRecognizing: true,
+        error: null,
+      }))
+
+      try {
+        const result = await window.electronAPI.omr.recognizeSheet({
+          imagePath,
+          cells,
+          cellConfigs,
+          expectedCorners,
+          params: currentParams,
+          pageIndex,
+          studentId,
+        })
+
+        setState((prev) => ({
+          ...prev,
+          isRecognizing: false,
+          sheetResults: [...prev.sheetResults, result],
+          allCellResults: [
+            ...prev.allCellResults,
+            ...result.cellResults.map((cr) => ({
+              ...cr,
+              studentId: result.studentId,
+            })),
+          ],
+        }))
+
+        return result
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          isRecognizing: false,
+          error: error instanceof Error ? error.message : "認識に失敗しました",
+        }))
+        return null
+      }
+    },
+    [cells, cellConfigs, expectedCorners, currentParams, pageIndex]
+  )
+
+  const recognizeBatch = useCallback(
+    async (
+      entries: { path: string; studentId?: string; studentName?: string }[]
+    ) => {
+      if (!window.electronAPI?.omr) {
+        setState((prev) => ({
+          ...prev,
+          error: "OMR APIが利用できません",
+        }))
+        return
+      }
+
+      setState({
+        isRecognizing: true,
+        progress: {
+          total: entries.length,
+          processed: 0,
+          succeeded: 0,
+          failed: 0,
+        },
+        sheetResults: [],
+        allCellResults: [],
+        error: null,
+      })
+
+      try {
+        const results = await window.electronAPI.omr.batchRecognize({
+          imagePaths: entries,
+          cells,
+          cellConfigs,
+          expectedCorners,
+          params: currentParams,
+          pageIndex,
+        })
+
+        const allCells: Array<OMRCellResult & { studentId?: string }> = []
+        for (const result of results) {
+          for (const cr of result.cellResults) {
+            allCells.push({ ...cr, studentId: result.studentId })
+          }
+        }
+
+        setState({
+          isRecognizing: false,
+          progress: {
+            total: entries.length,
+            processed: entries.length,
+            succeeded: results.filter((r) => r.success).length,
+            failed: results.filter((r) => !r.success).length,
+          },
+          sheetResults: results,
+          allCellResults: allCells,
+          error: null,
+        })
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          isRecognizing: false,
+          error:
+            error instanceof Error ? error.message : "バッチ認識に失敗しました",
+        }))
+      }
+    },
+    [cells, cellConfigs, expectedCorners, currentParams, pageIndex]
+  )
+
+  const clearResults = useCallback(() => {
+    setState({
+      isRecognizing: false,
+      progress: null,
+      sheetResults: [],
+      allCellResults: [],
+      error: null,
+    })
+  }, [])
+
+  const updateParams = useCallback((params: Partial<OMRRecognitionParams>) => {
+    setCurrentParams((prev) => ({ ...prev, ...params }))
+  }, [])
+
+  return {
+    ...state,
+    recognizeSingle,
+    recognizeBatch,
+    clearResults,
+    updateParams,
+    currentParams,
+  }
+}

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -6,6 +6,7 @@ import { setupDrawingHandlers } from "./drawingHandlers"
 import { setupExportHandlers } from "./exportHandlers"
 import { setupGradeProjectHandlers } from "./gradeProjectHandlers"
 import { setupMiscHandlers } from "./miscHandlers"
+import { setupOMRHandlers } from "./omrHandlers"
 import { setupPdfToolsHandlers } from "./pdfToolsHandlers"
 import { setupProjectClassHandlers } from "./projectClassHandlers"
 import { setupProjectHandlers } from "./projectHandlers"
@@ -36,4 +37,5 @@ export function setupAllIPCHandlers(): void {
   setupSubjectHandlers()
   setupGradeProjectHandlers()
   setupAnswerSheetBuilderHandlers()
+  setupOMRHandlers()
 }

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -1,0 +1,336 @@
+/**
+ * OMR（光学マーク認識）IPC ハンドラー
+ */
+
+import { BrowserWindow, ipcMain } from "electron"
+import fs from "fs"
+import path from "path"
+
+import type { ComputedCell } from "../../types/answerSheetBuilder.types"
+import type {
+  MarkerDetectionResult,
+  OMRBatchProgress,
+  OMRCellConfig,
+  OMRRecognitionParams,
+  OMRSheetResult,
+  OMRTemplate,
+} from "../../types/omr.types"
+import { getDataDirectory } from "../lib/dataManager"
+import {
+  createTransform,
+  detectCornerMarkers,
+  loadImageRaw,
+  recognizeCells,
+} from "../lib/omr"
+
+export function setupOMRHandlers(): void {
+  // ────────────────────────────────────────
+  // 単一画像のコーナーマーカー検出
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:detect-markers",
+    async (
+      _event,
+      imagePath: string,
+      colorThreshold?: number
+    ): Promise<MarkerDetectionResult> => {
+      return detectCornerMarkers(imagePath, colorThreshold)
+    }
+  )
+
+  // ────────────────────────────────────────
+  // 1枚の答案シート認識
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:recognize-sheet",
+    async (
+      _event,
+      args: {
+        imagePath: string
+        cells: ComputedCell[]
+        cellConfigs: Record<string, OMRCellConfig>
+        expectedCorners: [
+          { x: number; y: number },
+          { x: number; y: number },
+          { x: number; y: number },
+          { x: number; y: number },
+        ]
+        params: OMRRecognitionParams
+        pageIndex?: number
+        studentId?: string
+      }
+    ): Promise<OMRSheetResult> => {
+      try {
+        // 1. マーカー検出
+        const markerResult = await detectCornerMarkers(
+          args.imagePath,
+          args.params.colorThreshold
+        )
+        if (!markerResult.success) {
+          return {
+            success: false,
+            pageIndex: args.pageIndex ?? 0,
+            markerDetection: markerResult,
+            cellResults: [],
+            error: markerResult.error,
+          }
+        }
+
+        // 2. 座標変換を構築
+        const sortedMarkers = {
+          TL: markerResult.markers.find((m) => m.corner === "TL")!,
+          TR: markerResult.markers.find((m) => m.corner === "TR")!,
+          BL: markerResult.markers.find((m) => m.corner === "BL")!,
+          BR: markerResult.markers.find((m) => m.corner === "BR")!,
+        }
+
+        const transform = createTransform(
+          [
+            { x: sortedMarkers.TL.centerX, y: sortedMarkers.TL.centerY },
+            { x: sortedMarkers.TR.centerX, y: sortedMarkers.TR.centerY },
+            { x: sortedMarkers.BL.centerX, y: sortedMarkers.BL.centerY },
+            { x: sortedMarkers.BR.centerX, y: sortedMarkers.BR.centerY },
+          ],
+          args.expectedCorners,
+          markerResult.imageWidth,
+          markerResult.imageHeight
+        )
+
+        // 3. 画像読み込み
+        const rawImage = await loadImageRaw(args.imagePath)
+
+        // 4. マーク認識
+        const cellResults = await recognizeCells(
+          args.cells,
+          args.cellConfigs,
+          rawImage,
+          transform,
+          args.params
+        )
+
+        return {
+          success: true,
+          studentId: args.studentId,
+          pageIndex: args.pageIndex ?? 0,
+          markerDetection: markerResult,
+          cellResults,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          pageIndex: args.pageIndex ?? 0,
+          markerDetection: {
+            success: false,
+            markers: [],
+            imageWidth: 0,
+            imageHeight: 0,
+            error: String(error),
+          },
+          cellResults: [],
+          error:
+            error instanceof Error ? error.message : "OMR認識に失敗しました",
+        }
+      }
+    }
+  )
+
+  // ────────────────────────────────────────
+  // バッチ認識（プロジェクト全答案）
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:batch-recognize",
+    async (
+      _event,
+      args: {
+        imagePaths: { path: string; studentId?: string; studentName?: string }[]
+        cells: ComputedCell[]
+        cellConfigs: Record<string, OMRCellConfig>
+        expectedCorners: [
+          { x: number; y: number },
+          { x: number; y: number },
+          { x: number; y: number },
+          { x: number; y: number },
+        ]
+        params: OMRRecognitionParams
+        pageIndex?: number
+      }
+    ): Promise<OMRSheetResult[]> => {
+      const results: OMRSheetResult[] = []
+      const total = args.imagePaths.length
+      let processed = 0
+      let succeeded = 0
+      let failed = 0
+
+      for (const entry of args.imagePaths) {
+        // プログレス通知
+        const progress: OMRBatchProgress = {
+          total,
+          processed,
+          succeeded,
+          failed,
+          currentStudentName: entry.studentName,
+        }
+        const windows = BrowserWindow.getAllWindows()
+        for (const win of windows) {
+          win.webContents.send("omr:batch-progress", progress)
+        }
+
+        try {
+          const markerResult = await detectCornerMarkers(
+            entry.path,
+            args.params.colorThreshold
+          )
+
+          if (!markerResult.success) {
+            results.push({
+              success: false,
+              studentId: entry.studentId,
+              pageIndex: args.pageIndex ?? 0,
+              markerDetection: markerResult,
+              cellResults: [],
+              error: markerResult.error,
+            })
+            failed++
+          } else {
+            const sortedMarkers = {
+              TL: markerResult.markers.find((m) => m.corner === "TL")!,
+              TR: markerResult.markers.find((m) => m.corner === "TR")!,
+              BL: markerResult.markers.find((m) => m.corner === "BL")!,
+              BR: markerResult.markers.find((m) => m.corner === "BR")!,
+            }
+
+            const transform = createTransform(
+              [
+                { x: sortedMarkers.TL.centerX, y: sortedMarkers.TL.centerY },
+                { x: sortedMarkers.TR.centerX, y: sortedMarkers.TR.centerY },
+                { x: sortedMarkers.BL.centerX, y: sortedMarkers.BL.centerY },
+                { x: sortedMarkers.BR.centerX, y: sortedMarkers.BR.centerY },
+              ],
+              args.expectedCorners,
+              markerResult.imageWidth,
+              markerResult.imageHeight
+            )
+
+            const rawImage = await loadImageRaw(entry.path)
+            const cellResults = await recognizeCells(
+              args.cells,
+              args.cellConfigs,
+              rawImage,
+              transform,
+              args.params
+            )
+
+            results.push({
+              success: true,
+              studentId: entry.studentId,
+              pageIndex: args.pageIndex ?? 0,
+              markerDetection: markerResult,
+              cellResults,
+            })
+            succeeded++
+          }
+        } catch (error) {
+          results.push({
+            success: false,
+            studentId: entry.studentId,
+            pageIndex: args.pageIndex ?? 0,
+            markerDetection: {
+              success: false,
+              markers: [],
+              imageWidth: 0,
+              imageHeight: 0,
+            },
+            cellResults: [],
+            error: String(error),
+          })
+          failed++
+        }
+
+        processed++
+      }
+
+      // 完了通知
+      const windows = BrowserWindow.getAllWindows()
+      for (const win of windows) {
+        win.webContents.send("omr:batch-progress", {
+          total,
+          processed,
+          succeeded,
+          failed,
+        })
+      }
+
+      return results
+    }
+  )
+
+  // ────────────────────────────────────────
+  // OMRテンプレート保存
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:save-template",
+    async (
+      _event,
+      projectId: string,
+      template: OMRTemplate
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const dataDir = getDataDirectory()
+        const projectDir = path.join(dataDir, "projects", projectId)
+        if (!fs.existsSync(projectDir)) {
+          fs.mkdirSync(projectDir, { recursive: true })
+        }
+        const templatePath = path.join(projectDir, "omr-template.json")
+        fs.writeFileSync(templatePath, JSON.stringify(template, null, 2))
+        return { success: true }
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "テンプレート保存に失敗しました",
+        }
+      }
+    }
+  )
+
+  // ────────────────────────────────────────
+  // OMRテンプレート読み込み
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:load-template",
+    async (
+      _event,
+      projectId: string
+    ): Promise<{
+      success: boolean
+      template?: OMRTemplate
+      error?: string
+    }> => {
+      try {
+        const dataDir = getDataDirectory()
+        const templatePath = path.join(
+          dataDir,
+          "projects",
+          projectId,
+          "omr-template.json"
+        )
+        if (!fs.existsSync(templatePath)) {
+          return { success: false, error: "テンプレートが見つかりません" }
+        }
+        const content = fs.readFileSync(templatePath, "utf-8")
+        const template = JSON.parse(content) as OMRTemplate
+        return { success: true, template }
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "テンプレート読み込みに失敗しました",
+        }
+      }
+    }
+  )
+}

--- a/electron-src/lib/answer-sheet-builder/layoutEngine.ts
+++ b/electron-src/lib/answer-sheet-builder/layoutEngine.ts
@@ -7,16 +7,47 @@
 
 import type {
   AnswerSheetDefinition,
+  BorderConfig,
+  BranchLayoutRow,
+  BranchQuestion,
   ComputedCell,
   ComputedLayout,
   ComputedLine,
+  ComputedMultiPageLayout,
   ComputedNumberLabel,
   ComputedOMRMarker,
+  ComputedPageLayout,
   GlobalSettings,
+  LayoutRow,
   LineStyle,
   MajorQuestion,
+  ManuscriptGrid,
   SubQuestion,
 } from "../../../types/answerSheetBuilder.types"
+import type {
+  ComputedOMRBubble,
+  ComputedOMRDigitBox,
+  OMRCellConfig,
+} from "../../../types/omr.types"
+
+/** lineType から BorderConfig の線幅を取得するヘルパー */
+function getLineWidth(lineType: string, borderConfig: BorderConfig): number {
+  switch (lineType) {
+    case "outer":
+      return borderConfig.outerBorderWidth ?? 0.7
+    case "major":
+      return borderConfig.majorDividerWidth ?? 0.5
+    case "sub":
+    case "subHorizontalDivider":
+      return borderConfig.subDividerWidth ?? 0.4
+    case "branch":
+      return borderConfig.branchDividerWidth ?? 0.3
+    case "numberColumn":
+      return borderConfig.numberColumnDividerWidth ?? 0.4
+    default:
+      return 0.4
+  }
+}
 
 // 用紙サイズ定義（mmで直接持つ: Electron側ではcomponents/をimportしない）
 const PAPER_SIZES: Record<string, { width: number; height: number }> = {
@@ -36,6 +67,95 @@ function getPaperDimensions(settings: GlobalSettings): {
     return { width: base.height, height: base.width }
   }
   return { width: base.width, height: base.height }
+}
+
+/**
+ * OMR choiceセルのバブル位置を計算（0-1正規化座標）
+ */
+function computeOMRBubbles(
+  cellX: number,
+  cellY: number,
+  cellWidth: number,
+  cellHeight: number,
+  paperWidth: number,
+  paperHeight: number,
+  config: OMRCellConfig & { type: "choice" }
+): ComputedOMRBubble[] {
+  const bubbles: ComputedOMRBubble[] = []
+  const n = config.numChoices
+
+  // バブル半径（セル高さの25%を上限）
+  const maxRadiusMm = Math.min(cellHeight * 0.25, cellWidth / (n * 2.5 + 1))
+  const radiusMm = Math.max(1.5, maxRadiusMm)
+
+  if (config.layout === "horizontal") {
+    // 水平配置: セル内に等間隔で横並び
+    const spacing = cellWidth / (n + 1)
+    const cy = cellY + cellHeight / 2
+
+    for (let i = 0; i < n; i++) {
+      const cx = cellX + spacing * (i + 1)
+      bubbles.push({
+        normalizedCx: cx / paperWidth,
+        normalizedCy: cy / paperHeight,
+        normalizedRadius: radiusMm / paperWidth,
+        choiceIndex: i,
+        label: config.labels[i] ?? String(i + 1),
+      })
+    }
+  } else {
+    // 垂直配置: セル内に等間隔で縦並び
+    const spacing = cellHeight / (n + 1)
+    const cx = cellX + cellWidth / 2
+
+    for (let i = 0; i < n; i++) {
+      const cy = cellY + spacing * (i + 1)
+      bubbles.push({
+        normalizedCx: cx / paperWidth,
+        normalizedCy: cy / paperHeight,
+        normalizedRadius: radiusMm / paperWidth,
+        choiceIndex: i,
+        label: config.labels[i] ?? String(i + 1),
+      })
+    }
+  }
+
+  return bubbles
+}
+
+/**
+ * OMR handwritten-digitセルの数字欄位置を計算（0-1正規化座標）
+ */
+function computeOMRDigitBoxes(
+  cellX: number,
+  cellY: number,
+  cellWidth: number,
+  cellHeight: number,
+  paperWidth: number,
+  paperHeight: number,
+  config: OMRCellConfig & { type: "handwritten-digit" }
+): ComputedOMRDigitBox[] {
+  const boxes: ComputedOMRDigitBox[] = []
+  const n = config.numDigits
+
+  // 数字欄のサイズ（セル高さの80%を正方形として使用）
+  const boxHeight = cellHeight * 0.8
+  const boxWidth = Math.min(boxHeight, cellWidth / (n + 0.5))
+  const totalWidth = boxWidth * n
+  const startX = cellX + (cellWidth - totalWidth) / 2
+  const startY = cellY + (cellHeight - boxHeight) / 2
+
+  for (let i = 0; i < n; i++) {
+    boxes.push({
+      normalizedX: (startX + boxWidth * i) / paperWidth,
+      normalizedY: startY / paperHeight,
+      normalizedW: boxWidth / paperWidth,
+      normalizedH: boxHeight / paperHeight,
+      digitIndex: i,
+    })
+  }
+
+  return boxes
 }
 
 /** レイアウト計算のメイン関数 */
@@ -74,7 +194,7 @@ export function computeLayout(
   // 各大問を処理
   majorQuestions.forEach((major, mi) => {
     // 大問前スペーシング
-    if (major.spacingBefore && mi > 0) {
+    if (mi > 0) {
       currentY += spacing.majorQuestionSpacing
     }
 
@@ -82,7 +202,7 @@ export function computeLayout(
     const majorHeight = computeMajorHeight(major, baseRowHeight)
 
     // 大問番号セル
-    if (major.numberDisplayMode === "multirow") {
+    if (settings.numberDisplayMode === "multirow") {
       numberLabels.push({
         text: major.label,
         x: majorNumX,
@@ -105,20 +225,16 @@ export function computeLayout(
       })
     }
 
-    const isHorizontal =
-      (major.subQuestionLayout ?? "vertical") === "horizontal"
+    // buildLayoutRows で統一的にレイアウト行を生成
+    const layoutRows = buildLayoutRows(
+      major.subQuestions,
+      major.horizontalColumnsPerRow
+    )
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
 
-    if (isHorizontal) {
-      // 横配置: 大問番号列の右端から用紙右マージンまでが利用可能幅
-      const horizontalAreaX = majorNumX + majorNumWidth
-      const horizontalAreaWidth = contentRight - horizontalAreaX
-
-      const rows = assignSubsToRows(
-        major.subQuestions,
-        major.horizontalColumnsPerRow
-      )
-
-      rows.forEach((row, ri) => {
+    layoutRows.forEach((row, ri) => {
+      if (row.type === "horizontal") {
         const rowMaxH = Math.max(
           ...row.subs.map((s) => s.sub.heightMultiplier),
           1
@@ -152,11 +268,13 @@ export function computeLayout(
               entry.sub.points,
               entry.sub.textElements,
               entry.sub.modelAnswer,
-              "answer"
+              "answer",
+              0,
+              computeManuscriptGrid(entry.sub, cellX, currentY, cellWidth),
+              entry.sub.omrConfig
             )
           )
 
-          // 列間の垂直区切り線（セル右端が領域右端でない場合）
           const cellRight = cellX + cellWidth
           if (Math.abs(cellRight - contentRight) > 0.01) {
             lines.push({
@@ -165,38 +283,24 @@ export function computeLayout(
               x2: cellRight,
               y2: currentY + rowHeight,
               style: settings.borderConfig.subDivider,
+              strokeWidth: getLineWidth(
+                "subHorizontalDivider",
+                settings.borderConfig
+              ),
               lineType: "subHorizontalDivider",
             })
           }
         })
 
         currentY += rowHeight
-
-        // 行間の水平区切り線（最後の行以外）
-        if (ri < rows.length - 1) {
-          lines.push({
-            x1: horizontalAreaX,
-            y1: currentY,
-            x2: contentRight,
-            y2: currentY,
-            style: settings.borderConfig.subDivider,
-            lineType: "subHorizontalDivider",
-          })
-        }
-      })
-    } else {
-      // 各小問を処理（縦配置）
-      major.subQuestions.forEach((sub, si) => {
+      } else {
+        // vertical-sub
+        const sub = row.sub
+        const si = row.subIndex
         const subStartY = currentY
         const hasBranches = sub.branchQuestions.length > 0
-        const subHeight = hasBranches
-          ? sub.branchQuestions.reduce(
-              (sum, bq) => sum + bq.heightMultiplier * baseRowHeight,
-              0
-            )
-          : sub.heightMultiplier * baseRowHeight
+        const subHeight = computeSubHeight(sub, baseRowHeight)
 
-        // 小問番号ラベル
         numberLabels.push({
           text: sub.label,
           x: subNumX,
@@ -208,55 +312,128 @@ export function computeLayout(
         })
 
         if (hasBranches) {
-          // 枝問あり: 各枝問のセルを作成
+          const branchRows = buildBranchLayoutRows(
+            sub.branchQuestions,
+            sub.branchHorizontalColumnsPerRow
+          )
+          const branchAreaX = subNumX + subNumWidth
+          const branchAreaWidth = contentRight - branchAreaX
           let branchY = subStartY
-          sub.branchQuestions.forEach((branch, bi) => {
-            const branchHeight = branch.heightMultiplier * baseRowHeight
 
-            // 枝問番号ラベル
-            numberLabels.push({
-              text: branch.label,
-              x: branchNumX,
-              y: branchY,
-              width: branchNumWidth,
-              height: branchHeight,
-              fontSize: settings.fonts.numberSize - 1,
-              displayMode: "branch",
-            })
-
-            // 解答セル
-            cells.push(
-              createCell(
-                [mi, si, bi],
-                answerX,
-                branchY,
-                answerWidth,
-                branchHeight,
-                paper,
-                `${major.label}-${sub.label}-${branch.label}`,
-                branch.points,
-                branch.textElements,
-                branch.modelAnswer,
-                "answer"
+          branchRows.forEach((bRow, bri) => {
+            if (bRow.type === "horizontal") {
+              const rowMaxH = Math.max(
+                ...bRow.branches.map((b) => b.branch.heightMultiplier),
+                1
               )
-            )
+              const bRowHeight = rowMaxH * baseRowHeight
+              const unitWidth = branchAreaWidth / bRow.columns
 
-            // 枝問の区切り線（最後以外）
-            if (bi < sub.branchQuestions.length - 1) {
+              bRow.branches.forEach((entry) => {
+                const cellX = branchAreaX + entry.colStart * unitWidth
+                const cellWidth = entry.span * unitWidth
+
+                numberLabels.push({
+                  text: entry.branch.label,
+                  x: cellX,
+                  y: branchY,
+                  width: cellWidth,
+                  height: bRowHeight,
+                  fontSize: settings.fonts.numberSize - 1,
+                  displayMode: "branch-horizontal",
+                })
+
+                cells.push(
+                  createCell(
+                    [mi, si, entry.branchIndex],
+                    cellX,
+                    branchY,
+                    cellWidth,
+                    bRowHeight,
+                    paper,
+                    `${major.label}-${sub.label}-${entry.branch.label}`,
+                    entry.branch.points,
+                    entry.branch.textElements,
+                    entry.branch.modelAnswer,
+                    "answer",
+                    0,
+                    undefined,
+                    entry.branch.omrConfig
+                  )
+                )
+
+                // 列間の垂直区切り線
+                const cellRight = cellX + cellWidth
+                if (Math.abs(cellRight - contentRight) > 0.01) {
+                  lines.push({
+                    x1: cellRight,
+                    y1: branchY,
+                    x2: cellRight,
+                    y2: branchY + bRowHeight,
+                    style: settings.borderConfig.branchDivider,
+                    strokeWidth: getLineWidth("branch", settings.borderConfig),
+                    lineType: "branch",
+                  })
+                }
+              })
+
+              branchY += bRowHeight
+            } else {
+              // vertical-branch
+              const branch = bRow.branch
+              const branchHeight = branch.heightMultiplier * baseRowHeight
+
+              numberLabels.push({
+                text: branch.label,
+                x: branchNumX,
+                y: branchY,
+                width: branchNumWidth,
+                height: branchHeight,
+                fontSize: settings.fonts.numberSize - 1,
+                displayMode: "branch",
+              })
+
+              cells.push(
+                createCell(
+                  [mi, si, bRow.branchIndex],
+                  answerX,
+                  branchY,
+                  answerWidth,
+                  branchHeight,
+                  paper,
+                  `${major.label}-${sub.label}-${branch.label}`,
+                  branch.points,
+                  branch.textElements,
+                  branch.modelAnswer,
+                  "answer",
+                  0,
+                  undefined,
+                  branch.omrConfig
+                )
+              )
+
+              branchY += branchHeight
+            }
+
+            // 枝問行間の区切り線
+            if (bri < branchRows.length - 1) {
+              const nextBRow = branchRows[bri + 1]
+              const lineX =
+                bRow.type === "horizontal" || nextBRow.type === "horizontal"
+                  ? branchAreaX
+                  : branchNumX
               lines.push({
-                x1: branchNumX,
-                y1: branchY + branchHeight,
+                x1: lineX,
+                y1: branchY,
                 x2: contentRight,
-                y2: branchY + branchHeight,
+                y2: branchY,
                 style: settings.borderConfig.branchDivider,
+                strokeWidth: getLineWidth("branch", settings.borderConfig),
                 lineType: "branch",
               })
             }
-
-            branchY += branchHeight
           })
         } else {
-          // 枝問なし: 小問のセルを直接作成
           cells.push(
             createCell(
               [mi, si],
@@ -269,26 +446,46 @@ export function computeLayout(
               sub.points,
               sub.textElements,
               sub.modelAnswer,
-              "answer"
+              "answer",
+              0,
+              computeManuscriptGrid(sub, answerX, subStartY, answerWidth),
+              sub.omrConfig
             )
           )
         }
 
         currentY += subHeight
+      }
 
-        // 小問の区切り線（最後以外）
-        if (si < major.subQuestions.length - 1) {
+      // 行間の区切り線（最後の行以外）
+      if (ri < layoutRows.length - 1) {
+        const nextRow = layoutRows[ri + 1]
+        if (row.type === "horizontal" && nextRow.type === "horizontal") {
           lines.push({
-            x1: subNumX,
+            x1: horizontalAreaX,
             y1: currentY,
             x2: contentRight,
             y2: currentY,
             style: settings.borderConfig.subDivider,
+            strokeWidth: getLineWidth(
+              "subHorizontalDivider",
+              settings.borderConfig
+            ),
+            lineType: "subHorizontalDivider",
+          })
+        } else {
+          lines.push({
+            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            y1: currentY,
+            x2: contentRight,
+            y2: currentY,
+            style: settings.borderConfig.subDivider,
+            strokeWidth: getLineWidth("sub", settings.borderConfig),
             lineType: "sub",
           })
         }
-      })
-    }
+      }
+    })
 
     // 大問の区切り線（最後以外）
     if (mi < majorQuestions.length - 1) {
@@ -298,6 +495,7 @@ export function computeLayout(
         x2: contentRight,
         y2: currentY,
         style: settings.borderConfig.majorDivider,
+        strokeWidth: getLineWidth("major", settings.borderConfig),
         lineType: "major",
       })
     }
@@ -312,23 +510,68 @@ export function computeLayout(
     margins.top + spacing.headerHeight,
     contentRight,
     contentBottom,
-    settings.borderConfig.outerBorder
+    settings.borderConfig.outerBorder,
+    settings.borderConfig
   )
 
-  // 縦配置の大問のY範囲を収集（番号列セグメント化用）
+  // vertical-sub 行のY範囲を収集（小問番号列セグメント化用）
+  // branchVerticalRanges: vertical-sub 行内の vertical-branch 行のY範囲（枝問番号列用）
   const verticalRanges: { top: number; bottom: number }[] = []
+  const branchVerticalRanges: { top: number; bottom: number }[] = []
   {
     let trackY = margins.top + spacing.headerHeight
-    majorQuestions.forEach((mq, mi2) => {
-      if (mq.spacingBefore && mi2 > 0) {
+    for (let mi2 = 0; mi2 < majorQuestions.length; mi2++) {
+      const mq = majorQuestions[mi2]
+      if (mi2 > 0) {
         trackY += spacing.majorQuestionSpacing
       }
-      const mh = computeMajorHeight(mq, baseRowHeight)
-      if ((mq.subQuestionLayout ?? "vertical") === "vertical") {
-        verticalRanges.push({ top: trackY, bottom: trackY + mh })
+      const rows = buildLayoutRows(mq.subQuestions, mq.horizontalColumnsPerRow)
+      let segStart: number | null = null
+      for (const r of rows) {
+        if (r.type === "vertical-sub") {
+          if (segStart === null) segStart = trackY
+          // 枝問番号列のセグメント: vertical-branch行のみ
+          if (r.sub.branchQuestions.length > 0) {
+            const bRows = buildBranchLayoutRows(
+              r.sub.branchQuestions,
+              r.sub.branchHorizontalColumnsPerRow
+            )
+            let bTrackY = trackY
+            let bSegStart: number | null = null
+            for (const br of bRows) {
+              if (br.type === "vertical-branch") {
+                if (bSegStart === null) bSegStart = bTrackY
+                bTrackY += br.branch.heightMultiplier * baseRowHeight
+              } else {
+                if (bSegStart !== null) {
+                  branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
+                  bSegStart = null
+                }
+                const maxH = Math.max(
+                  ...br.branches.map((b) => b.branch.heightMultiplier),
+                  1
+                )
+                bTrackY += maxH * baseRowHeight
+              }
+            }
+            if (bSegStart !== null) {
+              branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
+            }
+          }
+          trackY += computeSubHeight(r.sub, baseRowHeight)
+        } else {
+          if (segStart !== null) {
+            verticalRanges.push({ top: segStart, bottom: trackY })
+            segStart = null
+          }
+          const maxH = Math.max(...r.subs.map((s) => s.sub.heightMultiplier), 1)
+          trackY += maxH * baseRowHeight
+        }
       }
-      trackY += mh
-    })
+      if (segStart !== null) {
+        verticalRanges.push({ top: segStart, bottom: trackY })
+      }
+    }
   }
 
   // 大問番号列の縦線 → 全高（従来通り）
@@ -337,10 +580,11 @@ export function computeLayout(
     majorNumX + majorNumWidth,
     margins.top + spacing.headerHeight,
     contentBottom,
-    settings.borderConfig.numberColumnDivider
+    settings.borderConfig.numberColumnDivider,
+    settings.borderConfig
   )
 
-  // 小問/枝問番号列の縦線 → 縦配置のセグメントのみ
+  // 小問番号列の縦線 → 縦配置のセグメントのみ
   for (const range of verticalRanges) {
     addNumberColumnLines(
       lines,
@@ -349,7 +593,11 @@ export function computeLayout(
       range.bottom,
       settings.borderConfig.numberColumnDivider
     )
-    if (hasBranch) {
+  }
+
+  // 枝問番号列の縦線 → vertical-branch セグメントのみ
+  if (hasBranch) {
+    for (const range of branchVerticalRanges) {
       addNumberColumnLines(
         lines,
         branchNumX + branchNumWidth,
@@ -381,85 +629,185 @@ export function computeLayout(
 // ヘルパー関数
 // =====================
 
-interface HorizontalRowAssignment {
-  subs: { sub: SubQuestion; subIndex: number; colStart: number; span: number }[]
-  columns: number
-}
-
-function assignSubsToRows(
+/**
+ * 小問を LayoutRow[] に変換する。
+ * - columnsPerRow が空/undefined → 全て vertical-sub
+ * - 配列の各要素を順に消費して横配置行を生成
+ * - 枝問2つ以上の小問は横配置行から抽出して独立 vertical-sub 行にする
+ * - 配列を使い切った残りは全て vertical-sub
+ */
+function buildLayoutRows(
   subQuestions: SubQuestion[],
   columnsPerRow: number[] | undefined
-): HorizontalRowAssignment[] {
-  const rows: HorizontalRowAssignment[] = []
-  let rowIdx = 0
-  let usedCols = 0
-  const defaultCols = subQuestions.length
+): LayoutRow[] {
+  if (!columnsPerRow || columnsPerRow.length === 0) {
+    return subQuestions.map((sub, si) => ({
+      type: "vertical-sub" as const,
+      sub,
+      subIndex: si,
+    }))
+  }
 
-  for (let si = 0; si < subQuestions.length; si++) {
-    const sub = subQuestions[si]
-    const span = sub.colSpan ?? 1
-    const maxCols =
-      columnsPerRow && columnsPerRow.length > 0
-        ? (columnsPerRow[rowIdx] ??
-          columnsPerRow[columnsPerRow.length - 1] ??
-          defaultCols)
-        : defaultCols
+  const rows: LayoutRow[] = []
+  let si = 0
+  let specIdx = 0
 
-    if (!rows[rowIdx]) {
-      rows[rowIdx] = { subs: [], columns: maxCols }
+  while (si < subQuestions.length && specIdx < columnsPerRow.length) {
+    const rowSpec = columnsPerRow[specIdx]
+    specIdx++
+
+    // この rowSpec 分の小問を消費
+    let consumed = 0
+    let batch: {
+      sub: SubQuestion
+      subIndex: number
+      colStart: number
+      span: number
+    }[] = []
+    let batchCols = 0
+
+    const flushBatch = () => {
+      if (batch.length > 0) {
+        rows.push({ type: "horizontal", subs: batch, columns: batchCols })
+        batch = []
+        batchCols = 0
+      }
     }
 
-    if (usedCols + span > maxCols && usedCols > 0) {
-      rowIdx++
-      usedCols = 0
-      const nextMaxCols =
-        columnsPerRow && columnsPerRow.length > 0
-          ? (columnsPerRow[rowIdx] ??
-            columnsPerRow[columnsPerRow.length - 1] ??
-            defaultCols)
-          : defaultCols
-      rows[rowIdx] = { subs: [], columns: nextMaxCols }
+    while (consumed < rowSpec && si < subQuestions.length) {
+      const sub = subQuestions[si]
+      const span = sub.colSpan ?? 1
+
+      // 枝問2つ以上 → 横配置行から抽出
+      if (sub.branchQuestions.length >= 2) {
+        flushBatch()
+        rows.push({ type: "vertical-sub", sub, subIndex: si })
+        si++
+        consumed += span
+        continue
+      }
+
+      batch.push({ sub, subIndex: si, colStart: batchCols, span })
+      batchCols += span
+      si++
+      consumed += span
     }
 
-    rows[rowIdx].subs.push({ sub, subIndex: si, colStart: usedCols, span })
-    usedCols += span
+    flushBatch()
+  }
 
-    const currentMaxCols = rows[rowIdx].columns
-    if (usedCols >= currentMaxCols) {
-      rowIdx++
-      usedCols = 0
-    }
+  // 配列を使い切った残り → 全て vertical-sub
+  while (si < subQuestions.length) {
+    rows.push({
+      type: "vertical-sub",
+      sub: subQuestions[si],
+      subIndex: si,
+    })
+    si++
   }
 
   return rows
+}
+
+/**
+ * 枝問を BranchLayoutRow[] に変換する。
+ * - columnsPerRow が空/undefined → 全て vertical-branch
+ * - 配列の各要素を順に消費して横配置行を生成
+ * - 配列を使い切った残りは全て vertical-branch
+ */
+function buildBranchLayoutRows(
+  branchQuestions: BranchQuestion[],
+  columnsPerRow: number[] | undefined
+): BranchLayoutRow[] {
+  if (!columnsPerRow || columnsPerRow.length === 0) {
+    return branchQuestions.map((branch, bi) => ({
+      type: "vertical-branch" as const,
+      branch,
+      branchIndex: bi,
+    }))
+  }
+
+  const rows: BranchLayoutRow[] = []
+  let bi = 0
+  let specIdx = 0
+
+  while (bi < branchQuestions.length && specIdx < columnsPerRow.length) {
+    const rowSpec = columnsPerRow[specIdx]
+    specIdx++
+
+    let consumed = 0
+    const batch: {
+      branch: BranchQuestion
+      branchIndex: number
+      colStart: number
+      span: number
+    }[] = []
+    let batchCols = 0
+
+    while (consumed < rowSpec && bi < branchQuestions.length) {
+      const branch = branchQuestions[bi]
+      const span = branch.colSpan ?? 1
+      batch.push({ branch, branchIndex: bi, colStart: batchCols, span })
+      batchCols += span
+      bi++
+      consumed += span
+    }
+
+    if (batch.length > 0) {
+      rows.push({ type: "horizontal", branches: batch, columns: batchCols })
+    }
+  }
+
+  // 配列を使い切った残り → 全て vertical-branch
+  while (bi < branchQuestions.length) {
+    rows.push({
+      type: "vertical-branch",
+      branch: branchQuestions[bi],
+      branchIndex: bi,
+    })
+    bi++
+  }
+
+  return rows
+}
+
+function computeSubHeight(sub: SubQuestion, baseRowHeight: number): number {
+  if (sub.branchQuestions.length > 0) {
+    const branchRows = buildBranchLayoutRows(
+      sub.branchQuestions,
+      sub.branchHorizontalColumnsPerRow
+    )
+    return branchRows.reduce((sum, row) => {
+      if (row.type === "horizontal") {
+        const maxH = Math.max(
+          ...row.branches.map((b) => b.branch.heightMultiplier),
+          1
+        )
+        return sum + maxH * baseRowHeight
+      }
+      return sum + row.branch.heightMultiplier * baseRowHeight
+    }, 0)
+  }
+  if (sub.manuscriptPaper?.enabled) {
+    return sub.manuscriptPaper.rows * sub.manuscriptPaper.cellSizeMm
+  }
+  return sub.heightMultiplier * baseRowHeight
 }
 
 function computeMajorHeight(
   major: MajorQuestion,
   baseRowHeight: number
 ): number {
-  const layout = major.subQuestionLayout ?? "vertical"
-  if (layout === "horizontal") {
-    const rows = assignSubsToRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
-    return rows.reduce((sum, row) => {
+  const layoutRows = buildLayoutRows(
+    major.subQuestions,
+    major.horizontalColumnsPerRow
+  )
+  return layoutRows.reduce((sum, row) => {
+    if (row.type === "horizontal") {
       const maxH = Math.max(...row.subs.map((s) => s.sub.heightMultiplier), 1)
       return sum + maxH * baseRowHeight
-    }, 0)
-  }
-  return major.subQuestions.reduce((sum, sub) => {
-    if (sub.branchQuestions.length > 0) {
-      return (
-        sum +
-        sub.branchQuestions.reduce(
-          (bSum, bq) => bSum + bq.heightMultiplier * baseRowHeight,
-          0
-        )
-      )
     }
-    return sum + sub.heightMultiplier * baseRowHeight
+    return sum + computeSubHeight(row.sub, baseRowHeight)
   }, 0)
 }
 
@@ -474,9 +822,12 @@ function createCell(
   points: number,
   textElements: ComputedCell["textElements"],
   modelAnswer: string | undefined,
-  cellType: ComputedCell["cellType"]
+  cellType: ComputedCell["cellType"],
+  pageIndex: number = 0,
+  manuscriptGrid?: ManuscriptGrid,
+  omrConfig?: OMRCellConfig
 ): ComputedCell {
-  return {
+  const cell: ComputedCell = {
     questionPath,
     x,
     y,
@@ -491,6 +842,54 @@ function createCell(
     textElements,
     modelAnswer,
     cellType,
+    pageIndex,
+    ...(manuscriptGrid ? { manuscriptGrid } : {}),
+  }
+
+  // OMRバブル/数字欄の位置計算
+  if (omrConfig?.type === "choice") {
+    cell.omrBubbles = computeOMRBubbles(
+      x,
+      y,
+      width,
+      height,
+      paper.width,
+      paper.height,
+      omrConfig
+    )
+  } else if (omrConfig?.type === "handwritten-digit") {
+    cell.omrDigitBoxes = computeOMRDigitBoxes(
+      x,
+      y,
+      width,
+      height,
+      paper.width,
+      paper.height,
+      omrConfig
+    )
+  }
+
+  return cell
+}
+
+function computeManuscriptGrid(
+  sub: SubQuestion,
+  cellX: number,
+  cellY: number,
+  cellWidth: number
+): ManuscriptGrid | undefined {
+  if (!sub.manuscriptPaper?.enabled) return undefined
+  const { columns, rows, cellSizeMm } = sub.manuscriptPaper
+  const gridWidth = columns * cellSizeMm
+  const gridHeight = rows * cellSizeMm
+  return {
+    columns,
+    rows,
+    cellSizeMm,
+    gridX: cellX + (cellWidth - gridWidth) / 2,
+    gridY: cellY,
+    gridWidth,
+    gridHeight,
   }
 }
 
@@ -500,8 +899,12 @@ function addOuterBorderLines(
   top: number,
   right: number,
   bottom: number,
-  style: LineStyle
+  style: LineStyle,
+  borderConfig?: BorderConfig
 ): void {
+  const strokeWidth = borderConfig
+    ? getLineWidth("outer", borderConfig)
+    : undefined
   // 上
   lines.push({
     x1: left,
@@ -509,6 +912,7 @@ function addOuterBorderLines(
     x2: right,
     y2: top,
     style,
+    strokeWidth,
     lineType: "outer",
   })
   // 下
@@ -518,6 +922,7 @@ function addOuterBorderLines(
     x2: right,
     y2: bottom,
     style,
+    strokeWidth,
     lineType: "outer",
   })
   // 左
@@ -527,6 +932,7 @@ function addOuterBorderLines(
     x2: left,
     y2: bottom,
     style,
+    strokeWidth,
     lineType: "outer",
   })
   // 右
@@ -536,6 +942,7 @@ function addOuterBorderLines(
     x2: right,
     y2: bottom,
     style,
+    strokeWidth,
     lineType: "outer",
   })
 }
@@ -545,14 +952,19 @@ function addNumberColumnLines(
   x: number,
   top: number,
   bottom: number,
-  style: LineStyle
+  style: LineStyle,
+  borderConfig?: BorderConfig
 ): void {
+  const strokeWidth = borderConfig
+    ? getLineWidth("numberColumn", borderConfig)
+    : undefined
   lines.push({
     x1: x,
     y1: top,
     x2: x,
     y2: bottom,
     style,
+    strokeWidth,
     lineType: "numberColumn",
   })
 }
@@ -578,4 +990,525 @@ function computeOMRMarkers(
       size: sizeMm,
     },
   ]
+}
+
+// =====================
+// 複数ページレイアウト
+// =====================
+
+/**
+ * 大問単位で自動ページ分割を行うレイアウト計算
+ */
+export function computeMultiPageLayout(
+  definition: AnswerSheetDefinition
+): ComputedMultiPageLayout {
+  const { settings, majorQuestions } = definition
+  const paper = getPaperDimensions(settings)
+  const { margins, baseRowHeight, columnWidths, spacing } = settings
+
+  const contentLeft = margins.left
+  const contentRight = paper.width - margins.right
+  const contentTop = margins.top + spacing.headerHeight
+  const contentMaxY = paper.height - margins.bottom
+
+  const majorNumX = contentLeft
+  const majorNumWidth = columnWidths.majorNumber
+  const subNumX = majorNumX + majorNumWidth
+  const subNumWidth = columnWidths.subNumber
+
+  const hasBranch = majorQuestions.some((mq) =>
+    mq.subQuestions.some((sq) => sq.branchQuestions.length > 0)
+  )
+  const branchNumX = subNumX + subNumWidth
+  const branchNumWidth = hasBranch ? columnWidths.branchNumber : 0
+  const answerX = branchNumX + branchNumWidth
+  const answerWidth = contentRight - answerX
+
+  // ページごとのデータ収集用
+  interface PageData {
+    cells: ComputedCell[]
+    lines: ComputedLine[]
+    numberLabels: ComputedNumberLabel[]
+    /** この大問が縦配置だった場合のY範囲（小問番号列用） */
+    verticalRanges: { top: number; bottom: number }[]
+    /** vertical-branch行のY範囲（枝問番号列用） */
+    branchVerticalRanges: { top: number; bottom: number }[]
+    contentBottomY: number
+  }
+
+  function newPageData(): PageData {
+    return {
+      cells: [],
+      lines: [],
+      numberLabels: [],
+      verticalRanges: [],
+      branchVerticalRanges: [],
+      contentBottomY: contentTop,
+    }
+  }
+
+  const pagesData: PageData[] = [newPageData()]
+  let currentPageIdx = 0
+  let currentY = contentTop
+
+  /**
+   * 1つの大問を currentY から配置し、cells/lines/numberLabels を page に追加する。
+   * 戻り値: 配置後の currentY。
+   */
+  function layoutMajorOnPage(
+    page: PageData,
+    major: MajorQuestion,
+    mi: number,
+    startY: number,
+    pageIdx: number
+  ): number {
+    let localY = startY
+    const majorStartY = localY
+    const majorHeight = computeMajorHeight(major, baseRowHeight)
+
+    // 大問番号ラベル
+    if (settings.numberDisplayMode === "multirow") {
+      page.numberLabels.push({
+        text: major.label,
+        x: majorNumX,
+        y: majorStartY,
+        width: majorNumWidth,
+        height: majorHeight,
+        fontSize: settings.fonts.numberSize,
+        displayMode: "multirow",
+      })
+    } else {
+      page.numberLabels.push({
+        text: major.label,
+        x: majorNumX,
+        y: majorStartY,
+        width: majorNumWidth,
+        height: baseRowHeight,
+        fontSize: settings.fonts.numberSize,
+        displayMode: "boxed-top",
+      })
+    }
+
+    const layoutRows = buildLayoutRows(
+      major.subQuestions,
+      major.horizontalColumnsPerRow
+    )
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
+
+    let vertSegStart: number | null = null
+
+    layoutRows.forEach((row, ri) => {
+      if (row.type === "horizontal") {
+        // vertical-sub セグメントをフラッシュ
+        if (vertSegStart !== null) {
+          page.verticalRanges.push({ top: vertSegStart, bottom: localY })
+          vertSegStart = null
+        }
+
+        const rowMaxH = Math.max(
+          ...row.subs.map((s) => s.sub.heightMultiplier),
+          1
+        )
+        const rowHeight = rowMaxH * baseRowHeight
+        const unitWidth = horizontalAreaWidth / row.columns
+
+        row.subs.forEach((entry) => {
+          const cellX = horizontalAreaX + entry.colStart * unitWidth
+          const cellWidth = entry.span * unitWidth
+
+          page.numberLabels.push({
+            text: entry.sub.label,
+            x: cellX,
+            y: localY,
+            width: cellWidth,
+            height: rowHeight,
+            fontSize: settings.fonts.numberSize,
+            displayMode: "sub-horizontal",
+          })
+
+          page.cells.push(
+            createCell(
+              [mi, entry.subIndex],
+              cellX,
+              localY,
+              cellWidth,
+              rowHeight,
+              paper,
+              `${major.label}-${entry.sub.label}`,
+              entry.sub.points,
+              entry.sub.textElements,
+              entry.sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(entry.sub, cellX, localY, cellWidth),
+              entry.sub.omrConfig
+            )
+          )
+
+          const cellRight = cellX + cellWidth
+          if (Math.abs(cellRight - contentRight) > 0.01) {
+            page.lines.push({
+              x1: cellRight,
+              y1: localY,
+              x2: cellRight,
+              y2: localY + rowHeight,
+              style: settings.borderConfig.subDivider,
+              strokeWidth: getLineWidth(
+                "subHorizontalDivider",
+                settings.borderConfig
+              ),
+              lineType: "subHorizontalDivider",
+            })
+          }
+        })
+
+        localY += rowHeight
+      } else {
+        // vertical-sub
+        if (vertSegStart === null) vertSegStart = localY
+
+        const sub = row.sub
+        const si = row.subIndex
+        const subStartY = localY
+        const hasBranches = sub.branchQuestions.length > 0
+        const subHeight = computeSubHeight(sub, baseRowHeight)
+
+        page.numberLabels.push({
+          text: sub.label,
+          x: subNumX,
+          y: subStartY,
+          width: subNumWidth,
+          height: subHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub",
+        })
+
+        if (hasBranches) {
+          const branchRows = buildBranchLayoutRows(
+            sub.branchQuestions,
+            sub.branchHorizontalColumnsPerRow
+          )
+          const branchAreaX = subNumX + subNumWidth
+          const branchAreaWidth = contentRight - branchAreaX
+          let branchY = subStartY
+          let bVertSegStart: number | null = null
+
+          branchRows.forEach((bRow, bri) => {
+            if (bRow.type === "horizontal") {
+              // branchVerticalRanges セグメントをフラッシュ
+              if (bVertSegStart !== null) {
+                page.branchVerticalRanges.push({
+                  top: bVertSegStart,
+                  bottom: branchY,
+                })
+                bVertSegStart = null
+              }
+
+              const rowMaxH = Math.max(
+                ...bRow.branches.map((b) => b.branch.heightMultiplier),
+                1
+              )
+              const bRowHeight = rowMaxH * baseRowHeight
+              const unitWidth = branchAreaWidth / bRow.columns
+
+              bRow.branches.forEach((entry) => {
+                const cellX = branchAreaX + entry.colStart * unitWidth
+                const cellWidth = entry.span * unitWidth
+
+                page.numberLabels.push({
+                  text: entry.branch.label,
+                  x: cellX,
+                  y: branchY,
+                  width: cellWidth,
+                  height: bRowHeight,
+                  fontSize: settings.fonts.numberSize - 1,
+                  displayMode: "branch-horizontal",
+                })
+
+                page.cells.push(
+                  createCell(
+                    [mi, si, entry.branchIndex],
+                    cellX,
+                    branchY,
+                    cellWidth,
+                    bRowHeight,
+                    paper,
+                    `${major.label}-${sub.label}-${entry.branch.label}`,
+                    entry.branch.points,
+                    entry.branch.textElements,
+                    entry.branch.modelAnswer,
+                    "answer",
+                    pageIdx,
+                    undefined,
+                    entry.branch.omrConfig
+                  )
+                )
+
+                const cellRight = cellX + cellWidth
+                if (Math.abs(cellRight - contentRight) > 0.01) {
+                  page.lines.push({
+                    x1: cellRight,
+                    y1: branchY,
+                    x2: cellRight,
+                    y2: branchY + bRowHeight,
+                    style: settings.borderConfig.branchDivider,
+                    strokeWidth: getLineWidth("branch", settings.borderConfig),
+                    lineType: "branch",
+                  })
+                }
+              })
+
+              branchY += bRowHeight
+            } else {
+              if (bVertSegStart === null) bVertSegStart = branchY
+
+              const branch = bRow.branch
+              const branchHeight = branch.heightMultiplier * baseRowHeight
+
+              page.numberLabels.push({
+                text: branch.label,
+                x: branchNumX,
+                y: branchY,
+                width: branchNumWidth,
+                height: branchHeight,
+                fontSize: settings.fonts.numberSize - 1,
+                displayMode: "branch",
+              })
+
+              page.cells.push(
+                createCell(
+                  [mi, si, bRow.branchIndex],
+                  answerX,
+                  branchY,
+                  answerWidth,
+                  branchHeight,
+                  paper,
+                  `${major.label}-${sub.label}-${branch.label}`,
+                  branch.points,
+                  branch.textElements,
+                  branch.modelAnswer,
+                  "answer",
+                  pageIdx,
+                  undefined,
+                  branch.omrConfig
+                )
+              )
+
+              branchY += branchHeight
+            }
+
+            // 枝問行間の区切り線
+            if (bri < branchRows.length - 1) {
+              const nextBRow = branchRows[bri + 1]
+              const lineX =
+                bRow.type === "horizontal" || nextBRow.type === "horizontal"
+                  ? branchAreaX
+                  : branchNumX
+              page.lines.push({
+                x1: lineX,
+                y1: branchY,
+                x2: contentRight,
+                y2: branchY,
+                style: settings.borderConfig.branchDivider,
+                strokeWidth: getLineWidth("branch", settings.borderConfig),
+                lineType: "branch",
+              })
+            }
+          })
+
+          // 残りの branchVerticalRanges セグメントをフラッシュ
+          if (bVertSegStart !== null) {
+            page.branchVerticalRanges.push({
+              top: bVertSegStart,
+              bottom: branchY,
+            })
+          }
+        } else {
+          page.cells.push(
+            createCell(
+              [mi, si],
+              answerX,
+              subStartY,
+              answerWidth,
+              subHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(sub, answerX, subStartY, answerWidth),
+              sub.omrConfig
+            )
+          )
+        }
+
+        localY += subHeight
+      }
+
+      // 行間の区切り線（最後の行以外）
+      if (ri < layoutRows.length - 1) {
+        const nextRow = layoutRows[ri + 1]
+        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+          page.lines.push({
+            x1: horizontalAreaX,
+            y1: localY,
+            x2: contentRight,
+            y2: localY,
+            style: settings.borderConfig.subDivider,
+            strokeWidth: getLineWidth(
+              "subHorizontalDivider",
+              settings.borderConfig
+            ),
+            lineType: "subHorizontalDivider",
+          })
+        } else {
+          page.lines.push({
+            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            y1: localY,
+            x2: contentRight,
+            y2: localY,
+            style: settings.borderConfig.subDivider,
+            strokeWidth: getLineWidth("sub", settings.borderConfig),
+            lineType: "sub",
+          })
+        }
+      }
+    })
+
+    // 残りの vertical-sub セグメントをフラッシュ
+    if (vertSegStart !== null) {
+      page.verticalRanges.push({ top: vertSegStart, bottom: localY })
+    }
+
+    return localY
+  }
+
+  // 大問を順番に配置、ページ分割判定
+  for (let mi = 0; mi < majorQuestions.length; mi++) {
+    const major = majorQuestions[mi]
+    const majorHeight = computeMajorHeight(major, baseRowHeight)
+    const spacingHeight =
+      mi > 0 && currentY > contentTop ? spacing.majorQuestionSpacing : 0
+
+    // ページに収まるかチェック
+    if (
+      currentY + spacingHeight + majorHeight > contentMaxY &&
+      currentY > contentTop
+    ) {
+      // 現在のページを確定
+      pagesData[currentPageIdx].contentBottomY = currentY
+      // 新しいページ開始
+      currentPageIdx++
+      pagesData.push(newPageData())
+      currentY = contentTop
+    } else {
+      currentY += spacingHeight
+    }
+
+    currentY = layoutMajorOnPage(
+      pagesData[currentPageIdx],
+      major,
+      mi,
+      currentY,
+      currentPageIdx
+    )
+
+    // 大問間区切り線（最後の大問以外、次の大問が同一ページに来る場合のみ）
+    if (mi < majorQuestions.length - 1) {
+      // 次の大問もこのページに来るか確認（暫定的に線を追加、ページ分割時は次のイテレーションで新ページ開始）
+      pagesData[currentPageIdx].lines.push({
+        x1: contentLeft,
+        y1: currentY,
+        x2: contentRight,
+        y2: currentY,
+        style: settings.borderConfig.majorDivider,
+        strokeWidth: getLineWidth("major", settings.borderConfig),
+        lineType: "major",
+      })
+    }
+  }
+
+  // 最後のページを確定
+  pagesData[currentPageIdx].contentBottomY = currentY
+
+  // ページごとにborder線・番号列線・OMRマーカーを追加して ComputedPageLayout に変換
+  const pages: ComputedPageLayout[] = pagesData.map((pd, idx) => {
+    const pageContentBottom = pd.contentBottomY
+
+    // もし最後のアイテムが大問区切り線（majorDivider）で、
+    // それがページ末尾（＝次の大問は次のページ）なら削除
+    const lastLine = pd.lines[pd.lines.length - 1]
+    if (
+      lastLine &&
+      lastLine.lineType === "major" &&
+      Math.abs(lastLine.y1 - pageContentBottom) < 0.01
+    ) {
+      pd.lines.pop()
+    }
+
+    // 外枠線
+    addOuterBorderLines(
+      pd.lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      pageContentBottom,
+      settings.borderConfig.outerBorder
+    )
+
+    // 大問番号列の縦線（全高）
+    addNumberColumnLines(
+      pd.lines,
+      majorNumX + majorNumWidth,
+      contentTop,
+      pageContentBottom,
+      settings.borderConfig.numberColumnDivider
+    )
+
+    // 小問番号列の縦線（縦配置セグメントのみ）
+    for (const range of pd.verticalRanges) {
+      addNumberColumnLines(
+        pd.lines,
+        subNumX + subNumWidth,
+        range.top,
+        range.bottom,
+        settings.borderConfig.numberColumnDivider
+      )
+    }
+
+    // 枝問番号列の縦線（vertical-branchセグメントのみ）
+    if (hasBranch) {
+      for (const range of pd.branchVerticalRanges) {
+        addNumberColumnLines(
+          pd.lines,
+          branchNumX + branchNumWidth,
+          range.top,
+          range.bottom,
+          settings.borderConfig.numberColumnDivider
+        )
+      }
+    }
+
+    // OMRマーカー
+    const omrMarkerPositions = computeOMRMarkers(settings, paper)
+
+    return {
+      pageIndex: idx,
+      cells: pd.cells,
+      lines: pd.lines,
+      numberLabels: pd.numberLabels,
+      omrMarkerPositions,
+      contentHeightMm: pageContentBottom - margins.top,
+    }
+  })
+
+  return {
+    pages,
+    totalPages: pages.length,
+    pageWidthMm: paper.width,
+    pageHeightMm: paper.height,
+  }
 }

--- a/electron-src/lib/answer-sheet-builder/pdfGenerator.ts
+++ b/electron-src/lib/answer-sheet-builder/pdfGenerator.ts
@@ -6,15 +6,23 @@
 
 import fs from "fs"
 import path from "path"
-import { PDFDocument, rgb, StandardFonts } from "pdf-lib"
+import {
+  LineCapStyle,
+  PDFDocument,
+  PDFFont,
+  PDFPage,
+  rgb,
+  StandardFonts,
+} from "pdf-lib"
 
 const fontkit = require("fontkit")
 
 import type {
   AnswerSheetDefinition,
+  ComputedPageLayout,
   LineStyle,
 } from "../../../types/answerSheetBuilder.types"
-import { computeLayout } from "./layoutEngine"
+import { computeMultiPageLayout } from "./layoutEngine"
 
 /** 1mm = 2.835pt */
 const MM_TO_PT = 2.835
@@ -24,17 +32,24 @@ function getStrokeDashArray(style: LineStyle): number[] | undefined {
     case "dashed":
       return [4, 2]
     case "dotted":
-      return [1, 2]
+      return [0.01, 3]
     default:
       return undefined
   }
+}
+
+function getLineCap(style: LineStyle): LineCapStyle | undefined {
+  if (style === "dashed" || style === "dotted") {
+    return LineCapStyle.Round
+  }
+  return undefined
 }
 
 export async function generatePdf(
   definition: AnswerSheetDefinition,
   outputPath: string
 ): Promise<void> {
-  const layout = computeLayout(definition)
+  const multiLayout = computeMultiPageLayout(definition)
   const pdfDoc = await PDFDocument.create()
 
   // フォント登録
@@ -55,16 +70,34 @@ export async function generatePdf(
     font = await pdfDoc.embedFont(StandardFonts.Helvetica)
   }
 
-  const pageWidthPt = layout.pageWidthMm * MM_TO_PT
-  const pageHeightPt = layout.pageHeightMm * MM_TO_PT
-
-  const page = pdfDoc.addPage([pageWidthPt, pageHeightPt])
+  const pageWidthPt = multiLayout.pageWidthMm * MM_TO_PT
+  const pageHeightPt = multiLayout.pageHeightMm * MM_TO_PT
 
   // pdf-lib座標: 原点=左下、Y軸上向き → mm座標（原点=左上）からの変換
   const toY = (mmY: number): number => pageHeightPt - mmY * MM_TO_PT
 
+  for (const pageLayout of multiLayout.pages) {
+    const page = pdfDoc.addPage([pageWidthPt, pageHeightPt])
+    drawPageContent(page, pageLayout, definition, font, toY)
+  }
+
+  const pdfBytes = await pdfDoc.save()
+  const outputDir = path.dirname(outputPath)
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+  fs.writeFileSync(outputPath, pdfBytes)
+}
+
+function drawPageContent(
+  page: PDFPage,
+  pageLayout: ComputedPageLayout,
+  definition: AnswerSheetDefinition,
+  font: PDFFont,
+  toY: (mmY: number) => number
+): void {
   // OMRマーカー
-  for (const marker of layout.omrMarkerPositions) {
+  for (const marker of pageLayout.omrMarkerPositions) {
     page.drawRectangle({
       x: marker.x * MM_TO_PT,
       y: toY(marker.y + marker.size),
@@ -75,24 +108,25 @@ export async function generatePdf(
   }
 
   // 罫線
-  for (const line of layout.lines) {
+  for (const line of pageLayout.lines) {
     const dashArray = getStrokeDashArray(line.style)
+    const lineCap = getLineCap(line.style)
     page.drawLine({
       start: { x: line.x1 * MM_TO_PT, y: toY(line.y1) },
       end: { x: line.x2 * MM_TO_PT, y: toY(line.y2) },
       thickness: 0.5,
       color: rgb(0, 0, 0),
       dashArray,
+      lineCap,
     })
   }
 
   // 番号ラベル
-  for (const label of layout.numberLabels) {
+  for (const label of pageLayout.numberLabels) {
     const fontSize = Math.min(label.fontSize, label.height * 0.7)
     const textWidth = font.widthOfTextAtSize(label.text, fontSize)
 
     if (label.displayMode === "sub-horizontal") {
-      // 横配置時の小問ラベル: 左寄せ + 垂直中央
       const lx = (label.x + 1) * MM_TO_PT
       const ly = toY(label.y + label.height / 2) - fontSize / 3
       page.drawText(label.text, {
@@ -103,7 +137,6 @@ export async function generatePdf(
         color: rgb(0, 0, 0),
       })
     } else {
-      // その他: 中央配置
       const cx = (label.x + label.width / 2) * MM_TO_PT - textWidth / 2
       const cy = toY(label.y + label.height / 2) - fontSize / 3
       page.drawText(label.text, {
@@ -118,7 +151,7 @@ export async function generatePdf(
 
   // 模範解答テキスト
   if (definition.renderMode === "model-answer") {
-    for (const cell of layout.cells) {
+    for (const cell of pageLayout.cells) {
       if (cell.cellType === "answer" && cell.modelAnswer) {
         const fontSize = 10
         const textWidth = font.widthOfTextAtSize(cell.modelAnswer, fontSize)
@@ -137,7 +170,7 @@ export async function generatePdf(
   }
 
   // テキスト要素
-  for (const cell of layout.cells) {
+  for (const cell of pageLayout.cells) {
     if (cell.cellType !== "answer") continue
     for (const te of cell.textElements) {
       const textWidth = font.widthOfTextAtSize(te.text, te.fontSize)
@@ -169,10 +202,78 @@ export async function generatePdf(
     }
   }
 
-  const pdfBytes = await pdfDoc.save()
-  const outputDir = path.dirname(outputPath)
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true })
+  // OMRバブル
+  {
+    const pageWMm = page.getWidth() / MM_TO_PT
+    const pageHMm = page.getHeight() / MM_TO_PT
+    for (const cell of pageLayout.cells) {
+      if (!cell.omrBubbles || cell.omrBubbles.length === 0) continue
+      for (const bubble of cell.omrBubbles) {
+        const cxMm = bubble.normalizedCx * pageWMm
+        const cyMm = bubble.normalizedCy * pageHMm
+        const rMm = bubble.normalizedRadius * pageWMm
+        page.drawCircle({
+          x: cxMm * MM_TO_PT,
+          y: toY(cyMm),
+          size: rMm * MM_TO_PT,
+          borderColor: rgb(0, 0, 0),
+          borderWidth: 0.3 * MM_TO_PT,
+        })
+        // ラベルテキスト
+        const labelSize = 2.5
+        const textWidth = font.widthOfTextAtSize(bubble.label, labelSize)
+        page.drawText(bubble.label, {
+          x: cxMm * MM_TO_PT - textWidth / 2,
+          y: toY(cyMm + rMm + 2),
+          size: labelSize,
+          font,
+          color: rgb(0.2, 0.2, 0.2),
+        })
+      }
+    }
+
+    // OMR数字欄
+    for (const cell of pageLayout.cells) {
+      if (!cell.omrDigitBoxes || cell.omrDigitBoxes.length === 0) continue
+      for (const box of cell.omrDigitBoxes) {
+        const bxMm = box.normalizedX * pageWMm
+        const byMm = box.normalizedY * pageHMm
+        const bwMm = box.normalizedW * pageWMm
+        const bhMm = box.normalizedH * pageHMm
+        page.drawRectangle({
+          x: bxMm * MM_TO_PT,
+          y: toY(byMm + bhMm),
+          width: bwMm * MM_TO_PT,
+          height: bhMm * MM_TO_PT,
+          borderColor: rgb(0.4, 0.4, 0.4),
+          borderWidth: 0.3 * MM_TO_PT,
+        })
+      }
+    }
   }
-  fs.writeFileSync(outputPath, pdfBytes)
+
+  // 原稿用紙グリッド
+  const gridColor = rgb(0.8, 0.8, 0.8)
+  for (const cell of pageLayout.cells) {
+    if (cell.cellType !== "answer" || !cell.manuscriptGrid) continue
+    const g = cell.manuscriptGrid
+    for (let col = 1; col < g.columns; col++) {
+      const x = (g.gridX + col * g.cellSizeMm) * MM_TO_PT
+      page.drawLine({
+        start: { x, y: toY(g.gridY) },
+        end: { x, y: toY(g.gridY + g.gridHeight) },
+        thickness: 0.2 * MM_TO_PT,
+        color: gridColor,
+      })
+    }
+    for (let row = 1; row < g.rows; row++) {
+      const y = toY(g.gridY + row * g.cellSizeMm)
+      page.drawLine({
+        start: { x: g.gridX * MM_TO_PT, y },
+        end: { x: (g.gridX + g.gridWidth) * MM_TO_PT, y },
+        thickness: 0.2 * MM_TO_PT,
+        color: gridColor,
+      })
+    }
+  }
 }

--- a/electron-src/lib/answer-sheet-builder/projectConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/projectConverter.ts
@@ -8,14 +8,16 @@ import fs from "fs"
 import path from "path"
 
 import type { AnswerSheetDefinition } from "../../../types/answerSheetBuilder.types"
+import type { OMRCellConfig, OMRTemplate } from "../../../types/omr.types"
 import {
+  getDataDirectory,
   getMasterAnswersDirectory,
   getRelativePathFromData,
 } from "../dataManager"
 import prisma from "../prisma/client"
 import { createProject } from "../prisma/project"
 import { createProjectPage } from "../prisma/projectPage"
-import { computeLayout } from "./layoutEngine"
+import { computeMultiPageLayout } from "./layoutEngine"
 import { generatePngBuffer } from "./pngGenerator"
 
 export interface ConvertToProjectResult {
@@ -26,6 +28,7 @@ export interface ConvertToProjectResult {
 
 /**
  * 解答用紙定義を採点プロジェクトに変換
+ * 複数ページ対応: ページごとにProjectPage + MasterImage + CropRegionを作成
  */
 export async function convertToProject(
   definition: AnswerSheetDefinition,
@@ -33,79 +36,128 @@ export async function convertToProject(
   svgString?: string
 ): Promise<ConvertToProjectResult> {
   try {
-    // 1. レイアウト計算
-    const layout = computeLayout(definition)
+    // 0. OMR設定を問題定義から抽出
+    const omrCellConfigs: Record<string, OMRCellConfig> = {}
+    definition.majorQuestions.forEach((major, mi) => {
+      major.subQuestions.forEach((sub, si) => {
+        if (sub.omrConfig) {
+          omrCellConfigs[`${mi}-${si}`] = sub.omrConfig
+        }
+        sub.branchQuestions.forEach((branch, bi) => {
+          if (branch.omrConfig) {
+            omrCellConfigs[`${mi}-${si}-${bi}`] = branch.omrConfig
+          }
+        })
+      })
+    })
+
+    // 1. レイアウト計算（複数ページ）
+    const multiLayout = computeMultiPageLayout(definition)
 
     // 2. プロジェクト作成
     const project = await createProject(
       {
         examName: definition.name,
-        description: `解答用紙ビルダーから生成（${definition.settings.paperSize} ${definition.settings.orientation}）`,
+        description: `解答用紙ビルダーから生成（${definition.settings.paperSize} ${definition.settings.orientation}、${multiLayout.totalPages}ページ）`,
       },
       userId
     )
 
-    // 3. PNG生成（模範解答なしの空白解答用紙）
+    // 3. PNG生成（空白解答用紙 + 模範解答、ページごと）
     const answerSheetDef: AnswerSheetDefinition = {
       ...definition,
       renderMode: "answer-sheet",
     }
-    const pngBuffer = await generatePngBuffer(answerSheetDef, 300, svgString)
+    const templateBuffers = await generatePngBuffer(
+      answerSheetDef,
+      300,
+      svgString
+    )
 
-    // 4. 模範解答PNG生成
     const modelAnswerDef: AnswerSheetDefinition = {
       ...definition,
       renderMode: "model-answer",
     }
-    const modelPngBuffer = await generatePngBuffer(modelAnswerDef, 300)
+    const modelBuffers = await generatePngBuffer(modelAnswerDef, 300)
 
-    // 5. 画像ファイル保存
+    // 4. 画像ファイル保存 + DB作成（ページごと）
     const masterDir = getMasterAnswersDirectory(project.id)
     if (!fs.existsSync(masterDir)) {
       fs.mkdirSync(masterDir, { recursive: true })
     }
 
-    const masterImageFileName = `master-${Date.now()}.png`
-    const masterImagePath = path.join(masterDir, masterImageFileName)
-    fs.writeFileSync(masterImagePath, modelPngBuffer)
-    const relativeMasterPath = getRelativePathFromData(masterImagePath)
+    let globalOrderIndex = 0
 
-    // 答案テンプレート画像も保存（空白解答用紙）
-    const templateFileName = `template-${Date.now()}.png`
-    const templatePath = path.join(masterDir, templateFileName)
-    fs.writeFileSync(templatePath, pngBuffer)
+    for (let pi = 0; pi < multiLayout.totalPages; pi++) {
+      const pageLayout = multiLayout.pages[pi]
+      const timestamp = Date.now() + pi
 
-    // 6. ProjectPage作成
-    const projectPage = await createProjectPage({
-      projectId: project.id,
-      pageNumber: 1,
-    })
+      // 模範解答PNG保存
+      const masterImageFileName = `master-${timestamp}.png`
+      const masterImagePath = path.join(masterDir, masterImageFileName)
+      fs.writeFileSync(masterImagePath, modelBuffers[pi])
+      const relativeMasterPath = getRelativePathFromData(masterImagePath)
 
-    // 7. MasterImage作成
-    await prisma.masterImage.create({
-      data: {
-        projectPageId: projectPage.id,
-        imagePath: relativeMasterPath,
-      },
-    })
+      // 答案テンプレートPNG保存
+      const templateFileName = `template-${timestamp}.png`
+      const templatePath = path.join(masterDir, templateFileName)
+      fs.writeFileSync(templatePath, templateBuffers[pi])
 
-    // 8. CropRegion作成（解答セルのみ）
-    const answerCells = layout.cells.filter((c) => c.cellType === "answer")
-    for (let i = 0; i < answerCells.length; i++) {
-      const cell = answerCells[i]
-      await prisma.cropRegion.create({
+      // ProjectPage作成
+      const projectPage = await createProjectPage({
+        projectId: project.id,
+        pageNumber: pi + 1,
+      })
+
+      // MasterImage作成
+      await prisma.masterImage.create({
         data: {
           projectPageId: projectPage.id,
-          label: cell.label,
-          type: "QUESTION_ANSWER",
-          x: cell.normalizedX,
-          y: cell.normalizedY,
-          width: cell.normalizedW,
-          height: cell.normalizedH,
-          points: cell.points,
-          orderIndex: i,
+          imagePath: relativeMasterPath,
         },
       })
+
+      // CropRegion作成（このページの解答セルのみ）
+      const answerCells = pageLayout.cells.filter(
+        (c) => c.cellType === "answer"
+      )
+      for (let i = 0; i < answerCells.length; i++) {
+        const cell = answerCells[i]
+        await prisma.cropRegion.create({
+          data: {
+            projectPageId: projectPage.id,
+            label: cell.label,
+            type: "QUESTION_ANSWER",
+            x: cell.normalizedX,
+            y: cell.normalizedY,
+            width: cell.normalizedW,
+            height: cell.normalizedH,
+            points: cell.points,
+            orderIndex: globalOrderIndex++,
+          },
+        })
+      }
+    }
+
+    // 5. OMRテンプレート保存（OMR設定がある場合）
+    if (Object.keys(omrCellConfigs).length > 0) {
+      const omrTemplate: OMRTemplate = {
+        definitionId: definition.id,
+        cellConfigs: omrCellConfigs,
+        recognitionParams: {
+          colorThreshold: 25,
+          areaThreshold: 0.4,
+        },
+      }
+      const dataDir = getDataDirectory()
+      const projectDir = path.join(dataDir, "projects", project.id)
+      if (!fs.existsSync(projectDir)) {
+        fs.mkdirSync(projectDir, { recursive: true })
+      }
+      fs.writeFileSync(
+        path.join(projectDir, "omr-template.json"),
+        JSON.stringify(omrTemplate, null, 2)
+      )
     }
 
     return { success: true, projectId: project.id }

--- a/electron-src/lib/answer-sheet-builder/svgRenderer.ts
+++ b/electron-src/lib/answer-sheet-builder/svgRenderer.ts
@@ -6,8 +6,11 @@
  */
 
 import type {
+  ComputedCell,
   ComputedLayout,
   ComputedLine,
+  ComputedMultiPageLayout,
+  ComputedPageLayout,
   LineStyle,
   RenderMode,
 } from "../../../types/answerSheetBuilder.types"
@@ -15,15 +18,33 @@ import type {
 /** mm → SVGのpx変換（出力DPIに応じて外部でスケーリング） */
 const MM_SCALE = 1
 
-function lineStyleToSvg(style: LineStyle): string {
+/**
+ * 破線/点線のSVG属性を生成（中央基準パターン）
+ * - 破線: dash = sw*3, gap = sw*1
+ * - 点線: dash = sw*1, gap = sw*1
+ * lineLength を渡すと stroke-dashoffset で中央対称にする
+ */
+function lineDashAttrs(
+  style: LineStyle,
+  strokeWidth: number,
+  lineLength: number
+): string {
+  let dash: number, gap: number
   switch (style) {
     case "dashed":
-      return 'stroke-dasharray="4 2"'
+      dash = strokeWidth * 3
+      gap = strokeWidth * 1
+      break
     case "dotted":
-      return 'stroke-dasharray="1 2"'
+      dash = 0.01
+      gap = strokeWidth * 2
+      break
     default:
       return ""
   }
+  const period = dash + gap
+  const offset = ((lineLength / 2) % period) - dash / 2
+  return `stroke-dasharray="${dash} ${gap}" stroke-dashoffset="${offset}" stroke-linecap="round"`
 }
 
 function escapeXml(str: string): string {
@@ -64,7 +85,10 @@ export function renderSvgString(
 
   // 番号ラベル
   for (const label of layout.numberLabels) {
-    if (label.displayMode === "sub-horizontal") {
+    if (
+      label.displayMode === "sub-horizontal" ||
+      label.displayMode === "branch-horizontal"
+    ) {
       // 横配置時の小問ラベル: セル内左側に配置
       const lx = label.x + 1
       const ly = label.y + label.height / 2
@@ -121,17 +145,236 @@ export function renderSvgString(
           : te.verticalAlign === "bottom"
             ? "auto"
             : "central"
+      const extraAttrs = [
+        te.fontStyle === "italic" ? ' font-style="italic"' : "",
+        te.textDecoration === "line-through"
+          ? ' text-decoration="line-through"'
+          : "",
+      ].join("")
       parts.push(
-        `<text x="${tx}" y="${ty}" font-size="${te.fontSize}" font-weight="${te.fontWeight}" font-family="'Noto Sans JP', sans-serif" text-anchor="${anchor}" dominant-baseline="${baseline}" fill="#000">${escapeXml(te.text)}</text>`
+        `<text x="${tx}" y="${ty}" font-size="${te.fontSize}" font-weight="${te.fontWeight}"${extraAttrs} font-family="'Noto Sans JP', sans-serif" text-anchor="${anchor}" dominant-baseline="${baseline}" fill="#000">${escapeXml(te.text)}</text>`
       )
     }
+  }
+
+  // OMRバブル
+  for (const cell of layout.cells) {
+    parts.push(
+      ...renderOMRBubbles(cell, layout.pageWidthMm, layout.pageHeightMm)
+    )
+  }
+
+  // OMR数字欄
+  for (const cell of layout.cells) {
+    parts.push(
+      ...renderOMRDigitBoxes(cell, layout.pageWidthMm, layout.pageHeightMm)
+    )
+  }
+
+  // 原稿用紙グリッド
+  for (const cell of layout.cells) {
+    parts.push(...renderManuscriptGrid(cell))
   }
 
   parts.push("</svg>")
   return parts.join("\n")
 }
 
+/** 単一ページのSVG文字列を生成（ComputedPageLayout版） */
+export function renderPageSvgString(
+  pageLayout: ComputedPageLayout,
+  pageWidthMm: number,
+  pageHeightMm: number,
+  renderMode: RenderMode = "answer-sheet"
+): string {
+  const w = pageWidthMm * MM_SCALE
+  const h = pageHeightMm * MM_SCALE
+  const parts: string[] = []
+
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`
+  )
+
+  parts.push(`<rect width="${w}" height="${h}" fill="white"/>`)
+
+  for (const marker of pageLayout.omrMarkerPositions) {
+    parts.push(
+      `<rect x="${marker.x}" y="${marker.y}" width="${marker.size}" height="${marker.size}" fill="black"/>`
+    )
+  }
+
+  for (const line of pageLayout.lines) {
+    parts.push(renderLine(line))
+  }
+
+  for (const label of pageLayout.numberLabels) {
+    if (
+      label.displayMode === "sub-horizontal" ||
+      label.displayMode === "branch-horizontal"
+    ) {
+      const lx = label.x + 1
+      const ly = label.y + label.height / 2
+      parts.push(
+        `<text x="${lx}" y="${ly}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="start" dominant-baseline="central">${escapeXml(label.text)}</text>`
+      )
+    } else {
+      const cx = label.x + label.width / 2
+      const cy = label.y + label.height / 2
+      parts.push(
+        `<text x="${cx}" y="${cy}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central">${escapeXml(label.text)}</text>`
+      )
+    }
+  }
+
+  if (renderMode === "model-answer") {
+    for (const cell of pageLayout.cells) {
+      if (cell.cellType === "answer" && cell.modelAnswer) {
+        const cx = cell.x + cell.width / 2
+        const cy = cell.y + cell.height / 2
+        parts.push(
+          `<text x="${cx}" y="${cy}" font-size="10" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central" fill="#333">${escapeXml(cell.modelAnswer)}</text>`
+        )
+      }
+    }
+  }
+
+  for (const cell of pageLayout.cells) {
+    if (cell.cellType !== "answer") continue
+    for (const te of cell.textElements) {
+      const tx =
+        te.horizontalAlign === "left"
+          ? cell.x + 2
+          : te.horizontalAlign === "right"
+            ? cell.x + cell.width - 2
+            : cell.x + cell.width / 2
+      const ty =
+        te.verticalAlign === "top"
+          ? cell.y + te.fontSize
+          : te.verticalAlign === "bottom"
+            ? cell.y + cell.height - 2
+            : cell.y + cell.height / 2
+      const anchor =
+        te.horizontalAlign === "left"
+          ? "start"
+          : te.horizontalAlign === "right"
+            ? "end"
+            : "middle"
+      const baseline =
+        te.verticalAlign === "top"
+          ? "hanging"
+          : te.verticalAlign === "bottom"
+            ? "auto"
+            : "central"
+      const extraAttrs = [
+        te.fontStyle === "italic" ? ' font-style="italic"' : "",
+        te.textDecoration === "line-through"
+          ? ' text-decoration="line-through"'
+          : "",
+      ].join("")
+      parts.push(
+        `<text x="${tx}" y="${ty}" font-size="${te.fontSize}" font-weight="${te.fontWeight}"${extraAttrs} font-family="'Noto Sans JP', sans-serif" text-anchor="${anchor}" dominant-baseline="${baseline}" fill="#000">${escapeXml(te.text)}</text>`
+      )
+    }
+  }
+
+  // OMRバブル
+  for (const cell of pageLayout.cells) {
+    parts.push(...renderOMRBubbles(cell, pageWidthMm, pageHeightMm))
+  }
+
+  // OMR数字欄
+  for (const cell of pageLayout.cells) {
+    parts.push(...renderOMRDigitBoxes(cell, pageWidthMm, pageHeightMm))
+  }
+
+  // 原稿用紙グリッド
+  for (const cell of pageLayout.cells) {
+    parts.push(...renderManuscriptGrid(cell))
+  }
+
+  parts.push("</svg>")
+  return parts.join("\n")
+}
+
+/** 複数ページのSVG文字列を一括生成 */
+export function renderMultiPageSvgStrings(
+  multiPageLayout: ComputedMultiPageLayout,
+  renderMode: RenderMode = "answer-sheet"
+): string[] {
+  return multiPageLayout.pages.map((page) =>
+    renderPageSvgString(
+      page,
+      multiPageLayout.pageWidthMm,
+      multiPageLayout.pageHeightMm,
+      renderMode
+    )
+  )
+}
+
 function renderLine(line: ComputedLine): string {
-  const dashAttr = lineStyleToSvg(line.style)
-  return `<line x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" stroke="black" stroke-width="0.5" ${dashAttr}/>`
+  const sw = line.strokeWidth ?? 0.5
+  const len = Math.hypot(line.x2 - line.x1, line.y2 - line.y1)
+  const dashAttr = lineDashAttrs(line.style, sw, len)
+  return `<line x1="${line.x1}" y1="${line.y1}" x2="${line.x2}" y2="${line.y2}" stroke="black" stroke-width="${sw}" ${dashAttr}/>`
+}
+
+function renderOMRBubbles(
+  cell: ComputedCell,
+  pageWidthMm: number,
+  pageHeightMm: number
+): string[] {
+  if (!cell.omrBubbles || cell.omrBubbles.length === 0) return []
+  const parts: string[] = []
+  for (const bubble of cell.omrBubbles) {
+    const cx = bubble.normalizedCx * pageWidthMm
+    const cy = bubble.normalizedCy * pageHeightMm
+    const r = bubble.normalizedRadius * pageWidthMm
+    // 空円（塗りつぶし前のバブル）
+    parts.push(
+      `<circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="black" stroke-width="0.3"/>`
+    )
+    // ラベルテキスト（バブルの下）
+    parts.push(
+      `<text x="${cx}" y="${cy + r + 2}" font-size="2.5" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="hanging" fill="#333">${escapeXml(bubble.label)}</text>`
+    )
+  }
+  return parts
+}
+
+function renderOMRDigitBoxes(
+  cell: ComputedCell,
+  pageWidthMm: number,
+  pageHeightMm: number
+): string[] {
+  if (!cell.omrDigitBoxes || cell.omrDigitBoxes.length === 0) return []
+  const parts: string[] = []
+  for (const box of cell.omrDigitBoxes) {
+    const x = box.normalizedX * pageWidthMm
+    const y = box.normalizedY * pageHeightMm
+    const w = box.normalizedW * pageWidthMm
+    const h = box.normalizedH * pageHeightMm
+    parts.push(
+      `<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="none" stroke="#666" stroke-width="0.3"/>`
+    )
+  }
+  return parts
+}
+
+function renderManuscriptGrid(cell: ComputedCell): string[] {
+  if (!cell.manuscriptGrid) return []
+  const g = cell.manuscriptGrid
+  const lines: string[] = []
+  for (let col = 1; col < g.columns; col++) {
+    const x = g.gridX + col * g.cellSizeMm
+    lines.push(
+      `<line x1="${x}" y1="${g.gridY}" x2="${x}" y2="${g.gridY + g.gridHeight}" stroke="#ccc" stroke-width="0.2"/>`
+    )
+  }
+  for (let row = 1; row < g.rows; row++) {
+    const y = g.gridY + row * g.cellSizeMm
+    lines.push(
+      `<line x1="${g.gridX}" y1="${y}" x2="${g.gridX + g.gridWidth}" y2="${y}" stroke="#ccc" stroke-width="0.2"/>`
+    )
+  }
+  return lines
 }

--- a/electron-src/lib/omr/autoScorer.ts
+++ b/electron-src/lib/omr/autoScorer.ts
@@ -1,0 +1,93 @@
+/**
+ * OMR自動採点モジュール
+ *
+ * OMR認識結果を既存のQuestionScore APIを通じて採点データとして書き込む。
+ */
+
+import type { OMRCellConfig, OMRCellResult } from "../../../types/omr.types"
+
+export interface AutoScoreEntry {
+  /** CropRegionラベル（QuestionScore特定用） */
+  label: string
+  questionPath: number[]
+  /** 認識されたステータス */
+  status: "correct" | "incorrect" | "partial" | "no_answer" | "ambiguous"
+  /** 得点 */
+  score: number
+  /** 満点 */
+  maxPoints: number
+  /** 認識された回答値 */
+  recognizedValues: string[]
+}
+
+/**
+ * OMR認識結果を採点エントリに変換
+ *
+ * @param cellResults OMR認識結果の配列
+ * @param cellConfigs セルパスキー→設定のマップ
+ * @param pointsMap セルパスキー→配点のマップ
+ */
+export function convertToScoreEntries(
+  cellResults: OMRCellResult[],
+  cellConfigs: Record<string, OMRCellConfig>,
+  pointsMap: Record<string, number>
+): AutoScoreEntry[] {
+  return cellResults.map((result) => {
+    const configKey = result.questionPath.join("-")
+    const config = cellConfigs[configKey]
+    const maxPoints = pointsMap[configKey] ?? 0
+
+    let status: AutoScoreEntry["status"]
+    let score: number
+
+    switch (result.autoScoreStatus) {
+      case "correct":
+        status = "correct"
+        score = maxPoints
+        break
+      case "incorrect":
+        status = "incorrect"
+        score = 0
+        break
+      case "no_answer":
+        status = "no_answer"
+        score = 0
+        break
+      case "ambiguous":
+        status = "ambiguous"
+        score = 0
+        break
+      default:
+        status = "no_answer"
+        score = 0
+    }
+
+    // 複数正解の部分点（choiceで複数正解の場合）
+    if (
+      config?.type === "choice" &&
+      config.correctAnswers.length > 1 &&
+      result.recognizedValues.length > 0 &&
+      result.autoScoreStatus === "incorrect"
+    ) {
+      const correctCount = result.recognizedValues.filter((v) => {
+        const idx = config.labels.indexOf(v)
+        return idx !== -1 && config.correctAnswers.includes(idx)
+      }).length
+      if (correctCount > 0 && correctCount < config.correctAnswers.length) {
+        status = "partial"
+        score = Math.floor(
+          (maxPoints * correctCount) / config.correctAnswers.length
+        )
+      }
+    }
+
+    return {
+      label: result.label,
+      questionPath: result.questionPath,
+      status,
+      score,
+      maxPoints,
+      recognizedValues: result.recognizedValues,
+    }
+  })
+}

--- a/electron-src/lib/omr/coordinateTransform.ts
+++ b/electron-src/lib/omr/coordinateTransform.ts
@@ -1,0 +1,116 @@
+/**
+ * 双一次補間による座標変換
+ *
+ * Mark2の BilinearInterpolation を移植。
+ * 4つのコーナーマーカー位置を対応点として、
+ * 0-1正規化座標 → 実画像ピクセル座標に変換する。
+ */
+
+import type {
+  BoundingBox,
+  CoordinateTransform,
+  Point,
+} from "../../../types/omr.types"
+
+/**
+ * CoordinateTransform を構築する
+ *
+ * @param detectedCorners 検出された4隅のピクセル座標 [TL, TR, BL, BR]
+ * @param expectedCorners レイアウト上の4隅の0-1正規化座標 [TL, TR, BL, BR]
+ * @param imageWidth 画像幅(px)
+ * @param imageHeight 画像高さ(px)
+ */
+export function createTransform(
+  detectedCorners: [Point, Point, Point, Point],
+  expectedCorners: [Point, Point, Point, Point],
+  imageWidth: number,
+  imageHeight: number
+): CoordinateTransform {
+  return {
+    detectedCorners,
+    expectedCorners,
+    imageWidth,
+    imageHeight,
+  }
+}
+
+/**
+ * 0-1正規化座標 → 実画像ピクセル座標へ変換（双一次補間）
+ *
+ * 4つのコーナーマーカーの検出位置と期待位置から補間係数を求め、
+ * 任意の正規化座標をピクセル座標に変換する。
+ *
+ * 双一次補間の式:
+ * P(u,v) = (1-u)(1-v) * P_TL + u(1-v) * P_TR + (1-u)v * P_BL + uv * P_BR
+ *
+ * ここで u, v は正規化座標を期待コーナーの範囲にマッピングした0-1パラメータ。
+ */
+export function normalizedToPixel(
+  nx: number,
+  ny: number,
+  transform: CoordinateTransform
+): Point {
+  const eTL = transform.expectedCorners[0]
+  const eTR = transform.expectedCorners[1]
+  const eBL = transform.expectedCorners[2]
+  const [dTL, dTR, dBL, dBR] = transform.detectedCorners
+
+  // 正規化座標を期待コーナーの範囲にマッピング
+  // u: 左→右 (0→1), v: 上→下 (0→1)
+  const u = inverseLerp(eTL.x, eTR.x, nx)
+  const v = inverseLerp(eTL.y, eBL.y, ny)
+
+  // 双一次補間
+  const px =
+    (1 - u) * (1 - v) * dTL.x +
+    u * (1 - v) * dTR.x +
+    (1 - u) * v * dBL.x +
+    u * v * dBR.x
+
+  const py =
+    (1 - u) * (1 - v) * dTL.y +
+    u * (1 - v) * dTR.y +
+    (1 - u) * v * dBL.y +
+    u * v * dBR.y
+
+  return { x: px, y: py }
+}
+
+/**
+ * 0-1正規化矩形 → ピクセル矩形へ変換
+ *
+ * 矩形の4隅を個別に変換し、それらを包含するバウンディングボックスを返す。
+ */
+export function normalizedRectToPixelRect(
+  nx: number,
+  ny: number,
+  nw: number,
+  nh: number,
+  transform: CoordinateTransform
+): BoundingBox {
+  // 4隅を変換
+  const tl = normalizedToPixel(nx, ny, transform)
+  const tr = normalizedToPixel(nx + nw, ny, transform)
+  const bl = normalizedToPixel(nx, ny + nh, transform)
+  const br = normalizedToPixel(nx + nw, ny + nh, transform)
+
+  const minX = Math.min(tl.x, tr.x, bl.x, br.x)
+  const minY = Math.min(tl.y, tr.y, bl.y, br.y)
+  const maxX = Math.max(tl.x, tr.x, bl.x, br.x)
+  const maxY = Math.max(tl.y, tr.y, bl.y, br.y)
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}
+
+/**
+ * 逆線形補間: a→bの範囲でvが占める割合を返す
+ */
+function inverseLerp(a: number, b: number, v: number): number {
+  if (Math.abs(b - a) < 1e-10) return 0
+  return (v - a) / (b - a)
+}

--- a/electron-src/lib/omr/cornerMarkerDetector.ts
+++ b/electron-src/lib/omr/cornerMarkerDetector.ts
@@ -1,0 +1,282 @@
+/**
+ * コーナーマーカー検出
+ *
+ * Mark2の DetectSquares アルゴリズムを移植。
+ * 画像の4隅にある黒い正方形マーカーの中心座標を検出する。
+ *
+ * アルゴリズム:
+ * 1. 4隅それぞれに探索領域（隅から1%マージン、幅30%×高さ8%）を設定
+ * 2. R値 < colorThreshold のピクセルを「黒」としてマスク
+ * 3. 8近傍連結成分分析（Union-Find）で最大コンポーネントを検出
+ * 4. バウンディングボックス中心 = マーカー中心座標
+ */
+
+import type {
+  DetectedCornerMarker,
+  MarkerDetectionResult,
+  RawImageData,
+} from "../../../types/omr.types"
+import { loadImageRaw } from "./imageProcessor"
+
+/** 探索領域設定 */
+interface SearchRegion {
+  x: number
+  y: number
+  width: number
+  height: number
+  corner: "TL" | "TR" | "BL" | "BR"
+}
+
+/**
+ * 画像ファイルからコーナーマーカーを検出
+ */
+export async function detectCornerMarkers(
+  imagePath: string,
+  colorThreshold: number = 128
+): Promise<MarkerDetectionResult> {
+  const rawImage = await loadImageRaw(imagePath)
+  return detectCornerMarkersFromRaw(rawImage, colorThreshold)
+}
+
+/**
+ * RAWイメージデータからコーナーマーカーを検出
+ */
+export function detectCornerMarkersFromRaw(
+  rawImage: RawImageData,
+  colorThreshold: number = 128
+): MarkerDetectionResult {
+  const { width, height } = rawImage
+  const searchRegions = computeSearchRegions(width, height)
+  const markers: DetectedCornerMarker[] = []
+
+  for (const region of searchRegions) {
+    const marker = detectMarkerInRegion(rawImage, region, colorThreshold)
+    if (marker) {
+      markers.push(marker)
+    }
+  }
+
+  return {
+    success: markers.length === 4,
+    markers,
+    imageWidth: width,
+    imageHeight: height,
+    error:
+      markers.length < 4
+        ? `${markers.length}/4 のマーカーのみ検出されました`
+        : undefined,
+  }
+}
+
+/**
+ * 4隅の探索領域を計算
+ *
+ * 各隅から1%マージン、横幅30%×縦8%の領域を探索する。
+ */
+function computeSearchRegions(
+  imageWidth: number,
+  imageHeight: number
+): SearchRegion[] {
+  const marginX = Math.floor(imageWidth * 0.01)
+  const marginY = Math.floor(imageHeight * 0.01)
+  const searchW = Math.floor(imageWidth * 0.3)
+  const searchH = Math.floor(imageHeight * 0.08)
+
+  return [
+    {
+      x: marginX,
+      y: marginY,
+      width: searchW,
+      height: searchH,
+      corner: "TL",
+    },
+    {
+      x: imageWidth - marginX - searchW,
+      y: marginY,
+      width: searchW,
+      height: searchH,
+      corner: "TR",
+    },
+    {
+      x: marginX,
+      y: imageHeight - marginY - searchH,
+      width: searchW,
+      height: searchH,
+      corner: "BL",
+    },
+    {
+      x: imageWidth - marginX - searchW,
+      y: imageHeight - marginY - searchH,
+      width: searchW,
+      height: searchH,
+      corner: "BR",
+    },
+  ]
+}
+
+/**
+ * 探索領域内でマーカーを検出
+ *
+ * 1. 二値化マスクを作成
+ * 2. Union-Find で連結成分分析
+ * 3. 最大コンポーネントのバウンディングボックス中心を返す
+ */
+function detectMarkerInRegion(
+  rawImage: RawImageData,
+  region: SearchRegion,
+  colorThreshold: number
+): DetectedCornerMarker | null {
+  const { data, width, channels } = rawImage
+  const { x: rx, y: ry, width: rw, height: rh } = region
+
+  // 1. 二値化マスク作成（探索領域内の黒ピクセル）
+  const mask = new Uint8Array(rw * rh)
+  for (let dy = 0; dy < rh; dy++) {
+    for (let dx = 0; dx < rw; dx++) {
+      const imgX = rx + dx
+      const imgY = ry + dy
+      const idx = (imgY * width + imgX) * channels
+      // R値で判定（グレースケール近似）
+      if (data[idx] < colorThreshold) {
+        mask[dy * rw + dx] = 1
+      }
+    }
+  }
+
+  // 2. 8近傍連結成分分析（Union-Find）
+  const parent = new Int32Array(rw * rh)
+  const rank = new Int32Array(rw * rh)
+  for (let i = 0; i < parent.length; i++) {
+    parent[i] = -1 // -1 = 背景
+  }
+
+  // 黒ピクセルのみUnion-Findに登録
+  for (let i = 0; i < mask.length; i++) {
+    if (mask[i]) {
+      parent[i] = i
+    }
+  }
+
+  function find(x: number): number {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]] // path compression
+      x = parent[x]
+    }
+    return x
+  }
+
+  function union(a: number, b: number): void {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra === rb) return
+    if (rank[ra] < rank[rb]) {
+      parent[ra] = rb
+    } else if (rank[ra] > rank[rb]) {
+      parent[rb] = ra
+    } else {
+      parent[rb] = ra
+      rank[ra]++
+    }
+  }
+
+  // 8近傍で連結
+  for (let dy = 0; dy < rh; dy++) {
+    for (let dx = 0; dx < rw; dx++) {
+      const idx = dy * rw + dx
+      if (!mask[idx]) continue
+
+      // 右、右下、下、左下の4方向をチェック（上・左は既に処理済み）
+      const neighbors = [
+        [dx + 1, dy],
+        [dx + 1, dy + 1],
+        [dx, dy + 1],
+        [dx - 1, dy + 1],
+        // 上方向も必要（上・左上・右上）
+        [dx - 1, dy],
+        [dx - 1, dy - 1],
+        [dx, dy - 1],
+        [dx + 1, dy - 1],
+      ]
+
+      for (const [nx, ny] of neighbors) {
+        if (nx >= 0 && nx < rw && ny >= 0 && ny < rh) {
+          const nIdx = ny * rw + nx
+          if (mask[nIdx]) {
+            union(idx, nIdx)
+          }
+        }
+      }
+    }
+  }
+
+  // 3. 最大コンポーネントを見つける
+  const componentSizes = new Map<number, number>()
+  const componentBounds = new Map<
+    number,
+    { minX: number; minY: number; maxX: number; maxY: number }
+  >()
+
+  for (let dy = 0; dy < rh; dy++) {
+    for (let dx = 0; dx < rw; dx++) {
+      const idx = dy * rw + dx
+      if (parent[idx] === -1) continue
+
+      const root = find(idx)
+      componentSizes.set(root, (componentSizes.get(root) ?? 0) + 1)
+
+      const bounds = componentBounds.get(root)
+      if (bounds) {
+        bounds.minX = Math.min(bounds.minX, dx)
+        bounds.minY = Math.min(bounds.minY, dy)
+        bounds.maxX = Math.max(bounds.maxX, dx)
+        bounds.maxY = Math.max(bounds.maxY, dy)
+      } else {
+        componentBounds.set(root, {
+          minX: dx,
+          minY: dy,
+          maxX: dx,
+          maxY: dy,
+        })
+      }
+    }
+  }
+
+  if (componentSizes.size === 0) return null
+
+  // 最大コンポーネントを選択
+  let maxRoot = -1
+  let maxSize = 0
+  for (const [root, size] of componentSizes) {
+    if (size > maxSize) {
+      maxSize = size
+      maxRoot = root
+    }
+  }
+
+  if (maxRoot === -1) return null
+
+  // 最小面積チェック（ノイズ除去）
+  const minArea = Math.max(9, rw * rh * 0.001) // 探索領域の0.1%以上
+  if (maxSize < minArea) return null
+
+  const bounds = componentBounds.get(maxRoot)!
+  const bboxWidth = bounds.maxX - bounds.minX + 1
+  const bboxHeight = bounds.maxY - bounds.minY + 1
+  const size = Math.max(bboxWidth, bboxHeight)
+
+  // マーカー中心座標（探索領域ローカル→画像グローバル）
+  const centerX = rx + bounds.minX + bboxWidth / 2
+  const centerY = ry + bounds.minY + bboxHeight / 2
+
+  // アスペクト比チェック（正方形に近いか）
+  const aspectRatio = Math.min(bboxWidth, bboxHeight) / size
+  const confidence = aspectRatio // 正方形に近いほど高信頼
+
+  return {
+    centerX,
+    centerY,
+    size,
+    corner: region.corner,
+    confidence,
+  }
+}

--- a/electron-src/lib/omr/digitRecognizer.ts
+++ b/electron-src/lib/omr/digitRecognizer.ts
@@ -1,0 +1,261 @@
+/**
+ * 手書き数字認識エンジン
+ *
+ * Mark2のType 2認識を移植。
+ * ONNX Runtime で MNIST 分類モデルを使用し、
+ * 手書き数字画像から数字（0-9）を認識する。
+ *
+ * アルゴリズム:
+ * 1. 座標変換で数字欄の実画像位置を取得
+ * 2. 領域切り出し → グレースケール化 → 28x28リサイズ（sharp）
+ * 3. 手書き文字の重心をセンタリング
+ * 4. 0-1正規化 → ONNX推論 → 数字（0-9）+ 信頼度
+ */
+
+import fs from "fs"
+import path from "path"
+import sharp from "sharp"
+
+import type { ComputedCell } from "../../../types/answerSheetBuilder.types"
+import type {
+  BoundingBox,
+  CoordinateTransform,
+  OMRCellResult,
+  OMRRecognitionParams,
+  RawImageData,
+} from "../../../types/omr.types"
+import { normalizedRectToPixelRect } from "./coordinateTransform"
+
+// ONNX Runtime（遅延ロード）
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let ort: any = null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let session: any = null
+let sessionLoadFailed = false
+
+/**
+ * MNISTモデルのファイルパスを解決
+ */
+function getModelPath(): string {
+  // Electron packaged app の場合
+  const appPath =
+    process.env.NODE_ENV === "production"
+      ? path.join(process.resourcesPath ?? "", "public", "models", "mnist.onnx")
+      : path.join(process.cwd(), "public", "models", "mnist.onnx")
+  return appPath
+}
+
+/**
+ * ONNX セッションを初期化（遅延ロード）
+ */
+async function ensureSession(): Promise<boolean> {
+  if (session) return true
+  if (sessionLoadFailed) return false
+
+  try {
+    const modelPath = getModelPath()
+    if (!fs.existsSync(modelPath)) {
+      console.warn(
+        `[OMR] MNISTモデルが見つかりません: ${modelPath}. 手書き数字認識は無効です。`
+      )
+      sessionLoadFailed = true
+      return false
+    }
+
+    // onnxruntime-nodeを動的インポート
+    if (!ort) {
+      ort = await import("onnxruntime-node")
+    }
+
+    session = await ort.InferenceSession.create(modelPath)
+    return true
+  } catch (error) {
+    console.error("[OMR] MNISTモデルのロードに失敗:", error)
+    sessionLoadFailed = true
+    return false
+  }
+}
+
+/**
+ * 画像領域から28x28のMNIST入力テンソルを作成
+ *
+ * 1. 領域をグレースケール化
+ * 2. 28x28にリサイズ
+ * 3. 反転（白背景黒文字 → 黒背景白文字）
+ * 4. 0-1に正規化
+ */
+async function prepareDigitInput(
+  rawImage: RawImageData,
+  bbox: BoundingBox
+): Promise<Float32Array> {
+  // 領域をクランプ
+  const x0 = Math.max(0, Math.floor(bbox.x))
+  const y0 = Math.max(0, Math.floor(bbox.y))
+  const x1 = Math.min(rawImage.width, Math.ceil(bbox.x + bbox.width))
+  const y1 = Math.min(rawImage.height, Math.ceil(bbox.y + bbox.height))
+  const regionW = x1 - x0
+  const regionH = y1 - y0
+
+  if (regionW <= 0 || regionH <= 0) {
+    return new Float32Array(28 * 28)
+  }
+
+  // RAW RGBバッファから領域を切り出し
+  const regionBuf = Buffer.alloc(regionW * regionH * rawImage.channels)
+  for (let row = 0; row < regionH; row++) {
+    const srcOffset = ((y0 + row) * rawImage.width + x0) * rawImage.channels
+    const dstOffset = row * regionW * rawImage.channels
+    rawImage.data.copy(
+      regionBuf,
+      dstOffset,
+      srcOffset,
+      srcOffset + regionW * rawImage.channels
+    )
+  }
+
+  // sharpでグレースケール→28x28リサイズ
+  const resized = await sharp(regionBuf, {
+    raw: {
+      width: regionW,
+      height: regionH,
+      channels: rawImage.channels as 1 | 2 | 3 | 4,
+    },
+  })
+    .greyscale()
+    .resize(28, 28, { fit: "contain", background: { r: 255, g: 255, b: 255 } })
+    .raw()
+    .toBuffer()
+
+  // Float32Arrayに変換（反転 + 正規化）
+  const tensor = new Float32Array(28 * 28)
+  for (let i = 0; i < 28 * 28; i++) {
+    // MNISTは黒背景白文字なので反転: (255 - pixel) / 255
+    tensor[i] = (255 - resized[i]) / 255
+  }
+
+  return tensor
+}
+
+/**
+ * ONNX推論で数字を認識
+ *
+ * @returns [認識された数字, 信頼度(0-1)]
+ */
+async function inferDigit(
+  input: Float32Array
+): Promise<[number, number] | null> {
+  if (!session || !ort) return null
+
+  try {
+    const inputTensor = new ort.Tensor("float32", input, [1, 1, 28, 28])
+    const feeds: Record<string, InstanceType<typeof ort.Tensor>> = {}
+
+    // モデルの入力名を取得
+    const inputName = session.inputNames[0] ?? "input"
+    feeds[inputName] = inputTensor
+
+    const results = await session.run(feeds)
+    const outputName = session.outputNames[0] ?? "output"
+    const output = results[outputName]
+
+    if (!output) return null
+
+    const data = output.data as Float32Array
+
+    // softmaxして最大値のインデックスを取得
+    let maxVal = -Infinity
+    let maxIdx = 0
+    let sumExp = 0
+
+    for (let i = 0; i < 10; i++) {
+      const v = Math.exp(data[i])
+      sumExp += v
+      if (v > maxVal) {
+        maxVal = v
+        maxIdx = i
+      }
+    }
+
+    const confidence = maxVal / sumExp
+
+    return [maxIdx, confidence]
+  } catch (error) {
+    console.error("[OMR] ONNX推論エラー:", error)
+    return null
+  }
+}
+
+/**
+ * 1つのセルの手書き数字を認識
+ */
+export async function recognizeDigitCell(
+  cell: ComputedCell,
+  rawImage: RawImageData,
+  transform: CoordinateTransform,
+  params: OMRRecognitionParams
+): Promise<OMRCellResult> {
+  const modelAvailable = await ensureSession()
+
+  if (
+    !modelAvailable ||
+    !cell.omrDigitBoxes ||
+    cell.omrDigitBoxes.length === 0
+  ) {
+    return {
+      label: cell.label,
+      questionPath: cell.questionPath,
+      recognizedValues: [],
+      confidence: 0,
+      autoScoreStatus: "no_answer",
+    }
+  }
+
+  const recognizedDigits: string[] = []
+  let totalConfidence = 0
+
+  for (const box of cell.omrDigitBoxes) {
+    // 正規化座標→ピクセル座標
+    const pixelRect = normalizedRectToPixelRect(
+      box.normalizedX,
+      box.normalizedY,
+      box.normalizedW,
+      box.normalizedH,
+      transform
+    )
+
+    // MNIST入力テンソル作成
+    const input = await prepareDigitInput(rawImage, pixelRect)
+
+    // 空欄チェック: ほとんど白い場合はスキップ
+    // colorThresholdを0-1スケールに変換して空欄判定に利用
+    const blankThreshold = params.colorThreshold / 255
+    const nonZeroCount = input.filter((v) => v > blankThreshold).length
+    if (nonZeroCount < 10) {
+      recognizedDigits.push("")
+      continue
+    }
+
+    // ONNX推論
+    const result = await inferDigit(input)
+    if (result) {
+      const [digit, conf] = result
+      recognizedDigits.push(String(digit))
+      totalConfidence += conf
+    } else {
+      recognizedDigits.push("")
+    }
+  }
+
+  const validDigits = recognizedDigits.filter((d) => d !== "")
+  const recognizedValue = recognizedDigits.join("")
+  const confidence =
+    validDigits.length > 0 ? totalConfidence / validDigits.length : 0
+
+  return {
+    label: cell.label,
+    questionPath: cell.questionPath,
+    recognizedValues: recognizedValue ? [recognizedValue] : [],
+    confidence,
+    autoScoreStatus: recognizedValue ? undefined : "no_answer",
+  }
+}

--- a/electron-src/lib/omr/imageProcessor.ts
+++ b/electron-src/lib/omr/imageProcessor.ts
@@ -1,0 +1,150 @@
+/**
+ * 画像ピクセル操作ユーティリティ
+ *
+ * sharpを使ったRAWピクセルバッファ操作。
+ * OMR認識パイプラインの基盤。
+ */
+
+import sharp from "sharp"
+
+import type { BoundingBox, RawImageData } from "../../../types/omr.types"
+
+/**
+ * 画像をRAWピクセルバッファとして読み込む
+ * @param imagePath 画像ファイルパス
+ * @returns RawImageData (RGB 3チャンネル)
+ */
+export async function loadImageRaw(imagePath: string): Promise<RawImageData> {
+  const { data, info } = await sharp(imagePath)
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  return {
+    data,
+    width: info.width,
+    height: info.height,
+    channels: info.channels,
+  }
+}
+
+/**
+ * バッファから画像をRAWピクセルバッファとして読み込む
+ */
+export async function loadImageRawFromBuffer(
+  buffer: Buffer
+): Promise<RawImageData> {
+  const { data, info } = await sharp(buffer)
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  return {
+    data,
+    width: info.width,
+    height: info.height,
+    channels: info.channels,
+  }
+}
+
+/**
+ * RAWバッファから矩形領域のピクセルを切り出す
+ * @returns 切り出し領域のRGBバッファ
+ */
+export function extractRegionPixels(
+  rawData: RawImageData,
+  region: BoundingBox
+): Buffer {
+  const { data, width, channels } = rawData
+
+  // 領域をクランプ
+  const x0 = Math.max(0, Math.floor(region.x))
+  const y0 = Math.max(0, Math.floor(region.y))
+  const x1 = Math.min(rawData.width, Math.ceil(region.x + region.width))
+  const y1 = Math.min(rawData.height, Math.ceil(region.y + region.height))
+  const rw = x1 - x0
+  const rh = y1 - y0
+
+  const regionBuf = Buffer.alloc(rw * rh * channels)
+
+  for (let row = 0; row < rh; row++) {
+    const srcOffset = ((y0 + row) * width + x0) * channels
+    const dstOffset = row * rw * channels
+    data.copy(regionBuf, dstOffset, srcOffset, srcOffset + rw * channels)
+  }
+
+  return regionBuf
+}
+
+/**
+ * ピクセルバッファ内の暗いピクセルの比率（塗りつぶし率）を計算
+ *
+ * R値が threshold 未満のピクセルを「暗い」と判定。
+ *
+ * @param pixels RGBピクセルバッファ
+ * @param width 領域幅
+ * @param height 領域高さ
+ * @param channels チャンネル数（通常3）
+ * @param threshold 暗さ閾値（0-255）
+ * @returns 暗いピクセルの比率（0-1）
+ */
+export function computeFillRatio(
+  pixels: Buffer,
+  width: number,
+  height: number,
+  channels: number,
+  threshold: number
+): number {
+  const totalPixels = width * height
+  if (totalPixels === 0) return 0
+
+  let darkCount = 0
+  for (let i = 0; i < totalPixels; i++) {
+    const r = pixels[i * channels]
+    if (r < threshold) {
+      darkCount++
+    }
+  }
+
+  return darkCount / totalPixels
+}
+
+/**
+ * 円形領域のピクセルの塗りつぶし率を計算
+ *
+ * 指定された中心と半径の円内のピクセルのみを対象とする。
+ */
+export function computeCircularFillRatio(
+  rawData: RawImageData,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  threshold: number
+): number {
+  const { data, width, height, channels } = rawData
+  const r2 = radius * radius
+
+  let totalPixels = 0
+  let darkCount = 0
+
+  const x0 = Math.max(0, Math.floor(centerX - radius))
+  const x1 = Math.min(width - 1, Math.ceil(centerX + radius))
+  const y0 = Math.max(0, Math.floor(centerY - radius))
+  const y1 = Math.min(height - 1, Math.ceil(centerY + radius))
+
+  for (let py = y0; py <= y1; py++) {
+    for (let px = x0; px <= x1; px++) {
+      const dx = px - centerX
+      const dy = py - centerY
+      if (dx * dx + dy * dy <= r2) {
+        totalPixels++
+        const idx = (py * width + px) * channels
+        if (data[idx] < threshold) {
+          darkCount++
+        }
+      }
+    }
+  }
+
+  return totalPixels === 0 ? 0 : darkCount / totalPixels
+}

--- a/electron-src/lib/omr/index.ts
+++ b/electron-src/lib/omr/index.ts
@@ -1,0 +1,23 @@
+/**
+ * OMRモジュール バレルエクスポート
+ */
+
+export { convertToScoreEntries } from "./autoScorer"
+export {
+  createTransform,
+  normalizedRectToPixelRect,
+  normalizedToPixel,
+} from "./coordinateTransform"
+export {
+  detectCornerMarkers,
+  detectCornerMarkersFromRaw,
+} from "./cornerMarkerDetector"
+export { recognizeDigitCell } from "./digitRecognizer"
+export {
+  computeCircularFillRatio,
+  computeFillRatio,
+  extractRegionPixels,
+  loadImageRaw,
+  loadImageRawFromBuffer,
+} from "./imageProcessor"
+export { recognizeCell, recognizeCells } from "./markRecognizer"

--- a/electron-src/lib/omr/markRecognizer.ts
+++ b/electron-src/lib/omr/markRecognizer.ts
@@ -1,0 +1,158 @@
+/**
+ * マーク認識エンジン
+ *
+ * 選択式（バブル）マークの塗りつぶし認識。
+ * 座標変換済みの画像上でバブル位置のピクセルを解析し、
+ * 塗りつぶし率からマーク状態を判定する。
+ */
+
+import type { ComputedCell } from "../../../types/answerSheetBuilder.types"
+import type {
+  CoordinateTransform,
+  OMRCellConfig,
+  OMRCellResult,
+  OMRRecognitionParams,
+  RawImageData,
+} from "../../../types/omr.types"
+import { normalizedToPixel } from "./coordinateTransform"
+import { recognizeDigitCell } from "./digitRecognizer"
+import { computeCircularFillRatio } from "./imageProcessor"
+
+/**
+ * 1つのセルのマーク認識を実行
+ */
+export async function recognizeCell(
+  cell: ComputedCell,
+  omrConfig: OMRCellConfig,
+  rawImage: RawImageData,
+  transform: CoordinateTransform,
+  params: OMRRecognitionParams
+): Promise<OMRCellResult> {
+  if (omrConfig.type === "choice") {
+    return recognizeChoiceCell(cell, omrConfig, rawImage, transform, params)
+  }
+
+  // handwritten-digit: ONNX Runtime による手書き数字認識
+  return recognizeDigitCell(cell, rawImage, transform, params)
+}
+
+/**
+ * 選択式（バブル）セルのマーク認識
+ */
+function recognizeChoiceCell(
+  cell: ComputedCell,
+  config: OMRCellConfig & { type: "choice" },
+  rawImage: RawImageData,
+  transform: CoordinateTransform,
+  params: OMRRecognitionParams
+): OMRCellResult {
+  if (!cell.omrBubbles || cell.omrBubbles.length === 0) {
+    return {
+      label: cell.label,
+      questionPath: cell.questionPath,
+      recognizedValues: [],
+      confidence: 0,
+      autoScoreStatus: "no_answer",
+    }
+  }
+
+  const fillRatios: number[] = []
+  const markedIndices: number[] = []
+
+  for (const bubble of cell.omrBubbles) {
+    // 正規化座標→ピクセル座標
+    const center = normalizedToPixel(
+      bubble.normalizedCx,
+      bubble.normalizedCy,
+      transform
+    )
+    const radiusPx = bubble.normalizedRadius * rawImage.width
+
+    // 塗りつぶし率を計算
+    const ratio = computeCircularFillRatio(
+      rawImage,
+      center.x,
+      center.y,
+      radiusPx,
+      params.colorThreshold
+    )
+    fillRatios.push(ratio)
+
+    if (ratio >= params.areaThreshold) {
+      markedIndices.push(bubble.choiceIndex)
+    }
+  }
+
+  // 認識結果を構築
+  const recognizedValues = markedIndices.map(
+    (idx) => config.labels[idx] ?? String(idx)
+  )
+
+  // 信頼度計算
+  let confidence: number
+  if (markedIndices.length === 0) {
+    // 未回答: 全て低い塗りつぶし率なら高信頼
+    const maxRatio = Math.max(...fillRatios)
+    confidence = 1 - maxRatio / params.areaThreshold
+  } else if (markedIndices.length === 1) {
+    // 単一回答: マーク済みの塗りつぶし率が高いほど、他との差が大きいほど高信頼
+    const markedRatio = fillRatios[markedIndices[0]]
+    const otherMaxRatio = Math.max(
+      ...fillRatios.filter((_, i) => !markedIndices.includes(i)),
+      0
+    )
+    confidence = Math.min(
+      markedRatio / params.areaThreshold,
+      1 - otherMaxRatio / params.areaThreshold
+    )
+    confidence = Math.max(0, Math.min(1, confidence))
+  } else {
+    // 複数マーク: 信頼度は低い
+    confidence = 0.3
+  }
+
+  // 自動採点
+  let autoScoreStatus: OMRCellResult["autoScoreStatus"]
+  if (markedIndices.length === 0) {
+    autoScoreStatus = "no_answer"
+  } else if (markedIndices.length > config.correctAnswers.length) {
+    autoScoreStatus = "ambiguous"
+  } else {
+    const isCorrect =
+      markedIndices.length === config.correctAnswers.length &&
+      markedIndices.every((idx) => config.correctAnswers.includes(idx))
+    autoScoreStatus = isCorrect ? "correct" : "incorrect"
+  }
+
+  return {
+    label: cell.label,
+    questionPath: cell.questionPath,
+    recognizedValues,
+    fillRatios,
+    confidence,
+    autoScoreStatus,
+  }
+}
+
+/**
+ * 複数セルのマーク認識をバッチ実行
+ */
+export async function recognizeCells(
+  cells: ComputedCell[],
+  cellConfigs: Record<string, OMRCellConfig>,
+  rawImage: RawImageData,
+  transform: CoordinateTransform,
+  params: OMRRecognitionParams
+): Promise<OMRCellResult[]> {
+  const results: OMRCellResult[] = []
+
+  for (const cell of cells) {
+    const configKey = cell.questionPath.join("-")
+    const config = cellConfigs[configKey]
+    if (!config) continue
+
+    results.push(await recognizeCell(cell, config, rawImage, transform, params))
+  }
+
+  return results
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -1163,6 +1163,61 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // =============================================================================
   // Answer Sheet Builder（解答用紙作成）
   // =============================================================================
+  // =============================================================================
+  // OMR（光学マーク認識）
+  // =============================================================================
+  omr: {
+    detectMarkers: (imagePath: string, colorThreshold?: number) =>
+      ipcRenderer.invoke("omr:detect-markers", imagePath, colorThreshold),
+    recognizeSheet: (args: {
+      imagePath: string
+      cells: unknown[]
+      cellConfigs: Record<string, unknown>
+      expectedCorners: [
+        { x: number; y: number },
+        { x: number; y: number },
+        { x: number; y: number },
+        { x: number; y: number },
+      ]
+      params: { colorThreshold: number; areaThreshold: number }
+      pageIndex?: number
+      studentId?: string
+    }) => ipcRenderer.invoke("omr:recognize-sheet", args),
+    batchRecognize: (args: {
+      imagePaths: { path: string; studentId?: string; studentName?: string }[]
+      cells: unknown[]
+      cellConfigs: Record<string, unknown>
+      expectedCorners: [
+        { x: number; y: number },
+        { x: number; y: number },
+        { x: number; y: number },
+        { x: number; y: number },
+      ]
+      params: { colorThreshold: number; areaThreshold: number }
+      pageIndex?: number
+    }) => ipcRenderer.invoke("omr:batch-recognize", args),
+    saveTemplate: (projectId: string, template: unknown) =>
+      ipcRenderer.invoke("omr:save-template", projectId, template),
+    loadTemplate: (projectId: string) =>
+      ipcRenderer.invoke("omr:load-template", projectId),
+    onBatchProgress: (
+      callback: (progress: {
+        total: number
+        processed: number
+        succeeded: number
+        failed: number
+        currentStudentName?: string
+      }) => void
+    ) => {
+      ipcRenderer.on("omr:batch-progress", (_event, progress) =>
+        callback(progress)
+      )
+      return () => {
+        ipcRenderer.removeAllListeners("omr:batch-progress")
+      }
+    },
+  },
+
   answerSheetBuilder: {
     listDefinitions: () => ipcRenderer.invoke("asb:list-definitions"),
     loadDefinition: (id: string) =>
@@ -1183,9 +1238,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
     convertToProject: (
       args: import("../types/answerSheetBuilder.types").ASBConvertToProjectArgs
     ) => ipcRenderer.invoke("asb:convert-to-project", args),
-    print: (
-      args: import("../types/answerSheetBuilder.types").ASBPrintArgs
-    ) => ipcRenderer.invoke("asb:print", args),
+    print: (args: import("../types/answerSheetBuilder.types").ASBPrintArgs) =>
+      ipcRenderer.invoke("asb:print", args),
   },
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "mathjax": "^4.1.1",
         "next": "^16.1.6",
         "next-themes": "^0.4.6",
+        "onnxruntime-node": "^1.24.2",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^5.4.624",
         "react": "^19.2.4",
@@ -8659,9 +8660,7 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.3",
@@ -10020,7 +10019,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -10038,7 +10036,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -10098,9 +10095,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -11250,7 +11245,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11260,7 +11254,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11365,9 +11358,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -13418,9 +13409,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -13466,7 +13455,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -13483,7 +13471,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13551,7 +13538,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -14797,9 +14783,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -15957,9 +15941,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -17516,7 +17498,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17653,6 +17634,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.2.tgz",
+      "integrity": "sha512-S0FFhJaI05jr1c3HVJ/DuPFB/aYdXmnUBuuQfuvLtcNn7WAfpm2ewSXn1vHs9Wa1l8T8OznhfCEdFv8qCn0/xw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.2.tgz",
+      "integrity": "sha512-ZtTkUHNNk+Xpi2Sq2BcFjzc9Vx4n3o5RxYLgRvdrFzCBsGUU1dQRFf4LM9tCc7vFhPSoZqbvzZtkzRMXoDqKNg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.2"
       }
     },
     "node_modules/optionator": {
@@ -19325,9 +19329,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -19592,17 +19594,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -19617,9 +19615,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -20095,9 +20091,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "mathjax": "^4.1.1",
     "next": "^16.1.6",
     "next-themes": "^0.4.6",
+    "onnxruntime-node": "^1.24.2",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^5.4.624",
     "react": "^19.2.4",

--- a/types/answerSheetBuilder.types.ts
+++ b/types/answerSheetBuilder.types.ts
@@ -5,6 +5,12 @@
  * 解答用紙のレイアウト定義・計算結果・エクスポート設定。
  */
 
+import type {
+  ComputedOMRBubble,
+  ComputedOMRDigitBox,
+  OMRCellConfig,
+} from "./omr.types"
+
 // =====================
 // 基本型
 // =====================
@@ -13,7 +19,6 @@ export type PaperSize = "A4" | "B4" | "A3" | "B5"
 export type Orientation = "portrait" | "landscape"
 export type LineStyle = "solid" | "dashed" | "dotted"
 export type MajorNumberDisplayMode = "multirow" | "boxed-top"
-export type SubQuestionLayout = "vertical" | "horizontal"
 export type RenderMode = "answer-sheet" | "model-answer"
 export type HorizontalAlign = "left" | "center" | "right"
 export type VerticalAlign = "top" | "middle" | "bottom"
@@ -27,6 +32,8 @@ export interface CellTextElement {
   text: string
   fontSize: number
   fontWeight: "normal" | "bold"
+  fontStyle?: "normal" | "italic"
+  textDecoration?: "none" | "line-through"
   horizontalAlign: HorizontalAlign
   verticalAlign: VerticalAlign
   isMathJax?: boolean
@@ -66,6 +73,10 @@ export interface BranchQuestion {
   textElements: CellTextElement[]
   modelAnswer?: string
   borderStyles?: BorderStyles
+  /** 横配置時の列スパン（デフォルト1） */
+  colSpan?: number
+  /** OMR自動認識設定 */
+  omrConfig?: OMRCellConfig
 }
 
 export interface SubQuestion {
@@ -80,18 +91,63 @@ export interface SubQuestion {
   borderStyles?: BorderStyles
   /** 横配置時の列スパン（デフォルト1） */
   colSpan?: number
+  /** 枝問横配置の行ごとの列数 (例: [3, 2])。空/未定義なら全て縦配置 */
+  branchHorizontalColumnsPerRow?: number[]
+  /** 枝問ごとに配点するか（undefined/true=枝問配点、false=完答） */
+  usesBranchPoints?: boolean
+  /** OMR自動認識設定 */
+  omrConfig?: OMRCellConfig
 }
 
 export interface MajorQuestion {
   id: string
   label: string
-  numberDisplayMode: MajorNumberDisplayMode
   subQuestions: SubQuestion[]
-  spacingBefore: boolean
-  subQuestionLayout: SubQuestionLayout
-  /** 横配置時の行ごとの列数 (例: [3, 4, 2]) */
+  /** 横配置時の行ごとの列数 (例: [3, 4, 2])。空/未定義なら全て縦配置 */
   horizontalColumnsPerRow?: number[]
 }
+
+// =====================
+// レイアウト行（buildLayoutRows用）
+// =====================
+
+export type LayoutRow =
+  | {
+      type: "horizontal"
+      subs: {
+        sub: SubQuestion
+        subIndex: number
+        colStart: number
+        span: number
+      }[]
+      columns: number
+    }
+  | {
+      type: "vertical-sub"
+      sub: SubQuestion
+      subIndex: number
+    }
+
+// =====================
+// 枝問レイアウト行（buildBranchLayoutRows用）
+// =====================
+
+export type BranchLayoutRow =
+  | {
+      type: "horizontal"
+      branches: {
+        branch: BranchQuestion
+        branchIndex: number
+        colStart: number
+        span: number
+      }[]
+      columns: number
+    }
+  | {
+      type: "vertical-branch"
+      branch: BranchQuestion
+      branchIndex: number
+    }
 
 // =====================
 // マージン設定
@@ -133,6 +189,11 @@ export interface BorderConfig {
   subDivider: LineStyle
   branchDivider: LineStyle
   numberColumnDivider: LineStyle
+  outerBorderWidth?: number
+  majorDividerWidth?: number
+  subDividerWidth?: number
+  branchDividerWidth?: number
+  numberColumnDividerWidth?: number
 }
 
 // =====================
@@ -169,11 +230,18 @@ export interface GlobalSettings {
   borderConfig: BorderConfig
   omrMarkers: OMRMarkerConfig
   fonts: FontConfig
+  numberDisplayMode: MajorNumberDisplayMode
 }
 
 // =====================
 // 解答用紙定義（トップレベル）
 // =====================
+
+export interface LabelPresets {
+  major?: string
+  sub?: string
+  branch?: string
+}
 
 export interface AnswerSheetDefinition {
   id: string
@@ -181,8 +249,27 @@ export interface AnswerSheetDefinition {
   settings: GlobalSettings
   majorQuestions: MajorQuestion[]
   renderMode: RenderMode
+  labelPresets?: LabelPresets
   createdAt?: string
   updatedAt?: string
+}
+
+// =====================
+// 原稿用紙グリッド（レイアウト計算結果）
+// =====================
+
+export interface ManuscriptGrid {
+  columns: number
+  rows: number
+  cellSizeMm: number
+  /** グリッド開始X座標（mm） */
+  gridX: number
+  /** グリッド開始Y座標（mm） */
+  gridY: number
+  /** = columns * cellSizeMm */
+  gridWidth: number
+  /** = rows * cellSizeMm */
+  gridHeight: number
 }
 
 // =====================
@@ -212,6 +299,14 @@ export interface ComputedCell {
   modelAnswer?: string
   /** セル種類 */
   cellType: "answer" | "major-number" | "sub-number" | "branch-number"
+  /** このセルが属するページ (0-indexed) */
+  pageIndex: number
+  /** 原稿用紙グリッド情報 */
+  manuscriptGrid?: ManuscriptGrid
+  /** OMRバブル位置（choiceセル用） */
+  omrBubbles?: ComputedOMRBubble[]
+  /** OMR数字欄位置（handwritten-digitセル用） */
+  omrDigitBoxes?: ComputedOMRDigitBox[]
 }
 
 export interface DragInfo {
@@ -237,6 +332,8 @@ export interface ComputedLine {
   x2: number
   y2: number
   style: LineStyle
+  /** 線幅 (mm) */
+  strokeWidth?: number
   /** 線種: outer / major / sub / branch / numberColumn / subHorizontalDivider */
   lineType: string
   /** ドラッグ操作情報（インタラクティブモード用） */
@@ -250,7 +347,12 @@ export interface ComputedNumberLabel {
   width: number
   height: number
   fontSize: number
-  displayMode: MajorNumberDisplayMode | "sub" | "sub-horizontal" | "branch"
+  displayMode:
+    | MajorNumberDisplayMode
+    | "sub"
+    | "sub-horizontal"
+    | "branch"
+    | "branch-horizontal"
 }
 
 export interface ComputedOMRMarker {
@@ -270,6 +372,26 @@ export interface ComputedLayout {
   overflow: boolean
   /** 使用した高さ（mm） */
   contentHeightMm: number
+}
+
+// =====================
+// 複数ページレイアウト
+// =====================
+
+export interface ComputedPageLayout {
+  pageIndex: number
+  cells: ComputedCell[]
+  lines: ComputedLine[]
+  numberLabels: ComputedNumberLabel[]
+  omrMarkerPositions: ComputedOMRMarker[]
+  contentHeightMm: number
+}
+
+export interface ComputedMultiPageLayout {
+  pages: ComputedPageLayout[]
+  totalPages: number
+  pageWidthMm: number
+  pageHeightMm: number
 }
 
 // =====================
@@ -320,8 +442,25 @@ export type AnswerSheetAction =
       }
     }
   | {
+      type: "REORDER_SUB_QUESTIONS"
+      payload: { majorIndex: number; fromIndex: number; toIndex: number }
+    }
+  | {
+      type: "REORDER_BRANCH_QUESTIONS"
+      payload: {
+        majorIndex: number
+        subIndex: number
+        fromIndex: number
+        toIndex: number
+      }
+    }
+  | {
       type: "DELETE_BRANCH_QUESTION"
       payload: { majorIndex: number; subIndex: number; branchIndex: number }
+    }
+  | {
+      type: "SET_LABEL_PRESET"
+      payload: { category: "major" | "sub" | "branch"; preset: string }
     }
 
 // =====================
@@ -345,6 +484,10 @@ export interface ASBConvertToProjectArgs {
   definition: AnswerSheetDefinition
   userId: string
   svgString?: string
+}
+
+export interface ASBPrintArgs {
+  definition: AnswerSheetDefinition
 }
 
 export interface ASBExportResult {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -2222,6 +2222,55 @@ export interface MyAPI {
       args: import("./answerSheetBuilder.types").ASBPrintArgs
     ) => Promise<{ success: boolean; error?: string }>
   }
+
+  // =============================================================================
+  // OMR（光学マーク認識）
+  // =============================================================================
+  omr: {
+    detectMarkers: (
+      imagePath: string,
+      colorThreshold?: number
+    ) => Promise<import("./omr.types").MarkerDetectionResult>
+    recognizeSheet: (args: {
+      imagePath: string
+      cells: import("./answerSheetBuilder.types").ComputedCell[]
+      cellConfigs: Record<string, import("./omr.types").OMRCellConfig>
+      expectedCorners: [
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+      ]
+      params: import("./omr.types").OMRRecognitionParams
+      pageIndex?: number
+      studentId?: string
+    }) => Promise<import("./omr.types").OMRSheetResult>
+    batchRecognize: (args: {
+      imagePaths: { path: string; studentId?: string; studentName?: string }[]
+      cells: import("./answerSheetBuilder.types").ComputedCell[]
+      cellConfigs: Record<string, import("./omr.types").OMRCellConfig>
+      expectedCorners: [
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+        import("./omr.types").Point,
+      ]
+      params: import("./omr.types").OMRRecognitionParams
+      pageIndex?: number
+    }) => Promise<import("./omr.types").OMRSheetResult[]>
+    saveTemplate: (
+      projectId: string,
+      template: import("./omr.types").OMRTemplate
+    ) => Promise<{ success: boolean; error?: string }>
+    loadTemplate: (projectId: string) => Promise<{
+      success: boolean
+      template?: import("./omr.types").OMRTemplate
+      error?: string
+    }>
+    onBatchProgress: (
+      callback: (progress: import("./omr.types").OMRBatchProgress) => void
+    ) => () => void
+  }
 }
 
 // =============================================================================

--- a/types/omr.types.ts
+++ b/types/omr.types.ts
@@ -1,0 +1,191 @@
+/**
+ * OMR（光学マーク認識）関連の型定義
+ *
+ * Mark2アルゴリズムをベースとしたOMR認識パイプラインの型。
+ * コーナーマーカー検出、座標変換、マーク認識、手書き数字認識、自動採点。
+ */
+
+// =====================
+// 基本型
+// =====================
+
+export interface Point {
+  x: number
+  y: number
+}
+
+// =====================
+// OMRセル設定（問題定義に紐付く）
+// =====================
+
+export type OMRAnswerType = "choice" | "handwritten-digit"
+
+export interface OMRChoiceConfig {
+  type: "choice"
+  /** 選択肢数（2-10） */
+  numChoices: number
+  /** 選択肢ラベル（"ア","イ","ウ"... or "A","B","C"...） */
+  labels: string[]
+  /** 正解インデックス（複数対応） */
+  correctAnswers: number[]
+  /** バブル配置方向 */
+  layout: "horizontal" | "vertical"
+}
+
+export interface OMRDigitConfig {
+  type: "handwritten-digit"
+  /** 桁数（1-5） */
+  numDigits: number
+  /** 正解文字列（"42" など） */
+  correctAnswer?: string
+}
+
+export type OMRCellConfig = OMRChoiceConfig | OMRDigitConfig
+
+// =====================
+// コーナーマーカー検出
+// =====================
+
+export interface DetectedCornerMarker {
+  centerX: number
+  centerY: number
+  size: number
+  corner: "TL" | "TR" | "BL" | "BR"
+  confidence: number
+}
+
+export interface MarkerDetectionResult {
+  success: boolean
+  markers: DetectedCornerMarker[]
+  imageWidth: number
+  imageHeight: number
+  error?: string
+}
+
+// =====================
+// 座標変換
+// =====================
+
+export interface CoordinateTransform {
+  /** 検出された4隅のピクセル座標 [TL, TR, BL, BR] */
+  detectedCorners: [Point, Point, Point, Point]
+  /** 期待される4隅の0-1正規化座標 [TL, TR, BL, BR] */
+  expectedCorners: [Point, Point, Point, Point]
+  imageWidth: number
+  imageHeight: number
+}
+
+// =====================
+// OMR認識パラメータ
+// =====================
+
+export interface OMRRecognitionParams {
+  /** ピクセル暗さ閾値（0-255、デフォルト25） */
+  colorThreshold: number
+  /** 塗りつぶし面積閾値（0-1、デフォルト0.4） */
+  areaThreshold: number
+}
+
+export const DEFAULT_OMR_RECOGNITION_PARAMS: OMRRecognitionParams = {
+  colorThreshold: 25,
+  areaThreshold: 0.4,
+}
+
+// =====================
+// OMR認識結果
+// =====================
+
+export interface OMRCellResult {
+  /** セルラベル */
+  label: string
+  /** 問題パス [majorIndex, subIndex, branchIndex?] */
+  questionPath: number[]
+  /** 認識された値（選択肢ラベル or 数字） */
+  recognizedValues: string[]
+  /** 各選択肢の塗りつぶし率（choiceセルのみ） */
+  fillRatios?: number[]
+  /** 認識信頼度（0-1） */
+  confidence: number
+  /** 自動採点結果 */
+  autoScoreStatus?: "correct" | "incorrect" | "no_answer" | "ambiguous"
+}
+
+export interface OMRSheetResult {
+  success: boolean
+  studentId?: string
+  pageIndex: number
+  markerDetection: MarkerDetectionResult
+  cellResults: OMRCellResult[]
+  error?: string
+}
+
+// =====================
+// バッチ処理進捗
+// =====================
+
+export interface OMRBatchProgress {
+  total: number
+  processed: number
+  succeeded: number
+  failed: number
+  currentStudentName?: string
+}
+
+// =====================
+// OMRテンプレート
+// =====================
+
+export interface OMRTemplate {
+  definitionId: string
+  /** セルパスキー（"0-1-2" 形式）→ OMRセル設定 */
+  cellConfigs: Record<string, OMRCellConfig>
+  recognitionParams: OMRRecognitionParams
+}
+
+// =====================
+// バブル・数字欄の計算結果（ComputedCell拡張用）
+// =====================
+
+export interface ComputedOMRBubble {
+  /** バブル中心X（0-1正規化） */
+  normalizedCx: number
+  /** バブル中心Y（0-1正規化） */
+  normalizedCy: number
+  /** バブル半径（0-1正規化） */
+  normalizedRadius: number
+  /** 選択肢インデックス */
+  choiceIndex: number
+  /** ラベル（"ア", "イ" など） */
+  label: string
+}
+
+export interface ComputedOMRDigitBox {
+  /** 数字欄左上X（0-1正規化） */
+  normalizedX: number
+  /** 数字欄左上Y（0-1正規化） */
+  normalizedY: number
+  /** 数字欄幅（0-1正規化） */
+  normalizedW: number
+  /** 数字欄高さ（0-1正規化） */
+  normalizedH: number
+  /** 桁インデックス（0始まり） */
+  digitIndex: number
+}
+
+// =====================
+// 画像処理ユーティリティ
+// =====================
+
+export interface RawImageData {
+  data: Buffer
+  width: number
+  height: number
+  channels: number
+}
+
+export interface BoundingBox {
+  x: number
+  y: number
+  width: number
+  height: number
+}


### PR DESCRIPTION
## Summary
- Mark2のOMRアルゴリズムを移植（コーナーマーカー検出・座標変換・マーク認識・手書き数字認識）
- 解答用紙ビルダーにOMR設定UI・バブル/数字欄描画を統合
- OMR認識パネルUI（バッチ処理・結果テーブル・手動修正）
- プロジェクト変換時にOMRテンプレートJSONを保存（DBスキーマ変更なし）

Closes #400

## Test plan
- [x] コーナーマーカー検出テスト（5件パス）
- [x] 座標変換テスト（8件パス）
- [x] 手書き数字認識テスト（4件パス）
- [x] npm run lint クリーン
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)