### PR TITLE
fix: 小問番号空文字列時の枝問番号罫線X座標を修正

### DIFF
--- a/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -107,7 +107,6 @@ export function computeLayoutFromDefinition(
   const hasBranch = majorQuestions.some((mq) =>
     mq.subQuestions.some((sq) => sq.branchQuestions.length > 0)
   )
-  const branchNumX = subNumX + subNumWidth
   const branchNumWidth = hasBranch ? columnWidths.branchNumber : 0
 
   const cells: ComputedCell[] = []
@@ -582,7 +581,8 @@ export function computeLayoutFromDefinition(
 
   // vertical-sub 行のY範囲を収集（小問番号列セグメント化用）
   const verticalRanges: { top: number; bottom: number }[] = []
-  const branchVerticalRanges: { top: number; bottom: number }[] = []
+  const branchVerticalRanges: { top: number; bottom: number; lineX: number }[] =
+    []
   const horizontalMajorRanges: { top: number; bottom: number }[] = []
   {
     let trackY = margins.top + effectiveHeaderHeight
@@ -611,6 +611,8 @@ export function computeLayoutFromDefinition(
           }
           if (sub.branchQuestions.length > 0) {
             if (!isGridHorizontal(sub.branchQuestions)) {
+              const effSubNumW = sub.label === "" ? 0 : subNumWidth
+              const effBranchLineX = subNumX + effSubNumW + branchNumWidth
               let branchSegStart: number | null = null
               let branchY = trackY
               for (const bq of sub.branchQuestions) {
@@ -622,6 +624,7 @@ export function computeLayoutFromDefinition(
                     branchVerticalRanges.push({
                       top: branchSegStart,
                       bottom: branchY,
+                      lineX: effBranchLineX,
                     })
                     branchSegStart = null
                   }
@@ -632,6 +635,7 @@ export function computeLayoutFromDefinition(
                 branchVerticalRanges.push({
                   top: branchSegStart,
                   bottom: branchY,
+                  lineX: effBranchLineX,
                 })
               }
             }
@@ -745,9 +749,9 @@ export function computeLayoutFromDefinition(
       const clipped = clipRangeToMajorLayouts(range, majorLayoutRanges)
       for (const cr of clipped) {
         lines.push({
-          x1: branchNumX + branchNumWidth,
+          x1: range.lineX,
           y1: cr.top,
-          x2: branchNumX + branchNumWidth,
+          x2: range.lineX,
           y2: cr.bottom,
           style: settings.borderConfig.branchNumberDivider,
           lineType: "branchNumberColumn",

--- a/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -123,7 +123,7 @@ export function computeMultiPageLayoutFromDefinition(
 
   interface PerColData {
     verticalRanges: { top: number; bottom: number }[]
-    branchVerticalRanges: { top: number; bottom: number }[]
+    branchVerticalRanges: { top: number; bottom: number; lineX: number }[]
     horizontalMajorRanges: { top: number; bottom: number }[]
     rowRightEdges: { yTop: number; yBottom: number; rightX: number }[]
     rowLeftEdges: { yTop: number; yBottom: number; leftX: number }[]
@@ -492,6 +492,7 @@ export function computeMultiPageLayoutFromDefinition(
 
           // 枝問番号列のセグメント（ラベルのある枝問のみ）
           if (!isGridHorizontal(sub.branchQuestions)) {
+            const effBranchLineX = effBranchNumX + branchNumWidth
             let branchSegStart: number | null = null
             let branchY = subStartY
             for (const bq of sub.branchQuestions) {
@@ -503,6 +504,7 @@ export function computeMultiPageLayoutFromDefinition(
                   colData.branchVerticalRanges.push({
                     top: branchSegStart,
                     bottom: branchY,
+                    lineX: effBranchLineX,
                   })
                   branchSegStart = null
                 }
@@ -513,6 +515,7 @@ export function computeMultiPageLayoutFromDefinition(
               colData.branchVerticalRanges.push({
                 top: branchSegStart,
                 bottom: branchY,
+                lineX: effBranchLineX,
               })
             }
           }
@@ -855,9 +858,9 @@ export function computeMultiPageLayoutFromDefinition(
           )
           for (const cr of clipped) {
             pd.lines.push({
-              x1: col.branchNumX + branchNumWidth,
+              x1: range.lineX,
               y1: cr.top,
-              x2: col.branchNumX + branchNumWidth,
+              x2: range.lineX,
               y2: cr.bottom,
               style: settings.borderConfig.branchNumberDivider,
               lineType: "branchNumberColumn",


### PR DESCRIPTION
## Summary

- 小問番号が空文字列の場合に枝問番号列の縦罫線X座標がずれる問題を修正
- `branchVerticalRanges` に `lineX` プロパティを追加し、小問番号の有無に応じた正しいX座標を記録
- 単一ページ (`computeLayout.ts`) と複数ページ (`computeMultiPageLayout.ts`) の両方を修正

Closes #466

## Test plan

- [ ] 小問番号を空文字列・枝問番号ありの場合、枝問番号罫線が正しい位置に表示されることを確認
- [ ] 小問番号あり・枝問番号ありの場合、既存の動作に変更がないことを確認
- [ ] 両方空文字列の場合、既存の動作に変更がないことを確認
- [ ] 段組みレイアウトでも同様に正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)