### PR TITLE
fix: 横配置モードの同一行小問の右端エッジマージで外枠誤ステップを修正

### DIFF
--- a/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -28,6 +28,7 @@ import {
   computeGridRowRightEdges,
   gridTotalHeight,
   isGridHorizontal,
+  mergeAbsoluteRightEdges,
 } from "./gridBuilder"
 import { computeHeaderFieldLayout } from "./headerFieldLayout"
 import {
@@ -270,6 +271,8 @@ export function computeLayoutFromDefinition(
       }
 
       // rowRightEdges: Y区間ごとの右端X座標を計算（枝問横配置を考慮）
+      const rawRightEdges: { yTop: number; yBottom: number; rightX: number }[] =
+        []
       for (const gc of gridCells) {
         const sub2 = gc.item
         const gcCellX = horizontalAreaX + gc.x * horizontalAreaWidth
@@ -293,15 +296,18 @@ export function computeLayoutFromDefinition(
             branchAreaWidth,
             baseRowHeight
           )) {
-            majorRightEdges.push(edge)
+            rawRightEdges.push(edge)
           }
         } else {
-          majorRightEdges.push({
+          rawRightEdges.push({
             yTop: gcCellY,
             yBottom: gcCellY + gcCellH,
             rightX: gcCellRight,
           })
         }
+      }
+      for (const edge of mergeAbsoluteRightEdges(rawRightEdges)) {
+        majorRightEdges.push(edge)
       }
 
       // rowLeftEdges: Y区間ごとの左端X座標を計算

--- a/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -31,6 +31,7 @@ import {
   computeGridRowRightEdges,
   gridTotalHeight,
   isGridHorizontal,
+  mergeAbsoluteRightEdges,
 } from "./gridBuilder"
 import { computeHeaderFieldLayout } from "./headerFieldLayout"
 import {
@@ -314,6 +315,8 @@ export function computeMultiPageLayoutFromDefinition(
       }
 
       // rowRightEdges（枝問横配置を考慮）
+      const rawRightEdges: { yTop: number; yBottom: number; rightX: number }[] =
+        []
       for (const gc of gridCells) {
         const sub2 = gc.item
         const gcCellX = horizontalAreaX + gc.x * horizontalAreaWidth
@@ -337,15 +340,18 @@ export function computeMultiPageLayoutFromDefinition(
             branchAreaWidth,
             baseRowHeight
           )) {
-            colData.rowRightEdges.push(edge)
+            rawRightEdges.push(edge)
           }
         } else {
-          colData.rowRightEdges.push({
+          rawRightEdges.push({
             yTop: gcCellY,
             yBottom: gcCellY + gcCellH,
             rightX: gcCellRight,
           })
         }
+      }
+      for (const edge of mergeAbsoluteRightEdges(rawRightEdges)) {
+        colData.rowRightEdges.push(edge)
       }
 
       // rowLeftEdges

--- a/components/answer-sheet-builder/hooks/layout/gridBuilder.ts
+++ b/components/answer-sheet-builder/hooks/layout/gridBuilder.ts
@@ -219,6 +219,42 @@ export function gridTotalHeight<T>(cells: GridCell<T>[]): number {
   return Math.max(...cells.map((c) => c.y + c.height))
 }
 
+/** 絶対座標のY区間・右端エントリをマージする（同一Y区間の最大rightXを取る） */
+export function mergeAbsoluteRightEdges(
+  edges: { yTop: number; yBottom: number; rightX: number }[]
+): { yTop: number; yBottom: number; rightX: number }[] {
+  if (edges.length === 0) return []
+  const ySet = new Set<number>()
+  for (const e of edges) {
+    ySet.add(e.yTop)
+    ySet.add(e.yBottom)
+  }
+  const sortedYs = Array.from(ySet).sort((a, b) => a - b)
+  const result: { yTop: number; yBottom: number; rightX: number }[] = []
+  for (let i = 0; i < sortedYs.length - 1; i++) {
+    const yTop = sortedYs[i]
+    const yBottom = sortedYs[i + 1]
+    const midY = (yTop + yBottom) / 2
+    let maxRightX = 0
+    for (const e of edges) {
+      if (e.yTop <= midY + 1e-9 && e.yBottom >= midY - 1e-9) {
+        maxRightX = Math.max(maxRightX, e.rightX)
+      }
+    }
+    if (maxRightX > 0) {
+      if (
+        result.length > 0 &&
+        Math.abs(result[result.length - 1].rightX - maxRightX) < 0.01
+      ) {
+        result[result.length - 1].yBottom = yBottom
+      } else {
+        result.push({ yTop, yBottom, rightX: maxRightX })
+      }
+    }
+  }
+  return result
+}
+
 /** グリッドセルからY区間ごとの右端X座標を計算（ステップ外枠描画用） */
 export function computeGridRowRightEdges<T>(
   gridCells: GridCell<T>[],


### PR DESCRIPTION
## Summary

- 横配置モードで同一行に複数小問が並ぶ際、右端エッジがマージされず外枠が誤ステップする問題を修正
- `mergeAbsoluteRightEdges`関数を`gridBuilder.ts`に追加
- `computeLayout.ts`と`computeMultiPageLayout.ts`でper-cellエッジを収集後マージするよう変更

Closes #480

## Test plan

- [ ] (1)全幅、(2)1/2、(3)1/2の構成で外枠が正しく表示されることを確認
- [ ] 枝問横配置との組み合わせで外枠ステップが正常に動作することを確認
- [ ] 既存の縦配置モードに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)