### PR TITLE
feat: 採点キャンバスに印字設定プレビュー機能を追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
@@ -11,6 +11,7 @@ import type {
   ScoringStatus,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
+import type { ScoringMarkConfig } from "@/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
 /**
@@ -19,6 +20,7 @@ import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotati
 export interface CropRegionWithStatus {
   cropRegion: CropRegionWithExamPage
   status: ScoringStatus
+  actualScore: number | null
 }
 
 /**
@@ -52,6 +54,8 @@ export interface UseImageCanvasProps {
   hoveredElementId?: string | null
   // 全設問の採点ステータス（全設問マーク描画用）
   allCropRegionsWithStatus?: CropRegionWithStatus[]
+  // 印字設定（採点マーク・点数表示のプレビュー用）
+  scoringMarkConfig?: ScoringMarkConfig | null
 }
 
 /**

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -17,6 +17,10 @@ import type {
   ScoringData,
   ScoringStatus,
 } from "@/components/exams/07-score-at-once/types"
+import type {
+  MarkPosition,
+  ScoringMarkConfig,
+} from "@/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
 import {
@@ -26,6 +30,122 @@ import {
 import type { CropRegionWithStatus } from "./types"
 import { useDrawingRenderer } from "./useDrawingRenderer"
 import { getScoringMarkKey } from "./useScoringMarks"
+
+/**
+ * 印字設定に基づくマーク位置計算
+ */
+function calculateMarkPosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  markSize: number,
+  position: MarkPosition,
+  offsetX: number = 0,
+  offsetY: number = 0
+): { x: number; y: number } {
+  const padding = 5
+  let x: number
+  let y: number
+
+  switch (position) {
+    case "top-left":
+      x = regionX + padding
+      y = regionY + padding
+      break
+    case "top-center":
+      x = regionX + (regionWidth - markSize) / 2
+      y = regionY + padding
+      break
+    case "top-right":
+      x = regionX + regionWidth - markSize - padding
+      y = regionY + padding
+      break
+    case "middle-left":
+      x = regionX + padding
+      y = regionY + (regionHeight - markSize) / 2
+      break
+    case "middle-right":
+      x = regionX + regionWidth - markSize - padding
+      y = regionY + (regionHeight - markSize) / 2
+      break
+    case "bottom-left":
+      x = regionX + padding
+      y = regionY + regionHeight - markSize - padding
+      break
+    case "bottom-center":
+      x = regionX + (regionWidth - markSize) / 2
+      y = regionY + regionHeight - markSize - padding
+      break
+    case "bottom-right":
+      x = regionX + regionWidth - markSize - padding
+      y = regionY + regionHeight - markSize - padding
+      break
+    default: // middle-center
+      x = regionX + (regionWidth - markSize) / 2
+      y = regionY + (regionHeight - markSize) / 2
+      break
+  }
+
+  return { x: x + offsetX, y: y + offsetY }
+}
+
+/**
+ * 印字設定に基づく点数テキスト位置計算
+ */
+function calculateScorePosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  position: MarkPosition,
+  offsetX: number = 0,
+  offsetY: number = 0
+): { x: number; y: number } {
+  let baseX: number
+  let baseY: number
+
+  switch (position) {
+    case "top-left":
+      baseX = regionX
+      baseY = regionY
+      break
+    case "top-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY
+      break
+    case "top-right":
+      baseX = regionX + regionWidth
+      baseY = regionY
+      break
+    case "middle-left":
+      baseX = regionX
+      baseY = regionY + regionHeight / 2
+      break
+    case "middle-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight / 2
+      break
+    case "bottom-left":
+      baseX = regionX
+      baseY = regionY + regionHeight
+      break
+    case "bottom-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight
+      break
+    case "bottom-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight
+      break
+    default: // middle-center
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight / 2
+      break
+  }
+
+  return { x: baseX + offsetX, y: baseY + offsetY }
+}
 
 interface UseCanvasDrawingProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
@@ -52,6 +172,7 @@ interface UseCanvasDrawingProps {
   currentCropRegionId?: string | null
   hoveredElementId?: string | null
   allCropRegionsWithStatus?: CropRegionWithStatus[]
+  scoringMarkConfig?: ScoringMarkConfig | null
 }
 
 /**
@@ -80,6 +201,7 @@ export function useCanvasDrawing({
   currentCropRegionId,
   hoveredElementId,
   allCropRegionsWithStatus = [],
+  scoringMarkConfig,
 }: UseCanvasDrawingProps): void {
   const { convertAnnotationToDrawingElement, drawSingleElement } =
     useDrawingRenderer()
@@ -156,11 +278,16 @@ export function useCanvasDrawing({
         currentY += img.naturalHeight + (images.length > 1 ? pageSpacing : 0)
       })
 
+      // 透明度定数
+      const CURRENT_OPACITY = 0.8
+      const OTHER_OPACITY = 0.4
+
       // 採点領域の描画ヘルパー関数
       const drawCropRegionMark = (
         region: CropRegionWithExamPage,
         status: ScoringStatus,
-        isCurrent: boolean
+        isCurrent: boolean,
+        actualScore: number | null
       ) => {
         const regionPageNumber = region.examPage?.pageNumber || 1
         const regionPageIndex = regionPageNumber - 1
@@ -184,6 +311,8 @@ export function useCanvasDrawing({
         const regionWidth = region.width * img.naturalWidth
         const regionHeight = region.height * img.naturalHeight
 
+        const opacity = isCurrent ? CURRENT_OPACITY : OTHER_OPACITY
+
         // 枠とラベルの描画
         if (isCurrent) {
           ctx.strokeStyle = "#22c55e"
@@ -193,6 +322,7 @@ export function useCanvasDrawing({
           ctx.lineWidth = 1
         }
         ctx.setLineDash([])
+        ctx.globalAlpha = opacity
         ctx.strokeRect(regionX, regionY, regionWidth, regionHeight)
 
         const labelFontSize = Math.max(12, 14 / zoom)
@@ -200,39 +330,115 @@ export function useCanvasDrawing({
         ctx.fillStyle = isCurrent ? "#22c55e" : "#9ca3af"
         ctx.fillText(region.label, regionX, regionY - 5)
 
-        // 採点記号の描画
-        if (status !== "unscored") {
+        // 採点記号の描画（印字設定に基づく）
+        const shouldShowMark = scoringMarkConfig
+          ? (scoringMarkConfig.showMarkForStatus[
+              status as keyof typeof scoringMarkConfig.showMarkForStatus
+            ] ?? false)
+          : status !== "unscored"
+
+        if (shouldShowMark) {
           const markKey = getScoringMarkKey(status)
           const markImage = markKey
             ? scoringMarkImagesRef.current.get(markKey)
             : null
 
           if (markImage) {
-            ctx.globalAlpha = isCurrent ? 1.0 : 0.6
-            const markSize = Math.min(regionHeight * 0.5, 100)
-            const markX = regionX + (regionWidth - markSize) / 2
-            const markY = regionY + (regionHeight - markSize) / 2
-            ctx.drawImage(markImage, markX, markY, markSize, markSize)
-            ctx.globalAlpha = 1.0
+            const configMarkSize = scoringMarkConfig?.markSize ?? 50
+            const markSize = Math.min(
+              configMarkSize,
+              regionWidth * 0.8,
+              regionHeight * 0.8
+            )
+
+            const markPos = scoringMarkConfig
+              ? calculateMarkPosition(
+                  regionX,
+                  regionY,
+                  regionWidth,
+                  regionHeight,
+                  markSize,
+                  scoringMarkConfig.markPosition,
+                  scoringMarkConfig.markOffsetX,
+                  scoringMarkConfig.markOffsetY
+                )
+              : {
+                  x: regionX + (regionWidth - markSize) / 2,
+                  y: regionY + (regionHeight - markSize) / 2,
+                }
+
+            ctx.globalAlpha = opacity
+            ctx.drawImage(markImage, markPos.x, markPos.y, markSize, markSize)
           }
         }
+
+        // 点数テキストの描画（印字設定に基づく）
+        const shouldShowScore = scoringMarkConfig
+          ? (scoringMarkConfig.showScoreForStatus[
+              status as keyof typeof scoringMarkConfig.showScoreForStatus
+            ] ?? false)
+          : false
+
+        if (shouldShowScore && actualScore !== null) {
+          ctx.save()
+          // 印字設定からスコア表示設定を取得
+          const scoreConfig = scoringMarkConfig?.useSeparateScoreSettings
+            ? scoringMarkConfig.partialScore
+            : {
+                position: scoringMarkConfig?.scorePosition ?? "bottom-right",
+                offsetX: scoringMarkConfig?.scoreOffsetX ?? 0,
+                offsetY: scoringMarkConfig?.scoreOffsetY ?? 0,
+                size: scoringMarkConfig?.scoreSize ?? 14,
+                alignment: scoringMarkConfig?.scoreAlignment ?? "center",
+              }
+
+          const fontSize = scoreConfig.size
+          ctx.font = `bold ${fontSize}px sans-serif`
+          ctx.fillStyle = "#ef4444" // 赤色
+          ctx.globalAlpha = opacity
+          ctx.textAlign = scoreConfig.alignment as CanvasTextAlign
+          ctx.textBaseline = "middle"
+
+          const scorePos = calculateScorePosition(
+            regionX,
+            regionY,
+            regionWidth,
+            regionHeight,
+            scoreConfig.position as MarkPosition,
+            scoreConfig.offsetX,
+            scoreConfig.offsetY
+          )
+          ctx.fillText(String(actualScore), scorePos.x, scorePos.y)
+          ctx.restore()
+        }
+
+        ctx.globalAlpha = 1.0
       }
 
-      // 全設問の枠と採点記号を描画
+      // 全設問の枠と採点記号・点数を描画
       if (images.length > 0) {
         // 他の設問を先に描画（半透明）
-        for (const { cropRegion, status } of allCropRegionsWithStatus) {
+        for (const {
+          cropRegion,
+          status,
+          actualScore,
+        } of allCropRegionsWithStatus) {
           if (cropRegion.id === currentCropRegion?.id) continue
-          drawCropRegionMark(cropRegion, status, false)
+          drawCropRegionMark(cropRegion, status, false, actualScore)
         }
 
         // 現在の設問を最後に描画（前面に表示）
         if (currentCropRegion) {
           const currentStatus = currentScoringData?.status ?? "unscored"
+          // 現在の設問のスコアをallCropRegionsWithStatusから取得
+          const currentRegionData = allCropRegionsWithStatus.find(
+            (r) => r.cropRegion.id === currentCropRegion.id
+          )
           drawCropRegionMark(
             currentCropRegion,
             currentStatus as ScoringStatus,
-            true
+            true,
+            currentRegionData?.actualScore ?? null
           )
         }
       }
@@ -337,6 +543,7 @@ export function useCanvasDrawing({
       convertAnnotationToDrawingElement,
       drawSingleElement,
       allCropRegionsWithStatus,
+      scoringMarkConfig,
     ]
   )
 

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
@@ -37,6 +37,7 @@ export function useImageCanvas({
   currentCropRegionId,
   hoveredElementId,
   allCropRegionsWithStatus = [],
+  scoringMarkConfig,
 }: UseImageCanvasProps): UseImageCanvasReturn {
   // キャンバス参照管理
   const {
@@ -57,9 +58,10 @@ export function useImageCanvas({
     imageRef,
   })
 
-  // 採点記号画像のプリロード
+  // 採点記号画像のプリロード（印字設定の透過設定を反映）
   useScoringMarks({
     scoringMarkImagesRef,
+    useTransparent: scoringMarkConfig?.useTransparent ?? false,
   })
 
   // Canvas描画ロジック
@@ -86,6 +88,7 @@ export function useImageCanvas({
     currentCropRegionId,
     hoveredElementId,
     allCropRegionsWithStatus,
+    scoringMarkConfig,
   })
 
   return {

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useScoringMarks.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useScoringMarks.ts
@@ -2,8 +2,9 @@
  * 採点記号画像管理フック
  * - 採点記号画像のプリロード
  * - キャッシュ管理
+ * - 透過マーク切替対応
  */
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 const MARK_TYPES = [
   "correct",
@@ -16,6 +17,7 @@ type MarkType = (typeof MARK_TYPES)[number]
 
 interface UseScoringMarksProps {
   scoringMarkImagesRef: React.MutableRefObject<Map<string, HTMLImageElement>>
+  useTransparent?: boolean
 }
 
 /**
@@ -23,12 +25,20 @@ interface UseScoringMarksProps {
  */
 export function useScoringMarks({
   scoringMarkImagesRef,
+  useTransparent = false,
 }: UseScoringMarksProps): void {
-  // 採点記号画像のプリロード
+  const prevTransparentRef = useRef(useTransparent)
+
+  // 採点記号画像のプリロード（透過設定変更時は再ロード）
   useEffect(() => {
+    const transparentChanged = prevTransparentRef.current !== useTransparent
+    prevTransparentRef.current = useTransparent
+    const prefix = useTransparent ? "tp_" : ""
+
     const loadPromises = MARK_TYPES.map((type) => {
       return new Promise<void>((resolve) => {
-        if (scoringMarkImagesRef.current.has(type)) {
+        // 透過設定が変わった場合はキャッシュをクリアして再ロード
+        if (!transparentChanged && scoringMarkImagesRef.current.has(type)) {
           resolve()
           return
         }
@@ -38,15 +48,15 @@ export function useScoringMarks({
           resolve()
         }
         img.onerror = () => {
-          console.warn(`Failed to load scoring mark: ${type}`)
+          console.warn(`Failed to load scoring mark: ${prefix}${type}`)
           resolve()
         }
         // Next.jsのpublicフォルダからロード
-        img.src = `/score-assets/${type}.png`
+        img.src = `/score-assets/${prefix}${type}.png`
       })
     })
     Promise.all(loadPromises)
-  }, [scoringMarkImagesRef])
+  }, [scoringMarkImagesRef, useTransparent])
 }
 
 /**


### PR DESCRIPTION
## 概要

Closes #452

採点キャンバス上で印字設定（ScoringMarkConfig）に基づいた採点マークと点数のプレビュー表示を実装。

## 変更内容

- 印字設定に基づくマーク位置・サイズ・オフセットの描画対応
- ステータス別の採点マーク表示/非表示制御
- 点数テキストの描画（位置・サイズ・配置設定対応）
- 透過マーク切替対応（useTransparentフラグ）
- CropRegionWithStatusにactualScoreフィールドを追加

## テスト計画

- [ ] 印字設定なしの場合、従来通りの採点マーク描画が行われることを確認
- [ ] 印字設定ありの場合、マーク位置・サイズが設定通りに反映されることを確認
- [ ] 各ステータス（正解・不正解・部分点・未採点）でマーク表示/非表示が正しく動作することを確認
- [ ] 点数テキストが設定した位置・サイズで正しく表示されることを確認
- [ ] 透過マーク切替が正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)