### PR TITLE
fix: projects/→exams/リネームに伴う答案画像表示エラーを修正

### DIFF
--- a/electron-src/appInitializer.ts
+++ b/electron-src/appInitializer.ts
@@ -4,6 +4,31 @@ import {
 } from "./lib/dataManager"
 import { optimizeDatabaseForSharedDrive } from "./lib/prisma/databaseInitializer"
 
+// DB内の imagePath を projects/ → exams/ に一括更新（v0.6.x リネーム対応）
+async function migrateImagePathsInDatabase(): Promise<void> {
+  try {
+    const { getPrismaClient } = await import("./lib/prisma/client")
+    const prisma = getPrismaClient()
+
+    const [masterResult, answerResult] = await prisma.$transaction([
+      prisma.$executeRawUnsafe(
+        `UPDATE "MasterImage" SET "imagePath" = 'exams/' || SUBSTR("imagePath", LENGTH('projects/') + 1) WHERE "imagePath" LIKE 'projects/%'`
+      ),
+      prisma.$executeRawUnsafe(
+        `UPDATE "StudentAnswerImage" SET "imagePath" = 'exams/' || SUBSTR("imagePath", LENGTH('projects/') + 1) WHERE "imagePath" LIKE 'projects/%'`
+      ),
+    ])
+
+    if (masterResult > 0 || answerResult > 0) {
+      console.log(
+        `Migrated imagePath in DB: MasterImage=${masterResult}, StudentAnswerImage=${answerResult}`
+      )
+    }
+  } catch (error) {
+    console.error("Failed to migrate imagePath in database:", error)
+  }
+}
+
 export async function initializeApp(): Promise<void> {
   try {
     // データディレクトリの初期化
@@ -33,6 +58,9 @@ export async function initializeApp(): Promise<void> {
         `Database initialization failed: ${dbError instanceof Error ? dbError.message : dbError}`
       )
     }
+
+    // DB内の imagePath を projects/ → exams/ に更新（v0.6.x リネーム対応）
+    await migrateImagePathsInDatabase()
 
     // 共有ドライブ用の最適化
     await optimizeDatabaseForSharedDrive()

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -70,6 +70,11 @@ app.on("ready", async () => {
           request.url.replace(/^appimg:\/\/\/?/, "")
         )
 
+        // projects/ → exams/ パス正規化（v0.6.x リネーム対応）
+        if (filePath.startsWith("projects/")) {
+          filePath = "exams/" + filePath.slice("projects/".length)
+        }
+
         // 相対パスの場合はデータディレクトリからの絶対パスに変換
         if (!path.isAbsolute(filePath)) {
           filePath = getAbsolutePathFromData(filePath)

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -218,11 +218,14 @@ export async function collectExamData(
 
     for (const page of exam.examPages) {
       for (const img of page.masterImages) {
-        masterImagePaths.push(img.imagePath)
+        // projects/ → exams/ パス正規化（v0.6.x リネーム対応）
+        const normalized = img.imagePath.replace(/^projects\//, "exams/")
+        masterImagePaths.push(normalized)
       }
       if (!isTemplate) {
         for (const img of page.studentAnswerImages) {
-          answerSheetPaths.push(img.imagePath)
+          const normalized = img.imagePath.replace(/^projects\//, "exams/")
+          answerSheetPaths.push(normalized)
         }
       }
     }


### PR DESCRIPTION
## Summary

- `appimg://` プロトコルハンドラに `projects/` → `exams/` パス正規化を追加（即時修復）
- アプリ起動時にDB内の `MasterImage` / `StudentAnswerImage` の `imagePath` を一括更新
- アーカイブエクスポート時にもパス正規化を適用（安全策）

Closes #438

## Test plan

- [ ] 一括採点画面で答案画像が正しく表示されることを確認
- [ ] アーカイブエクスポートに画像が含まれることを確認
- [ ] 起動後にDBの `imagePath` が `exams/` に更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)