### PR TITLE
fix: 枝問横配置時の外枠ステップ描画を修正

### DIFF
--- a/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -22,6 +22,7 @@ import {
 } from "./cellBuilder"
 import { computeMultiPageLayoutFromDefinition } from "./computeMultiPageLayout"
 import {
+  buildBranchGridLayout,
   buildSubGridLayout,
   computeGridRowLeftEdges,
   computeGridRowRightEdges,
@@ -268,15 +269,39 @@ export function computeLayoutFromDefinition(
         }
       }
 
-      // rowRightEdges: Y区間ごとの右端X座標を計算
-      for (const edge of computeGridRowRightEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )) {
-        majorRightEdges.push(edge)
+      // rowRightEdges: Y区間ごとの右端X座標を計算（枝問横配置を考慮）
+      for (const gc of gridCells) {
+        const sub2 = gc.item
+        const gcCellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const gcCellW = gc.width * horizontalAreaWidth
+        const gcCellY = majorStartY + gc.y * baseRowHeight
+        const gcCellH = gc.height * baseRowHeight
+        const gcCellRight = gcCellX + gcCellW
+        const gcEffSubNumW = sub2.label === "" ? 0 : subNumWidth
+
+        if (
+          sub2.branchQuestions.length > 0 &&
+          isGridHorizontal(sub2.branchQuestions)
+        ) {
+          const branchAreaX = gcCellX + gcEffSubNumW
+          const branchAreaWidth = gcCellRight - branchAreaX
+          const branchCells = buildBranchGridLayout(sub2.branchQuestions)
+          for (const edge of computeGridRowRightEdges(
+            branchCells,
+            gcCellY,
+            branchAreaX,
+            branchAreaWidth,
+            baseRowHeight
+          )) {
+            majorRightEdges.push(edge)
+          }
+        } else {
+          majorRightEdges.push({
+            yTop: gcCellY,
+            yBottom: gcCellY + gcCellH,
+            rightX: gcCellRight,
+          })
+        }
       }
 
       // rowLeftEdges: Y区間ごとの左端X座標を計算
@@ -476,12 +501,27 @@ export function computeLayoutFromDefinition(
           )
         }
 
-        // vertical-sub行の右端（原稿用紙セルは必要幅に制限）
-        majorRightEdges.push({
-          yTop: subStartY,
-          yBottom: subStartY + subHeight,
-          rightX: subRightEdges[si],
-        })
+        // vertical-sub行の右端（枝問横配置時は枝問グリッドの右端を使用）
+        if (hasBranches && isGridHorizontal(sub.branchQuestions)) {
+          const branchAreaX = subNumX + effSubNumW
+          const branchAreaWidth = subRightEdges[si] - branchAreaX
+          const branchCells = buildBranchGridLayout(sub.branchQuestions)
+          for (const edge of computeGridRowRightEdges(
+            branchCells,
+            subStartY,
+            branchAreaX,
+            branchAreaWidth,
+            baseRowHeight
+          )) {
+            majorRightEdges.push(edge)
+          }
+        } else {
+          majorRightEdges.push({
+            yTop: subStartY,
+            yBottom: subStartY + subHeight,
+            rightX: subRightEdges[si],
+          })
+        }
         // vertical-sub行の左端は常にcontentLeft
         majorLeftEdges.push({
           yTop: subStartY,

--- a/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -25,6 +25,7 @@ import {
   createCell,
 } from "./cellBuilder"
 import {
+  buildBranchGridLayout,
   buildSubGridLayout,
   computeGridRowLeftEdges,
   computeGridRowRightEdges,
@@ -310,15 +311,39 @@ export function computeMultiPageLayoutFromDefinition(
         }
       }
 
-      // rowRightEdges
-      for (const edge of computeGridRowRightEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )) {
-        colData.rowRightEdges.push(edge)
+      // rowRightEdges（枝問横配置を考慮）
+      for (const gc of gridCells) {
+        const sub2 = gc.item
+        const gcCellX = horizontalAreaX + gc.x * horizontalAreaWidth
+        const gcCellW = gc.width * horizontalAreaWidth
+        const gcCellY = majorStartY + gc.y * baseRowHeight
+        const gcCellH = gc.height * baseRowHeight
+        const gcCellRight = gcCellX + gcCellW
+        const gcEffSubNumW = sub2.label === "" ? 0 : subNumWidth
+
+        if (
+          sub2.branchQuestions.length > 0 &&
+          isGridHorizontal(sub2.branchQuestions)
+        ) {
+          const branchAreaX = gcCellX + gcEffSubNumW
+          const branchAreaWidth = gcCellRight - branchAreaX
+          const branchCells = buildBranchGridLayout(sub2.branchQuestions)
+          for (const edge of computeGridRowRightEdges(
+            branchCells,
+            gcCellY,
+            branchAreaX,
+            branchAreaWidth,
+            baseRowHeight
+          )) {
+            colData.rowRightEdges.push(edge)
+          }
+        } else {
+          colData.rowRightEdges.push({
+            yTop: gcCellY,
+            yBottom: gcCellY + gcCellH,
+            rightX: gcCellRight,
+          })
+        }
       }
 
       // rowLeftEdges
@@ -552,12 +577,27 @@ export function computeMultiPageLayoutFromDefinition(
           )
         }
 
-        // vertical-sub行の右端
-        colData.rowRightEdges.push({
-          yTop: subStartY,
-          yBottom: subStartY + subHeight,
-          rightX: subRightEdges[si],
-        })
+        // vertical-sub行の右端（枝問横配置時は枝問グリッドの右端を使用）
+        if (hasBranches && isGridHorizontal(sub.branchQuestions)) {
+          const branchAreaX = col.subNumX + effSubNumW
+          const branchAreaWidth = subRightEdges[si] - branchAreaX
+          const branchCells = buildBranchGridLayout(sub.branchQuestions)
+          for (const edge of computeGridRowRightEdges(
+            branchCells,
+            subStartY,
+            branchAreaX,
+            branchAreaWidth,
+            baseRowHeight
+          )) {
+            colData.rowRightEdges.push(edge)
+          }
+        } else {
+          colData.rowRightEdges.push({
+            yTop: subStartY,
+            yBottom: subStartY + subHeight,
+            rightX: subRightEdges[si],
+          })
+        }
         colData.rowLeftEdges.push({
           yTop: subStartY,
           yBottom: subStartY + subHeight,


### PR DESCRIPTION
## Summary

- 枝問に `layoutWidth` を設定した際、外枠がL字型にステップしない不具合を修正
- 横配置・縦配置の両モードで、枝問グリッドの実際のセル幅から右端座標を計算するように変更

Closes #474

## 変更内容

- `computeLayout.ts`: 横配置モードの `rowRightEdges` 計算を小問セル単位から枝問セル単位に変更。縦配置モードも同様に修正。
- `computeMultiPageLayout.ts`: 同上の修正を適用。

## Test plan

- [ ] 枝問に `幅 2/3` を設定し、外枠がL字型にステップすることを確認
- [ ] 枝問に幅設定がない場合、従来通り矩形の外枠が描画されることを確認
- [ ] 横配置モード・縦配置モードの両方で動作確認
- [ ] 段組みレイアウトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)