### PR TITLE
feat: 個別採点ビューで全設問の採点記号をプレビュー表示

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import { useMemo } from "react"
+
+import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
+import { getScoringStatusFromArray } from "@/components/exams/07-score-at-once/types"
+
 import { DrawingToolPalette } from "./DrawingToolPalette"
 import { useDrawingState } from "./hooks/core/useDrawingState"
 import { useImageCanvas } from "./hooks/core/useImageCanvas"
@@ -24,6 +29,7 @@ export default function AnswerIndividualView({
   scoringDatas,
   currentScoringDataId,
   currentCropRegion,
+  cropRegions,
   studentAnswerImages,
   showMultiplePages = true, // 常に複数ページ表示
   pageSpacing = 20,
@@ -42,6 +48,20 @@ export default function AnswerIndividualView({
     scoringDatas.find(
       (scoringData) => scoringData.id === currentScoringDataId
     ) ?? null
+
+  // 全設問の採点ステータスを計算（全設問マーク描画用）
+  const allCropRegionsWithStatus = useMemo(() => {
+    if (!cropRegions || !questionScores || !currentScoringData) return []
+    const studentId = currentScoringData.studentId
+    return cropRegions.map((cr) => ({
+      cropRegion: cr,
+      status: getScoringStatusFromArray(
+        questionScores,
+        studentId,
+        cr.id
+      ) as ScoringStatus,
+    }))
+  }, [cropRegions, questionScores, currentScoringData])
 
   // QuestionScore自動作成フック（設問表示時にQuestionScoreが存在しない場合は自動作成）
   const { currentQuestionScoreId } = useAutoCreateQuestionScore({
@@ -112,6 +132,8 @@ export default function AnswerIndividualView({
     currentCropRegionId: currentCropRegion?.id,
     // ホバー要素ID（ハンドル表示用）
     hoveredElementId: drawingState.hoveredElementId,
+    // 全設問の採点ステータス（全設問マーク描画用）
+    allCropRegionsWithStatus,
   })
 
   // Canvas・V4統合フック

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
@@ -8,9 +8,18 @@ import type {
 import type {
   CropRegionWithExamPage,
   ScoringData,
+  ScoringStatus,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
+
+/**
+ * 採点領域と採点ステータスのペア（全設問マーク描画用）
+ */
+export interface CropRegionWithStatus {
+  cropRegion: CropRegionWithExamPage
+  status: ScoringStatus
+}
 
 /**
  * useImageCanvasのプロパティ
@@ -41,6 +50,8 @@ export interface UseImageCanvasProps {
   currentCropRegionId?: string | null
   // ホバー中の要素ID（ハンドル表示用）
   hoveredElementId?: string | null
+  // 全設問の採点ステータス（全設問マーク描画用）
+  allCropRegionsWithStatus?: CropRegionWithStatus[]
 }
 
 /**

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   CropRegionWithExamPage,
   ScoringData,
+  ScoringStatus,
 } from "@/components/exams/07-score-at-once/types"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
@@ -22,6 +23,7 @@ import {
   clearSvgCache,
   renderTextElementV4,
 } from "../../utils/canvasTextRendererV4"
+import type { CropRegionWithStatus } from "./types"
 import { useDrawingRenderer } from "./useDrawingRenderer"
 import { getScoringMarkKey } from "./useScoringMarks"
 
@@ -49,6 +51,7 @@ interface UseCanvasDrawingProps {
   allAnnotations?: DrawingAnnotationWithQuestionScore[]
   currentCropRegionId?: string | null
   hoveredElementId?: string | null
+  allCropRegionsWithStatus?: CropRegionWithStatus[]
 }
 
 /**
@@ -76,6 +79,7 @@ export function useCanvasDrawing({
   allAnnotations = [],
   currentCropRegionId,
   hoveredElementId,
+  allCropRegionsWithStatus = [],
 }: UseCanvasDrawingProps): void {
   const { convertAnnotationToDrawingElement, drawSingleElement } =
     useDrawingRenderer()
@@ -152,57 +156,84 @@ export function useCanvasDrawing({
         currentY += img.naturalHeight + (images.length > 1 ? pageSpacing : 0)
       })
 
-      // 設問枠描画
-      if (currentCropRegion && images.length > 0) {
-        const questionPageNumber = currentCropRegion.examPage?.pageNumber || 1
-        const questionPageIndex = questionPageNumber - 1
+      // 採点領域の描画ヘルパー関数
+      const drawCropRegionMark = (
+        region: CropRegionWithExamPage,
+        status: ScoringStatus,
+        isCurrent: boolean
+      ) => {
+        const regionPageNumber = region.examPage?.pageNumber || 1
+        const regionPageIndex = regionPageNumber - 1
 
-        if (questionPageIndex >= 0 && questionPageIndex < images.length) {
-          const img = images[questionPageIndex]
+        if (regionPageIndex < 0 || regionPageIndex >= images.length) return
 
-          if (img) {
-            let pageOffsetY = 0
-            for (let i = 0; i < questionPageIndex; i++) {
-              pageOffsetY +=
-                images[i].naturalHeight + (images.length > 1 ? pageSpacing : 0)
-            }
+        const img = images[regionPageIndex]
+        if (!img) return
 
-            const offsetX = (canvasWidth - img.naturalWidth) / 2
-            const offsetY = pageOffsetY
+        let pageOffsetY = 0
+        for (let i = 0; i < regionPageIndex; i++) {
+          pageOffsetY +=
+            images[i].naturalHeight + (images.length > 1 ? pageSpacing : 0)
+        }
 
-            const questionX = currentCropRegion.x * img.naturalWidth + offsetX
-            const questionY = currentCropRegion.y * img.naturalHeight + offsetY
-            const questionWidth = currentCropRegion.width * img.naturalWidth
-            const questionHeight = currentCropRegion.height * img.naturalHeight
+        const offsetX = (canvasWidth - img.naturalWidth) / 2
+        const offsetY = pageOffsetY
 
-            ctx.strokeStyle = "#22c55e"
-            ctx.lineWidth = 2
-            ctx.setLineDash([])
-            ctx.strokeRect(questionX, questionY, questionWidth, questionHeight)
+        const regionX = region.x * img.naturalWidth + offsetX
+        const regionY = region.y * img.naturalHeight + offsetY
+        const regionWidth = region.width * img.naturalWidth
+        const regionHeight = region.height * img.naturalHeight
 
-            ctx.fillStyle = "#22c55e"
-            const labelFontSize = Math.max(12, 14 / zoom)
-            ctx.font = `${labelFontSize}px sans-serif`
-            ctx.fillText(currentCropRegion.label, questionX, questionY - 5)
+        // 枠とラベルの描画
+        if (isCurrent) {
+          ctx.strokeStyle = "#22c55e"
+          ctx.lineWidth = 2
+        } else {
+          ctx.strokeStyle = "#9ca3af"
+          ctx.lineWidth = 1
+        }
+        ctx.setLineDash([])
+        ctx.strokeRect(regionX, regionY, regionWidth, regionHeight)
 
-            // 採点記号の描画
-            if (
-              currentScoringData &&
-              currentScoringData.status !== "unscored"
-            ) {
-              const markKey = getScoringMarkKey(currentScoringData.status)
-              const markImage = markKey
-                ? scoringMarkImagesRef.current.get(markKey)
-                : null
+        const labelFontSize = Math.max(12, 14 / zoom)
+        ctx.font = `${labelFontSize}px sans-serif`
+        ctx.fillStyle = isCurrent ? "#22c55e" : "#9ca3af"
+        ctx.fillText(region.label, regionX, regionY - 5)
 
-              if (markImage) {
-                const markSize = Math.min(questionHeight * 0.5, 100)
-                const markX = questionX + (questionWidth - markSize) / 2
-                const markY = questionY + (questionHeight - markSize) / 2
-                ctx.drawImage(markImage, markX, markY, markSize, markSize)
-              }
-            }
+        // 採点記号の描画
+        if (status !== "unscored") {
+          const markKey = getScoringMarkKey(status)
+          const markImage = markKey
+            ? scoringMarkImagesRef.current.get(markKey)
+            : null
+
+          if (markImage) {
+            ctx.globalAlpha = isCurrent ? 1.0 : 0.6
+            const markSize = Math.min(regionHeight * 0.5, 100)
+            const markX = regionX + (regionWidth - markSize) / 2
+            const markY = regionY + (regionHeight - markSize) / 2
+            ctx.drawImage(markImage, markX, markY, markSize, markSize)
+            ctx.globalAlpha = 1.0
           }
+        }
+      }
+
+      // 全設問の枠と採点記号を描画
+      if (images.length > 0) {
+        // 他の設問を先に描画（半透明）
+        for (const { cropRegion, status } of allCropRegionsWithStatus) {
+          if (cropRegion.id === currentCropRegion?.id) continue
+          drawCropRegionMark(cropRegion, status, false)
+        }
+
+        // 現在の設問を最後に描画（前面に表示）
+        if (currentCropRegion) {
+          const currentStatus = currentScoringData?.status ?? "unscored"
+          drawCropRegionMark(
+            currentCropRegion,
+            currentStatus as ScoringStatus,
+            true
+          )
         }
       }
 
@@ -305,6 +336,7 @@ export function useCanvasDrawing({
       scoringMarkImagesRef,
       convertAnnotationToDrawingElement,
       drawSingleElement,
+      allCropRegionsWithStatus,
     ]
   )
 

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
@@ -36,6 +36,7 @@ export function useImageCanvas({
   allAnnotations = [],
   currentCropRegionId,
   hoveredElementId,
+  allCropRegionsWithStatus = [],
 }: UseImageCanvasProps): UseImageCanvasReturn {
   // キャンバス参照管理
   const {
@@ -84,6 +85,7 @@ export function useImageCanvas({
     allAnnotations,
     currentCropRegionId,
     hoveredElementId,
+    allCropRegionsWithStatus,
   })
 
   return {

--- a/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -74,6 +74,7 @@ export interface AnswerIndividualViewProps {
 
   // 設問情報（派生済みオブジェクト）
   currentCropRegion?: CropRegionWithExamPage | null // 現在の設問領域
+  cropRegions?: CropRegionWithExamPage[] // 全採点領域（全設問マーク描画用）
 
   // QuestionScore自動作成用のコンテキスト情報
   currentStudentId?: string

--- a/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -23,6 +23,8 @@ interface ScoringContentAreaProps {
 
   /** 設問情報（Individual表示のみ必要） */
   currentCropRegion?: CropRegionWithExamPage
+  /** 全採点領域（Individual表示の全設問マーク描画用） */
+  cropRegions?: CropRegionWithExamPage[]
 
   /** 操作関数（両View共通） */
   onScoringDataSelect: (dataId: string, isSelected: boolean) => void
@@ -59,6 +61,7 @@ export function ScoringContentArea({
   filteredScoringDataIds,
   selectedScoringDataIds,
   currentCropRegion,
+  cropRegions,
   onScoringDataSelect,
   onScoringDataReplace,
   layoutDirection,
@@ -90,6 +93,7 @@ export function ScoringContentArea({
       scoringDatas={allScoringData}
       currentScoringDataId={currentScoringDataId}
       currentCropRegion={currentCropRegion}
+      cropRegions={cropRegions}
       studentAnswerImages={studentAnswerImages}
       onTextInputStateChange={onTextInputStateChange}
       currentStudentId={currentStudentId}


### PR DESCRIPTION
## Summary

- 個別採点ビューで全設問の採点枠に採点記号をプレビュー描画
- 選択中の設問: 緑枠(2px) + 100%不透明マーク / 他の設問: グレー枠(1px) + 60%透明マーク
- `cropRegions` + `questionScores` をScoringMainView→useCanvasDrawingまでデータ伝搬

Closes #424

## Test plan

- [ ] 個別採点ビューで全ての採点枠に採点記号が表示されることを確認
- [ ] 選択中の設問が緑枠で強調表示されることを確認
- [ ] 他の設問のマークが60%透明度で表示されることを確認
- [ ] 設問切替時に正しくマークが更新されることを確認
- [ ] グリッドビューに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)