### PR TITLE
fix: 原稿用紙セルのUI改善と横配置時の大問番号位置修正

### DIFF
--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -102,6 +102,9 @@ export function SubQuestionForm({
     [sub.branchQuestions]
   )
 
+  const isManuscriptPaper = !!sub.manuscriptPaper?.enabled && !hasBranches
+  const participatesInHorizontal = !!sub.layoutWidth || isManuscriptPaper
+
   const goUpActive = sub.goUp != null
   const isGoUpInvalid =
     goUpActive &&
@@ -160,31 +163,33 @@ export function SubQuestionForm({
               />
             </div>
           )}
-          {/* 幅 (layoutWidth) */}
-          <div className="flex items-center gap-0.5 px-1.5">
-            <span className="text-muted-foreground">幅</span>
-            <input
-              className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
-              value={sub.layoutWidth ?? ""}
-              onChange={(e) => {
-                const v = e.target.value.trim()
-                if (v === "") {
-                  onUpdate({
-                    layoutWidth: undefined,
-                    nextPlacement: undefined,
-                    goUp: undefined,
-                  })
-                } else {
-                  onUpdate({ layoutWidth: v })
-                }
-              }}
-              placeholder="—"
-              aria-label="幅"
-            />
-          </div>
+          {/* 幅 (layoutWidth) - 原稿用紙有効時は列数から自動計算のため非表示 */}
+          {!isManuscriptPaper && (
+            <div className="flex items-center gap-0.5 px-1.5">
+              <span className="text-muted-foreground">幅</span>
+              <input
+                className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
+                value={sub.layoutWidth ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value.trim()
+                  if (v === "") {
+                    onUpdate({
+                      layoutWidth: undefined,
+                      nextPlacement: undefined,
+                      goUp: undefined,
+                    })
+                  } else {
+                    onUpdate({ layoutWidth: v })
+                  }
+                }}
+                placeholder="—"
+                aria-label="幅"
+              />
+            </div>
+          )}
         </div>
         {/* 改行ボタン */}
-        {sub.layoutWidth && (
+        {participatesInHorizontal && (
           <Button
             variant="outline"
             size="icon"
@@ -202,7 +207,7 @@ export function SubQuestionForm({
           </Button>
         )}
         {/* 戻るボタン（自分自身をN行上に配置） */}
-        {sub.layoutWidth && (
+        {participatesInHorizontal && (
           <div className="inline-flex items-center gap-0">
             <Button
               variant="outline"
@@ -347,7 +352,14 @@ export function SubQuestionForm({
           />
           <ManuscriptPaperSettings
             config={sub.manuscriptPaper}
-            onUpdate={(config) => onUpdate({ manuscriptPaper: config })}
+            onUpdate={(config) => {
+              const updates: Partial<SubQuestion> = { manuscriptPaper: config }
+              // 原稿用紙有効化時にlayoutWidthが未設定なら自動設定（横配置参加のため）
+              if (config.enabled && !sub.layoutWidth) {
+                updates.layoutWidth = "1"
+              }
+              onUpdate(updates)
+            }}
           />
           <OMRCellConfigForm
             config={sub.omrConfig}

--- a/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
@@ -260,10 +260,15 @@ function buildBranchGridLayout(
 }
 
 /** グリッドレイアウトが横配置モードかどうか */
-export function isGridHorizontal<T extends { layoutWidth?: string }>(
-  items: T[]
-): boolean {
-  return items.some((item) => item.layoutWidth != null)
+export function isGridHorizontal<
+  T extends {
+    layoutWidth?: string
+    manuscriptPaper?: { enabled: boolean }
+  },
+>(items: T[]): boolean {
+  return items.some(
+    (item) => item.layoutWidth != null || item.manuscriptPaper?.enabled
+  )
 }
 
 /** グリッドセル配列の合計高さ（baseRowHeight単位） */
@@ -552,10 +557,31 @@ function computeManuscriptGrid(
 
 function computeMajorHeight(
   major: MajorQuestion,
-  baseRowHeight: number
+  baseRowHeight: number,
+  horizontalAreaWidth?: number,
+  subNumWidth?: number
 ): number {
   if (isGridHorizontal(major.subQuestions)) {
-    const gridCells = buildSubGridLayout(major.subQuestions)
+    // 原稿用紙セルの layoutWidth を必要幅に合わせる（レンダリングと同じ計算）
+    const subs =
+      horizontalAreaWidth != null && subNumWidth != null
+        ? major.subQuestions.map((sub) => {
+            if (
+              sub.manuscriptPaper?.enabled &&
+              sub.branchQuestions.length === 0
+            ) {
+              const snw = sub.label === "" ? 0 : subNumWidth
+              const reqW =
+                baseRowHeight *
+                  sub.heightMultiplier *
+                  sub.manuscriptPaper.columns +
+                snw
+              return { ...sub, layoutWidth: String(reqW / horizontalAreaWidth) }
+            }
+            return sub
+          })
+        : major.subQuestions
+    const gridCells = buildSubGridLayout(subs)
     return gridTotalHeight(gridCells) * baseRowHeight
   }
   return major.subQuestions.reduce(
@@ -981,7 +1007,14 @@ function computeLayoutFromDefinition(
     }
 
     const majorStartY = currentY
-    const majorHeight = computeMajorHeight(major, baseRowHeight)
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
+    const majorHeight = computeMajorHeight(
+      major,
+      baseRowHeight,
+      horizontalAreaWidth,
+      subNumWidth
+    )
     // 大問ごとの行エッジ追跡
     const majorRightEdges: {
       yTop: number
@@ -1005,8 +1038,6 @@ function computeLayoutFromDefinition(
       displayMode: settings.numberDisplayMode,
     })
 
-    const horizontalAreaX = majorNumX + majorNumWidth
-    const horizontalAreaWidth = contentRight - horizontalAreaX
     const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
     if (subIsHorizontal) {
@@ -1947,7 +1978,14 @@ export function computeMultiPageLayoutFromDefinition(
   ): number {
     let localY = startY
     const majorStartY = localY
-    const majorHeight = computeMajorHeight(major, baseRowHeight)
+    const horizontalAreaX = majorNumX + majorNumWidth
+    const horizontalAreaWidth = contentRight - horizontalAreaX
+    const majorHeight = computeMajorHeight(
+      major,
+      baseRowHeight,
+      horizontalAreaWidth,
+      subNumWidth
+    )
 
     // 大問番号ラベル
     page.numberLabels.push({
@@ -1961,8 +1999,6 @@ export function computeMultiPageLayoutFromDefinition(
       displayMode: settings.numberDisplayMode,
     })
 
-    const horizontalAreaX = majorNumX + majorNumWidth
-    const horizontalAreaWidth = contentRight - horizontalAreaX
     const subIsHorizontal = isGridHorizontal(major.subQuestions)
 
     if (subIsHorizontal) {
@@ -2366,7 +2402,13 @@ export function computeMultiPageLayoutFromDefinition(
   // 大問を順番に配置
   for (let mi = 0; mi < majorQuestions.length; mi++) {
     const major = majorQuestions[mi]
-    const majorHeight = computeMajorHeight(major, baseRowHeight)
+    const pgHorizontalAreaWidth = contentRight - majorNumX - majorNumWidth
+    const majorHeight = computeMajorHeight(
+      major,
+      baseRowHeight,
+      pgHorizontalAreaWidth,
+      subNumWidth
+    )
     const spacingHeight =
       mi > 0 && currentY > contentTop ? spacing.majorQuestionSpacing : 0
 


### PR DESCRIPTION
## Summary
- 原稿用紙有効時に幅入力フィールドを非表示化（列数から自動計算のため）
- 原稿用紙セルでも改行（↵）・上に行く（↑）ボタンを表示可能に
- `computeMajorHeight` に原稿用紙の幅オーバーライドを追加し、大問番号の位置ずれを修正

Closes #450

## 変更ファイル
- `SubQuestionForm.tsx`: UI条件分岐の修正、原稿用紙有効化時のlayoutWidth自動設定
- `useAnswerSheetLayout.ts`: `isGridHorizontal`拡張、`computeMajorHeight`修正（3箇所の呼び出し更新）

## Test plan
- [ ] 原稿用紙を有効にした小問で幅フィールドが非表示になることを確認
- [ ] 原稿用紙セルで改行・上に行くボタンが表示・機能することを確認
- [ ] 横配置で原稿用紙を有効にした際、大問番号の位置が正しいことを確認
- [ ] 原稿用紙なしの通常セルの動作に影響がないことを確認
- [ ] マルチページレイアウトでページ送り判定が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)