### PR TITLE
feat: アノテーション再利用パネルとお気に入り機能を実装

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 
 import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
 import { getScoringStatusFromArray } from "@/components/exams/07-score-at-once/types"
@@ -263,6 +263,44 @@ export default function AnswerIndividualView({
       textBoundsCache,
     })
 
+  // お気に入りアノテーションIDのセット
+  const favoriteElementIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const el of drawingState.drawingElements) {
+      if ((el as { isFavorite?: boolean }).isFavorite) {
+        ids.add(el.id)
+      }
+    }
+    return ids
+  }, [drawingState.drawingElements])
+
+  // お気に入り切替ハンドラ
+  const handleToggleFavorite = useCallback(
+    async (elementIds: string[]) => {
+      for (const elementId of elementIds) {
+        const isFavorite = favoriteElementIds.has(elementId)
+        try {
+          const result = await window.electronAPI.drawing.toggleFavorite(
+            elementId,
+            !isFavorite
+          )
+          if (result.success) {
+            // ローカル状態を更新
+            drawingState.setDrawingElements(
+              (prev: typeof drawingState.drawingElements) =>
+                prev.map((el: (typeof prev)[number]) =>
+                  el.id === elementId ? { ...el, isFavorite: !isFavorite } : el
+                )
+            )
+          }
+        } catch (error) {
+          console.error("お気に入り切替エラー:", error)
+        }
+      }
+    },
+    [favoriteElementIds, drawingState]
+  )
+
   // 採点データが選択されていない場合の早期リターン
   if (!currentScoringData) {
     return (
@@ -474,6 +512,8 @@ export default function AnswerIndividualView({
         )}
         onUpdateSelectedElements={drawingState.updateDrawingElements}
         onClearSelection={drawingState.clearSelection}
+        onToggleFavorite={handleToggleFavorite}
+        favoriteElementIds={favoriteElementIds}
       />
 
       {/* V4統合: 高品質テキストエディターモーダル */}

--- a/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
@@ -6,6 +6,7 @@ import {
   Hand,
   Maximize,
   MousePointer2,
+  Star,
   ZoomIn,
   ZoomOut,
 } from "lucide-react"
@@ -58,6 +59,10 @@ interface DrawingToolPaletteProps {
     updates: Array<{ id: string; updates: Partial<DrawingElement> }>
   ) => void
   onClearSelection?: () => void
+
+  // お気に入り機能
+  onToggleFavorite?: (elementIds: string[]) => void
+  favoriteElementIds?: Set<string>
 }
 
 export function DrawingToolPalette({
@@ -78,6 +83,8 @@ export function DrawingToolPalette({
   selectedElements = [],
   onUpdateSelectedElements,
   onClearSelection,
+  onToggleFavorite,
+  favoriteElementIds,
 }: DrawingToolPaletteProps) {
   // 選択中の各タイプの要素を取得（複数選択対応）
   const selectedLines = selectedElements.filter((el) => el.type === "line")
@@ -540,6 +547,44 @@ export function DrawingToolPalette({
               }
               onClearSelection={onClearSelection}
             />
+
+            {/* お気に入り登録ボタン（要素選択時のみ表示） */}
+            {selectedElements.length > 0 && onToggleFavorite && (
+              <>
+                <Separator className="my-1" />
+                <TooltipPrimitive.Root>
+                  <TooltipPrimitive.Trigger asChild>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() =>
+                        onToggleFavorite(selectedElements.map((el) => el.id))
+                      }
+                    >
+                      <Star
+                        className={cn(
+                          "h-4 w-4",
+                          selectedElements.some((el) =>
+                            favoriteElementIds?.has(el.id)
+                          ) && "fill-yellow-400 text-yellow-400"
+                        )}
+                      />
+                    </Button>
+                  </TooltipPrimitive.Trigger>
+                  <TooltipPrimitive.Portal>
+                    <TooltipPrimitive.Content
+                      side="right"
+                      sideOffset={5}
+                      className={tooltipContentClass}
+                    >
+                      <div className="text-center">
+                        <div className="font-medium">お気に入り</div>
+                      </div>
+                    </TooltipPrimitive.Content>
+                  </TooltipPrimitive.Portal>
+                </TooltipPrimitive.Root>
+              </>
+            )}
           </div>
         </Card>
       </div>

--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -410,6 +410,11 @@ function ScoringMainViewContent() {
               onScoringBehaviorChange={(behavior) =>
                 setScoringBehavior(behavior)
               }
+              currentUserId={currentUserId ?? undefined}
+              selectedScoringDataIds={Array.from(selectedStudentAnswerImageIds)}
+              questionScores={questionScores}
+              allScoringData={allScoringData}
+              onQuestionScoreCreated={handleQuestionScoreCreated}
             />
           </div>
         </div>

--- a/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
@@ -1,0 +1,412 @@
+"use client"
+
+import {
+  Circle,
+  Minus,
+  Plus,
+  RectangleHorizontal,
+  Star,
+  Type,
+} from "lucide-react"
+import { useCallback, useEffect, useMemo } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import type { AnnotationWithContext } from "@/types/drawingAnnotation.types"
+
+import type { CropRegionWithExamPage } from "../types"
+import type {
+  AddToTargetsParams,
+  AnnotationDisplayItem,
+  AnnotationFilters,
+} from "./hooks/useAnnotationBrowser"
+
+interface AnnotationBrowserPanelProps {
+  examId: string
+  currentUserId?: string
+  currentCropRegionId?: string
+  currentStudentId?: string
+  cropRegions: CropRegionWithExamPage[]
+  gradingMode: "grid" | "individual"
+  // ブラウザーhookから
+  displayItems: AnnotationDisplayItem[]
+  filters: AnnotationFilters
+  isLoading: boolean
+  onFiltersChange: (partial: Partial<AnnotationFilters>) => void
+  onLoadAnnotations: (examId: string) => Promise<void>
+  onToggleFavorite: (id: string, currentFavorite: boolean) => Promise<void>
+  onAddToTargets: (params: AddToTargetsParams) => Promise<void>
+  // QuestionScore確保用
+  questionScores: Array<{
+    id: string
+    studentId: string
+    cropRegionId: string
+  }>
+  selectedScoringDataIds: string[]
+  allScoringData: Array<{ id: string; studentId: string }>
+  onQuestionScoreCreated?: () => void
+}
+
+// アノテーションタイプのアイコン
+function TypeIcon({ type }: { type: string }) {
+  switch (type) {
+    case "text":
+      return <Type className="h-3.5 w-3.5" />
+    case "line":
+      return <Minus className="h-3.5 w-3.5" />
+    case "rectangle":
+      return <RectangleHorizontal className="h-3.5 w-3.5" />
+    case "ellipse":
+      return <Circle className="h-3.5 w-3.5" />
+    default:
+      return null
+  }
+}
+
+// アノテーションの説明テキスト
+function getDescription(annotation: AnnotationWithContext): string {
+  if (annotation.type === "text") {
+    const text = annotation.text || ""
+    return text.length > 20 ? text.substring(0, 20) + "…" : text || "(空)"
+  }
+  const typeNames: Record<string, string> = {
+    line: "直線",
+    rectangle: "長方形",
+    ellipse: "楕円",
+  }
+  return typeNames[annotation.type] || annotation.type
+}
+
+// ソース情報（設問 + 生徒）
+function getSourceInfo(annotation: AnnotationWithContext): string {
+  const parts: string[] = []
+  if (annotation.questionScore?.cropRegion?.label) {
+    parts.push(annotation.questionScore.cropRegion.label)
+  }
+  if (annotation.questionScore?.student) {
+    const s = annotation.questionScore.student
+    parts.push(`${s.lastName}${s.firstName}`)
+  }
+  return parts.join(" / ") || "—"
+}
+
+export function AnnotationBrowserPanel({
+  examId,
+  currentUserId,
+  currentCropRegionId,
+  currentStudentId,
+  cropRegions,
+  gradingMode,
+  displayItems,
+  filters,
+  isLoading,
+  onFiltersChange,
+  onLoadAnnotations,
+  onToggleFavorite,
+  onAddToTargets,
+  questionScores,
+  selectedScoringDataIds,
+  allScoringData,
+  onQuestionScoreCreated,
+}: AnnotationBrowserPanelProps) {
+  // 初回ロード
+  useEffect(() => {
+    onLoadAnnotations(examId)
+  }, [examId, onLoadAnnotations])
+
+  // ユニークな生徒リスト
+  const uniqueStudents = useMemo(() => {
+    const studentMap = new Map<
+      string,
+      { id: string; studentNumber: string; name: string }
+    >()
+    for (const item of displayItems) {
+      const student = item.representative.questionScore?.student
+      if (student && !studentMap.has(student.id)) {
+        studentMap.set(student.id, {
+          id: student.id,
+          studentNumber: student.studentNumber,
+          name: `${student.lastName}${student.firstName}`,
+        })
+      }
+    }
+    return Array.from(studentMap.values()).sort((a, b) =>
+      a.studentNumber.localeCompare(b.studentNumber, "ja", { numeric: true })
+    )
+  }, [displayItems])
+
+  // QuestionScoreを確保または取得する
+  const ensureQuestionScore = useCallback(
+    async (studentId: string, cropRegionId: string): Promise<string | null> => {
+      // 既存のQuestionScoreを探す
+      const existing = questionScores.find(
+        (qs) => qs.studentId === studentId && qs.cropRegionId === cropRegionId
+      )
+      if (existing) return existing.id
+
+      // なければ作成
+      if (!currentUserId) return null
+      try {
+        const result = await window.electronAPI.createQuestionScore({
+          cropRegionId,
+          studentId,
+          userId: currentUserId,
+          status: "unscored",
+        })
+        if (result?.success && result.score?.id) {
+          onQuestionScoreCreated?.()
+          return result.score.id
+        }
+      } catch (error) {
+        console.error("QuestionScore作成エラー:", error)
+      }
+      return null
+    },
+    [questionScores, currentUserId, onQuestionScoreCreated]
+  )
+
+  // 「追加」ボタンハンドラ
+  const handleAdd = useCallback(
+    async (item: AnnotationDisplayItem) => {
+      if (!currentUserId) return
+
+      const source = item.representative
+      const sourceCropRegionId = source.questionScore?.cropRegionId ?? ""
+
+      if (gradingMode === "individual") {
+        // 個別モード: 現在の生徒+設問に追加
+        if (!currentStudentId || !currentCropRegionId) return
+        const qsId = await ensureQuestionScore(
+          currentStudentId,
+          currentCropRegionId
+        )
+        if (!qsId) return
+
+        await onAddToTargets({
+          sourceAnnotation: source,
+          targetQuestionScoreIds: [qsId],
+          targetCropRegionId: currentCropRegionId,
+          sourceCropRegionId,
+          userId: currentUserId,
+        })
+      } else {
+        // 一覧モード: 選択中の全生徒に追加
+        if (selectedScoringDataIds.length === 0 || !currentCropRegionId) return
+
+        // selectedScoringDataIdsからstudentIdをマッピング
+        const targetStudentIds = selectedScoringDataIds
+          .map((sdId) => {
+            const sd = allScoringData.find((s) => s.id === sdId)
+            return sd?.studentId
+          })
+          .filter((id): id is string => !!id)
+
+        // 各生徒のQuestionScoreを確保
+        const targetQsIds: string[] = []
+        for (const studentId of targetStudentIds) {
+          const qsId = await ensureQuestionScore(studentId, currentCropRegionId)
+          if (qsId) targetQsIds.push(qsId)
+        }
+
+        if (targetQsIds.length === 0) return
+
+        await onAddToTargets({
+          sourceAnnotation: source,
+          targetQuestionScoreIds: targetQsIds,
+          targetCropRegionId: currentCropRegionId,
+          sourceCropRegionId,
+          userId: currentUserId,
+        })
+      }
+
+      // 追加後にアノテーション一覧を再ロード
+      await onLoadAnnotations(examId)
+    },
+    [
+      currentUserId,
+      currentStudentId,
+      currentCropRegionId,
+      gradingMode,
+      selectedScoringDataIds,
+      allScoringData,
+      ensureQuestionScore,
+      onAddToTargets,
+      onLoadAnnotations,
+      examId,
+    ]
+  )
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* フィルタバー */}
+      <div className="space-y-2 border-b p-3">
+        <div className="grid grid-cols-2 gap-2">
+          {/* 設問フィルタ */}
+          <Select
+            value={filters.cropRegionId ?? "all"}
+            onValueChange={(v) =>
+              onFiltersChange({ cropRegionId: v === "all" ? null : v })
+            }
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="設問" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全設問</SelectItem>
+              {cropRegions.map((cr) => (
+                <SelectItem key={cr.id} value={cr.id}>
+                  {cr.label || cr.id.slice(0, 6)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* 生徒フィルタ */}
+          <Select
+            value={filters.studentId ?? "all"}
+            onValueChange={(v) =>
+              onFiltersChange({ studentId: v === "all" ? null : v })
+            }
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="生徒" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全生徒</SelectItem>
+              {uniqueStudents.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.studentNumber} {s.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* 種類フィルタ */}
+          <Select
+            value={filters.type ?? "all"}
+            onValueChange={(v) =>
+              onFiltersChange({
+                type:
+                  v === "all"
+                    ? null
+                    : (v as "text" | "line" | "rectangle" | "ellipse"),
+              })
+            }
+          >
+            <SelectTrigger className="h-8 flex-1 text-xs">
+              <SelectValue placeholder="種類" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全種類</SelectItem>
+              <SelectItem value="text">テキスト</SelectItem>
+              <SelectItem value="line">直線</SelectItem>
+              <SelectItem value="rectangle">長方形</SelectItem>
+              <SelectItem value="ellipse">楕円</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {/* お気に入りのみトグル */}
+          <Button
+            variant={filters.favoritesOnly ? "default" : "outline"}
+            size="sm"
+            className="h-8 shrink-0 px-2"
+            onClick={() =>
+              onFiltersChange({ favoritesOnly: !filters.favoritesOnly })
+            }
+          >
+            <Star
+              className={cn(
+                "h-3.5 w-3.5",
+                filters.favoritesOnly && "fill-current"
+              )}
+            />
+          </Button>
+        </div>
+      </div>
+
+      {/* リスト */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center p-8 text-sm text-gray-400">
+            読み込み中...
+          </div>
+        ) : displayItems.length === 0 ? (
+          <div className="flex items-center justify-center p-8 text-sm text-gray-400">
+            アノテーションがありません
+          </div>
+        ) : (
+          <div className="divide-y">
+            {displayItems.map((item) => (
+              <div
+                key={item.representative.id}
+                className="flex items-center gap-2 px-3 py-2 hover:bg-gray-50"
+              >
+                {/* タイプアイコン */}
+                <div className="shrink-0 text-gray-500">
+                  <TypeIcon type={item.representative.type} />
+                </div>
+
+                {/* 説明 + ソース */}
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-xs font-medium">
+                    {getDescription(item.representative)}
+                  </div>
+                  <div className="truncate text-xs text-gray-400">
+                    {getSourceInfo(item.representative)}
+                  </div>
+                </div>
+
+                {/* 色ドット */}
+                <div
+                  className="h-3 w-3 shrink-0 rounded-full border border-gray-200"
+                  style={{ backgroundColor: item.representative.color }}
+                />
+
+                {/* 件数バッジ */}
+                {item.count > 1 && (
+                  <span className="shrink-0 rounded-full bg-gray-200 px-1.5 py-0.5 text-xs text-gray-600">
+                    ×{item.count}
+                  </span>
+                )}
+
+                {/* 星アイコン */}
+                <button
+                  className="shrink-0 text-gray-400 hover:text-yellow-500"
+                  onClick={() =>
+                    onToggleFavorite(item.representative.id, item.isFavorite)
+                  }
+                >
+                  <Star
+                    className={cn(
+                      "h-3.5 w-3.5",
+                      item.isFavorite && "fill-yellow-400 text-yellow-400"
+                    )}
+                  />
+                </button>
+
+                {/* 追加ボタン */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 shrink-0 px-1.5"
+                  onClick={() => handleAdd(item)}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -13,6 +13,10 @@ import type {
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
 import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+import { AnnotationBrowserPanel } from "./AnnotationBrowserPanel"
+import { useAnnotationBrowser } from "./hooks/useAnnotationBrowser"
 
 interface ScoringSidePanelProps {
   examId: string
@@ -25,7 +29,6 @@ interface ScoringSidePanelProps {
   questionProgress: QuestionProgress
   // Scoring Toolbar props
   selectedAnswersCount: number
-  // currentCropRegion は上記で統一済み
   filterSettings: {
     unscored: boolean
     correct: boolean
@@ -72,6 +75,16 @@ interface ScoringSidePanelProps {
   onScoringBehaviorChange?: (
     behavior: "next-student" | "next-question" | "stay"
   ) => void
+  // アノテーションブラウザー用追加props
+  currentUserId?: string
+  selectedScoringDataIds?: string[]
+  questionScores?: Array<{
+    id: string
+    studentId: string
+    cropRegionId: string
+  }>
+  allScoringData?: Array<{ id: string; studentId: string }>
+  onQuestionScoreCreated?: () => void
 }
 
 export function ScoringSidePanel({
@@ -107,78 +120,125 @@ export function ScoringSidePanel({
   studentAnswerImages,
   scoringBehavior,
   onScoringBehaviorChange,
+  // アノテーションブラウザー用
+  currentUserId,
+  selectedScoringDataIds,
+  questionScores,
+  allScoringData,
+  onQuestionScoreCreated,
 }: ScoringSidePanelProps) {
+  const annotationBrowser = useAnnotationBrowser()
+
+  // 現在のstudentIdを取得
+  const currentStudentId = (() => {
+    if (!selectedStudentAnswerImageIds || !studentAnswerImages) return undefined
+    const selectedId = Array.from(selectedStudentAnswerImageIds)[0]
+    const selectedAnswer = studentAnswerImages.find((a) => a.id === selectedId)
+    return selectedAnswer?.student?.id
+  })()
+
   return (
-    <div className="w-96 overflow-y-auto border-l border-gray-200 bg-white px-4">
-      {/* 設問ナビゲーター */}
-      <QuestionNavigator
-        questionRegions={cropRegions}
-        currentCropRegion={currentCropRegion}
-        onCropRegionChange={onCropRegionChange}
-        onPrevQuestion={onPrevQuestion}
-        onNextQuestion={onNextQuestion}
-        questionProgress={questionProgress}
-      />
+    <div className="flex h-full w-96 flex-col border-l border-gray-200 bg-white">
+      <Tabs defaultValue="scoring" className="flex h-full flex-col">
+        <TabsList className="mx-4 mt-2 w-[calc(100%-2rem)] shrink-0">
+          <TabsTrigger value="scoring">採点</TabsTrigger>
+          <TabsTrigger value="annotations">アノテーション</TabsTrigger>
+        </TabsList>
 
-      <Separator />
+        <TabsContent value="scoring" className="flex-1 overflow-y-auto px-4">
+          {/* 設問ナビゲーター */}
+          <QuestionNavigator
+            questionRegions={cropRegions}
+            currentCropRegion={currentCropRegion}
+            onCropRegionChange={onCropRegionChange}
+            onPrevQuestion={onPrevQuestion}
+            onNextQuestion={onNextQuestion}
+            questionProgress={questionProgress}
+          />
 
-      {/* 採点ツールバー */}
-      <ScoringToolbar
-        selectedAnswersCount={selectedAnswersCount}
-        currentCropRegion={currentCropRegion}
-        filterSettings={filterSettings}
-        onScore={onScore}
-        onToggleFilter={onToggleFilter}
-        onRefreshFilter={onRefreshFilter}
-        partialScoreInput={partialScoreInput}
-        gradingMode={gradingMode}
-      />
+          <Separator />
 
-      {/* 個別表示モード時：生徒選択パネル */}
-      {gradingMode === "individual" &&
-        students &&
-        onStudentChange &&
-        onScoringBehaviorChange &&
-        scoringBehavior && (
-          <>
-            <Separator />
-            <IndividualModePanel
-              students={students}
-              selectedAnswers={selectedStudentAnswerImageIds}
-              studentAnswerImages={studentAnswerImages}
-              onStudentChange={onStudentChange}
-              scoringBehavior={scoringBehavior}
-              onScoringBehaviorChange={onScoringBehaviorChange}
-            />
-          </>
-        )}
+          {/* 採点ツールバー */}
+          <ScoringToolbar
+            selectedAnswersCount={selectedAnswersCount}
+            currentCropRegion={currentCropRegion}
+            filterSettings={filterSettings}
+            onScore={onScore}
+            onToggleFilter={onToggleFilter}
+            onRefreshFilter={onRefreshFilter}
+            partialScoreInput={partialScoreInput}
+            gradingMode={gradingMode}
+          />
 
-      <Separator />
+          {/* 個別表示モード時：生徒選択パネル */}
+          {gradingMode === "individual" &&
+            students &&
+            onStudentChange &&
+            onScoringBehaviorChange &&
+            scoringBehavior && (
+              <>
+                <Separator />
+                <IndividualModePanel
+                  students={students}
+                  selectedAnswers={selectedStudentAnswerImageIds}
+                  studentAnswerImages={studentAnswerImages}
+                  onStudentChange={onStudentChange}
+                  scoringBehavior={scoringBehavior}
+                  onScoringBehaviorChange={onScoringBehaviorChange}
+                />
+              </>
+            )}
 
-      {/* ナビゲーション制御 */}
-      <NavigationControls
-        layoutDirection={layoutDirection}
-        selectedAnswersCount={selectedAnswersCount}
-        visibleAnswersCount={visibleAnswersCount}
-        totalAnswersCount={totalAnswersCount}
-        onLayoutDirectionChange={onLayoutDirectionChange}
-        onGridNavigation={onGridNavigation}
-        onRefreshView={onRefreshView}
-        itemsPerRow={itemsPerLine}
-        onItemsPerRowChange={onItemsPerLineChange}
-        autoScroll={autoScroll}
-        onAutoScrollChange={onAutoScrollChange}
-        gradingMode={gradingMode}
-        expandMargin={expandMargin}
-        onExpandMarginChange={onExpandMarginChange}
-      />
+          <Separator />
 
-      <Separator />
+          {/* ナビゲーション制御 */}
+          <NavigationControls
+            layoutDirection={layoutDirection}
+            selectedAnswersCount={selectedAnswersCount}
+            visibleAnswersCount={visibleAnswersCount}
+            totalAnswersCount={totalAnswersCount}
+            onLayoutDirectionChange={onLayoutDirectionChange}
+            onGridNavigation={onGridNavigation}
+            onRefreshView={onRefreshView}
+            itemsPerRow={itemsPerLine}
+            onItemsPerRowChange={onItemsPerLineChange}
+            autoScroll={autoScroll}
+            onAutoScrollChange={onAutoScrollChange}
+            gradingMode={gradingMode}
+            expandMargin={expandMargin}
+            onExpandMarginChange={onExpandMarginChange}
+          />
 
-      {/* 試験進捗 */}
-      <div className="py-3">
-        <ExamProgressCard examId={examId} />
-      </div>
+          <Separator />
+
+          {/* 試験進捗 */}
+          <div className="py-3">
+            <ExamProgressCard examId={examId} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="annotations" className="flex-1 overflow-y-auto">
+          <AnnotationBrowserPanel
+            examId={examId}
+            currentUserId={currentUserId}
+            currentCropRegionId={currentCropRegion?.id}
+            currentStudentId={currentStudentId}
+            cropRegions={cropRegions}
+            gradingMode={gradingMode}
+            displayItems={annotationBrowser.displayItems}
+            filters={annotationBrowser.filters}
+            isLoading={annotationBrowser.isLoading}
+            onFiltersChange={annotationBrowser.setFilters}
+            onLoadAnnotations={annotationBrowser.loadAnnotations}
+            onToggleFavorite={annotationBrowser.toggleFavorite}
+            onAddToTargets={annotationBrowser.addToTargets}
+            questionScores={questionScores ?? []}
+            selectedScoringDataIds={selectedScoringDataIds ?? []}
+            allScoringData={allScoringData ?? []}
+            onQuestionScoreCreated={onQuestionScoreCreated}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
+++ b/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
@@ -1,0 +1,295 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+
+import type {
+  AnnotationWithContext,
+  DrawingCreateData,
+  DrawingType,
+} from "@/types/drawingAnnotation.types"
+
+// 重複省略後の表示アイテム
+export interface AnnotationDisplayItem {
+  /** 代表アノテーション */
+  representative: AnnotationWithContext
+  /** グループ内のアノテーション数 */
+  count: number
+  /** グループ内にお気に入りが1件でもあるか */
+  isFavorite: boolean
+  /** グループ内の全アノテーションID */
+  allIds: string[]
+}
+
+// フィルタ設定
+export interface AnnotationFilters {
+  cropRegionId: string | null
+  studentId: string | null
+  type: DrawingType | null
+  favoritesOnly: boolean
+}
+
+// addToTargets用パラメータ
+export interface AddToTargetsParams {
+  sourceAnnotation: AnnotationWithContext
+  targetQuestionScoreIds: string[]
+  targetCropRegionId: string
+  sourceCropRegionId: string
+  userId: string
+}
+
+/**
+ * 重複省略のグルーピングキーを生成
+ */
+function getGroupingKey(a: AnnotationWithContext): string {
+  const cropRegionId = a.questionScore?.cropRegionId ?? ""
+  return [
+    cropRegionId,
+    a.type,
+    a.text,
+    a.color,
+    a.strokeWidth,
+    a.fontSize,
+    a.lineStyle,
+    a.x.toFixed(3),
+    a.y.toFixed(3),
+    a.width.toFixed(3),
+    a.height.toFixed(3),
+    a.endX.toFixed(3),
+    a.endY.toFixed(3),
+  ].join("|")
+}
+
+/**
+ * アノテーションの位置を中央配置に変換する
+ */
+function centerPosition(
+  source: AnnotationWithContext
+): Partial<DrawingCreateData> {
+  if (source.type === "line") {
+    const midX = (source.x + source.endX) / 2
+    const midY = (source.y + source.endY) / 2
+    const offsetX = 0.5 - midX
+    const offsetY = 0.5 - midY
+    return {
+      x: source.x + offsetX,
+      y: source.y + offsetY,
+      endX: source.endX + offsetX,
+      endY: source.endY + offsetY,
+      displayX: source.x + offsetX,
+      displayY: source.y + offsetY,
+    }
+  }
+  // rect/ellipse/text
+  const w = source.type === "text" ? source.textBoxWidth : source.width
+  const h = source.type === "text" ? source.textBoxHeight : source.height
+  return {
+    x: 0.5 - w / 2,
+    y: 0.5 - h / 2,
+    displayX: 0.5 - w / 2,
+    displayY: 0.5 - h / 2,
+  }
+}
+
+export interface UseAnnotationBrowserReturn {
+  allAnnotations: AnnotationWithContext[]
+  displayItems: AnnotationDisplayItem[]
+  isLoading: boolean
+  filters: AnnotationFilters
+  setFilters: (partial: Partial<AnnotationFilters>) => void
+  loadAnnotations: (examId: string) => Promise<void>
+  toggleFavorite: (id: string, currentFavorite: boolean) => Promise<void>
+  addToTargets: (params: AddToTargetsParams) => Promise<void>
+}
+
+export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
+  const [allAnnotations, setAllAnnotations] = useState<AnnotationWithContext[]>(
+    []
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [filters, setFiltersState] = useState<AnnotationFilters>({
+    cropRegionId: null,
+    studentId: null,
+    type: null,
+    favoritesOnly: false,
+  })
+
+  const setFilters = useCallback((partial: Partial<AnnotationFilters>) => {
+    setFiltersState((prev) => ({ ...prev, ...partial }))
+  }, [])
+
+  const loadAnnotations = useCallback(async (examId: string) => {
+    setIsLoading(true)
+    try {
+      const result = await window.electronAPI.drawing.getForBrowse(examId)
+      if (result.success && result.data) {
+        setAllAnnotations(result.data)
+      }
+    } catch (error) {
+      console.error("アノテーション読み込みエラー:", error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // フィルタ + 重複省略後の表示リスト
+  const displayItems = useMemo(() => {
+    // フィルタ適用
+    let filtered = allAnnotations
+    if (filters.cropRegionId) {
+      filtered = filtered.filter(
+        (a) => a.questionScore?.cropRegionId === filters.cropRegionId
+      )
+    }
+    if (filters.studentId) {
+      filtered = filtered.filter(
+        (a) => a.questionScore?.studentId === filters.studentId
+      )
+    }
+    if (filters.type) {
+      filtered = filtered.filter((a) => a.type === filters.type)
+    }
+    if (filters.favoritesOnly) {
+      filtered = filtered.filter((a) => a.isFavorite)
+    }
+
+    // 重複省略: グルーピング
+    const groups = new Map<string, AnnotationWithContext[]>()
+    for (const annotation of filtered) {
+      const key = getGroupingKey(annotation)
+      const existing = groups.get(key)
+      if (existing) {
+        existing.push(annotation)
+      } else {
+        groups.set(key, [annotation])
+      }
+    }
+
+    // 表示アイテムに変換
+    const items: AnnotationDisplayItem[] = []
+    for (const annotations of groups.values()) {
+      // updatedAt descで最新を代表にする
+      const sorted = [...annotations].sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      )
+      items.push({
+        representative: sorted[0],
+        count: annotations.length,
+        isFavorite: annotations.some((a) => a.isFavorite),
+        allIds: annotations.map((a) => a.id),
+      })
+    }
+
+    // ソート: お気に入り優先 → updatedAt desc
+    items.sort((a, b) => {
+      if (a.isFavorite !== b.isFavorite) return a.isFavorite ? -1 : 1
+      return (
+        new Date(b.representative.updatedAt).getTime() -
+        new Date(a.representative.updatedAt).getTime()
+      )
+    })
+
+    return items
+  }, [allAnnotations, filters])
+
+  const toggleFavorite = useCallback(
+    async (id: string, currentFavorite: boolean) => {
+      try {
+        const result = await window.electronAPI.drawing.toggleFavorite(
+          id,
+          !currentFavorite
+        )
+        if (result.success) {
+          // ローカル状態を即時更新
+          setAllAnnotations((prev) =>
+            prev.map((a) =>
+              a.id === id ? { ...a, isFavorite: !currentFavorite } : a
+            )
+          )
+        }
+      } catch (error) {
+        console.error("お気に入り切替エラー:", error)
+      }
+    },
+    []
+  )
+
+  const addToTargets = useCallback(async (params: AddToTargetsParams) => {
+    const {
+      sourceAnnotation,
+      targetQuestionScoreIds,
+      targetCropRegionId,
+      sourceCropRegionId,
+      userId,
+    } = params
+
+    // 位置計算: 同一設問→同位置、異設問→中央配置
+    const isSameQuestion = sourceCropRegionId === targetCropRegionId
+    const positionOverride = isSameQuestion
+      ? {}
+      : centerPosition(sourceAnnotation)
+
+    const createDataList: DrawingCreateData[] = targetQuestionScoreIds.map(
+      (qsId) => ({
+        questionScoreId: qsId,
+        type: sourceAnnotation.type,
+        x: sourceAnnotation.x,
+        y: sourceAnnotation.y,
+        color: sourceAnnotation.color,
+        strokeWidth: sourceAnnotation.strokeWidth,
+        width: sourceAnnotation.width,
+        height: sourceAnnotation.height,
+        endX: sourceAnnotation.endX,
+        endY: sourceAnnotation.endY,
+        lineStyle: sourceAnnotation.lineStyle,
+        text: sourceAnnotation.text,
+        fontSize: sourceAnnotation.fontSize,
+        textBoxWidth: sourceAnnotation.textBoxWidth,
+        textBoxHeight: sourceAnnotation.textBoxHeight,
+        horizontalAlign: sourceAnnotation.horizontalAlign,
+        verticalAlign: sourceAnnotation.verticalAlign,
+        anchorDirection: sourceAnnotation.anchorDirection,
+        displayX: sourceAnnotation.displayX,
+        displayY: sourceAnnotation.displayY,
+        userId,
+        ...positionOverride,
+      })
+    )
+
+    try {
+      if (createDataList.length === 1) {
+        const result = await window.electronAPI.drawing.create(
+          createDataList[0]
+        )
+        if (result.success && result.data) {
+          setAllAnnotations((prev) => [
+            result.data as AnnotationWithContext,
+            ...prev,
+          ])
+        }
+      } else if (createDataList.length > 1) {
+        const result =
+          await window.electronAPI.drawing.batchCreate(createDataList)
+        if (result.success && result.data) {
+          setAllAnnotations((prev) => [
+            ...(result.data as AnnotationWithContext[]),
+            ...prev,
+          ])
+        }
+      }
+    } catch (error) {
+      console.error("アノテーション追加エラー:", error)
+    }
+  }, [])
+
+  return {
+    allAnnotations,
+    displayItems,
+    isLoading,
+    filters,
+    setFilters,
+    loadAnnotations,
+    toggleFavorite,
+    addToTargets,
+  }
+}

--- a/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -292,6 +292,7 @@ export function PdfCanvasRenderer({
           | "bottom-left"
           | "bottom"
           | "bottom-right",
+        isFavorite: false,
         createdAt: new Date(),
         updatedAt: new Date(),
         userId: a.userId,

--- a/electron-src/ipc-handlers/drawingHandlers.ts
+++ b/electron-src/ipc-handlers/drawingHandlers.ts
@@ -261,6 +261,50 @@ export function setupDrawingHandlers() {
   })
 
   /**
+   * アノテーションお気に入り切替
+   */
+  ipcMain.handle(
+    "drawing:toggleFavorite",
+    async (_, id: string, isFavorite: boolean) => {
+      try {
+        const result = await drawingService.toggleAnnotationFavorite(
+          id,
+          isFavorite
+        )
+        return { success: true, data: result }
+      } catch (error) {
+        console.error("🚫 アノテーションお気に入り切替エラー:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "アノテーションお気に入り切替に失敗しました",
+        }
+      }
+    }
+  )
+
+  /**
+   * ブラウズ用アノテーション取得
+   */
+  ipcMain.handle("drawing:getForBrowse", async (_, examId: string) => {
+    try {
+      const result = await drawingService.getAnnotationsForBrowse(examId)
+      return { success: true, data: result }
+    } catch (error) {
+      console.error("🚫 ブラウズ用アノテーション取得エラー:", error)
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "ブラウズ用アノテーション取得に失敗しました",
+      }
+    }
+  })
+
+  /**
    * 描画アノテーションID取得
    */
   ipcMain.handle("drawing:getById", async (_, id: string) => {
@@ -296,6 +340,8 @@ export function removeDrawingHandlers() {
     "drawing:batchUpdate",
     "drawing:getStats",
     "drawing:getById",
+    "drawing:toggleFavorite",
+    "drawing:getForBrowse",
   ]
 
   handlers.forEach((handler) => {

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  AnnotationWithContext,
   DrawingAnnotation,
   DrawingAnnotationStats,
   DrawingCreateData,
@@ -511,6 +512,118 @@ export async function getDrawingAnnotationById(
     return result as DrawingAnnotation | null
   } catch (error) {
     console.error("描画アノテーション単体取得エラー:", error)
+    throw error
+  }
+}
+
+/**
+ * アノテーションのお気に入りフラグを切り替える
+ * @param id 描画アノテーションのID
+ * @param isFavorite お気に入り状態
+ * @returns Promise<DrawingAnnotation> 更新された描画アノテーション
+ */
+export async function toggleAnnotationFavorite(
+  id: string,
+  isFavorite: boolean
+): Promise<DrawingAnnotation> {
+  try {
+    const result = await prisma.drawingAnnotation.update({
+      where: { id },
+      data: { isFavorite },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            studentId: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+            student: {
+              select: {
+                id: true,
+                studentNumber: true,
+                lastName: true,
+                firstName: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    return result as DrawingAnnotation
+  } catch (error) {
+    console.error("アノテーションお気に入り切替エラー:", error)
+    throw error
+  }
+}
+
+/**
+ * 試験全体のアノテーションをブラウズ用に取得する（コンテキスト情報付き）
+ * @param examId 試験ID
+ * @returns Promise<AnnotationWithContext[]> コンテキスト情報付きアノテーション配列
+ */
+export async function getAnnotationsForBrowse(
+  examId: string
+): Promise<AnnotationWithContext[]> {
+  try {
+    const result = await prisma.drawingAnnotation.findMany({
+      where: {
+        questionScore: {
+          cropRegion: {
+            examPage: {
+              examId: examId,
+            },
+          },
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            studentId: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+            student: {
+              select: {
+                id: true,
+                studentNumber: true,
+                lastName: true,
+                firstName: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    return result as AnnotationWithContext[]
+  } catch (error) {
+    console.error("ブラウズ用アノテーション取得エラー:", error)
     throw error
   }
 }

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -602,6 +602,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     getStats: (questionScoreId: string) =>
       ipcRenderer.invoke("drawing:getStats", questionScoreId),
     getById: (id: string) => ipcRenderer.invoke("drawing:getById", id),
+    toggleFavorite: (id: string, isFavorite: boolean) =>
+      ipcRenderer.invoke("drawing:toggleFavorite", id, isFavorite),
+    getForBrowse: (examId: string) =>
+      ipcRenderer.invoke("drawing:getForBrowse", examId),
   },
 
   // Exam Archive (Export/Import) related

--- a/prisma/migrations/20260303200000_add_annotation_favorite/migration.sql
+++ b/prisma/migrations/20260303200000_add_annotation_favorite/migration.sql
@@ -1,0 +1,41 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_DrawingAnnotation" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "questionScoreId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "x" REAL NOT NULL,
+    "y" REAL NOT NULL,
+    "color" TEXT NOT NULL DEFAULT '#ef4444',
+    "strokeWidth" INTEGER NOT NULL DEFAULT 3,
+    "width" REAL NOT NULL DEFAULT 0.0,
+    "height" REAL NOT NULL DEFAULT 0.0,
+    "endX" REAL NOT NULL DEFAULT 0.0,
+    "endY" REAL NOT NULL DEFAULT 0.0,
+    "lineStyle" TEXT NOT NULL DEFAULT 'solid',
+    "text" TEXT NOT NULL DEFAULT '',
+    "fontSize" INTEGER NOT NULL DEFAULT 16,
+    "textBoxWidth" REAL NOT NULL DEFAULT 0.0,
+    "textBoxHeight" REAL NOT NULL DEFAULT 0.0,
+    "horizontalAlign" TEXT NOT NULL DEFAULT 'left',
+    "verticalAlign" TEXT NOT NULL DEFAULT 'top',
+    "anchorDirection" TEXT NOT NULL DEFAULT 'top-left',
+    "displayX" REAL NOT NULL DEFAULT 0.0,
+    "displayY" REAL NOT NULL DEFAULT 0.0,
+    "isFavorite" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "DrawingAnnotation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "DrawingAnnotation_questionScoreId_fkey" FOREIGN KEY ("questionScoreId") REFERENCES "QuestionScore" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_DrawingAnnotation" ("anchorDirection", "color", "createdAt", "displayX", "displayY", "endX", "endY", "fontSize", "height", "horizontalAlign", "id", "lineStyle", "questionScoreId", "strokeWidth", "text", "textBoxHeight", "textBoxWidth", "type", "updatedAt", "userId", "verticalAlign", "width", "x", "y") SELECT "anchorDirection", "color", "createdAt", "displayX", "displayY", "endX", "endY", "fontSize", "height", "horizontalAlign", "id", "lineStyle", "questionScoreId", "strokeWidth", "text", "textBoxHeight", "textBoxWidth", "type", "updatedAt", "userId", "verticalAlign", "width", "x", "y" FROM "DrawingAnnotation";
+DROP TABLE "DrawingAnnotation";
+ALTER TABLE "new_DrawingAnnotation" RENAME TO "DrawingAnnotation";
+CREATE INDEX "DrawingAnnotation_questionScoreId_idx" ON "DrawingAnnotation"("questionScoreId");
+CREATE INDEX "DrawingAnnotation_type_idx" ON "DrawingAnnotation"("type");
+CREATE INDEX "DrawingAnnotation_createdAt_idx" ON "DrawingAnnotation"("createdAt");
+CREATE INDEX "DrawingAnnotation_isFavorite_idx" ON "DrawingAnnotation"("isFavorite");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -273,6 +273,7 @@ model DrawingAnnotation {
   anchorDirection String        @default("top-left")
   displayX        Float         @default(0.0)
   displayY        Float         @default(0.0)
+  isFavorite      Boolean       @default(false)
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
   userId          String
@@ -282,6 +283,7 @@ model DrawingAnnotation {
   @@index([questionScoreId])
   @@index([type])
   @@index([createdAt])
+  @@index([isFavorite])
 }
 
 model ExamClass {

--- a/types/drawingAnnotation.types.ts
+++ b/types/drawingAnnotation.types.ts
@@ -62,6 +62,9 @@ export interface DrawingAnnotation {
   displayX: number // 0.0 - 1.0
   displayY: number // 0.0 - 1.0
 
+  // お気に入り
+  isFavorite: boolean
+
   // メタデータ
   createdAt: Date
   updatedAt: Date
@@ -120,6 +123,7 @@ export interface DrawingUpdateData {
   anchorDirection?: AnchorDirection
   displayX?: number
   displayY?: number
+  isFavorite?: boolean
 }
 
 // 型ガード関数
@@ -176,6 +180,27 @@ export interface DrawingAnnotationResponse {
   success: boolean
   data?: DrawingAnnotation | DrawingAnnotation[]
   error?: string
+}
+
+// QuestionScore情報を含む拡張型（アノテーションブラウズパネル用）
+export interface AnnotationWithContext extends DrawingAnnotation {
+  questionScore?: {
+    id: string
+    studentId: string
+    cropRegionId: string
+    cropRegion?: { id: string; label: string }
+    student?: {
+      id: string
+      studentNumber: string
+      lastName: string
+      firstName: string
+    }
+  } | null
+  user?: {
+    id: string
+    username: string
+    name: string | null
+  } | null
 }
 
 // QuestionScore情報を含む拡張型（透明度制御用）

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1449,6 +1449,19 @@ export interface MyAPI {
       data?: import("./drawing-annotation.types").DrawingAnnotation | null
       error?: string
     }>
+    toggleFavorite: (
+      id: string,
+      isFavorite: boolean
+    ) => Promise<{
+      success: boolean
+      data?: import("./drawing-annotation.types").DrawingAnnotation
+      error?: string
+    }>
+    getForBrowse: (examId: string) => Promise<{
+      success: boolean
+      data?: import("./drawing-annotation.types").AnnotationWithContext[]
+      error?: string
+    }>
   }
 
   // ExamClass関連


### PR DESCRIPTION
## Summary

Closes #432

- `DrawingAnnotation` に `isFavorite` フラグを追加し、お気に入り登録機能を実装
- サイドパネルをタブ化し、アノテーションブラウズパネルを追加
- 設問・生徒・種類・お気に入りでフィルタ可能な一覧表示
- 同一設問→同位置コピー、異設問→中央配置の位置ロジック
- 個別モード・一覧モード両方でのアノテーション追加に対応
- 重複アノテーションは代表1件＋件数バッジで省略表示

## 変更ファイル（14ファイル、+1167/-65行）

| カテゴリ | ファイル | 変更内容 |
|---|---|---|
| DB | `prisma/schema.prisma` | isFavorite + index 追加 |
| DB | `prisma/migrations/...` | マイグレーションSQL |
| 型 | `types/drawingAnnotation.types.ts` | isFavorite, AnnotationWithContext |
| 型 | `types/electron.d.ts` | 新IPC型定義 |
| BE | `electron-src/lib/prisma/drawingAnnotation.ts` | 2関数追加 |
| BE | `electron-src/ipc-handlers/drawingHandlers.ts` | 2ハンドラー追加 |
| BE | `electron-src/preload.ts` | Preload API追加 |
| FE | `ScoringSidePanel.tsx` | タブ化 + 追加props |
| FE | `AnnotationBrowserPanel.tsx` | **新規** ブラウズUI |
| FE | `hooks/useAnnotationBrowser.ts` | **新規** データ管理hook |
| FE | `DrawingToolPalette.tsx` | 星ボタン追加 |
| FE | `AnswerIndividualView.tsx` | toggleFavorite配線 |
| FE | `ScoringMainView.tsx` | 追加props引き渡し |
| FE | `PdfCanvasRenderer.tsx` | isFavorite型互換修正 |

## Test plan

- [ ] `npx prisma migrate deploy` でマイグレーション正常適用
- [ ] `npm run typecheck` 通過
- [ ] `npm run lint` 通過（変更ファイルのみ）
- [ ] 個別表示でアノテーション作成 → 星ボタンでお気に入り登録
- [ ] サイドパネル「アノテーション」タブ切替 → 全アノテーション一覧表示
- [ ] フィルタ操作（設問/生徒/種類/お気に入りのみ）
- [ ] 同一設問の「追加」→ 同位置にコピー確認
- [ ] 異設問の「追加」→ 中央配置確認
- [ ] 一覧表示で複数セル選択 → 「追加」→ 全選択生徒にアノテーション追加確認
- [ ] 一括追加後のパネル表示 → 重複が代表1件+×Nバッジで省略
- [ ] 採点タブとの切替でstate保持確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)