### PR TITLE
feat: ヘッダーフィールドに採点領域連携(linkedRegionType)を追加

### DIFF
--- a/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
+++ b/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
@@ -22,6 +22,7 @@ import type {
   HeaderFieldDefinition,
   HeaderFieldType,
   LineStyle,
+  LinkedRegionType,
 } from "@/types/answerSheetDefinition.types"
 
 import { HEADER_FIELD_PRESETS } from "../../constants"
@@ -39,6 +40,14 @@ const TYPE_LABELS: Record<HeaderFieldType, string> = {
   field: "記入欄",
   hfill: "可変スペース",
   label: "ラベル",
+}
+
+const LINKED_REGION_LABELS: Record<string, string> = {
+  none: "なし",
+  TOTAL_SCORE: "合計点",
+  SUBTOTAL_SCORE: "小計点",
+  STUDENT_NAME: "氏名",
+  STUDENT_ID: "受験番号",
 }
 
 export function HeaderFieldEditor({
@@ -187,43 +196,70 @@ export function HeaderFieldEditor({
               </div>
             )}
 
-            {/* field タイプのみ: マス数・罫線 */}
+            {/* field タイプのみ: マス数・罫線・採点領域連携 */}
             {fieldType === "field" && (
-              <div className="grid grid-cols-2 gap-2">
-                <div>
-                  <Label className="text-[10px]">マス数</Label>
-                  <Input
-                    type="number"
-                    value={field.gridCount}
-                    onChange={(e) =>
-                      onUpdate(field.id, {
-                        gridCount: Math.max(0, parseInt(e.target.value) || 0),
-                      })
-                    }
-                    className="h-7 text-xs"
-                    min={0}
-                    max={20}
-                  />
+              <>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <Label className="text-[10px]">マス数</Label>
+                    <Input
+                      type="number"
+                      value={field.gridCount}
+                      onChange={(e) =>
+                        onUpdate(field.id, {
+                          gridCount: Math.max(0, parseInt(e.target.value) || 0),
+                        })
+                      }
+                      className="h-7 text-xs"
+                      min={0}
+                      max={20}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-[10px]">罫線</Label>
+                    <Select
+                      value={field.lineStyle}
+                      onValueChange={(v) =>
+                        onUpdate(field.id, { lineStyle: v as LineStyle })
+                      }
+                    >
+                      <SelectTrigger className="h-7 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="solid">実線</SelectItem>
+                        <SelectItem value="dashed">破線</SelectItem>
+                        <SelectItem value="dotted">点線</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
                 <div>
-                  <Label className="text-[10px]">罫線</Label>
+                  <Label className="text-[10px]">採点領域連携</Label>
                   <Select
-                    value={field.lineStyle}
+                    value={field.linkedRegionType ?? "none"}
                     onValueChange={(v) =>
-                      onUpdate(field.id, { lineStyle: v as LineStyle })
+                      onUpdate(field.id, {
+                        linkedRegionType:
+                          v === "none" ? undefined : (v as LinkedRegionType),
+                      })
                     }
                   >
                     <SelectTrigger className="h-7 text-xs">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="solid">実線</SelectItem>
-                      <SelectItem value="dashed">破線</SelectItem>
-                      <SelectItem value="dotted">点線</SelectItem>
+                      {Object.entries(LINKED_REGION_LABELS).map(
+                        ([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        )
+                      )}
                     </SelectContent>
                   </Select>
                 </div>
-              </div>
+              </>
             )}
           </div>
         )

--- a/components/answer-sheet-builder/constants.ts
+++ b/components/answer-sheet-builder/constants.ts
@@ -126,6 +126,7 @@ export function createDefaultHeaderField(
     lineWidth: overrides?.lineWidth ?? 0.4,
     order: overrides?.order ?? 0,
     fontSize: overrides?.fontSize,
+    linkedRegionType: overrides?.linkedRegionType,
   }
 }
 
@@ -135,7 +136,13 @@ export const HEADER_FIELD_PRESETS: {
 }[] = [
   {
     label: "受験番号",
-    defaults: { type: "field", label: "受験番号", widthMm: 40, gridCount: 8 },
+    defaults: {
+      type: "field",
+      label: "受験番号",
+      widthMm: 40,
+      gridCount: 8,
+      linkedRegionType: "STUDENT_ID",
+    },
   },
   {
     label: "クラス",
@@ -147,7 +154,33 @@ export const HEADER_FIELD_PRESETS: {
   },
   {
     label: "氏名",
-    defaults: { type: "field", label: "氏名", widthMm: 60, gridCount: 0 },
+    defaults: {
+      type: "field",
+      label: "氏名",
+      widthMm: 60,
+      gridCount: 0,
+      linkedRegionType: "STUDENT_NAME",
+    },
+  },
+  {
+    label: "合計点",
+    defaults: {
+      type: "field",
+      label: "合計点",
+      widthMm: 30,
+      gridCount: 0,
+      linkedRegionType: "TOTAL_SCORE",
+    },
+  },
+  {
+    label: "小計点",
+    defaults: {
+      type: "field",
+      label: "小計点",
+      widthMm: 30,
+      gridCount: 0,
+      linkedRegionType: "SUBTOTAL_SCORE",
+    },
   },
   {
     label: "可変スペース",

--- a/components/answer-sheet-builder/hooks/layout/headerFieldLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/headerFieldLayout.ts
@@ -66,6 +66,7 @@ export function computeHeaderFieldLayout(
           ? field.widthMm / field.gridCount
           : undefined,
       fontSize: fieldType === "label" ? (field.fontSize ?? 5) : undefined,
+      linkedRegionType: field.linkedRegionType,
     }
     currentX += effectiveWidth + gap
     return computed

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -137,6 +137,30 @@ export async function convertToExam(
           },
         })
       }
+
+      // CropRegion作成（ヘッダーフィールドのlinkedRegionType）
+      const linkedFields = pageLayout.headerFields.filter(
+        (hf) => hf.linkedRegionType
+      )
+      for (const hf of linkedFields) {
+        const normalizedX = hf.x / multiPageLayout.pageWidthMm
+        const normalizedY = hf.y / multiPageLayout.pageHeightMm
+        const normalizedW = hf.width / multiPageLayout.pageWidthMm
+        const normalizedH = hf.height / multiPageLayout.pageHeightMm
+        await prisma.cropRegion.create({
+          data: {
+            examPageId: examPage.id,
+            label: hf.label,
+            type: hf.linkedRegionType!,
+            x: normalizedX,
+            y: normalizedY,
+            width: normalizedW,
+            height: normalizedH,
+            points: null,
+            orderIndex: globalOrderIndex++,
+          },
+        })
+      }
     }
 
     // 4. OMRテンプレート保存（OMR設定がある場合）

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -224,6 +224,7 @@ export async function saveAsbDefinition(
           lineWidth: hf.lineWidth,
           order: hi,
           fontSize: hf.fontSize ?? null,
+          linkedRegionType: hf.linkedRegionType ?? null,
         },
       })
     }

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -23,6 +23,7 @@ import type {
   GlobalSettings,
   HeaderFieldDefinition,
   LineStyle,
+  LinkedRegionType,
   MajorQuestion,
   SubQuestion,
 } from "../../../types/answerSheetDefinition.types"
@@ -263,6 +264,8 @@ export function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
         lineWidth: hf.lineWidth,
         order: hf.order,
         fontSize: hf.fontSize ?? undefined,
+        linkedRegionType:
+          (hf.linkedRegionType as LinkedRegionType) ?? undefined,
       })
     )
   }

--- a/prisma/migrations/20260307000000_add_linked_region_type/migration.sql
+++ b/prisma/migrations/20260307000000_add_linked_region_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AsbHeaderField" ADD COLUMN "linkedRegionType" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -681,17 +681,18 @@ model AsbDefinition {
 
 /// ヘッダー記入欄
 model AsbHeaderField {
-  id           String @id @default(uuid())
-  definitionId String
-  type         String @default("field") // "field" | "hfill" | "label"
-  label        String
-  widthMm      Float  @default(30)
-  heightMm     Float  @default(8)
-  gridCount    Int    @default(0)
-  lineStyle    String @default("solid")
-  lineWidth    Float  @default(0.4)
-  order        Int    @default(0)
-  fontSize     Float? // label タイプ用
+  id               String  @id @default(uuid())
+  definitionId     String
+  type             String  @default("field") // "field" | "hfill" | "label"
+  label            String
+  widthMm          Float   @default(30)
+  heightMm         Float   @default(8)
+  gridCount        Int     @default(0)
+  lineStyle        String  @default("solid")
+  lineWidth        Float   @default(0.4)
+  order            Int     @default(0)
+  fontSize         Float? // label タイプ用
+  linkedRegionType String? // "TOTAL_SCORE" | "SUBTOTAL_SCORE" | "STUDENT_NAME" | "STUDENT_ID"
 
   definition AsbDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
 

--- a/types/answerSheetDefinition.types.ts
+++ b/types/answerSheetDefinition.types.ts
@@ -214,6 +214,12 @@ export interface MultiColumnConfig {
 
 export type HeaderFieldType = "field" | "hfill" | "label"
 
+export type LinkedRegionType =
+  | "TOTAL_SCORE"
+  | "SUBTOTAL_SCORE"
+  | "STUDENT_NAME"
+  | "STUDENT_ID"
+
 export interface HeaderFieldDefinition {
   id: string
   type: HeaderFieldType
@@ -226,6 +232,8 @@ export interface HeaderFieldDefinition {
   order: number
   /** label タイプのフォントサイズ (mm) */
   fontSize?: number
+  /** 試験変換時に対応するCropRegionを自動生成する */
+  linkedRegionType?: LinkedRegionType
 }
 
 // =====================

--- a/types/answerSheetLayout.types.ts
+++ b/types/answerSheetLayout.types.ts
@@ -152,6 +152,12 @@ export interface ComputedHeaderField {
   gridCellWidthMm?: number
   /** label タイプのフォントサイズ (mm) */
   fontSize?: number
+  /** 試験変換時に対応するCropRegionを自動生成する */
+  linkedRegionType?:
+    | "TOTAL_SCORE"
+    | "SUBTOTAL_SCORE"
+    | "STUDENT_NAME"
+    | "STUDENT_ID"
 }
 
 export interface ComputedLayout {


### PR DESCRIPTION
## Summary

- ヘッダー記入欄に`linkedRegionType`プロパティを追加し、試験変換時にCropRegionを自動生成
- 対応タイプ: TOTAL_SCORE, SUBTOTAL_SCORE, STUDENT_NAME, STUDENT_ID
- ヘッダーフィールドエディタに「採点領域連携」セレクトUIを追加
- プリセットに合計点・小計点を追加

Closes #486

## Test plan

- [ ] 解答用紙ビルダーでヘッダーフィールドに採点領域連携を設定できること
- [ ] プリセットから合計点・小計点を追加できること
- [ ] 試験変換後にCropRegionが正しく生成されること
- [ ] 既存のヘッダーフィールド（連携なし）が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)