### PR TITLE
解答用紙ビルダーの機能拡張とインポート統合の改善

### DIFF
--- a/__tests__/answer-sheet-builder/buildGridLayout.test.ts
+++ b/__tests__/answer-sheet-builder/buildGridLayout.test.ts
@@ -1,0 +1,1031 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildGridLayout,
+  gridTotalHeight,
+  isGridHorizontal,
+  parseFraction,
+} from "@/electron-src/lib/answer-sheet-builder/layoutEngine"
+
+// ─── テスト用ヘルパー ───
+
+interface TestItem {
+  layoutWidth?: string
+  nextPlacement?: "inline" | "break"
+  goUp?: number
+  heightMultiplier: number
+}
+
+/** テスト項目のファクトリ。heightMultiplier のデフォルトは 1 */
+function item(opts: Partial<TestItem> = {}): TestItem {
+  return { heightMultiplier: 1, ...opts }
+}
+
+/** セル座標を簡略化して比較しやすくする (浮動小数点を丸める) */
+function simplify(
+  cells: ReturnType<typeof buildGridLayout<TestItem>>
+): { x: number; y: number; w: number; h: number }[] {
+  return cells.map((c) => ({
+    x: round(c.x),
+    y: round(c.y),
+    w: round(c.width),
+    h: round(c.height),
+  }))
+}
+
+function round(n: number): number {
+  return Math.round(n * 10000) / 10000
+}
+
+// ─── parseFraction テスト ───
+
+describe("parseFraction", () => {
+  it("1/2 → 0.5", () => {
+    expect(parseFraction("1/2")).toBe(0.5)
+  })
+
+  it("1/3 → 0.3333...", () => {
+    expect(parseFraction("1/3")).toBeCloseTo(1 / 3)
+  })
+
+  it("1/4 → 0.25", () => {
+    expect(parseFraction("1/4")).toBe(0.25)
+  })
+
+  it("2/3 → 0.6666...", () => {
+    expect(parseFraction("2/3")).toBeCloseTo(2 / 3)
+  })
+
+  it("3/4 → 0.75", () => {
+    expect(parseFraction("3/4")).toBe(0.75)
+  })
+
+  it("1/1 → 1", () => {
+    expect(parseFraction("1/1")).toBe(1)
+  })
+
+  it("小数文字列 '0.5' → 0.5", () => {
+    expect(parseFraction("0.5")).toBe(0.5)
+  })
+
+  it("整数文字列 '1' → 1", () => {
+    expect(parseFraction("1")).toBe(1)
+  })
+
+  it("不正な文字列 → 1 (デフォルト)", () => {
+    expect(parseFraction("abc")).toBe(1)
+  })
+})
+
+// ─── isGridHorizontal テスト ───
+
+describe("isGridHorizontal", () => {
+  it("layoutWidth が1つでもあれば true", () => {
+    expect(isGridHorizontal([item(), item({ layoutWidth: "1/2" })])).toBe(true)
+  })
+
+  it("全て layoutWidth なしなら false", () => {
+    expect(isGridHorizontal([item(), item()])).toBe(false)
+  })
+
+  it("空配列 → false", () => {
+    expect(isGridHorizontal([])).toBe(false)
+  })
+})
+
+// ─── buildGridLayout: 基本 ───
+
+describe("buildGridLayout: 基本", () => {
+  it("空配列 → 空結果", () => {
+    expect(buildGridLayout([])).toEqual([])
+  })
+
+  it("layoutWidth なし1件 → 全幅縦配置", () => {
+    const cells = buildGridLayout([item()])
+    expect(simplify(cells)).toEqual([{ x: 0, y: 0, w: 1, h: 1 }])
+  })
+
+  it("layoutWidth なし3件 → 縦に積み重ね", () => {
+    const cells = buildGridLayout([
+      item(),
+      item(),
+      item({ heightMultiplier: 2 }),
+    ])
+    expect(simplify(cells)).toEqual([
+      { x: 0, y: 0, w: 1, h: 1 },
+      { x: 0, y: 1, w: 1, h: 1 },
+      { x: 0, y: 2, w: 1, h: 2 },
+    ])
+  })
+
+  it("layoutWidth なし → 高さは heightMultiplier の合計", () => {
+    const cells = buildGridLayout([
+      item({ heightMultiplier: 2 }),
+      item({ heightMultiplier: 3 }),
+    ])
+    expect(gridTotalHeight(cells)).toBe(5)
+  })
+})
+
+// ─── buildGridLayout: 均等幅 ───
+
+describe("buildGridLayout: 均等幅", () => {
+  it("2等分: 1/2 + 1/2 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    expect(simplify(cells)).toEqual([
+      { x: 0, y: 0, w: 0.5, h: 1 },
+      { x: 0.5, y: 0, w: 0.5, h: 1 },
+    ])
+  })
+
+  it("3等分: 1/3 × 3 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: round(1 / 3), h: 1 })
+    expect(s[1]).toEqual({ x: round(1 / 3), y: 0, w: round(1 / 3), h: 1 })
+    expect(s[2]).toEqual({ x: round(2 / 3), y: 0, w: round(1 / 3), h: 1 })
+  })
+
+  it("4等分: 1/4 × 4 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+    ])
+    const s = simplify(cells)
+    expect(s.every((c) => c.y === 0)).toBe(true)
+    expect(s.map((c) => c.x)).toEqual([0, 0.25, 0.5, 0.75])
+    expect(s.every((c) => c.w === 0.25)).toBe(true)
+  })
+})
+
+// ─── buildGridLayout: 不均等幅 ───
+
+describe("buildGridLayout: 不均等幅", () => {
+  it("1/4 + 3/4 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "3/4" }),
+    ])
+    expect(simplify(cells)).toEqual([
+      { x: 0, y: 0, w: 0.25, h: 1 },
+      { x: 0.25, y: 0, w: 0.75, h: 1 },
+    ])
+  })
+
+  it("1/3 + 2/3 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "2/3" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].x).toBe(0)
+    expect(s[1].x).toBeCloseTo(1 / 3, 4)
+    expect(s[0].w + s[1].w).toBeCloseTo(1, 4)
+  })
+
+  it("1/4 + 1/4 + 1/2 → 1行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s.every((c) => c.y === 0)).toBe(true)
+    expect(s[0].x).toBe(0)
+    expect(s[1].x).toBe(0.25)
+    expect(s[2].x).toBe(0.5)
+  })
+})
+
+// ─── buildGridLayout: 自動改行 ───
+
+describe("buildGridLayout: 自動改行", () => {
+  it("1/2 × 3 → 2行 (2+1)", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    // 3つ目: 1/2 + 1/2 = 1 で自動改行後、次の行に
+    expect(s[2]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+  })
+
+  it("1/2 × 4 → 2行 (2+2)", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(0)
+    expect(s[2].y).toBe(1)
+    expect(s[3].y).toBe(1)
+  })
+
+  it("1/3 × 5 → 2行 (3+2)", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    expect(s.filter((c) => c.y === 0)).toHaveLength(3)
+    expect(s.filter((c) => c.y === 1)).toHaveLength(2)
+  })
+
+  it("1/3 × 9 → 3行 (3+3+3)", () => {
+    const items = Array.from({ length: 9 }, () => item({ layoutWidth: "1/3" }))
+    const cells = buildGridLayout(items)
+    const s = simplify(cells)
+    expect(s.filter((c) => c.y === 0)).toHaveLength(3)
+    expect(s.filter((c) => c.y === 1)).toHaveLength(3)
+    expect(s.filter((c) => c.y === 2)).toHaveLength(3)
+  })
+
+  it("幅超過で改行: 1/2 + 1/2 + 1/3 + 2/3", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "2/3" }),
+    ])
+    const s = simplify(cells)
+    // 行0: 1/2 + 1/2 = 1 → 自動改行
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(0)
+    // 行1: 1/3 + 2/3 = 1
+    expect(s[2].y).toBe(1)
+    expect(s[3].y).toBe(1)
+  })
+
+  it("1を超えるアイテムは改行してから配置", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "3/4" }), // 1/2 + 3/4 > 1 → この項目の前で改行
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.75, h: 1 })
+  })
+})
+
+// ─── buildGridLayout: 明示的 break ───
+
+describe("buildGridLayout: 明示的 break (↵)", () => {
+  it("1/4 ↵ + 1/4 → 2行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.25, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.25, h: 1 })
+  })
+
+  it("L字型: 1/2 + 1/2 ↵ + 1/1", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 1, w: 1, h: 1 })
+  })
+
+  it("逆L字型: 1/1 ↵ + 1/2 + 1/2", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/1", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 1, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+  })
+
+  it("T字型: 1/3 + 1/3 + 1/3 ↵ + 1/1", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(0)
+    expect(s[2].y).toBe(0)
+    expect(s[3]).toEqual({ x: 0, y: 1, w: 1, h: 1 })
+  })
+
+  it("逆T字型: 1/1 ↵ + 1/3 + 1/3 + 1/3", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/1", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 1, h: 1 })
+    expect(s[1].y).toBe(1)
+    expect(s[2].y).toBe(1)
+    expect(s[3].y).toBe(1)
+  })
+
+  it("連続 break: 1/4 ↵ + 1/4 ↵ + 1/4", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(1)
+    expect(s[2].y).toBe(2)
+    expect(s.every((c) => c.x === 0)).toBe(true)
+  })
+})
+
+// ─── buildGridLayout: goUp (↑) ───
+
+describe("buildGridLayout: goUp (↑)", () => {
+  it("1/2 ↵ + 1/2 ↑1 → 横並び", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", goUp: 1 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+  })
+
+  it("左2段 + 右1枠: 1/4 ↵ + 1/4 + 1/2 ↑1", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/2", goUp: 1, heightMultiplier: 2 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.25, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.25, h: 1 })
+    // ↑1 → row0に戻る、x = max(rightX of rows 0..1) = 1/4
+    expect(s[2]).toEqual({ x: 0.25, y: 0, w: 0.5, h: 2 })
+  })
+
+  it("左3段 + 右大枠: 1/4 ↵ × 2 + 1/4 + 3/4 ↑2", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "3/4", goUp: 2, heightMultiplier: 3 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.25, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.25, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.25, h: 1 })
+    expect(s[3]).toEqual({ x: 0.25, y: 0, w: 0.75, h: 3 })
+  })
+
+  it("goUp=0 は効果なし", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", goUp: 0 }),
+    ])
+    const s = simplify(cells)
+    // goUp=0 → 移動しない → 2行目に配置
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+  })
+
+  it("goUp が行数を超える場合は row 0 にクランプ", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", goUp: 99 }),
+    ])
+    const s = simplify(cells)
+    // goUp=99 → row 0 にクランプ
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+  })
+})
+
+// ─── buildGridLayout: goUp + 後続の配置 ───
+
+describe("buildGridLayout: goUp 後の後続配置", () => {
+  it("左3段 + 右大枠 + 下に全幅", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "3/4", goUp: 2, heightMultiplier: 3 }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    // ①②③ は左カラム
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.25, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.25, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.25, h: 1 })
+    // ④ は右の大枠 (h=3)
+    expect(s[3]).toEqual({ x: 0.25, y: 0, w: 0.75, h: 3 })
+    // ⑤ はブロック全体の下 (y=3)、x=0 に戻る
+    expect(s[4]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+
+  it("左3段 + 右大枠 + 下に2分割", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "3/4", goUp: 2, heightMultiplier: 3 }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    // ⑤⑥ は y=3 の行に横並び
+    expect(s[4]).toEqual({ x: 0, y: 3, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0.5, y: 3, w: 0.5, h: 1 })
+  })
+
+  it("左2段 + 右大枠 + 下段 + さらに下段", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 1, heightMultiplier: 2 }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    // ①② 左列
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    // ③ 右大枠
+    expect(s[2]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 2 })
+    // ④⑤⑥ 下に3等分 (y=2)
+    expect(s[3].y).toBe(2)
+    expect(s[4].y).toBe(2)
+    expect(s[5].y).toBe(2)
+  })
+})
+
+// ─── buildGridLayout: 高さバリエーション ───
+
+describe("buildGridLayout: 高さ", () => {
+  it("異なる高さの横並び", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 1 }),
+      item({ layoutWidth: "1/2", heightMultiplier: 3 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 3 })
+    expect(gridTotalHeight(cells)).toBe(3)
+  })
+
+  it("高さが異なる行の自動改行後の Y 位置", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 2 }),
+      item({ layoutWidth: "1/2", heightMultiplier: 1 }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    // 行0の maxH = 2 → 次の行は y=2
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.5, h: 1 })
+  })
+
+  it("break 後の Y 位置は行の最大高さ基準", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 1 }),
+      item({ layoutWidth: "1/2", heightMultiplier: 3, nextPlacement: "break" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    // 行0の maxH = 3 → 次の行は y=3
+    expect(s[2]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+
+  it("goUp + 高さ混在: 全高さは最大の下端", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", heightMultiplier: 1, nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", heightMultiplier: 1 }),
+      item({ layoutWidth: "3/4", goUp: 1, heightMultiplier: 2 }),
+    ])
+    // 全高さ: max(0+1, 1+1, 0+2) = 2
+    expect(gridTotalHeight(cells)).toBe(2)
+  })
+})
+
+// ─── buildGridLayout: 2×2 / グリッドパターン ───
+
+describe("buildGridLayout: グリッドパターン", () => {
+  it("2×2 グリッド (自動改行)", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s).toEqual([
+      { x: 0, y: 0, w: 0.5, h: 1 },
+      { x: 0.5, y: 0, w: 0.5, h: 1 },
+      { x: 0, y: 1, w: 0.5, h: 1 },
+      { x: 0.5, y: 1, w: 0.5, h: 1 },
+    ])
+  })
+
+  it("3×2 グリッド", () => {
+    const items = Array.from({ length: 6 }, () => item({ layoutWidth: "1/3" }))
+    const cells = buildGridLayout(items)
+    const s = simplify(cells)
+    // 行0: 3つ、行1: 3つ
+    expect(s.filter((c) => c.y === 0)).toHaveLength(3)
+    expect(s.filter((c) => c.y === 1)).toHaveLength(3)
+  })
+
+  it("2×2 + 全幅下段", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[4]).toEqual({ x: 0, y: 2, w: 1, h: 1 })
+  })
+
+  it("全幅上段 + 2×2 + 全幅下段 (サンドイッチ)", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/1", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 1, h: 1 })
+    expect(s[1].y).toBe(1)
+    expect(s[2].y).toBe(1)
+    expect(s[3].y).toBe(2)
+    expect(s[4].y).toBe(2)
+    expect(s[5]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+})
+
+// ─── buildGridLayout: 複雑な組み合わせ ───
+
+describe("buildGridLayout: 複雑な組み合わせ", () => {
+  it("上2列 + 中央大枠 + 下3列", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/1" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    // 行0: 1/2 + 1/2 (自動改行)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(0)
+    // 行1: 1/1 (自動改行)
+    expect(s[2]).toEqual({ x: 0, y: 1, w: 1, h: 1 })
+    // 行2: 1/3 × 3
+    expect(s[3].y).toBe(2)
+    expect(s[4].y).toBe(2)
+    expect(s[5].y).toBe(2)
+  })
+
+  it("凸型: 中央が広い", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/1", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+    ])
+    const s = simplify(cells)
+    // 行0: 2つ (中央寄り短い)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(0)
+    // 行1: 全幅
+    expect(s[2]).toEqual({ x: 0, y: 1, w: 1, h: 1 })
+    // 行2: 2つ
+    expect(s[3].y).toBe(2)
+    expect(s[4].y).toBe(2)
+  })
+
+  it("階段型: 段々幅が広がる", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "3/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.25, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.75, h: 1 })
+    expect(s[3]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+
+  it("goUp 2回使用: 3カラム", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3", goUp: 3, heightMultiplier: 3 }),
+      item({ layoutWidth: "1/3", goUp: 3, heightMultiplier: 3 }),
+    ])
+    const s = simplify(cells)
+    // 左列
+    expect(s[0]).toEqual({ x: 0, y: 0, w: round(1 / 3), h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: round(1 / 3), h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: round(1 / 3), h: 1 })
+    // 中央列 (goUp 3 → row 0, x = 1/3)
+    expect(s[3].x).toBeCloseTo(1 / 3, 4)
+    expect(s[3].y).toBe(0)
+    expect(s[3].h).toBe(3)
+    // 右列 (goUp 3 → row 0, x = 2/3)
+    expect(s[4].x).toBeCloseTo(2 / 3, 4)
+    expect(s[4].y).toBe(0)
+    expect(s[4].h).toBe(3)
+  })
+
+  it("goUp + break + 全幅 の繰り返し", () => {
+    const cells = buildGridLayout([
+      // ブロック1: 左右分割
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 1, heightMultiplier: 2 }),
+      // ブロック2: 全幅
+      item({ layoutWidth: "1/1", nextPlacement: "break" }),
+      // ブロック3: 3分割
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    // ブロック1
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 2 })
+    // ブロック2: y=2
+    expect(s[3]).toEqual({ x: 0, y: 2, w: 1, h: 1 })
+    // ブロック3: y=3
+    expect(s[4].y).toBe(3)
+    expect(s[5].y).toBe(3)
+    expect(s[6].y).toBe(3)
+  })
+})
+
+// ─── buildGridLayout: エッジケース ───
+
+describe("buildGridLayout: エッジケース", () => {
+  it("layoutWidth あり1件のみ → 横配置モード、1セル", () => {
+    const cells = buildGridLayout([item({ layoutWidth: "1/2" })])
+    const s = simplify(cells)
+    expect(s).toEqual([{ x: 0, y: 0, w: 0.5, h: 1 }])
+  })
+
+  it("layoutWidth なしが混在 → 未指定は幅1扱い", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item(), // layoutWidth なし → "1" → 幅1
+    ])
+    const s = simplify(cells)
+    // ①: x=0, w=0.5
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    // ②: layoutWidth 未指定 → 幅1 → 1/2+1 > 1 で改行
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 1, h: 1 })
+  })
+
+  it("heightMultiplier が 0.5 のアイテム", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 0.5 }),
+      item({ layoutWidth: "1/2", heightMultiplier: 1.5 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].h).toBe(0.5)
+    expect(s[1].h).toBe(1.5)
+    expect(gridTotalHeight(cells)).toBe(1.5)
+  })
+
+  it("break + goUp の組み合わせ: break は goUp より先に評価されない", () => {
+    // ① が break → 次の行へ
+    // ② が goUp=1 → 配置前に row 0 に戻る
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", goUp: 1 }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    // ② は goUp で row 0 に戻り、①の右に配置
+    expect(s[1]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+  })
+
+  it("全アイテムに break → 全て別の行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3", nextPlacement: "break" }),
+      item({ layoutWidth: "1/3" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0].y).toBe(0)
+    expect(s[1].y).toBe(1)
+    expect(s[2].y).toBe(2)
+  })
+
+  it("goUp なし + nextPlacement なし → 全て inline", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "1/4" }),
+    ])
+    const s = simplify(cells)
+    expect(s.every((c) => c.y === 0)).toBe(true)
+  })
+
+  it("自動改行後に goUp で戻れる", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }), // 自動改行
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 1 }), // row0 に戻る... が rightX=1 なので収まらない
+    ])
+    const s = simplify(cells)
+    // row0: ① ② → rightX=1
+    // row1: ③ (x=0, w=0.5) → rightX=0.5
+    // ④ goUp=1 → targetIdx=0, maxRightX = max(1, 0.5) = 1
+    // curX=1 → 幅超過で改行 → 新しい行
+    expect(s[3].y).toBe(2)
+    expect(s[3].x).toBe(0)
+  })
+})
+
+// ─── goUp + 既存行自動進行テスト ───
+
+describe("buildGridLayout: goUp + 既存行自動進行（2カラムパターン）", () => {
+  it("2列3行: 左3段 + goUp + 右3段", () => {
+    // (1)(4) / (2)(5) / (3)(6)
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 2 }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.5, h: 1 })
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[4]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+  })
+
+  it("2列2行: goUp 後に既存行を埋める", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 1 }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[3]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+  })
+
+  it("2列3行 + 下に全幅行", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 2 }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    // 右列が既存3行を埋める
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[4]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+    // 全幅行は下に配置
+    expect(s[6]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+
+  it("左3段(h=1) + 右大枠(h=3, goUp): 後続は下に配置", () => {
+    // goUp アイテムの高さが大きい場合、後続は goUp ブロックを抜ける
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4", nextPlacement: "break" }),
+      item({ layoutWidth: "1/4" }),
+      item({ layoutWidth: "3/4", goUp: 2, heightMultiplier: 3 }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    // ⑤ は goUp ブロックの下に配置 (y=3)
+    expect(s[4].y).toBe(3)
+    expect(s[4].x).toBe(0)
+  })
+
+  it("2列 + 右列に h=2 セル: lastCellBottom でスキップ", () => {
+    // ④ が h=2 で row 0-1 をカバー → ⑤ は row 2 に進む
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 2, heightMultiplier: 2 }),
+      item({ layoutWidth: "1/2" }),
+    ])
+    const s = simplify(cells)
+    // ④ at (0.5, 0) h=2 → lastCellBottom=2
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 2 })
+    // ⑤ は row 2 (y=2) に進む（row 1 は ④ のカバー範囲内なのでスキップ）
+    expect(s[4]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+  })
+
+  it("2列 + 左列に h=2 セル: 右列は4アイテムで埋まる", () => {
+    // ユーザー例: 1 5 / 2 6 / 3 7 / 3 8 / 9
+    // item 3 が h=2、右列は4アイテム(h=1)でitem 3 の高さ分を埋める
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }), // ① h=1
+      item({ layoutWidth: "1/2", nextPlacement: "break" }), // ② h=1
+      item({ layoutWidth: "1/2", heightMultiplier: 2 }), // ③ h=2
+      item({ layoutWidth: "1/2", goUp: 2 }), // ④ h=1
+      item({ layoutWidth: "1/2" }), // ⑤ h=1
+      item({ layoutWidth: "1/2" }), // ⑥ h=1
+      item({ layoutWidth: "1/2" }), // ⑦ h=1
+      item({ layoutWidth: "1/1" }), // ⑧ 全幅
+    ])
+    const s = simplify(cells)
+    // 左列
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 1 })
+    expect(s[1]).toEqual({ x: 0, y: 1, w: 0.5, h: 1 })
+    expect(s[2]).toEqual({ x: 0, y: 2, w: 0.5, h: 2 }) // h=2
+    // 右列: 4アイテムが y=0,1,2,3 に配置
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[4]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+    expect(s[6]).toEqual({ x: 0.5, y: 3, w: 0.5, h: 1 }) // ③のh=2内
+    // 全幅行は下に
+    expect(s[7]).toEqual({ x: 0, y: 4, w: 1, h: 1 })
+  })
+
+  it("2列 + 左列先頭が h=2: 右列は既存行を埋めてから新行", () => {
+    // ① h=2, ② h=1 → 左列合計高さ3 → 右列は3アイテム配置可能
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 2, nextPlacement: "break" }), // ① h=2
+      item({ layoutWidth: "1/2" }), // ② h=1
+      item({ layoutWidth: "1/2", goUp: 1 }), // ③
+      item({ layoutWidth: "1/2" }), // ④
+      item({ layoutWidth: "1/2" }), // ⑤
+    ])
+    const s = simplify(cells)
+    // 左列
+    expect(s[0]).toEqual({ x: 0, y: 0, w: 0.5, h: 2 })
+    expect(s[1]).toEqual({ x: 0, y: 2, w: 0.5, h: 1 })
+    // 右列: ③④⑤ が y=0,1,2 で ① (h=2) の空間を埋める
+    expect(s[2]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    // ④: ①のh=2内のy=1に中間行を作成して配置
+    expect(s[3]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+    // ⑤: 既存行 (y=2) に配置
+    expect(s[4]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+  })
+
+  it("2列 + 左列中間が h=3: 右列がグリッド内で自動拡張", () => {
+    // ① h=1, ② h=3, ③ h=1 → 左列合計高さ5
+    // 右列は5アイテム配置可能
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }), // ① h=1
+      item({ layoutWidth: "1/2", heightMultiplier: 3, nextPlacement: "break" }), // ② h=3
+      item({ layoutWidth: "1/2" }), // ③ h=1
+      item({ layoutWidth: "1/2", goUp: 2 }), // ④
+      item({ layoutWidth: "1/2" }), // ⑤
+      item({ layoutWidth: "1/2" }), // ⑥
+      item({ layoutWidth: "1/2" }), // ⑦
+      item({ layoutWidth: "1/2" }), // ⑧
+    ])
+    const s = simplify(cells)
+    // 右列: y=0,1,2,3,4
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 1 })
+    expect(s[4]).toEqual({ x: 0.5, y: 1, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+    expect(s[6]).toEqual({ x: 0.5, y: 3, w: 0.5, h: 1 })
+    expect(s[7]).toEqual({ x: 0.5, y: 4, w: 0.5, h: 1 })
+  })
+
+  it("2列 + 右列に h=2 混在: 後続は lastCellBottom を尊重", () => {
+    // 左列: ①h=1, ②h=1, ③h=1 → 3行
+    // 右列: ④h=2, ⑤h=1 → ④がy=0〜2をカバー、⑤はy=2に配置
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 2, heightMultiplier: 2 }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/1" }),
+    ])
+    const s = simplify(cells)
+    expect(s[3]).toEqual({ x: 0.5, y: 0, w: 0.5, h: 2 })
+    expect(s[4]).toEqual({ x: 0.5, y: 2, w: 0.5, h: 1 })
+    expect(s[5]).toEqual({ x: 0, y: 3, w: 1, h: 1 })
+  })
+
+  it("3列パターン: 3段 + goUp × 2（中間カラムに明示break）", () => {
+    // 3カラム: 左(①②③) + 中(④⑤⑥) + 右(⑦⑧⑨)
+    // 3列では 1/3+1/3+1/3=1.0 で auto-break が発動しないため、
+    // 中間カラムの④⑤に明示的 break が必要
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/3", nextPlacement: "break" }), // ①
+      item({ layoutWidth: "1/3", nextPlacement: "break" }), // ②
+      item({ layoutWidth: "1/3" }), // ③
+      item({ layoutWidth: "1/3", goUp: 2, nextPlacement: "break" }), // ④
+      item({ layoutWidth: "1/3", nextPlacement: "break" }), // ⑤
+      item({ layoutWidth: "1/3" }), // ⑥
+      item({ layoutWidth: "1/3", goUp: 2 }), // ⑦
+      item({ layoutWidth: "1/3" }), // ⑧
+      item({ layoutWidth: "1/3" }), // ⑨
+    ])
+    const s = simplify(cells)
+    // 左列 (x=0)
+    expect(s[0].x).toBe(0)
+    expect(s[0].y).toBe(0)
+    expect(s[1].x).toBe(0)
+    expect(s[1].y).toBe(1)
+    expect(s[2].x).toBe(0)
+    expect(s[2].y).toBe(2)
+    // 中列 (x≈1/3)
+    expect(s[3].x).toBeCloseTo(1 / 3)
+    expect(s[3].y).toBe(0)
+    expect(s[4].x).toBeCloseTo(1 / 3)
+    expect(s[4].y).toBe(1)
+    expect(s[5].x).toBeCloseTo(1 / 3)
+    expect(s[5].y).toBe(2)
+    // 右列 (x≈2/3)
+    expect(s[6].x).toBeCloseTo(2 / 3)
+    expect(s[6].y).toBe(0)
+    expect(s[7].x).toBeCloseTo(2 / 3)
+    expect(s[7].y).toBe(1)
+    expect(s[8].x).toBeCloseTo(2 / 3)
+    expect(s[8].y).toBe(2)
+  })
+})
+
+// ─── gridTotalHeight テスト ───
+
+describe("gridTotalHeight", () => {
+  it("空配列 → 0", () => {
+    expect(gridTotalHeight([])).toBe(0)
+  })
+
+  it("1セル → y + height", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 3 }),
+    ])
+    expect(gridTotalHeight(cells)).toBe(3)
+  })
+
+  it("複数行 → 最下端", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", heightMultiplier: 1 }),
+      item({ layoutWidth: "1/2", heightMultiplier: 1 }),
+      item({ layoutWidth: "1/1", heightMultiplier: 2 }),
+    ])
+    // 行0: y=0, 行1: y=1, h=2 → 下端 = 3
+    expect(gridTotalHeight(cells)).toBe(3)
+  })
+
+  it("goUp で上に配置されたアイテムの高さも考慮", () => {
+    const cells = buildGridLayout([
+      item({ layoutWidth: "1/2", nextPlacement: "break" }),
+      item({ layoutWidth: "1/2" }),
+      item({ layoutWidth: "1/2", goUp: 1, heightMultiplier: 5 }),
+    ])
+    // ③ は y=0, h=5 → 下端=5
+    expect(gridTotalHeight(cells)).toBe(5)
+  })
+})

--- a/__tests__/renderer/helpers/mockWizard.ts
+++ b/__tests__/renderer/helpers/mockWizard.ts
@@ -34,6 +34,8 @@ export function createMockWizard(
     setAllScoringConflictResolutions: vi.fn(),
     acceptHszDisclaimer: vi.fn().mockResolvedValue(true),
     dismissHszDisclaimer: vi.fn(),
+    updateSubtotalMapping: vi.fn(),
+    clearSubtotalMappings: vi.fn(),
     goToNextStep: vi.fn(),
     goBack: vi.fn(),
     executeImport: vi.fn().mockResolvedValue({

--- a/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { RenderMode } from "@/types/answerSheetBuilder.types"
 
 import { ExportDialog } from "./components/export/ExportDialog"
@@ -18,7 +19,10 @@ import { OMRMarkerSettings } from "./components/form/OMRMarkerSettings"
 import { QuestionListEditor } from "./components/form/QuestionListEditor"
 import { AnswerSheetPreview } from "./components/preview/AnswerSheetPreview"
 import { useAnswerSheetDefinition } from "./hooks/useAnswerSheetDefinition"
-import { useAnswerSheetLayout } from "./hooks/useAnswerSheetLayout"
+import {
+  useAnswerSheetLayout,
+  useMultiPageLayout,
+} from "./hooks/useAnswerSheetLayout"
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts"
 
 export function AnswerSheetBuilderMainView() {
@@ -36,6 +40,10 @@ export function AnswerSheetBuilderMainView() {
     addBranchQuestion,
     updateBranchQuestion,
     deleteBranchQuestion,
+    reorderMajorQuestions,
+    reorderSubQuestions,
+    reorderBranchQuestions,
+    setLabelPreset,
     canUndo,
     canRedo,
     undo,
@@ -43,17 +51,17 @@ export function AnswerSheetBuilderMainView() {
   } = useAnswerSheetDefinition()
 
   const layout = useAnswerSheetLayout(definition)
+  const multiPageLayout = useMultiPageLayout(definition)
 
   useUndoRedoShortcuts({ undo, redo, canUndo, canRedo })
 
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [projectDialogOpen, setProjectDialogOpen] = useState(false)
 
-  // 問題統計
-  const totalQuestions = layout.cells.filter(
-    (c) => c.cellType === "answer"
-  ).length
-  const totalPoints = layout.cells
+  // 問題統計（全ページのセルから集計）
+  const allCells = multiPageLayout.pages.flatMap((p) => p.cells)
+  const totalQuestions = allCells.filter((c) => c.cellType === "answer").length
+  const totalPoints = allCells
     .filter((c) => c.cellType === "answer")
     .reduce((sum, c) => sum + c.points, 0)
 
@@ -79,9 +87,9 @@ export function AnswerSheetBuilderMainView() {
   }, [definition])
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-screen">
       {/* 左パネル: フォーム */}
-      <div className="flex w-1/2 max-w-2xl flex-shrink-0 flex-col border-r">
+      <div className="flex w-1/2 max-w-2xl shrink-0 flex-col overflow-hidden border-r">
         {/* 名前入力 */}
         <div className="border-b p-3">
           <Input
@@ -144,70 +152,111 @@ export function AnswerSheetBuilderMainView() {
           </Button>
         </div>
 
-        {/* フォーム本体 */}
-        <ScrollArea className="flex-1">
-          <div className="space-y-4 p-3">
-            <GlobalSettingsForm
-              settings={definition.settings}
-              onUpdate={updateSettings}
-            />
+        {/* タブ付きフォーム本体 */}
+        <Tabs defaultValue="questions" className="flex min-h-0 flex-1 flex-col">
+          <TabsList className="mx-3 mt-2 w-auto">
+            <TabsTrigger value="questions" className="text-xs">
+              問題構成
+            </TabsTrigger>
+            <TabsTrigger value="paper" className="text-xs">
+              用紙設定
+            </TabsTrigger>
+            <TabsTrigger value="lines" className="text-xs">
+              罫線
+            </TabsTrigger>
+            <TabsTrigger value="omr" className="text-xs">
+              OMR
+            </TabsTrigger>
+          </TabsList>
 
-            <Separator />
+          <TabsContent value="questions" className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <div className="p-3">
+                <QuestionListEditor
+                  majorQuestions={definition.majorQuestions}
+                  labelPresets={definition.labelPresets}
+                  onSetLabelPreset={setLabelPreset}
+                  onAddMajor={addMajorQuestion}
+                  onUpdateMajor={updateMajorQuestion}
+                  onDeleteMajor={deleteMajorQuestion}
+                  onReorderMajor={reorderMajorQuestions}
+                  onAddSub={addSubQuestion}
+                  onUpdateSub={updateSubQuestion}
+                  onDeleteSub={deleteSubQuestion}
+                  onReorderSub={reorderSubQuestions}
+                  onAddBranch={addBranchQuestion}
+                  onUpdateBranch={updateBranchQuestion}
+                  onDeleteBranch={deleteBranchQuestion}
+                  onReorderBranch={reorderBranchQuestions}
+                />
+              </div>
+            </ScrollArea>
+          </TabsContent>
 
-            <LineStylePicker
-              borderConfig={definition.settings.borderConfig}
-              onUpdate={(borderConfig) =>
-                updateSettings({
-                  borderConfig: {
-                    ...definition.settings.borderConfig,
-                    ...borderConfig,
-                  },
-                })
-              }
-            />
+          <TabsContent value="paper" className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <div className="p-3">
+                <GlobalSettingsForm
+                  settings={definition.settings}
+                  onUpdate={updateSettings}
+                />
+              </div>
+            </ScrollArea>
+          </TabsContent>
 
-            <Separator />
+          <TabsContent value="lines" className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <div className="p-3">
+                <LineStylePicker
+                  borderConfig={definition.settings.borderConfig}
+                  onUpdate={(borderConfig) =>
+                    updateSettings({
+                      borderConfig: {
+                        ...definition.settings.borderConfig,
+                        ...borderConfig,
+                      },
+                    })
+                  }
+                />
+              </div>
+            </ScrollArea>
+          </TabsContent>
 
-            <OMRMarkerSettings
-              config={definition.settings.omrMarkers}
-              onUpdate={(omrMarkers) =>
-                updateSettings({
-                  omrMarkers: {
-                    ...definition.settings.omrMarkers,
-                    ...omrMarkers,
-                  },
-                })
-              }
-            />
-
-            <Separator />
-
-            <QuestionListEditor
-              majorQuestions={definition.majorQuestions}
-              onAddMajor={addMajorQuestion}
-              onUpdateMajor={updateMajorQuestion}
-              onDeleteMajor={deleteMajorQuestion}
-              onAddSub={addSubQuestion}
-              onUpdateSub={updateSubQuestion}
-              onDeleteSub={deleteSubQuestion}
-              onAddBranch={addBranchQuestion}
-              onUpdateBranch={updateBranchQuestion}
-              onDeleteBranch={deleteBranchQuestion}
-            />
-          </div>
-        </ScrollArea>
+          <TabsContent value="omr" className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <div className="p-3">
+                <OMRMarkerSettings
+                  config={definition.settings.omrMarkers}
+                  onUpdate={(omrMarkers) =>
+                    updateSettings({
+                      omrMarkers: {
+                        ...definition.settings.omrMarkers,
+                        ...omrMarkers,
+                      },
+                    })
+                  }
+                />
+              </div>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
 
         {/* フッター統計 */}
         <div className="text-muted-foreground flex justify-between border-t p-2 text-xs">
-          <span>{totalQuestions}問</span>
+          <span>
+            {totalQuestions}問
+            {multiPageLayout.totalPages > 1 &&
+              ` / ${multiPageLayout.totalPages}ページ`}
+          </span>
           <span>合計 {totalPoints}点</span>
         </div>
       </div>
 
       {/* 右パネル: プレビュー */}
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <AnswerSheetPreview
           layout={layout}
+          multiPageLayout={multiPageLayout}
           renderMode={definition.renderMode}
           onRenderModeChange={handleRenderModeChange}
           dispatch={dispatch}

--- a/components/answer-sheet-builder/components/export/ExportDialog.tsx
+++ b/components/answer-sheet-builder/components/export/ExportDialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FileImage, FileText } from "lucide-react"
+import { FileImage, FileText, Printer } from "lucide-react"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -27,7 +27,8 @@ export function ExportDialog({
   onOpenChange,
   definition,
 }: ExportDialogProps) {
-  const { exportPdf, exportPng, isExporting } = useAnswerSheetExport()
+  const { exportPdf, exportPng, printSheet, isExporting } =
+    useAnswerSheetExport()
   const [dpi, setDpi] = useState(300)
 
   return (
@@ -86,6 +87,24 @@ export function ExportDialog({
               />
             </div>
           </div>
+
+          <Button
+            variant="outline"
+            className="h-12 w-full justify-start gap-3"
+            disabled={isExporting}
+            onClick={() => {
+              printSheet(definition)
+              onOpenChange(false)
+            }}
+          >
+            <Printer className="h-5 w-5 text-green-500" />
+            <div className="text-left">
+              <div className="text-sm font-medium">印刷</div>
+              <div className="text-muted-foreground text-xs">
+                システム印刷ダイアログを表示
+              </div>
+            </div>
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -14,8 +14,8 @@ interface BranchQuestionFormProps {
   branch: BranchQuestion
   branchIndex: number
   totalBranchCount: number
-  isHorizontal?: boolean
   showPoints?: boolean
+  maxGoUp: number
   onUpdate: (data: Partial<BranchQuestion>) => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -24,8 +24,8 @@ interface BranchQuestionFormProps {
 
 export function BranchQuestionForm({
   branch,
-  isHorizontal,
   showPoints = true,
+  maxGoUp,
   onUpdate,
   onDelete,
   onMoveUp,
@@ -35,6 +35,13 @@ export function BranchQuestionForm({
 
   const hasDetailContent =
     !!branch.modelAnswer || branch.textElements.length > 0
+
+  const goUpActive = branch.goUp != null
+  const isGoUpInvalid =
+    goUpActive &&
+    (!Number.isInteger(branch.goUp) ||
+      branch.goUp! < 1 ||
+      branch.goUp! > maxGoUp)
 
   return (
     <div className="border-muted-foreground/20 ml-4 space-y-1 border-l-2 py-1 pl-4">
@@ -83,26 +90,109 @@ export function BranchQuestionForm({
               }}
             />
           </div>
-          {isHorizontal && (
-            <div className="flex items-center gap-0.5 px-1.5">
-              <span className="text-muted-foreground">幅</span>
+          {/* 幅 (layoutWidth) */}
+          <div className="flex items-center gap-0.5 px-1.5">
+            <span className="text-muted-foreground">幅</span>
+            <input
+              className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
+              value={branch.layoutWidth ?? ""}
+              onChange={(e) => {
+                const v = e.target.value.trim()
+                if (v === "") {
+                  onUpdate({
+                    layoutWidth: undefined,
+                    nextPlacement: undefined,
+                    goUp: undefined,
+                  })
+                } else {
+                  onUpdate({ layoutWidth: v })
+                }
+              }}
+              placeholder="—"
+            />
+          </div>
+        </div>
+        {/* 改行ボタン */}
+        {branch.layoutWidth && (
+          <Button
+            variant="outline"
+            size="icon"
+            className={`h-7 w-7 text-xs ${branch.nextPlacement === "break" ? "bg-primary/10 text-primary border-primary/50 hover:bg-primary/20" : "text-muted-foreground"}`}
+            onClick={() => {
+              if (branch.nextPlacement === "break") {
+                onUpdate({ nextPlacement: undefined })
+              } else {
+                onUpdate({ nextPlacement: "break" })
+              }
+            }}
+            title="改行"
+          >
+            ↵
+          </Button>
+        )}
+        {/* 戻るボタン（自分自身をN行上に配置） */}
+        {branch.layoutWidth && (
+          <div className="inline-flex items-center gap-0">
+            <Button
+              variant="outline"
+              size="icon"
+              className={`h-7 w-7 text-xs ${goUpActive && branch.goUp! > 0 ? "bg-primary/10 text-primary border-primary/50 hover:bg-primary/20" : "text-muted-foreground"} ${goUpActive ? "rounded-r-none" : ""}`}
+              onClick={() => {
+                if (goUpActive) {
+                  onUpdate({ goUp: undefined })
+                } else {
+                  onUpdate({ goUp: Math.min(1, maxGoUp) })
+                }
+              }}
+              disabled={!goUpActive && maxGoUp < 1}
+              title={
+                maxGoUp < 1
+                  ? "戻れる行がありません"
+                  : `N行上に戻して配置 (最大${maxGoUp})`
+              }
+            >
+              ↑
+            </Button>
+            {goUpActive && (
               <input
                 type="number"
-                className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                value={branch.colSpan ?? 1}
+                aria-label="戻り行数"
+                className={`border-primary/50 h-7 w-8 [appearance:textfield] rounded-r-md border border-l-0 px-0.5 text-center text-xs outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${isGoUpInvalid ? "bg-red-100 dark:bg-red-900/30" : "bg-transparent"}`}
+                value={branch.goUp || ""}
                 min={1}
-                max={10}
-                step={1}
-                onChange={(e) =>
-                  onUpdate({ colSpan: Number(e.target.value) || 1 })
-                }
-                onBlur={(e) => {
-                  e.target.value = String(Number(e.target.value) || 1)
+                max={maxGoUp}
+                onChange={(e) => {
+                  const v = e.target.value
+                  if (v === "") {
+                    onUpdate({ goUp: 0 })
+                  } else {
+                    onUpdate({ goUp: Number(v) })
+                  }
+                }}
+                onBlur={() => {
+                  if (
+                    branch.goUp == null ||
+                    !Number.isInteger(branch.goUp) ||
+                    branch.goUp < 1 ||
+                    branch.goUp > maxGoUp
+                  ) {
+                    onUpdate({ goUp: undefined })
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                    e.preventDefault()
+                    const cur = branch.goUp ?? 0
+                    const next = e.key === "ArrowUp" ? cur + 1 : cur - 1
+                    if (next >= 1 && next <= maxGoUp) {
+                      onUpdate({ goUp: next })
+                    }
+                  }
                 }}
               />
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
         <div className="ml-auto flex items-center gap-1.5">
           <div className="inline-flex items-center rounded-md border">
             <Button

--- a/components/answer-sheet-builder/components/form/GlobalSettingsForm.tsx
+++ b/components/answer-sheet-builder/components/form/GlobalSettingsForm.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -11,11 +10,13 @@ import {
 } from "@/components/ui/select"
 import type {
   GlobalSettings,
+  MajorNumberDisplayMode,
   Orientation,
   PaperSize,
 } from "@/types/answerSheetBuilder.types"
 
 import { PAPER_SIZE_OPTIONS } from "../../constants"
+import { SliderWithInput } from "./SliderWithInput"
 
 interface GlobalSettingsFormProps {
   settings: GlobalSettings
@@ -30,8 +31,8 @@ export function GlobalSettingsForm({
     <div className="space-y-4">
       <h3 className="text-muted-foreground text-sm font-semibold">用紙設定</h3>
 
-      {/* 用紙サイズ・向き */}
-      <div className="grid grid-cols-2 gap-3">
+      {/* 用紙サイズ・向き・大問番号表示 */}
+      <div className="grid grid-cols-3 gap-3">
         <div>
           <Label className="text-xs">用紙サイズ</Label>
           <Select
@@ -65,191 +66,156 @@ export function GlobalSettingsForm({
             </SelectContent>
           </Select>
         </div>
-      </div>
-
-      {/* マージン */}
-      <div>
-        <Label className="text-xs">余白 (mm)</Label>
-        <div className="grid grid-cols-4 gap-2">
-          {(["top", "bottom", "left", "right"] as const).map((side) => (
-            <div key={side}>
-              <Label className="text-muted-foreground text-[10px]">
-                {side === "top"
-                  ? "上"
-                  : side === "bottom"
-                    ? "下"
-                    : side === "left"
-                      ? "左"
-                      : "右"}
-              </Label>
-              <Input
-                type="number"
-                className="h-7 text-xs"
-                value={settings.margins[side]}
-                min={0}
-                max={50}
-                onChange={(e) =>
-                  onUpdate({
-                    margins: {
-                      ...settings.margins,
-                      [side]: Number(e.target.value),
-                    },
-                  })
-                }
-              />
-            </div>
-          ))}
+        <div>
+          <Label className="text-xs">大問番号</Label>
+          <Select
+            value={settings.numberDisplayMode}
+            onValueChange={(v) =>
+              onUpdate({ numberDisplayMode: v as MajorNumberDisplayMode })
+            }
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="multirow">結合</SelectItem>
+              <SelectItem value="boxed-top">四角</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
       </div>
 
+      {/* マージン */}
+      <div className="space-y-2">
+        <Label className="text-xs">余白 (mm)</Label>
+        {(
+          [
+            ["top", "上"],
+            ["bottom", "下"],
+            ["left", "左"],
+            ["right", "右"],
+          ] as const
+        ).map(([side, label]) => (
+          <SliderWithInput
+            key={side}
+            label={label}
+            value={settings.margins[side]}
+            min={0}
+            max={50}
+            step={1}
+            onChange={(v) =>
+              onUpdate({ margins: { ...settings.margins, [side]: v } })
+            }
+          />
+        ))}
+      </div>
+
       {/* 行高さ */}
-      <div>
+      <div className="space-y-2">
         <Label className="text-xs">基本行高さ (mm)</Label>
-        <Input
-          type="number"
-          className="h-8 text-xs"
+        <SliderWithInput
+          label=""
           value={settings.baseRowHeight}
           min={5}
           max={50}
           step={1}
-          onChange={(e) => onUpdate({ baseRowHeight: Number(e.target.value) })}
+          onChange={(v) => onUpdate({ baseRowHeight: v })}
         />
       </div>
 
       {/* 列幅 */}
-      <div>
+      <div className="space-y-2">
         <Label className="text-xs">列幅 (mm)</Label>
-        <div className="grid grid-cols-3 gap-2">
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              大問番号
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={settings.columnWidths.majorNumber}
-              min={5}
-              max={30}
-              onChange={(e) =>
-                onUpdate({
-                  columnWidths: {
-                    ...settings.columnWidths,
-                    majorNumber: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </div>
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              小問番号
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={settings.columnWidths.subNumber}
-              min={5}
-              max={30}
-              onChange={(e) =>
-                onUpdate({
-                  columnWidths: {
-                    ...settings.columnWidths,
-                    subNumber: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </div>
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              枝問番号
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={settings.columnWidths.branchNumber}
-              min={5}
-              max={30}
-              onChange={(e) =>
-                onUpdate({
-                  columnWidths: {
-                    ...settings.columnWidths,
-                    branchNumber: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </div>
-        </div>
+        <SliderWithInput
+          label="大問番号"
+          value={settings.columnWidths.majorNumber}
+          min={5}
+          max={30}
+          step={1}
+          onChange={(v) =>
+            onUpdate({
+              columnWidths: { ...settings.columnWidths, majorNumber: v },
+            })
+          }
+        />
+        <SliderWithInput
+          label="小問番号"
+          value={settings.columnWidths.subNumber}
+          min={5}
+          max={30}
+          step={1}
+          onChange={(v) =>
+            onUpdate({
+              columnWidths: { ...settings.columnWidths, subNumber: v },
+            })
+          }
+        />
+        <SliderWithInput
+          label="枝問番号"
+          value={settings.columnWidths.branchNumber}
+          min={5}
+          max={30}
+          step={1}
+          onChange={(v) =>
+            onUpdate({
+              columnWidths: { ...settings.columnWidths, branchNumber: v },
+            })
+          }
+        />
       </div>
 
-      {/* 大問間スペーシング */}
-      <div>
-        <Label className="text-xs">大問間スペース (mm)</Label>
-        <Input
-          type="number"
-          className="h-8 text-xs"
+      {/* スペーシング */}
+      <div className="space-y-2">
+        <Label className="text-xs">スペーシング (mm)</Label>
+        <SliderWithInput
+          label="大問間"
           value={settings.spacing.majorQuestionSpacing}
           min={0}
           max={20}
-          onChange={(e) =>
+          step={1}
+          onChange={(v) =>
             onUpdate({
-              spacing: {
-                ...settings.spacing,
-                majorQuestionSpacing: Number(e.target.value),
-              },
+              spacing: { ...settings.spacing, majorQuestionSpacing: v },
+            })
+          }
+        />
+        <SliderWithInput
+          label="ヘッダー"
+          value={settings.spacing.headerHeight}
+          min={0}
+          max={50}
+          step={1}
+          onChange={(v) =>
+            onUpdate({
+              spacing: { ...settings.spacing, headerHeight: v },
             })
           }
         />
       </div>
 
       {/* フォントサイズ */}
-      <div>
+      <div className="space-y-2">
         <Label className="text-xs">フォントサイズ (pt)</Label>
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              テキスト
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={settings.fonts.defaultSize}
-              min={6}
-              max={24}
-              step={0.5}
-              onChange={(e) =>
-                onUpdate({
-                  fonts: {
-                    ...settings.fonts,
-                    defaultSize: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </div>
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              設問番号
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={settings.fonts.numberSize}
-              min={6}
-              max={24}
-              step={0.5}
-              onChange={(e) =>
-                onUpdate({
-                  fonts: {
-                    ...settings.fonts,
-                    numberSize: Number(e.target.value),
-                  },
-                })
-              }
-            />
-          </div>
-        </div>
+        <SliderWithInput
+          label="テキスト"
+          value={settings.fonts.defaultSize}
+          min={6}
+          max={24}
+          step={0.5}
+          onChange={(v) =>
+            onUpdate({ fonts: { ...settings.fonts, defaultSize: v } })
+          }
+        />
+        <SliderWithInput
+          label="設問番号"
+          value={settings.fonts.numberSize}
+          min={6}
+          max={24}
+          step={0.5}
+          onChange={(v) =>
+            onUpdate({ fonts: { ...settings.fonts, numberSize: v } })
+          }
+        />
       </div>
     </div>
   )

--- a/components/answer-sheet-builder/components/form/LineStylePicker.tsx
+++ b/components/answer-sheet-builder/components/form/LineStylePicker.tsx
@@ -1,13 +1,9 @@
 "use client"
 
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { Slider } from "@/components/ui/slider"
+import { cn } from "@/lib/utils"
 import type { BorderConfig, LineStyle } from "@/types/answerSheetBuilder.types"
 
 interface LineStylePickerProps {
@@ -15,19 +11,155 @@ interface LineStylePickerProps {
   onUpdate: (config: Partial<BorderConfig>) => void
 }
 
-const LINE_STYLE_OPTIONS: { value: LineStyle; label: string }[] = [
-  { value: "solid", label: "実線" },
-  { value: "dashed", label: "破線" },
-  { value: "dotted", label: "点線" },
+const LINE_STYLES: { value: LineStyle; title: string }[] = [
+  { value: "solid", title: "実線" },
+  { value: "dashed", title: "破線" },
+  { value: "dotted", title: "点線" },
 ]
 
-const BORDER_FIELDS: { key: keyof BorderConfig; label: string }[] = [
-  { key: "outerBorder", label: "外枠" },
-  { key: "majorDivider", label: "大問区切" },
-  { key: "subDivider", label: "小問区切" },
-  { key: "branchDivider", label: "枝問区切" },
-  { key: "numberColumnDivider", label: "番号列" },
+const BORDER_FIELDS: {
+  styleKey: keyof BorderConfig
+  widthKey: keyof BorderConfig
+  label: string
+  defaultWidth: number
+}[] = [
+  {
+    styleKey: "outerBorder",
+    widthKey: "outerBorderWidth",
+    label: "外枠",
+    defaultWidth: 0.7,
+  },
+  {
+    styleKey: "majorDivider",
+    widthKey: "majorDividerWidth",
+    label: "大問",
+    defaultWidth: 0.5,
+  },
+  {
+    styleKey: "subDivider",
+    widthKey: "subDividerWidth",
+    label: "小問",
+    defaultWidth: 0.4,
+  },
+  {
+    styleKey: "branchDivider",
+    widthKey: "branchDividerWidth",
+    label: "枝問",
+    defaultWidth: 0.3,
+  },
+  {
+    styleKey: "numberColumnDivider",
+    widthKey: "numberColumnDividerWidth",
+    label: "番号列",
+    defaultWidth: 0.4,
+  },
 ]
+
+function LineIcon({ style }: { style: LineStyle }) {
+  const sw = 1.5
+  const lineLen = 18 // x2 - x1 = 19 - 1
+
+  let dashProps: {
+    strokeDasharray?: string
+    strokeDashoffset?: number
+  } = {}
+  if (style === "dashed") {
+    const dash = sw * 3
+    const gap = sw * 1
+    const period = dash + gap
+    const offset = ((lineLen / 2) % period) - dash / 2
+    dashProps = { strokeDasharray: `${dash} ${gap}`, strokeDashoffset: offset }
+  } else if (style === "dotted") {
+    const dash = sw * 1
+    const gap = sw * 1
+    const period = dash + gap
+    const offset = ((lineLen / 2) % period) - dash / 2
+    dashProps = { strokeDasharray: `${dash} ${gap}`, strokeDashoffset: offset }
+  }
+
+  return (
+    <svg width="20" height="10" viewBox="0 0 20 10" className="block">
+      <line
+        x1="1"
+        y1="5"
+        x2="19"
+        y2="5"
+        stroke="currentColor"
+        strokeWidth={sw}
+        {...dashProps}
+      />
+    </svg>
+  )
+}
+
+function EditableValue({
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  value: number
+  min: number
+  max: number
+  step: number
+  onChange: (v: number) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editing])
+
+  const handleChange = useCallback(
+    (raw: string) => {
+      setEditValue(raw)
+      const parsed = parseFloat(raw)
+      if (!isNaN(parsed) && parsed >= min && parsed <= max) {
+        onChange(parsed)
+      }
+    },
+    [min, max, onChange]
+  )
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="number"
+        aria-label="線の太さ"
+        className="border-input bg-background box-border h-5 w-8 shrink-0 rounded border text-center text-[10px] outline-none"
+        value={editValue}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => handleChange(e.target.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === "Escape") setEditing(false)
+        }}
+      />
+    )
+  }
+
+  return (
+    <span
+      className="text-muted-foreground inline-flex h-5 w-8 shrink-0 cursor-pointer items-center justify-end text-[10px] select-none hover:underline"
+      onDoubleClick={() => {
+        setEditValue(value.toFixed(1))
+        setEditing(true)
+      }}
+      title="ダブルクリックで直接入力"
+    >
+      {value.toFixed(1)}
+    </span>
+  )
+}
 
 export function LineStylePicker({
   borderConfig,
@@ -35,33 +167,53 @@ export function LineStylePicker({
 }: LineStylePickerProps) {
   return (
     <div className="space-y-3">
-      <h3 className="text-muted-foreground text-sm font-semibold">
-        罫線スタイル
-      </h3>
-      <div className="grid grid-cols-2 gap-2">
-        {BORDER_FIELDS.map((field) => (
-          <div key={field.key}>
-            <Label className="text-muted-foreground text-[10px]">
+      {BORDER_FIELDS.map((field) => {
+        const width =
+          (borderConfig[field.widthKey] as number | undefined) ??
+          field.defaultWidth
+        return (
+          <div key={field.styleKey} className="flex min-h-6 items-center gap-2">
+            <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
               {field.label}
-            </Label>
-            <Select
-              value={borderConfig[field.key]}
-              onValueChange={(v) => onUpdate({ [field.key]: v as LineStyle })}
-            >
-              <SelectTrigger className="h-7 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {LINE_STYLE_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            </span>
+            <div className="border-input flex shrink-0 rounded-md border">
+              {LINE_STYLES.map((ls) => (
+                <button
+                  key={ls.value}
+                  type="button"
+                  title={ls.title}
+                  className={cn(
+                    "hover:bg-accent flex h-6 w-7 items-center justify-center transition-colors first:rounded-l-md last:rounded-r-md",
+                    borderConfig[field.styleKey] === ls.value
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground"
+                  )}
+                  onClick={() =>
+                    onUpdate({ [field.styleKey]: ls.value as LineStyle })
+                  }
+                >
+                  <LineIcon style={ls.value} />
+                </button>
+              ))}
+            </div>
+            <Slider
+              className="min-w-12 flex-1"
+              value={[width]}
+              min={0.1}
+              max={1.5}
+              step={0.1}
+              onValueChange={([v]) => onUpdate({ [field.widthKey]: v })}
+            />
+            <EditableValue
+              value={width}
+              min={0.1}
+              max={1.5}
+              step={0.1}
+              onChange={(v) => onUpdate({ [field.widthKey]: v })}
+            />
           </div>
-        ))}
-      </div>
+        )
+      })}
     </div>
   )
 }

--- a/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
@@ -1,37 +1,78 @@
 "use client"
 
-import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react"
-import { useState } from "react"
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Plus,
+  Trash2,
+} from "lucide-react"
+import { useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Switch } from "@/components/ui/switch"
 import type {
   BranchQuestion,
-  MajorNumberDisplayMode,
   MajorQuestion,
   SubQuestion,
-  SubQuestionLayout,
 } from "@/types/answerSheetBuilder.types"
 
 import { SubQuestionForm } from "./SubQuestionForm"
 
+/** 簡易分数パース (例: "1/3" → 0.333) */
+function parseFractionSimple(s: string): number {
+  const m = s.match(/^(\d+)\/(\d+)$/)
+  if (m) return parseInt(m[1]) / parseInt(m[2])
+  const n = parseFloat(s)
+  return isNaN(n) ? 1 : n
+}
+
+/** 各小問の maxGoUp (= その小問の goUp 適用前の行インデックス) を計算 */
+function calcSubMaxGoUps(subs: SubQuestion[]): number[] {
+  const result: number[] = []
+  let row = 0
+  let curX = 0
+  for (let i = 0; i < subs.length; i++) {
+    const s = subs[i]
+    const w = parseFractionSimple(s.layoutWidth ?? "1")
+
+    // auto-break: 前の要素の配置結果で現在行に収まらない場合
+    if (curX > 1e-9 && curX + w > 1 + 1e-9) {
+      row++
+      curX = 0
+    }
+
+    // maxGoUp = goUp 適用前の行インデックス
+    result.push(row)
+
+    // goUp 適用
+    if (s.goUp != null && s.goUp > 0) {
+      row = Math.max(0, row - s.goUp)
+      curX = 0.5
+    }
+
+    curX += w
+
+    if (s.nextPlacement === "break") {
+      row++
+      curX = 0
+    }
+  }
+  return result
+}
+
 interface MajorQuestionFormProps {
   major: MajorQuestion
   majorIndex: number
+  totalMajorCount: number
   onUpdate: (data: Partial<MajorQuestion>) => void
   onDelete: () => void
+  onMoveUp?: () => void
+  onMoveDown?: () => void
   onAddSub: () => void
   onUpdateSub: (subIndex: number, data: Partial<SubQuestion>) => void
   onDeleteSub: (subIndex: number) => void
+  onReorderSub: (fromIndex: number, toIndex: number) => void
   onAddBranch: (subIndex: number) => void
   onUpdateBranch: (
     subIndex: number,
@@ -39,6 +80,11 @@ interface MajorQuestionFormProps {
     data: Partial<BranchQuestion>
   ) => void
   onDeleteBranch: (subIndex: number, branchIndex: number) => void
+  onReorderBranch: (
+    subIndex: number,
+    fromIndex: number,
+    toIndex: number
+  ) => void
 }
 
 export function MajorQuestionForm({
@@ -46,148 +92,124 @@ export function MajorQuestionForm({
   majorIndex,
   onUpdate,
   onDelete,
+  onMoveUp,
+  onMoveDown,
   onAddSub,
   onUpdateSub,
   onDeleteSub,
+  onReorderSub,
   onAddBranch,
   onUpdateBranch,
   onDeleteBranch,
+  onReorderBranch,
 }: MajorQuestionFormProps) {
   const [isOpen, setIsOpen] = useState(true)
 
+  const subMaxGoUps = useMemo(
+    () => calcSubMaxGoUps(major.subQuestions),
+    [major.subQuestions]
+  )
+
   return (
-    <div className="space-y-2 rounded-md border p-3">
-      {/* 大問ヘッダー */}
-      <div className="space-y-1.5">
-        {/* 1行目: 開閉・ラベル・表示モード・間隔 */}
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 flex-shrink-0"
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            {isOpen ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronRight className="h-4 w-4" />
-            )}
-          </Button>
-          <span className="text-muted-foreground text-xs font-medium whitespace-nowrap">
-            大問 {majorIndex + 1}
-          </span>
-          <Input
-            className="h-7 w-16 text-xs"
-            value={major.label}
-            onChange={(e) => onUpdate({ label: e.target.value })}
-            placeholder="番号"
-          />
-          <Select
-            value={major.numberDisplayMode}
-            onValueChange={(v) =>
-              onUpdate({ numberDisplayMode: v as MajorNumberDisplayMode })
-            }
-          >
-            <SelectTrigger className="h-7 w-24 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="multirow">結合</SelectItem>
-              <SelectItem value="boxed-top">四角</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select
-            value={major.subQuestionLayout ?? "vertical"}
-            onValueChange={(v) =>
-              onUpdate({ subQuestionLayout: v as SubQuestionLayout })
-            }
-          >
-            <SelectTrigger className="h-7 w-20 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="vertical">縦</SelectItem>
-              <SelectItem value="horizontal">横</SelectItem>
-            </SelectContent>
-          </Select>
-          {(major.subQuestionLayout ?? "vertical") === "horizontal" && (
-            <div className="flex items-center gap-1">
-              <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-                列数/行
-              </Label>
-              <Input
-                className="h-7 w-20 text-xs"
-                value={
-                  major.horizontalColumnsPerRow
-                    ? major.horizontalColumnsPerRow.join(",")
-                    : ""
-                }
-                onChange={(e) => {
-                  const val = e.target.value.trim()
-                  if (val === "") {
-                    onUpdate({ horizontalColumnsPerRow: undefined })
-                  } else {
-                    const nums = val
-                      .split(",")
-                      .map((s) => parseInt(s.trim(), 10))
-                      .filter((n) => !isNaN(n) && n > 0)
-                    if (nums.length > 0) {
-                      onUpdate({ horizontalColumnsPerRow: nums })
-                    }
-                  }
-                }}
-                placeholder="3,4,2"
-              />
-            </div>
+    <div className="bg-muted/30 rounded-lg border">
+      {/* ── ヘッダーバー ── */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
           )}
-          <div className="flex items-center gap-1.5">
-            <Label className="text-muted-foreground text-[10px]">間隔</Label>
-            <Switch
-              checked={major.spacingBefore}
-              onCheckedChange={(v) => onUpdate({ spacingBefore: v })}
-            />
-          </div>
-          <div className="ml-auto flex gap-1">
+        </Button>
+        <span className="bg-primary/10 text-primary rounded px-2 py-0.5 text-xs font-semibold whitespace-nowrap">
+          大問 {majorIndex + 1}
+        </span>
+        <Input
+          className="h-7 w-20 text-xs"
+          value={major.label}
+          onChange={(e) => onUpdate({ label: e.target.value })}
+          placeholder=""
+        />
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={onAddSub}
+            title="小問を追加"
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            小問
+          </Button>
+          <div className="inline-flex items-center rounded-md border">
             <Button
-              variant="outline"
-              size="sm"
-              className="h-6 px-2 text-xs"
-              onClick={onAddSub}
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground h-7 w-7 rounded-r-none"
+              onClick={onMoveUp}
+              disabled={!onMoveUp}
+              title="上へ移動"
             >
-              <Plus className="mr-1 h-3 w-3" />
-              小問
+              <ChevronUp className="h-3.5 w-3.5" />
             </Button>
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-destructive h-6 w-6"
-              onClick={onDelete}
+              className="text-muted-foreground h-7 w-7 rounded-l-none border-l"
+              onClick={onMoveDown}
+              disabled={!onMoveDown}
+              title="下へ移動"
             >
-              <Trash2 className="h-3 w-3" />
+              <ChevronDown className="h-3.5 w-3.5" />
             </Button>
           </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:text-destructive h-7 w-7"
+            onClick={onDelete}
+            title="大問を削除"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
         </div>
       </div>
 
-      {/* 小問リスト */}
+      {/* ── 展開コンテンツ ── */}
       {isOpen && (
-        <div className="space-y-2">
-          {major.subQuestions.map((sub, si) => (
-            <SubQuestionForm
-              key={sub.id}
-              sub={sub}
-              majorIndex={majorIndex}
-              subIndex={si}
-              isHorizontalLayout={
-                (major.subQuestionLayout ?? "vertical") === "horizontal"
-              }
-              onUpdate={(data) => onUpdateSub(si, data)}
-              onDelete={() => onDeleteSub(si)}
-              onAddBranch={() => onAddBranch(si)}
-              onUpdateBranch={(bi, data) => onUpdateBranch(si, bi, data)}
-              onDeleteBranch={(bi) => onDeleteBranch(si, bi)}
-            />
-          ))}
+        <div className="space-y-3 border-t px-3 pt-2 pb-3">
+          {/* 小問リスト */}
+          {major.subQuestions.length > 0 && (
+            <div className="space-y-2 pl-2">
+              {major.subQuestions.map((sub, si) => (
+                <SubQuestionForm
+                  key={sub.id}
+                  sub={sub}
+                  majorIndex={majorIndex}
+                  subIndex={si}
+                  totalSubCount={major.subQuestions.length}
+                  maxGoUp={subMaxGoUps[si]}
+                  onUpdate={(data) => onUpdateSub(si, data)}
+                  onDelete={() => onDeleteSub(si)}
+                  onMoveUp={si > 0 ? () => onReorderSub(si, si - 1) : undefined}
+                  onMoveDown={
+                    si < major.subQuestions.length - 1
+                      ? () => onReorderSub(si, si + 1)
+                      : undefined
+                  }
+                  onAddBranch={() => onAddBranch(si)}
+                  onUpdateBranch={(bi, data) => onUpdateBranch(si, bi, data)}
+                  onDeleteBranch={(bi) => onDeleteBranch(si, bi)}
+                  onReorderBranch={(from, to) => onReorderBranch(si, from, to)}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
+++ b/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
@@ -35,7 +35,11 @@ export function ManuscriptPaperSettings({
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <Label className="text-xs">原稿用紙</Label>
-        <Switch checked={current.enabled} onCheckedChange={handleToggle} />
+        <Switch
+          className="scale-75"
+          checked={current.enabled}
+          onCheckedChange={handleToggle}
+        />
       </div>
 
       {current.enabled && (
@@ -51,6 +55,9 @@ export function ManuscriptPaperSettings({
               onChange={(e) =>
                 handleChange({ columns: Number(e.target.value) })
               }
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
             />
           </div>
           <div>
@@ -62,6 +69,9 @@ export function ManuscriptPaperSettings({
               min={1}
               max={20}
               onChange={(e) => handleChange({ rows: Number(e.target.value) })}
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
             />
           </div>
           <div>
@@ -78,6 +88,9 @@ export function ManuscriptPaperSettings({
               onChange={(e) =>
                 handleChange({ cellSizeMm: Number(e.target.value) })
               }
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
             />
           </div>
         </div>

--- a/components/answer-sheet-builder/components/form/ModelAnswerEditor.tsx
+++ b/components/answer-sheet-builder/components/form/ModelAnswerEditor.tsx
@@ -13,11 +13,11 @@ export function ModelAnswerEditor({ value, onChange }: ModelAnswerEditorProps) {
     <div className="space-y-1">
       <Label className="text-xs">模範解答</Label>
       <Textarea
-        className="min-h-[2rem] resize-none text-xs"
+        className="min-h-8 resize-none text-xs"
         rows={2}
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="模範解答（模範解答モードで表示）"
+        placeholder="模範解答"
       />
     </div>
   )

--- a/components/answer-sheet-builder/components/form/OMRMarkerSettings.tsx
+++ b/components/answer-sheet-builder/components/form/OMRMarkerSettings.tsx
@@ -40,6 +40,9 @@ export function OMRMarkerSettings({
               max={15}
               step={0.5}
               onChange={(e) => onUpdate({ sizeMm: Number(e.target.value) })}
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
             />
           </div>
           <div>
@@ -54,6 +57,9 @@ export function OMRMarkerSettings({
               max={20}
               step={0.5}
               onChange={(e) => onUpdate({ offsetMm: Number(e.target.value) })}
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
             />
           </div>
         </div>

--- a/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
+++ b/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
@@ -3,19 +3,46 @@
 import { Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import type {
   BranchQuestion,
+  LabelPresets,
   MajorQuestion,
   SubQuestion,
 } from "@/types/answerSheetBuilder.types"
 
+import {
+  BRANCH_QUESTION_LABEL_PRESETS,
+  MAJOR_QUESTION_LABEL_PRESETS,
+  parsePresetLabels,
+  SUB_QUESTION_LABEL_PRESETS,
+} from "../../constants"
 import { MajorQuestionForm } from "./MajorQuestionForm"
+
+/** プリセット文字列の短縮表示ラベルを生成 */
+function presetShortLabel(preset: string): string {
+  const labels = parsePresetLabels(preset)
+  if (labels.length >= 3) return `${labels[0]}${labels[1]}${labels[2]}...`
+  return labels.join("")
+}
 
 interface QuestionListEditorProps {
   majorQuestions: MajorQuestion[]
+  labelPresets?: LabelPresets
+  onSetLabelPreset: (
+    category: "major" | "sub" | "branch",
+    preset: string
+  ) => void
   onAddMajor: () => void
   onUpdateMajor: (index: number, data: Partial<MajorQuestion>) => void
   onDeleteMajor: (index: number) => void
+  onReorderMajor: (fromIndex: number, toIndex: number) => void
   onAddSub: (majorIndex: number) => void
   onUpdateSub: (
     majorIndex: number,
@@ -23,6 +50,7 @@ interface QuestionListEditorProps {
     data: Partial<SubQuestion>
   ) => void
   onDeleteSub: (majorIndex: number, subIndex: number) => void
+  onReorderSub: (majorIndex: number, fromIndex: number, toIndex: number) => void
   onAddBranch: (majorIndex: number, subIndex: number) => void
   onUpdateBranch: (
     majorIndex: number,
@@ -35,22 +63,96 @@ interface QuestionListEditorProps {
     subIndex: number,
     branchIndex: number
   ) => void
+  onReorderBranch: (
+    majorIndex: number,
+    subIndex: number,
+    fromIndex: number,
+    toIndex: number
+  ) => void
 }
 
 export function QuestionListEditor({
   majorQuestions,
+  labelPresets,
+  onSetLabelPreset,
   onAddMajor,
   onUpdateMajor,
   onDeleteMajor,
+  onReorderMajor,
   onAddSub,
   onUpdateSub,
   onDeleteSub,
+  onReorderSub,
   onAddBranch,
   onUpdateBranch,
   onDeleteBranch,
+  onReorderBranch,
 }: QuestionListEditorProps) {
   return (
     <div className="space-y-3">
+      {/* 既定の番号 */}
+      <div className="bg-muted/30 rounded-lg border p-3">
+        <h4 className="text-muted-foreground mb-2 text-xs font-semibold">
+          既定の番号
+        </h4>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs whitespace-nowrap">大問</span>
+            <Select
+              value={labelPresets?.major ?? ""}
+              onValueChange={(v) => onSetLabelPreset("major", v)}
+            >
+              <SelectTrigger className="h-7 w-28 text-xs">
+                <SelectValue placeholder="選択..." />
+              </SelectTrigger>
+              <SelectContent>
+                {MAJOR_QUESTION_LABEL_PRESETS.map((preset) => (
+                  <SelectItem key={preset} value={preset} className="text-xs">
+                    {presetShortLabel(preset)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs whitespace-nowrap">小問</span>
+            <Select
+              value={labelPresets?.sub ?? ""}
+              onValueChange={(v) => onSetLabelPreset("sub", v)}
+            >
+              <SelectTrigger className="h-7 w-32 text-xs">
+                <SelectValue placeholder="選択..." />
+              </SelectTrigger>
+              <SelectContent>
+                {SUB_QUESTION_LABEL_PRESETS.map((preset) => (
+                  <SelectItem key={preset} value={preset} className="text-xs">
+                    {presetShortLabel(preset)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs whitespace-nowrap">枝問</span>
+            <Select
+              value={labelPresets?.branch ?? ""}
+              onValueChange={(v) => onSetLabelPreset("branch", v)}
+            >
+              <SelectTrigger className="h-7 w-32 text-xs">
+                <SelectValue placeholder="選択..." />
+              </SelectTrigger>
+              <SelectContent>
+                {BRANCH_QUESTION_LABEL_PRESETS.map((preset) => (
+                  <SelectItem key={preset} value={preset} className="text-xs">
+                    {presetShortLabel(preset)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
       <div className="flex items-center justify-between">
         <h3 className="text-muted-foreground text-sm font-semibold">
           問題構成
@@ -72,14 +174,25 @@ export function QuestionListEditor({
             key={major.id}
             major={major}
             majorIndex={mi}
+            totalMajorCount={majorQuestions.length}
             onUpdate={(data) => onUpdateMajor(mi, data)}
             onDelete={() => onDeleteMajor(mi)}
+            onMoveUp={mi > 0 ? () => onReorderMajor(mi, mi - 1) : undefined}
+            onMoveDown={
+              mi < majorQuestions.length - 1
+                ? () => onReorderMajor(mi, mi + 1)
+                : undefined
+            }
             onAddSub={() => onAddSub(mi)}
             onUpdateSub={(si, data) => onUpdateSub(mi, si, data)}
             onDeleteSub={(si) => onDeleteSub(mi, si)}
+            onReorderSub={(from, to) => onReorderSub(mi, from, to)}
             onAddBranch={(si) => onAddBranch(mi, si)}
             onUpdateBranch={(si, bi, data) => onUpdateBranch(mi, si, bi, data)}
             onDeleteBranch={(si, bi) => onDeleteBranch(mi, si, bi)}
+            onReorderBranch={(si, from, to) =>
+              onReorderBranch(mi, si, from, to)
+            }
           />
         ))}
       </div>

--- a/components/answer-sheet-builder/components/form/SliderWithInput.tsx
+++ b/components/answer-sheet-builder/components/form/SliderWithInput.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { Slider } from "@/components/ui/slider"
+
+interface SliderWithInputProps {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  /** 表示小数桁数 (デフォルト: step < 1 なら1、それ以外は0) */
+  decimals?: number
+  onChange: (value: number) => void
+}
+
+export function SliderWithInput({
+  label,
+  value,
+  min,
+  max,
+  step,
+  decimals,
+  onChange,
+}: SliderWithInputProps) {
+  const displayDecimals = decimals ?? (step < 1 ? 1 : 0)
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editing])
+
+  const handleChange = useCallback(
+    (raw: string) => {
+      setEditValue(raw)
+      const parsed = parseFloat(raw)
+      if (!isNaN(parsed) && parsed >= min && parsed <= max) {
+        onChange(parsed)
+      }
+    },
+    [min, max, onChange]
+  )
+
+  const startEdit = useCallback(() => {
+    setEditValue(value.toFixed(displayDecimals))
+    setEditing(true)
+  }, [value, displayDecimals])
+
+  return (
+    <div className="flex min-h-6 items-center gap-2">
+      <span className="text-muted-foreground w-16 shrink-0 text-[10px]">
+        {label}
+      </span>
+      <Slider
+        className="min-w-12 flex-1"
+        value={[value]}
+        min={min}
+        max={max}
+        step={step}
+        onValueChange={([v]) => onChange(v)}
+      />
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="number"
+          aria-label={label}
+          className="border-input bg-background box-border h-5 w-10 shrink-0 rounded border text-center text-[10px] outline-none"
+          value={editValue}
+          min={min}
+          max={max}
+          step={step}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={() => setEditing(false)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Escape") setEditing(false)
+          }}
+        />
+      ) : (
+        <span
+          className="text-muted-foreground inline-flex h-5 w-10 shrink-0 cursor-pointer items-center justify-end text-[10px] select-none hover:underline"
+          onDoubleClick={startEdit}
+          title="ダブルクリックで直接入力"
+        >
+          {value.toFixed(displayDecimals)}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -7,11 +7,9 @@ import {
   Settings2,
   Trash2,
 } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import type {
   BranchQuestion,
@@ -24,12 +22,54 @@ import { ModelAnswerEditor } from "./ModelAnswerEditor"
 import { OMRCellConfigForm } from "./OMRCellConfigForm"
 import { TextElementEditor } from "./TextElementEditor"
 
+/** 簡易分数パース (例: "1/3" → 0.333) */
+function parseFractionSimple(s: string): number {
+  const m = s.match(/^(\d+)\/(\d+)$/)
+  if (m) return parseInt(m[1]) / parseInt(m[2])
+  const n = parseFloat(s)
+  return isNaN(n) ? 1 : n
+}
+
+/** 各枝問の maxGoUp (= その枝問の goUp 適用前の行インデックス) を計算 */
+function calcBranchMaxGoUps(branches: BranchQuestion[]): number[] {
+  const result: number[] = []
+  let row = 0
+  let curX = 0
+  for (let i = 0; i < branches.length; i++) {
+    const b = branches[i]
+    const w = parseFractionSimple(b.layoutWidth ?? "1")
+
+    // auto-break
+    if (curX > 1e-9 && curX + w > 1 + 1e-9) {
+      row++
+      curX = 0
+    }
+
+    // maxGoUp = goUp 適用前の行インデックス
+    result.push(row)
+
+    // goUp 適用
+    if (b.goUp != null && b.goUp > 0) {
+      row = Math.max(0, row - b.goUp)
+      curX = 0.5
+    }
+
+    curX += w
+
+    if (b.nextPlacement === "break") {
+      row++
+      curX = 0
+    }
+  }
+  return result
+}
+
 interface SubQuestionFormProps {
   sub: SubQuestion
   majorIndex: number
   subIndex: number
   totalSubCount: number
-  isHorizontal?: boolean
+  maxGoUp: number
   onUpdate: (data: Partial<SubQuestion>) => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -42,7 +82,7 @@ interface SubQuestionFormProps {
 
 export function SubQuestionForm({
   sub,
-  isHorizontal,
+  maxGoUp,
   onUpdate,
   onDelete,
   onMoveUp,
@@ -60,6 +100,16 @@ export function SubQuestionForm({
     sub.textElements.length > 0 ||
     !!sub.manuscriptPaper?.enabled
 
+  const branchMaxGoUps = useMemo(
+    () => calcBranchMaxGoUps(sub.branchQuestions),
+    [sub.branchQuestions]
+  )
+
+  const goUpActive = sub.goUp != null
+  const isGoUpInvalid =
+    goUpActive &&
+    (!Number.isInteger(sub.goUp) || sub.goUp! < 1 || sub.goUp! > maxGoUp)
+
   return (
     <div className="border-primary/30 space-y-1 border-l-2 pl-4">
       {/* 小問ヘッダー */}
@@ -71,7 +121,7 @@ export function SubQuestionForm({
               className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
               value={sub.label}
               onChange={(e) => onUpdate({ label: e.target.value })}
-              placeholder=""
+              aria-label="小問番号"
             />
           </div>
           {/* 配点: 枝問なし or 完答モード(usesBranchPoints=false)の時に表示 */}
@@ -80,6 +130,7 @@ export function SubQuestionForm({
               <span className="text-muted-foreground">配点</span>
               <input
                 type="number"
+                aria-label="配点"
                 className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 value={sub.points}
                 min={0}
@@ -91,47 +142,131 @@ export function SubQuestionForm({
               />
             </div>
           )}
+          {/* 高さ: 枝問なしの時のみ */}
           {!hasBranches && (
-            <>
-              <div className="flex items-center gap-0.5 px-1.5">
-                <span className="text-muted-foreground">高さ</span>
-                <input
-                  type="number"
-                  className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                  value={sub.heightMultiplier}
-                  min={1}
-                  max={10}
-                  step={0.5}
-                  onChange={(e) =>
-                    onUpdate({ heightMultiplier: Number(e.target.value) })
-                  }
-                  onBlur={(e) => {
-                    e.target.value = String(Number(e.target.value))
-                  }}
-                />
-              </div>
-              {isHorizontal && (
-                <div className="flex items-center gap-0.5 px-1.5">
-                  <span className="text-muted-foreground">幅</span>
-                  <input
-                    type="number"
-                    className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                    value={sub.colSpan ?? 1}
-                    min={1}
-                    max={10}
-                    step={1}
-                    onChange={(e) =>
-                      onUpdate({ colSpan: Number(e.target.value) || 1 })
-                    }
-                    onBlur={(e) => {
-                      e.target.value = String(Number(e.target.value) || 1)
-                    }}
-                  />
-                </div>
-              )}
-            </>
+            <div className="flex items-center gap-0.5 px-1.5">
+              <span className="text-muted-foreground">高さ</span>
+              <input
+                type="number"
+                aria-label="高さ"
+                className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                value={sub.heightMultiplier}
+                min={1}
+                max={10}
+                step={0.5}
+                onChange={(e) =>
+                  onUpdate({ heightMultiplier: Number(e.target.value) })
+                }
+                onBlur={(e) => {
+                  e.target.value = String(Number(e.target.value))
+                }}
+              />
+            </div>
           )}
+          {/* 幅 (layoutWidth) */}
+          <div className="flex items-center gap-0.5 px-1.5">
+            <span className="text-muted-foreground">幅</span>
+            <input
+              className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
+              value={sub.layoutWidth ?? ""}
+              onChange={(e) => {
+                const v = e.target.value.trim()
+                if (v === "") {
+                  onUpdate({
+                    layoutWidth: undefined,
+                    nextPlacement: undefined,
+                    goUp: undefined,
+                  })
+                } else {
+                  onUpdate({ layoutWidth: v })
+                }
+              }}
+              placeholder="—"
+              aria-label="幅"
+            />
+          </div>
         </div>
+        {/* 改行ボタン */}
+        {sub.layoutWidth && (
+          <Button
+            variant="outline"
+            size="icon"
+            className={`h-7 w-7 text-xs ${sub.nextPlacement === "break" ? "bg-primary/10 text-primary border-primary/50 hover:bg-primary/20" : "text-muted-foreground"}`}
+            onClick={() => {
+              if (sub.nextPlacement === "break") {
+                onUpdate({ nextPlacement: undefined })
+              } else {
+                onUpdate({ nextPlacement: "break" })
+              }
+            }}
+            title="改行"
+          >
+            ↵
+          </Button>
+        )}
+        {/* 戻るボタン（自分自身をN行上に配置） */}
+        {sub.layoutWidth && (
+          <div className="inline-flex items-center gap-0">
+            <Button
+              variant="outline"
+              size="icon"
+              className={`h-7 w-7 text-xs ${goUpActive && sub.goUp! > 0 ? "bg-primary/10 text-primary border-primary/50 hover:bg-primary/20" : "text-muted-foreground"} ${goUpActive ? "rounded-r-none" : ""}`}
+              onClick={() => {
+                if (goUpActive) {
+                  onUpdate({ goUp: undefined })
+                } else {
+                  onUpdate({ goUp: Math.min(1, maxGoUp) })
+                }
+              }}
+              disabled={!goUpActive && maxGoUp < 1}
+              title={
+                maxGoUp < 1
+                  ? "戻れる行がありません"
+                  : `N行上に戻して配置 (最大${maxGoUp})`
+              }
+            >
+              ↑
+            </Button>
+            {goUpActive && (
+              <input
+                type="number"
+                aria-label="戻り行数"
+                className={`border-primary/50 h-7 w-8 [appearance:textfield] rounded-r-md border border-l-0 px-0.5 text-center text-xs outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${isGoUpInvalid ? "bg-red-100 dark:bg-red-900/30" : "bg-transparent"}`}
+                value={sub.goUp || ""}
+                min={1}
+                max={maxGoUp}
+                onChange={(e) => {
+                  const v = e.target.value
+                  if (v === "") {
+                    onUpdate({ goUp: 0 })
+                  } else {
+                    onUpdate({ goUp: Number(v) })
+                  }
+                }}
+                onBlur={() => {
+                  if (
+                    sub.goUp == null ||
+                    !Number.isInteger(sub.goUp) ||
+                    sub.goUp < 1 ||
+                    sub.goUp > maxGoUp
+                  ) {
+                    onUpdate({ goUp: undefined })
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                    e.preventDefault()
+                    const cur = sub.goUp ?? 0
+                    const next = e.key === "ArrowUp" ? cur + 1 : cur - 1
+                    if (next >= 1 && next <= maxGoUp) {
+                      onUpdate({ goUp: next })
+                    }
+                  }
+                }}
+              />
+            )}
+          </div>
+        )}
 
         {/* 枝問配点スイッチ（枝問がある場合のみ） */}
         {hasBranches && (
@@ -228,36 +363,6 @@ export function SubQuestionForm({
         </div>
       )}
 
-      {/* 枝問横配置設定 */}
-      {hasBranches && (
-        <div className="flex items-center gap-1.5 pl-1">
-          <Label className="text-muted-foreground text-xs whitespace-nowrap">
-            枝問横配置
-          </Label>
-          <Input
-            className="h-7 w-24 text-xs"
-            value={sub.branchHorizontalColumnsPerRow?.join(",") ?? ""}
-            onChange={(e) => {
-              const val = e.target.value.trim()
-              if (val === "") {
-                onUpdate({ branchHorizontalColumnsPerRow: undefined })
-              } else {
-                const nums = val
-                  .split(",")
-                  .map((s) => parseInt(s.trim(), 10))
-                  .filter((n) => !isNaN(n) && n > 0)
-                onUpdate({
-                  branchHorizontalColumnsPerRow:
-                    nums.length > 0 ? nums : undefined,
-                })
-              }
-            }}
-            placeholder="空欄=縦"
-            title="枝問の横配置列数をコンマ区切りで指定。例:「3」→3列1行。空欄→全て縦配置。"
-          />
-        </div>
-      )}
-
       {/* 枝問リスト */}
       {hasBranches && (
         <div className="space-y-0.5">
@@ -267,8 +372,8 @@ export function SubQuestionForm({
               branch={branch}
               branchIndex={bi}
               totalBranchCount={sub.branchQuestions.length}
-              isHorizontal={!!sub.branchHorizontalColumnsPerRow?.length}
               showPoints={sub.usesBranchPoints !== false}
+              maxGoUp={branchMaxGoUps[bi]}
               onUpdate={(data) => onUpdateBranch(bi, data)}
               onDelete={() => onDeleteBranch(bi)}
               onMoveUp={bi > 0 ? () => onReorderBranch(bi, bi - 1) : undefined}

--- a/components/answer-sheet-builder/components/form/TextElementEditor.tsx
+++ b/components/answer-sheet-builder/components/form/TextElementEditor.tsx
@@ -1,17 +1,23 @@
 "use client"
 
-import { Plus, Trash2 } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  ArrowDownToLine,
+  ArrowUpToLine,
+  Bold,
+  Italic,
+  Plus,
+  Strikethrough,
+  Trash2,
+  UnfoldVertical,
+} from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Toggle } from "@/components/ui/toggle"
 import type {
   CellTextElement,
   HorizontalAlign,
@@ -19,6 +25,31 @@ import type {
 } from "@/types/answerSheetBuilder.types"
 
 import { generateId } from "../../constants"
+
+const H_ALIGNS: HorizontalAlign[] = ["left", "center", "right"]
+const V_ALIGNS: VerticalAlign[] = ["top", "middle", "bottom"]
+
+const H_ALIGN_ICON: Record<HorizontalAlign, LucideIcon> = {
+  left: AlignLeft,
+  center: AlignCenter,
+  right: AlignRight,
+}
+const H_ALIGN_TITLE: Record<HorizontalAlign, string> = {
+  left: "左揃え",
+  center: "中央揃え",
+  right: "右揃え",
+}
+
+const V_ALIGN_ICON: Record<VerticalAlign, LucideIcon> = {
+  top: ArrowUpToLine,
+  middle: UnfoldVertical,
+  bottom: ArrowDownToLine,
+}
+const V_ALIGN_TITLE: Record<VerticalAlign, string> = {
+  top: "上揃え",
+  middle: "中央",
+  bottom: "下揃え",
+}
 
 interface TextElementEditorProps {
   textElements: CellTextElement[]
@@ -58,7 +89,7 @@ export function TextElementEditor({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label className="text-xs">テキスト要素</Label>
+        <span className="text-xs">テキスト要素</span>
         <Button
           variant="ghost"
           size="sm"
@@ -71,89 +102,101 @@ export function TextElementEditor({
       </div>
 
       {textElements.map((el, i) => (
-        <div key={el.id} className="space-y-1.5 rounded border p-2">
-          {/* テキスト入力 */}
+        <div key={el.id} className="space-y-1 rounded border p-1.5">
+          {/* Row 1: テキスト + 削除 */}
           <div className="flex items-center gap-1">
             <Input
-              className="h-7 flex-1 text-xs"
+              className="h-7 min-w-0 flex-1 text-xs"
               value={el.text}
               onChange={(e) => handleChange(i, { text: e.target.value })}
-              placeholder="テキスト（LaTeX可: $x^2$）"
+              placeholder="テキスト"
             />
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-destructive h-6 w-6 flex-shrink-0"
+              className="text-muted-foreground hover:text-destructive h-7 w-7 shrink-0"
               onClick={() => handleRemove(i)}
             >
               <Trash2 className="h-3 w-3" />
             </Button>
           </div>
 
-          {/* スタイル設定 */}
-          <div className="flex flex-wrap items-center gap-1.5">
-            <div className="flex items-center gap-1">
-              <Label className="text-muted-foreground text-[10px] whitespace-nowrap">
-                サイズ
-              </Label>
-              <Input
-                type="number"
-                className="h-6 w-12 text-xs"
-                value={el.fontSize}
-                min={6}
-                max={24}
-                step={0.5}
-                onChange={(e) =>
-                  handleChange(i, { fontSize: Number(e.target.value) })
-                }
-              />
-            </div>
-            <Select
-              value={el.fontWeight}
-              onValueChange={(v) =>
+          {/* Row 2: 書式ツールバー */}
+          <div className="flex items-center gap-1">
+            <Input
+              type="number"
+              className="h-7 w-14 shrink-0 text-center text-xs"
+              value={el.fontSize}
+              min={6}
+              max={24}
+              step={0.5}
+              onChange={(e) =>
+                handleChange(i, { fontSize: Number(e.target.value) })
+              }
+              onBlur={(e) => {
+                e.target.value = String(Number(e.target.value))
+              }}
+              title="フォントサイズ"
+            />
+
+            <Toggle
+              variant="outline"
+              size="sm"
+              className="h-7 w-7 min-w-0 p-0"
+              pressed={el.fontWeight === "bold"}
+              onPressedChange={(pressed) =>
+                handleChange(i, { fontWeight: pressed ? "bold" : "normal" })
+              }
+              title="太字"
+            >
+              <Bold className="h-3.5 w-3.5" />
+            </Toggle>
+
+            <Toggle
+              variant="outline"
+              size="sm"
+              className="h-7 w-7 min-w-0 p-0"
+              pressed={el.fontStyle === "italic"}
+              onPressedChange={(pressed) =>
                 handleChange(i, {
-                  fontWeight: v as "normal" | "bold",
+                  fontStyle: pressed ? "italic" : "normal",
                 })
               }
+              title="斜体"
             >
-              <SelectTrigger className="h-6 w-16 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="normal">通常</SelectItem>
-                <SelectItem value="bold">太字</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select
-              value={el.horizontalAlign}
-              onValueChange={(v) =>
-                handleChange(i, { horizontalAlign: v as HorizontalAlign })
+              <Italic className="h-3.5 w-3.5" />
+            </Toggle>
+
+            <Toggle
+              variant="outline"
+              size="sm"
+              className="h-7 w-7 min-w-0 p-0"
+              pressed={el.textDecoration === "line-through"}
+              onPressedChange={(pressed) =>
+                handleChange(i, {
+                  textDecoration: pressed ? "line-through" : "none",
+                })
               }
+              title="取り消し線"
             >
-              <SelectTrigger className="h-6 w-14 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="left">左</SelectItem>
-                <SelectItem value="center">中央</SelectItem>
-                <SelectItem value="right">右</SelectItem>
-              </SelectContent>
-            </Select>
-            <Select
-              value={el.verticalAlign}
-              onValueChange={(v) =>
-                handleChange(i, { verticalAlign: v as VerticalAlign })
-              }
-            >
-              <SelectTrigger className="h-6 w-14 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="top">上</SelectItem>
-                <SelectItem value="middle">中</SelectItem>
-                <SelectItem value="bottom">下</SelectItem>
-              </SelectContent>
-            </Select>
+              <Strikethrough className="h-3.5 w-3.5" />
+            </Toggle>
+
+            <CycleButton
+              values={H_ALIGNS}
+              current={el.horizontalAlign}
+              icons={H_ALIGN_ICON}
+              titles={H_ALIGN_TITLE}
+              onChange={(v) => handleChange(i, { horizontalAlign: v })}
+            />
+
+            <CycleButton
+              values={V_ALIGNS}
+              current={el.verticalAlign}
+              icons={V_ALIGN_ICON}
+              titles={V_ALIGN_TITLE}
+              onChange={(v) => handleChange(i, { verticalAlign: v })}
+            />
           </div>
         </div>
       ))}
@@ -164,5 +207,40 @@ export function TextElementEditor({
         </p>
       )}
     </div>
+  )
+}
+
+/** クリックで次の値にサイクルするボタン */
+function CycleButton<T extends string>({
+  values,
+  current,
+  icons,
+  titles,
+  onChange,
+}: {
+  values: T[]
+  current: T
+  icons: Record<T, LucideIcon>
+  titles: Record<T, string>
+  onChange: (v: T) => void
+}) {
+  const idx = values.indexOf(current)
+  const Icon: LucideIcon = icons[current]
+
+  const handleClick = () => {
+    const next = values[(idx + 1) % values.length]
+    onChange(next)
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className="h-7 w-7 min-w-0 p-0"
+      onClick={handleClick}
+      title={titles[current]}
+    >
+      <Icon className="h-3.5 w-3.5" />
+    </Button>
   )
 }

--- a/components/answer-sheet-builder/components/preview/AnswerSheetPreview.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetPreview.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react"
 import type {
   AnswerSheetAction,
   ComputedLayout,
+  ComputedMultiPageLayout,
   RenderMode,
 } from "@/types/answerSheetBuilder.types"
 
@@ -14,6 +15,7 @@ import { PreviewToolbar } from "./PreviewToolbar"
 
 interface AnswerSheetPreviewProps {
   layout: ComputedLayout
+  multiPageLayout: ComputedMultiPageLayout
   renderMode: RenderMode
   onRenderModeChange: (mode: RenderMode) => void
   dispatch: (action: AnswerSheetAction) => void
@@ -22,6 +24,7 @@ interface AnswerSheetPreviewProps {
 
 export function AnswerSheetPreview({
   layout,
+  multiPageLayout,
   renderMode,
   onRenderModeChange,
   dispatch,
@@ -29,6 +32,7 @@ export function AnswerSheetPreview({
 }: AnswerSheetPreviewProps) {
   const [zoom, setZoom] = useState(100)
   const [interactive, setInteractive] = useState(false)
+  const [currentPage, setCurrentPage] = useState(0)
   const svgRef = useRef<SVGSVGElement>(null)
 
   const {
@@ -40,7 +44,17 @@ export function AnswerSheetPreview({
     cursor,
   } = usePreviewDragInteraction(layout, interactive, dispatch, baseRowHeight)
 
+  const { totalPages } = multiPageLayout
+  const currentPageLayout =
+    totalPages > 1 ? multiPageLayout.pages[currentPage] : undefined
+
   const pageInfo = `${layout.pageWidthMm}×${layout.pageHeightMm}mm`
+
+  const handlePageChange = (page: number) => {
+    if (page >= 0 && page < totalPages) {
+      setCurrentPage(page)
+    }
+  }
 
   return (
     <div className="flex h-full flex-col">
@@ -52,6 +66,9 @@ export function AnswerSheetPreview({
         pageInfo={pageInfo}
         interactive={interactive}
         onInteractiveChange={setInteractive}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
       />
       <div className="flex-1 overflow-auto bg-gray-100 p-4 dark:bg-gray-900">
         <div
@@ -78,6 +95,7 @@ export function AnswerSheetPreview({
           >
             <AnswerSheetSVGRenderer
               layout={layout}
+              pageLayout={currentPageLayout}
               renderMode={renderMode}
               interactive={interactive}
               hoveredDragInfo={hoveredDragInfo}

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -153,42 +153,20 @@ export function AnswerSheetSVGRenderer({
       })}
 
       {/* 番号ラベル */}
-      {numberLabels.map((label, i) => {
-        // 横配置時の小問ラベル: セル内左側に配置
-        if (
-          label.displayMode === "sub-horizontal" ||
-          label.displayMode === "branch-horizontal"
-        ) {
-          return (
-            <text
-              key={`label-${i}`}
-              x={label.x + 1}
-              y={label.y + label.height / 2}
-              fontSize={label.fontSize}
-              fontFamily="'Noto Sans JP', sans-serif"
-              textAnchor="start"
-              dominantBaseline="central"
-              fill="#000"
-            >
-              {label.text}
-            </text>
-          )
-        }
-        return (
-          <text
-            key={`label-${i}`}
-            x={label.x + label.width / 2}
-            y={label.y + label.height / 2}
-            fontSize={label.fontSize}
-            fontFamily="'Noto Sans JP', sans-serif"
-            textAnchor="middle"
-            dominantBaseline="central"
-            fill="#000"
-          >
-            {label.text}
-          </text>
-        )
-      })}
+      {numberLabels.map((label, i) => (
+        <text
+          key={`label-${i}`}
+          x={label.x + label.width / 2}
+          y={label.y + label.height / 2}
+          fontSize={label.fontSize}
+          fontFamily="'Noto Sans JP', sans-serif"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fill="#000"
+        >
+          {label.text}
+        </text>
+      ))}
 
       {/* 模範解答テキスト */}
       {renderMode === "model-answer" &&

--- a/components/answer-sheet-builder/components/preview/PreviewToolbar.tsx
+++ b/components/answer-sheet-builder/components/preview/PreviewToolbar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Minus, Move, Plus } from "lucide-react"
+import { ChevronLeft, ChevronRight, Minus, Move, Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -20,6 +20,9 @@ interface PreviewToolbarProps {
   pageInfo: string
   interactive?: boolean
   onInteractiveChange?: (interactive: boolean) => void
+  currentPage?: number
+  totalPages?: number
+  onPageChange?: (page: number) => void
 }
 
 const ZOOM_STEPS = [50, 75, 100, 125, 150, 200]
@@ -32,6 +35,9 @@ export function PreviewToolbar({
   pageInfo,
   interactive,
   onInteractiveChange,
+  currentPage,
+  totalPages,
+  onPageChange,
 }: PreviewToolbarProps) {
   const zoomIn = () => {
     const nextIdx = ZOOM_STEPS.findIndex((s) => s > zoom)
@@ -68,7 +74,7 @@ export function PreviewToolbar({
         </Button>
       </div>
 
-      {/* 調整トグル + ページ情報 */}
+      {/* 調整トグル + ページナビゲーション + ページ情報 */}
       <div className="flex items-center gap-2">
         {onInteractiveChange && (
           <Button
@@ -82,6 +88,34 @@ export function PreviewToolbar({
             調整
           </Button>
         )}
+        {totalPages != null &&
+          totalPages > 1 &&
+          onPageChange &&
+          currentPage != null && (
+            <div className="flex items-center gap-0.5">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage <= 0}
+              >
+                <ChevronLeft className="h-3 w-3" />
+              </Button>
+              <span className="min-w-12 text-center text-xs">
+                {currentPage + 1}/{totalPages}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage >= totalPages - 1}
+              >
+                <ChevronRight className="h-3 w-3" />
+              </Button>
+            </div>
+          )}
         <span className="text-muted-foreground text-xs">{pageInfo}</span>
       </div>
 

--- a/components/answer-sheet-builder/constants.ts
+++ b/components/answer-sheet-builder/constants.ts
@@ -39,9 +39,15 @@ export const DEFAULT_SETTINGS: GlobalSettings = {
     subDivider: "solid",
     branchDivider: "dashed",
     numberColumnDivider: "solid",
+    outerBorderWidth: 0.7,
+    majorDividerWidth: 0.5,
+    subDividerWidth: 0.4,
+    branchDividerWidth: 0.3,
+    numberColumnDividerWidth: 0.4,
   },
   omrMarkers: { enabled: false, sizeMm: 5, offsetMm: 3 },
   fonts: { family: "Noto Sans JP", defaultSize: 6, numberSize: 6 },
+  numberDisplayMode: "multirow",
 }
 
 // =====================
@@ -66,7 +72,7 @@ export function createDefaultBranchQuestion(label?: string): BranchQuestion {
 export function createDefaultSubQuestion(label?: string): SubQuestion {
   return {
     id: generateId(),
-    label: label ?? "①",
+    label: label ?? "(1)",
     branchQuestions: [],
     heightMultiplier: 1,
     points: 1,
@@ -78,10 +84,7 @@ export function createDefaultMajorQuestion(label?: string): MajorQuestion {
   return {
     id: generateId(),
     label: label ?? "1",
-    numberDisplayMode: "multirow",
     subQuestions: [createDefaultSubQuestion()],
-    spacingBefore: false,
-    subQuestionLayout: "vertical",
   }
 }
 
@@ -107,24 +110,75 @@ export const PAPER_SIZE_OPTIONS: { value: PaperSize; label: string }[] = [
 ]
 
 // =====================
-// 小問番号プリセット
+// プリセット用ヘルパー
 // =====================
 
+/** 丸数字番号を取得（1〜50対応） */
+export function getCircledNumber(n: number): string {
+  if (n >= 1 && n <= 20) return String.fromCodePoint(0x245f + n)
+  if (n >= 21 && n <= 35) return String.fromCodePoint(0x3250 + n - 20)
+  if (n >= 36 && n <= 50) return String.fromCodePoint(0x32b0 + n - 35)
+  return `(${n})`
+}
+
+/** 漢数字（1〜99） */
+function kanjiNumber(n: number): string {
+  const d = ["", "一", "二", "三", "四", "五", "六", "七", "八", "九"]
+  if (n >= 1 && n <= 9) return d[n]
+  if (n === 10) return "十"
+  const tens = Math.floor(n / 10)
+  const ones = n % 10
+  if (tens === 1) return `十${d[ones]}`
+  return `${d[tens]}十${ones > 0 ? d[ones] : ""}`
+}
+
+/** 全角数字変換 */
+function toFullWidth(n: number): string {
+  return String(n).replace(/\d/g, (c) =>
+    String.fromCodePoint(c.charCodeAt(0) + 0xfee0)
+  )
+}
+
+/** プリセット文字列を個別ラベル配列にパースする */
+export function parsePresetLabels(preset: string): string[] {
+  // 括弧付き: "(x)", "[x]", "〔x〕"
+  const bracketMatches = preset.match(/(?:\([^)]+\)|\[[^\]]+\]|〔[^〕]+〕)/g)
+  if (bracketMatches) return bracketMatches
+  // カンマ区切り: "1,2,3,..."
+  if (preset.includes(",")) return preset.split(",")
+  // 丸数字や単文字: "①②③..." or "abcdefghij"
+  return [...preset]
+}
+
+// =====================
+// プリセット定数（~50対応）
+// =====================
+
+const N = 50
+const KATAKANA =
+  "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン"
+
+export const MAJOR_QUESTION_LABEL_PRESETS = [
+  Array.from({ length: N }, (_, i) => String(i + 1)).join(","),
+  "ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫ",
+  Array.from({ length: N }, (_, i) => kanjiNumber(i + 1)).join(","),
+  Array.from({ length: N }, (_, i) => `[${i + 1}]`).join(""),
+]
+
 export const SUB_QUESTION_LABEL_PRESETS = [
-  "①②③④⑤⑥⑦⑧⑨⑩",
-  "(1)(2)(3)(4)(5)(6)(7)(8)(9)(10)",
-  "abcdefghij",
+  Array.from({ length: N }, (_, i) => `(${i + 1})`).join(""),
+  Array.from({ length: N }, (_, i) => getCircledNumber(i + 1)).join(""),
+  Array.from({ length: N }, (_, i) => `〔問${toFullWidth(i + 1)}〕`).join(""),
+  "abcdefghijklmnopqrstuvwxyz",
 ]
 
 export const BRANCH_QUESTION_LABEL_PRESETS = [
-  "(ア)(イ)(ウ)(エ)(オ)(カ)(キ)(ク)(ケ)(コ)",
-  "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)",
-  "(1)(2)(3)(4)(5)(6)(7)(8)(9)(10)",
+  Array.from({ length: KATAKANA.length }, (_, i) => `(${KATAKANA[i]})`).join(
+    ""
+  ),
+  Array.from({ length: 26 }, (_, i) => `(${String.fromCharCode(97 + i)})`).join(
+    ""
+  ),
+  Array.from({ length: N }, (_, i) => `(${i + 1})`).join(""),
+  Array.from({ length: N }, (_, i) => getCircledNumber(i + 1)).join(""),
 ]
-
-/** 丸数字番号を取得 */
-export function getCircledNumber(n: number): string {
-  const circledNumbers = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳"
-  if (n >= 1 && n <= 20) return circledNumbers[n - 1]
-  return `(${n})`
-}

--- a/components/answer-sheet-builder/hooks/useAnswerSheetDefinition.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetDefinition.ts
@@ -9,6 +9,7 @@ import type {
   AnswerSheetDefinition,
   BranchQuestion,
   GlobalSettings,
+  LabelPresets,
   MajorQuestion,
   SubQuestion,
 } from "@/types/answerSheetBuilder.types"
@@ -19,6 +20,7 @@ import {
   createDefaultMajorQuestion,
   createDefaultSubQuestion,
   getCircledNumber,
+  parsePresetLabels,
 } from "../constants"
 import { useUndoableReducer } from "./useUndoableReducer"
 
@@ -43,7 +45,14 @@ function reducer(
       return { ...state, renderMode: action.payload }
 
     case "ADD_MAJOR_QUESTION": {
-      const nextLabel = String(state.majorQuestions.length + 1)
+      const idx = state.majorQuestions.length
+      let nextLabel: string
+      if (state.labelPresets?.major) {
+        const labels = parsePresetLabels(state.labelPresets.major)
+        nextLabel = labels[idx] ?? String(idx + 1)
+      } else {
+        nextLabel = String(idx + 1)
+      }
       return {
         ...state,
         majorQuestions: [
@@ -79,7 +88,14 @@ function reducer(
       const { majorIndex } = action.payload
       const majorQuestions = [...state.majorQuestions]
       const major = { ...majorQuestions[majorIndex] }
-      const nextLabel = getCircledNumber(major.subQuestions.length + 1)
+      const idx = major.subQuestions.length
+      let nextLabel: string
+      if (state.labelPresets?.sub) {
+        const labels = parsePresetLabels(state.labelPresets.sub)
+        nextLabel = labels[idx] ?? getCircledNumber(idx + 1)
+      } else {
+        nextLabel = getCircledNumber(idx + 1)
+      }
       major.subQuestions = [
         ...major.subQuestions,
         createDefaultSubQuestion(nextLabel),
@@ -94,6 +110,21 @@ function reducer(
       const major = { ...majorQuestions[majorIndex] }
       const subs = [...major.subQuestions]
       subs[subIndex] = { ...subs[subIndex], ...data }
+      // goUp/break 相互排他
+      if (data.goUp != null && subIndex > 0) {
+        // goUp をセット → 前の小問の break を解除
+        const prev = subs[subIndex - 1]
+        if (prev.nextPlacement === "break") {
+          subs[subIndex - 1] = { ...prev, nextPlacement: undefined }
+        }
+      }
+      if (data.nextPlacement === "break" && subIndex < subs.length - 1) {
+        // break をセット → 次の小問の goUp を解除
+        const next = subs[subIndex + 1]
+        if (next.goUp != null) {
+          subs[subIndex + 1] = { ...next, goUp: undefined }
+        }
+      }
       major.subQuestions = subs
       majorQuestions[majorIndex] = major
       return { ...state, majorQuestions }
@@ -114,7 +145,8 @@ function reducer(
       const major = { ...majorQuestions[majorIndex] }
       const subs = [...major.subQuestions]
       const sub = { ...subs[subIndex] }
-      const branchLabels = [
+      const idx = sub.branchQuestions.length
+      const defaultBranchLabels = [
         "(ア)",
         "(イ)",
         "(ウ)",
@@ -126,9 +158,13 @@ function reducer(
         "(ケ)",
         "(コ)",
       ]
-      const nextLabel =
-        branchLabels[sub.branchQuestions.length] ??
-        `(${sub.branchQuestions.length + 1})`
+      let nextLabel: string
+      if (state.labelPresets?.branch) {
+        const labels = parsePresetLabels(state.labelPresets.branch)
+        nextLabel = labels[idx] ?? `(${idx + 1})`
+      } else {
+        nextLabel = defaultBranchLabels[idx] ?? `(${idx + 1})`
+      }
       sub.branchQuestions = [
         ...sub.branchQuestions,
         createDefaultBranchQuestion(nextLabel),
@@ -147,6 +183,47 @@ function reducer(
       const sub = { ...subs[subIndex] }
       const branches = [...sub.branchQuestions]
       branches[branchIndex] = { ...branches[branchIndex], ...data }
+      // goUp/break 相互排他
+      if (data.goUp != null && branchIndex > 0) {
+        const prev = branches[branchIndex - 1]
+        if (prev.nextPlacement === "break") {
+          branches[branchIndex - 1] = { ...prev, nextPlacement: undefined }
+        }
+      }
+      if (data.nextPlacement === "break" && branchIndex < branches.length - 1) {
+        const next = branches[branchIndex + 1]
+        if (next.goUp != null) {
+          branches[branchIndex + 1] = { ...next, goUp: undefined }
+        }
+      }
+      sub.branchQuestions = branches
+      subs[subIndex] = sub
+      major.subQuestions = subs
+      majorQuestions[majorIndex] = major
+      return { ...state, majorQuestions }
+    }
+
+    case "REORDER_SUB_QUESTIONS": {
+      const { majorIndex, fromIndex, toIndex } = action.payload
+      const majorQuestions = [...state.majorQuestions]
+      const major = { ...majorQuestions[majorIndex] }
+      const subs = [...major.subQuestions]
+      const [moved] = subs.splice(fromIndex, 1)
+      subs.splice(toIndex, 0, moved)
+      major.subQuestions = subs
+      majorQuestions[majorIndex] = major
+      return { ...state, majorQuestions }
+    }
+
+    case "REORDER_BRANCH_QUESTIONS": {
+      const { majorIndex, subIndex, fromIndex, toIndex } = action.payload
+      const majorQuestions = [...state.majorQuestions]
+      const major = { ...majorQuestions[majorIndex] }
+      const subs = [...major.subQuestions]
+      const sub = { ...subs[subIndex] }
+      const branches = [...sub.branchQuestions]
+      const [moved] = branches.splice(fromIndex, 1)
+      branches.splice(toIndex, 0, moved)
       sub.branchQuestions = branches
       subs[subIndex] = sub
       major.subQuestions = subs
@@ -167,6 +244,41 @@ function reducer(
       major.subQuestions = subs
       majorQuestions[majorIndex] = major
       return { ...state, majorQuestions }
+    }
+
+    case "SET_LABEL_PRESET": {
+      const { category, preset } = action.payload
+      const newPresets: LabelPresets = {
+        ...state.labelPresets,
+        [category]: preset,
+      }
+      const labels = parsePresetLabels(preset)
+      const majorQuestions = state.majorQuestions.map((mq, mi) => {
+        if (category === "major") {
+          return { ...mq, label: labels[mi] ?? mq.label }
+        }
+        if (category === "sub") {
+          return {
+            ...mq,
+            subQuestions: mq.subQuestions.map((sq, si) => ({
+              ...sq,
+              label: labels[si] ?? sq.label,
+            })),
+          }
+        }
+        // branch: 小問ごとに0からリスタート
+        return {
+          ...mq,
+          subQuestions: mq.subQuestions.map((sq) => ({
+            ...sq,
+            branchQuestions: sq.branchQuestions.map((bq, bi) => ({
+              ...bq,
+              label: labels[bi] ?? bq.label,
+            })),
+          })),
+        }
+      })
+      return { ...state, labelPresets: newPresets, majorQuestions }
     }
 
     default:
@@ -268,9 +380,47 @@ export function useAnswerSheetDefinition(initial?: AnswerSheetDefinition) {
     [dispatch]
   )
 
+  const reorderMajorQuestions = useCallback(
+    (fromIndex: number, toIndex: number) =>
+      dispatch({
+        type: "REORDER_MAJOR_QUESTIONS",
+        payload: { fromIndex, toIndex },
+      }),
+    [dispatch]
+  )
+
+  const reorderSubQuestions = useCallback(
+    (majorIndex: number, fromIndex: number, toIndex: number) =>
+      dispatch({
+        type: "REORDER_SUB_QUESTIONS",
+        payload: { majorIndex, fromIndex, toIndex },
+      }),
+    [dispatch]
+  )
+
+  const reorderBranchQuestions = useCallback(
+    (
+      majorIndex: number,
+      subIndex: number,
+      fromIndex: number,
+      toIndex: number
+    ) =>
+      dispatch({
+        type: "REORDER_BRANCH_QUESTIONS",
+        payload: { majorIndex, subIndex, fromIndex, toIndex },
+      }),
+    [dispatch]
+  )
+
   const setDefinition = useCallback(
     (def: AnswerSheetDefinition) =>
       dispatch({ type: "SET_DEFINITION", payload: def }),
+    [dispatch]
+  )
+
+  const setLabelPreset = useCallback(
+    (category: "major" | "sub" | "branch", preset: string) =>
+      dispatch({ type: "SET_LABEL_PRESET", payload: { category, preset } }),
     [dispatch]
   )
 
@@ -289,6 +439,10 @@ export function useAnswerSheetDefinition(initial?: AnswerSheetDefinition) {
     addBranchQuestion,
     updateBranchQuestion,
     deleteBranchQuestion,
+    reorderMajorQuestions,
+    reorderSubQuestions,
+    reorderBranchQuestions,
+    setLabelPreset,
     canUndo,
     canRedo,
     undo,

--- a/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
@@ -86,5 +86,31 @@ export function useAnswerSheetExport() {
     []
   )
 
-  return { exportPdf, exportPng, isExporting }
+  const printSheet = useCallback(async (definition: AnswerSheetDefinition) => {
+    const api = window.electronAPI?.answerSheetBuilder
+    if (!api) {
+      toast.error("Electron APIが利用できません")
+      return
+    }
+
+    try {
+      setIsExporting(true)
+
+      const result = await api.print({ definition })
+
+      if (result.success) {
+        toast.success("印刷を開始しました")
+      } else if (result.error) {
+        toast.error(`印刷エラー: ${result.error}`)
+      }
+    } catch (error) {
+      toast.error(
+        `印刷エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
+      )
+    } finally {
+      setIsExporting(false)
+    }
+  }, [])
+
+  return { exportPdf, exportPng, printSheet, isExporting }
 }

--- a/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
@@ -11,7 +11,7 @@ import { useMemo } from "react"
 import type {
   AnswerSheetDefinition,
   BorderConfig,
-  BranchLayoutRow,
+  BranchGridCell,
   BranchQuestion,
   ComputedCell,
   ComputedLayout,
@@ -21,10 +21,12 @@ import type {
   ComputedOMRMarker,
   ComputedPageLayout,
   GlobalSettings,
-  LayoutRow,
+  GridCell,
   LineStyle,
   MajorQuestion,
   ManuscriptGrid,
+  NextPlacement,
+  SubGridCell,
   SubQuestion,
 } from "@/types/answerSheetBuilder.types"
 import type {
@@ -62,147 +64,254 @@ function getPaperDimensions(settings: GlobalSettings) {
   return { width: base.width, height: base.height }
 }
 
-function buildLayoutRows(
-  subQuestions: SubQuestion[],
-  columnsPerRow: number[] | undefined
-): LayoutRow[] {
-  if (!columnsPerRow || columnsPerRow.length === 0) {
-    return subQuestions.map((sub, si) => ({
-      type: "vertical-sub" as const,
-      sub,
-      subIndex: si,
-    }))
-  }
-
-  const rows: LayoutRow[] = []
-  let si = 0
-  let specIdx = 0
-
-  while (si < subQuestions.length && specIdx < columnsPerRow.length) {
-    const rowSpec = columnsPerRow[specIdx]
-    specIdx++
-
-    let consumed = 0
-    let batch: {
-      sub: SubQuestion
-      subIndex: number
-      colStart: number
-      span: number
-    }[] = []
-    let batchCols = 0
-
-    const flushBatch = () => {
-      if (batch.length > 0) {
-        rows.push({ type: "horizontal", subs: batch, columns: batchCols })
-        batch = []
-        batchCols = 0
-      }
-    }
-
-    while (consumed < rowSpec && si < subQuestions.length) {
-      const sub = subQuestions[si]
-      const span = sub.colSpan ?? 1
-
-      if (sub.branchQuestions.length >= 2) {
-        flushBatch()
-        rows.push({ type: "vertical-sub", sub, subIndex: si })
-        si++
-        consumed += span
-        continue
-      }
-
-      batch.push({ sub, subIndex: si, colStart: batchCols, span })
-      batchCols += span
-      si++
-      consumed += span
-    }
-
-    flushBatch()
-  }
-
-  while (si < subQuestions.length) {
-    rows.push({
-      type: "vertical-sub",
-      sub: subQuestions[si],
-      subIndex: si,
-    })
-    si++
-  }
-
-  return rows
+/** 分数文字列 (e.g. "1/4", "3/4") を 0〜1 の数値に変換 */
+function parseFraction(s: string): number {
+  const m = s.match(/^(\d+)\/(\d+)$/)
+  if (m) return parseInt(m[1]) / parseInt(m[2])
+  const n = parseFloat(s)
+  return isNaN(n) ? 1 : n
 }
 
-function buildBranchLayoutRows(
-  branchQuestions: BranchQuestion[],
-  columnsPerRow: number[] | undefined
-): BranchLayoutRow[] {
-  if (!columnsPerRow || columnsPerRow.length === 0) {
-    return branchQuestions.map((branch, bi) => ({
-      type: "vertical-branch" as const,
-      branch,
-      branchIndex: bi,
-    }))
-  }
+interface RowTrack {
+  y: number // この行のY位置（baseRowHeight単位）
+  rightX: number // この行の最右端X（0〜1）
+  maxH: number // この行内の最大高さ
+}
 
-  const rows: BranchLayoutRow[] = []
-  let bi = 0
-  let specIdx = 0
-
-  while (bi < branchQuestions.length && specIdx < columnsPerRow.length) {
-    const rowSpec = columnsPerRow[specIdx]
-    specIdx++
-
-    let consumed = 0
-    const batch: {
-      branch: BranchQuestion
-      branchIndex: number
-      colStart: number
-      span: number
-    }[] = []
-    let batchCols = 0
-
-    while (consumed < rowSpec && bi < branchQuestions.length) {
-      const branch = branchQuestions[bi]
-      const span = branch.colSpan ?? 1
-      batch.push({ branch, branchIndex: bi, colStart: batchCols, span })
-      batchCols += span
-      bi++
-      consumed += span
-    }
-
-    if (batch.length > 0) {
-      rows.push({ type: "horizontal", branches: batch, columns: batchCols })
-    }
-  }
-
-  while (bi < branchQuestions.length) {
-    rows.push({
-      type: "vertical-branch",
-      branch: branchQuestions[bi],
-      branchIndex: bi,
+/**
+ * 汎用グリッドレイアウトビルダー
+ * layoutWidth を持つ要素が1つでもあれば横配置モード。
+ */
+function buildGridLayout<
+  T extends {
+    layoutWidth?: string
+    nextPlacement?: NextPlacement
+    goUp?: number
+    heightMultiplier: number
+  },
+>(items: T[]): GridCell<T>[] {
+  const isHorizontal = items.some((item) => item.layoutWidth != null)
+  if (!isHorizontal) {
+    // 全て縦配置: 各要素は全幅
+    let y = 0
+    return items.map((item, i) => {
+      const cell: GridCell<T> = {
+        item,
+        itemIndex: i,
+        x: 0,
+        y,
+        width: 1,
+        height: item.heightMultiplier,
+      }
+      y += item.heightMultiplier
+      return cell
     })
-    bi++
   }
 
-  return rows
+  const cells: GridCell<T>[] = []
+  const rows: RowTrack[] = [{ y: 0, rightX: 0, maxH: 0 }]
+  let curRowIdx = 0
+  let curX = 0
+  let blockLeftX = 0
+  let lastCellBottom = 0 // 最後に配置したセルの下端Y（goUpブロック内の行スキップ用）
+
+  /** 次の行に進む。既存行の再利用 → ブロック内中間行の作成 → ブロック脱出 の順で試行。 */
+  function advanceRow(nextW: number) {
+    let advanced = false
+
+    if (blockLeftX + nextW <= 1 + 1e-9) {
+      // 幅的にブロック内に収まる → lastCellBottom に一致する既存行を探す
+      for (let r = 0; r < rows.length; r++) {
+        if (Math.abs(rows[r].y - lastCellBottom) < 1e-9) {
+          curRowIdx = r
+          curX = blockLeftX
+          advanced = true
+          break
+        }
+      }
+    }
+
+    if (!advanced) {
+      // グリッド全体の下端を計算
+      let gridBottom = 0
+      for (const r of rows) {
+        gridBottom = Math.max(gridBottom, r.y + r.maxH)
+      }
+
+      if (
+        blockLeftX > 1e-9 &&
+        blockLeftX + nextW <= 1 + 1e-9 &&
+        lastCellBottom < gridBottom - 1e-9
+      ) {
+        // goUpブロック内でグリッド高さ内に収まる → 中間行を作成
+        curRowIdx = rows.length
+        rows.push({ y: lastCellBottom, rightX: 0, maxH: 0 })
+        curX = blockLeftX
+      } else {
+        // goUpブロックを抜ける or 幅超過 → 新しい行を末尾に追加
+        const newY = Math.max(gridBottom, lastCellBottom)
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    const w = parseFraction(item.layoutWidth ?? "1")
+    const h = item.heightMultiplier
+
+    // goUp: この要素自身をN行上に戻して配置
+    if (item.goUp != null && item.goUp > 0) {
+      const targetIdx = Math.max(0, curRowIdx - item.goUp)
+      let maxRightX = 0
+      for (let r = targetIdx; r <= curRowIdx; r++) {
+        maxRightX = Math.max(maxRightX, rows[r].rightX)
+      }
+      curRowIdx = targetIdx
+      curX = maxRightX
+      blockLeftX = maxRightX
+
+      // goUp先に空きがない場合、全行の末尾に新しい行を追加
+      if (curX + w > 1 + 1e-9) {
+        const lastRow = rows[rows.length - 1]
+        const newY = Math.max(lastRow.y + lastRow.maxH, lastCellBottom)
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+
+    // 配置前チェック: この項目を置くと1を超える場合、先に改行
+    if (curX > blockLeftX + 1e-9 && curX + w > 1 + 1e-9) {
+      advanceRow(w)
+    }
+
+    cells.push({
+      item,
+      itemIndex: i,
+      x: curX,
+      y: rows[curRowIdx].y,
+      width: w,
+      height: h,
+    })
+
+    lastCellBottom = rows[curRowIdx].y + h
+    rows[curRowIdx].rightX = Math.max(rows[curRowIdx].rightX, curX + w)
+    rows[curRowIdx].maxH = Math.max(rows[curRowIdx].maxH, h)
+
+    const np = item.nextPlacement ?? "inline"
+    if (np === "inline") {
+      curX += w
+    } else if (np === "break") {
+      if (blockLeftX > 1e-9) {
+        // goUpブロック内の break → ブロック残幅で既存行を検索
+        advanceRow(1 - blockLeftX)
+      } else {
+        // 通常の break → 新しい行を追加
+        const lastRow = rows[rows.length - 1]
+        const newY = lastRow.y + lastRow.maxH
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+  }
+  return cells
+}
+
+/** SubQuestion 用のグリッドレイアウト */
+function buildSubGridLayout(subQuestions: SubQuestion[]): SubGridCell[] {
+  // 枝問がある小問は、枝問レイアウトの要求高さで heightMultiplier を上書き
+  const adjusted = subQuestions.map((sub) => {
+    if (sub.branchQuestions.length === 0) return sub
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+    const branchHeight = gridTotalHeight(branchCells)
+    if (branchHeight !== sub.heightMultiplier) {
+      return { ...sub, heightMultiplier: branchHeight }
+    }
+    return sub
+  })
+  return buildGridLayout(adjusted)
+}
+
+/** BranchQuestion 用のグリッドレイアウト */
+function buildBranchGridLayout(
+  branchQuestions: BranchQuestion[]
+): BranchGridCell[] {
+  return buildGridLayout(branchQuestions)
+}
+
+/** グリッドレイアウトが横配置モードかどうか */
+function isGridHorizontal<T extends { layoutWidth?: string }>(
+  items: T[]
+): boolean {
+  return items.some((item) => item.layoutWidth != null)
+}
+
+/** グリッドセル配列の合計高さ（baseRowHeight単位） */
+function gridTotalHeight<T>(cells: GridCell<T>[]): number {
+  if (cells.length === 0) return 0
+  return Math.max(...cells.map((c) => c.y + c.height))
+}
+
+/** グリッドセルからY区間ごとの右端X座標を計算（ステップ外枠描画用） */
+function computeGridRowRightEdges<T>(
+  gridCells: GridCell<T>[],
+  areaStartY: number,
+  areaX: number,
+  areaWidth: number,
+  baseRowHeight: number
+): { yTop: number; yBottom: number; rightX: number }[] {
+  const ySet = new Set<number>()
+  const absCells: { y: number; yEnd: number; rightX: number }[] = []
+  for (const gc of gridCells) {
+    const cellY = areaStartY + gc.y * baseRowHeight
+    const cellYEnd = cellY + gc.height * baseRowHeight
+    const cellRightX = areaX + (gc.x + gc.width) * areaWidth
+    ySet.add(cellY)
+    ySet.add(cellYEnd)
+    absCells.push({ y: cellY, yEnd: cellYEnd, rightX: cellRightX })
+  }
+
+  const sortedYs = Array.from(ySet).sort((a, b) => a - b)
+  const result: { yTop: number; yBottom: number; rightX: number }[] = []
+
+  for (let i = 0; i < sortedYs.length - 1; i++) {
+    const yTop = sortedYs[i]
+    const yBottom = sortedYs[i + 1]
+    const midY = (yTop + yBottom) / 2
+
+    let maxRightX = 0
+    for (const cell of absCells) {
+      if (cell.y <= midY + 1e-9 && cell.yEnd >= midY - 1e-9) {
+        maxRightX = Math.max(maxRightX, cell.rightX)
+      }
+    }
+
+    if (maxRightX > 0) {
+      if (
+        result.length > 0 &&
+        Math.abs(result[result.length - 1].rightX - maxRightX) < 0.01
+      ) {
+        result[result.length - 1].yBottom = yBottom
+      } else {
+        result.push({ yTop, yBottom, rightX: maxRightX })
+      }
+    }
+  }
+
+  return result
 }
 
 function computeSubHeight(sub: SubQuestion, baseRowHeight: number): number {
   if (sub.branchQuestions.length > 0) {
-    const branchRows = buildBranchLayoutRows(
-      sub.branchQuestions,
-      sub.branchHorizontalColumnsPerRow
-    )
-    return branchRows.reduce((sum, row) => {
-      if (row.type === "horizontal") {
-        const maxH = Math.max(
-          ...row.branches.map((b) => b.branch.heightMultiplier),
-          1
-        )
-        return sum + maxH * baseRowHeight
-      }
-      return sum + row.branch.heightMultiplier * baseRowHeight
-    }, 0)
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+    return gridTotalHeight(branchCells) * baseRowHeight
   }
   if (sub.manuscriptPaper?.enabled) {
     return sub.manuscriptPaper.rows * sub.manuscriptPaper.cellSizeMm
@@ -383,17 +492,238 @@ function computeMajorHeight(
   major: MajorQuestion,
   baseRowHeight: number
 ): number {
-  const layoutRows = buildLayoutRows(
-    major.subQuestions,
-    major.horizontalColumnsPerRow
+  if (isGridHorizontal(major.subQuestions)) {
+    const gridCells = buildSubGridLayout(major.subQuestions)
+    return gridTotalHeight(gridCells) * baseRowHeight
+  }
+  return major.subQuestions.reduce(
+    (sum, sub) => sum + computeSubHeight(sub, baseRowHeight),
+    0
   )
-  return layoutRows.reduce((sum, row) => {
-    if (row.type === "horizontal") {
-      const maxH = Math.max(...row.subs.map((s) => s.sub.heightMultiplier), 1)
-      return sum + maxH * baseRowHeight
+}
+
+/** グリッドセル間の区切り線を描画 */
+function renderGridDividerLines<
+  T extends {
+    layoutWidth?: string
+    nextPlacement?: NextPlacement
+    heightMultiplier: number
+  },
+>(
+  gridCells: GridCell<T>[],
+  areaStartY: number,
+  areaX: number,
+  areaWidth: number,
+  baseRowHeight: number,
+  settings: GlobalSettings,
+  lines: ComputedLine[],
+  level: "sub" | "branch"
+) {
+  const lineType = level === "sub" ? "subHorizontalDivider" : "branch"
+  const divStyle =
+    level === "sub"
+      ? settings.borderConfig.subDivider
+      : settings.borderConfig.branchDivider
+  const divSw = getLineWidth(lineType, settings.borderConfig)
+
+  // 隣接セル間の共有辺に区切り線を描画
+  for (let i = 0; i < gridCells.length; i++) {
+    const a = gridCells[i]
+    for (let j = i + 1; j < gridCells.length; j++) {
+      const b = gridCells[j]
+
+      // 垂直共有辺: aの右端 === bの左端 かつ Y方向にオーバーラップ
+      const aRight = a.x + a.width
+      const bLeft = b.x
+      if (Math.abs(aRight - bLeft) < 1e-9) {
+        const overlapTop = Math.max(a.y, b.y)
+        const overlapBottom = Math.min(a.y + a.height, b.y + b.height)
+        if (overlapBottom > overlapTop + 1e-9) {
+          const lineX = areaX + aRight * areaWidth
+          lines.push({
+            x1: lineX,
+            y1: areaStartY + overlapTop * baseRowHeight,
+            x2: lineX,
+            y2: areaStartY + overlapBottom * baseRowHeight,
+            style: divStyle,
+            lineType,
+            strokeWidth: divSw,
+          })
+        }
+      }
+
+      // 水平共有辺: aの下端 === bの上端 かつ X方向にオーバーラップ
+      const aBottom = a.y + a.height
+      const bTop = b.y
+      if (Math.abs(aBottom - bTop) < 1e-9) {
+        const overlapLeft = Math.max(a.x, b.x)
+        const overlapRight = Math.min(a.x + a.width, b.x + b.width)
+        if (overlapRight > overlapLeft + 1e-9) {
+          const lineY = areaStartY + aBottom * baseRowHeight
+          lines.push({
+            x1: areaX + overlapLeft * areaWidth,
+            y1: lineY,
+            x2: areaX + overlapRight * areaWidth,
+            y2: lineY,
+            style: divStyle,
+            lineType,
+            strokeWidth: divSw,
+          })
+        }
+      }
     }
-    return sum + computeSubHeight(row.sub, baseRowHeight)
-  }, 0)
+  }
+}
+
+/** 枝問の描画（横配置・縦配置両対応） */
+function renderBranchQuestions(
+  sub: SubQuestion,
+  mi: number,
+  si: number,
+  majorLabel: string,
+  subStartY: number,
+  pageIndex: number,
+  subNumX: number,
+  subNumWidth: number,
+  branchNumX: number,
+  branchNumWidth: number,
+  answerX: number,
+  answerWidth: number,
+  contentRight: number,
+  baseRowHeight: number,
+  paper: { width: number; height: number },
+  settings: GlobalSettings,
+  cells: ComputedCell[],
+  lines: ComputedLine[],
+  numberLabels: ComputedNumberLabel[],
+  _rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
+) {
+  const branchIsHorizontal = isGridHorizontal(sub.branchQuestions)
+
+  if (branchIsHorizontal) {
+    const branchAreaX = subNumX + subNumWidth
+    const branchAreaWidth = contentRight - branchAreaX
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+
+    for (const gc of branchCells) {
+      const cellX = branchAreaX + gc.x * branchAreaWidth
+      const cellWidth = gc.width * branchAreaWidth
+      const cellY = subStartY + gc.y * baseRowHeight
+      const cellHeight = gc.height * baseRowHeight
+
+      numberLabels.push({
+        text: gc.item.label,
+        x: cellX,
+        y: cellY,
+        width: branchNumWidth,
+        height: cellHeight,
+        fontSize: settings.fonts.numberSize - 1,
+        displayMode: "branch-horizontal",
+      })
+
+      cells.push(
+        createCell(
+          [mi, si, gc.itemIndex],
+          cellX + branchNumWidth,
+          cellY,
+          cellWidth - branchNumWidth,
+          cellHeight,
+          paper,
+          `${majorLabel}-${sub.label}-${gc.item.label}`,
+          gc.item.points,
+          gc.item.textElements,
+          gc.item.modelAnswer,
+          "answer",
+          pageIndex,
+          undefined,
+          gc.item.omrConfig
+        )
+      )
+
+      // 番号ラベル右側の区切り線
+      lines.push({
+        x1: cellX + branchNumWidth,
+        y1: cellY,
+        x2: cellX + branchNumWidth,
+        y2: cellY + cellHeight,
+        style: settings.borderConfig.numberColumnDivider,
+        lineType: "numberColumn",
+        strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+      })
+    }
+
+    // グリッドセル間の区切り線
+    renderGridDividerLines(
+      branchCells,
+      subStartY,
+      branchAreaX,
+      branchAreaWidth,
+      baseRowHeight,
+      settings,
+      lines,
+      "branch"
+    )
+  } else {
+    // 縦配置
+    let branchY = subStartY
+    sub.branchQuestions.forEach((branch, bi) => {
+      const branchHeight = branch.heightMultiplier * baseRowHeight
+
+      numberLabels.push({
+        text: branch.label,
+        x: branchNumX,
+        y: branchY,
+        width: branchNumWidth,
+        height: branchHeight,
+        fontSize: settings.fonts.numberSize - 1,
+        displayMode: "branch",
+      })
+
+      cells.push(
+        createCell(
+          [mi, si, bi],
+          answerX,
+          branchY,
+          answerWidth,
+          branchHeight,
+          paper,
+          `${majorLabel}-${sub.label}-${branch.label}`,
+          branch.points,
+          branch.textElements,
+          branch.modelAnswer,
+          "answer",
+          pageIndex,
+          undefined,
+          branch.omrConfig
+        )
+      )
+
+      if (bi < sub.branchQuestions.length - 1) {
+        lines.push({
+          x1: branchNumX,
+          y1: branchY + branchHeight,
+          x2: contentRight,
+          y2: branchY + branchHeight,
+          style: settings.borderConfig.branchDivider,
+          lineType: "branch",
+          strokeWidth: getLineWidth("branch", settings.borderConfig),
+          dragInfo: {
+            axis: "horizontal",
+            target: {
+              type: "heightMultiplier",
+              majorIndex: mi,
+              subIndex: si,
+              branchIndex: bi,
+            },
+            currentValueMm: branchHeight,
+            minMm: baseRowHeight * 0.5,
+          },
+        })
+      }
+
+      branchY += branchHeight
+    })
+  }
 }
 
 function computeLayoutFromDefinition(
@@ -424,11 +754,21 @@ function computeLayoutFromDefinition(
   const lines: ComputedLine[] = []
   const numberLabels: ComputedNumberLabel[] = []
 
+  // 各行の右端X座標を追跡（ステップ外枠描画用）
+  const rowRightEdges: { yTop: number; yBottom: number; rightX: number }[] = []
+
   let currentY = margins.top + spacing.headerHeight
 
   majorQuestions.forEach((major, mi) => {
     if (mi > 0) {
+      // 大問間スペーシング: 前後の大問のrightXを維持
+      const spacingTop = currentY
       currentY += spacing.majorQuestionSpacing
+      rowRightEdges.push({
+        yTop: spacingTop,
+        yBottom: currentY,
+        rightX: contentRight,
+      })
     }
 
     const majorStartY = currentY
@@ -445,77 +785,125 @@ function computeLayoutFromDefinition(
       displayMode: settings.numberDisplayMode,
     })
 
-    const layoutRows = buildLayoutRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
     const horizontalAreaX = majorNumX + majorNumWidth
     const horizontalAreaWidth = contentRight - horizontalAreaX
+    const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
-    layoutRows.forEach((row, ri) => {
-      if (row.type === "horizontal") {
-        const rowMaxH = Math.max(
-          ...row.subs.map((s) => s.sub.heightMultiplier),
-          1
-        )
-        const rowHeight = rowMaxH * baseRowHeight
-        const unitWidth = horizontalAreaWidth / row.columns
+    if (subIsHorizontal) {
+      // === 横配置（グリッド）モード ===
+      const gridCells = buildSubGridLayout(major.subQuestions)
+      for (const gc of gridCells) {
+        const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const cellWidth = gc.width * horizontalAreaWidth
+        const cellY = majorStartY + gc.y * baseRowHeight
+        const cellHeight = gc.height * baseRowHeight
+        const sub = gc.item
+        const hasBranches = sub.branchQuestions.length > 0
 
-        row.subs.forEach((entry) => {
-          const cellX = horizontalAreaX + entry.colStart * unitWidth
-          const cellWidth = entry.span * unitWidth
-
-          numberLabels.push({
-            text: entry.sub.label,
-            x: cellX,
-            y: currentY,
-            width: cellWidth,
-            height: rowHeight,
-            fontSize: settings.fonts.numberSize,
-            displayMode: "sub-horizontal",
-          })
-
-          cells.push(
-            createCell(
-              [mi, entry.subIndex],
-              cellX,
-              currentY,
-              cellWidth,
-              rowHeight,
-              paper,
-              `${major.label}-${entry.sub.label}`,
-              entry.sub.points,
-              entry.sub.textElements,
-              entry.sub.modelAnswer,
-              "answer",
-              0,
-              computeManuscriptGrid(entry.sub, cellX, currentY, cellWidth),
-              entry.sub.omrConfig
-            )
-          )
-
-          const cellRight = cellX + cellWidth
-          if (Math.abs(cellRight - contentRight) > 0.01) {
-            lines.push({
-              x1: cellRight,
-              y1: currentY,
-              x2: cellRight,
-              y2: currentY + rowHeight,
-              style: settings.borderConfig.subDivider,
-              lineType: "subHorizontalDivider",
-              strokeWidth: getLineWidth(
-                "subHorizontalDivider",
-                settings.borderConfig
-              ),
-            })
-          }
+        numberLabels.push({
+          text: sub.label,
+          x: cellX,
+          y: cellY,
+          width: subNumWidth,
+          height: cellHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub-horizontal",
         })
 
-        currentY += rowHeight
-      } else {
-        // vertical-sub
-        const sub = row.sub
-        const si = row.subIndex
+        if (hasBranches) {
+          // 枝問をセル内でレンダリング
+          const cellBranchNumX = cellX + subNumWidth
+          const cellBranchNumWidth = branchNumWidth
+          const cellAnswerX = cellBranchNumX + cellBranchNumWidth
+          const cellAnswerWidth = cellWidth - subNumWidth - cellBranchNumWidth
+          const cellRight = cellX + cellWidth
+          renderBranchQuestions(
+            sub,
+            mi,
+            gc.itemIndex,
+            major.label,
+            cellY,
+            0,
+            cellX,
+            subNumWidth,
+            cellBranchNumX,
+            cellBranchNumWidth,
+            cellAnswerX,
+            cellAnswerWidth,
+            cellRight,
+            baseRowHeight,
+            paper,
+            settings,
+            cells,
+            lines,
+            numberLabels,
+            rowRightEdges
+          )
+        } else {
+          cells.push(
+            createCell(
+              [mi, gc.itemIndex],
+              cellX + subNumWidth,
+              cellY,
+              cellWidth - subNumWidth,
+              cellHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              0,
+              computeManuscriptGrid(
+                sub,
+                cellX + subNumWidth,
+                cellY,
+                cellWidth - subNumWidth
+              ),
+              sub.omrConfig
+            )
+          )
+        }
+
+        // 番号ラベル右側の区切り線
+        lines.push({
+          x1: cellX + subNumWidth,
+          y1: cellY,
+          x2: cellX + subNumWidth,
+          y2: cellY + cellHeight,
+          style: settings.borderConfig.numberColumnDivider,
+          lineType: "numberColumn",
+          strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+        })
+      }
+
+      // rowRightEdges: Y区間ごとの右端X座標を計算
+      for (const edge of computeGridRowRightEdges(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight
+      )) {
+        rowRightEdges.push(edge)
+      }
+
+      // グリッドセル間の区切り線（隣接セル間の共有辺）
+      renderGridDividerLines(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight,
+        settings,
+        lines,
+        "sub"
+      )
+
+      currentY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
+    } else {
+      // === 縦配置モード ===
+      major.subQuestions.forEach((sub, si) => {
         const subStartY = currentY
         const hasBranches = sub.branchQuestions.length > 0
         const subHeight = computeSubHeight(sub, baseRowHeight)
@@ -531,152 +919,28 @@ function computeLayoutFromDefinition(
         })
 
         if (hasBranches) {
-          const branchRows = buildBranchLayoutRows(
-            sub.branchQuestions,
-            sub.branchHorizontalColumnsPerRow
+          renderBranchQuestions(
+            sub,
+            mi,
+            si,
+            major.label,
+            subStartY,
+            0,
+            subNumX,
+            subNumWidth,
+            branchNumX,
+            branchNumWidth,
+            answerX,
+            answerWidth,
+            contentRight,
+            baseRowHeight,
+            paper,
+            settings,
+            cells,
+            lines,
+            numberLabels,
+            rowRightEdges
           )
-          const branchAreaX = subNumX + subNumWidth
-          const branchAreaWidth = contentRight - branchAreaX
-          let branchY = subStartY
-
-          branchRows.forEach((bRow, bri) => {
-            if (bRow.type === "horizontal") {
-              const rowMaxH = Math.max(
-                ...bRow.branches.map((b) => b.branch.heightMultiplier),
-                1
-              )
-              const bRowHeight = rowMaxH * baseRowHeight
-              const unitWidth = branchAreaWidth / bRow.columns
-
-              bRow.branches.forEach((entry) => {
-                const cellX = branchAreaX + entry.colStart * unitWidth
-                const cellWidth = entry.span * unitWidth
-
-                numberLabels.push({
-                  text: entry.branch.label,
-                  x: cellX,
-                  y: branchY,
-                  width: cellWidth,
-                  height: bRowHeight,
-                  fontSize: settings.fonts.numberSize - 1,
-                  displayMode: "branch-horizontal",
-                })
-
-                cells.push(
-                  createCell(
-                    [mi, si, entry.branchIndex],
-                    cellX,
-                    branchY,
-                    cellWidth,
-                    bRowHeight,
-                    paper,
-                    `${major.label}-${sub.label}-${entry.branch.label}`,
-                    entry.branch.points,
-                    entry.branch.textElements,
-                    entry.branch.modelAnswer,
-                    "answer",
-                    0,
-                    undefined,
-                    entry.branch.omrConfig
-                  )
-                )
-
-                const cellRight = cellX + cellWidth
-                if (Math.abs(cellRight - contentRight) > 0.01) {
-                  lines.push({
-                    x1: cellRight,
-                    y1: branchY,
-                    x2: cellRight,
-                    y2: branchY + bRowHeight,
-                    style: settings.borderConfig.branchDivider,
-                    lineType: "branch",
-                    strokeWidth: getLineWidth("branch", settings.borderConfig),
-                  })
-                }
-              })
-
-              branchY += bRowHeight
-            } else {
-              const branch = bRow.branch
-              const branchHeight = branch.heightMultiplier * baseRowHeight
-
-              numberLabels.push({
-                text: branch.label,
-                x: branchNumX,
-                y: branchY,
-                width: branchNumWidth,
-                height: branchHeight,
-                fontSize: settings.fonts.numberSize - 1,
-                displayMode: "branch",
-              })
-
-              cells.push(
-                createCell(
-                  [mi, si, bRow.branchIndex],
-                  answerX,
-                  branchY,
-                  answerWidth,
-                  branchHeight,
-                  paper,
-                  `${major.label}-${sub.label}-${branch.label}`,
-                  branch.points,
-                  branch.textElements,
-                  branch.modelAnswer,
-                  "answer",
-                  0,
-                  undefined,
-                  branch.omrConfig
-                )
-              )
-
-              if (bri < branchRows.length - 1) {
-                lines.push({
-                  x1: branchNumX,
-                  y1: branchY + branchHeight,
-                  x2: contentRight,
-                  y2: branchY + branchHeight,
-                  style: settings.borderConfig.branchDivider,
-                  lineType: "branch",
-                  strokeWidth: getLineWidth("branch", settings.borderConfig),
-                  dragInfo: {
-                    axis: "horizontal",
-                    target: {
-                      type: "heightMultiplier",
-                      majorIndex: mi,
-                      subIndex: si,
-                      branchIndex: bRow.branchIndex,
-                    },
-                    currentValueMm: branchHeight,
-                    minMm: baseRowHeight * 0.5,
-                  },
-                })
-              }
-
-              branchY += branchHeight
-            }
-
-            // 枝問行間の区切り線（横配置行が関わる場合）
-            if (
-              bri < branchRows.length - 1 &&
-              (bRow.type === "horizontal" ||
-                branchRows[bri + 1].type === "horizontal")
-            ) {
-              const nextBRow = branchRows[bri + 1]
-              const lineX =
-                bRow.type === "horizontal" || nextBRow.type === "horizontal"
-                  ? branchAreaX
-                  : branchNumX
-              lines.push({
-                x1: lineX,
-                y1: branchY,
-                x2: contentRight,
-                y2: branchY,
-                style: settings.borderConfig.branchDivider,
-                lineType: "branch",
-                strokeWidth: getLineWidth("branch", settings.borderConfig),
-              })
-            }
-          })
         } else {
           cells.push(
             createCell(
@@ -698,29 +962,17 @@ function computeLayoutFromDefinition(
           )
         }
 
-        currentY += subHeight
-      }
+        // vertical-sub行の右端は常にcontentRight
+        rowRightEdges.push({
+          yTop: subStartY,
+          yBottom: subStartY + subHeight,
+          rightX: contentRight,
+        })
 
-      // 行間の区切り線（最後の行以外）
-      if (ri < layoutRows.length - 1) {
-        const nextRow = layoutRows[ri + 1]
-        if (row.type === "horizontal" && nextRow.type === "horizontal") {
-          lines.push({
-            x1: horizontalAreaX,
-            y1: currentY,
-            x2: contentRight,
-            y2: currentY,
-            style: settings.borderConfig.subDivider,
-            lineType: "subHorizontalDivider",
-            strokeWidth: getLineWidth(
-              "subHorizontalDivider",
-              settings.borderConfig
-            ),
-          })
-        } else if (row.type === "vertical-sub") {
-          const sub = row.sub
-          const si = row.subIndex
-          const hasBranches = sub.branchQuestions.length > 0
+        currentY += subHeight
+
+        // 行間の区切り線（最後の行以外）
+        if (si < major.subQuestions.length - 1) {
           lines.push({
             x1: subNumX,
             y1: currentY,
@@ -745,19 +997,9 @@ function computeLayoutFromDefinition(
               minMm: baseRowHeight * 0.5,
             },
           })
-        } else {
-          lines.push({
-            x1: horizontalAreaX,
-            y1: currentY,
-            x2: contentRight,
-            y2: currentY,
-            style: settings.borderConfig.subDivider,
-            lineType: "sub",
-            strokeWidth: getLineWidth("sub", settings.borderConfig),
-          })
         }
-      }
-    })
+      })
+    }
 
     if (mi < majorQuestions.length - 1) {
       lines.push({
@@ -775,15 +1017,16 @@ function computeLayoutFromDefinition(
   const contentBottom = currentY
   const contentTop = margins.top + spacing.headerHeight
 
-  // 外枠
-  addBorderLines(
+  // 外枠（ステップ形状対応）
+  addSteppedBorderLines(
     lines,
     contentLeft,
     contentTop,
     contentRight,
     contentBottom,
     settings.borderConfig.outerBorder,
-    settings.borderConfig
+    settings.borderConfig,
+    rowRightEdges
   )
 
   // vertical-sub 行のY範囲を収集（小問番号列セグメント化用）
@@ -797,50 +1040,28 @@ function computeLayoutFromDefinition(
       if (mi2 > 0) {
         trackY += spacing.majorQuestionSpacing
       }
-      const rows = buildLayoutRows(mq.subQuestions, mq.horizontalColumnsPerRow)
-      let segStart: number | null = null
-      for (const r of rows) {
-        if (r.type === "vertical-sub") {
-          if (segStart === null) segStart = trackY
-          // 枝問番号列のセグメント: vertical-branch行のみ
-          if (r.sub.branchQuestions.length > 0) {
-            const bRows = buildBranchLayoutRows(
-              r.sub.branchQuestions,
-              r.sub.branchHorizontalColumnsPerRow
-            )
-            let bTrackY = trackY
-            let bSegStart: number | null = null
-            for (const br of bRows) {
-              if (br.type === "vertical-branch") {
-                if (bSegStart === null) bSegStart = bTrackY
-                bTrackY += br.branch.heightMultiplier * baseRowHeight
-              } else {
-                if (bSegStart !== null) {
-                  branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
-                  bSegStart = null
-                }
-                const maxH = Math.max(
-                  ...br.branches.map((b) => b.branch.heightMultiplier),
-                  1
-                )
-                bTrackY += maxH * baseRowHeight
-              }
+
+      if (isGridHorizontal(mq.subQuestions)) {
+        // 横配置モード: 小問番号列は不要
+        const gridCells = buildSubGridLayout(mq.subQuestions)
+        trackY += gridTotalHeight(gridCells) * baseRowHeight
+      } else {
+        // 縦配置モード: 全体がvertical-sub
+        const segStart = trackY
+        for (const sub of mq.subQuestions) {
+          // 枝問番号列のセグメント
+          if (sub.branchQuestions.length > 0) {
+            if (!isGridHorizontal(sub.branchQuestions)) {
+              // 全て縦配置 → 連続した垂直セグメント
+              branchVerticalRanges.push({
+                top: trackY,
+                bottom: trackY + computeSubHeight(sub, baseRowHeight),
+              })
             }
-            if (bSegStart !== null) {
-              branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
-            }
+            // 横配置の場合は枝問番号列は不要（個別セル内に番号を表示）
           }
-          trackY += computeSubHeight(r.sub, baseRowHeight)
-        } else {
-          if (segStart !== null) {
-            verticalRanges.push({ top: segStart, bottom: trackY })
-            segStart = null
-          }
-          const maxH = Math.max(...r.subs.map((s) => s.sub.heightMultiplier), 1)
-          trackY += maxH * baseRowHeight
+          trackY += computeSubHeight(sub, baseRowHeight)
         }
-      }
-      if (segStart !== null) {
         verticalRanges.push({ top: segStart, bottom: trackY })
       }
     }
@@ -967,6 +1188,133 @@ function addBorderLines(
   })
 }
 
+/**
+ * ステップ外枠描画: partial行がある場合、右辺と下辺をL字型に凹ませる。
+ * 全行がcontentRightまで到達している場合は通常の矩形外枠を描画。
+ */
+function addSteppedBorderLines(
+  lines: ComputedLine[],
+  contentLeft: number,
+  contentTop: number,
+  contentRight: number,
+  contentBottom: number,
+  style: LineStyle,
+  borderConfig: BorderConfig,
+  rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
+) {
+  const sw = getLineWidth("outer", borderConfig)
+
+  // 全行がcontentRightに到達しているか確認
+  const hasPartialRow = rowRightEdges.some(
+    (r) => Math.abs(r.rightX - contentRight) > 0.01
+  )
+
+  if (!hasPartialRow) {
+    // 通常の矩形外枠
+    addBorderLines(
+      lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      contentBottom,
+      style,
+      borderConfig
+    )
+    return
+  }
+
+  if (rowRightEdges.length === 0) {
+    addBorderLines(
+      lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      contentBottom,
+      style,
+      borderConfig
+    )
+    return
+  }
+
+  // 上辺: 最初の行のrightXまで
+  const topRightX = rowRightEdges[0].rightX
+  lines.push({
+    x1: contentLeft,
+    y1: contentTop,
+    x2: topRightX,
+    y2: contentTop,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+
+  // 左辺: 常にフル高
+  lines.push({
+    x1: contentLeft,
+    y1: contentTop,
+    x2: contentLeft,
+    y2: contentBottom,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+
+  // 右辺 + 下辺: ステップ描画
+  let curY = contentTop
+  let curRightX = topRightX
+
+  for (let i = 1; i < rowRightEdges.length; i++) {
+    const edge = rowRightEdges[i]
+
+    if (Math.abs(edge.rightX - curRightX) > 0.01) {
+      // 垂直線: curRightX で curY → edge.yTop
+      lines.push({
+        x1: curRightX,
+        y1: curY,
+        x2: curRightX,
+        y2: edge.yTop,
+        style,
+        lineType: "outer",
+        strokeWidth: sw,
+      })
+      // 水平線: curRightX → edge.rightX at edge.yTop
+      lines.push({
+        x1: Math.min(curRightX, edge.rightX),
+        y1: edge.yTop,
+        x2: Math.max(curRightX, edge.rightX),
+        y2: edge.yTop,
+        style,
+        lineType: "outer",
+        strokeWidth: sw,
+      })
+      curY = edge.yTop
+      curRightX = edge.rightX
+    }
+  }
+
+  // 最後の行の下端まで右辺を描画
+  lines.push({
+    x1: curRightX,
+    y1: curY,
+    x2: curRightX,
+    y2: contentBottom,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+
+  // 下辺: contentBottom で curRightX → contentLeft
+  lines.push({
+    x1: contentLeft,
+    y1: contentBottom,
+    x2: curRightX,
+    y2: contentBottom,
+    style,
+    lineType: "outer",
+    strokeWidth: sw,
+  })
+}
+
 function computeOMRMarkers(
   settings: GlobalSettings,
   paper: { width: number; height: number }
@@ -1016,6 +1364,7 @@ function computeMultiPageLayoutFromDefinition(
     numberLabels: ComputedNumberLabel[]
     verticalRanges: { top: number; bottom: number }[]
     branchVerticalRanges: { top: number; bottom: number }[]
+    rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
     contentBottomY: number
   }
 
@@ -1026,6 +1375,7 @@ function computeMultiPageLayoutFromDefinition(
       numberLabels: [],
       verticalRanges: [],
       branchVerticalRanges: [],
+      rowRightEdges: [],
       contentBottomY: contentTop,
     }
   }
@@ -1057,85 +1407,125 @@ function computeMultiPageLayoutFromDefinition(
       displayMode: settings.numberDisplayMode,
     })
 
-    const layoutRows = buildLayoutRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
     const horizontalAreaX = majorNumX + majorNumWidth
     const horizontalAreaWidth = contentRight - horizontalAreaX
+    const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
-    let vertSegStart: number | null = null
+    if (subIsHorizontal) {
+      // === 横配置（グリッド）モード ===
+      const gridCells = buildSubGridLayout(major.subQuestions)
+      for (const gc of gridCells) {
+        const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const cellWidth = gc.width * horizontalAreaWidth
+        const cellY = majorStartY + gc.y * baseRowHeight
+        const cellHeight = gc.height * baseRowHeight
+        const sub = gc.item
+        const hasBranches = sub.branchQuestions.length > 0
 
-    layoutRows.forEach((row, ri) => {
-      if (row.type === "horizontal") {
-        if (vertSegStart !== null) {
-          page.verticalRanges.push({ top: vertSegStart, bottom: localY })
-          vertSegStart = null
-        }
-
-        const rowMaxH = Math.max(
-          ...row.subs.map((s) => s.sub.heightMultiplier),
-          1
-        )
-        const rowHeight = rowMaxH * baseRowHeight
-        const unitWidth = horizontalAreaWidth / row.columns
-
-        row.subs.forEach((entry) => {
-          const cellX = horizontalAreaX + entry.colStart * unitWidth
-          const cellWidth = entry.span * unitWidth
-
-          page.numberLabels.push({
-            text: entry.sub.label,
-            x: cellX,
-            y: localY,
-            width: cellWidth,
-            height: rowHeight,
-            fontSize: settings.fonts.numberSize,
-            displayMode: "sub-horizontal",
-          })
-
-          page.cells.push(
-            createCell(
-              [mi, entry.subIndex],
-              cellX,
-              localY,
-              cellWidth,
-              rowHeight,
-              paper,
-              `${major.label}-${entry.sub.label}`,
-              entry.sub.points,
-              entry.sub.textElements,
-              entry.sub.modelAnswer,
-              "answer",
-              pageIdx,
-              computeManuscriptGrid(entry.sub, cellX, localY, cellWidth),
-              entry.sub.omrConfig
-            )
-          )
-
-          const cellRight = cellX + cellWidth
-          if (Math.abs(cellRight - contentRight) > 0.01) {
-            page.lines.push({
-              x1: cellRight,
-              y1: localY,
-              x2: cellRight,
-              y2: localY + rowHeight,
-              style: settings.borderConfig.subDivider,
-              lineType: "subHorizontalDivider",
-              strokeWidth: getLineWidth(
-                "subHorizontalDivider",
-                settings.borderConfig
-              ),
-            })
-          }
+        page.numberLabels.push({
+          text: sub.label,
+          x: cellX,
+          y: cellY,
+          width: subNumWidth,
+          height: cellHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub-horizontal",
         })
 
-        localY += rowHeight
-      } else {
-        if (vertSegStart === null) vertSegStart = localY
+        if (hasBranches) {
+          const cellBranchNumX = cellX + subNumWidth
+          const cellBranchNumWidth = branchNumWidth
+          const cellAnswerX = cellBranchNumX + cellBranchNumWidth
+          const cellAnswerWidth = cellWidth - subNumWidth - cellBranchNumWidth
+          const cellRight = cellX + cellWidth
+          renderBranchQuestions(
+            sub,
+            mi,
+            gc.itemIndex,
+            major.label,
+            cellY,
+            pageIdx,
+            cellX,
+            subNumWidth,
+            cellBranchNumX,
+            cellBranchNumWidth,
+            cellAnswerX,
+            cellAnswerWidth,
+            cellRight,
+            baseRowHeight,
+            paper,
+            settings,
+            page.cells,
+            page.lines,
+            page.numberLabels,
+            page.rowRightEdges
+          )
+        } else {
+          page.cells.push(
+            createCell(
+              [mi, gc.itemIndex],
+              cellX + subNumWidth,
+              cellY,
+              cellWidth - subNumWidth,
+              cellHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(
+                sub,
+                cellX + subNumWidth,
+                cellY,
+                cellWidth - subNumWidth
+              ),
+              sub.omrConfig
+            )
+          )
+        }
 
-        const sub = row.sub
-        const si = row.subIndex
+        // 番号ラベル右側の区切り線
+        page.lines.push({
+          x1: cellX + subNumWidth,
+          y1: cellY,
+          x2: cellX + subNumWidth,
+          y2: cellY + cellHeight,
+          style: settings.borderConfig.numberColumnDivider,
+          lineType: "numberColumn",
+          strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+        })
+      }
+
+      // rowRightEdges: Y区間ごとの右端X座標を計算
+      for (const edge of computeGridRowRightEdges(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight
+      )) {
+        page.rowRightEdges.push(edge)
+      }
+
+      // グリッドセル間の区切り線
+      renderGridDividerLines(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight,
+        settings,
+        page.lines,
+        "sub"
+      )
+
+      localY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
+    } else {
+      // === 縦配置モード ===
+      const vertSegStart = localY
+      major.subQuestions.forEach((sub, si) => {
         const subStartY = localY
         const hasBranches = sub.branchQuestions.length > 0
         const subHeight = computeSubHeight(sub, baseRowHeight)
@@ -1151,141 +1541,34 @@ function computeMultiPageLayoutFromDefinition(
         })
 
         if (hasBranches) {
-          const branchRows = buildBranchLayoutRows(
-            sub.branchQuestions,
-            sub.branchHorizontalColumnsPerRow
+          renderBranchQuestions(
+            sub,
+            mi,
+            si,
+            major.label,
+            subStartY,
+            pageIdx,
+            subNumX,
+            subNumWidth,
+            branchNumX,
+            branchNumWidth,
+            answerX,
+            answerWidth,
+            contentRight,
+            baseRowHeight,
+            paper,
+            settings,
+            page.cells,
+            page.lines,
+            page.numberLabels,
+            page.rowRightEdges
           )
-          const branchAreaX = subNumX + subNumWidth
-          const branchAreaWidth = contentRight - branchAreaX
-          let branchY = subStartY
-          let bVertSegStart: number | null = null
 
-          branchRows.forEach((bRow, bri) => {
-            if (bRow.type === "horizontal") {
-              if (bVertSegStart !== null) {
-                page.branchVerticalRanges.push({
-                  top: bVertSegStart,
-                  bottom: branchY,
-                })
-                bVertSegStart = null
-              }
-
-              const rowMaxH = Math.max(
-                ...bRow.branches.map((b) => b.branch.heightMultiplier),
-                1
-              )
-              const bRowHeight = rowMaxH * baseRowHeight
-              const unitWidth = branchAreaWidth / bRow.columns
-
-              bRow.branches.forEach((entry) => {
-                const cellX = branchAreaX + entry.colStart * unitWidth
-                const cellWidth = entry.span * unitWidth
-
-                page.numberLabels.push({
-                  text: entry.branch.label,
-                  x: cellX,
-                  y: branchY,
-                  width: cellWidth,
-                  height: bRowHeight,
-                  fontSize: settings.fonts.numberSize - 1,
-                  displayMode: "branch-horizontal",
-                })
-
-                page.cells.push(
-                  createCell(
-                    [mi, si, entry.branchIndex],
-                    cellX,
-                    branchY,
-                    cellWidth,
-                    bRowHeight,
-                    paper,
-                    `${major.label}-${sub.label}-${entry.branch.label}`,
-                    entry.branch.points,
-                    entry.branch.textElements,
-                    entry.branch.modelAnswer,
-                    "answer",
-                    pageIdx,
-                    undefined,
-                    entry.branch.omrConfig
-                  )
-                )
-
-                const cellRight = cellX + cellWidth
-                if (Math.abs(cellRight - contentRight) > 0.01) {
-                  page.lines.push({
-                    x1: cellRight,
-                    y1: branchY,
-                    x2: cellRight,
-                    y2: branchY + bRowHeight,
-                    style: settings.borderConfig.branchDivider,
-                    lineType: "branch",
-                    strokeWidth: getLineWidth("branch", settings.borderConfig),
-                  })
-                }
-              })
-
-              branchY += bRowHeight
-            } else {
-              if (bVertSegStart === null) bVertSegStart = branchY
-
-              const branch = bRow.branch
-              const branchHeight = branch.heightMultiplier * baseRowHeight
-
-              page.numberLabels.push({
-                text: branch.label,
-                x: branchNumX,
-                y: branchY,
-                width: branchNumWidth,
-                height: branchHeight,
-                fontSize: settings.fonts.numberSize - 1,
-                displayMode: "branch",
-              })
-
-              page.cells.push(
-                createCell(
-                  [mi, si, bRow.branchIndex],
-                  answerX,
-                  branchY,
-                  answerWidth,
-                  branchHeight,
-                  paper,
-                  `${major.label}-${sub.label}-${branch.label}`,
-                  branch.points,
-                  branch.textElements,
-                  branch.modelAnswer,
-                  "answer",
-                  pageIdx,
-                  undefined,
-                  branch.omrConfig
-                )
-              )
-
-              branchY += branchHeight
-            }
-
-            // 枝問行間の区切り線
-            if (bri < branchRows.length - 1) {
-              const nextBRow = branchRows[bri + 1]
-              const lineX =
-                bRow.type === "horizontal" || nextBRow.type === "horizontal"
-                  ? branchAreaX
-                  : branchNumX
-              page.lines.push({
-                x1: lineX,
-                y1: branchY,
-                x2: contentRight,
-                y2: branchY,
-                style: settings.borderConfig.branchDivider,
-                lineType: "branch",
-                strokeWidth: getLineWidth("branch", settings.borderConfig),
-              })
-            }
-          })
-
-          if (bVertSegStart !== null) {
+          // 枝問番号列のセグメント
+          if (!isGridHorizontal(sub.branchQuestions)) {
             page.branchVerticalRanges.push({
-              top: bVertSegStart,
-              bottom: branchY,
+              top: subStartY,
+              bottom: subStartY + subHeight,
             })
           }
         } else {
@@ -1309,28 +1592,19 @@ function computeMultiPageLayoutFromDefinition(
           )
         }
 
-        localY += subHeight
-      }
+        // vertical-sub行の右端は常にcontentRight
+        page.rowRightEdges.push({
+          yTop: subStartY,
+          yBottom: subStartY + subHeight,
+          rightX: contentRight,
+        })
 
-      // 行間の区切り線（最後の行以外）
-      if (ri < layoutRows.length - 1) {
-        const nextRow = layoutRows[ri + 1]
-        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+        localY += subHeight
+
+        // 行間の区切り線（最後の行以外）
+        if (si < major.subQuestions.length - 1) {
           page.lines.push({
-            x1: horizontalAreaX,
-            y1: localY,
-            x2: contentRight,
-            y2: localY,
-            style: settings.borderConfig.subDivider,
-            lineType: "subHorizontalDivider",
-            strokeWidth: getLineWidth(
-              "subHorizontalDivider",
-              settings.borderConfig
-            ),
-          })
-        } else {
-          page.lines.push({
-            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            x1: subNumX,
             y1: localY,
             x2: contentRight,
             y2: localY,
@@ -1339,10 +1613,8 @@ function computeMultiPageLayoutFromDefinition(
             strokeWidth: getLineWidth("sub", settings.borderConfig),
           })
         }
-      }
-    })
+      })
 
-    if (vertSegStart !== null) {
       page.verticalRanges.push({ top: vertSegStart, bottom: localY })
     }
 
@@ -1365,7 +1637,16 @@ function computeMultiPageLayoutFromDefinition(
       pagesData.push(newPageData())
       currentY = contentTop
     } else {
-      currentY += spacingHeight
+      if (spacingHeight > 0) {
+        // 大問間スペーシングのrightX追跡
+        const spacingTop = currentY
+        currentY += spacingHeight
+        pagesData[currentPageIdx].rowRightEdges.push({
+          yTop: spacingTop,
+          yBottom: currentY,
+          rightX: contentRight,
+        })
+      }
     }
 
     currentY = layoutMajorOnPage(
@@ -1405,15 +1686,16 @@ function computeMultiPageLayoutFromDefinition(
       pd.lines.pop()
     }
 
-    // 外枠線
-    addBorderLines(
+    // 外枠線（ステップ形状対応）
+    addSteppedBorderLines(
       pd.lines,
       contentLeft,
       contentTop,
       contentRight,
       pageContentBottom,
       settings.borderConfig.outerBorder,
-      settings.borderConfig
+      settings.borderConfig,
+      pd.rowRightEdges
     )
 
     // 番号列の縦線

--- a/components/import/HszDisclaimerModal.tsx
+++ b/components/import/HszDisclaimerModal.tsx
@@ -112,7 +112,9 @@ export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
                   本機能による読み込み結果の正確性・完全性について、いかなる保証も行いません。読み込み後のデータについては、必ずご自身で内容をご確認ください。
                 </li>
                 <li>
-                  <span className="font-medium">データ形式の変更について：</span>
+                  <span className="font-medium">
+                    データ形式の変更について：
+                  </span>
                   ソフトウェアの更新等によりデータ形式が変更された場合、本機能が正常に動作しなくなる可能性があります。
                 </li>
                 <li>
@@ -141,7 +143,7 @@ export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
           </div>
 
           {/* 同意チェックボックス */}
-          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 select-none has-[:checked]:border-amber-400 has-[:checked]:bg-amber-50 dark:has-[:checked]:bg-amber-950/20">
+          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 select-none has-checked:border-amber-400 has-checked:bg-amber-50 dark:has-checked:bg-amber-950/20">
             <Checkbox
               checked={agreed}
               onCheckedChange={(checked) => setAgreed(checked === true)}

--- a/components/import/steps/id-integration/DetailPanel.tsx
+++ b/components/import/steps/id-integration/DetailPanel.tsx
@@ -87,6 +87,7 @@ export function DetailPanel({
                     idChoice,
                   })
                 }
+                wizard={entityType === "subtotalGroup" ? wizard : undefined}
               />
             )
           })}

--- a/components/import/steps/id-integration/MatchedItemRow.tsx
+++ b/components/import/steps/id-integration/MatchedItemRow.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { ChevronDown, ChevronRight } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import {
@@ -11,6 +12,8 @@ import {
 } from "@/components/ui/select"
 import type { IdChoice } from "@/types/projectArchive.types"
 
+import { SubtotalMappingEditor } from "./SubtotalMappingEditor"
+import { SubtotalPreview } from "./SubtotalPreview"
 import type { DecisionType, MatchedItemRowProps } from "./types"
 import { ENTITY_LABELS } from "./types"
 
@@ -23,6 +26,7 @@ export function MatchedItemRow({
   currentDecision,
   currentIdChoice,
   onDecisionChange,
+  wizard,
 }: MatchedItemRowProps) {
   const [decision, setDecision] = useState<DecisionType>(
     currentDecision ?? "same_person"
@@ -39,7 +43,17 @@ export function MatchedItemRow({
     if (currentIdChoice !== undefined) setIdChoice(currentIdChoice)
   }, [currentIdChoice])
 
+  const [showPreview, setShowPreview] = useState(false)
+
   const labels = ENTITY_LABELS[entityType]
+  const hasSubtotalPreview =
+    entityType === "subtotalGroup" && item.additionalInfo
+  const showMappingEditor =
+    entityType === "subtotalGroup" &&
+    decision === "same_person" &&
+    wizard &&
+    item.additionalInfo?.importSubtotals?.length &&
+    item.additionalInfo?.existingSubtotals?.length
 
   const handleDecisionChange = (value: string) => {
     const newDecision = value as DecisionType
@@ -59,11 +73,36 @@ export function MatchedItemRow({
   return (
     <div className="rounded-lg border p-3">
       <div className="mb-2 flex items-center justify-between">
-        <span className="font-medium">{item.displayLabel}</span>
+        <div className="flex items-center gap-1">
+          <span className="font-medium">{item.displayLabel}</span>
+          {hasSubtotalPreview && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground ml-1 inline-flex items-center gap-0.5 text-xs"
+              onClick={() => setShowPreview((v) => !v)}
+            >
+              {showPreview ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              小計項目
+            </button>
+          )}
+        </div>
         <span className="text-muted-foreground text-xs">
           {item.matchReason}
         </span>
       </div>
+
+      {/* 小計項目プレビュー */}
+      {hasSubtotalPreview && showPreview && (
+        <SubtotalPreview
+          importSubtotals={item.additionalInfo?.importSubtotals}
+          existingSubtotals={item.additionalInfo?.existingSubtotals}
+        />
+      )}
+
       <div className="flex flex-col gap-2">
         <Select value={decision} onValueChange={handleDecisionChange}>
           <SelectTrigger className="w-full">
@@ -96,6 +135,15 @@ export function MatchedItemRow({
               </SelectContent>
             </Select>
           </div>
+        )}
+
+        {/* 小計項目マッピングエディタ（subtotalGroup + same_person の場合） */}
+        {showMappingEditor && (
+          <SubtotalMappingEditor
+            wizard={wizard}
+            importSubtotals={item.additionalInfo!.importSubtotals!}
+            existingSubtotals={item.additionalInfo!.existingSubtotals!}
+          />
         )}
       </div>
     </div>

--- a/components/import/steps/id-integration/NoMatchItemRow.tsx
+++ b/components/import/steps/id-integration/NoMatchItemRow.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { ChevronDown, ChevronRight } from "lucide-react"
 import { useState } from "react"
 
 import {
@@ -9,7 +10,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import type { SubtotalInfo } from "@/types/projectArchive.types"
 
+import { SubtotalPreview } from "./SubtotalPreview"
 import type { NoMatchDecisionType, NoMatchItemRowProps } from "./types"
 
 /**
@@ -20,6 +23,7 @@ export function NoMatchItemRow({
   onDecisionChange,
 }: NoMatchItemRowProps) {
   const [decision, setDecision] = useState<NoMatchDecisionType>("create_new")
+  const [showPreview, setShowPreview] = useState(false)
 
   const handleDecisionChange = (value: string) => {
     const newDecision = value as NoMatchDecisionType
@@ -27,14 +31,41 @@ export function NoMatchItemRow({
     onDecisionChange(newDecision)
   }
 
+  const importSubtotals = (
+    item as { additionalInfo?: { importSubtotals?: SubtotalInfo[] } }
+  ).additionalInfo?.importSubtotals
+  const hasSubtotalPreview = !!importSubtotals?.length
+
   return (
     <div className="rounded-lg border p-3">
       <div className="mb-2 flex items-center justify-between">
-        <span className="font-medium">{item.displayLabel}</span>
+        <div className="flex items-center gap-1">
+          <span className="font-medium">{item.displayLabel}</span>
+          {hasSubtotalPreview && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground ml-1 inline-flex items-center gap-0.5 text-xs"
+              onClick={() => setShowPreview((v) => !v)}
+            >
+              {showPreview ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              小計項目
+            </button>
+          )}
+        </div>
         <span className="text-muted-foreground text-xs">
           このPCに同じデータなし
         </span>
       </div>
+
+      {/* 小計項目プレビュー */}
+      {hasSubtotalPreview && showPreview && (
+        <SubtotalPreview importSubtotals={importSubtotals} />
+      )}
+
       <Select value={decision} onValueChange={handleDecisionChange}>
         <SelectTrigger className="w-full">
           <SelectValue />

--- a/components/import/steps/id-integration/SubtotalGroupIntegrationPanel.tsx
+++ b/components/import/steps/id-integration/SubtotalGroupIntegrationPanel.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { Info } from "lucide-react"
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { RadioGroup } from "@/components/ui/radio-group"
 import type { SubtotalGroupMatchingStrategy } from "@/types/projectArchive.types"
@@ -19,6 +21,8 @@ export function SubtotalGroupIntegrationPanel({
   const overview = state.fileOverviewData?.subtotalGroup
   const strategy = state.idIntegrationConfig.subtotalGroup
     .strategy as SubtotalGroupMatchingStrategy
+  const isExternalFormat =
+    state.sourceFormat === "hsz" || state.sourceFormat === "dat"
 
   if (!overview) return null
 
@@ -40,6 +44,16 @@ export function SubtotalGroupIntegrationPanel({
 
   return (
     <div className="space-y-4">
+      {/* 外部フォーマット時の推奨バナー */}
+      {isExternalFormat && (
+        <div className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            他社フォーマットからのインポートです。「大問」「観点」等の同名グループが既に存在する場合、「グループ名で紐づける」の使用をおすすめします。
+          </p>
+        </div>
+      )}
+
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">

--- a/components/import/steps/id-integration/SubtotalMappingEditor.tsx
+++ b/components/import/steps/id-integration/SubtotalMappingEditor.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useMemo } from "react"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
+import { cn } from "@/lib/utils"
+import type { SubtotalInfo } from "@/types/projectArchive.types"
+
+interface SubtotalMappingEditorProps {
+  wizard: UseImportWizardReturn
+  importSubtotals: SubtotalInfo[]
+  existingSubtotals: SubtotalInfo[]
+}
+
+const NEW_MARKER = "__new__"
+
+/**
+ * 小計項目レベルの直接マッピングエディタ
+ *
+ * 「同じグループとして扱う」を選択した場合にのみ表示され、
+ * インポート小計項目と既存小計項目の結びつけを制御する。
+ */
+export function SubtotalMappingEditor({
+  wizard,
+  importSubtotals,
+  existingSubtotals,
+}: SubtotalMappingEditorProps) {
+  const { updateSubtotalMapping } = wizard
+  const currentMappings = useMemo(
+    () => wizard.state.idIntegrationConfig.subtotalMappings ?? {},
+    [wizard.state.idIntegrationConfig.subtotalMappings]
+  )
+
+  // 既存SubtotalのIDマップ（名前→ID）
+  const existingIdByName = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const s of existingSubtotals) {
+      map.set(s.name, s.id)
+    }
+    return map
+  }, [existingSubtotals])
+
+  // 各インポート項目の解決済みの値（表示用）
+  const resolvedValues = useMemo(() => {
+    const values: Record<string, string> = {}
+    for (const importSub of importSubtotals) {
+      if (currentMappings[importSub.id]) {
+        values[importSub.id] = currentMappings[importSub.id]
+      } else {
+        // デフォルト: 名前一致する既存項目のID、またはNEW
+        const existingId = existingIdByName.get(importSub.name)
+        values[importSub.id] = existingId ?? NEW_MARKER
+      }
+    }
+    return values
+  }, [importSubtotals, currentMappings, existingIdByName])
+
+  // 既に選択済みの既存IDを追跡（重複防止）
+  const usedExistingIds = useMemo(() => {
+    const used = new Set<string>()
+    for (const value of Object.values(resolvedValues)) {
+      if (value !== NEW_MARKER) {
+        used.add(value)
+      }
+    }
+    return used
+  }, [resolvedValues])
+
+  return (
+    <div className="mt-3 rounded border p-3">
+      <div className="text-muted-foreground mb-2 text-xs font-medium">
+        小計項目の結びつけ
+      </div>
+      <div className="space-y-2">
+        {importSubtotals.map((importSub) => {
+          const currentValue = resolvedValues[importSub.id]
+          const isAutoMatch =
+            !currentMappings[importSub.id] &&
+            existingIdByName.has(importSub.name)
+
+          return (
+            <div key={importSub.id} className="flex items-center gap-2">
+              <span className="w-1/3 truncate text-sm font-medium">
+                {importSub.name}
+              </span>
+              <span className="text-muted-foreground text-sm">→</span>
+              <div className="flex-1">
+                <Select
+                  value={currentValue}
+                  onValueChange={(value) => {
+                    updateSubtotalMapping(importSub.id, value)
+                  }}
+                >
+                  <SelectTrigger
+                    className={cn(
+                      "w-full text-sm",
+                      isAutoMatch && "border-green-300 dark:border-green-700"
+                    )}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {existingSubtotals.map((existingSub) => {
+                      const isUsedByOther =
+                        usedExistingIds.has(existingSub.id) &&
+                        currentValue !== existingSub.id
+                      const isNameMatch = existingSub.name === importSub.name
+                      return (
+                        <SelectItem
+                          key={existingSub.id}
+                          value={existingSub.id}
+                          disabled={isUsedByOther}
+                        >
+                          {existingSub.name}
+                          {isNameMatch && " (自動一致)"}
+                          {isUsedByOther && " (使用済み)"}
+                        </SelectItem>
+                      )
+                    })}
+                    <SelectItem value={NEW_MARKER}>+ 新規作成</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/import/steps/id-integration/SubtotalPreview.tsx
+++ b/components/import/steps/id-integration/SubtotalPreview.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { SubtotalInfo } from "@/types/projectArchive.types"
+
+interface SubtotalPreviewProps {
+  importSubtotals?: SubtotalInfo[]
+  existingSubtotals?: SubtotalInfo[]
+}
+
+/**
+ * 小計グループ配下の小計項目プレビュー（Collapsible内に表示）
+ */
+export function SubtotalPreview({
+  importSubtotals,
+  existingSubtotals,
+}: SubtotalPreviewProps) {
+  if (!importSubtotals?.length && !existingSubtotals?.length) return null
+
+  const importNames = new Set(importSubtotals?.map((s) => s.name) ?? [])
+  const existingNames = new Set(existingSubtotals?.map((s) => s.name) ?? [])
+
+  return (
+    <div className="mt-2 grid grid-cols-2 gap-3 rounded border p-2 text-xs">
+      <div>
+        <div className="text-muted-foreground mb-1 font-medium">
+          ファイルの小計項目
+        </div>
+        {importSubtotals?.length ? (
+          <ul className="space-y-0.5">
+            {importSubtotals.map((s) => (
+              <li
+                key={`${s.name}-${s.order}`}
+                className={cn(
+                  "rounded px-1.5 py-0.5",
+                  existingNames.has(s.name)
+                    ? "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+                    : "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                )}
+              >
+                {s.name}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <span className="text-muted-foreground">なし</span>
+        )}
+      </div>
+      <div>
+        <div className="text-muted-foreground mb-1 font-medium">
+          このPCの小計項目
+        </div>
+        {existingSubtotals?.length ? (
+          <ul className="space-y-0.5">
+            {existingSubtotals.map((s) => (
+              <li
+                key={`${s.name}-${s.order}`}
+                className={cn(
+                  "rounded px-1.5 py-0.5",
+                  importNames.has(s.name)
+                    ? "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300"
+                    : "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                )}
+              >
+                {s.name}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <span className="text-muted-foreground">なし</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/import/steps/id-integration/types.ts
+++ b/components/import/steps/id-integration/types.ts
@@ -90,6 +90,8 @@ export interface MatchedItemRowProps {
   currentDecision?: DecisionType
   currentIdChoice?: IdChoice
   onDecisionChange: (decision: DecisionType, idChoice?: IdChoice) => void
+  /** wizardインスタンス（subtotalGroupのマッピングエディタ用） */
+  wizard?: UseImportWizardReturn
 }
 
 /** マッチしなかったアイテム行のProps */

--- a/components/pdf-tools/export-panel/ExportPanel.tsx
+++ b/components/pdf-tools/export-panel/ExportPanel.tsx
@@ -121,9 +121,7 @@ function isPageExcluded(page: OutputPage, excludedPages: Set<string>): boolean {
       excludedPages.has(`${page.sourceFileId}:${pn}`)
     )
   }
-  return excludedPages.has(
-    `${page.sourceFileId}:${page.sourcePageNumber}`
-  )
+  return excludedPages.has(`${page.sourceFileId}:${page.sourcePageNumber}`)
 }
 
 /**

--- a/components/pdf-tools/export-panel/OutputPreview.tsx
+++ b/components/pdf-tools/export-panel/OutputPreview.tsx
@@ -102,7 +102,12 @@ interface SortablePageItemProps {
   onDelete: () => void
 }
 
-function SortablePageItem({ page, index, disabled, onDelete }: SortablePageItemProps) {
+function SortablePageItem({
+  page,
+  index,
+  disabled,
+  onDelete,
+}: SortablePageItemProps) {
   const {
     attributes,
     listeners,

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -2,13 +2,17 @@
  * 解答用紙作成機能のIPCハンドラー
  */
 
-import { dialog, ipcMain } from "electron"
+import { BrowserWindow, dialog, ipcMain } from "electron"
+import fs from "fs"
+import os from "os"
+import path from "path"
 
 import type {
   AnswerSheetDefinition,
   ASBConvertToProjectArgs,
   ASBExportPdfArgs,
   ASBExportPngArgs,
+  ASBPrintArgs,
 } from "../../types/answerSheetBuilder.types"
 import {
   deleteDefinition,
@@ -43,6 +47,78 @@ export function setupAnswerSheetBuilderHandlers(): void {
       const definition = loadDefinition(id)
       if (!definition) {
         return { success: false, error: "定義が見つかりません" }
+      }
+      // マイグレーション: 旧フォーマットからの移行
+      for (const major of definition.majorQuestions) {
+        const raw = major as unknown as Record<string, unknown>
+        // subQuestionLayout → layoutWidth
+        if (raw.subQuestionLayout === "horizontal") {
+          const cols = major.subQuestions.length
+          for (const sub of major.subQuestions) {
+            if (!sub.layoutWidth) {
+              sub.layoutWidth = `1/${cols}`
+            }
+          }
+        }
+        delete raw.subQuestionLayout
+
+        // horizontalColumnsPerRow → layoutWidth/nextPlacement
+        const cpr = raw.horizontalColumnsPerRow as number[] | undefined
+        if (cpr?.length) {
+          let si = 0
+          for (const cols of cpr) {
+            for (let c = 0; c < cols && si < major.subQuestions.length; si++) {
+              const sub = major.subQuestions[si]
+              const span =
+                ((raw as Record<string, unknown>).colSpan as number) ??
+                ((sub as unknown as Record<string, unknown>)
+                  .colSpan as number) ??
+                1
+              if (!sub.layoutWidth) {
+                sub.layoutWidth = `${span}/${cols}`
+              }
+              c += span
+              if (c >= cols && si < major.subQuestions.length - 1) {
+                sub.nextPlacement = "break"
+              }
+              delete (sub as unknown as Record<string, unknown>).colSpan
+            }
+          }
+          delete raw.horizontalColumnsPerRow
+        }
+
+        // branchHorizontalColumnsPerRow → layoutWidth/nextPlacement
+        for (const sub of major.subQuestions) {
+          const subRaw = sub as unknown as Record<string, unknown>
+          const bcpr = subRaw.branchHorizontalColumnsPerRow as
+            | number[]
+            | undefined
+          if (bcpr?.length) {
+            let bi = 0
+            for (const cols of bcpr) {
+              for (
+                let c = 0;
+                c < cols && bi < sub.branchQuestions.length;
+                bi++
+              ) {
+                const branch = sub.branchQuestions[bi]
+                const branchRaw = branch as unknown as Record<string, unknown>
+                const span = (branchRaw.colSpan as number) ?? 1
+                if (!branch.layoutWidth) {
+                  branch.layoutWidth = `${span}/${cols}`
+                }
+                c += span
+                if (c >= cols && bi < sub.branchQuestions.length - 1) {
+                  branch.nextPlacement = "break"
+                }
+                delete branchRaw.colSpan
+              }
+            }
+            delete subRaw.branchHorizontalColumnsPerRow
+          }
+          // Clean up any leftover colSpan
+          delete subRaw.colSpan
+        }
       }
       return { success: true, data: definition }
     } catch (error) {
@@ -175,4 +251,61 @@ export function setupAnswerSheetBuilderHandlers(): void {
       }
     }
   )
+
+  // 印刷
+  ipcMain.handle("asb:print", async (_event, args: ASBPrintArgs) => {
+    let tempPath: string | null = null
+    let printWin: BrowserWindow | null = null
+    try {
+      // 1. 一時PDF生成
+      tempPath = path.join(os.tmpdir(), `asb-print-${Date.now()}.pdf`)
+      await generatePdf(args.definition, tempPath)
+
+      // 2. 隠しBrowserWindowでPDFをロード
+      printWin = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: false, contextIsolation: true },
+      })
+      await printWin.loadURL(`file://${tempPath}`)
+
+      // 3. 印刷ダイアログ表示
+      return await new Promise<{ success: boolean; error?: string }>(
+        (resolve) => {
+          printWin!.webContents.print({}, (success, failureReason) => {
+            printWin?.close()
+            printWin = null
+            if (tempPath) {
+              try {
+                fs.unlinkSync(tempPath)
+              } catch {
+                // 一時ファイル削除失敗は無視
+              }
+            }
+            if (success) {
+              resolve({ success: true })
+            } else {
+              resolve({
+                success: false,
+                error: failureReason || "印刷がキャンセルされました",
+              })
+            }
+          })
+        }
+      )
+    } catch (error) {
+      printWin?.close()
+      if (tempPath) {
+        try {
+          fs.unlinkSync(tempPath)
+        } catch {
+          // ignore
+        }
+      }
+      console.error("asb:print error:", error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "印刷に失敗しました",
+      }
+    }
+  })
 }

--- a/electron-src/lib/answer-sheet-builder/layoutEngine.ts
+++ b/electron-src/lib/answer-sheet-builder/layoutEngine.ts
@@ -8,7 +8,7 @@
 import type {
   AnswerSheetDefinition,
   BorderConfig,
-  BranchLayoutRow,
+  BranchGridCell,
   BranchQuestion,
   ComputedCell,
   ComputedLayout,
@@ -18,10 +18,12 @@ import type {
   ComputedOMRMarker,
   ComputedPageLayout,
   GlobalSettings,
-  LayoutRow,
+  GridCell,
   LineStyle,
   MajorQuestion,
   ManuscriptGrid,
+  NextPlacement,
+  SubGridCell,
   SubQuestion,
 } from "../../../types/answerSheetBuilder.types"
 import type {
@@ -189,13 +191,23 @@ export function computeLayout(
   const lines: ComputedLine[] = []
   const numberLabels: ComputedNumberLabel[] = []
 
+  // 各行の右端X座標を追跡（ステップ外枠描画用）
+  const rowRightEdges: { yTop: number; yBottom: number; rightX: number }[] = []
+
   let currentY = margins.top + spacing.headerHeight
 
   // 各大問を処理
   majorQuestions.forEach((major, mi) => {
     // 大問前スペーシング
     if (mi > 0) {
+      // 大問間スペーシングのrightX追跡
+      const spacingTop = currentY
       currentY += spacing.majorQuestionSpacing
+      rowRightEdges.push({
+        yTop: spacingTop,
+        yBottom: currentY,
+        rightX: contentRight,
+      })
     }
 
     const majorStartY = currentY
@@ -225,78 +237,122 @@ export function computeLayout(
       })
     }
 
-    // buildLayoutRows で統一的にレイアウト行を生成
-    const layoutRows = buildLayoutRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
     const horizontalAreaX = majorNumX + majorNumWidth
     const horizontalAreaWidth = contentRight - horizontalAreaX
+    const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
-    layoutRows.forEach((row, ri) => {
-      if (row.type === "horizontal") {
-        const rowMaxH = Math.max(
-          ...row.subs.map((s) => s.sub.heightMultiplier),
-          1
-        )
-        const rowHeight = rowMaxH * baseRowHeight
-        const unitWidth = horizontalAreaWidth / row.columns
+    if (subIsHorizontal) {
+      const gridCells = buildSubGridLayout(major.subQuestions)
 
-        row.subs.forEach((entry) => {
-          const cellX = horizontalAreaX + entry.colStart * unitWidth
-          const cellWidth = entry.span * unitWidth
+      for (const gc of gridCells) {
+        const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const cellWidth = gc.width * horizontalAreaWidth
+        const cellY = majorStartY + gc.y * baseRowHeight
+        const cellHeight = gc.height * baseRowHeight
+        const sub = gc.item
+        const hasBranches = sub.branchQuestions.length > 0
 
-          numberLabels.push({
-            text: entry.sub.label,
-            x: cellX,
-            y: currentY,
-            width: cellWidth,
-            height: rowHeight,
-            fontSize: settings.fonts.numberSize,
-            displayMode: "sub-horizontal",
-          })
-
-          cells.push(
-            createCell(
-              [mi, entry.subIndex],
-              cellX,
-              currentY,
-              cellWidth,
-              rowHeight,
-              paper,
-              `${major.label}-${entry.sub.label}`,
-              entry.sub.points,
-              entry.sub.textElements,
-              entry.sub.modelAnswer,
-              "answer",
-              0,
-              computeManuscriptGrid(entry.sub, cellX, currentY, cellWidth),
-              entry.sub.omrConfig
-            )
-          )
-
-          const cellRight = cellX + cellWidth
-          if (Math.abs(cellRight - contentRight) > 0.01) {
-            lines.push({
-              x1: cellRight,
-              y1: currentY,
-              x2: cellRight,
-              y2: currentY + rowHeight,
-              style: settings.borderConfig.subDivider,
-              strokeWidth: getLineWidth(
-                "subHorizontalDivider",
-                settings.borderConfig
-              ),
-              lineType: "subHorizontalDivider",
-            })
-          }
+        numberLabels.push({
+          text: sub.label,
+          x: cellX,
+          y: cellY,
+          width: subNumWidth,
+          height: cellHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub-horizontal",
         })
 
-        currentY += rowHeight
-      } else {
-        // vertical-sub
-        const sub = row.sub
-        const si = row.subIndex
+        if (hasBranches) {
+          // 枝問をセル内でレンダリング（セル幅からsubNumWidthを引いた残りが枝問の全幅）
+          const cellBranchNumX = cellX + subNumWidth
+          const cellBranchNumWidth = branchNumWidth
+          const cellAnswerX = cellBranchNumX + cellBranchNumWidth
+          const cellAnswerWidth = cellWidth - subNumWidth - cellBranchNumWidth
+          const cellRight = cellX + cellWidth
+          renderBranchQuestions(
+            sub,
+            mi,
+            gc.itemIndex,
+            major.label,
+            cellY,
+            0,
+            cellX,
+            subNumWidth,
+            cellBranchNumX,
+            cellBranchNumWidth,
+            cellAnswerX,
+            cellAnswerWidth,
+            cellRight,
+            baseRowHeight,
+            paper,
+            settings,
+            cells,
+            lines,
+            numberLabels,
+            rowRightEdges
+          )
+        } else {
+          cells.push(
+            createCell(
+              [mi, gc.itemIndex],
+              cellX + subNumWidth,
+              cellY,
+              cellWidth - subNumWidth,
+              cellHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              0,
+              computeManuscriptGrid(
+                sub,
+                cellX + subNumWidth,
+                cellY,
+                cellWidth - subNumWidth
+              ),
+              sub.omrConfig
+            )
+          )
+        }
+
+        lines.push({
+          x1: cellX + subNumWidth,
+          y1: cellY,
+          x2: cellX + subNumWidth,
+          y2: cellY + cellHeight,
+          style: settings.borderConfig.numberColumnDivider,
+          strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+          lineType: "numberColumn",
+        })
+      }
+
+      // rowRightEdges: Y区間ごとの右端X座標を計算
+      for (const edge of computeGridRowRightEdges(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight
+      )) {
+        rowRightEdges.push(edge)
+      }
+
+      renderGridDividerLines(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight,
+        settings,
+        lines,
+        "sub"
+      )
+
+      currentY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
+    } else {
+      major.subQuestions.forEach((sub, si) => {
         const subStartY = currentY
         const hasBranches = sub.branchQuestions.length > 0
         const subHeight = computeSubHeight(sub, baseRowHeight)
@@ -312,127 +368,28 @@ export function computeLayout(
         })
 
         if (hasBranches) {
-          const branchRows = buildBranchLayoutRows(
-            sub.branchQuestions,
-            sub.branchHorizontalColumnsPerRow
+          renderBranchQuestions(
+            sub,
+            mi,
+            si,
+            major.label,
+            subStartY,
+            0,
+            subNumX,
+            subNumWidth,
+            branchNumX,
+            branchNumWidth,
+            answerX,
+            answerWidth,
+            contentRight,
+            baseRowHeight,
+            paper,
+            settings,
+            cells,
+            lines,
+            numberLabels,
+            rowRightEdges
           )
-          const branchAreaX = subNumX + subNumWidth
-          const branchAreaWidth = contentRight - branchAreaX
-          let branchY = subStartY
-
-          branchRows.forEach((bRow, bri) => {
-            if (bRow.type === "horizontal") {
-              const rowMaxH = Math.max(
-                ...bRow.branches.map((b) => b.branch.heightMultiplier),
-                1
-              )
-              const bRowHeight = rowMaxH * baseRowHeight
-              const unitWidth = branchAreaWidth / bRow.columns
-
-              bRow.branches.forEach((entry) => {
-                const cellX = branchAreaX + entry.colStart * unitWidth
-                const cellWidth = entry.span * unitWidth
-
-                numberLabels.push({
-                  text: entry.branch.label,
-                  x: cellX,
-                  y: branchY,
-                  width: cellWidth,
-                  height: bRowHeight,
-                  fontSize: settings.fonts.numberSize - 1,
-                  displayMode: "branch-horizontal",
-                })
-
-                cells.push(
-                  createCell(
-                    [mi, si, entry.branchIndex],
-                    cellX,
-                    branchY,
-                    cellWidth,
-                    bRowHeight,
-                    paper,
-                    `${major.label}-${sub.label}-${entry.branch.label}`,
-                    entry.branch.points,
-                    entry.branch.textElements,
-                    entry.branch.modelAnswer,
-                    "answer",
-                    0,
-                    undefined,
-                    entry.branch.omrConfig
-                  )
-                )
-
-                // 列間の垂直区切り線
-                const cellRight = cellX + cellWidth
-                if (Math.abs(cellRight - contentRight) > 0.01) {
-                  lines.push({
-                    x1: cellRight,
-                    y1: branchY,
-                    x2: cellRight,
-                    y2: branchY + bRowHeight,
-                    style: settings.borderConfig.branchDivider,
-                    strokeWidth: getLineWidth("branch", settings.borderConfig),
-                    lineType: "branch",
-                  })
-                }
-              })
-
-              branchY += bRowHeight
-            } else {
-              // vertical-branch
-              const branch = bRow.branch
-              const branchHeight = branch.heightMultiplier * baseRowHeight
-
-              numberLabels.push({
-                text: branch.label,
-                x: branchNumX,
-                y: branchY,
-                width: branchNumWidth,
-                height: branchHeight,
-                fontSize: settings.fonts.numberSize - 1,
-                displayMode: "branch",
-              })
-
-              cells.push(
-                createCell(
-                  [mi, si, bRow.branchIndex],
-                  answerX,
-                  branchY,
-                  answerWidth,
-                  branchHeight,
-                  paper,
-                  `${major.label}-${sub.label}-${branch.label}`,
-                  branch.points,
-                  branch.textElements,
-                  branch.modelAnswer,
-                  "answer",
-                  0,
-                  undefined,
-                  branch.omrConfig
-                )
-              )
-
-              branchY += branchHeight
-            }
-
-            // 枝問行間の区切り線
-            if (bri < branchRows.length - 1) {
-              const nextBRow = branchRows[bri + 1]
-              const lineX =
-                bRow.type === "horizontal" || nextBRow.type === "horizontal"
-                  ? branchAreaX
-                  : branchNumX
-              lines.push({
-                x1: lineX,
-                y1: branchY,
-                x2: contentRight,
-                y2: branchY,
-                style: settings.borderConfig.branchDivider,
-                strokeWidth: getLineWidth("branch", settings.borderConfig),
-                lineType: "branch",
-              })
-            }
-          })
         } else {
           cells.push(
             createCell(
@@ -454,28 +411,17 @@ export function computeLayout(
           )
         }
 
-        currentY += subHeight
-      }
+        rowRightEdges.push({
+          yTop: subStartY,
+          yBottom: subStartY + subHeight,
+          rightX: contentRight,
+        })
 
-      // 行間の区切り線（最後の行以外）
-      if (ri < layoutRows.length - 1) {
-        const nextRow = layoutRows[ri + 1]
-        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+        currentY += subHeight
+
+        if (si < major.subQuestions.length - 1) {
           lines.push({
-            x1: horizontalAreaX,
-            y1: currentY,
-            x2: contentRight,
-            y2: currentY,
-            style: settings.borderConfig.subDivider,
-            strokeWidth: getLineWidth(
-              "subHorizontalDivider",
-              settings.borderConfig
-            ),
-            lineType: "subHorizontalDivider",
-          })
-        } else {
-          lines.push({
-            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            x1: subNumX,
             y1: currentY,
             x2: contentRight,
             y2: currentY,
@@ -484,8 +430,8 @@ export function computeLayout(
             lineType: "sub",
           })
         }
-      }
-    })
+      })
+    }
 
     // 大問の区切り線（最後以外）
     if (mi < majorQuestions.length - 1) {
@@ -503,19 +449,19 @@ export function computeLayout(
 
   const contentBottom = currentY
 
-  // 外枠線
-  addOuterBorderLines(
+  // 外枠線（ステップ形状対応）
+  addSteppedBorderLines(
     lines,
     contentLeft,
     margins.top + spacing.headerHeight,
     contentRight,
     contentBottom,
     settings.borderConfig.outerBorder,
-    settings.borderConfig
+    settings.borderConfig,
+    rowRightEdges
   )
 
   // vertical-sub 行のY範囲を収集（小問番号列セグメント化用）
-  // branchVerticalRanges: vertical-sub 行内の vertical-branch 行のY範囲（枝問番号列用）
   const verticalRanges: { top: number; bottom: number }[] = []
   const branchVerticalRanges: { top: number; bottom: number }[] = []
   {
@@ -525,50 +471,23 @@ export function computeLayout(
       if (mi2 > 0) {
         trackY += spacing.majorQuestionSpacing
       }
-      const rows = buildLayoutRows(mq.subQuestions, mq.horizontalColumnsPerRow)
-      let segStart: number | null = null
-      for (const r of rows) {
-        if (r.type === "vertical-sub") {
-          if (segStart === null) segStart = trackY
-          // 枝問番号列のセグメント: vertical-branch行のみ
-          if (r.sub.branchQuestions.length > 0) {
-            const bRows = buildBranchLayoutRows(
-              r.sub.branchQuestions,
-              r.sub.branchHorizontalColumnsPerRow
-            )
-            let bTrackY = trackY
-            let bSegStart: number | null = null
-            for (const br of bRows) {
-              if (br.type === "vertical-branch") {
-                if (bSegStart === null) bSegStart = bTrackY
-                bTrackY += br.branch.heightMultiplier * baseRowHeight
-              } else {
-                if (bSegStart !== null) {
-                  branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
-                  bSegStart = null
-                }
-                const maxH = Math.max(
-                  ...br.branches.map((b) => b.branch.heightMultiplier),
-                  1
-                )
-                bTrackY += maxH * baseRowHeight
-              }
-            }
-            if (bSegStart !== null) {
-              branchVerticalRanges.push({ top: bSegStart, bottom: bTrackY })
+
+      if (isGridHorizontal(mq.subQuestions)) {
+        const gridCells = buildSubGridLayout(mq.subQuestions)
+        trackY += gridTotalHeight(gridCells) * baseRowHeight
+      } else {
+        const segStart = trackY
+        for (const sub of mq.subQuestions) {
+          if (sub.branchQuestions.length > 0) {
+            if (!isGridHorizontal(sub.branchQuestions)) {
+              branchVerticalRanges.push({
+                top: trackY,
+                bottom: trackY + computeSubHeight(sub, baseRowHeight),
+              })
             }
           }
-          trackY += computeSubHeight(r.sub, baseRowHeight)
-        } else {
-          if (segStart !== null) {
-            verticalRanges.push({ top: segStart, bottom: trackY })
-            segStart = null
-          }
-          const maxH = Math.max(...r.subs.map((s) => s.sub.heightMultiplier), 1)
-          trackY += maxH * baseRowHeight
+          trackY += computeSubHeight(sub, baseRowHeight)
         }
-      }
-      if (segStart !== null) {
         verticalRanges.push({ top: segStart, bottom: trackY })
       }
     }
@@ -629,164 +548,251 @@ export function computeLayout(
 // ヘルパー関数
 // =====================
 
-/**
- * 小問を LayoutRow[] に変換する。
- * - columnsPerRow が空/undefined → 全て vertical-sub
- * - 配列の各要素を順に消費して横配置行を生成
- * - 枝問2つ以上の小問は横配置行から抽出して独立 vertical-sub 行にする
- * - 配列を使い切った残りは全て vertical-sub
- */
-function buildLayoutRows(
-  subQuestions: SubQuestion[],
-  columnsPerRow: number[] | undefined
-): LayoutRow[] {
-  if (!columnsPerRow || columnsPerRow.length === 0) {
-    return subQuestions.map((sub, si) => ({
-      type: "vertical-sub" as const,
-      sub,
-      subIndex: si,
-    }))
-  }
+/** 分数文字列 (e.g. "1/4", "3/4") を 0〜1 の数値に変換 */
+export function parseFraction(s: string): number {
+  const m = s.match(/^(\d+)\/(\d+)$/)
+  if (m) return parseInt(m[1]) / parseInt(m[2])
+  const n = parseFloat(s)
+  return isNaN(n) ? 1 : n
+}
 
-  const rows: LayoutRow[] = []
-  let si = 0
-  let specIdx = 0
-
-  while (si < subQuestions.length && specIdx < columnsPerRow.length) {
-    const rowSpec = columnsPerRow[specIdx]
-    specIdx++
-
-    // この rowSpec 分の小問を消費
-    let consumed = 0
-    let batch: {
-      sub: SubQuestion
-      subIndex: number
-      colStart: number
-      span: number
-    }[] = []
-    let batchCols = 0
-
-    const flushBatch = () => {
-      if (batch.length > 0) {
-        rows.push({ type: "horizontal", subs: batch, columns: batchCols })
-        batch = []
-        batchCols = 0
-      }
-    }
-
-    while (consumed < rowSpec && si < subQuestions.length) {
-      const sub = subQuestions[si]
-      const span = sub.colSpan ?? 1
-
-      // 枝問2つ以上 → 横配置行から抽出
-      if (sub.branchQuestions.length >= 2) {
-        flushBatch()
-        rows.push({ type: "vertical-sub", sub, subIndex: si })
-        si++
-        consumed += span
-        continue
-      }
-
-      batch.push({ sub, subIndex: si, colStart: batchCols, span })
-      batchCols += span
-      si++
-      consumed += span
-    }
-
-    flushBatch()
-  }
-
-  // 配列を使い切った残り → 全て vertical-sub
-  while (si < subQuestions.length) {
-    rows.push({
-      type: "vertical-sub",
-      sub: subQuestions[si],
-      subIndex: si,
-    })
-    si++
-  }
-
-  return rows
+interface RowTrack {
+  y: number
+  rightX: number
+  maxH: number
 }
 
 /**
- * 枝問を BranchLayoutRow[] に変換する。
- * - columnsPerRow が空/undefined → 全て vertical-branch
- * - 配列の各要素を順に消費して横配置行を生成
- * - 配列を使い切った残りは全て vertical-branch
+ * 汎用グリッドレイアウトビルダー
+ * layoutWidth を持つ要素が1つでもあれば横配置モード。
  */
-function buildBranchLayoutRows(
-  branchQuestions: BranchQuestion[],
-  columnsPerRow: number[] | undefined
-): BranchLayoutRow[] {
-  if (!columnsPerRow || columnsPerRow.length === 0) {
-    return branchQuestions.map((branch, bi) => ({
-      type: "vertical-branch" as const,
-      branch,
-      branchIndex: bi,
-    }))
-  }
-
-  const rows: BranchLayoutRow[] = []
-  let bi = 0
-  let specIdx = 0
-
-  while (bi < branchQuestions.length && specIdx < columnsPerRow.length) {
-    const rowSpec = columnsPerRow[specIdx]
-    specIdx++
-
-    let consumed = 0
-    const batch: {
-      branch: BranchQuestion
-      branchIndex: number
-      colStart: number
-      span: number
-    }[] = []
-    let batchCols = 0
-
-    while (consumed < rowSpec && bi < branchQuestions.length) {
-      const branch = branchQuestions[bi]
-      const span = branch.colSpan ?? 1
-      batch.push({ branch, branchIndex: bi, colStart: batchCols, span })
-      batchCols += span
-      bi++
-      consumed += span
-    }
-
-    if (batch.length > 0) {
-      rows.push({ type: "horizontal", branches: batch, columns: batchCols })
-    }
-  }
-
-  // 配列を使い切った残り → 全て vertical-branch
-  while (bi < branchQuestions.length) {
-    rows.push({
-      type: "vertical-branch",
-      branch: branchQuestions[bi],
-      branchIndex: bi,
+export function buildGridLayout<
+  T extends {
+    layoutWidth?: string
+    nextPlacement?: NextPlacement
+    goUp?: number
+    heightMultiplier: number
+  },
+>(items: T[]): GridCell<T>[] {
+  const isHorizontal = items.some((item) => item.layoutWidth != null)
+  if (!isHorizontal) {
+    let y = 0
+    return items.map((item, i) => {
+      const cell: GridCell<T> = {
+        item,
+        itemIndex: i,
+        x: 0,
+        y,
+        width: 1,
+        height: item.heightMultiplier,
+      }
+      y += item.heightMultiplier
+      return cell
     })
-    bi++
   }
 
-  return rows
+  const cells: GridCell<T>[] = []
+  const rows: RowTrack[] = [{ y: 0, rightX: 0, maxH: 0 }]
+  let curRowIdx = 0
+  let curX = 0
+  let blockLeftX = 0
+  let lastCellBottom = 0 // 最後に配置したセルの下端Y（goUpブロック内の行スキップ用）
+
+  /** 次の行に進む。既存行の再利用 → ブロック内中間行の作成 → ブロック脱出 の順で試行。 */
+  function advanceRow(nextW: number) {
+    let advanced = false
+
+    if (blockLeftX + nextW <= 1 + 1e-9) {
+      // 幅的にブロック内に収まる → lastCellBottom に一致する既存行を探す
+      for (let r = 0; r < rows.length; r++) {
+        if (Math.abs(rows[r].y - lastCellBottom) < 1e-9) {
+          curRowIdx = r
+          curX = blockLeftX
+          advanced = true
+          break
+        }
+      }
+    }
+
+    if (!advanced) {
+      // グリッド全体の下端を計算
+      let gridBottom = 0
+      for (const r of rows) {
+        gridBottom = Math.max(gridBottom, r.y + r.maxH)
+      }
+
+      if (
+        blockLeftX > 1e-9 &&
+        blockLeftX + nextW <= 1 + 1e-9 &&
+        lastCellBottom < gridBottom - 1e-9
+      ) {
+        // goUpブロック内でグリッド高さ内に収まる → 中間行を作成
+        curRowIdx = rows.length
+        rows.push({ y: lastCellBottom, rightX: 0, maxH: 0 })
+        curX = blockLeftX
+      } else {
+        // goUpブロックを抜ける or 幅超過 → 新しい行を末尾に追加
+        const newY = Math.max(gridBottom, lastCellBottom)
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    const w = parseFraction(item.layoutWidth ?? "1")
+    const h = item.heightMultiplier
+
+    // goUp: この要素自身をN行上に戻して配置
+    if (item.goUp != null && item.goUp > 0) {
+      const targetIdx = Math.max(0, curRowIdx - item.goUp)
+      let maxRightX = 0
+      for (let r = targetIdx; r <= curRowIdx; r++) {
+        maxRightX = Math.max(maxRightX, rows[r].rightX)
+      }
+      curRowIdx = targetIdx
+      curX = maxRightX
+      blockLeftX = maxRightX
+
+      // goUp先に空きがない場合、全行の末尾に新しい行を追加
+      if (curX + w > 1 + 1e-9) {
+        const lastRow = rows[rows.length - 1]
+        const newY = Math.max(lastRow.y + lastRow.maxH, lastCellBottom)
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+
+    // 配置前チェック: この項目を置くと1を超える場合、先に改行
+    if (curX > blockLeftX + 1e-9 && curX + w > 1 + 1e-9) {
+      advanceRow(w)
+    }
+
+    cells.push({
+      item,
+      itemIndex: i,
+      x: curX,
+      y: rows[curRowIdx].y,
+      width: w,
+      height: h,
+    })
+
+    lastCellBottom = rows[curRowIdx].y + h
+    rows[curRowIdx].rightX = Math.max(rows[curRowIdx].rightX, curX + w)
+    rows[curRowIdx].maxH = Math.max(rows[curRowIdx].maxH, h)
+
+    const np = item.nextPlacement ?? "inline"
+    if (np === "inline") {
+      curX += w
+    } else if (np === "break") {
+      if (blockLeftX > 1e-9) {
+        // goUpブロック内の break → ブロック残幅で既存行を検索
+        advanceRow(1 - blockLeftX)
+      } else {
+        // 通常の break → 新しい行を追加
+        const lastRow = rows[rows.length - 1]
+        const newY = lastRow.y + lastRow.maxH
+        curRowIdx = rows.length
+        rows.push({ y: newY, rightX: 0, maxH: 0 })
+        curX = 0
+        blockLeftX = 0
+      }
+    }
+  }
+  return cells
+}
+
+function buildSubGridLayout(subQuestions: SubQuestion[]): SubGridCell[] {
+  // 枝問がある小問は、枝問レイアウトの要求高さで heightMultiplier を上書き
+  const adjusted = subQuestions.map((sub) => {
+    if (sub.branchQuestions.length === 0) return sub
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+    const branchHeight = gridTotalHeight(branchCells)
+    if (branchHeight !== sub.heightMultiplier) {
+      return { ...sub, heightMultiplier: branchHeight }
+    }
+    return sub
+  })
+  return buildGridLayout(adjusted)
+}
+
+function buildBranchGridLayout(
+  branchQuestions: BranchQuestion[]
+): BranchGridCell[] {
+  return buildGridLayout(branchQuestions)
+}
+
+export function isGridHorizontal<T extends { layoutWidth?: string }>(
+  items: T[]
+): boolean {
+  return items.some((item) => item.layoutWidth != null)
+}
+
+export function gridTotalHeight<T>(cells: GridCell<T>[]): number {
+  if (cells.length === 0) return 0
+  return Math.max(...cells.map((c) => c.y + c.height))
+}
+
+/** グリッドセルからY区間ごとの右端X座標を計算（ステップ外枠描画用） */
+function computeGridRowRightEdges<T>(
+  gridCells: GridCell<T>[],
+  areaStartY: number,
+  areaX: number,
+  areaWidth: number,
+  baseRowHeight: number
+): { yTop: number; yBottom: number; rightX: number }[] {
+  // 全セルのY境界を収集
+  const ySet = new Set<number>()
+  const absCells: { y: number; yEnd: number; rightX: number }[] = []
+  for (const gc of gridCells) {
+    const cellY = areaStartY + gc.y * baseRowHeight
+    const cellYEnd = cellY + gc.height * baseRowHeight
+    const cellRightX = areaX + (gc.x + gc.width) * areaWidth
+    ySet.add(cellY)
+    ySet.add(cellYEnd)
+    absCells.push({ y: cellY, yEnd: cellYEnd, rightX: cellRightX })
+  }
+
+  const sortedYs = Array.from(ySet).sort((a, b) => a - b)
+  const result: { yTop: number; yBottom: number; rightX: number }[] = []
+
+  for (let i = 0; i < sortedYs.length - 1; i++) {
+    const yTop = sortedYs[i]
+    const yBottom = sortedYs[i + 1]
+    const midY = (yTop + yBottom) / 2
+
+    let maxRightX = 0
+    for (const cell of absCells) {
+      if (cell.y <= midY + 1e-9 && cell.yEnd >= midY - 1e-9) {
+        maxRightX = Math.max(maxRightX, cell.rightX)
+      }
+    }
+
+    if (maxRightX > 0) {
+      // 前の区間と同じrightXなら結合
+      if (
+        result.length > 0 &&
+        Math.abs(result[result.length - 1].rightX - maxRightX) < 0.01
+      ) {
+        result[result.length - 1].yBottom = yBottom
+      } else {
+        result.push({ yTop, yBottom, rightX: maxRightX })
+      }
+    }
+  }
+
+  return result
 }
 
 function computeSubHeight(sub: SubQuestion, baseRowHeight: number): number {
   if (sub.branchQuestions.length > 0) {
-    const branchRows = buildBranchLayoutRows(
-      sub.branchQuestions,
-      sub.branchHorizontalColumnsPerRow
-    )
-    return branchRows.reduce((sum, row) => {
-      if (row.type === "horizontal") {
-        const maxH = Math.max(
-          ...row.branches.map((b) => b.branch.heightMultiplier),
-          1
-        )
-        return sum + maxH * baseRowHeight
-      }
-      return sum + row.branch.heightMultiplier * baseRowHeight
-    }, 0)
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+    return gridTotalHeight(branchCells) * baseRowHeight
   }
   if (sub.manuscriptPaper?.enabled) {
     return sub.manuscriptPaper.rows * sub.manuscriptPaper.cellSizeMm
@@ -798,17 +804,221 @@ function computeMajorHeight(
   major: MajorQuestion,
   baseRowHeight: number
 ): number {
-  const layoutRows = buildLayoutRows(
-    major.subQuestions,
-    major.horizontalColumnsPerRow
+  if (isGridHorizontal(major.subQuestions)) {
+    const gridCells = buildSubGridLayout(major.subQuestions)
+    return gridTotalHeight(gridCells) * baseRowHeight
+  }
+  return major.subQuestions.reduce(
+    (sum, sub) => sum + computeSubHeight(sub, baseRowHeight),
+    0
   )
-  return layoutRows.reduce((sum, row) => {
-    if (row.type === "horizontal") {
-      const maxH = Math.max(...row.subs.map((s) => s.sub.heightMultiplier), 1)
-      return sum + maxH * baseRowHeight
+}
+
+/** グリッドセル間の区切り線を描画 */
+function renderGridDividerLines<
+  T extends {
+    layoutWidth?: string
+    nextPlacement?: NextPlacement
+    heightMultiplier: number
+  },
+>(
+  gridCells: GridCell<T>[],
+  areaStartY: number,
+  areaX: number,
+  areaWidth: number,
+  baseRowHeight: number,
+  settings: GlobalSettings,
+  lines: ComputedLine[],
+  level: "sub" | "branch"
+) {
+  const lineType = level === "sub" ? "subHorizontalDivider" : "branch"
+  const divStyle =
+    level === "sub"
+      ? settings.borderConfig.subDivider
+      : settings.borderConfig.branchDivider
+  const divSw = getLineWidth(lineType, settings.borderConfig)
+
+  for (let i = 0; i < gridCells.length; i++) {
+    const a = gridCells[i]
+    for (let j = i + 1; j < gridCells.length; j++) {
+      const b = gridCells[j]
+
+      const aRight = a.x + a.width
+      const bLeft = b.x
+      if (Math.abs(aRight - bLeft) < 1e-9) {
+        const overlapTop = Math.max(a.y, b.y)
+        const overlapBottom = Math.min(a.y + a.height, b.y + b.height)
+        if (overlapBottom > overlapTop + 1e-9) {
+          const lineX = areaX + aRight * areaWidth
+          lines.push({
+            x1: lineX,
+            y1: areaStartY + overlapTop * baseRowHeight,
+            x2: lineX,
+            y2: areaStartY + overlapBottom * baseRowHeight,
+            style: divStyle,
+            lineType,
+            strokeWidth: divSw,
+          })
+        }
+      }
+
+      const aBottom = a.y + a.height
+      const bTop = b.y
+      if (Math.abs(aBottom - bTop) < 1e-9) {
+        const overlapLeft = Math.max(a.x, b.x)
+        const overlapRight = Math.min(a.x + a.width, b.x + b.width)
+        if (overlapRight > overlapLeft + 1e-9) {
+          const lineY = areaStartY + aBottom * baseRowHeight
+          lines.push({
+            x1: areaX + overlapLeft * areaWidth,
+            y1: lineY,
+            x2: areaX + overlapRight * areaWidth,
+            y2: lineY,
+            style: divStyle,
+            lineType,
+            strokeWidth: divSw,
+          })
+        }
+      }
     }
-    return sum + computeSubHeight(row.sub, baseRowHeight)
-  }, 0)
+  }
+}
+
+/** 枝問の描画（横配置・縦配置両対応） */
+function renderBranchQuestions(
+  sub: SubQuestion,
+  mi: number,
+  si: number,
+  majorLabel: string,
+  subStartY: number,
+  pageIndex: number,
+  subNumX: number,
+  subNumWidth: number,
+  branchNumX: number,
+  branchNumWidth: number,
+  answerX: number,
+  answerWidth: number,
+  contentRight: number,
+  baseRowHeight: number,
+  paper: { width: number; height: number },
+  settings: GlobalSettings,
+  cells: ComputedCell[],
+  lines: ComputedLine[],
+  numberLabels: ComputedNumberLabel[],
+  _rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
+) {
+  const branchIsHorizontal = isGridHorizontal(sub.branchQuestions)
+
+  if (branchIsHorizontal) {
+    const branchAreaX = subNumX + subNumWidth
+    const branchAreaWidth = contentRight - branchAreaX
+    const branchCells = buildBranchGridLayout(sub.branchQuestions)
+
+    for (const gc of branchCells) {
+      const cellX = branchAreaX + gc.x * branchAreaWidth
+      const cellWidth = gc.width * branchAreaWidth
+      const cellY = subStartY + gc.y * baseRowHeight
+      const cellHeight = gc.height * baseRowHeight
+
+      numberLabels.push({
+        text: gc.item.label,
+        x: cellX,
+        y: cellY,
+        width: branchNumWidth,
+        height: cellHeight,
+        fontSize: settings.fonts.numberSize - 1,
+        displayMode: "branch-horizontal",
+      })
+
+      cells.push(
+        createCell(
+          [mi, si, gc.itemIndex],
+          cellX + branchNumWidth,
+          cellY,
+          cellWidth - branchNumWidth,
+          cellHeight,
+          paper,
+          `${majorLabel}-${sub.label}-${gc.item.label}`,
+          gc.item.points,
+          gc.item.textElements,
+          gc.item.modelAnswer,
+          "answer",
+          pageIndex,
+          undefined,
+          gc.item.omrConfig
+        )
+      )
+
+      lines.push({
+        x1: cellX + branchNumWidth,
+        y1: cellY,
+        x2: cellX + branchNumWidth,
+        y2: cellY + cellHeight,
+        style: settings.borderConfig.numberColumnDivider,
+        lineType: "numberColumn",
+        strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+      })
+    }
+
+    renderGridDividerLines(
+      branchCells,
+      subStartY,
+      branchAreaX,
+      branchAreaWidth,
+      baseRowHeight,
+      settings,
+      lines,
+      "branch"
+    )
+  } else {
+    let branchY = subStartY
+    sub.branchQuestions.forEach((branch, bi) => {
+      const branchHeight = branch.heightMultiplier * baseRowHeight
+
+      numberLabels.push({
+        text: branch.label,
+        x: branchNumX,
+        y: branchY,
+        width: branchNumWidth,
+        height: branchHeight,
+        fontSize: settings.fonts.numberSize - 1,
+        displayMode: "branch",
+      })
+
+      cells.push(
+        createCell(
+          [mi, si, bi],
+          answerX,
+          branchY,
+          answerWidth,
+          branchHeight,
+          paper,
+          `${majorLabel}-${sub.label}-${branch.label}`,
+          branch.points,
+          branch.textElements,
+          branch.modelAnswer,
+          "answer",
+          pageIndex,
+          undefined,
+          branch.omrConfig
+        )
+      )
+
+      if (bi < sub.branchQuestions.length - 1) {
+        lines.push({
+          x1: branchNumX,
+          y1: branchY + branchHeight,
+          x2: contentRight,
+          y2: branchY + branchHeight,
+          style: settings.borderConfig.branchDivider,
+          lineType: "branch",
+          strokeWidth: getLineWidth("branch", settings.borderConfig),
+        })
+      }
+
+      branchY += branchHeight
+    })
+  }
 }
 
 function createCell(
@@ -947,6 +1157,132 @@ function addOuterBorderLines(
   })
 }
 
+/**
+ * ステップ外枠描画: partial行がある場合、右辺と下辺をL字型に凹ませる。
+ * 全行がcontentRightまで到達している場合は通常の矩形外枠を描画。
+ */
+function addSteppedBorderLines(
+  lines: ComputedLine[],
+  contentLeft: number,
+  contentTop: number,
+  contentRight: number,
+  contentBottom: number,
+  style: LineStyle,
+  borderConfig: BorderConfig,
+  rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
+): void {
+  const sw = getLineWidth("outer", borderConfig)
+
+  // 全行がcontentRightに到達しているか確認
+  const hasPartialRow = rowRightEdges.some(
+    (r) => Math.abs(r.rightX - contentRight) > 0.01
+  )
+
+  if (!hasPartialRow) {
+    addOuterBorderLines(
+      lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      contentBottom,
+      style,
+      borderConfig
+    )
+    return
+  }
+
+  if (rowRightEdges.length === 0) {
+    addOuterBorderLines(
+      lines,
+      contentLeft,
+      contentTop,
+      contentRight,
+      contentBottom,
+      style,
+      borderConfig
+    )
+    return
+  }
+
+  // 上辺: 最初の行のrightXまで
+  const topRightX = rowRightEdges[0].rightX
+  lines.push({
+    x1: contentLeft,
+    y1: contentTop,
+    x2: topRightX,
+    y2: contentTop,
+    style,
+    strokeWidth: sw,
+    lineType: "outer",
+  })
+
+  // 左辺: 常にフル高
+  lines.push({
+    x1: contentLeft,
+    y1: contentTop,
+    x2: contentLeft,
+    y2: contentBottom,
+    style,
+    strokeWidth: sw,
+    lineType: "outer",
+  })
+
+  // 右辺 + 下辺: ステップ描画
+  let curY = contentTop
+  let curRightX = topRightX
+
+  for (let i = 1; i < rowRightEdges.length; i++) {
+    const edge = rowRightEdges[i]
+
+    if (Math.abs(edge.rightX - curRightX) > 0.01) {
+      // 垂直線: curRightX で curY → edge.yTop
+      lines.push({
+        x1: curRightX,
+        y1: curY,
+        x2: curRightX,
+        y2: edge.yTop,
+        style,
+        strokeWidth: sw,
+        lineType: "outer",
+      })
+      // 水平線: curRightX → edge.rightX at edge.yTop
+      lines.push({
+        x1: Math.min(curRightX, edge.rightX),
+        y1: edge.yTop,
+        x2: Math.max(curRightX, edge.rightX),
+        y2: edge.yTop,
+        style,
+        strokeWidth: sw,
+        lineType: "outer",
+      })
+      curY = edge.yTop
+      curRightX = edge.rightX
+    }
+  }
+
+  // 最後の行の下端まで右辺を描画
+  lines.push({
+    x1: curRightX,
+    y1: curY,
+    x2: curRightX,
+    y2: contentBottom,
+    style,
+    strokeWidth: sw,
+    lineType: "outer",
+  })
+
+  // 下辺: contentBottom で curRightX → contentLeft
+  lines.push({
+    x1: contentLeft,
+    y1: contentBottom,
+    x2: curRightX,
+    y2: contentBottom,
+    style,
+    strokeWidth: sw,
+    lineType: "outer",
+  })
+}
+
 function addNumberColumnLines(
   lines: ComputedLine[],
   x: number,
@@ -1033,6 +1369,8 @@ export function computeMultiPageLayout(
     verticalRanges: { top: number; bottom: number }[]
     /** vertical-branch行のY範囲（枝問番号列用） */
     branchVerticalRanges: { top: number; bottom: number }[]
+    /** 各行の右端X座標（ステップ外枠描画用） */
+    rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
     contentBottomY: number
   }
 
@@ -1043,6 +1381,7 @@ export function computeMultiPageLayout(
       numberLabels: [],
       verticalRanges: [],
       branchVerticalRanges: [],
+      rowRightEdges: [],
       contentBottomY: contentTop,
     }
   }
@@ -1089,87 +1428,121 @@ export function computeMultiPageLayout(
       })
     }
 
-    const layoutRows = buildLayoutRows(
-      major.subQuestions,
-      major.horizontalColumnsPerRow
-    )
     const horizontalAreaX = majorNumX + majorNumWidth
     const horizontalAreaWidth = contentRight - horizontalAreaX
+    const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
-    let vertSegStart: number | null = null
+    if (subIsHorizontal) {
+      const gridCells = buildSubGridLayout(major.subQuestions)
+      for (const gc of gridCells) {
+        const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const cellWidth = gc.width * horizontalAreaWidth
+        const cellY = majorStartY + gc.y * baseRowHeight
+        const cellHeight = gc.height * baseRowHeight
+        const sub = gc.item
+        const hasBranches = sub.branchQuestions.length > 0
 
-    layoutRows.forEach((row, ri) => {
-      if (row.type === "horizontal") {
-        // vertical-sub セグメントをフラッシュ
-        if (vertSegStart !== null) {
-          page.verticalRanges.push({ top: vertSegStart, bottom: localY })
-          vertSegStart = null
-        }
-
-        const rowMaxH = Math.max(
-          ...row.subs.map((s) => s.sub.heightMultiplier),
-          1
-        )
-        const rowHeight = rowMaxH * baseRowHeight
-        const unitWidth = horizontalAreaWidth / row.columns
-
-        row.subs.forEach((entry) => {
-          const cellX = horizontalAreaX + entry.colStart * unitWidth
-          const cellWidth = entry.span * unitWidth
-
-          page.numberLabels.push({
-            text: entry.sub.label,
-            x: cellX,
-            y: localY,
-            width: cellWidth,
-            height: rowHeight,
-            fontSize: settings.fonts.numberSize,
-            displayMode: "sub-horizontal",
-          })
-
-          page.cells.push(
-            createCell(
-              [mi, entry.subIndex],
-              cellX,
-              localY,
-              cellWidth,
-              rowHeight,
-              paper,
-              `${major.label}-${entry.sub.label}`,
-              entry.sub.points,
-              entry.sub.textElements,
-              entry.sub.modelAnswer,
-              "answer",
-              pageIdx,
-              computeManuscriptGrid(entry.sub, cellX, localY, cellWidth),
-              entry.sub.omrConfig
-            )
-          )
-
-          const cellRight = cellX + cellWidth
-          if (Math.abs(cellRight - contentRight) > 0.01) {
-            page.lines.push({
-              x1: cellRight,
-              y1: localY,
-              x2: cellRight,
-              y2: localY + rowHeight,
-              style: settings.borderConfig.subDivider,
-              strokeWidth: getLineWidth(
-                "subHorizontalDivider",
-                settings.borderConfig
-              ),
-              lineType: "subHorizontalDivider",
-            })
-          }
+        page.numberLabels.push({
+          text: sub.label,
+          x: cellX,
+          y: cellY,
+          width: subNumWidth,
+          height: cellHeight,
+          fontSize: settings.fonts.numberSize,
+          displayMode: "sub-horizontal",
         })
 
-        localY += rowHeight
-      } else {
-        // vertical-sub
-        if (vertSegStart === null) vertSegStart = localY
+        if (hasBranches) {
+          const cellBranchNumX = cellX + subNumWidth
+          const cellBranchNumWidth = branchNumWidth
+          const cellAnswerX = cellBranchNumX + cellBranchNumWidth
+          const cellAnswerWidth = cellWidth - subNumWidth - cellBranchNumWidth
+          const cellRight = cellX + cellWidth
+          renderBranchQuestions(
+            sub,
+            mi,
+            gc.itemIndex,
+            major.label,
+            cellY,
+            pageIdx,
+            cellX,
+            subNumWidth,
+            cellBranchNumX,
+            cellBranchNumWidth,
+            cellAnswerX,
+            cellAnswerWidth,
+            cellRight,
+            baseRowHeight,
+            paper,
+            settings,
+            page.cells,
+            page.lines,
+            page.numberLabels,
+            page.rowRightEdges
+          )
+        } else {
+          page.cells.push(
+            createCell(
+              [mi, gc.itemIndex],
+              cellX + subNumWidth,
+              cellY,
+              cellWidth - subNumWidth,
+              cellHeight,
+              paper,
+              `${major.label}-${sub.label}`,
+              sub.points,
+              sub.textElements,
+              sub.modelAnswer,
+              "answer",
+              pageIdx,
+              computeManuscriptGrid(
+                sub,
+                cellX + subNumWidth,
+                cellY,
+                cellWidth - subNumWidth
+              ),
+              sub.omrConfig
+            )
+          )
+        }
 
-        const sub = row.sub
-        const si = row.subIndex
+        page.lines.push({
+          x1: cellX + subNumWidth,
+          y1: cellY,
+          x2: cellX + subNumWidth,
+          y2: cellY + cellHeight,
+          style: settings.borderConfig.numberColumnDivider,
+          strokeWidth: getLineWidth("numberColumn", settings.borderConfig),
+          lineType: "numberColumn",
+        })
+      }
+
+      // rowRightEdges: Y区間ごとの右端X座標を計算
+      for (const edge of computeGridRowRightEdges(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight
+      )) {
+        page.rowRightEdges.push(edge)
+      }
+
+      renderGridDividerLines(
+        gridCells,
+        majorStartY,
+        horizontalAreaX,
+        horizontalAreaWidth,
+        baseRowHeight,
+        settings,
+        page.lines,
+        "sub"
+      )
+
+      localY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
+    } else {
+      const vertSegStart = localY
+      major.subQuestions.forEach((sub, si) => {
         const subStartY = localY
         const hasBranches = sub.branchQuestions.length > 0
         const subHeight = computeSubHeight(sub, baseRowHeight)
@@ -1185,143 +1558,33 @@ export function computeMultiPageLayout(
         })
 
         if (hasBranches) {
-          const branchRows = buildBranchLayoutRows(
-            sub.branchQuestions,
-            sub.branchHorizontalColumnsPerRow
+          renderBranchQuestions(
+            sub,
+            mi,
+            si,
+            major.label,
+            subStartY,
+            pageIdx,
+            subNumX,
+            subNumWidth,
+            branchNumX,
+            branchNumWidth,
+            answerX,
+            answerWidth,
+            contentRight,
+            baseRowHeight,
+            paper,
+            settings,
+            page.cells,
+            page.lines,
+            page.numberLabels,
+            page.rowRightEdges
           )
-          const branchAreaX = subNumX + subNumWidth
-          const branchAreaWidth = contentRight - branchAreaX
-          let branchY = subStartY
-          let bVertSegStart: number | null = null
 
-          branchRows.forEach((bRow, bri) => {
-            if (bRow.type === "horizontal") {
-              // branchVerticalRanges セグメントをフラッシュ
-              if (bVertSegStart !== null) {
-                page.branchVerticalRanges.push({
-                  top: bVertSegStart,
-                  bottom: branchY,
-                })
-                bVertSegStart = null
-              }
-
-              const rowMaxH = Math.max(
-                ...bRow.branches.map((b) => b.branch.heightMultiplier),
-                1
-              )
-              const bRowHeight = rowMaxH * baseRowHeight
-              const unitWidth = branchAreaWidth / bRow.columns
-
-              bRow.branches.forEach((entry) => {
-                const cellX = branchAreaX + entry.colStart * unitWidth
-                const cellWidth = entry.span * unitWidth
-
-                page.numberLabels.push({
-                  text: entry.branch.label,
-                  x: cellX,
-                  y: branchY,
-                  width: cellWidth,
-                  height: bRowHeight,
-                  fontSize: settings.fonts.numberSize - 1,
-                  displayMode: "branch-horizontal",
-                })
-
-                page.cells.push(
-                  createCell(
-                    [mi, si, entry.branchIndex],
-                    cellX,
-                    branchY,
-                    cellWidth,
-                    bRowHeight,
-                    paper,
-                    `${major.label}-${sub.label}-${entry.branch.label}`,
-                    entry.branch.points,
-                    entry.branch.textElements,
-                    entry.branch.modelAnswer,
-                    "answer",
-                    pageIdx,
-                    undefined,
-                    entry.branch.omrConfig
-                  )
-                )
-
-                const cellRight = cellX + cellWidth
-                if (Math.abs(cellRight - contentRight) > 0.01) {
-                  page.lines.push({
-                    x1: cellRight,
-                    y1: branchY,
-                    x2: cellRight,
-                    y2: branchY + bRowHeight,
-                    style: settings.borderConfig.branchDivider,
-                    strokeWidth: getLineWidth("branch", settings.borderConfig),
-                    lineType: "branch",
-                  })
-                }
-              })
-
-              branchY += bRowHeight
-            } else {
-              if (bVertSegStart === null) bVertSegStart = branchY
-
-              const branch = bRow.branch
-              const branchHeight = branch.heightMultiplier * baseRowHeight
-
-              page.numberLabels.push({
-                text: branch.label,
-                x: branchNumX,
-                y: branchY,
-                width: branchNumWidth,
-                height: branchHeight,
-                fontSize: settings.fonts.numberSize - 1,
-                displayMode: "branch",
-              })
-
-              page.cells.push(
-                createCell(
-                  [mi, si, bRow.branchIndex],
-                  answerX,
-                  branchY,
-                  answerWidth,
-                  branchHeight,
-                  paper,
-                  `${major.label}-${sub.label}-${branch.label}`,
-                  branch.points,
-                  branch.textElements,
-                  branch.modelAnswer,
-                  "answer",
-                  pageIdx,
-                  undefined,
-                  branch.omrConfig
-                )
-              )
-
-              branchY += branchHeight
-            }
-
-            // 枝問行間の区切り線
-            if (bri < branchRows.length - 1) {
-              const nextBRow = branchRows[bri + 1]
-              const lineX =
-                bRow.type === "horizontal" || nextBRow.type === "horizontal"
-                  ? branchAreaX
-                  : branchNumX
-              page.lines.push({
-                x1: lineX,
-                y1: branchY,
-                x2: contentRight,
-                y2: branchY,
-                style: settings.borderConfig.branchDivider,
-                strokeWidth: getLineWidth("branch", settings.borderConfig),
-                lineType: "branch",
-              })
-            }
-          })
-
-          // 残りの branchVerticalRanges セグメントをフラッシュ
-          if (bVertSegStart !== null) {
+          if (!isGridHorizontal(sub.branchQuestions)) {
             page.branchVerticalRanges.push({
-              top: bVertSegStart,
-              bottom: branchY,
+              top: subStartY,
+              bottom: subStartY + subHeight,
             })
           }
         } else {
@@ -1345,28 +1608,17 @@ export function computeMultiPageLayout(
           )
         }
 
-        localY += subHeight
-      }
+        page.rowRightEdges.push({
+          yTop: subStartY,
+          yBottom: subStartY + subHeight,
+          rightX: contentRight,
+        })
 
-      // 行間の区切り線（最後の行以外）
-      if (ri < layoutRows.length - 1) {
-        const nextRow = layoutRows[ri + 1]
-        if (row.type === "horizontal" && nextRow.type === "horizontal") {
+        localY += subHeight
+
+        if (si < major.subQuestions.length - 1) {
           page.lines.push({
-            x1: horizontalAreaX,
-            y1: localY,
-            x2: contentRight,
-            y2: localY,
-            style: settings.borderConfig.subDivider,
-            strokeWidth: getLineWidth(
-              "subHorizontalDivider",
-              settings.borderConfig
-            ),
-            lineType: "subHorizontalDivider",
-          })
-        } else {
-          page.lines.push({
-            x1: row.type === "horizontal" ? horizontalAreaX : subNumX,
+            x1: subNumX,
             y1: localY,
             x2: contentRight,
             y2: localY,
@@ -1375,11 +1627,8 @@ export function computeMultiPageLayout(
             lineType: "sub",
           })
         }
-      }
-    })
+      })
 
-    // 残りの vertical-sub セグメントをフラッシュ
-    if (vertSegStart !== null) {
       page.verticalRanges.push({ top: vertSegStart, bottom: localY })
     }
 
@@ -1405,7 +1654,16 @@ export function computeMultiPageLayout(
       pagesData.push(newPageData())
       currentY = contentTop
     } else {
-      currentY += spacingHeight
+      if (spacingHeight > 0) {
+        // 大問間スペーシングのrightX追跡
+        const spacingTop = currentY
+        currentY += spacingHeight
+        pagesData[currentPageIdx].rowRightEdges.push({
+          yTop: spacingTop,
+          yBottom: currentY,
+          rightX: contentRight,
+        })
+      }
     }
 
     currentY = layoutMajorOnPage(
@@ -1449,14 +1707,16 @@ export function computeMultiPageLayout(
       pd.lines.pop()
     }
 
-    // 外枠線
-    addOuterBorderLines(
+    // 外枠線（ステップ形状対応）
+    addSteppedBorderLines(
       pd.lines,
       contentLeft,
       contentTop,
       contentRight,
       pageContentBottom,
-      settings.borderConfig.outerBorder
+      settings.borderConfig.outerBorder,
+      settings.borderConfig,
+      pd.rowRightEdges
     )
 
     // 大問番号列の縦線（全高）

--- a/electron-src/lib/answer-sheet-builder/pngGenerator.ts
+++ b/electron-src/lib/answer-sheet-builder/pngGenerator.ts
@@ -2,6 +2,7 @@
  * PNG生成（SVG文字列 → sharp）
  *
  * AnswerSheetDefinition → SVG文字列 → sharp PNG変換
+ * 複数ページ対応: ページごとに個別PNGファイルを生成
  */
 
 import fs from "fs"
@@ -9,15 +10,13 @@ import path from "path"
 import sharp from "sharp"
 
 import type { AnswerSheetDefinition } from "../../../types/answerSheetBuilder.types"
-import { computeLayout } from "./layoutEngine"
-import { renderSvgString } from "./svgRenderer"
+import { computeMultiPageLayout } from "./layoutEngine"
+import { renderMultiPageSvgStrings } from "./svgRenderer"
 
 /**
  * 解答用紙をPNG画像として出力
- * @param definition 解答用紙定義
- * @param outputPath 出力先パス
- * @param dpi 出力DPI（デフォルト: 300）
- * @param svgString 外部で生成済みのSVG文字列（MathJax処理済みなど）
+ * 複数ページの場合: name-1.png, name-2.png, ... を生成
+ * 単一ページの場合: name.png を生成（後方互換）
  */
 export async function generatePng(
   definition: AnswerSheetDefinition,
@@ -25,41 +24,74 @@ export async function generatePng(
   dpi: number = 300,
   svgString?: string
 ): Promise<void> {
-  const layout = computeLayout(definition)
-
-  // DPIからピクセルサイズを計算 (1インチ = 25.4mm)
-  const widthPx = Math.round((layout.pageWidthMm / 25.4) * dpi)
-  const heightPx = Math.round((layout.pageHeightMm / 25.4) * dpi)
-
-  // SVG文字列を生成（外部提供がなければサーバーサイドで生成）
-  const svg = svgString ?? renderSvgString(layout, definition.renderMode)
-
-  // SVGのviewBoxを出力サイズに合わせて変換
-  const svgBuffer = Buffer.from(svg)
+  const multiLayout = computeMultiPageLayout(definition)
+  const widthPx = Math.round((multiLayout.pageWidthMm / 25.4) * dpi)
+  const heightPx = Math.round((multiLayout.pageHeightMm / 25.4) * dpi)
 
   const outputDir = path.dirname(outputPath)
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true })
   }
 
-  await sharp(svgBuffer).resize(widthPx, heightPx).png().toFile(outputPath)
+  if (multiLayout.totalPages === 1) {
+    // 単一ページ: 後方互換（元のファイル名をそのまま使用）
+    const svg =
+      svgString ??
+      renderMultiPageSvgStrings(multiLayout, definition.renderMode)[0]
+    const svgBuffer = Buffer.from(svg)
+    await sharp(svgBuffer).resize(widthPx, heightPx).png().toFile(outputPath)
+  } else {
+    // 複数ページ: name-1.png, name-2.png, ...
+    const svgStrings = renderMultiPageSvgStrings(
+      multiLayout,
+      definition.renderMode
+    )
+    const ext = path.extname(outputPath)
+    const base = outputPath.slice(0, -ext.length)
+
+    for (let i = 0; i < svgStrings.length; i++) {
+      const pagePath = `${base}-${i + 1}${ext}`
+      const svgBuffer = Buffer.from(svgStrings[i])
+      await sharp(svgBuffer).resize(widthPx, heightPx).png().toFile(pagePath)
+    }
+  }
 }
 
 /**
  * PNG画像をBufferとして生成（プロジェクト変換用）
+ * 複数ページ対応: Buffer[] を返す
  */
 export async function generatePngBuffer(
   definition: AnswerSheetDefinition,
   dpi: number = 300,
   svgString?: string
-): Promise<Buffer> {
-  const layout = computeLayout(definition)
+): Promise<Buffer[]> {
+  const multiLayout = computeMultiPageLayout(definition)
+  const widthPx = Math.round((multiLayout.pageWidthMm / 25.4) * dpi)
+  const heightPx = Math.round((multiLayout.pageHeightMm / 25.4) * dpi)
 
-  const widthPx = Math.round((layout.pageWidthMm / 25.4) * dpi)
-  const heightPx = Math.round((layout.pageHeightMm / 25.4) * dpi)
+  if (multiLayout.totalPages === 1 && svgString) {
+    const svgBuffer = Buffer.from(svgString)
+    const buf = await sharp(svgBuffer)
+      .resize(widthPx, heightPx)
+      .png()
+      .toBuffer()
+    return [buf]
+  }
 
-  const svg = svgString ?? renderSvgString(layout, definition.renderMode)
-  const svgBuffer = Buffer.from(svg)
+  const svgStrings = renderMultiPageSvgStrings(
+    multiLayout,
+    definition.renderMode
+  )
 
-  return sharp(svgBuffer).resize(widthPx, heightPx).png().toBuffer()
+  const buffers: Buffer[] = []
+  for (const svg of svgStrings) {
+    const svgBuffer = Buffer.from(svg)
+    const buf = await sharp(svgBuffer)
+      .resize(widthPx, heightPx)
+      .png()
+      .toBuffer()
+    buffers.push(buf)
+  }
+  return buffers
 }

--- a/electron-src/lib/answer-sheet-builder/svgRenderer.ts
+++ b/electron-src/lib/answer-sheet-builder/svgRenderer.ts
@@ -85,23 +85,11 @@ export function renderSvgString(
 
   // 番号ラベル
   for (const label of layout.numberLabels) {
-    if (
-      label.displayMode === "sub-horizontal" ||
-      label.displayMode === "branch-horizontal"
-    ) {
-      // 横配置時の小問ラベル: セル内左側に配置
-      const lx = label.x + 1
-      const ly = label.y + label.height / 2
-      parts.push(
-        `<text x="${lx}" y="${ly}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="start" dominant-baseline="central">${escapeXml(label.text)}</text>`
-      )
-    } else {
-      const cx = label.x + label.width / 2
-      const cy = label.y + label.height / 2
-      parts.push(
-        `<text x="${cx}" y="${cy}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central">${escapeXml(label.text)}</text>`
-      )
-    }
+    const cx = label.x + label.width / 2
+    const cy = label.y + label.height / 2
+    parts.push(
+      `<text x="${cx}" y="${cy}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central">${escapeXml(label.text)}</text>`
+    )
   }
 
   // 模範解答モード: セル内にmodelAnswerテキストを表示
@@ -208,22 +196,11 @@ export function renderPageSvgString(
   }
 
   for (const label of pageLayout.numberLabels) {
-    if (
-      label.displayMode === "sub-horizontal" ||
-      label.displayMode === "branch-horizontal"
-    ) {
-      const lx = label.x + 1
-      const ly = label.y + label.height / 2
-      parts.push(
-        `<text x="${lx}" y="${ly}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="start" dominant-baseline="central">${escapeXml(label.text)}</text>`
-      )
-    } else {
-      const cx = label.x + label.width / 2
-      const cy = label.y + label.height / 2
-      parts.push(
-        `<text x="${cx}" y="${cy}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central">${escapeXml(label.text)}</text>`
-      )
-    }
+    const cx = label.x + label.width / 2
+    const cy = label.y + label.height / 2
+    parts.push(
+      `<text x="${cx}" y="${cy}" font-size="${label.fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central">${escapeXml(label.text)}</text>`
+    )
   }
 
   if (renderMode === "model-answer") {

--- a/electron-src/lib/import/external-formats/hsz/hszConverter.ts
+++ b/electron-src/lib/import/external-formats/hsz/hszConverter.ts
@@ -110,7 +110,12 @@ export async function convertHszToScore(
       regionToCropIds,
       scorePCropIdByPart1,
       scoreRCropIdByRegion,
-    } = convertFieldsToCropRegions(sheet_fields, pageUuidMap, pageImageSizeMap, now)
+    } = convertFieldsToCropRegions(
+      sheet_fields,
+      pageUuidMap,
+      pageImageSizeMap,
+      now
+    )
 
     // 7. SubtotalGroup / Subtotal / CropSubtotal 生成
     const subtotalData = generateHszSubtotalData(

--- a/electron-src/lib/import/external-formats/reattendant/datConverter.ts
+++ b/electron-src/lib/import/external-formats/reattendant/datConverter.ts
@@ -160,8 +160,7 @@ export async function convertDatToScore(
     const masterImageEntries = entries
       .filter(
         (e) =>
-          e.entryName.includes("/Correct/abc_m") &&
-          e.entryName.endsWith(".png")
+          e.entryName.includes("/Correct/abc_m") && e.entryName.endsWith(".png")
       )
       .sort((a, b) => a.entryName.localeCompare(b.entryName))
 
@@ -229,9 +228,7 @@ export async function convertDatToScore(
       ? JSON.parse(questionsEntry.getData().toString("utf8"))
       : []
 
-    const anglesEntry = entries.find((e) =>
-      e.entryName.endsWith("angles.json")
-    )
+    const anglesEntry = entries.find((e) => e.entryName.endsWith("angles.json"))
     const angles: DatAngle[] = anglesEntry
       ? JSON.parse(anglesEntry.getData().toString("utf8"))
       : []
@@ -280,8 +277,7 @@ export async function convertDatToScore(
 
     // 13. プロジェクトデータ構築
     const subjectName =
-      DAT_SUBJECT_MAP[workbook.subject_id] ||
-      `教科${workbook.subject_id}`
+      DAT_SUBJECT_MAP[workbook.subject_id] || `教科${workbook.subject_id}`
     const projectTitle = `${contents.contents_name} ${workbook.workbook_name}`
 
     const projectData = {
@@ -443,9 +439,7 @@ function extractScoreAreasFromAbcXml(
   // TotalScoreArea, LargeQuestionScoreArea, AngleScoreArea は全て自己閉じタグ
 
   // TotalScoreArea
-  const totalMatches = abcXml.matchAll(
-    /<TotalScoreArea\s+([^/]*?)\/>/g
-  )
+  const totalMatches = abcXml.matchAll(/<TotalScoreArea\s+([^/]*?)\/>/g)
   for (const match of totalMatches) {
     const attrs = parseXmlAttributes(match[1])
     const page = parseInt(attrs.Page || "1", 10)
@@ -462,9 +456,7 @@ function extractScoreAreasFromAbcXml(
   }
 
   // LargeQuestionScoreArea（大問小計）
-  const largeMatches = abcXml.matchAll(
-    /<LargeQuestionScoreArea\s+([^/]*?)\/>/g
-  )
+  const largeMatches = abcXml.matchAll(/<LargeQuestionScoreArea\s+([^/]*?)\/>/g)
   for (const match of largeMatches) {
     const attrs = parseXmlAttributes(match[1])
     if (attrs.Visible === "false") continue
@@ -486,9 +478,7 @@ function extractScoreAreasFromAbcXml(
   }
 
   // AngleScoreArea（観点別得点）
-  const angleMatches = abcXml.matchAll(
-    /<AngleScoreArea\s+([^/]*?)\/>/g
-  )
+  const angleMatches = abcXml.matchAll(/<AngleScoreArea\s+([^/]*?)\/>/g)
   let angleIndex = 0
   for (const match of angleMatches) {
     const attrs = parseXmlAttributes(match[1])

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -139,7 +139,13 @@ export async function executeIdIntegrationImport(
         )
 
         // 4. 小計のマージ
-        await processSubtotals(data, idMappings, tx)
+        await processSubtotals(
+          data,
+          idMappings,
+          warnings,
+          tx,
+          integrationConfig.subtotalMappings
+        )
 
         // 5. プロジェクト処理
         const isProjectIdMatch = preMatchResult.project?.isIdMatch ?? false
@@ -198,7 +204,13 @@ export async function executeIdIntegrationImport(
         await processProjectClasses(data, newProjectId, idMappings, tx)
 
         // 11. CropSubtotal
-        await processCropSubtotals(data, isProjectIdMatch, idMappings, tx)
+        await processCropSubtotals(
+          data,
+          isProjectIdMatch,
+          idMappings,
+          warnings,
+          tx
+        )
 
         // 12. QuestionScore（競合解決対応）
         await processQuestionScores(
@@ -272,12 +284,41 @@ type Tx = Parameters<Parameters<typeof prisma.$transaction>[0]>[0]
 async function processSubtotals(
   data: ExtractedArchiveData,
   idMappings: IdMappings,
-  tx: Tx
+  warnings: string[],
+  tx: Tx,
+  subtotalMappings?: Record<string, string>
 ): Promise<void> {
+  // スキップされた小計をグループ別に集計
+  const skippedByGroup: Record<string, string[]> = {}
+
   for (const s of data.subtotalsData.subtotals) {
     const newGroupId = idMappings.subtotalGroup[s.subtotalGroupId]
-    if (!newGroupId) continue
+    if (!newGroupId) {
+      // グループがスキップされた → 配下の小計もスキップ
+      const groupName =
+        data.subtotalsData.subtotalGroups.find(
+          (g) => g.id === s.subtotalGroupId
+        )?.name ?? s.subtotalGroupId
+      if (!skippedByGroup[groupName]) skippedByGroup[groupName] = []
+      skippedByGroup[groupName].push(s.name)
+      continue
+    }
 
+    // 1. 明示的なマッピングがあれば使う
+    const explicitTarget = subtotalMappings?.[s.id]
+    if (explicitTarget && explicitTarget !== "__new__") {
+      // 既存の小計項目に直接結びつけ
+      idMappings.subtotal[s.id] = explicitTarget
+      continue
+    }
+
+    // 2. "__new__" の場合は新規作成を強制
+    if (explicitTarget === "__new__") {
+      await createNewSubtotal(s, newGroupId, idMappings, tx)
+      continue
+    }
+
+    // 3. マッピング未設定（デフォルト動作: 従来の名前ベース自動マッチ）
     const existing = await tx.subtotal.findFirst({
       where: { subtotalGroupId: newGroupId, name: s.name },
     })
@@ -301,6 +342,56 @@ async function processSubtotals(
       idMappings.subtotal[s.id] = existing.id
     }
   }
+
+  // スキップされた小計の警告を出力
+  for (const [groupName, subtotalNames] of Object.entries(skippedByGroup)) {
+    warnings.push(
+      `小計グループ「${groupName}」がスキップされたため、配下の小計項目（${subtotalNames.join("、")}）もスキップされました`
+    )
+  }
+}
+
+/**
+ * 小計項目を新規作成（名前重複時はサフィックス付き）
+ */
+async function createNewSubtotal(
+  s: ExtractedArchiveData["subtotalsData"]["subtotals"][0],
+  newGroupId: string,
+  idMappings: IdMappings,
+  tx: Tx
+): Promise<void> {
+  // 同名の小計が既にあるかチェック
+  const existingWithName = await tx.subtotal.findFirst({
+    where: { subtotalGroupId: newGroupId, name: s.name },
+  })
+
+  let finalName = s.name
+  if (existingWithName) {
+    // サフィックス付きで新規作成
+    for (let i = 2; i <= 100; i++) {
+      const candidate = `${s.name} (${i})`
+      const dup = await tx.subtotal.findFirst({
+        where: { subtotalGroupId: newGroupId, name: candidate },
+      })
+      if (!dup) {
+        finalName = candidate
+        break
+      }
+    }
+  }
+
+  const existingById = await tx.subtotal.findUnique({ where: { id: s.id } })
+  const newId = existingById ? randomUUID() : s.id
+
+  await tx.subtotal.create({
+    data: {
+      id: newId,
+      name: finalName,
+      subtotalGroupId: newGroupId,
+      order: s.order,
+    },
+  })
+  idMappings.subtotal[s.id] = newId
 }
 
 async function processProject(
@@ -624,8 +715,11 @@ async function processCropSubtotals(
   data: ExtractedArchiveData,
   isProjectIdMatch: boolean,
   idMappings: IdMappings,
+  warnings: string[],
   tx: Tx
 ): Promise<void> {
+  let skippedCount = 0
+
   for (const cs of data.subtotalsData.cropSubtotals) {
     const newRegionId = idMappings.cropRegion[cs.cropRegionId]
     const newSubtotalId = idMappings.subtotal[cs.subtotalId]
@@ -656,7 +750,15 @@ async function processCropSubtotals(
         })
         idMappings.cropSubtotal[cs.id] = cs.id
       }
+    } else {
+      skippedCount++
     }
+  }
+
+  if (skippedCount > 0) {
+    warnings.push(
+      `${skippedCount}件の設問-小計の紐づけがスキップされました（関連データがインポートされなかったため）`
+    )
   }
 }
 

--- a/electron-src/lib/import/merge/matchers/subtotalGroupMatcher.ts
+++ b/electron-src/lib/import/merge/matchers/subtotalGroupMatcher.ts
@@ -7,6 +7,7 @@ import type {
   MatchedItem,
   PreMatchingResult,
   SubtotalGroupMatchingMethod,
+  SubtotalInfo,
 } from "../../../../../types/projectArchive.types"
 import prisma from "../../../prisma/client"
 import type { ExtractedArchiveData } from "../../project-archive/archiveExtractor"
@@ -83,13 +84,28 @@ export async function preMatchSubtotalGroups(
   const existingById = new Map(existingGroups.map((g) => [g.id, g]))
   const existingByName = new Map(existingGroups.map((g) => [g.name, g]))
 
+  // インポートデータからグループ別にSubtotalを収集
+  const importSubtotalsByGroup = buildImportSubtotalsByGroup(importData)
+
+  // 既存グループのSubtotal一覧を一括取得
+  const existingGroupIds = existingGroups.map((g) => g.id)
+  const existingSubtotals =
+    existingGroupIds.length > 0
+      ? await prisma.subtotal.findMany({
+          where: { subtotalGroupId: { in: existingGroupIds } },
+          orderBy: { order: "asc" },
+        })
+      : []
+  const existingSubtotalsByGroup = new Map<string, SubtotalInfo[]>()
+  for (const s of existingSubtotals) {
+    const list = existingSubtotalsByGroup.get(s.subtotalGroupId) ?? []
+    list.push({ id: s.id, name: s.name, order: s.order })
+    existingSubtotalsByGroup.set(s.subtotalGroupId, list)
+  }
+
   for (const importGroup of importData.subtotalsData.subtotalGroups) {
     const displayLabel = importGroup.name
-    const importItem: ImportItem = {
-      importId: importGroup.id,
-      importData: importGroup as unknown as Record<string, unknown>,
-      displayLabel,
-    }
+    const importSubs = importSubtotalsByGroup.get(importGroup.id)
 
     // ID照合
     const idMatch = existingById.get(importGroup.id)
@@ -101,6 +117,10 @@ export async function preMatchSubtotalGroups(
         existingData: idMatch as unknown as Record<string, unknown>,
         displayLabel,
         matchReason: "同じパソコンで作成されたデータ",
+        additionalInfo: {
+          importSubtotals: importSubs,
+          existingSubtotals: existingSubtotalsByGroup.get(idMatch.id),
+        },
       })
       continue
     }
@@ -115,11 +135,22 @@ export async function preMatchSubtotalGroups(
         existingData: nameMatch as unknown as Record<string, unknown>,
         displayLabel,
         matchReason: "グループ名が一致",
+        additionalInfo: {
+          importSubtotals: importSubs,
+          existingSubtotals: existingSubtotalsByGroup.get(nameMatch.id),
+        },
       })
       continue
     }
 
-    noMatch.push(importItem)
+    noMatch.push({
+      importId: importGroup.id,
+      importData: importGroup as unknown as Record<string, unknown>,
+      displayLabel,
+      additionalInfo: {
+        importSubtotals: importSubs,
+      },
+    })
   }
 
   return {
@@ -127,4 +158,23 @@ export async function preMatchSubtotalGroups(
     byName,
     noMatch,
   }
+}
+
+/**
+ * インポートデータからグループ別にSubtotal情報をマップに変換
+ */
+function buildImportSubtotalsByGroup(
+  importData: ExtractedArchiveData
+): Map<string, SubtotalInfo[]> {
+  const map = new Map<string, SubtotalInfo[]>()
+  for (const s of importData.subtotalsData.subtotals) {
+    const list = map.get(s.subtotalGroupId) ?? []
+    list.push({ id: s.id, name: s.name, order: s.order })
+    map.set(s.subtotalGroupId, list)
+  }
+  // order順にソート
+  for (const list of map.values()) {
+    list.sort((a, b) => a.order - b.order)
+  }
+  return map
 }

--- a/electron-src/lib/import/merge/processors/subtotalGroupProcessor.ts
+++ b/electron-src/lib/import/merge/processors/subtotalGroupProcessor.ts
@@ -2,6 +2,8 @@
  * 小計グループのID統合処理
  */
 
+import { randomUUID } from "crypto"
+
 import type {
   FileOverviewData,
   IdIntegrationConfig,
@@ -53,9 +55,19 @@ export async function processSubtotalGroupIdIntegration(
       })
 
       if (existingByName) {
-        idMappings.subtotalGroup[importId] = existingByName.id
+        // B5修正: create_new の意図を尊重し、サフィックス付きで新規作成
+        const newName = await generateUniqueName(importGroup.name, tx)
+        const newId = randomUUID()
+        await tx.subtotalGroup.create({
+          data: {
+            id: newId,
+            name: newName,
+          },
+        })
+        idMappings.subtotalGroup[importId] = newId
+        counts.created.subtotalGroups++
         warnings.push(
-          `小計グループ「${importGroup.name}」は既存データを使用します`
+          `小計グループ「${importGroup.name}」は同名のグループが存在するため「${newName}」として新規作成しました`
         )
       } else {
         // scoreファイルのIDをそのまま使用（存在チェック付き）
@@ -63,7 +75,16 @@ export async function processSubtotalGroupIdIntegration(
           where: { id: importId },
         })
         if (existingById) {
-          idMappings.subtotalGroup[importId] = importId
+          // IDが衝突する場合は新規IDで作成
+          const newId = randomUUID()
+          await tx.subtotalGroup.create({
+            data: {
+              id: newId,
+              name: importGroup.name,
+            },
+          })
+          idMappings.subtotalGroup[importId] = newId
+          counts.created.subtotalGroups++
         } else {
           await tx.subtotalGroup.create({
             data: {
@@ -179,4 +200,23 @@ export async function processSubtotalGroupIdIntegration(
       undefined
     )
   }
+}
+
+/**
+ * 同名の小計グループが存在する場合にサフィックス付きのユニーク名を生成
+ * 例: "大問" → "大問 (2)", "大問 (2)" → "大問 (3)"
+ */
+async function generateUniqueName(
+  baseName: string,
+  tx: PrismaTransaction
+): Promise<string> {
+  for (let i = 2; i <= 100; i++) {
+    const candidate = `${baseName} (${i})`
+    const existing = await tx.subtotalGroup.findFirst({
+      where: { name: candidate },
+    })
+    if (!existing) return candidate
+  }
+  // フォールバック: ランダム名
+  return `${baseName} (${randomUUID().slice(0, 8)})`
 }

--- a/electron-src/tsconfig.json
+++ b/electron-src/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "alwaysStrict": true,
     "esModuleInterop": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/hooks/import/useImportWizard.ts
+++ b/hooks/import/useImportWizard.ts
@@ -8,7 +8,6 @@ import type {
   CategoryMatchingSummary,
   FileOverviewData,
   IdChoice,
-  IdIntegrationConfig,
   IdIntegrationDecision,
   ImportWizardState,
   MatchingConfig,
@@ -162,6 +161,11 @@ export function useImportWizard() {
       setState((prev) => ({
         ...prev,
         hszOriginalTitle: convertResult.originalTitle,
+        // 外部フォーマット時は小計グループ戦略を by_name にデフォルト設定
+        idIntegrationConfig: {
+          ...prev.idIntegrationConfig,
+          subtotalGroup: { strategy: "by_name", decisions: [] },
+        },
       }))
 
       // 変換後の.scoreファイルで解析→事前照合
@@ -223,10 +227,13 @@ export function useImportWizard() {
     }
   }, [state.archivePath])
 
+  /** カテゴリキーの型（subtotalMappingsを除く） */
+  type IdIntegrationCategoryKey = "student" | "class" | "subtotalGroup"
+
   // ID統合設定を更新
   const updateIdIntegrationConfig = useCallback(
-    <K extends keyof IdIntegrationConfig>(
-      category: K,
+    (
+      category: IdIntegrationCategoryKey,
       config: CategoryIdIntegrationConfig
     ) => {
       setState((prev) => ({
@@ -243,7 +250,7 @@ export function useImportWizard() {
   // 個別のID統合決定を更新
   const updateIdIntegrationDecision = useCallback(
     (
-      category: keyof IdIntegrationConfig,
+      category: IdIntegrationCategoryKey,
       importId: string,
       decision: IdIntegrationDecision
     ) => {
@@ -270,7 +277,7 @@ export function useImportWizard() {
   // ID統合決定を一括更新（一括ID選択用）
   const batchUpdateIdIntegrationDecisions = useCallback(
     (
-      category: keyof IdIntegrationConfig,
+      category: IdIntegrationCategoryKey,
       items: Array<{ importId: string; existingId: string }>,
       decisionType: "same_person" | "create_new" | "skip",
       idChoice?: IdChoice
@@ -487,6 +494,43 @@ export function useImportWizard() {
     []
   )
 
+  // 小計項目の直接マッピングを更新
+  const updateSubtotalMapping = useCallback(
+    (importSubtotalId: string, targetId: string) => {
+      setState((prev) => ({
+        ...prev,
+        idIntegrationConfig: {
+          ...prev.idIntegrationConfig,
+          subtotalMappings: {
+            ...prev.idIntegrationConfig.subtotalMappings,
+            [importSubtotalId]: targetId,
+          },
+        },
+      }))
+    },
+    []
+  )
+
+  // 小計項目の直接マッピングを一括クリア（グループ変更時など）
+  const clearSubtotalMappings = useCallback((importSubtotalIds: string[]) => {
+    setState((prev) => {
+      const currentMappings = { ...prev.idIntegrationConfig.subtotalMappings }
+      for (const id of importSubtotalIds) {
+        delete currentMappings[id]
+      }
+      return {
+        ...prev,
+        idIntegrationConfig: {
+          ...prev.idIntegrationConfig,
+          subtotalMappings:
+            Object.keys(currentMappings).length > 0
+              ? currentMappings
+              : undefined,
+        },
+      }
+    })
+  }, [])
+
   // 複数の採点競合を一括解決
   const setAllScoringConflictResolutions = useCallback(
     (conflictIds: string[], resolution: "import" | "existing") => {
@@ -661,6 +705,8 @@ export function useImportWizard() {
     setAllScoringConflictResolutions,
     acceptHszDisclaimer,
     dismissHszDisclaimer,
+    updateSubtotalMapping,
+    clearSubtotalMappings,
 
     goToNextStep,
     goBack,

--- a/types/answerSheetBuilder.types.ts
+++ b/types/answerSheetBuilder.types.ts
@@ -65,6 +65,8 @@ export interface ManuscriptPaperConfig {
 // 3階層問題構造
 // =====================
 
+export type NextPlacement = "inline" | "break"
+
 export interface BranchQuestion {
   id: string
   label: string
@@ -73,8 +75,12 @@ export interface BranchQuestion {
   textElements: CellTextElement[]
   modelAnswer?: string
   borderStyles?: BorderStyles
-  /** 横配置時の列スパン（デフォルト1） */
-  colSpan?: number
+  /** 幅の分数表記 (例: "1/4", "1/3", "1/2")。未指定 = 全幅（縦配置） */
+  layoutWidth?: string
+  /** 次の要素の配置方法。デフォルト "inline" */
+  nextPlacement?: NextPlacement
+  /** この要素自身をN行上に戻して配置する。未指定 = 戻らない */
+  goUp?: number
   /** OMR自動認識設定 */
   omrConfig?: OMRCellConfig
 }
@@ -89,10 +95,12 @@ export interface SubQuestion {
   manuscriptPaper?: ManuscriptPaperConfig
   modelAnswer?: string
   borderStyles?: BorderStyles
-  /** 横配置時の列スパン（デフォルト1） */
-  colSpan?: number
-  /** 枝問横配置の行ごとの列数 (例: [3, 2])。空/未定義なら全て縦配置 */
-  branchHorizontalColumnsPerRow?: number[]
+  /** 幅の分数表記 (例: "1/4", "1/3", "1/2")。未指定 = 全幅（縦配置） */
+  layoutWidth?: string
+  /** 次の要素の配置方法。デフォルト "inline" */
+  nextPlacement?: NextPlacement
+  /** この要素自身をN行上に戻して配置する。未指定 = 戻らない */
+  goUp?: number
   /** 枝問ごとに配点するか（undefined/true=枝問配点、false=完答） */
   usesBranchPoints?: boolean
   /** OMR自動認識設定 */
@@ -103,51 +111,23 @@ export interface MajorQuestion {
   id: string
   label: string
   subQuestions: SubQuestion[]
-  /** 横配置時の行ごとの列数 (例: [3, 4, 2])。空/未定義なら全て縦配置 */
-  horizontalColumnsPerRow?: number[]
 }
 
 // =====================
-// レイアウト行（buildLayoutRows用）
+// グリッドセル（buildGridLayout用）
 // =====================
 
-export type LayoutRow =
-  | {
-      type: "horizontal"
-      subs: {
-        sub: SubQuestion
-        subIndex: number
-        colStart: number
-        span: number
-      }[]
-      columns: number
-    }
-  | {
-      type: "vertical-sub"
-      sub: SubQuestion
-      subIndex: number
-    }
+export interface GridCell<T> {
+  item: T
+  itemIndex: number
+  x: number // 0〜1 の相対X座標
+  y: number // baseRowHeight 単位のY座標
+  width: number // 0〜1 の相対幅
+  height: number // baseRowHeight 単位の高さ
+}
 
-// =====================
-// 枝問レイアウト行（buildBranchLayoutRows用）
-// =====================
-
-export type BranchLayoutRow =
-  | {
-      type: "horizontal"
-      branches: {
-        branch: BranchQuestion
-        branchIndex: number
-        colStart: number
-        span: number
-      }[]
-      columns: number
-    }
-  | {
-      type: "vertical-branch"
-      branch: BranchQuestion
-      branchIndex: number
-    }
+export type SubGridCell = GridCell<SubQuestion>
+export type BranchGridCell = GridCell<BranchQuestion>
 
 // =====================
 // マージン設定

--- a/types/projectArchive.types.ts
+++ b/types/projectArchive.types.ts
@@ -109,6 +109,15 @@ export interface PreMatchingResult {
 }
 
 /**
+ * 小計項目の概要情報（プレビュー・マッピング用）
+ */
+export interface SubtotalInfo {
+  id: string
+  name: string
+  order: number
+}
+
+/**
  * 照合でマッチしたアイテム
  */
 export interface MatchedItem {
@@ -124,6 +133,11 @@ export interface MatchedItem {
   displayLabel: string
   /** 一致理由（例: "学籍番号が一致"） */
   matchReason: string
+  /** 追加情報（小計グループの場合、配下の小計項目一覧） */
+  additionalInfo?: {
+    importSubtotals?: SubtotalInfo[]
+    existingSubtotals?: SubtotalInfo[]
+  }
 }
 
 /**
@@ -136,6 +150,10 @@ export interface ImportItem {
   importData: Record<string, unknown>
   /** 表示用ラベル */
   displayLabel: string
+  /** 追加情報（小計グループの場合、配下の小計項目一覧） */
+  additionalInfo?: {
+    importSubtotals?: SubtotalInfo[]
+  }
 }
 
 /**
@@ -243,6 +261,8 @@ export interface IdIntegrationConfig {
   student: CategoryIdIntegrationConfig
   class: CategoryIdIntegrationConfig
   subtotalGroup: CategoryIdIntegrationConfig
+  /** 小計項目の直接マッピング（importSubtotalId → existingSubtotalId | "__new__"） */
+  subtotalMappings?: Record<string, string>
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- 解答用紙ビルダーのフォーム・レイアウト・プレビュー機能を大幅に拡張
- インポート機能の小計グループ統合を改善
- buildGridLayout統合テストを追加

Closes #404

## 変更点（45ファイル、+5246/-2011行）

### 解答用紙ビルダー
- 枝問グリッドレイアウト（水平・垂直配置）の実装
- SliderWithInput、LineStylePicker等のフォームコンポーネント追加・改善
- テキスト要素エディタ、GlobalSettings、MajorQuestion/SubQuestionFormの強化
- レイアウトエンジンの複数ページ対応・グリッド配置計算の改善
- SVGレンダラー・PNGジェネレーター・エクスポート機能の更新

### インポート機能
- 小計グループマッチング・処理ロジックの強化
- SubtotalMappingEditor、SubtotalPreviewの新規追加
- ID統合インポーターの改善

### テスト
- `__tests__/answer-sheet-builder/buildGridLayout.test.ts` の追加（1031行）

## Test plan
- [ ] 解答用紙ビルダーで新規解答用紙を作成し、各フォームが正常に動作すること
- [ ] 枝問グリッドが水平・垂直両方向で正しくレイアウトされること
- [ ] 複数ページレイアウトが正常に動作すること
- [ ] インポート機能で小計グループの統合が正しく行われること
- [ ] buildGridLayoutテストが全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)