### PR TITLE
模範解答テキストの透明文字化とモード切替UIの改善

### DIFF
--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -73,7 +73,10 @@ function isDragInfoEqual(
   return false
 }
 
-function getSegmentStyle(seg: InlineSegment): React.CSSProperties {
+function getSegmentStyle(
+  seg: InlineSegment,
+  renderMode?: RenderMode
+): React.CSSProperties {
   const style: React.CSSProperties = {}
   if (seg.bold) style.fontWeight = "bold"
   if (seg.italic || seg.math) style.fontStyle = "italic"
@@ -83,7 +86,9 @@ function getSegmentStyle(seg: InlineSegment): React.CSSProperties {
       ? `${style.textDecoration} underline`
       : "underline"
   }
-  if (seg.modelAnswer) style.color = "#d00"
+  if (seg.modelAnswer) {
+    style.color = renderMode === "model-answer" ? "#d00" : "transparent"
+  }
   return style
 }
 
@@ -91,27 +96,31 @@ function renderSegmentsTspan(
   segments: InlineSegment[],
   renderMode: RenderMode
 ): React.ReactNode[] {
-  return segments
-    .filter((seg) => !seg.modelAnswer || renderMode === "model-answer")
-    .map((seg, i) => (
-      <tspan
-        key={i}
-        fontWeight={seg.bold ? "bold" : undefined}
-        fontStyle={seg.italic || seg.math ? "italic" : undefined}
-        textDecoration={
-          seg.strikethrough && seg.underline
-            ? "line-through underline"
-            : seg.strikethrough
-              ? "line-through"
-              : seg.underline
-                ? "underline"
-                : undefined
-        }
-        fill={seg.modelAnswer ? "#d00" : undefined}
-      >
-        {seg.text}
-      </tspan>
-    ))
+  return segments.map((seg, i) => (
+    <tspan
+      key={i}
+      fontWeight={seg.bold ? "bold" : undefined}
+      fontStyle={seg.italic || seg.math ? "italic" : undefined}
+      textDecoration={
+        seg.strikethrough && seg.underline
+          ? "line-through underline"
+          : seg.strikethrough
+            ? "line-through"
+            : seg.underline
+              ? "underline"
+              : undefined
+      }
+      fill={
+        seg.modelAnswer
+          ? renderMode === "model-answer"
+            ? "#d00"
+            : "transparent"
+          : undefined
+      }
+    >
+      {seg.text}
+    </tspan>
+  ))
 }
 
 function renderSegmentsHtml(
@@ -119,26 +128,24 @@ function renderSegmentsHtml(
   renderMode: RenderMode,
   fontSize: number
 ): React.ReactNode[] {
-  return segments
-    .filter((seg) => !seg.modelAnswer || renderMode === "model-answer")
-    .map((seg, i) => {
-      const style = getSegmentStyle(seg)
-      if (seg.math) {
-        return (
-          <span
-            key={i}
-            className="mathjax-inline"
-            style={{ ...style, fontSize: `${fontSize}px` }}
-            dangerouslySetInnerHTML={{ __html: `\\(${seg.text}\\)` }}
-          />
-        )
-      }
+  return segments.map((seg, i) => {
+    const style = getSegmentStyle(seg, renderMode)
+    if (seg.math) {
       return (
-        <span key={i} style={style}>
-          {seg.text}
-        </span>
+        <span
+          key={i}
+          className="mathjax-inline"
+          style={{ ...style, fontSize: `${fontSize}px` }}
+          dangerouslySetInnerHTML={{ __html: `\\(${seg.text}\\)` }}
+        />
       )
-    })
+    }
+    return (
+      <span key={i} style={style}>
+        {seg.text}
+      </span>
+    )
+  })
 }
 
 export function AnswerSheetSVGRenderer({

--- a/components/answer-sheet-builder/components/preview/PreviewToolbar.tsx
+++ b/components/answer-sheet-builder/components/preview/PreviewToolbar.tsx
@@ -3,13 +3,8 @@
 import { ChevronLeft, ChevronRight, Minus, Move, Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import type { RenderMode } from "@/types/answerSheetBuilder.types"
 
 interface PreviewToolbarProps {
@@ -120,18 +115,22 @@ export function PreviewToolbar({
       </div>
 
       {/* モード切替 */}
-      <Select
-        value={renderMode}
-        onValueChange={(v) => onRenderModeChange(v as RenderMode)}
-      >
-        <SelectTrigger className="h-7 w-28 text-xs">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="answer-sheet">解答用紙</SelectItem>
-          <SelectItem value="model-answer">模範解答</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex items-center gap-1.5">
+        <Switch
+          id="render-mode-toggle"
+          checked={renderMode === "model-answer"}
+          onCheckedChange={(checked) =>
+            onRenderModeChange(checked ? "model-answer" : "answer-sheet")
+          }
+          className="scale-75"
+        />
+        <Label
+          htmlFor="render-mode-toggle"
+          className="text-muted-foreground cursor-pointer text-xs"
+        >
+          模範解答の表示
+        </Label>
+      </div>
     </div>
   )
 }

--- a/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -62,18 +62,19 @@ function escapeXml(str: string): string {
 /** テキスト要素をインラインマークアップ対応でSVG tspan群に変換 */
 function renderTextElementTspans(text: string, renderMode: RenderMode): string {
   const segments = parseInlineMarkup(text)
-  const filtered = segments.filter(
-    (seg) => !seg.modelAnswer || renderMode === "model-answer"
-  )
-  if (filtered.length === 0) return ""
+  if (segments.length === 0) return ""
 
-  return filtered
+  return segments
     .map((seg) => {
       const attrs: string[] = []
       if (seg.bold) attrs.push('font-weight="bold"')
       if (seg.italic) attrs.push('font-style="italic"')
       if (seg.strikethrough) attrs.push('text-decoration="line-through"')
-      if (seg.modelAnswer) attrs.push('fill="#d00"')
+      if (seg.modelAnswer) {
+        attrs.push(
+          renderMode === "model-answer" ? 'fill="#d00"' : 'fill="transparent"'
+        )
+      }
       const attrStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : ""
       return `<tspan${attrStr}>${escapeXml(seg.text)}</tspan>`
     })


### PR DESCRIPTION
## Summary

- `||text||`模範解答テキストを非表示(filter)から透明文字(fill:transparent)に変更し、レイアウト維持
- モード切替をSelectドロップダウンからSwitch+ラベル「模範解答の表示」に変更
- SVGプレビュー・HTMLプレビュー・SVG出力の3箇所を統一的に修正

Closes #434

## Test plan

- [ ] 解答用紙モードで`||text||`テキストが透明（スペース確保）になること
- [ ] 模範解答モードで`||text||`テキストが赤色で表示されること
- [ ] Switchトグルで解答用紙/模範解答を切り替えられること
- [ ] PNG/PDF出力でも透明文字/赤色表示が正しく反映されること
- [ ] `npm run lint`が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)