### PR TITLE
fix: 設問枠の高さ倍率の上限を10から30に引き上げ

### DIFF
--- a/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -86,7 +86,7 @@ export function BranchQuestionForm({
               className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               value={branch.heightMultiplier}
               min={1}
-              max={10}
+              max={30}
               step={0.5}
               onChange={(e) =>
                 onUpdate({ heightMultiplier: Number(e.target.value) })

--- a/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -161,7 +161,7 @@ export function SubQuestionForm({
                 className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 value={sub.heightMultiplier}
                 min={1}
-                max={10}
+                max={30}
                 step={0.5}
                 onChange={(e) =>
                   onUpdate({ heightMultiplier: Number(e.target.value) })


### PR DESCRIPTION
## Summary
- 小問・枝問の heightMultiplier の max を10から30に変更

Closes #472

## Test plan
- [ ] 高さ倍率に10を超える値（例: 15）を入力できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)