### PR TITLE
ダッシュボードを試験一覧ページに置き換え

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,21 +1,14 @@
 "use client"
 
-import ProtectedRoute from "@/components/auth/ProtectedRoute"
-import Exams from "@/components/exams/list/ExamList"
-import { usePageHelp } from "@/components/help/usePageHelp"
-import PageHeader from "@/components/layout/PageHeader"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
 
 export default function DashboardPage() {
-  const { helpButton } = usePageHelp()
+  const router = useRouter()
 
-  return (
-    <ProtectedRoute>
-      <div className="flex h-full flex-col">
-        <PageHeader title="ダッシュボード" helpButton={helpButton} />
-        <div className="flex-1 overflow-hidden">
-          <Exams />
-        </div>
-      </div>
-    </ProtectedRoute>
-  )
+  useEffect(() => {
+    router.replace("/exams")
+  }, [router])
+
+  return null
 }

--- a/app/exams/page.tsx
+++ b/app/exams/page.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import ProtectedRoute from "@/components/auth/ProtectedRoute"
+import Exams from "@/components/exams/list/ExamList"
+import { usePageHelp } from "@/components/help/usePageHelp"
+import PageHeader from "@/components/layout/PageHeader"
+
+export default function ExamsPage() {
+  const { helpButton } = usePageHelp()
+
+  return (
+    <ProtectedRoute>
+      <div className="flex h-full flex-col">
+        <PageHeader title="試験一覧" helpButton={helpButton} />
+        <div className="flex-1 overflow-hidden">
+          <Exams />
+        </div>
+      </div>
+    </ProtectedRoute>
+  )
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -10,8 +10,8 @@ export default function NotFound() {
           Page Not Found
         </h2>
         <p className="mb-6 text-gray-600">Could not find the requested page.</p>
-        <Link href="/dashboard">
-          <Button variant="default">Return to Dashboard</Button>
+        <Link href="/exams">
+          <Button variant="default">試験一覧に戻る</Button>
         </Link>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ const Page = () => {
   useEffect(() => {
     if (!isLoading) {
       if (user) {
-        router.push("/dashboard")
+        router.push("/exams")
       } else {
         router.push("/login")
       }

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -41,7 +41,7 @@ interface NavItem {
 
 const navGroups: NavItem[][] = [
   [
-    { href: "/dashboard", label: "試験", icon: Home },
+    { href: "/exams", label: "試験一覧", icon: Home },
     { href: "/answer-sheet-builder", label: "解答用紙作成", icon: FileEdit },
     { href: "/pdf-tools", label: "PDF加工", icon: FileStack },
     { href: "/grades", label: "成績算出", icon: BarChart3 },
@@ -96,7 +96,7 @@ export default function Navigation({
         )}
       >
         {!isSidebarMinimized && (
-          <Link href="/dashboard" className="text-lg font-semibold">
+          <Link href="/exams" className="text-lg font-semibold">
             一括採点
           </Link>
         )}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -78,7 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         await window.electronAPI.saveAuthToken(result.token)
         setUser(result.user)
         toast.success("ログインしました")
-        router.push("/dashboard")
+        router.push("/exams")
         return true
       } else {
         toast.error(result.error || "ログインに失敗しました")
@@ -98,7 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // 簡易トークンとして user.id を保存
       await window.electronAPI.saveAuthToken(selectedUser.id)
       toast.success(`${selectedUser.name}さん、おかえりなさい！`)
-      router.push("/dashboard")
+      router.push("/exams")
     } catch (error) {
       console.error("Quick login failed:", error)
       toast.error("ログインに失敗しました")


### PR DESCRIPTION
## Summary

- Navigation の最初のリンク先を `/dashboard` → `/exams` に変更し、ラベルを「試験一覧」に更新
- `app/exams/page.tsx` を新規作成（試験一覧ページ）
- `app/dashboard/page.tsx` を `/exams` へのリダイレクトに変更（後方互換性維持）
- ルートページ・404ページ・認証後のリダイレクト先を `/exams` に統一

Closes #410

## Test plan

- [ ] `/exams` にアクセスして試験一覧が表示されることを確認
- [ ] `/dashboard` にアクセスすると `/exams` にリダイレクトされることを確認
- [ ] ログイン後に `/exams` に遷移することを確認
- [ ] サイドバーの「試験一覧」リンクが正しく動作することを確認
- [ ] 404ページの「試験一覧に戻る」ボタンが `/exams` に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)