### PR TITLE
fix: 枝問横配置時の外枠ステップに伴う謎罫線を除去

### DIFF
--- a/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -333,21 +333,7 @@ export function computeLayoutFromDefinition(
 
       const majorEndY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
 
-      // セルと空白スペースの境界線を補完
-      const subRightEdges = computeGridRowRightEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )
-      const subLeftEdges = computeGridRowLeftEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )
+      // セルと空白スペースの境界線を補完（枝問横配置を反映したrightEdgesを使用）
       renderGridCompletionLines(
         gridCells,
         majorStartY,
@@ -360,8 +346,8 @@ export function computeLayoutFromDefinition(
         {
           top: majorStartY,
           bottom: majorEndY,
-          rightEdges: subRightEdges,
-          leftEdges: subLeftEdges,
+          rightEdges: majorRightEdges,
+          leftEdges: majorLeftEdges,
         }
       )
 

--- a/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -220,6 +220,8 @@ export function computeMultiPageLayoutFromDefinition(
         return sub
       })
       const gridCells = buildSubGridLayout(subsForGrid)
+      const rightEdgesStart = colData.rowRightEdges.length
+      const leftEdgesStart = colData.rowLeftEdges.length
       for (const gc of gridCells) {
         const cellX = horizontalAreaX + gc.x * horizontalAreaWidth
         const cellWidth = gc.width * horizontalAreaWidth
@@ -375,21 +377,9 @@ export function computeMultiPageLayoutFromDefinition(
 
       const majorEndY = majorStartY + gridTotalHeight(gridCells) * baseRowHeight
 
-      // セルと空白スペースの境界線を補完
-      const subRightEdges = computeGridRowRightEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )
-      const subLeftEdges = computeGridRowLeftEdges(
-        gridCells,
-        majorStartY,
-        horizontalAreaX,
-        horizontalAreaWidth,
-        baseRowHeight
-      )
+      // セルと空白スペースの境界線を補完（枝問横配置を反映したrightEdgesを使用）
+      const majorRightEdges = colData.rowRightEdges.slice(rightEdgesStart)
+      const majorLeftEdges = colData.rowLeftEdges.slice(leftEdgesStart)
       renderGridCompletionLines(
         gridCells,
         majorStartY,
@@ -402,8 +392,8 @@ export function computeMultiPageLayoutFromDefinition(
         {
           top: majorStartY,
           bottom: majorEndY,
-          rightEdges: subRightEdges,
-          leftEdges: subLeftEdges,
+          rightEdges: majorRightEdges,
+          leftEdges: majorLeftEdges,
         }
       )
 

--- a/components/answer-sheet-builder/hooks/layout/lineRenderer.ts
+++ b/components/answer-sheet-builder/hooks/layout/lineRenderer.ts
@@ -23,10 +23,26 @@ import type {
 import { createCell } from "./cellBuilder"
 import {
   buildBranchGridLayout,
+  computeGridRowRightEdges,
   gridTotalHeight,
   isGridHorizontal,
 } from "./gridBuilder"
 import { getLineWidth } from "./layoutUtils"
+
+/** 指定Y位置で外枠の最大rightXを取得し、セル右端とのminを返す */
+function clipRightToOuter(
+  y: number,
+  cellRight: number,
+  rightEdges: { yTop: number; yBottom: number; rightX: number }[]
+): number {
+  let maxOuter = -Infinity
+  for (const re of rightEdges) {
+    if (re.yTop <= y + 1e-9 && re.yBottom >= y - 1e-9) {
+      maxOuter = Math.max(maxOuter, re.rightX)
+    }
+  }
+  return maxOuter > -Infinity ? Math.min(cellRight, maxOuter) : cellRight
+}
 
 /**
  * グリッドセルの空白隣接辺を描画する。
@@ -78,12 +94,12 @@ export function renderGridCompletionLines<
     const top = areaStartY + gc.y * baseRowHeight
     const bottom = areaStartY + (gc.y + gc.height) * baseRowHeight
 
-    // 右辺: 外枠の rightX と一致するY区間はスキップ
+    // 右辺: セルの右端が外枠の rightX 以上ならスキップ（外枠が境界を描画する）
     for (const re of rightEdges) {
       const oTop = Math.max(top, re.yTop)
       const oBottom = Math.min(bottom, re.yBottom)
       if (oBottom <= oTop + 1e-9) continue
-      if (Math.abs(right - re.rightX) < 0.01) continue
+      if (right >= re.rightX - 0.01) continue
       lines.push({
         x1: right,
         y1: oTop,
@@ -95,12 +111,12 @@ export function renderGridCompletionLines<
       })
     }
 
-    // 左辺: 外枠の leftX と一致するY区間はスキップ
+    // 左辺: セルの左端が外枠の leftX 以下ならスキップ
     for (const le of leftEdges) {
       const oTop = Math.max(top, le.yTop)
       const oBottom = Math.min(bottom, le.yBottom)
       if (oBottom <= oTop + 1e-9) continue
-      if (Math.abs(left - le.leftX) < 0.01) continue
+      if (left <= le.leftX + 0.01) continue
       lines.push({
         x1: left,
         y1: oTop,
@@ -112,30 +128,36 @@ export function renderGridCompletionLines<
       })
     }
 
-    // 下辺: グリッド外枠の底辺と一致しない場合のみ
+    // 下辺: グリッド外枠の底辺と一致しない場合のみ（右端を外枠にクリップ）
     if (Math.abs(bottom - outerBottom) > 0.01) {
-      lines.push({
-        x1: left,
-        y1: bottom,
-        x2: right,
-        y2: bottom,
-        style: divStyle,
-        lineType,
-        strokeWidth: sw,
-      })
+      const clipRight = clipRightToOuter(bottom, right, rightEdges)
+      if (clipRight > left + 1e-9) {
+        lines.push({
+          x1: left,
+          y1: bottom,
+          x2: clipRight,
+          y2: bottom,
+          style: divStyle,
+          lineType,
+          strokeWidth: sw,
+        })
+      }
     }
 
-    // 上辺: グリッド外枠の上辺と一致しない場合のみ
+    // 上辺: グリッド外枠の上辺と一致しない場合のみ（右端を外枠にクリップ）
     if (Math.abs(top - outerTop) > 0.01) {
-      lines.push({
-        x1: left,
-        y1: top,
-        x2: right,
-        y2: top,
-        style: divStyle,
-        lineType,
-        strokeWidth: sw,
-      })
+      const clipRight = clipRightToOuter(top, right, rightEdges)
+      if (clipRight > left + 1e-9) {
+        lines.push({
+          x1: left,
+          y1: top,
+          x2: clipRight,
+          y2: top,
+          style: divStyle,
+          lineType,
+          strokeWidth: sw,
+        })
+      }
     }
   }
 }
@@ -310,8 +332,15 @@ export function renderBranchQuestions(
       "branch"
     )
 
-    // セルと空白スペースの境界線を補完
+    // セルと空白スペースの境界線を補完（枝問グリッドの実際の右端を使用）
     const subBottom = subStartY + gridTotalHeight(branchCells) * baseRowHeight
+    const branchRightEdges = computeGridRowRightEdges(
+      branchCells,
+      subStartY,
+      branchAreaX,
+      branchAreaWidth,
+      baseRowHeight
+    )
     renderGridCompletionLines(
       branchCells,
       subStartY,
@@ -324,9 +353,7 @@ export function renderBranchQuestions(
       {
         top: subStartY,
         bottom: subBottom,
-        rightEdges: [
-          { yTop: subStartY, yBottom: subBottom, rightX: contentRight },
-        ],
+        rightEdges: branchRightEdges,
         leftEdges: [
           { yTop: subStartY, yBottom: subBottom, leftX: branchAreaX },
         ],


### PR DESCRIPTION
## Summary

- 枝問の外枠ステップ後に表示される余分な補完線（謎罫線）を除去
- `renderGridCompletionLines` のセル境界判定と水平線クリップを改善
- 枝問グリッドの実際の右端座標を補完線に反映

Closes #476

## 変更内容

- `lineRenderer.ts`: `renderGridCompletionLines` の右辺判定を `===` → `>=` に変更、上辺・下辺水平線を外枠rightXにクリップする `clipRightToOuter` ヘルパー追加。`renderBranchQuestions` で実際の枝問右端を渡すように変更。
- `computeLayout.ts`: sub補完線に `majorRightEdges` を使用
- `computeMultiPageLayout.ts`: 同上（大問ごとのエッジをsliceで取得）

## Test plan

- [ ] 枝問に `幅 2/3` を設定し、外枠ステップ後に余分な罫線がないことを確認
- [ ] 全枝問が全幅の場合、従来通り矩形の外枠が描画されることを確認
- [ ] 横配置・縦配置の両モードで動作確認
- [ ] 段組みレイアウトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)