### PR TITLE
feat: 一括採点一覧表示にアノテーションプレビューと自動更新を追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -5,12 +5,14 @@ import { useEffect, useRef, useState } from "react"
 import { DragSelectionOverlay } from "@/components/exams/07-score-at-once/ScoringGrid/DragSelectionOverlay"
 import { GridCell } from "@/components/exams/07-score-at-once/ScoringGrid/GridCell"
 import { useAutoScroll } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useAutoScroll"
+import { useGridAnnotations } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useGridAnnotations"
 import { useGridDragSelection } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useGridDragSelection"
 import { useGridLayout } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useGridLayout"
 import { useGridNavigation } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useGridNavigation"
 import { useGridSelection } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useGridSelection"
 import { useSelectionBorder } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder"
 import type {
+  CropRegionWithExamPage,
   LayoutDirection,
   MasterGridItem,
   ScoringData,
@@ -39,6 +41,12 @@ export interface AnswerGridViewProps {
   showStudentNames?: boolean
   /** 表示領域拡張率 (0-50%) */
   expandMargin?: number
+  /** アノテーション描画用: 現在の設問 */
+  currentCropRegion?: CropRegionWithExamPage
+  /** アノテーション描画用: 現在のユーザーID */
+  currentUserId?: string
+  /** アノテーションリフレッシュキー（変更検知用） */
+  annotationRefreshKey?: number
   className?: string
 }
 
@@ -54,6 +62,9 @@ export default function AnswerGridView({
   autoScroll = true,
   showStudentNames = true,
   expandMargin,
+  currentCropRegion,
+  currentUserId,
+  annotationRefreshKey,
   className = "",
 }: AnswerGridViewProps) {
   /** フィルタリングされた採点データ（模範解答 + 学生データ） */
@@ -110,6 +121,13 @@ export default function AnswerGridView({
 
   const selectionBorderColor = useSelectionBorder()
   const scoringColors = useScoringStatusColors()
+
+  /** アノテーション取得（設問ごとに全学生分を一括取得） */
+  const { annotationsByStudent } = useGridAnnotations({
+    cropRegionId: currentCropRegion?.id,
+    currentUserId,
+    refreshKey: annotationRefreshKey,
+  })
 
   const { effectiveGridSize, sortedAnswers } = useGridLayout({
     answers,
@@ -231,6 +249,7 @@ export default function AnswerGridView({
               selectionBorderColor={selectionBorderColor}
               scoringColors={scoringColors}
               expandMargin={expandMargin}
+              annotations={annotationsByStudent.get(answer.studentId)}
               onMouseDown={onCellMouseDown}
             />
           )

--- a/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -7,6 +7,7 @@ import CroppedAnswerImage from "@/components/exams/07-score-at-once/ScoringMain/
 import type { LayoutDirection } from "@/components/exams/07-score-at-once/types"
 import { Badge } from "@/components/ui/badge"
 import type { ScoringStatusColors } from "@/lib/scoringStatusColors"
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
 
 const VALID_STATUS_KEYS: ScoreStatusKey[] = [
   "unscored",
@@ -30,6 +31,7 @@ interface GridCellProps {
   selectionBorderColor: string
   scoringColors: ScoringStatusColors
   expandMargin?: number
+  annotations?: DrawingAnnotation[]
   onMouseDown: (e: React.MouseEvent, answerId: string) => void
 }
 
@@ -42,6 +44,7 @@ export function GridCell({
   selectionBorderColor,
   scoringColors,
   expandMargin,
+  annotations,
   onMouseDown,
 }: GridCellProps) {
   const statusConfig = getDynamicScoreStatusConfig(scoringColors)
@@ -128,6 +131,7 @@ export function GridCell({
         calculatedCellHeight={calculatedCellHeight}
         isSelected={isSelected}
         expandMargin={expandMargin}
+        annotations={annotations}
       />
 
       {/* 学生情報と採点状況 */}

--- a/components/exams/07-score-at-once/ScoringGrid/hooks/useGridAnnotations.ts
+++ b/components/exams/07-score-at-once/ScoringGrid/hooks/useGridAnnotations.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+
+interface UseGridAnnotationsProps {
+  cropRegionId: string | undefined
+  currentUserId: string | undefined
+  /** アノテーション変更検知用リフレッシュキー */
+  refreshKey?: number
+}
+
+interface UseGridAnnotationsReturn {
+  /** studentId → DrawingAnnotation[] のマップ */
+  annotationsByStudent: Map<string, DrawingAnnotation[]>
+  /** データ読み込み中フラグ */
+  isLoading: boolean
+}
+
+/**
+ * Grid表示用アノテーション取得フック
+ * 指定されたcropRegionの全学生のアノテーションを一括取得し、studentIdでグループ化する
+ */
+export function useGridAnnotations({
+  cropRegionId,
+  currentUserId,
+  refreshKey,
+}: UseGridAnnotationsProps): UseGridAnnotationsReturn {
+  const [annotationsByStudent, setAnnotationsByStudent] = useState<
+    Map<string, DrawingAnnotation[]>
+  >(new Map())
+  const [isLoading, setIsLoading] = useState(false)
+  const lastFetchedRef = useRef<string>("")
+
+  const fetchAnnotations = useCallback(async () => {
+    if (!cropRegionId) {
+      setAnnotationsByStudent(new Map())
+      return
+    }
+
+    // 同一cropRegionIdの重複取得を防止
+    const fetchKey = `${cropRegionId}:${currentUserId ?? ""}`
+    if (lastFetchedRef.current === fetchKey) return
+    lastFetchedRef.current = fetchKey
+
+    setIsLoading(true)
+    try {
+      const result = await window.electronAPI.drawing.getByCropRegion(
+        cropRegionId,
+        currentUserId
+      )
+
+      if (result.success && result.data) {
+        const grouped = new Map<string, DrawingAnnotation[]>()
+        for (const annotation of result.data) {
+          // questionScore.studentId を使用してグループ化
+          const studentId = (
+            annotation as DrawingAnnotation & {
+              questionScore?: { studentId?: string }
+            }
+          ).questionScore?.studentId
+          if (!studentId) continue
+
+          const existing = grouped.get(studentId) || []
+          existing.push(annotation)
+          grouped.set(studentId, existing)
+        }
+        setAnnotationsByStudent(grouped)
+      } else {
+        setAnnotationsByStudent(new Map())
+      }
+    } catch (error) {
+      console.error("Grid用アノテーション取得エラー:", error)
+      setAnnotationsByStudent(new Map())
+    } finally {
+      setIsLoading(false)
+    }
+  }, [cropRegionId, currentUserId])
+
+  // cropRegionId変更時 または refreshKey変更時に自動再取得
+  useEffect(() => {
+    lastFetchedRef.current = "" // リセットして再取得を許可
+    fetchAnnotations()
+  }, [fetchAnnotations, refreshKey])
+
+  return { annotationsByStudent, isLoading }
+}

--- a/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from "react"
 
 import type { CropRegionWithExamPage } from "@/components/exams/07-score-at-once/types"
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+
+import type { DrawingElement } from "../ScoringIndividual/types/answerIndividualTypes"
+import { renderTextElementV4 } from "../ScoringIndividual/utils/canvasTextRendererV4"
 
 /**
  * 画像表示について：
@@ -34,6 +38,7 @@ interface CroppedAnswerImageProps {
   calculatedCellHeight?: number // 親から渡された計算済みセル高さ
   isSelected?: boolean
   expandMargin?: number // 表示領域拡張率 (0-50%)
+  annotations?: DrawingAnnotation[] // Grid表示用アノテーション
 }
 
 // セル内の固定オフセット（padding + gap + footer）
@@ -49,6 +54,7 @@ export default function CroppedAnswerImage({
   calculatedCellHeight = 0,
   isSelected = false,
   expandMargin = 0,
+  annotations,
 }: CroppedAnswerImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
@@ -125,12 +131,36 @@ export default function CroppedAnswerImage({
       canvas.width,
       canvas.height
     )
+
+    // アノテーション描画（非同期: MathJaxテキスト変換を含む）
+    if (annotations && annotations.length > 0) {
+      let cancelled = false
+      const drawAsync = async () => {
+        await drawAnnotations(
+          ctx,
+          annotations,
+          newX,
+          newY,
+          newWidth,
+          newHeight,
+          canvas.width,
+          canvas.height,
+          imageElement.naturalWidth,
+          () => cancelled
+        )
+      }
+      drawAsync()
+      return () => {
+        cancelled = true
+      }
+    }
   }, [
     imageLoaded,
     cropRegion,
     isColumnLayout,
     calculatedCellHeight,
     expandMargin,
+    annotations,
   ])
 
   const handleImageLoad = () => {
@@ -166,4 +196,348 @@ export default function CroppedAnswerImage({
       )}
     </div>
   )
+}
+
+/**
+ * Grid表示用アノテーション描画
+ * アノテーションの0-1相対座標をクロップ領域→Canvasピクセル座標に変換して描画
+ * テキストはrenderTextElementV4を使用してMathJax対応
+ */
+async function drawAnnotations(
+  ctx: CanvasRenderingContext2D,
+  annotations: DrawingAnnotation[],
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  imageNaturalWidth: number,
+  isCancelled: () => boolean
+) {
+  const scaleFactor = canvasWidth / (visibleWidth * imageNaturalWidth)
+
+  for (const anno of annotations) {
+    if (isCancelled()) return
+
+    ctx.save()
+    ctx.strokeStyle = anno.color
+    ctx.fillStyle = anno.color
+    ctx.lineWidth = Math.max(1, anno.strokeWidth * scaleFactor)
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+
+    switch (anno.type) {
+      case "text":
+        await drawGridTextV4(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight,
+          scaleFactor
+        )
+        break
+      case "line":
+        drawGridLine(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight,
+          scaleFactor
+        )
+        break
+      case "rectangle":
+        drawGridRectangle(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight
+        )
+        break
+      case "ellipse":
+        drawGridEllipse(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight
+        )
+        break
+    }
+
+    ctx.restore()
+  }
+}
+
+/** 0-1相対座標→Canvasピクセル座標に変換 */
+function toCanvasX(
+  annoX: number,
+  visibleX: number,
+  visibleWidth: number,
+  canvasWidth: number
+): number {
+  return ((annoX - visibleX) / visibleWidth) * canvasWidth
+}
+
+function toCanvasY(
+  annoY: number,
+  visibleY: number,
+  visibleHeight: number,
+  canvasHeight: number
+): number {
+  return ((annoY - visibleY) / visibleHeight) * canvasHeight
+}
+
+/**
+ * テキスト描画（V4レンダラー使用: MathJax/SVG対応）
+ * DrawingAnnotationをDrawingElementに変換し、renderTextElementV4で描画
+ */
+async function drawGridTextV4(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  scaleFactor: number
+) {
+  if (!anno.text) return
+
+  // DrawingAnnotation → DrawingElement に変換
+  // renderTextElementV4は element.x * canvasWidth でアンカーピクセル位置を計算するため、
+  // Grid Canvas空間での0-1座標に変換する
+  const element: DrawingElement = {
+    id: `grid-${anno.id}`,
+    type: "text",
+    x: (anno.x - visibleX) / visibleWidth,
+    y: (anno.y - visibleY) / visibleHeight,
+    color: anno.color,
+    strokeWidth: anno.strokeWidth,
+    text: anno.text,
+    fontSize: Math.max(2, anno.fontSize * scaleFactor),
+    anchorDirection: anno.anchorDirection || "top-left",
+  }
+
+  await renderTextElementV4(
+    ctx,
+    element,
+    canvasWidth,
+    canvasHeight,
+    false, // isSelected
+    false, // showAnchor
+    1.0 // opacity
+  )
+}
+
+/** 線描画（全lineStyle対応） */
+function drawGridLine(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  scaleFactor: number
+) {
+  const startX = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const startY = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const endX = toCanvasX(anno.endX, visibleX, visibleWidth, canvasWidth)
+  const endY = toCanvasY(anno.endY, visibleY, visibleHeight, canvasHeight)
+
+  const dx = endX - startX
+  const dy = endY - startY
+  const lineLength = Math.sqrt(dx * dx + dy * dy)
+  const angle = Math.atan2(dy, dx)
+  const sw = Math.max(1, anno.strokeWidth * scaleFactor)
+  const arrowSize = Math.max(sw * 5, 8)
+
+  ctx.lineWidth = sw
+  ctx.setLineDash([])
+
+  switch (anno.lineStyle) {
+    case "wave": {
+      const waveAmplitude = sw * 3
+      const waveHalfPeriod = sw * 6
+      let numHalves = Math.max(Math.round(lineLength / waveHalfPeriod), 2)
+      if (numHalves % 2 !== 0) numHalves++
+      const perpX = -Math.sin(angle)
+      const perpY = Math.cos(angle)
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      for (let i = 0; i < numHalves; i++) {
+        const tMid = (i + 0.5) / numHalves
+        const tEnd = (i + 1) / numHalves
+        const controlAmplitude = (i % 2 === 0 ? 1 : -1) * waveAmplitude * 2
+        const ctrlX = startX + dx * tMid + perpX * controlAmplitude
+        const ctrlY = startY + dy * tMid + perpY * controlAmplitude
+        ctx.quadraticCurveTo(
+          ctrlX,
+          ctrlY,
+          startX + dx * tEnd,
+          startY + dy * tEnd
+        )
+      }
+      ctx.stroke()
+      break
+    }
+    case "zigzag": {
+      const zigAmplitude = sw * 3
+      const zigHalfPeriod = sw * 5
+      let numHalves = Math.max(Math.round(lineLength / zigHalfPeriod), 2)
+      if (numHalves % 2 !== 0) numHalves++
+      const perpX = -Math.sin(angle)
+      const perpY = Math.cos(angle)
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      for (let i = 1; i <= numHalves; i++) {
+        const t = i / numHalves
+        const baseX = startX + dx * t
+        const baseY = startY + dy * t
+        const offset =
+          i === numHalves ? 0 : i % 2 === 1 ? zigAmplitude : -zigAmplitude
+        ctx.lineTo(baseX + perpX * offset, baseY + perpY * offset)
+      }
+      ctx.stroke()
+      break
+    }
+    case "double": {
+      const offset = sw
+      const perpX = -Math.sin(angle) * offset
+      const perpY = Math.cos(angle) * offset
+      ctx.beginPath()
+      ctx.moveTo(startX + perpX, startY + perpY)
+      ctx.lineTo(endX + perpX, endY + perpY)
+      ctx.stroke()
+      ctx.beginPath()
+      ctx.moveTo(startX - perpX, startY - perpY)
+      ctx.lineTo(endX - perpX, endY - perpY)
+      ctx.stroke()
+      break
+    }
+    case "arrow": {
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      ctx.beginPath()
+      ctx.moveTo(endX, endY)
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle - Math.PI / 6),
+        endY - arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle + Math.PI / 6),
+        endY - arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      break
+    }
+    case "both_arrow": {
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      // 終点矢印
+      ctx.beginPath()
+      ctx.moveTo(endX, endY)
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle - Math.PI / 6),
+        endY - arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle + Math.PI / 6),
+        endY - arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      // 始点矢印
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(
+        startX + arrowSize * Math.cos(angle - Math.PI / 6),
+        startY + arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        startX + arrowSize * Math.cos(angle + Math.PI / 6),
+        startY + arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      break
+    }
+    default: {
+      // solid
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      break
+    }
+  }
+}
+
+/** 矩形描画 */
+function drawGridRectangle(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  const cx = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const cy = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const w = (anno.width / visibleWidth) * canvasWidth
+  const h = (anno.height / visibleHeight) * canvasHeight
+  ctx.strokeRect(cx, cy, w, h)
+}
+
+/** 楕円描画 */
+function drawGridEllipse(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  const cx = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const cy = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const w = (anno.width / visibleWidth) * canvasWidth
+  const h = (anno.height / visibleHeight) * canvasHeight
+  ctx.beginPath()
+  ctx.ellipse(
+    cx + w / 2,
+    cy + h / 2,
+    Math.abs(w) / 2,
+    Math.abs(h) / 2,
+    0,
+    0,
+    2 * Math.PI
+  )
+  ctx.stroke()
 }

--- a/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -57,6 +57,8 @@ interface ScoringContentAreaProps {
   onAnnotationChanged?: () => void
   /** 外部からのアノテーション追加後のリフレッシュキー（ブラウザパネル→キャンバス連携用） */
   annotationRefreshKey?: number
+  /** Grid表示用アノテーションリフレッシュキー */
+  gridAnnotationRefreshKey?: number
 }
 
 export function ScoringContentArea({
@@ -82,6 +84,7 @@ export function ScoringContentArea({
   onQuestionScoreCreated,
   onAnnotationChanged,
   annotationRefreshKey,
+  gridAnnotationRefreshKey,
 }: ScoringContentAreaProps) {
   /** 個別表示時：selectedの最初の要素を利用 */
   const currentScoringDataId =
@@ -124,6 +127,9 @@ export function ScoringContentArea({
       autoScroll={autoScroll}
       showStudentNames={showStudentNames}
       expandMargin={expandMargin}
+      currentCropRegion={currentCropRegion}
+      currentUserId={currentUserId}
+      annotationRefreshKey={gridAnnotationRefreshKey}
       className="p-4"
     />
   )

--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -77,15 +77,18 @@ function ScoringMainViewContent() {
     useState(0)
   const [annotationVersionForCanvas, setAnnotationVersionForCanvas] =
     useState(0)
+  const [annotationVersionForGrid, setAnnotationVersionForGrid] = useState(0)
 
-  // キャンバスでアノテーション変更 → ブラウザパネル一覧をリロード
+  // キャンバスでアノテーション変更 → ブラウザパネル一覧 + Grid一覧をリロード
   const handleCanvasAnnotationChanged = useCallback(() => {
     setAnnotationVersionForBrowser((v) => v + 1)
+    setAnnotationVersionForGrid((v) => v + 1)
   }, [])
 
-  // ブラウザの+ボタンでアノテーション追加 → キャンバスプレビューをリロード
+  // ブラウザの+ボタンでアノテーション追加 → キャンバスプレビュー + Grid一覧をリロード
   const handleBrowserAnnotationAdded = useCallback(() => {
     setAnnotationVersionForCanvas((v) => v + 1)
+    setAnnotationVersionForGrid((v) => v + 1)
   }, [])
 
   /** 個別表示用の状態 */
@@ -382,6 +385,7 @@ function ScoringMainViewContent() {
             expandMargin={expandMargin}
             onAnnotationChanged={handleCanvasAnnotationChanged}
             annotationRefreshKey={annotationVersionForCanvas}
+            gridAnnotationRefreshKey={annotationVersionForGrid}
           />
         </div>
 

--- a/electron-src/ipc-handlers/drawingHandlers.ts
+++ b/electron-src/ipc-handlers/drawingHandlers.ts
@@ -125,6 +125,31 @@ export function setupDrawingHandlers() {
   )
 
   /**
+   * CropRegion（設問）に紐づく全学生の描画アノテーション取得（Grid表示用）
+   */
+  ipcMain.handle(
+    "drawing:getByCropRegion",
+    async (_, cropRegionId: string, userId?: string) => {
+      try {
+        const result = await drawingService.getDrawingAnnotationsByCropRegion(
+          cropRegionId,
+          userId
+        )
+        return { success: true, data: result }
+      } catch (error) {
+        console.error("🚫 設問別描画アノテーション取得エラー:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "設問別描画アノテーション取得に失敗しました",
+        }
+      }
+    }
+  )
+
+  /**
    * 描画アノテーション更新
    */
   ipcMain.handle(
@@ -333,6 +358,7 @@ export function removeDrawingHandlers() {
     "drawing:getByQuestionScore",
     "drawing:getByStudent",
     "drawing:getByExam",
+    "drawing:getByCropRegion",
     "drawing:update",
     "drawing:delete",
     "drawing:deleteByQuestionScore",

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -291,6 +291,56 @@ export async function getDrawingAnnotationsByExam(
 }
 
 /**
+ * CropRegion（設問）に紐づく全学生の描画アノテーションを取得する（Grid表示用）
+ * @param cropRegionId CropRegionのID
+ * @param userId 作成者のユーザーID（オプション）
+ * @returns Promise<DrawingAnnotation[]> 描画アノテーション配列（studentId付き）
+ */
+export async function getDrawingAnnotationsByCropRegion(
+  cropRegionId: string,
+  userId?: string
+): Promise<DrawingAnnotation[]> {
+  try {
+    const result = await prisma.drawingAnnotation.findMany({
+      where: {
+        questionScore: {
+          cropRegionId,
+        },
+        ...(userId && { userId }),
+      },
+      orderBy: { createdAt: "asc" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            studentId: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    return result as DrawingAnnotation[]
+  } catch (error) {
+    console.error("設問別描画アノテーション取得エラー:", error)
+    throw error
+  }
+}
+
+/**
  * 描画アノテーションを更新する
  * @param id 描画アノテーションのID
  * @param data 更新データ

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -585,6 +585,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ),
     getByExam: (examId: string, type?: string, userId?: string) =>
       ipcRenderer.invoke("drawing:getByExam", examId, type, userId),
+    getByCropRegion: (cropRegionId: string, userId?: string) =>
+      ipcRenderer.invoke("drawing:getByCropRegion", cropRegionId, userId),
     update: (id: string, data: Partial<DrawingAnnotation>) =>
       ipcRenderer.invoke("drawing:update", id, data),
     delete: (id: string) => ipcRenderer.invoke("drawing:delete", id),

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1403,6 +1403,14 @@ export interface MyAPI {
       data?: import("./drawing-annotation.types").DrawingAnnotation[]
       error?: string
     }>
+    getByCropRegion: (
+      cropRegionId: string,
+      userId?: string
+    ) => Promise<{
+      success: boolean
+      data?: import("./drawing-annotation.types").DrawingAnnotation[]
+      error?: string
+    }>
     update: (
       id: string,
       data: import("./drawing-annotation.types").DrawingUpdateData


### PR DESCRIPTION
## Summary
- 一括採点一覧表示（Grid View）にアノテーションプレビュー描画を追加
- MathJax/SVG対応のV4テキストレンダラーをGrid Viewに統合
- アノテーション変更時の自動更新機能（refreshKey機構）を実装

Closes #448

## 変更ファイル（10ファイル）

### Backend（4ファイル）
- `electron-src/lib/prisma/drawingAnnotation.ts` — `getDrawingAnnotationsByCropRegion` クエリ追加
- `electron-src/ipc-handlers/drawingHandlers.ts` — `drawing:getByCropRegion` ハンドラー追加
- `electron-src/preload.ts` — API追加
- `types/electron.d.ts` — 型定義追加

### Frontend（6ファイル）
- `ScoringGrid/hooks/useGridAnnotations.ts` — 新規フック（cropRegion単位の一括取得 + refreshKey対応）
- `ScoringMain/CroppedAnswerImage.tsx` — V4テキストレンダラー統合 + 非テキスト描画
- `ScoringMain/ScoringMainView.tsx` — `annotationVersionForGrid` ステート追加
- `ScoringMain/ScoringContentArea.tsx` — Grid用refreshKeyのprops追加
- `ScoringGrid/AnswerGridView.tsx` — refreshKeyの受け渡し
- `ScoringGrid/GridCell.tsx` — annotationsプロパティのパススルー

## Test plan
- [ ] 個別表示でアノテーション追加後、一覧表示でプレビュー表示されること
- [ ] MathJax数式テキストが正しくレンダリングされること
- [ ] 個別表示でアノテーション変更後、一覧表示に即座に反映されること
- [ ] ブラウザパネルからアノテーション追加後、一覧表示に反映されること
- [ ] 設問切替時にアノテーションが正しく切り替わること
- [ ] `npm run typecheck` 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)