### PR TITLE
fix: GradeDataSource.type の project_total → exam_total リネーム

### DIFF
--- a/components/grades/03-data-sources/AddDataSourceInline.tsx
+++ b/components/grades/03-data-sources/AddDataSourceInline.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
-type DataSourceType = "project_total" | "subtotal" | "crop_region" | "manual"
+type DataSourceType = "exam_total" | "subtotal" | "crop_region" | "manual"
 
 interface AddDataSourceInlineProps {
   gradeItemId: string
@@ -54,7 +54,7 @@ export function AddDataSourceInline({
   onCreated,
 }: AddDataSourceInlineProps) {
   const [open, setOpen] = useState(false)
-  const [type, setType] = useState<DataSourceType>("project_total")
+  const [type, setType] = useState<DataSourceType>("exam_total")
   const [exams, setExams] = useState<ExamOption[]>([])
   const [selectedExamId, setSelectedExamId] = useState("")
   const [subtotalGroups, setSubtotalGroups] = useState<SubtotalGroupOption[]>(
@@ -115,7 +115,7 @@ export function AddDataSourceInline({
       cropRegionId?: string
     } = { type }
 
-    if (type === "project_total") {
+    if (type === "exam_total") {
       data.examId = selectedExamId
     } else if (type === "subtotal") {
       data.examId = selectedExamId
@@ -144,7 +144,7 @@ export function AddDataSourceInline({
     const exam = exams.find((p) => p.id === selectedExamId)
     if (!exam) return
 
-    if (type === "project_total") {
+    if (type === "exam_total") {
       setName(`${exam.examName}(合計)`)
     } else if (type === "subtotal" && selectedSubtotalId) {
       const sg = subtotalGroups.find((g) =>
@@ -202,7 +202,7 @@ export function AddDataSourceInline({
 
   const resetForm = () => {
     setOpen(false)
-    setType("project_total")
+    setType("exam_total")
     setSelectedExamId("")
     setSelectedSubtotalGroupId("")
     setSelectedSubtotalId("")
@@ -251,7 +251,7 @@ export function AddDataSourceInline({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="project_total">全設問合計</SelectItem>
+            <SelectItem value="exam_total">全設問合計</SelectItem>
             <SelectItem value="subtotal">小計点</SelectItem>
             <SelectItem value="crop_region">設問</SelectItem>
             <SelectItem value="manual">外部成績</SelectItem>

--- a/components/grades/03-data-sources/DataSourceRow.tsx
+++ b/components/grades/03-data-sources/DataSourceRow.tsx
@@ -11,7 +11,7 @@ import type { GradeDataSourceWithDetails } from "@/types/grade.types"
 import { EstimationSettingsPopover } from "./EstimationSettingsPopover"
 
 const TYPE_LABELS: Record<string, string> = {
-  project_total: "合計",
+  exam_total: "合計",
   subtotal: "小計",
   crop_region: "設問",
   manual: "外部",

--- a/components/grades/03-data-sources/EstimationSettingsPopover.tsx
+++ b/components/grades/03-data-sources/EstimationSettingsPopover.tsx
@@ -69,7 +69,7 @@ export function EstimationSettingsPopover({
   )
 
   const isExamSource =
-    dataSource.type === "project_total" ||
+    dataSource.type === "exam_total" ||
     dataSource.type === "subtotal" ||
     dataSource.type === "crop_region"
 

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -114,7 +114,7 @@ export async function collectGradeArchiveData(
   const examRefs = allDataSources
     .filter(
       (ds) =>
-        (ds.type === "project_total" ||
+        (ds.type === "exam_total" ||
           ds.type === "subtotal" ||
           ds.type === "crop_region") &&
         ds.exam

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -135,10 +135,15 @@ export async function importGradeArchive(
         })
 
         for (const dsData of giData.dataSources) {
+          // 旧アーカイブ互換: project_total → exam_total
+          if (dsData.type === "project_total") {
+            dsData.type = "exam_total"
+          }
+
           let examId: string | null = null
           if (
             dsData.examName &&
-            (dsData.type === "project_total" ||
+            (dsData.type === "exam_total" ||
               dsData.type === "subtotal" ||
               dsData.type === "crop_region")
           ) {

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -39,7 +39,7 @@ export async function getDataSourcesByGradeItemId(gradeItemId: string) {
  */
 export async function createDataSource(data: {
   gradeItemId: string
-  type: string // "project_total" | "subtotal" | "crop_region" | "manual"
+  type: string // "exam_total" | "subtotal" | "crop_region" | "manual"
   examId?: string
   subtotalId?: string
   cropRegionId?: string
@@ -324,7 +324,7 @@ export async function calculateSourceMaxScore(data: {
   cropRegionId?: string
 }): Promise<{ success: boolean; maxScore?: number; error?: string }> {
   try {
-    if (data.type === "project_total" && data.examId) {
+    if (data.type === "exam_total" && data.examId) {
       // 試験の全QUESTION_ANSWER CropRegionのpoints合計
       const pages = await prisma.examPage.findMany({
         where: { examId: data.examId },

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -116,7 +116,7 @@ export async function calculateGrades(gradeId: string): Promise<{
         allDataSources
           .filter(
             (ds) =>
-              (ds.type === "project_total" ||
+              (ds.type === "exam_total" ||
                 ds.type === "subtotal" ||
                 ds.type === "crop_region") &&
               ds.examId
@@ -462,7 +462,7 @@ async function getRawScore(
   },
   examDataCache: Map<string, ExamDataCache>
 ): Promise<number | null> {
-  if (ds.type === "project_total" && ds.examId) {
+  if (ds.type === "exam_total" && ds.examId) {
     return calculateExamTotalScore(studentId, ds.examId, examDataCache)
   } else if (ds.type === "subtotal" && ds.subtotalId && ds.examId) {
     const examData = examDataCache.get(ds.examId)
@@ -752,7 +752,7 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
- * project_total: 試験の全QUESTION_ANSWER CropRegionスコア合計
+ * exam_total: 試験の全QUESTION_ANSWER CropRegionスコア合計
  */
 function calculateExamTotalScore(
   studentId: string,

--- a/prisma/migrations/20260303000000_rename_project_to_exam/migration.sql
+++ b/prisma/migrations/20260303000000_rename_project_to_exam/migration.sql
@@ -177,3 +177,10 @@ CREATE INDEX "GradeOverride_gradeId_idx" ON "GradeOverride"("gradeId");
 -- --- GradeExportSettings (was GradeProjectExportSettings) ---
 DROP INDEX IF EXISTS "GradeProjectExportSettings_gradeProjectId_key";
 CREATE UNIQUE INDEX "GradeExportSettings_gradeId_key" ON "GradeExportSettings"("gradeId");
+
+-- =============================================================
+-- Step 4: Rename data values
+-- GradeDataSource.type: "project_total" → "exam_total"
+-- =============================================================
+
+UPDATE "GradeDataSource" SET "type" = 'exam_total' WHERE "type" = 'project_total';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -470,11 +470,11 @@ model GradeStudent {
   @@index([gradeId, customOrder])
 }
 
-/// 成績データソース（4種: project_total / subtotal / crop_region / manual）
+/// 成績データソース（4種: exam_total / subtotal / crop_region / manual）
 model GradeDataSource {
   id                     String   @id @default(uuid())
   gradeItemId            String
-  type                   String // "project_total" | "subtotal" | "crop_region" | "manual"
+  type                   String // "exam_total" | "subtotal" | "crop_region" | "manual"
   examId                 String?
   subtotalId             String?
   cropRegionId           String?

--- a/types/grade.types.ts
+++ b/types/grade.types.ts
@@ -43,7 +43,7 @@ export type EstimationMode = "all" | "selected"
 export interface GradeDataSourceWithDetails {
   id: string
   gradeItemId: string
-  type: string // "project_total" | "subtotal" | "crop_region" | "manual"
+  type: string // "exam_total" | "subtotal" | "crop_region" | "manual"
   examId: string | null
   subtotalId: string | null
   cropRegionId: string | null

--- a/types/gradeArchive.types.ts
+++ b/types/gradeArchive.types.ts
@@ -57,7 +57,7 @@ export interface ArchiveGradeItem {
 }
 
 export interface ArchiveDataSource {
-  type: string // "project_total" | "subtotal" | "crop_region" | "manual"
+  type: string // "exam_total" | "subtotal" | "crop_region" | "manual"
   name: string
   maxScore: number
   weight: number


### PR DESCRIPTION
## Summary
- GradeDataSource.type のDB保存値 `project_total` を `exam_total` にリネーム
- マイグレーションSQL・旧アーカイブインポート互換対応を含む

Closes #408

## Test plan
- [x] TypeScript型チェック: 0エラー
- [x] Vitest: 38ファイル / 483テスト パス
- [x] 開発環境DB: 8件の `project_total` → `exam_total` 更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)