### PR TITLE
fix: 解答用紙のPNG出力をHTML+capturePageベースに統一

### DIFF
--- a/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
@@ -1,9 +1,8 @@
 /**
  * PDF/PNG出力・印刷hook
  *
- * PDF/印刷: renderToStaticMarkup でプレビューと同じReactコンポーネントをHTML化
- *          → 既存の export:openPrintDialog / export:printHtmlToPdf で出力
- * PNG:     SVG文字列 → sharp でラスタライズ（従来通り）
+ * PDF/印刷/PNG: renderToStaticMarkup でプレビューと同じReactコンポーネントをHTML化
+ *              → BrowserWindow + printToPDF / capturePage で出力
  */
 
 import { useCallback, useState } from "react"
@@ -11,11 +10,10 @@ import { toast } from "sonner"
 
 import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 
-import { generateAnswerSheetPrintHtml } from "../utils/generatePrintHtml"
 import {
-  renderMultiPageSvgStrings,
-  resolveImageDataUris,
-} from "../utils/renderSvgStrings"
+  generateAnswerSheetPageHtmls,
+  generateAnswerSheetPrintHtml,
+} from "../utils/generatePrintHtml"
 import { computeMultiPageLayoutFromDefinition } from "./layout/computeMultiPageLayout"
 
 export function useAnswerSheetExport() {
@@ -83,16 +81,13 @@ export function useAnswerSheetExport() {
         if (!pathResult.success || !pathResult.filePath) return
 
         const multiLayout = computeMultiPageLayoutFromDefinition(definition)
-        const allCells = multiLayout.pages.flatMap((p) => p.cells)
-        const imageDataUris = await resolveImageDataUris(allCells)
-        const svgStrings = renderMultiPageSvgStrings(
-          multiLayout,
-          definition.renderMode,
-          imageDataUris
+        const htmlPages = await generateAnswerSheetPageHtmls(
+          definition,
+          multiLayout
         )
 
         const result = await api.exportPng({
-          svgStrings,
+          htmlPages,
           outputPath: pathResult.filePath,
           dpi,
           pageWidthMm: multiLayout.pageWidthMm,

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -7,6 +7,7 @@
 
 import { app, BrowserWindow } from "electron"
 import fs from "fs"
+import os from "os"
 import path from "path"
 
 let mathjaxCache: string | null = null
@@ -37,6 +38,55 @@ export function resolveMathJaxSrc(html: string): string {
   } catch (err) {
     console.error("Failed to load MathJax source:", err)
     return html.replace('<script src="__MATHJAX_SRC__"></script>', "")
+  }
+}
+
+/**
+ * HTML文字列をオフスクリーンBrowserWindowでロードし、capturePageでPNGバッファに変換。
+ * 解答用紙のPNG出力・試験変換の模範解答画像生成で共通使用。
+ */
+export async function htmlToPngBuffer(
+  html: string,
+  widthPx: number,
+  heightPx: number
+): Promise<Buffer> {
+  let tempHtmlPath: string | null = null
+  let win: BrowserWindow | null = null
+  try {
+    tempHtmlPath = path.join(
+      os.tmpdir(),
+      `asb-capture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.html`
+    )
+    fs.writeFileSync(tempHtmlPath, html, "utf-8")
+
+    win = new BrowserWindow({
+      show: false,
+      width: widthPx,
+      height: heightPx,
+      webPreferences: { offscreen: true },
+    })
+    await win.loadFile(tempHtmlPath)
+
+    // レンダリング完了を待つ
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    const image = await win.webContents.capturePage({
+      x: 0,
+      y: 0,
+      width: widthPx,
+      height: heightPx,
+    })
+
+    return image.toPNG()
+  } finally {
+    win?.destroy()
+    if (tempHtmlPath) {
+      try {
+        fs.unlinkSync(tempHtmlPath)
+      } catch {
+        // ignore
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #484

- PNG出力を `sharp(SVG)` から `BrowserWindow + capturePage` に変更
- `htmlToPngBuffer` を `printUtils.ts` に共通ユーティリティとして集約
- `examConverter.ts` のローカル実装を共通版に置換
- PDF/印刷/PNG/試験変換の全出力パスが同一のレンダリングロジックを使用

## Test plan

- [ ] 解答用紙のPNG出力でMathJax数式が正しくレンダリングされる
- [ ] 複数ページのPNG出力でページ番号付きファイルが生成される
- [ ] 試験変換の模範解答画像が引き続き正しく動作する
- [ ] PDF出力・印刷機能が影響を受けない

🤖 Generated with [Claude Code](https://claude.com/claude-code)