### PR TITLE
fix: 解答用紙のPDF/印刷出力を個人成績表と同じパターンで実装

### DIFF
--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -13,6 +13,7 @@ import {
   getDashProps,
   isDragInfoEqual,
   renderSegmentsHtml,
+  renderSegmentsHtmlForPrint,
   renderSegmentsTspan,
 } from "./svgRenderUtils"
 
@@ -23,6 +24,10 @@ interface AnswerSheetSVGRendererProps {
   renderMode: RenderMode
   interactive?: boolean
   hoveredDragInfo?: DragInfo | null
+  /** 印刷用モード: MathJaxデリミタ出力、appimg→file変換等 */
+  forPrint?: boolean
+  /** 印刷用: 画像パス → data URI のマップ */
+  imageDataUris?: Map<string, string>
 }
 
 /**
@@ -35,6 +40,8 @@ export function AnswerSheetSVGRenderer({
   renderMode,
   interactive,
   hoveredDragInfo,
+  forPrint,
+  imageDataUris,
 }: AnswerSheetSVGRendererProps) {
   const { pageWidthMm, pageHeightMm } = layout
   // pageLayoutが指定されている場合はそちらのデータを使用
@@ -297,11 +304,16 @@ export function AnswerSheetSVGRenderer({
                   >
                     {textLines.map((line, li) => (
                       <div key={li}>
-                        {renderSegmentsHtml(
-                          parseInlineMarkup(line),
-                          renderMode,
-                          te.fontSize
-                        )}
+                        {forPrint
+                          ? renderSegmentsHtmlForPrint(
+                              parseInlineMarkup(line),
+                              renderMode
+                            )
+                          : renderSegmentsHtml(
+                              parseInlineMarkup(line),
+                              renderMode,
+                              te.fontSize
+                            )}
                       </div>
                     ))}
                   </div>
@@ -372,10 +384,14 @@ export function AnswerSheetSVGRenderer({
                   : ie.objectFit === "cover"
                     ? "xMidYMid slice"
                     : "none"
+              const href =
+                forPrint && imageDataUris?.has(ie.imagePath)
+                  ? imageDataUris.get(ie.imagePath)!
+                  : `appimg:///${ie.imagePath}`
               return (
                 <image
                   key={`img-${cellIdx}-${cell.label}-${ii}`}
-                  href={`appimg:///${ie.imagePath}`}
+                  href={href}
                   x={ix}
                   y={iy}
                   width={iw}

--- a/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
+++ b/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
@@ -180,3 +180,50 @@ export function renderSegmentsHtml(
     )
   })
 }
+
+/**
+ * 印刷用: InlineSegment 配列を HTML <span> 要素配列に変換する。
+ * レンダラープロセスで window.MathJax.tex2svg() を使い数式を事前にSVG化する。
+ * オフスクリーンBrowserWindowでのMathJax読み込みは不要。
+ */
+export function renderSegmentsHtmlForPrint(
+  segments: InlineSegment[],
+  renderMode: RenderMode
+): React.ReactNode[] {
+  return segments.map((seg, i) => {
+    const style = getSegmentStyle(seg, renderMode)
+    if (seg.math) {
+      const mathStyle: React.CSSProperties = seg.displayMath
+        ? { ...style, display: "block", textAlign: "center" }
+        : { ...style, fontStyle: "italic" }
+      // レンダラープロセスのMathJaxでSVGにプリレンダリング
+      if (typeof window !== "undefined" && window.MathJax?.tex2svg) {
+        try {
+          const container = window.MathJax.tex2svg(seg.text, {
+            display: seg.displayMath ?? false,
+          })
+          const svgHtml = container.innerHTML
+          return (
+            <span
+              key={i}
+              style={mathStyle}
+              dangerouslySetInnerHTML={{ __html: svgHtml }}
+            />
+          )
+        } catch {
+          // フォールバック: テキストとして表示
+        }
+      }
+      return (
+        <span key={i} style={mathStyle}>
+          {seg.text}
+        </span>
+      )
+    }
+    return (
+      <span key={i} style={style}>
+        {seg.text}
+      </span>
+    )
+  })
+}

--- a/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
@@ -1,7 +1,9 @@
 /**
- * PDF/PNG出力hook
+ * PDF/PNG出力・印刷hook
  *
- * renderer側でlayout計算→SVG生成→main側にデータを渡す。
+ * PDF/印刷: renderToStaticMarkup でプレビューと同じReactコンポーネントをHTML化
+ *          → 既存の export:openPrintDialog / export:printHtmlToPdf で出力
+ * PNG:     SVG文字列 → sharp でラスタライズ（従来通り）
  */
 
 import { useCallback, useState } from "react"
@@ -9,10 +11,10 @@ import { toast } from "sonner"
 
 import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 
+import { generateAnswerSheetPrintHtml } from "../utils/generatePrintHtml"
 import {
   renderMultiPageSvgStrings,
   resolveImageDataUris,
-  wrapSvgsInHtml,
 } from "../utils/renderSvgStrings"
 import { computeMultiPageLayoutFromDefinition } from "./layout/computeMultiPageLayout"
 
@@ -20,8 +22,9 @@ export function useAnswerSheetExport() {
   const [isExporting, setIsExporting] = useState(false)
 
   const exportPdf = useCallback(async (definition: AnswerSheetDefinition) => {
-    const api = window.electronAPI?.answerSheetBuilder
-    if (!api) {
+    const asbApi = window.electronAPI?.answerSheetBuilder
+    const exportApi = window.electronAPI?.export
+    if (!asbApi || !exportApi) {
       toast.error("Electron APIが利用できません")
       return
     }
@@ -29,32 +32,23 @@ export function useAnswerSheetExport() {
     try {
       setIsExporting(true)
 
-      const pathResult = await api.selectSavePath({
+      const pathResult = await asbApi.selectSavePath({
         type: "pdf",
         defaultName: `${definition.name}.pdf`,
       })
-
       if (!pathResult.success || !pathResult.filePath) return
 
       const multiLayout = computeMultiPageLayoutFromDefinition(definition)
-      const allCells = multiLayout.pages.flatMap((p) => p.cells)
-      const imageDataUris = await resolveImageDataUris(allCells)
-      const svgStrings = renderMultiPageSvgStrings(
-        multiLayout,
-        definition.renderMode,
-        imageDataUris
-      )
-      const html = wrapSvgsInHtml(
-        svgStrings,
-        multiLayout.pageWidthMm,
-        multiLayout.pageHeightMm
-      )
+      const html = await generateAnswerSheetPrintHtml(definition, multiLayout)
 
-      const result = await api.exportPdf({
+      const result = await exportApi.printHtmlToPdf({
         html,
-        outputPath: pathResult.filePath,
-        pageWidthMm: multiLayout.pageWidthMm,
-        pageHeightMm: multiLayout.pageHeightMm,
+        filePath: pathResult.filePath,
+        pageSize: {
+          width: multiLayout.pageWidthMm,
+          height: multiLayout.pageHeightMm,
+        },
+        margins: { top: 0, bottom: 0, left: 0, right: 0 },
       })
 
       if (result.success) {
@@ -86,7 +80,6 @@ export function useAnswerSheetExport() {
           type: "png",
           defaultName: `${definition.name}.png`,
         })
-
         if (!pathResult.success || !pathResult.filePath) return
 
         const multiLayout = computeMultiPageLayoutFromDefinition(definition)
@@ -123,8 +116,8 @@ export function useAnswerSheetExport() {
   )
 
   const printSheet = useCallback(async (definition: AnswerSheetDefinition) => {
-    const api = window.electronAPI?.answerSheetBuilder
-    if (!api) {
+    const exportApi = window.electronAPI?.export
+    if (!exportApi) {
       toast.error("Electron APIが利用できません")
       return
     }
@@ -133,27 +126,19 @@ export function useAnswerSheetExport() {
       setIsExporting(true)
 
       const multiLayout = computeMultiPageLayoutFromDefinition(definition)
-      const allCells = multiLayout.pages.flatMap((p) => p.cells)
-      const imageDataUris = await resolveImageDataUris(allCells)
-      const svgStrings = renderMultiPageSvgStrings(
-        multiLayout,
-        definition.renderMode,
-        imageDataUris
-      )
-      const html = wrapSvgsInHtml(
-        svgStrings,
-        multiLayout.pageWidthMm,
-        multiLayout.pageHeightMm
-      )
+      const html = await generateAnswerSheetPrintHtml(definition, multiLayout)
 
-      const result = await api.print({
+      const result = await exportApi.openPrintDialog({
         html,
-        pageWidthMm: multiLayout.pageWidthMm,
-        pageHeightMm: multiLayout.pageHeightMm,
+        title: definition.name,
+        pageSize: {
+          width: multiLayout.pageWidthMm,
+          height: multiLayout.pageHeightMm,
+        },
       })
 
       if (result.success) {
-        toast.success("印刷を開始しました")
+        toast.success("印刷プレビューを開きました")
       } else if (result.error) {
         toast.error(`印刷エラー: ${result.error}`)
       }

--- a/components/answer-sheet-builder/utils/generatePrintHtml.ts
+++ b/components/answer-sheet-builder/utils/generatePrintHtml.ts
@@ -1,0 +1,127 @@
+/**
+ * 解答用紙の印刷/PDF出力用HTML生成
+ *
+ * 個人成績表と同じパターン: renderToStaticMarkup でReactコンポーネントをHTML化し、
+ * BrowserWindow + printToPDF で出力する。
+ * MathJaxはレンダラープロセスで事前にSVG化するため、出力HTMLにはMathJax不要。
+ */
+
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
+import type { ComputedMultiPageLayout } from "@/types/answerSheetLayout.types"
+
+import { AnswerSheetSVGRenderer } from "../components/preview/AnswerSheetSVGRenderer"
+import { resolveImageDataUris } from "./renderSvgStrings"
+
+/**
+ * 解答用紙の印刷用HTMLを生成する。
+ * プレビューと同じ AnswerSheetSVGRenderer を renderToStaticMarkup で使用。
+ */
+export async function generateAnswerSheetPrintHtml(
+  definition: AnswerSheetDefinition,
+  multiLayout: ComputedMultiPageLayout
+): Promise<string> {
+  const { pageWidthMm, pageHeightMm } = multiLayout
+
+  // 画像の data URI を事前解決
+  const allCells = multiLayout.pages.flatMap((p) => p.cells)
+  const imageDataUris = await resolveImageDataUris(allCells)
+
+  // 各ページを renderToStaticMarkup で HTML 化
+  // （renderSegmentsHtmlForPrint 内で MathJax.tex2svg() が呼ばれ、
+  //   グリフ定義がグローバルSVGキャッシュに蓄積される）
+  const pagesHtml = multiLayout.pages
+    .map((page, i) => {
+      const svgHtml = renderToStaticMarkup(
+        React.createElement(
+          "svg",
+          {
+            xmlns: "http://www.w3.org/2000/svg",
+            width: pageWidthMm,
+            height: pageHeightMm,
+            viewBox: `0 0 ${pageWidthMm} ${pageHeightMm}`,
+          },
+          React.createElement(AnswerSheetSVGRenderer, {
+            layout: {
+              pageWidthMm,
+              pageHeightMm,
+              cells: page.cells,
+              lines: page.lines,
+              numberLabels: page.numberLabels,
+              omrMarkerPositions: page.omrMarkerPositions,
+              headerFields: page.headerFields,
+              overflow: false,
+              contentHeightMm: pageHeightMm,
+            },
+            pageLayout: page,
+            renderMode: definition.renderMode,
+            forPrint: true,
+            imageDataUris,
+          })
+        )
+      )
+
+      const isLast = i === multiLayout.pages.length - 1
+      const pageBreak = isLast ? "" : " page-break-after"
+      return `<div class="page${pageBreak}">${svgHtml}</div>`
+    })
+    .join("\n")
+
+  // MathJaxのグローバルSVGキャッシュ（グリフ定義）を取得
+  // tex2svg()が生成するSVGは <use xlink:href="#MJX-..."> で共有グリフを参照するため、
+  // そのグリフ定義 (<defs>) を print HTML に含める必要がある
+  let mathJaxDefs = ""
+  if (typeof document !== "undefined") {
+    const defsContainer = document.querySelector("#MJX-SVG-global-cache")
+    if (defsContainer) {
+      mathJaxDefs = defsContainer.outerHTML
+    }
+  }
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>
+  @page {
+    size: ${pageWidthMm}mm ${pageHeightMm}mm;
+    margin: 0;
+  }
+  /* Tailwind preflight相当のCSS（プレビューと同じ環境を再現） */
+  *, *::before, *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  html {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+  }
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: "Noto Sans JP", "Hiragino Sans", sans-serif;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  .page {
+    width: ${pageWidthMm}mm;
+    height: ${pageHeightMm}mm;
+    overflow: hidden;
+  }
+  .page-break-after { page-break-after: always; }
+  .page > svg { display: block; width: 100%; height: 100%; }
+  /* MathJax SVGのベースライン以下の切れ防止 */
+  foreignObject svg[role="img"] { overflow: visible !important; display: inline !important; }
+</style>
+</head>
+<body>
+${mathJaxDefs}
+${pagesHtml}
+</body>
+</html>`
+}

--- a/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -229,7 +229,7 @@ export function renderMultiPageSvgStrings(
   )
 }
 
-/** PDF/印刷用: SVG群をHTML文字列にラップ */
+/** PDF/印刷用: SVG群をHTML文字列にラップ（PNG出力のフォールバック用） */
 export function wrapSvgsInHtml(
   svgStrings: string[],
   pageWidthMm: number,

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -190,8 +190,8 @@ export function setupAnswerSheetBuilderHandlers(): void {
 
       const pdfBuffer = await win.webContents.printToPDF({
         pageSize: {
-          width: args.pageWidthMm * 1000, // microns
-          height: args.pageHeightMm * 1000,
+          width: args.pageWidthMm / 25.4, // mm → inches
+          height: args.pageHeightMm / 25.4,
         },
         printBackground: true,
         margins: { marginType: "custom", top: 0, bottom: 0, left: 0, right: 0 },
@@ -338,8 +338,8 @@ export function setupAnswerSheetBuilderHandlers(): void {
 
       const pdfBuffer = await win.webContents.printToPDF({
         pageSize: {
-          width: args.pageWidthMm * 1000, // microns
-          height: args.pageHeightMm * 1000,
+          width: args.pageWidthMm / 25.4, // mm → inches
+          height: args.pageHeightMm / 25.4,
         },
         printBackground: true,
         margins: { marginType: "custom", top: 0, bottom: 0, left: 0, right: 0 },

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -6,6 +6,7 @@ import {
   fetchIndividualReportData,
   fetchSubtotalGroupsForReport,
 } from "../lib/export/individual-report"
+import { resolveMathJaxSrc, waitForRendering } from "../lib/printUtils"
 import { exportGradingDataExcel } from "../lib/prisma/excelExport"
 import {
   addPageToStreamingSession,
@@ -486,7 +487,7 @@ export function setupExportHandlers(): void {
       options: {
         html: string
         filePath: string
-        pageSize?: "A4" | "Letter"
+        pageSize?: "A4" | "Letter" | { width: number; height: number }
         landscape?: boolean
         margins?: {
           top?: number
@@ -514,19 +515,35 @@ export function setupExportHandlers(): void {
       })
 
       try {
-        // HTMLを一時ファイルに書き込み
-        await fs.writeFile(tempHtmlPath, options.html, "utf-8")
+        // MathJaxパスを解決してHTMLを一時ファイルに書き込み
+        const html = resolveMathJaxSrc(options.html)
+        await fs.writeFile(tempHtmlPath, html, "utf-8")
 
         // 一時HTMLファイルをロード
         await win.loadFile(tempHtmlPath)
 
-        // レンダリング完了を待つ
-        await new Promise((resolve) => setTimeout(resolve, 500))
+        // MathJax描画完了を待つ（MathJaxがなければ500ms待機）
+        await waitForRendering(win)
 
         // PDFを生成（マージンはインチ単位、デフォルト5mm ≈ 0.2インチ）
         const margins = options.margins || {}
+        // pageSizeがmmオブジェクトの場合はインチに変換
+        let resolvedPageSize:
+          | "A4"
+          | "Letter"
+          | { width: number; height: number } = options.pageSize || "A4"
+        if (
+          typeof resolvedPageSize === "object" &&
+          "width" in resolvedPageSize &&
+          "height" in resolvedPageSize
+        ) {
+          resolvedPageSize = {
+            width: resolvedPageSize.width / 25.4,
+            height: resolvedPageSize.height / 25.4,
+          }
+        }
         const pdfBuffer = await win.webContents.printToPDF({
-          pageSize: options.pageSize || "A4",
+          pageSize: resolvedPageSize,
           landscape: options.landscape || false,
           printBackground: true,
           margins: {
@@ -658,6 +675,8 @@ export function setupExportHandlers(): void {
       options: {
         html: string
         title?: string
+        pageSize?: "A4" | "Letter" | { width: number; height: number }
+        landscape?: boolean
       }
     ): Promise<{ success: boolean; error?: string }> => {
       const fs = require("fs").promises
@@ -681,19 +700,34 @@ export function setupExportHandlers(): void {
       })
 
       try {
-        // HTMLを一時ファイルに書き込み
-        await fs.writeFile(tempHtmlPath, options.html, "utf-8")
+        // MathJaxパスを解決してHTMLを一時ファイルに書き込み
+        const html = resolveMathJaxSrc(options.html)
+        await fs.writeFile(tempHtmlPath, html, "utf-8")
 
         // 一時HTMLファイルをロード
         await win.loadFile(tempHtmlPath)
 
-        // レンダリング完了を待つ
-        await new Promise((resolve) => setTimeout(resolve, 500))
+        // MathJax描画完了を待つ（MathJaxがなければ500ms待機）
+        await waitForRendering(win)
 
         // PDFを生成（マージンはCSSの@page marginに任せるため0に設定）
+        // pageSizeがmmオブジェクトの場合はインチに変換
+        let pageSize: "A4" | "Letter" | { width: number; height: number } =
+          options.pageSize || "A4"
+        if (
+          typeof pageSize === "object" &&
+          "width" in pageSize &&
+          "height" in pageSize
+        ) {
+          pageSize = {
+            width: pageSize.width / 25.4,
+            height: pageSize.height / 25.4,
+          }
+        }
+
         const pdfBuffer = await win.webContents.printToPDF({
-          pageSize: "A4",
-          landscape: false,
+          pageSize,
+          landscape: options.landscape || false,
           printBackground: true,
           margins: {
             marginType: "custom",

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -1,0 +1,63 @@
+/**
+ * 印刷・PDF出力ユーティリティ
+ *
+ * HTML内のMathJaxインライン埋め込みやレンダリング完了待機など、
+ * printToPDF系ハンドラの共通処理を提供する。
+ */
+
+import { app, BrowserWindow } from "electron"
+import fs from "fs"
+import path from "path"
+
+let mathjaxCache: string | null = null
+
+/** MathJax tex-svg.js の内容を読み込む（キャッシュ付き） */
+function getMathJaxSource(): string {
+  if (mathjaxCache) return mathjaxCache
+  const mathjaxPath = app.isPackaged
+    ? path.join(process.resourcesPath, "public/js/mathjax/tex-svg.js")
+    : path.join(__dirname, "../../../public/js/mathjax/tex-svg.js")
+  mathjaxCache = fs.readFileSync(mathjaxPath, "utf-8")
+  return mathjaxCache
+}
+
+/**
+ * HTML内の <script src="__MATHJAX_SRC__"></script> を
+ * MathJaxソースのインライン埋め込みに置換する。
+ * file:// のクロスオリジン制限を回避するため、外部参照ではなくインライン化。
+ */
+export function resolveMathJaxSrc(html: string): string {
+  if (!html.includes("__MATHJAX_SRC__")) return html
+  try {
+    const src = getMathJaxSource()
+    return html.replace(
+      '<script src="__MATHJAX_SRC__"></script>',
+      `<script>${src}</script>`
+    )
+  } catch (err) {
+    console.error("Failed to load MathJax source:", err)
+    return html.replace('<script src="__MATHJAX_SRC__"></script>', "")
+  }
+}
+
+/** MathJaxの描画完了を待つ。MathJaxがなければ500ms待機 */
+export async function waitForRendering(win: BrowserWindow): Promise<void> {
+  const hasMathJax = await win.webContents.executeJavaScript(
+    "typeof window.MathJax !== 'undefined'"
+  )
+  if (!hasMathJax) {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    return
+  }
+  // MathJaxの startup.promise が解決されるまでポーリング（最大10秒）
+  const timeout = 10_000
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    const ready = await win.webContents.executeJavaScript(
+      "window.__mathjax_ready === true"
+    )
+    if (ready) return
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  console.warn("MathJax rendering timeout, proceeding with PDF generation")
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -505,7 +505,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     printHtmlToPdf: (options: {
       html: string
       filePath: string
-      pageSize?: "A4" | "Letter"
+      pageSize?: "A4" | "Letter" | { width: number; height: number }
       landscape?: boolean
       margins?: {
         top?: number
@@ -526,8 +526,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
       selectedStudentIds: string[]
     }) => ipcRenderer.invoke("export:getExcelPreviewData", options),
     // 印刷ダイアログを開く
-    openPrintDialog: (options: { html: string; title?: string }) =>
-      ipcRenderer.invoke("export:openPrintDialog", options),
+    openPrintDialog: (options: {
+      html: string
+      title?: string
+      pageSize?: "A4" | "Letter" | { width: number; height: number }
+      landscape?: boolean
+    }) => ipcRenderer.invoke("export:openPrintDialog", options),
   },
 
   // Excel Export related

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1111,7 +1111,7 @@ export interface MyAPI {
     printHtmlToPdf: (options: {
       html: string
       filePath: string
-      pageSize?: "A4" | "Letter"
+      pageSize?: "A4" | "Letter" | { width: number; height: number }
       landscape?: boolean
       margins?: {
         top?: number
@@ -1185,7 +1185,12 @@ export interface MyAPI {
     }>
 
     // 印刷ダイアログを開く
-    openPrintDialog: (options: { html: string; title?: string }) => Promise<{
+    openPrintDialog: (options: {
+      html: string
+      title?: string
+      pageSize?: "A4" | "Letter" | { width: number; height: number }
+      landscape?: boolean
+    }) => Promise<{
       success: boolean
       error?: string
     }>


### PR DESCRIPTION
## Summary

Closes #478

- 解答用紙のPDF/印刷出力を `renderToStaticMarkup` + `BrowserWindow.printToPDF` パターンに統一
- MathJax数式をレンダラープロセスで事前にSVG化し、グリフ定義をHTMLに含める
- `printToPDF`のpageSize単位修正（ミクロン→インチ）、カスタムpageSize対応
- Tailwind preflight相当のCSS、foreignObject SVG overflow修正

## Test plan

- [ ] 解答用紙のPDF出力が正しいレイアウトで生成される
- [ ] 解答用紙の印刷プレビューが正しく表示される
- [ ] MathJax数式がPDF/印刷に正しく反映される
- [ ] 分数・下付き文字などベースライン以下の数式が切れない
- [ ] PNG出力は従来通り動作する
- [ ] 個人成績表のPDF/印刷機能が既存動作を維持する

🤖 Generated with [Claude Code](https://claude.com/claude-code)