### PR TITLE
原稿用紙セルの設問幅を基準高さ×高さ×列数に正確に一致させる

### DIFF
--- a/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
+++ b/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
@@ -14,7 +14,6 @@ const DEFAULT_CONFIG: ManuscriptPaperConfig = {
   enabled: false,
   columns: 20,
   rows: 10,
-  cellSizeMm: 5,
 }
 
 export function ManuscriptPaperSettings({
@@ -43,7 +42,7 @@ export function ManuscriptPaperSettings({
       </div>
 
       {current.enabled && (
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 gap-2">
           <div>
             <Label className="text-muted-foreground text-[10px]">列数</Label>
             <Input
@@ -69,25 +68,6 @@ export function ManuscriptPaperSettings({
               min={1}
               max={20}
               onChange={(e) => handleChange({ rows: Number(e.target.value) })}
-              onBlur={(e) => {
-                e.target.value = String(Number(e.target.value))
-              }}
-            />
-          </div>
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              マス目 (mm)
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={current.cellSizeMm}
-              min={2}
-              max={15}
-              step={0.5}
-              onChange={(e) =>
-                handleChange({ cellSizeMm: Number(e.target.value) })
-              }
               onBlur={(e) => {
                 e.target.value = String(Number(e.target.value))
               }}

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -248,8 +248,66 @@ export function AnswerSheetSVGRenderer({
       {/* セル内テキスト要素（インラインマークアップ対応） */}
       {cells
         .filter((c) => c.cellType === "answer")
-        .flatMap((cell) =>
-          cell.textElements.map((te, ti) => {
+        .flatMap((cell) => {
+          // 原稿用紙セル: 字埋めレンダリング
+          if (cell.manuscriptGrid) {
+            const g = cell.manuscriptGrid
+            const fontSize = g.cellSizeMm * 0.8
+            // 全テキスト要素のセグメントをフラット化して1文字ずつに分解
+            const chars: { char: string; seg: InlineSegment }[] = []
+            for (const te of cell.textElements) {
+              const segments = parseInlineMarkup(te.text)
+              for (const seg of segments) {
+                if (seg.modelAnswer && renderMode !== "model-answer") continue
+                for (const ch of seg.text) {
+                  chars.push({ char: ch, seg })
+                }
+              }
+            }
+            return chars
+              .map(({ char, seg }, ci) => {
+                const col = ci % g.columns
+                const row = Math.floor(ci / g.columns)
+                if (row >= g.rows) return null
+                const cx = g.gridX + col * g.cellSizeMm + g.cellSizeMm / 2
+                const cy = g.gridY + row * g.cellSizeMm + g.cellSizeMm / 2
+                return (
+                  <text
+                    key={`mc-${cell.label}-${ci}`}
+                    x={cx}
+                    y={cy}
+                    fontSize={fontSize}
+                    fontFamily="'Noto Sans JP', sans-serif"
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill={
+                      seg.modelAnswer
+                        ? renderMode === "model-answer"
+                          ? "#d00"
+                          : "transparent"
+                        : "#000"
+                    }
+                    fontWeight={seg.bold ? "bold" : undefined}
+                    fontStyle={seg.italic ? "italic" : undefined}
+                    textDecoration={
+                      seg.strikethrough && seg.underline
+                        ? "line-through underline"
+                        : seg.strikethrough
+                          ? "line-through"
+                          : seg.underline
+                            ? "underline"
+                            : undefined
+                    }
+                  >
+                    {char}
+                  </text>
+                )
+              })
+              .filter(Boolean)
+          }
+
+          // 通常セル
+          return cell.textElements.map((te, ti) => {
             const tx =
               te.horizontalAlign === "left"
                 ? cell.x + 2
@@ -330,7 +388,7 @@ export function AnswerSheetSVGRenderer({
               </text>
             )
           })
-        )}
+        })}
 
       {/* OMRバブル */}
       {cells

--- a/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
@@ -231,12 +231,21 @@ export function buildGridLayout<
 /** SubQuestion 用のグリッドレイアウト */
 function buildSubGridLayout(subQuestions: SubQuestion[]): SubGridCell[] {
   // 枝問がある小問は、枝問レイアウトの要求高さで heightMultiplier を上書き
+  // 原稿用紙有効時は heightMultiplier × rows に拡張
   const adjusted = subQuestions.map((sub) => {
-    if (sub.branchQuestions.length === 0) return sub
-    const branchCells = buildBranchGridLayout(sub.branchQuestions)
-    const branchHeight = gridTotalHeight(branchCells)
-    if (branchHeight !== sub.heightMultiplier) {
-      return { ...sub, heightMultiplier: branchHeight }
+    if (sub.branchQuestions.length > 0) {
+      const branchCells = buildBranchGridLayout(sub.branchQuestions)
+      const branchHeight = gridTotalHeight(branchCells)
+      if (branchHeight !== sub.heightMultiplier) {
+        return { ...sub, heightMultiplier: branchHeight }
+      }
+      return sub
+    }
+    if (sub.manuscriptPaper?.enabled) {
+      return {
+        ...sub,
+        heightMultiplier: sub.heightMultiplier * sub.manuscriptPaper.rows,
+      }
     }
     return sub
   })
@@ -365,6 +374,9 @@ function computeSubHeight(sub: SubQuestion, baseRowHeight: number): number {
   if (sub.branchQuestions.length > 0) {
     const branchCells = buildBranchGridLayout(sub.branchQuestions)
     return gridTotalHeight(branchCells) * baseRowHeight
+  }
+  if (sub.manuscriptPaper?.enabled) {
+    return sub.heightMultiplier * baseRowHeight * sub.manuscriptPaper.rows
   }
   return sub.heightMultiplier * baseRowHeight
 }
@@ -999,7 +1011,18 @@ function computeLayoutFromDefinition(
 
     if (subIsHorizontal) {
       // === 横配置（グリッド）モード ===
-      const gridCells = buildSubGridLayout(major.subQuestions)
+      // 原稿用紙セルの layoutWidth を必要幅に合わせる
+      const subsForGrid = major.subQuestions.map((sub) => {
+        if (sub.manuscriptPaper?.enabled && sub.branchQuestions.length === 0) {
+          const snw = sub.label === "" ? 0 : subNumWidth
+          const reqW =
+            baseRowHeight * sub.heightMultiplier * sub.manuscriptPaper.columns +
+            snw
+          return { ...sub, layoutWidth: String(reqW / horizontalAreaWidth) }
+        }
+        return sub
+      })
+      const gridCells = buildSubGridLayout(subsForGrid)
       for (const gc of gridCells) {
         const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
         const cellWidth = gc.width * horizontalAreaWidth
@@ -1051,12 +1074,19 @@ function computeLayoutFromDefinition(
             majorRightEdges
           )
         } else {
+          let ansX = cellX + effSubNumW
+          let ansW = cellWidth - effSubNumW
+          if (sub.manuscriptPaper?.enabled) {
+            const cellSz = cellHeight / sub.manuscriptPaper.rows
+            const gridW = cellSz * sub.manuscriptPaper.columns
+            ansW = gridW
+          }
           cells.push(
             createCell(
               [mi, gc.itemIndex],
-              cellX + effSubNumW,
+              ansX,
               cellY,
-              cellWidth - effSubNumW,
+              ansW,
               cellHeight,
               paper,
               `${major.label}-${sub.label}`,
@@ -1064,13 +1094,7 @@ function computeLayoutFromDefinition(
               sub.textElements,
               "answer",
               0,
-              computeManuscriptGrid(
-                sub,
-                cellX + effSubNumW,
-                cellY,
-                cellWidth - effSubNumW,
-                cellHeight
-              ),
+              computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
               sub.omrConfig
             )
           )
@@ -1210,6 +1234,18 @@ function computeLayoutFromDefinition(
       currentY = majorEndY
     } else {
       // === 縦配置モード ===
+      // 各小問の右端X座標を事前計算（原稿用紙セルは必要幅に制限）
+      const subRightEdges = major.subQuestions.map((sub) => {
+        const hb = sub.branchQuestions.length > 0
+        if (hb || !sub.manuscriptPaper?.enabled) return contentRight
+        const sh = computeSubHeight(sub, baseRowHeight)
+        const esnw = sub.label === "" ? 0 : subNumWidth
+        const eax = subNumX + esnw + branchNumWidth
+        return (
+          eax + (sh / sub.manuscriptPaper.rows) * sub.manuscriptPaper.columns
+        )
+      })
+
       major.subQuestions.forEach((sub, si) => {
         const subStartY = currentY
         const hasBranches = sub.branchQuestions.length > 0
@@ -1245,7 +1281,7 @@ function computeLayoutFromDefinition(
             branchNumWidth,
             effAnswerX,
             effAnswerWidth,
-            contentRight,
+            subRightEdges[si],
             baseRowHeight,
             paper,
             settings,
@@ -1255,12 +1291,18 @@ function computeLayoutFromDefinition(
             majorRightEdges
           )
         } else {
+          let ansW = effAnswerWidth
+          if (sub.manuscriptPaper?.enabled) {
+            const cellSz = subHeight / sub.manuscriptPaper.rows
+            const gridW = cellSz * sub.manuscriptPaper.columns
+            ansW = gridW
+          }
           cells.push(
             createCell(
               [mi, si],
               effAnswerX,
               subStartY,
-              effAnswerWidth,
+              ansW,
               subHeight,
               paper,
               `${major.label}-${sub.label}`,
@@ -1272,7 +1314,7 @@ function computeLayoutFromDefinition(
                 sub,
                 effAnswerX,
                 subStartY,
-                effAnswerWidth,
+                ansW,
                 subHeight
               ),
               sub.omrConfig
@@ -1280,11 +1322,11 @@ function computeLayoutFromDefinition(
           )
         }
 
-        // vertical-sub行の右端は常にcontentRight
+        // vertical-sub行の右端（原稿用紙セルは必要幅に制限）
         majorRightEdges.push({
           yTop: subStartY,
           yBottom: subStartY + subHeight,
-          rightX: contentRight,
+          rightX: subRightEdges[si],
         })
         // vertical-sub行の左端は常にcontentLeft
         majorLeftEdges.push({
@@ -1297,10 +1339,14 @@ function computeLayoutFromDefinition(
 
         // 行間の区切り線（最後の行以外）
         if (si < major.subQuestions.length - 1) {
+          const dividerRightX = Math.max(
+            subRightEdges[si],
+            subRightEdges[si + 1]
+          )
           lines.push({
             x1: subNumX,
             y1: currentY,
-            x2: contentRight,
+            x2: dividerRightX,
             y2: currentY,
             style: settings.borderConfig.subDivider,
             lineType: "sub",
@@ -1921,7 +1967,18 @@ export function computeMultiPageLayoutFromDefinition(
 
     if (subIsHorizontal) {
       // === 横配置（グリッド）モード ===
-      const gridCells = buildSubGridLayout(major.subQuestions)
+      // 原稿用紙セルの layoutWidth を必要幅に合わせる
+      const subsForGrid = major.subQuestions.map((sub) => {
+        if (sub.manuscriptPaper?.enabled && sub.branchQuestions.length === 0) {
+          const snw = sub.label === "" ? 0 : subNumWidth
+          const reqW =
+            baseRowHeight * sub.heightMultiplier * sub.manuscriptPaper.columns +
+            snw
+          return { ...sub, layoutWidth: String(reqW / horizontalAreaWidth) }
+        }
+        return sub
+      })
+      const gridCells = buildSubGridLayout(subsForGrid)
       for (const gc of gridCells) {
         const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
         const cellWidth = gc.width * horizontalAreaWidth
@@ -1972,12 +2029,19 @@ export function computeMultiPageLayoutFromDefinition(
             page.rowRightEdges
           )
         } else {
+          let ansX = cellX + effSubNumW
+          let ansW = cellWidth - effSubNumW
+          if (sub.manuscriptPaper?.enabled) {
+            const cellSz = cellHeight / sub.manuscriptPaper.rows
+            const gridW = cellSz * sub.manuscriptPaper.columns
+            ansW = gridW
+          }
           page.cells.push(
             createCell(
               [mi, gc.itemIndex],
-              cellX + effSubNumW,
+              ansX,
               cellY,
-              cellWidth - effSubNumW,
+              ansW,
               cellHeight,
               paper,
               `${major.label}-${sub.label}`,
@@ -1985,13 +2049,7 @@ export function computeMultiPageLayoutFromDefinition(
               sub.textElements,
               "answer",
               pageIdx,
-              computeManuscriptGrid(
-                sub,
-                cellX + effSubNumW,
-                cellY,
-                cellWidth - effSubNumW,
-                cellHeight
-              ),
+              computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
               sub.omrConfig
             )
           )
@@ -2131,6 +2189,19 @@ export function computeMultiPageLayoutFromDefinition(
     } else {
       // === 縦配置モード ===
       const vertSegStart = localY
+
+      // 各小問の右端X座標を事前計算（原稿用紙セルは必要幅に制限）
+      const subRightEdges = major.subQuestions.map((sub) => {
+        const hb = sub.branchQuestions.length > 0
+        if (hb || !sub.manuscriptPaper?.enabled) return contentRight
+        const sh = computeSubHeight(sub, baseRowHeight)
+        const esnw = sub.label === "" ? 0 : subNumWidth
+        const eax = subNumX + esnw + branchNumWidth
+        return (
+          eax + (sh / sub.manuscriptPaper.rows) * sub.manuscriptPaper.columns
+        )
+      })
+
       major.subQuestions.forEach((sub, si) => {
         const subStartY = localY
         const hasBranches = sub.branchQuestions.length > 0
@@ -2166,7 +2237,7 @@ export function computeMultiPageLayoutFromDefinition(
             branchNumWidth,
             effAnswerX,
             effAnswerWidth,
-            contentRight,
+            subRightEdges[si],
             baseRowHeight,
             paper,
             settings,
@@ -2203,12 +2274,18 @@ export function computeMultiPageLayoutFromDefinition(
             }
           }
         } else {
+          let ansW = effAnswerWidth
+          if (sub.manuscriptPaper?.enabled) {
+            const cellSz = subHeight / sub.manuscriptPaper.rows
+            const gridW = cellSz * sub.manuscriptPaper.columns
+            ansW = gridW
+          }
           page.cells.push(
             createCell(
               [mi, si],
               effAnswerX,
               subStartY,
-              effAnswerWidth,
+              ansW,
               subHeight,
               paper,
               `${major.label}-${sub.label}`,
@@ -2220,7 +2297,7 @@ export function computeMultiPageLayoutFromDefinition(
                 sub,
                 effAnswerX,
                 subStartY,
-                effAnswerWidth,
+                ansW,
                 subHeight
               ),
               sub.omrConfig
@@ -2228,11 +2305,11 @@ export function computeMultiPageLayoutFromDefinition(
           )
         }
 
-        // vertical-sub行の右端は常にcontentRight
+        // vertical-sub行の右端（原稿用紙セルは必要幅に制限）
         page.rowRightEdges.push({
           yTop: subStartY,
           yBottom: subStartY + subHeight,
-          rightX: contentRight,
+          rightX: subRightEdges[si],
         })
         // vertical-sub行の左端は常にcontentLeft
         page.rowLeftEdges.push({
@@ -2245,10 +2322,14 @@ export function computeMultiPageLayoutFromDefinition(
 
         // 行間の区切り線（最後の行以外）
         if (si < major.subQuestions.length - 1) {
+          const dividerRightX = Math.max(
+            subRightEdges[si],
+            subRightEdges[si + 1]
+          )
           page.lines.push({
             x1: subNumX,
             y1: localY,
-            x2: contentRight,
+            x2: dividerRightX,
             y2: localY,
             style: settings.borderConfig.subDivider,
             lineType: "sub",

--- a/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -118,6 +118,13 @@ function renderPageSvgString(
 
   for (const cell of pageLayout.cells) {
     if (cell.cellType !== "answer") continue
+
+    // 原稿用紙セル: 字埋めレンダリング
+    if (cell.manuscriptGrid) {
+      parts.push(...renderManuscriptTextElements(cell, renderMode))
+      continue
+    }
+
     for (const te of cell.textElements) {
       // マークアップ記法を除いたプレーンテキストが空なら表示しない
       const plainText = stripMarkup(te.text)
@@ -297,4 +304,51 @@ function renderManuscriptGrid(cell: ComputedCell): string[] {
     )
   }
   return lines
+}
+
+function renderManuscriptTextElements(
+  cell: ComputedCell,
+  renderMode: RenderMode
+): string[] {
+  if (!cell.manuscriptGrid) return []
+  const g = cell.manuscriptGrid
+  const fontSize = g.cellSizeMm * 0.8
+  const parts: string[] = []
+
+  // 全テキスト要素のセグメントをフラット化して1文字ずつに分解
+  const chars: { char: string; attrs: string }[] = []
+  for (const te of cell.textElements) {
+    const segments = parseInlineMarkup(te.text)
+    for (const seg of segments) {
+      if (seg.modelAnswer && renderMode !== "model-answer") continue
+      const segAttrs: string[] = []
+      if (seg.bold) segAttrs.push('font-weight="bold"')
+      if (seg.italic) segAttrs.push('font-style="italic"')
+      if (seg.strikethrough) segAttrs.push('text-decoration="line-through"')
+      if (seg.modelAnswer) {
+        segAttrs.push(
+          renderMode === "model-answer" ? 'fill="#d00"' : 'fill="transparent"'
+        )
+      }
+      const attrStr = segAttrs.length > 0 ? ` ${segAttrs.join(" ")}` : ""
+      for (const ch of seg.text) {
+        chars.push({ char: ch, attrs: attrStr })
+      }
+    }
+  }
+
+  for (let ci = 0; ci < chars.length; ci++) {
+    const col = ci % g.columns
+    const row = Math.floor(ci / g.columns)
+    if (row >= g.rows) break
+    const cx = g.gridX + col * g.cellSizeMm + g.cellSizeMm / 2
+    const cy = g.gridY + row * g.cellSizeMm + g.cellSizeMm / 2
+    const { char, attrs } = chars[ci]
+    const fill = attrs.includes("fill=") ? "" : ' fill="#000"'
+    parts.push(
+      `<text x="${cx}" y="${cy}" font-size="${fontSize}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central"${fill}${attrs}>${escapeXml(char)}</text>`
+    )
+  }
+
+  return parts
 }


### PR DESCRIPTION
## Summary

- 原稿用紙有効時にセル幅が設問枠より狭く右余白が生じていた問題を修正
- 縦配置: `majorRightEdges` の右端を原稿用紙の必要幅に合わせ、ディバイダーは隣接行の最大右端に制限
- 横配置: `buildSubGridLayout` 前に `layoutWidth` を原稿用紙の必要幅から逆算

Closes #442

## Test plan

- [ ] 原稿用紙を有効にした小問で、セル幅が設問枠に過不足なく一致することを確認
- [ ] 縦配置・横配置の両方で外枠が原稿用紙グリッドにぴったり合うこと
- [ ] 原稿用紙無効の小問は従来通りcontentRightまで拡がること
- [ ] 原稿用紙セルと通常セルが混在する場合のディバイダー表示が正常であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)