### PR TITLE
fix: electron-src tsconfig.json の TS6059 エラーを修正

### DIFF
--- a/electron-src/tsconfig.json
+++ b/electron-src/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    // "ignoreDeprecations": "6.0",
     "allowJs": true,
     "alwaysStrict": true,
     "esModuleInterop": true,
@@ -18,11 +17,12 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
+    "rootDir": "..",
     "outDir": "../main",
     "paths": {
       "@/*": ["../*"]
     }
   },
   "exclude": ["node_modules", "../node_modules"],
-  "include": ["**/*.ts", "**/*.tsx", "**/*.js"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "../types/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- `electron-src/tsconfig.json` の `include` に `../types/**/*.ts` を追加
- `rootDir` を `".."` に明示的に設定し、TS6059エラーを解消

Closes #402

## Test plan
- [ ] `npm run typecheck` でTypeScriptエラーが発生しないことを確認
- [ ] `npm run build` でビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)