### PR TITLE
feat: 画像要素に表示モード制限機能を追加

### DIFF
--- a/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -38,6 +38,10 @@ export function BranchQuestionForm({
   const hasDetailContent =
     branch.textElements.length > 0 || (branch.imageElements?.length ?? 0) > 0
 
+  const hasVisibilityRestricted = branch.imageElements?.some(
+    (ie) => ie.visibility && ie.visibility !== "both"
+  )
+
   const goUpActive = branch.goUp != null
   const isGoUpInvalid =
     goUpActive &&
@@ -221,13 +225,15 @@ export function BranchQuestionForm({
           <Button
             variant="ghost"
             size="icon"
-            className={`relative h-7 w-7 ${detailOpen ? "text-primary" : "text-muted-foreground"}`}
+            className={`relative h-7 w-7 ${hasVisibilityRestricted ? "text-orange-500" : detailOpen ? "text-primary" : "text-muted-foreground"}`}
             onClick={() => setDetailOpen(!detailOpen)}
             title="詳細設定"
           >
             <Settings2 className="h-3.5 w-3.5" />
             {hasDetailContent && (
-              <span className="bg-primary absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full" />
+              <span
+                className={`absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full ${hasVisibilityRestricted ? "bg-orange-500" : "bg-primary"}`}
+              />
             )}
           </Button>
           <Button

--- a/components/answer-sheet-builder/components/form/ImageElementEditor.tsx
+++ b/components/answer-sheet-builder/components/form/ImageElementEditor.tsx
@@ -15,6 +15,7 @@ import { Slider } from "@/components/ui/slider"
 import type {
   CellImageElement,
   ImageObjectFit,
+  ImageVisibility,
 } from "@/types/answerSheetDefinition.types"
 
 import { generateId } from "../../constants"
@@ -23,6 +24,12 @@ const OBJECT_FIT_OPTIONS: { value: ImageObjectFit; label: string }[] = [
   { value: "contain", label: "収める" },
   { value: "cover", label: "覆う" },
   { value: "fill", label: "引き伸ばす" },
+]
+
+const VISIBILITY_OPTIONS: { value: ImageVisibility; label: string }[] = [
+  { value: "both", label: "常に表示" },
+  { value: "answer-sheet-only", label: "解答用紙のみ" },
+  { value: "model-answer-only", label: "模範解答のみ" },
 ]
 
 interface ImageElementEditorProps {
@@ -139,7 +146,7 @@ export function ImageElementEditor({
             </Button>
           </div>
 
-          {/* Row 2: objectFit + 不透明度 */}
+          {/* Row 2: objectFit + 表示モード */}
           <div className="flex items-center gap-2">
             <Select
               value={el.objectFit}
@@ -159,22 +166,41 @@ export function ImageElementEditor({
               </SelectContent>
             </Select>
 
-            <div className="flex flex-1 items-center gap-1.5">
-              <span className="text-muted-foreground shrink-0 text-[10px]">
-                透明度
-              </span>
-              <Slider
-                min={0}
-                max={100}
-                step={5}
-                value={[Math.round(el.opacity * 100)]}
-                onValueChange={([v]) => handleChange(i, { opacity: v / 100 })}
-                className="flex-1"
-              />
-              <span className="w-8 shrink-0 text-right text-[10px]">
-                {Math.round(el.opacity * 100)}%
-              </span>
-            </div>
+            <Select
+              value={el.visibility ?? "both"}
+              onValueChange={(v) =>
+                handleChange(i, { visibility: v as ImageVisibility })
+              }
+            >
+              <SelectTrigger className="h-7 w-28 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {VISIBILITY_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Row 3: 不透明度 */}
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground shrink-0 text-[10px]">
+              透明度
+            </span>
+            <Slider
+              min={0}
+              max={100}
+              step={5}
+              value={[Math.round(el.opacity * 100)]}
+              onValueChange={([v]) => handleChange(i, { opacity: v / 100 })}
+              className="flex-1"
+            />
+            <span className="w-8 shrink-0 text-right text-[10px]">
+              {Math.round(el.opacity * 100)}%
+            </span>
           </div>
         </div>
       ))}

--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -102,6 +102,10 @@ export function SubQuestionForm({
     (sub.imageElements?.length ?? 0) > 0 ||
     !!sub.manuscriptPaper?.enabled
 
+  const hasVisibilityRestricted = sub.imageElements?.some(
+    (ie) => ie.visibility && ie.visibility !== "both"
+  )
+
   const branchMaxGoUps = useMemo(
     () => calcBranchMaxGoUps(sub.branchQuestions),
     [sub.branchQuestions]
@@ -317,13 +321,15 @@ export function SubQuestionForm({
             <Button
               variant="ghost"
               size="icon"
-              className={`relative h-7 w-7 ${detailOpen ? "text-primary" : "text-muted-foreground"}`}
+              className={`relative h-7 w-7 ${hasVisibilityRestricted ? "text-orange-500" : detailOpen ? "text-primary" : "text-muted-foreground"}`}
               onClick={() => setDetailOpen(!detailOpen)}
               title="詳細設定"
             >
               <Settings2 className="h-3.5 w-3.5" />
               {hasDetailContent && (
-                <span className="bg-primary absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full" />
+                <span
+                  className={`absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full ${hasVisibilityRestricted ? "bg-orange-500" : "bg-primary"}`}
+                />
               )}
             </Button>
           )}

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -350,31 +350,41 @@ export function AnswerSheetSVGRenderer({
       {cells
         .filter((c) => c.cellType === "answer" && c.imageElements?.length)
         .flatMap((cell) =>
-          cell.imageElements!.map((ie, ii) => {
-            const pad = 1
-            const ix = cell.x + pad
-            const iy = cell.y + pad
-            const iw = cell.width - pad * 2
-            const ih = cell.height - pad * 2
-            const par =
-              ie.objectFit === "contain"
-                ? "xMidYMid meet"
-                : ie.objectFit === "cover"
-                  ? "xMidYMid slice"
-                  : "none"
-            return (
-              <image
-                key={`img-${cell.label}-${ii}`}
-                href={`appimg:///${ie.imagePath}`}
-                x={ix}
-                y={iy}
-                width={iw}
-                height={ih}
-                preserveAspectRatio={par}
-                opacity={ie.opacity}
-              />
-            )
-          })
+          cell
+            .imageElements!.filter((ie) => {
+              const vis = ie.visibility ?? "both"
+              if (vis === "both") return true
+              if (vis === "answer-sheet-only")
+                return renderMode === "answer-sheet"
+              if (vis === "model-answer-only")
+                return renderMode === "model-answer"
+              return true
+            })
+            .map((ie, ii) => {
+              const pad = 1
+              const ix = cell.x + pad
+              const iy = cell.y + pad
+              const iw = cell.width - pad * 2
+              const ih = cell.height - pad * 2
+              const par =
+                ie.objectFit === "contain"
+                  ? "xMidYMid meet"
+                  : ie.objectFit === "cover"
+                    ? "xMidYMid slice"
+                    : "none"
+              return (
+                <image
+                  key={`img-${cell.label}-${ii}`}
+                  href={`appimg:///${ie.imagePath}`}
+                  x={ix}
+                  y={iy}
+                  width={iw}
+                  height={ih}
+                  preserveAspectRatio={par}
+                  opacity={ie.opacity}
+                />
+              )
+            })
         )}
 
       {/* OMRバブル */}

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -295,6 +295,7 @@ export async function saveAsbDefinition(
                 horizontalAlign: ie.horizontalAlign,
                 verticalAlign: ie.verticalAlign,
                 opacity: ie.opacity,
+                visibility: ie.visibility ?? "both",
                 order: ii,
               },
             })
@@ -357,6 +358,7 @@ export async function saveAsbDefinition(
                   horizontalAlign: ie.horizontalAlign,
                   verticalAlign: ie.verticalAlign,
                   opacity: ie.opacity,
+                  visibility: ie.visibility ?? "both",
                   order: ii,
                 },
               })

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -213,6 +213,10 @@ export function dbImageElements(
     horizontalAlign: ie.horizontalAlign as CellImageElement["horizontalAlign"],
     verticalAlign: ie.verticalAlign as CellImageElement["verticalAlign"],
     opacity: ie.opacity,
+    visibility:
+      ie.visibility !== "both"
+        ? (ie.visibility as CellImageElement["visibility"])
+        : undefined,
   }))
 }
 

--- a/prisma/migrations/20260305100000_add_visibility_to_asb_image_element/migration.sql
+++ b/prisma/migrations/20260305100000_add_visibility_to_asb_image_element/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AsbImageElement" ADD COLUMN "visibility" TEXT NOT NULL DEFAULT 'both';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -807,6 +807,7 @@ model AsbImageElement {
   horizontalAlign  String  @default("center")
   verticalAlign    String  @default("middle")
   opacity          Float   @default(1)
+  visibility       String  @default("both") // "both" | "answer-sheet-only" | "model-answer-only"
   order            Int     @default(0)
 
   createdAt DateTime @default(now())

--- a/types/answerSheetDefinition.types.ts
+++ b/types/answerSheetDefinition.types.ts
@@ -36,6 +36,7 @@ export interface CellTextElement {
 // =====================
 
 export type ImageObjectFit = "contain" | "cover" | "fill"
+export type ImageVisibility = "both" | "answer-sheet-only" | "model-answer-only"
 
 export interface CellImageElement {
   id: string
@@ -45,6 +46,8 @@ export interface CellImageElement {
   horizontalAlign: HorizontalAlign
   verticalAlign: VerticalAlign
   opacity: number // 0-1
+  /** 表示モード制限。未指定 = "both"（常に表示） */
+  visibility?: ImageVisibility
 }
 
 // =====================


### PR DESCRIPTION
## Summary
- 画像要素に「常に表示」「解答用紙のみ」「模範解答のみ」の表示モード制限を追加
- モード限定画像がある問題の詳細設定ボタンをオレンジ色で警告表示
- DBスキーマ・保存/読み込みロジックに `visibility` フィールドを対応

Closes #464

## Test plan
- [ ] 画像要素を追加し、表示モードを「解答用紙のみ」に設定 → 模範解答モードで非表示になること
- [ ] 表示モードを「模範解答のみ」に設定 → 解答用紙モードで非表示になること
- [ ] モード限定画像がある問題のSettings2ボタンがオレンジ色になること
- [ ] 「常に表示」に戻すとボタンの色が元に戻ること
- [ ] 保存→リロード後もvisibility設定が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)