### PR TITLE
解答用紙ビルダーの手動保存を即時自動保存に変更

### DIFF
--- a/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -1,17 +1,11 @@
 "use client"
 
-import {
-  ArrowLeft,
-  Download,
-  FolderOpen,
-  Redo2,
-  Save,
-  Undo2,
-} from "lucide-react"
+import { ArrowLeft, Download, FolderOpen, Redo2, Undo2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
+import { useSaveStatus } from "@/components/hooks/useSaveStatus"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -69,6 +63,7 @@ export function AnswerSheetBuilderMainView({
   } = useAnswerSheetDefinition()
 
   const [isLoaded, setIsLoaded] = useState(false)
+  const { saveStatus, showSaving, showSaved } = useSaveStatus()
 
   // DBから定義をロード
   useEffect(() => {
@@ -85,6 +80,23 @@ export function AnswerSheetBuilderMainView({
     }
     load()
   }, [definitionId, setDefinition])
+
+  // 即時自動保存
+  useEffect(() => {
+    if (!isLoaded) return
+
+    const api = window.electronAPI?.answerSheetBuilder
+    if (!api || !user?.id) return
+
+    showSaving()
+    api.saveDefinition(definition, user.id).then((result) => {
+      if (result.success) {
+        showSaved()
+      } else {
+        toast.error(`保存エラー: ${result.error}`)
+      }
+    })
+  }, [definition, isLoaded, user?.id, showSaving, showSaved])
 
   const layout = useAnswerSheetLayout(definition)
   const multiPageLayout = useMultiPageLayout(definition)
@@ -107,20 +119,6 @@ export function AnswerSheetBuilderMainView({
     },
     [dispatch]
   )
-
-  const handleSave = useCallback(async () => {
-    const api = window.electronAPI?.answerSheetBuilder
-    if (!api || !user?.id) {
-      toast.error("Electron APIが利用できません")
-      return
-    }
-    const result = await api.saveDefinition(definition, user.id)
-    if (result.success) {
-      toast.success("定義を保存しました")
-    } else {
-      toast.error(`保存エラー: ${result.error}`)
-    }
-  }, [definition, user?.id])
 
   if (!isLoaded) {
     return (
@@ -176,15 +174,6 @@ export function AnswerSheetBuilderMainView({
             <Redo2 className="h-3.5 w-3.5" />
           </Button>
           <Separator orientation="vertical" className="mx-1 h-5 self-center" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs"
-            onClick={handleSave}
-          >
-            <Save className="mr-1 h-3 w-3" />
-            保存
-          </Button>
           <Button
             variant="ghost"
             size="sm"
@@ -301,6 +290,7 @@ export function AnswerSheetBuilderMainView({
             {multiPageLayout.totalPages > 1 &&
               ` / ${multiPageLayout.totalPages}ページ`}
           </span>
+          <span>{saveStatus}</span>
           <span>合計 {totalPoints}点</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- `definition`の変更を`useEffect`で即時検知し、自動的にDBへ保存する方式に変更
- `useSaveStatus`フックによる保存ステータス表示をフッターに追加
- 手動保存ボタンを削除し、ユーザーが保存を忘れるリスクを排除

Closes #430

## Test plan

- [ ] エディタで名前・設問・設定を変更すると即時自動保存されること
- [ ] フッターに「保存しています...」→「保存されました」が表示されること
- [ ] Undo/Redo操作でも自動保存がトリガーされること
- [ ] 初期ロード時に不要な保存が発生しないこと
- [ ] `npm run typecheck`が通ること
- [ ] `npm run lint`が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)