### PR TITLE
feat: 解答用紙作成にセル内画像要素機能を追加

### DIFF
--- a/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -217,6 +217,7 @@ export function AnswerSheetBuilderMainView({
                 <QuestionListEditor
                   majorQuestions={definition.majorQuestions}
                   labelPresets={definition.labelPresets}
+                  definitionId={definition.id}
                   onSetLabelPreset={setLabelPreset}
                   onAddMajor={addMajorQuestion}
                   onUpdateMajor={updateMajorQuestion}

--- a/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import type { BranchQuestion } from "@/types/answerSheetBuilder.types"
 
+import { ImageElementEditor } from "./ImageElementEditor"
 import { OMRCellConfigForm } from "./OMRCellConfigForm"
 import { TextElementEditor } from "./TextElementEditor"
 
@@ -15,6 +16,7 @@ interface BranchQuestionFormProps {
   totalBranchCount: number
   showPoints?: boolean
   maxGoUp: number
+  definitionId: string
   onUpdate: (data: Partial<BranchQuestion>) => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -25,6 +27,7 @@ export function BranchQuestionForm({
   branch,
   showPoints = true,
   maxGoUp,
+  definitionId,
   onUpdate,
   onDelete,
   onMoveUp,
@@ -32,7 +35,8 @@ export function BranchQuestionForm({
 }: BranchQuestionFormProps) {
   const [detailOpen, setDetailOpen] = useState(false)
 
-  const hasDetailContent = branch.textElements.length > 0
+  const hasDetailContent =
+    branch.textElements.length > 0 || (branch.imageElements?.length ?? 0) > 0
 
   const goUpActive = branch.goUp != null
   const isGoUpInvalid =
@@ -244,6 +248,11 @@ export function BranchQuestionForm({
           <TextElementEditor
             textElements={branch.textElements}
             onUpdate={(elements) => onUpdate({ textElements: elements })}
+          />
+          <ImageElementEditor
+            imageElements={branch.imageElements ?? []}
+            onUpdate={(elements) => onUpdate({ imageElements: elements })}
+            definitionId={definitionId}
           />
           <OMRCellConfigForm
             config={branch.omrConfig}

--- a/components/answer-sheet-builder/components/form/ImageElementEditor.tsx
+++ b/components/answer-sheet-builder/components/form/ImageElementEditor.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { ImagePlus, Trash2 } from "lucide-react"
+import { useCallback } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Slider } from "@/components/ui/slider"
+import type {
+  CellImageElement,
+  ImageObjectFit,
+} from "@/types/answerSheetBuilder.types"
+
+import { generateId } from "../../constants"
+
+const OBJECT_FIT_OPTIONS: { value: ImageObjectFit; label: string }[] = [
+  { value: "contain", label: "収める" },
+  { value: "cover", label: "覆う" },
+  { value: "fill", label: "引き伸ばす" },
+]
+
+interface ImageElementEditorProps {
+  imageElements: CellImageElement[]
+  onUpdate: (elements: CellImageElement[]) => void
+  definitionId: string
+}
+
+export function ImageElementEditor({
+  imageElements,
+  onUpdate,
+  definitionId,
+}: ImageElementEditorProps) {
+  const handleAdd = useCallback(async () => {
+    const api = window.electronAPI
+    if (!api?.answerSheetBuilder) return
+
+    // ファイル選択ダイアログ
+    const input = document.createElement("input")
+    input.type = "file"
+    input.accept = "image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      if (!file) return
+
+      // Electron の webUtils.getPathForFile でローカルパスを取得
+      const filePath = window.electronAPI?.pdfTools?.getPathForFile(file)
+      if (!filePath) return
+      const result = await api.answerSheetBuilder.uploadImage({
+        definitionId,
+        filePath,
+        originalName: file.name,
+      })
+
+      if (result.success && result.imagePath) {
+        const newElement: CellImageElement = {
+          id: generateId(),
+          imagePath: result.imagePath,
+          originalName: file.name,
+          objectFit: "contain",
+          horizontalAlign: "center",
+          verticalAlign: "middle",
+          opacity: 1,
+        }
+        onUpdate([...imageElements, newElement])
+      }
+    }
+    input.click()
+  }, [definitionId, imageElements, onUpdate])
+
+  const handleRemove = useCallback(
+    async (index: number) => {
+      const element = imageElements[index]
+      const api = window.electronAPI
+      if (api?.answerSheetBuilder) {
+        await api.answerSheetBuilder.deleteImage({
+          imagePath: element.imagePath,
+        })
+      }
+      onUpdate(imageElements.filter((_, i) => i !== index))
+    },
+    [imageElements, onUpdate]
+  )
+
+  const handleChange = useCallback(
+    (index: number, data: Partial<CellImageElement>) => {
+      const updated = imageElements.map((el, i) =>
+        i === index ? { ...el, ...data } : el
+      )
+      onUpdate(updated)
+    },
+    [imageElements, onUpdate]
+  )
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs">画像要素</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={handleAdd}
+        >
+          <ImagePlus className="mr-1 h-3 w-3" />
+          追加
+        </Button>
+      </div>
+
+      {imageElements.map((el, i) => (
+        <div key={el.id} className="space-y-1.5 rounded border p-1.5">
+          {/* Row 1: サムネイル + ファイル名 + 削除 */}
+          <div className="flex items-center gap-1.5">
+            <img
+              src={`appimg:///${el.imagePath}`}
+              alt={el.originalName}
+              className="h-8 w-8 shrink-0 rounded border object-contain"
+            />
+            <span className="min-w-0 flex-1 truncate text-xs">
+              {el.originalName}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-destructive h-7 w-7 shrink-0"
+              onClick={() => handleRemove(i)}
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+
+          {/* Row 2: objectFit + 不透明度 */}
+          <div className="flex items-center gap-2">
+            <Select
+              value={el.objectFit}
+              onValueChange={(v) =>
+                handleChange(i, { objectFit: v as ImageObjectFit })
+              }
+            >
+              <SelectTrigger className="h-7 w-24 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {OBJECT_FIT_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="flex flex-1 items-center gap-1.5">
+              <span className="text-muted-foreground shrink-0 text-[10px]">
+                透明度
+              </span>
+              <Slider
+                min={0}
+                max={100}
+                step={5}
+                value={[Math.round(el.opacity * 100)]}
+                onValueChange={([v]) => handleChange(i, { opacity: v / 100 })}
+                className="flex-1"
+              />
+              <span className="w-8 shrink-0 text-right text-[10px]">
+                {Math.round(el.opacity * 100)}%
+              </span>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {imageElements.length === 0 && (
+        <p className="text-muted-foreground text-[10px]">
+          画像要素はありません
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
@@ -65,6 +65,7 @@ interface MajorQuestionFormProps {
   major: MajorQuestion
   majorIndex: number
   totalMajorCount: number
+  definitionId: string
   onUpdate: (data: Partial<MajorQuestion>) => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -90,6 +91,7 @@ interface MajorQuestionFormProps {
 export function MajorQuestionForm({
   major,
   majorIndex,
+  definitionId,
   onUpdate,
   onDelete,
   onMoveUp,
@@ -194,6 +196,7 @@ export function MajorQuestionForm({
                   subIndex={si}
                   totalSubCount={major.subQuestions.length}
                   maxGoUp={subMaxGoUps[si]}
+                  definitionId={definitionId}
                   onUpdate={(data) => onUpdateSub(si, data)}
                   onDelete={() => onDeleteSub(si)}
                   onMoveUp={si > 0 ? () => onReorderSub(si, si - 1) : undefined}

--- a/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
+++ b/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
@@ -35,6 +35,7 @@ function presetShortLabel(preset: string): string {
 interface QuestionListEditorProps {
   majorQuestions: MajorQuestion[]
   labelPresets?: LabelPresets
+  definitionId: string
   onSetLabelPreset: (
     category: "major" | "sub" | "branch",
     preset: string
@@ -74,6 +75,7 @@ interface QuestionListEditorProps {
 export function QuestionListEditor({
   majorQuestions,
   labelPresets,
+  definitionId,
   onSetLabelPreset,
   onAddMajor,
   onUpdateMajor,
@@ -175,6 +177,7 @@ export function QuestionListEditor({
             major={major}
             majorIndex={mi}
             totalMajorCount={majorQuestions.length}
+            definitionId={definitionId}
             onUpdate={(data) => onUpdateMajor(mi, data)}
             onDelete={() => onDeleteMajor(mi)}
             onMoveUp={mi > 0 ? () => onReorderMajor(mi, mi - 1) : undefined}

--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@/types/answerSheetBuilder.types"
 
 import { BranchQuestionForm } from "./BranchQuestionForm"
+import { ImageElementEditor } from "./ImageElementEditor"
 import { ManuscriptPaperSettings } from "./ManuscriptPaperSettings"
 import { OMRCellConfigForm } from "./OMRCellConfigForm"
 import { TextElementEditor } from "./TextElementEditor"
@@ -69,6 +70,7 @@ interface SubQuestionFormProps {
   subIndex: number
   totalSubCount: number
   maxGoUp: number
+  definitionId: string
   onUpdate: (data: Partial<SubQuestion>) => void
   onDelete: () => void
   onMoveUp?: () => void
@@ -82,6 +84,7 @@ interface SubQuestionFormProps {
 export function SubQuestionForm({
   sub,
   maxGoUp,
+  definitionId,
   onUpdate,
   onDelete,
   onMoveUp,
@@ -95,7 +98,9 @@ export function SubQuestionForm({
   const [detailOpen, setDetailOpen] = useState(false)
 
   const hasDetailContent =
-    sub.textElements.length > 0 || !!sub.manuscriptPaper?.enabled
+    sub.textElements.length > 0 ||
+    (sub.imageElements?.length ?? 0) > 0 ||
+    !!sub.manuscriptPaper?.enabled
 
   const branchMaxGoUps = useMemo(
     () => calcBranchMaxGoUps(sub.branchQuestions),
@@ -350,6 +355,11 @@ export function SubQuestionForm({
             textElements={sub.textElements}
             onUpdate={(elements) => onUpdate({ textElements: elements })}
           />
+          <ImageElementEditor
+            imageElements={sub.imageElements ?? []}
+            onUpdate={(elements) => onUpdate({ imageElements: elements })}
+            definitionId={definitionId}
+          />
           <ManuscriptPaperSettings
             config={sub.manuscriptPaper}
             onUpdate={(config) => {
@@ -379,6 +389,7 @@ export function SubQuestionForm({
               totalBranchCount={sub.branchQuestions.length}
               showPoints={sub.usesBranchPoints !== false}
               maxGoUp={branchMaxGoUps[bi]}
+              definitionId={definitionId}
               onUpdate={(data) => onUpdateBranch(bi, data)}
               onDelete={() => onDeleteBranch(bi)}
               onMoveUp={bi > 0 ? () => onReorderBranch(bi, bi - 1) : undefined}

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -390,6 +390,37 @@ export function AnswerSheetSVGRenderer({
           })
         })}
 
+      {/* 画像要素 */}
+      {cells
+        .filter((c) => c.cellType === "answer" && c.imageElements?.length)
+        .flatMap((cell) =>
+          cell.imageElements!.map((ie, ii) => {
+            const pad = 1
+            const ix = cell.x + pad
+            const iy = cell.y + pad
+            const iw = cell.width - pad * 2
+            const ih = cell.height - pad * 2
+            const par =
+              ie.objectFit === "contain"
+                ? "xMidYMid meet"
+                : ie.objectFit === "cover"
+                  ? "xMidYMid slice"
+                  : "none"
+            return (
+              <image
+                key={`img-${cell.label}-${ii}`}
+                href={`appimg:///${ie.imagePath}`}
+                x={ix}
+                y={iy}
+                width={iw}
+                height={ih}
+                preserveAspectRatio={par}
+                opacity={ie.opacity}
+              />
+            )
+          })
+        )}
+
       {/* OMRバブル */}
       {cells
         .filter((c) => c.cellType === "answer" && c.omrBubbles?.length)

--- a/components/answer-sheet-builder/constants.ts
+++ b/components/answer-sheet-builder/constants.ts
@@ -76,6 +76,7 @@ export function createDefaultBranchQuestion(label?: string): BranchQuestion {
     heightMultiplier: 1,
     points: 1,
     textElements: [],
+    imageElements: [],
   }
 }
 
@@ -87,6 +88,7 @@ export function createDefaultSubQuestion(label?: string): SubQuestion {
     heightMultiplier: 1,
     points: 1,
     textElements: [],
+    imageElements: [],
   }
 }
 

--- a/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
@@ -11,6 +11,7 @@ import type { AnswerSheetDefinition } from "@/types/answerSheetBuilder.types"
 
 import {
   renderMultiPageSvgStrings,
+  resolveImageDataUris,
   wrapSvgsInHtml,
 } from "../utils/renderSvgStrings"
 import { computeMultiPageLayoutFromDefinition } from "./useAnswerSheetLayout"
@@ -36,9 +37,12 @@ export function useAnswerSheetExport() {
       if (!pathResult.success || !pathResult.filePath) return
 
       const multiLayout = computeMultiPageLayoutFromDefinition(definition)
+      const allCells = multiLayout.pages.flatMap((p) => p.cells)
+      const imageDataUris = await resolveImageDataUris(allCells)
       const svgStrings = renderMultiPageSvgStrings(
         multiLayout,
-        definition.renderMode
+        definition.renderMode,
+        imageDataUris
       )
       const html = wrapSvgsInHtml(
         svgStrings,
@@ -86,9 +90,12 @@ export function useAnswerSheetExport() {
         if (!pathResult.success || !pathResult.filePath) return
 
         const multiLayout = computeMultiPageLayoutFromDefinition(definition)
+        const allCells = multiLayout.pages.flatMap((p) => p.cells)
+        const imageDataUris = await resolveImageDataUris(allCells)
         const svgStrings = renderMultiPageSvgStrings(
           multiLayout,
-          definition.renderMode
+          definition.renderMode,
+          imageDataUris
         )
 
         const result = await api.exportPng({
@@ -126,9 +133,12 @@ export function useAnswerSheetExport() {
       setIsExporting(true)
 
       const multiLayout = computeMultiPageLayoutFromDefinition(definition)
+      const allCells = multiLayout.pages.flatMap((p) => p.cells)
+      const imageDataUris = await resolveImageDataUris(allCells)
       const svgStrings = renderMultiPageSvgStrings(
         multiLayout,
-        definition.renderMode
+        definition.renderMode,
+        imageDataUris
       )
       const html = wrapSvgsInHtml(
         svgStrings,

--- a/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetLayout.ts
@@ -68,6 +68,26 @@ function getPaperDimensions(settings: GlobalSettings) {
   return { width: base.width, height: base.height }
 }
 
+/**
+ * 縦線の範囲を大問レイアウト範囲内にクリップする。
+ * majorQuestionSpacing > 0 の場合に大問間のギャップを跨がないようにする。
+ */
+function clipRangeToMajorLayouts(
+  range: { top: number; bottom: number },
+  majorLayouts: Array<{ startY: number; endY: number }>
+): Array<{ top: number; bottom: number }> {
+  if (majorLayouts.length === 0) return [range]
+  const result: Array<{ top: number; bottom: number }> = []
+  for (const ml of majorLayouts) {
+    const top = Math.max(range.top, ml.startY)
+    const bottom = Math.min(range.bottom, ml.endY)
+    if (top < bottom - 0.01) {
+      result.push({ top, bottom })
+    }
+  }
+  return result.length > 0 ? result : [range]
+}
+
 /** 分数文字列 (e.g. "1/4", "3/4") を 0〜1 の数値に変換 */
 export function parseFraction(s: string): number {
   const m = s.match(/^(\d+)\/(\d+)$/)
@@ -487,7 +507,8 @@ function createCell(
   cellType: ComputedCell["cellType"],
   pageIndex: number = 0,
   manuscriptGrid?: ManuscriptGrid,
-  omrConfig?: OMRCellConfig
+  omrConfig?: OMRCellConfig,
+  imageElements?: ComputedCell["imageElements"]
 ): ComputedCell {
   const cell: ComputedCell = {
     questionPath,
@@ -502,6 +523,7 @@ function createCell(
     label,
     points,
     textElements,
+    imageElements,
     cellType,
     pageIndex,
     ...(manuscriptGrid ? { manuscriptGrid } : {}),
@@ -841,7 +863,8 @@ function renderBranchQuestions(
           "answer",
           pageIndex,
           undefined,
-          gc.item.omrConfig
+          gc.item.omrConfig,
+          gc.item.imageElements
         )
       )
 
@@ -932,7 +955,8 @@ function renderBranchQuestions(
           "answer",
           pageIndex,
           undefined,
-          branch.omrConfig
+          branch.omrConfig,
+          branch.imageElements
         )
       )
 
@@ -1126,7 +1150,8 @@ function computeLayoutFromDefinition(
               "answer",
               0,
               computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
-              sub.omrConfig
+              sub.omrConfig,
+              sub.imageElements
             )
           )
         }
@@ -1348,7 +1373,8 @@ function computeLayoutFromDefinition(
                 ansW,
                 subHeight
               ),
-              sub.omrConfig
+              sub.omrConfig,
+              sub.imageElements
             )
           )
         }
@@ -1600,45 +1626,52 @@ function computeLayoutFromDefinition(
     }
   }
 
-  // 小問番号列の縦線 → 縦配置のセグメントのみ
+  // 小問番号列の縦線 → 縦配置のセグメントのみ（大問外枠内にクリップ）
   const subNcSw = getLineWidth("subNumberColumn", settings.borderConfig)
   for (const range of verticalRanges) {
-    lines.push({
-      x1: subNumX + subNumWidth,
-      y1: range.top,
-      x2: subNumX + subNumWidth,
-      y2: range.bottom,
-      style: settings.borderConfig.subNumberDivider,
-      lineType: "subNumberColumn",
-      strokeWidth: subNcSw,
-      dragInfo: {
-        axis: "vertical",
-        target: { type: "columnWidth", column: "subNumber" },
-        currentValueMm: subNumWidth,
-        minMm: 5,
-      },
-    })
-  }
-
-  // 枝問番号列の縦線 → vertical-branchセグメントのみ
-  if (hasBranch) {
-    const branchNcSw = getLineWidth("branchNumberColumn", settings.borderConfig)
-    for (const range of branchVerticalRanges) {
+    // 大問間スペーシングで範囲を分割してクリップ
+    const clipped = clipRangeToMajorLayouts(range, majorLayoutRanges)
+    for (const cr of clipped) {
       lines.push({
-        x1: branchNumX + branchNumWidth,
-        y1: range.top,
-        x2: branchNumX + branchNumWidth,
-        y2: range.bottom,
-        style: settings.borderConfig.branchNumberDivider,
-        lineType: "branchNumberColumn",
-        strokeWidth: branchNcSw,
+        x1: subNumX + subNumWidth,
+        y1: cr.top,
+        x2: subNumX + subNumWidth,
+        y2: cr.bottom,
+        style: settings.borderConfig.subNumberDivider,
+        lineType: "subNumberColumn",
+        strokeWidth: subNcSw,
         dragInfo: {
           axis: "vertical",
-          target: { type: "columnWidth", column: "branchNumber" },
-          currentValueMm: branchNumWidth,
+          target: { type: "columnWidth", column: "subNumber" },
+          currentValueMm: subNumWidth,
           minMm: 5,
         },
       })
+    }
+  }
+
+  // 枝問番号列の縦線 → vertical-branchセグメントのみ（大問外枠内にクリップ）
+  if (hasBranch) {
+    const branchNcSw = getLineWidth("branchNumberColumn", settings.borderConfig)
+    for (const range of branchVerticalRanges) {
+      const clipped = clipRangeToMajorLayouts(range, majorLayoutRanges)
+      for (const cr of clipped) {
+        lines.push({
+          x1: branchNumX + branchNumWidth,
+          y1: cr.top,
+          x2: branchNumX + branchNumWidth,
+          y2: cr.bottom,
+          style: settings.borderConfig.branchNumberDivider,
+          lineType: "branchNumberColumn",
+          strokeWidth: branchNcSw,
+          dragInfo: {
+            axis: "vertical",
+            target: { type: "columnWidth", column: "branchNumber" },
+            currentValueMm: branchNumWidth,
+            minMm: 5,
+          },
+        })
+      }
     }
   }
 
@@ -2086,7 +2119,8 @@ export function computeMultiPageLayoutFromDefinition(
               "answer",
               pageIdx,
               computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
-              sub.omrConfig
+              sub.omrConfig,
+              sub.imageElements
             )
           )
         }
@@ -2336,7 +2370,8 @@ export function computeMultiPageLayoutFromDefinition(
                 ansW,
                 subHeight
               ),
-              sub.omrConfig
+              sub.omrConfig,
+              sub.imageElements
             )
           )
         }
@@ -2546,38 +2581,44 @@ export function computeMultiPageLayoutFromDefinition(
       }
     }
 
-    // 小問番号列の縦線（縦配置セグメントのみ）
+    // 小問番号列の縦線（縦配置セグメントのみ、大問外枠内にクリップ）
     {
       const subNcSwPage = getLineWidth("subNumberColumn", settings.borderConfig)
       for (const range of pd.verticalRanges) {
-        pd.lines.push({
-          x1: subNumX + subNumWidth,
-          y1: range.top,
-          x2: subNumX + subNumWidth,
-          y2: range.bottom,
-          style: settings.borderConfig.subNumberDivider,
-          lineType: "subNumberColumn",
-          strokeWidth: subNcSwPage,
-        })
+        const clipped = clipRangeToMajorLayouts(range, pd.majorLayoutRanges)
+        for (const cr of clipped) {
+          pd.lines.push({
+            x1: subNumX + subNumWidth,
+            y1: cr.top,
+            x2: subNumX + subNumWidth,
+            y2: cr.bottom,
+            style: settings.borderConfig.subNumberDivider,
+            lineType: "subNumberColumn",
+            strokeWidth: subNcSwPage,
+          })
+        }
       }
     }
 
-    // 枝問番号列の縦線（vertical-branchセグメントのみ）
+    // 枝問番号列の縦線（vertical-branchセグメントのみ、大問外枠内にクリップ）
     if (hasBranch) {
       const branchNcSwPage = getLineWidth(
         "branchNumberColumn",
         settings.borderConfig
       )
       for (const range of pd.branchVerticalRanges) {
-        pd.lines.push({
-          x1: branchNumX + branchNumWidth,
-          y1: range.top,
-          x2: branchNumX + branchNumWidth,
-          y2: range.bottom,
-          style: settings.borderConfig.branchNumberDivider,
-          lineType: "branchNumberColumn",
-          strokeWidth: branchNcSwPage,
-        })
+        const clipped = clipRangeToMajorLayouts(range, pd.majorLayoutRanges)
+        for (const cr of clipped) {
+          pd.lines.push({
+            x1: branchNumX + branchNumWidth,
+            y1: cr.top,
+            x2: branchNumX + branchNumWidth,
+            y2: cr.bottom,
+            style: settings.borderConfig.branchNumberDivider,
+            lineType: "branchNumberColumn",
+            strokeWidth: branchNcSwPage,
+          })
+        }
       }
     }
 

--- a/components/answer-sheet-builder/hooks/useExamIntegration.ts
+++ b/components/answer-sheet-builder/hooks/useExamIntegration.ts
@@ -11,7 +11,10 @@ import { toast } from "sonner"
 import { useAuth } from "@/contexts/AuthContext"
 import type { AnswerSheetDefinition } from "@/types/answerSheetBuilder.types"
 
-import { renderMultiPageSvgStrings } from "../utils/renderSvgStrings"
+import {
+  renderMultiPageSvgStrings,
+  resolveImageDataUris,
+} from "../utils/renderSvgStrings"
 import { computeMultiPageLayoutFromDefinition } from "./useAnswerSheetLayout"
 
 export function useExamIntegration() {
@@ -36,14 +39,18 @@ export function useExamIntegration() {
         setIsConverting(true)
 
         const multiPageLayout = computeMultiPageLayoutFromDefinition(definition)
+        const allCells = multiPageLayout.pages.flatMap((p) => p.cells)
+        const imageDataUris = await resolveImageDataUris(allCells)
 
         const answerSheetSvgStrings = renderMultiPageSvgStrings(
           multiPageLayout,
-          "answer-sheet"
+          "answer-sheet",
+          imageDataUris
         )
         const modelAnswerSvgStrings = renderMultiPageSvgStrings(
           multiPageLayout,
-          "model-answer"
+          "model-answer",
+          imageDataUris
         )
 
         const result = await api.convertToExam({

--- a/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -86,7 +86,8 @@ function renderPageSvgString(
   pageLayout: ComputedPageLayout,
   pageWidthMm: number,
   pageHeightMm: number,
-  renderMode: RenderMode = "answer-sheet"
+  renderMode: RenderMode = "answer-sheet",
+  imageDataUris?: Map<string, string>
 ): string {
   const w = pageWidthMm * MM_SCALE
   const h = pageHeightMm * MM_SCALE
@@ -169,6 +170,30 @@ function renderPageSvgString(
     }
   }
 
+  // 画像要素
+  for (const cell of pageLayout.cells) {
+    if (cell.cellType !== "answer" || !cell.imageElements?.length) continue
+    for (const ie of cell.imageElements) {
+      const pad = 1
+      const ix = cell.x + pad
+      const iy = cell.y + pad
+      const iw = cell.width - pad * 2
+      const ih = cell.height - pad * 2
+      const par =
+        ie.objectFit === "contain"
+          ? "xMidYMid meet"
+          : ie.objectFit === "cover"
+            ? "xMidYMid slice"
+            : "none"
+      // エクスポート時はbase64 data URIを使用、プレビュー時はappimg://
+      const href =
+        imageDataUris?.get(ie.imagePath) ?? `appimg:///${ie.imagePath}`
+      parts.push(
+        `<image href="${escapeXml(href)}" x="${ix}" y="${iy}" width="${iw}" height="${ih}" preserveAspectRatio="${par}" opacity="${ie.opacity}"/>`
+      )
+    }
+  }
+
   // OMRバブル
   for (const cell of pageLayout.cells) {
     parts.push(...renderOMRBubbles(cell, pageWidthMm, pageHeightMm))
@@ -191,14 +216,16 @@ function renderPageSvgString(
 /** 複数ページのSVG文字列を一括生成 */
 export function renderMultiPageSvgStrings(
   multiPageLayout: ComputedMultiPageLayout,
-  renderMode: RenderMode = "answer-sheet"
+  renderMode: RenderMode = "answer-sheet",
+  imageDataUris?: Map<string, string>
 ): string[] {
   return multiPageLayout.pages.map((page) =>
     renderPageSvgString(
       page,
       multiPageLayout.pageWidthMm,
       multiPageLayout.pageHeightMm,
-      renderMode
+      renderMode,
+      imageDataUris
     )
   )
 }
@@ -351,4 +378,42 @@ function renderManuscriptTextElements(
   }
 
   return parts
+}
+
+/**
+ * セル群から画像要素のパスを収集し、appimg:// → base64 data URI に変換する。
+ * エクスポート時（PDF/PNG/印刷）に使用。
+ */
+export async function resolveImageDataUris(
+  cells: ComputedCell[]
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>()
+  const paths = new Set<string>()
+
+  for (const cell of cells) {
+    if (!cell.imageElements?.length) continue
+    for (const ie of cell.imageElements) {
+      paths.add(ie.imagePath)
+    }
+  }
+
+  if (paths.size === 0) return map
+
+  const api = window.electronAPI
+  if (!api?.getImageData) return map
+
+  await Promise.all(
+    [...paths].map(async (imagePath) => {
+      try {
+        const result = await api.getImageData(imagePath)
+        if (result.success && result.data) {
+          map.set(imagePath, result.data)
+        }
+      } catch {
+        console.warn("Failed to resolve image data URI:", imagePath)
+      }
+    })
+  )
+
+  return map
 }

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -11,11 +11,18 @@ import sharp from "sharp"
 import type {
   AnswerSheetDefinition,
   ASBConvertToExamArgs,
+  ASBDeleteImageArgs,
   ASBExportPdfArgs,
   ASBExportPngArgs,
   ASBPrintArgs,
+  ASBUploadImageArgs,
 } from "../../types/answerSheetBuilder.types"
 import { convertToExam } from "../lib/answer-sheet-builder/examConverter"
+import {
+  getAbsolutePathFromData,
+  getAsbImagesDirectory,
+  getRelativePathFromData,
+} from "../lib/dataManager"
 import {
   deleteAsbDefinition,
   getAsbDefinition,
@@ -77,10 +84,26 @@ export function setupAnswerSheetBuilderHandlers(): void {
     }
   )
 
-  // 定義削除
+  // 定義削除（画像ディレクトリも削除）
   ipcMain.handle("asb:delete-definition", async (_event, id: string) => {
     try {
       const deleted = await deleteAsbDefinition(id)
+      if (deleted) {
+        // 画像ディレクトリの削除
+        const imagesDir = getAsbImagesDirectory(id)
+        try {
+          // ディレクトリの親（definitionId ディレクトリ）ごと削除
+          const definitionDir = path.dirname(imagesDir)
+          if (fs.existsSync(definitionDir)) {
+            fs.rmSync(definitionDir, { recursive: true, force: true })
+          }
+        } catch (cleanupError) {
+          console.warn(
+            "asb:delete-definition image cleanup warning:",
+            cleanupError
+          )
+        }
+      }
       return { success: deleted }
     } catch (error) {
       console.error("asb:delete-definition error:", error)
@@ -91,6 +114,62 @@ export function setupAnswerSheetBuilderHandlers(): void {
       }
     }
   })
+
+  // 画像アップロード
+  ipcMain.handle(
+    "asb:upload-image",
+    async (_event, args: ASBUploadImageArgs) => {
+      try {
+        const imagesDir = getAsbImagesDirectory(args.definitionId)
+        if (!fs.existsSync(imagesDir)) {
+          fs.mkdirSync(imagesDir, { recursive: true })
+        }
+
+        // ユニークなファイル名を生成
+        const ext = path.extname(args.originalName)
+        const baseName = path.basename(args.originalName, ext)
+        const uniqueName = `${baseName}_${Date.now()}${ext}`
+        const destPath = path.join(imagesDir, uniqueName)
+
+        // ファイルコピー
+        fs.copyFileSync(args.filePath, destPath)
+
+        // data/ からの相対パスを返す
+        const relativePath = getRelativePathFromData(destPath)
+        return { success: true, imagePath: relativePath }
+      } catch (error) {
+        console.error("asb:upload-image error:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "画像のアップロードに失敗しました",
+        }
+      }
+    }
+  )
+
+  // 画像削除
+  ipcMain.handle(
+    "asb:delete-image",
+    async (_event, args: ASBDeleteImageArgs) => {
+      try {
+        const absolutePath = getAbsolutePathFromData(args.imagePath)
+        if (fs.existsSync(absolutePath)) {
+          fs.unlinkSync(absolutePath)
+        }
+        return { success: true }
+      } catch (error) {
+        console.error("asb:delete-image error:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "画像の削除に失敗しました",
+        }
+      }
+    }
+  )
 
   // PDF出力: HTMLを受け取り → 一時ファイル → BrowserWindow → printToPDF
   ipcMain.handle("asb:export-pdf", async (_event, args: ASBExportPdfArgs) => {

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -59,6 +59,16 @@ export const getMasterAnswersDirectory = (examId: string): string => {
   return path.join(getExamDirectory(examId), "master-answers")
 }
 
+// ASB画像保存ディレクトリのパス
+export const getAsbImagesDirectory = (definitionId: string): string => {
+  return path.join(
+    getDataDirectory(),
+    "answer-sheet-builder",
+    definitionId,
+    "images"
+  )
+}
+
 // 出力ディレクトリのパス
 export const getExportsDirectory = (): string => {
   return path.join(getDataDirectory(), "exports")

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -7,6 +7,7 @@
 import type {
   AsbBranchQuestion,
   AsbDefinition,
+  AsbImageElement,
   AsbMajorQuestion,
   AsbOmrConfig,
   AsbSubQuestion,
@@ -19,6 +20,7 @@ import type {
   ASBDefinitionListItem,
   BorderConfig,
   BranchQuestion,
+  CellImageElement,
   CellTextElement,
   FontConfig,
   GlobalSettings,
@@ -96,6 +98,7 @@ type DbDefinitionFull = AsbDefinition & {
     subQuestions: (AsbSubQuestion & {
       branchQuestions: (AsbBranchQuestion & {
         textElements: AsbTextElement[]
+        imageElements: AsbImageElement[]
         omrConfig:
           | (AsbOmrConfig & {
               choiceOptions: {
@@ -107,6 +110,7 @@ type DbDefinitionFull = AsbDefinition & {
           | null
       })[]
       textElements: AsbTextElement[]
+      imageElements: AsbImageElement[]
       omrConfig:
         | (AsbOmrConfig & {
             choiceOptions: {
@@ -131,6 +135,7 @@ const fullInclude = {
             orderBy: { order: "asc" as const },
             include: {
               textElements: { orderBy: { order: "asc" as const } },
+              imageElements: { orderBy: { order: "asc" as const } },
               omrConfig: {
                 include: {
                   choiceOptions: {
@@ -142,6 +147,7 @@ const fullInclude = {
             },
           },
           textElements: { orderBy: { order: "asc" as const } },
+          imageElements: { orderBy: { order: "asc" as const } },
           omrConfig: {
             include: {
               choiceOptions: {
@@ -251,6 +257,26 @@ export async function saveAsbDefinition(
           })
         }
 
+        // 画像要素（小問）
+        if (sq.imageElements) {
+          for (let ii = 0; ii < sq.imageElements.length; ii++) {
+            const ie = sq.imageElements[ii]
+            await tx.asbImageElement.create({
+              data: {
+                id: ie.id,
+                subQuestionId: sq.id,
+                imagePath: ie.imagePath,
+                originalName: ie.originalName,
+                objectFit: ie.objectFit,
+                horizontalAlign: ie.horizontalAlign,
+                verticalAlign: ie.verticalAlign,
+                opacity: ie.opacity,
+                order: ii,
+              },
+            })
+          }
+        }
+
         // OMR設定（小問）
         if (sq.omrConfig) {
           await createOmrConfig(tx, { subQuestionId: sq.id }, sq.omrConfig)
@@ -291,6 +317,26 @@ export async function saveAsbDefinition(
                 order: ti,
               },
             })
+          }
+
+          // 画像要素（枝問）
+          if (bq.imageElements) {
+            for (let ii = 0; ii < bq.imageElements.length; ii++) {
+              const ie = bq.imageElements[ii]
+              await tx.asbImageElement.create({
+                data: {
+                  id: ie.id,
+                  branchQuestionId: bq.id,
+                  imagePath: ie.imagePath,
+                  originalName: ie.originalName,
+                  objectFit: ie.objectFit,
+                  horizontalAlign: ie.horizontalAlign,
+                  verticalAlign: ie.verticalAlign,
+                  opacity: ie.opacity,
+                  order: ii,
+                },
+              })
+            }
           }
 
           // OMR設定（枝問）
@@ -467,6 +513,18 @@ function dbTextElements(elements: AsbTextElement[]): CellTextElement[] {
   }))
 }
 
+function dbImageElements(elements: AsbImageElement[]): CellImageElement[] {
+  return elements.map((ie) => ({
+    id: ie.id,
+    imagePath: ie.imagePath,
+    originalName: ie.originalName,
+    objectFit: ie.objectFit as CellImageElement["objectFit"],
+    horizontalAlign: ie.horizontalAlign as CellImageElement["horizontalAlign"],
+    verticalAlign: ie.verticalAlign as CellImageElement["verticalAlign"],
+    opacity: ie.opacity,
+  }))
+}
+
 function dbToOmrConfig(
   config: AsbOmrConfig & {
     choiceOptions: { choiceIndex: number; label: string; isCorrect: boolean }[]
@@ -576,6 +634,7 @@ function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
             heightMultiplier: bq.heightMultiplier,
             points: bq.points,
             textElements: dbTextElements(bq.textElements),
+            imageElements: dbImageElements(bq.imageElements),
             borderStyles: bqBorderStyles as BranchQuestion["borderStyles"],
             layoutWidth: bq.layoutWidth ?? undefined,
             nextPlacement: bq.nextPlacement as BranchQuestion["nextPlacement"],
@@ -586,6 +645,7 @@ function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
         heightMultiplier: sq.heightMultiplier,
         points: sq.points,
         textElements: dbTextElements(sq.textElements),
+        imageElements: dbImageElements(sq.imageElements),
         manuscriptPaper,
         borderStyles: borderStyles as SubQuestion["borderStyles"],
         layoutWidth: sq.layoutWidth ?? undefined,

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -1185,6 +1185,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ) => ipcRenderer.invoke("asb:convert-to-exam", args),
     print: (args: import("../types/answerSheetBuilder.types").ASBPrintArgs) =>
       ipcRenderer.invoke("asb:print", args),
+    uploadImage: (
+      args: import("../types/answerSheetBuilder.types").ASBUploadImageArgs
+    ) => ipcRenderer.invoke("asb:upload-image", args),
+    deleteImage: (
+      args: import("../types/answerSheetBuilder.types").ASBDeleteImageArgs
+    ) => ipcRenderer.invoke("asb:delete-image", args),
   },
 })
 

--- a/prisma/migrations/20260304000000_add_asb_image_element/migration.sql
+++ b/prisma/migrations/20260304000000_add_asb_image_element/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "AsbImageElement" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subQuestionId" TEXT,
+    "branchQuestionId" TEXT,
+    "imagePath" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "objectFit" TEXT NOT NULL DEFAULT 'contain',
+    "horizontalAlign" TEXT NOT NULL DEFAULT 'center',
+    "verticalAlign" TEXT NOT NULL DEFAULT 'middle',
+    "opacity" REAL NOT NULL DEFAULT 1,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbImageElement_subQuestionId_fkey" FOREIGN KEY ("subQuestionId") REFERENCES "AsbSubQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AsbImageElement_branchQuestionId_fkey" FOREIGN KEY ("branchQuestionId") REFERENCES "AsbBranchQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "AsbImageElement_subQuestionId_idx" ON "AsbImageElement"("subQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbImageElement_branchQuestionId_idx" ON "AsbImageElement"("branchQuestionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -716,6 +716,7 @@ model AsbSubQuestion {
   majorQuestion   AsbMajorQuestion  @relation(fields: [majorQuestionId], references: [id], onDelete: Cascade)
   branchQuestions AsbBranchQuestion[]
   textElements    AsbTextElement[]
+  imageElements   AsbImageElement[]
   omrConfig       AsbOmrConfig?
 
   @@index([majorQuestionId])
@@ -742,6 +743,7 @@ model AsbBranchQuestion {
 
   subQuestion  AsbSubQuestion    @relation(fields: [subQuestionId], references: [id], onDelete: Cascade)
   textElements AsbTextElement[]
+  imageElements AsbImageElement[]
   omrConfig    AsbOmrConfig?
 
   @@index([subQuestionId])
@@ -756,6 +758,29 @@ model AsbTextElement {
   fontSize         Float
   horizontalAlign  String  @default("left")
   verticalAlign    String  @default("top")
+  order            Int     @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  subQuestion    AsbSubQuestion?    @relation(fields: [subQuestionId], references: [id], onDelete: Cascade)
+  branchQuestion AsbBranchQuestion? @relation(fields: [branchQuestionId], references: [id], onDelete: Cascade)
+
+  @@index([subQuestionId])
+  @@index([branchQuestionId])
+}
+
+/// セル内画像要素（小問 or 枝問に紐付く dual FK）
+model AsbImageElement {
+  id               String  @id @default(uuid())
+  subQuestionId    String?
+  branchQuestionId String?
+  imagePath        String
+  originalName     String
+  objectFit        String  @default("contain")
+  horizontalAlign  String  @default("center")
+  verticalAlign    String  @default("middle")
+  opacity          Float   @default(1)
   order            Int     @default(0)
 
   createdAt DateTime @default(now())

--- a/types/answerSheetBuilder.types.ts
+++ b/types/answerSheetBuilder.types.ts
@@ -36,6 +36,22 @@ export interface CellTextElement {
 }
 
 // =====================
+// セル内画像要素
+// =====================
+
+export type ImageObjectFit = "contain" | "cover" | "fill"
+
+export interface CellImageElement {
+  id: string
+  imagePath: string // data/ からの相対パス
+  originalName: string // 表示用ファイル名
+  objectFit: ImageObjectFit
+  horizontalAlign: HorizontalAlign
+  verticalAlign: VerticalAlign
+  opacity: number // 0-1
+}
+
+// =====================
 // 罫線設定
 // =====================
 
@@ -68,6 +84,7 @@ export interface BranchQuestion {
   heightMultiplier: number
   points: number
   textElements: CellTextElement[]
+  imageElements?: CellImageElement[]
   borderStyles?: BorderStyles
   /** 幅の分数表記 (例: "1/4", "1/3", "1/2")。未指定 = 全幅（縦配置） */
   layoutWidth?: string
@@ -86,6 +103,7 @@ export interface SubQuestion {
   heightMultiplier: number
   points: number
   textElements: CellTextElement[]
+  imageElements?: CellImageElement[]
   manuscriptPaper?: ManuscriptPaperConfig
   borderStyles?: BorderStyles
   /** 幅の分数表記 (例: "1/4", "1/3", "1/2")。未指定 = 全幅（縦配置） */
@@ -274,6 +292,8 @@ export interface ComputedCell {
   points: number
   /** テキスト要素 */
   textElements: CellTextElement[]
+  /** 画像要素 */
+  imageElements?: CellImageElement[]
   /** セル種類 */
   cellType: "answer" | "major-number" | "sub-number" | "branch-number"
   /** このセルが属するページ (0-indexed) */
@@ -483,6 +503,22 @@ export interface ASBConvertResult {
   success: boolean
   examId?: string
   error?: string
+}
+
+export interface ASBUploadImageArgs {
+  definitionId: string
+  filePath: string
+  originalName: string
+}
+
+export interface ASBUploadImageResult {
+  success: boolean
+  imagePath?: string // data/ からの相対パス
+  error?: string
+}
+
+export interface ASBDeleteImageArgs {
+  imagePath: string // data/ からの相対パス
 }
 
 export interface ASBDefinitionListItem {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -2205,6 +2205,12 @@ export interface MyAPI {
     print: (
       args: import("./answerSheetBuilder.types").ASBPrintArgs
     ) => Promise<{ success: boolean; error?: string }>
+    uploadImage: (
+      args: import("./answerSheetBuilder.types").ASBUploadImageArgs
+    ) => Promise<import("./answerSheetBuilder.types").ASBUploadImageResult>
+    deleteImage: (
+      args: import("./answerSheetBuilder.types").ASBDeleteImageArgs
+    ) => Promise<{ success: boolean; error?: string }>
   }
 
   // =============================================================================


### PR DESCRIPTION
## Summary

- 解答用紙作成（ASB）のセル内に画像要素を追加・編集・削除できる機能を実装
- 小問/枝問番号列の縦線が大問間スペーシングを跨ぐバグを修正
- 画像アップロード時の `file.path` が `undefined` になるエラーを修正

Closes #454

## 変更内容

### 新機能: 画像要素
- `CellImageElement` 型・`AsbImageElement` Prismaモデル（dual FKパターン）
- `asb:upload-image` / `asb:delete-image` IPCハンドラー
- `ImageElementEditor` UI（ファイル選択、objectFit、透明度）
- SVGプレビュー・PDF/PNG出力にbase64 data URI埋め込み
- 定義削除時の画像ディレクトリクリーンアップ

### バグ修正
- `clipRangeToMajorLayouts` で縦線を大問範囲内にクリップ
- `webUtils.getPathForFile` を使用して画像パス取得を修正

## Test plan

- [ ] 小問/枝問の詳細設定で画像追加ボタンが表示される
- [ ] 画像を選択→`data/answer-sheet-builder/[id]/images/`に保存される
- [ ] SVGプレビューに画像が表示される
- [ ] objectFit / opacity変更がプレビューに反映される
- [ ] 定義保存→再読み込みで画像が復元される
- [ ] PDF/PNG出力に画像が含まれる
- [ ] 大問間スペーシング使用時に小問番号列の縦線が正しくクリップされる
- [ ] `npm run typecheck` / `npm run lint` がパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)