### PR TITLE
試験変換の模範解答画像生成をPDF出力と同じHTML+capturePageに統一

### DIFF
--- a/components/answer-sheet-builder/hooks/useExamIntegration.ts
+++ b/components/answer-sheet-builder/hooks/useExamIntegration.ts
@@ -1,7 +1,7 @@
 /**
  * 試験変換hook
  *
- * renderer側でlayout計算→SVG生成→main側にデータを渡す。
+ * renderer側でlayout計算→HTML生成→main側にデータを渡す。
  */
 
 import { useRouter } from "next/navigation"
@@ -11,10 +11,7 @@ import { toast } from "sonner"
 import { useAuth } from "@/contexts/AuthContext"
 import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 
-import {
-  renderMultiPageSvgStrings,
-  resolveImageDataUris,
-} from "../utils/renderSvgStrings"
+import { generateAnswerSheetPageHtmls } from "../utils/generatePrintHtml"
 import { computeMultiPageLayoutFromDefinition } from "./layout/computeMultiPageLayout"
 
 export function useExamIntegration() {
@@ -39,26 +36,24 @@ export function useExamIntegration() {
         setIsConverting(true)
 
         const multiPageLayout = computeMultiPageLayoutFromDefinition(definition)
-        const allCells = multiPageLayout.pages.flatMap((p) => p.cells)
-        const imageDataUris = await resolveImageDataUris(allCells)
 
-        const answerSheetSvgStrings = renderMultiPageSvgStrings(
+        const answerSheetHtmlPages = await generateAnswerSheetPageHtmls(
+          definition,
           multiPageLayout,
-          "answer-sheet",
-          imageDataUris
+          "answer-sheet"
         )
-        const modelAnswerSvgStrings = renderMultiPageSvgStrings(
+        const modelAnswerHtmlPages = await generateAnswerSheetPageHtmls(
+          definition,
           multiPageLayout,
-          "model-answer",
-          imageDataUris
+          "model-answer"
         )
 
         const result = await api.convertToExam({
           definition,
           userId: user.id,
           multiPageLayout,
-          answerSheetSvgStrings,
-          modelAnswerSvgStrings,
+          answerSheetHtmlPages,
+          modelAnswerHtmlPages,
         })
 
         if (result.success && result.examId) {

--- a/components/answer-sheet-builder/utils/generatePrintHtml.ts
+++ b/components/answer-sheet-builder/utils/generatePrintHtml.ts
@@ -9,21 +9,25 @@
 import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 
-import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
+import type {
+  AnswerSheetDefinition,
+  RenderMode,
+} from "@/types/answerSheetDefinition.types"
 import type { ComputedMultiPageLayout } from "@/types/answerSheetLayout.types"
 
 import { AnswerSheetSVGRenderer } from "../components/preview/AnswerSheetSVGRenderer"
 import { resolveImageDataUris } from "./renderSvgStrings"
 
 /**
- * 解答用紙の印刷用HTMLを生成する。
- * プレビューと同じ AnswerSheetSVGRenderer を renderToStaticMarkup で使用。
+ * ページごとのSVG HTML文字列と MathJax defs を生成する内部ヘルパー
  */
-export async function generateAnswerSheetPrintHtml(
+async function renderPageSvgHtmls(
   definition: AnswerSheetDefinition,
-  multiLayout: ComputedMultiPageLayout
-): Promise<string> {
+  multiLayout: ComputedMultiPageLayout,
+  renderMode?: RenderMode
+): Promise<{ pageSvgHtmls: string[]; mathJaxDefs: string }> {
   const { pageWidthMm, pageHeightMm } = multiLayout
+  const effectiveRenderMode = renderMode ?? definition.renderMode
 
   // 画像の data URI を事前解決
   const allCells = multiLayout.pages.flatMap((p) => p.cells)
@@ -32,46 +36,38 @@ export async function generateAnswerSheetPrintHtml(
   // 各ページを renderToStaticMarkup で HTML 化
   // （renderSegmentsHtmlForPrint 内で MathJax.tex2svg() が呼ばれ、
   //   グリフ定義がグローバルSVGキャッシュに蓄積される）
-  const pagesHtml = multiLayout.pages
-    .map((page, i) => {
-      const svgHtml = renderToStaticMarkup(
-        React.createElement(
-          "svg",
-          {
-            xmlns: "http://www.w3.org/2000/svg",
-            width: pageWidthMm,
-            height: pageHeightMm,
-            viewBox: `0 0 ${pageWidthMm} ${pageHeightMm}`,
+  const pageSvgHtmls = multiLayout.pages.map((page) =>
+    renderToStaticMarkup(
+      React.createElement(
+        "svg",
+        {
+          xmlns: "http://www.w3.org/2000/svg",
+          width: pageWidthMm,
+          height: pageHeightMm,
+          viewBox: `0 0 ${pageWidthMm} ${pageHeightMm}`,
+        },
+        React.createElement(AnswerSheetSVGRenderer, {
+          layout: {
+            pageWidthMm,
+            pageHeightMm,
+            cells: page.cells,
+            lines: page.lines,
+            numberLabels: page.numberLabels,
+            omrMarkerPositions: page.omrMarkerPositions,
+            headerFields: page.headerFields,
+            overflow: false,
+            contentHeightMm: pageHeightMm,
           },
-          React.createElement(AnswerSheetSVGRenderer, {
-            layout: {
-              pageWidthMm,
-              pageHeightMm,
-              cells: page.cells,
-              lines: page.lines,
-              numberLabels: page.numberLabels,
-              omrMarkerPositions: page.omrMarkerPositions,
-              headerFields: page.headerFields,
-              overflow: false,
-              contentHeightMm: pageHeightMm,
-            },
-            pageLayout: page,
-            renderMode: definition.renderMode,
-            forPrint: true,
-            imageDataUris,
-          })
-        )
+          pageLayout: page,
+          renderMode: effectiveRenderMode,
+          forPrint: true,
+          imageDataUris,
+        })
       )
-
-      const isLast = i === multiLayout.pages.length - 1
-      const pageBreak = isLast ? "" : " page-break-after"
-      return `<div class="page${pageBreak}">${svgHtml}</div>`
-    })
-    .join("\n")
+    )
+  )
 
   // MathJaxのグローバルSVGキャッシュ（グリフ定義）を取得
-  // tex2svg()が生成するSVGは <use xlink:href="#MJX-..."> で共有グリフを参照するため、
-  // そのグリフ定義 (<defs>) を print HTML に含める必要がある
   let mathJaxDefs = ""
   if (typeof document !== "undefined") {
     const defsContainer = document.querySelector("#MJX-SVG-global-cache")
@@ -80,11 +76,12 @@ export async function generateAnswerSheetPrintHtml(
     }
   }
 
-  return `<!DOCTYPE html>
-<html lang="ja">
-<head>
-<meta charset="utf-8">
-<style>
+  return { pageSvgHtmls, mathJaxDefs }
+}
+
+/** ページ用の共通CSSを生成 */
+function generatePageCss(pageWidthMm: number, pageHeightMm: number): string {
+  return `
   @page {
     size: ${pageWidthMm}mm ${pageHeightMm}mm;
     margin: 0;
@@ -116,7 +113,38 @@ export async function generateAnswerSheetPrintHtml(
   .page-break-after { page-break-after: always; }
   .page > svg { display: block; width: 100%; height: 100%; }
   /* MathJax SVGのベースライン以下の切れ防止 */
-  foreignObject svg[role="img"] { overflow: visible !important; display: inline !important; }
+  foreignObject svg[role="img"] { overflow: visible !important; display: inline !important; }`
+}
+
+/**
+ * 解答用紙の印刷用HTMLを生成する。
+ * プレビューと同じ AnswerSheetSVGRenderer を renderToStaticMarkup で使用。
+ */
+export async function generateAnswerSheetPrintHtml(
+  definition: AnswerSheetDefinition,
+  multiLayout: ComputedMultiPageLayout
+): Promise<string> {
+  const { pageWidthMm, pageHeightMm } = multiLayout
+  const { pageSvgHtmls, mathJaxDefs } = await renderPageSvgHtmls(
+    definition,
+    multiLayout
+  )
+
+  const pagesHtml = pageSvgHtmls
+    .map((svgHtml, i) => {
+      const isLast = i === pageSvgHtmls.length - 1
+      const pageBreak = isLast ? "" : " page-break-after"
+      return `<div class="page${pageBreak}">${svgHtml}</div>`
+    })
+    .join("\n")
+
+  const css = generatePageCss(pageWidthMm, pageHeightMm)
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>${css}
 </style>
 </head>
 <body>
@@ -124,4 +152,39 @@ ${mathJaxDefs}
 ${pagesHtml}
 </body>
 </html>`
+}
+
+/**
+ * 解答用紙のページごとの独立HTMLを生成する。
+ * BrowserWindow + capturePage でPNG化するために使用。
+ * 各HTMLは1ページ分のSVGを含む完全なHTML文書。
+ */
+export async function generateAnswerSheetPageHtmls(
+  definition: AnswerSheetDefinition,
+  multiLayout: ComputedMultiPageLayout,
+  renderMode?: RenderMode
+): Promise<string[]> {
+  const { pageWidthMm, pageHeightMm } = multiLayout
+  const { pageSvgHtmls, mathJaxDefs } = await renderPageSvgHtmls(
+    definition,
+    multiLayout,
+    renderMode
+  )
+
+  const css = generatePageCss(pageWidthMm, pageHeightMm)
+
+  return pageSvgHtmls.map(
+    (svgHtml) => `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>${css}
+</style>
+</head>
+<body>
+${mathJaxDefs}
+<div class="page">${svgHtml}</div>
+</body>
+</html>`
+  )
 }

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -6,7 +6,6 @@ import { BrowserWindow, dialog, ipcMain, shell } from "electron"
 import fs from "fs"
 import os from "os"
 import path from "path"
-import sharp from "sharp"
 
 import type {
   ASBConvertToExamArgs,
@@ -23,6 +22,7 @@ import {
   getAsbImagesDirectory,
   getRelativePathFromData,
 } from "../lib/dataManager"
+import { htmlToPngBuffer } from "../lib/printUtils"
 import {
   deleteAsbDefinition,
   getAsbDefinition,
@@ -222,7 +222,7 @@ export function setupAnswerSheetBuilderHandlers(): void {
     }
   })
 
-  // PNG出力: SVG文字列を受け取り → sharp でラスタライズ
+  // PNG出力: HTML文字列を受け取り → BrowserWindow + capturePage でラスタライズ
   ipcMain.handle("asb:export-png", async (_event, args: ASBExportPngArgs) => {
     try {
       const widthPx = Math.round((args.pageWidthMm / 25.4) * args.dpi)
@@ -233,22 +233,20 @@ export function setupAnswerSheetBuilderHandlers(): void {
         fs.mkdirSync(outputDir, { recursive: true })
       }
 
-      if (args.svgStrings.length === 1) {
-        const svgBuffer = Buffer.from(args.svgStrings[0])
-        await sharp(svgBuffer)
-          .resize(widthPx, heightPx)
-          .png()
-          .toFile(args.outputPath)
+      if (args.htmlPages.length === 1) {
+        const buf = await htmlToPngBuffer(args.htmlPages[0], widthPx, heightPx)
+        fs.writeFileSync(args.outputPath, buf)
       } else {
         const ext = path.extname(args.outputPath)
         const base = args.outputPath.slice(0, -ext.length)
-        for (let i = 0; i < args.svgStrings.length; i++) {
+        for (let i = 0; i < args.htmlPages.length; i++) {
           const pagePath = `${base}-${i + 1}${ext}`
-          const svgBuffer = Buffer.from(args.svgStrings[i])
-          await sharp(svgBuffer)
-            .resize(widthPx, heightPx)
-            .png()
-            .toFile(pagePath)
+          const buf = await htmlToPngBuffer(
+            args.htmlPages[i],
+            widthPx,
+            heightPx
+          )
+          fs.writeFileSync(pagePath, buf)
         }
       }
 
@@ -293,7 +291,7 @@ export function setupAnswerSheetBuilderHandlers(): void {
     }
   )
 
-  // 試験変換: multiPageLayout + SVG文字列を受け取り
+  // 試験変換: multiPageLayout + HTML文字列を受け取り
   ipcMain.handle(
     "asb:convert-to-exam",
     async (_event, args: ASBConvertToExamArgs) => {
@@ -302,8 +300,8 @@ export function setupAnswerSheetBuilderHandlers(): void {
           args.definition,
           args.userId,
           args.multiPageLayout,
-          args.answerSheetSvgStrings,
-          args.modelAnswerSvgStrings
+          args.answerSheetHtmlPages,
+          args.modelAnswerHtmlPages
         )
         return result
       } catch (error) {

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -1,12 +1,12 @@
 /**
  * 解答用紙定義 → 採点試験変換
  *
- * renderer側から受け取った multiPageLayout + SVG文字列 → Exam + ExamPage + MasterImage + CropRegion 作成
+ * renderer側から受け取った multiPageLayout + HTML文字列 → BrowserWindow + capturePage でPNG化
+ * → Exam + ExamPage + MasterImage + CropRegion 作成
  */
 
 import fs from "fs"
 import path from "path"
-import sharp from "sharp"
 
 import type { AnswerSheetDefinition } from "../../../types/answerSheetDefinition.types"
 import type { ComputedMultiPageLayout } from "../../../types/answerSheetLayout.types"
@@ -16,6 +16,7 @@ import {
   getMasterAnswersDirectory,
   getRelativePathFromData,
 } from "../dataManager"
+import { htmlToPngBuffer } from "../printUtils"
 import prisma from "../prisma/client"
 import { createExam } from "../prisma/exam"
 import { createExamPage } from "../prisma/examPage"
@@ -28,14 +29,14 @@ export interface ConvertToExamResult {
 
 /**
  * 解答用紙定義を採点試験に変換
- * renderer側からmultiPageLayout + SVG文字列を受け取り、PNGバッファ生成→DB作成
+ * renderer側からmultiPageLayout + HTML文字列を受け取り、PNGバッファ生成→DB作成
  */
 export async function convertToExam(
   definition: AnswerSheetDefinition,
   userId: string,
   multiPageLayout: ComputedMultiPageLayout,
-  answerSheetSvgStrings: string[],
-  modelAnswerSvgStrings: string[]
+  answerSheetHtmlPages: string[],
+  modelAnswerHtmlPages: string[]
 ): Promise<ConvertToExamResult> {
   try {
     // 0. OMR設定を問題定義から抽出
@@ -62,26 +63,20 @@ export async function convertToExam(
       userId
     )
 
-    // 2. SVG文字列 → PNG Buffer 生成
+    // 2. HTML → PNG Buffer 生成（BrowserWindow + capturePage）
     const dpi = 300
     const widthPx = Math.round((multiPageLayout.pageWidthMm / 25.4) * dpi)
     const heightPx = Math.round((multiPageLayout.pageHeightMm / 25.4) * dpi)
 
     const templateBuffers: Buffer[] = []
-    for (const svg of answerSheetSvgStrings) {
-      const buf = await sharp(Buffer.from(svg))
-        .resize(widthPx, heightPx)
-        .png()
-        .toBuffer()
+    for (const html of answerSheetHtmlPages) {
+      const buf = await htmlToPngBuffer(html, widthPx, heightPx)
       templateBuffers.push(buf)
     }
 
     const modelBuffers: Buffer[] = []
-    for (const svg of modelAnswerSvgStrings) {
-      const buf = await sharp(Buffer.from(svg))
-        .resize(widthPx, heightPx)
-        .png()
-        .toBuffer()
+    for (const html of modelAnswerHtmlPages) {
+      const buf = await htmlToPngBuffer(html, widthPx, heightPx)
       modelBuffers.push(buf)
     }
 

--- a/types/answerSheetBuilder.types.ts
+++ b/types/answerSheetBuilder.types.ts
@@ -16,7 +16,7 @@ export interface ASBExportPdfArgs {
 }
 
 export interface ASBExportPngArgs {
-  svgStrings: string[]
+  htmlPages: string[]
   outputPath: string
   dpi: number
   pageWidthMm: number
@@ -27,8 +27,8 @@ export interface ASBConvertToExamArgs {
   definition: AnswerSheetDefinition
   userId: string
   multiPageLayout: ComputedMultiPageLayout
-  answerSheetSvgStrings: string[]
-  modelAnswerSvgStrings: string[]
+  answerSheetHtmlPages: string[]
+  modelAnswerHtmlPages: string[]
 }
 
 export interface ASBPrintArgs {


### PR DESCRIPTION
## Summary

- 試験変換時の模範解答PNG生成を `sharp(SVG)` から `BrowserWindow + capturePage` に置き換え
- `generatePrintHtml.ts` のロジックを共有し、PDF出力と完全に同じレンダリングパスを使用
- MathJax数式やforeignObjectの改行テキストが正しくレンダリングされるように

Closes #482

## 変更内容

- `generateAnswerSheetPageHtmls()` を追加（ページごとの独立HTML生成）
- `renderPageSvgHtmls()` / `generatePageCss()` を内部ヘルパーとして抽出（既存関数と共有）
- `examConverter` に `htmlToPngBuffer()` ヘルパーを追加
- `ASBConvertToExamArgs` のプロパティを `SvgStrings` → `HtmlPages` に変更
- IPC引数を統一

## Test plan

- [ ] 解答用紙を試験に変換し、模範解答画像にMathJax数式・改行テキストが正しく含まれることを確認
- [ ] PDF出力との見た目の一致を確認
- [ ] 既存のPDF出力・印刷機能が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)