### PR TITLE
feat: ヘッダー記入欄に可変スペースとラベルタイプを追加

### DIFF
--- a/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
+++ b/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select"
 import type {
   HeaderFieldDefinition,
+  HeaderFieldType,
   LineStyle,
 } from "@/types/answerSheetDefinition.types"
 
@@ -32,6 +33,12 @@ interface HeaderFieldEditorProps {
   onUpdate: (fieldId: string, data: Partial<HeaderFieldDefinition>) => void
   onDelete: (fieldId: string) => void
   onReorder: (fromIndex: number, toIndex: number) => void
+}
+
+const TYPE_LABELS: Record<HeaderFieldType, string> = {
+  field: "記入欄",
+  hfill: "可変スペース",
+  label: "ラベル",
 }
 
 export function HeaderFieldEditor({
@@ -74,99 +81,153 @@ export function HeaderFieldEditor({
         </p>
       )}
 
-      {fields.map((field, index) => (
-        <div key={field.id} className="space-y-2 rounded border p-2">
-          <div className="flex items-center gap-1">
-            <Input
-              value={field.label}
-              onChange={(e) => onUpdate(field.id, { label: e.target.value })}
-              className="h-7 flex-1 text-xs"
-              placeholder="ラベル"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={() => onReorder(index, index - 1)}
-              disabled={index === 0}
-            >
-              <ArrowUp className="h-3 w-3" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={() => onReorder(index, index + 1)}
-              disabled={index === fields.length - 1}
-            >
-              <ArrowDown className="h-3 w-3" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-destructive h-6 w-6"
-              onClick={() => onDelete(field.id)}
-            >
-              <Trash2 className="h-3 w-3" />
-            </Button>
-          </div>
-
-          <div className="grid grid-cols-2 gap-2">
-            <SliderWithInput
-              label="幅"
-              value={field.widthMm}
-              min={10}
-              max={100}
-              step={1}
-              onChange={(v) => onUpdate(field.id, { widthMm: v })}
-            />
-            <SliderWithInput
-              label="高さ"
-              value={field.heightMm}
-              min={4}
-              max={20}
-              step={1}
-              onChange={(v) => onUpdate(field.id, { heightMm: v })}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-2">
-            <div>
-              <Label className="text-[10px]">マス数</Label>
-              <Input
-                type="number"
-                value={field.gridCount}
-                onChange={(e) =>
-                  onUpdate(field.id, {
-                    gridCount: Math.max(0, parseInt(e.target.value) || 0),
-                  })
-                }
-                className="h-7 text-xs"
-                min={0}
-                max={20}
-              />
-            </div>
-            <div>
-              <Label className="text-[10px]">罫線</Label>
-              <Select
-                value={field.lineStyle}
-                onValueChange={(v) =>
-                  onUpdate(field.id, { lineStyle: v as LineStyle })
-                }
+      {fields.map((field, index) => {
+        const fieldType = field.type ?? "field"
+        return (
+          <div key={field.id} className="space-y-2 rounded border p-2">
+            <div className="flex items-center gap-1">
+              {/* hfill はラベル不要なのでタイプ表示のみ */}
+              {fieldType === "hfill" ? (
+                <span className="text-muted-foreground flex-1 text-xs italic">
+                  可変スペース
+                </span>
+              ) : (
+                <Input
+                  value={field.label}
+                  onChange={(e) =>
+                    onUpdate(field.id, { label: e.target.value })
+                  }
+                  className="h-7 flex-1 text-xs"
+                  placeholder="ラベル"
+                />
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => onReorder(index, index - 1)}
+                disabled={index === 0}
               >
-                <SelectTrigger className="h-7 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="solid">実線</SelectItem>
-                  <SelectItem value="dashed">破線</SelectItem>
-                  <SelectItem value="dotted">点線</SelectItem>
-                </SelectContent>
-              </Select>
+                <ArrowUp className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => onReorder(index, index + 1)}
+                disabled={index === fields.length - 1}
+              >
+                <ArrowDown className="h-3 w-3" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive h-6 w-6"
+                onClick={() => onDelete(field.id)}
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
             </div>
+
+            {/* タイプ切替 */}
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label className="text-[10px]">タイプ</Label>
+                <Select
+                  value={fieldType}
+                  onValueChange={(v) =>
+                    onUpdate(field.id, { type: v as HeaderFieldType })
+                  }
+                >
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(TYPE_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* label タイプ: フォントサイズ */}
+              {fieldType === "label" && (
+                <SliderWithInput
+                  label="文字サイズ"
+                  value={field.fontSize ?? 5}
+                  min={2}
+                  max={15}
+                  step={0.5}
+                  onChange={(v) => onUpdate(field.id, { fontSize: v })}
+                />
+              )}
+            </div>
+
+            {/* field / label: 幅・高さ */}
+            {fieldType !== "hfill" && (
+              <div className="grid grid-cols-2 gap-2">
+                <SliderWithInput
+                  label="幅"
+                  value={field.widthMm}
+                  min={10}
+                  max={100}
+                  step={1}
+                  onChange={(v) => onUpdate(field.id, { widthMm: v })}
+                />
+                <SliderWithInput
+                  label="高さ"
+                  value={field.heightMm}
+                  min={4}
+                  max={20}
+                  step={1}
+                  onChange={(v) => onUpdate(field.id, { heightMm: v })}
+                />
+              </div>
+            )}
+
+            {/* field タイプのみ: マス数・罫線 */}
+            {fieldType === "field" && (
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label className="text-[10px]">マス数</Label>
+                  <Input
+                    type="number"
+                    value={field.gridCount}
+                    onChange={(e) =>
+                      onUpdate(field.id, {
+                        gridCount: Math.max(0, parseInt(e.target.value) || 0),
+                      })
+                    }
+                    className="h-7 text-xs"
+                    min={0}
+                    max={20}
+                  />
+                </div>
+                <div>
+                  <Label className="text-[10px]">罫線</Label>
+                  <Select
+                    value={field.lineStyle}
+                    onValueChange={(v) =>
+                      onUpdate(field.id, { lineStyle: v as LineStyle })
+                    }
+                  >
+                    <SelectTrigger className="h-7 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="solid">実線</SelectItem>
+                      <SelectItem value="dashed">破線</SelectItem>
+                      <SelectItem value="dotted">点線</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/components/answer-sheet-builder/constants.ts
+++ b/components/answer-sheet-builder/constants.ts
@@ -117,6 +117,7 @@ export function createDefaultHeaderField(
 ): HeaderFieldDefinition {
   return {
     id: generateId(),
+    type: overrides?.type ?? "field",
     label: overrides?.label ?? "フィールド",
     widthMm: overrides?.widthMm ?? 30,
     heightMm: overrides?.heightMm ?? 8,
@@ -124,6 +125,7 @@ export function createDefaultHeaderField(
     lineStyle: overrides?.lineStyle ?? "solid",
     lineWidth: overrides?.lineWidth ?? 0.4,
     order: overrides?.order ?? 0,
+    fontSize: overrides?.fontSize,
   }
 }
 
@@ -133,11 +135,34 @@ export const HEADER_FIELD_PRESETS: {
 }[] = [
   {
     label: "受験番号",
-    defaults: { label: "受験番号", widthMm: 40, gridCount: 8 },
+    defaults: { type: "field", label: "受験番号", widthMm: 40, gridCount: 8 },
   },
-  { label: "クラス", defaults: { label: "クラス", widthMm: 20, gridCount: 3 } },
-  { label: "番号", defaults: { label: "番号", widthMm: 20, gridCount: 3 } },
-  { label: "氏名", defaults: { label: "氏名", widthMm: 60, gridCount: 0 } },
+  {
+    label: "クラス",
+    defaults: { type: "field", label: "クラス", widthMm: 20, gridCount: 3 },
+  },
+  {
+    label: "番号",
+    defaults: { type: "field", label: "番号", widthMm: 20, gridCount: 3 },
+  },
+  {
+    label: "氏名",
+    defaults: { type: "field", label: "氏名", widthMm: 60, gridCount: 0 },
+  },
+  {
+    label: "可変スペース",
+    defaults: { type: "hfill", label: "", widthMm: 0, heightMm: 8 },
+  },
+  {
+    label: "ラベル（テキスト表示）",
+    defaults: {
+      type: "label",
+      label: "試験名",
+      widthMm: 40,
+      heightMm: 8,
+      fontSize: 5,
+    },
+  },
 ]
 
 export function createDefaultDefinition(): AnswerSheetDefinition {

--- a/components/answer-sheet-builder/hooks/layout/headerFieldLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/headerFieldLayout.ts
@@ -3,6 +3,8 @@
  *
  * HeaderFieldDefinition[] → ComputedHeaderField[] への変換を行う。
  * フィールドを order 順に左から配置し、マス目のセル幅を計算する。
+ * hfill 要素は固定幅要素の残り幅を均等配分して伸縮する。
+ * label 要素はボックスなしのテキスト表示用。
  */
 
 import type { GlobalSettings } from "@/types/answerSheetDefinition.types"
@@ -11,7 +13,8 @@ import type { ComputedHeaderField } from "@/types/answerSheetLayout.types"
 export function computeHeaderFieldLayout(
   settings: GlobalSettings,
   contentLeft: number,
-  headerTopY: number
+  headerTopY: number,
+  contentRight?: number
 ): { fields: ComputedHeaderField[]; totalHeightMm: number } {
   const { headerFields } = settings
   if (headerFields.length === 0) {
@@ -20,27 +23,60 @@ export function computeHeaderFieldLayout(
 
   const sorted = [...headerFields].sort((a, b) => a.order - b.order)
   const gap = 2 // フィールド間のギャップ (mm)
+
+  // hfill の幅を計算: 全幅から固定要素とギャップを引いた残りを均等配分
+  const hfillCount = sorted.filter(
+    (f) => (f.type ?? "field") === "hfill"
+  ).length
+  let hfillWidth = 0
+
+  if (hfillCount > 0 && contentRight != null) {
+    const totalAvailableWidth = contentRight - contentLeft
+    const fixedWidth = sorted.reduce((sum, f) => {
+      if ((f.type ?? "field") === "hfill") return sum
+      return sum + f.widthMm
+    }, 0)
+    const totalGaps = (sorted.length - 1) * gap
+    const remainingWidth = Math.max(
+      0,
+      totalAvailableWidth - fixedWidth - totalGaps
+    )
+    hfillWidth = remainingWidth / hfillCount
+  }
+
   let currentX = contentLeft
 
   const fields: ComputedHeaderField[] = sorted.map((field) => {
+    const fieldType = field.type ?? "field"
+    const effectiveWidth = fieldType === "hfill" ? hfillWidth : field.widthMm
+
     const computed: ComputedHeaderField = {
       fieldId: field.id,
+      type: fieldType,
       label: field.label,
       x: currentX,
       y: headerTopY,
-      width: field.widthMm,
+      width: effectiveWidth,
       height: field.heightMm,
-      gridCount: field.gridCount,
+      gridCount: fieldType === "field" ? field.gridCount : 0,
       lineStyle: field.lineStyle,
       lineWidth: field.lineWidth,
       gridCellWidthMm:
-        field.gridCount > 0 ? field.widthMm / field.gridCount : undefined,
+        fieldType === "field" && field.gridCount > 0
+          ? field.widthMm / field.gridCount
+          : undefined,
+      fontSize: fieldType === "label" ? (field.fontSize ?? 5) : undefined,
     }
-    currentX += field.widthMm + gap
+    currentX += effectiveWidth + gap
     return computed
   })
 
-  const totalHeightMm = Math.max(...sorted.map((f) => f.heightMm))
+  // hfill は高さ 0 として扱わない: field/label の最大高さを使う
+  const nonHfillFields = sorted.filter((f) => (f.type ?? "field") !== "hfill")
+  const totalHeightMm =
+    nonHfillFields.length > 0
+      ? Math.max(...nonHfillFields.map((f) => f.heightMm))
+      : 0
 
   return { fields, totalHeightMm }
 }

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -215,6 +215,7 @@ export async function saveAsbDefinition(
         data: {
           id: hf.id,
           definitionId: definition.id,
+          type: hf.type ?? "field",
           label: hf.label,
           widthMm: hf.widthMm,
           heightMm: hf.heightMm,
@@ -222,6 +223,7 @@ export async function saveAsbDefinition(
           lineStyle: hf.lineStyle,
           lineWidth: hf.lineWidth,
           order: hi,
+          fontSize: hf.fontSize ?? null,
         },
       })
     }

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -250,6 +250,7 @@ export function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
     settings.headerFields = row.headerFields.map(
       (hf): HeaderFieldDefinition => ({
         id: hf.id,
+        type: (hf.type as HeaderFieldDefinition["type"]) ?? "field",
         label: hf.label,
         widthMm: hf.widthMm,
         heightMm: hf.heightMm,
@@ -257,6 +258,7 @@ export function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
         lineStyle: hf.lineStyle as LineStyle,
         lineWidth: hf.lineWidth,
         order: hf.order,
+        fontSize: hf.fontSize ?? undefined,
       })
     )
   }

--- a/prisma/migrations/20260306000000_add_headerfield_type/migration.sql
+++ b/prisma/migrations/20260306000000_add_headerfield_type/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: ヘッダーフィールドに type と fontSize を追加
+ALTER TABLE "AsbHeaderField" ADD COLUMN "type" TEXT NOT NULL DEFAULT 'field';
+ALTER TABLE "AsbHeaderField" ADD COLUMN "fontSize" REAL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -683,6 +683,7 @@ model AsbDefinition {
 model AsbHeaderField {
   id           String @id @default(uuid())
   definitionId String
+  type         String @default("field") // "field" | "hfill" | "label"
   label        String
   widthMm      Float  @default(30)
   heightMm     Float  @default(8)
@@ -690,6 +691,7 @@ model AsbHeaderField {
   lineStyle    String @default("solid")
   lineWidth    Float  @default(0.4)
   order        Int    @default(0)
+  fontSize     Float? // label タイプ用
 
   definition AsbDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
 

--- a/types/answerSheetDefinition.types.ts
+++ b/types/answerSheetDefinition.types.ts
@@ -209,8 +209,11 @@ export interface MultiColumnConfig {
 // ヘッダーフィールド定義
 // =====================
 
+export type HeaderFieldType = "field" | "hfill" | "label"
+
 export interface HeaderFieldDefinition {
   id: string
+  type: HeaderFieldType
   label: string
   widthMm: number
   heightMm: number
@@ -218,6 +221,8 @@ export interface HeaderFieldDefinition {
   lineStyle: LineStyle
   lineWidth: number
   order: number
+  /** label タイプのフォントサイズ (mm) */
+  fontSize?: number
 }
 
 // =====================

--- a/types/answerSheetLayout.types.ts
+++ b/types/answerSheetLayout.types.ts
@@ -140,6 +140,7 @@ export interface ComputedOMRMarker {
 
 export interface ComputedHeaderField {
   fieldId: string
+  type: "field" | "hfill" | "label"
   label: string
   x: number
   y: number
@@ -149,6 +150,8 @@ export interface ComputedHeaderField {
   lineStyle: LineStyle
   lineWidth: number
   gridCellWidthMm?: number
+  /** label タイプのフォントサイズ (mm) */
+  fontSize?: number
 }
 
 export interface ComputedLayout {


### PR DESCRIPTION
## Summary
- ヘッダーフィールドに3種類のタイプ（field/hfill/label）を導入
- 可変スペース: 残り幅を均等配分する柔軟なスペース要素
- ラベル: テキスト表示のみ（試験名等の表示用）
- ヘッダースペーシング設定が反映されない不具合を修正

Closes #462

## Test plan
- [ ] ヘッダーフィールドに可変スペースを追加し、残り幅が均等配分されることを確認
- [ ] ラベルタイプを追加し、テキストのみ表示されることを確認
- [ ] 3タイプ混在時のレイアウトが正しいことを確認
- [ ] ヘッダースペーシング設定変更がプレビューに反映されることを確認
- [ ] 保存→再読み込みでデータが保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)