### PR TITLE
refactor: ヘッダー記入欄を独立タブに分離

### DIFF
--- a/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -216,6 +216,9 @@ export function AnswerSheetBuilderMainView({
             <TabsTrigger value="lines" className="text-xs">
               罫線
             </TabsTrigger>
+            <TabsTrigger value="header" className="text-xs">
+              ヘッダー
+            </TabsTrigger>
             <TabsTrigger value="omr" className="text-xs">
               OMR
             </TabsTrigger>
@@ -258,7 +261,13 @@ export function AnswerSheetBuilderMainView({
                   settings={definition.settings}
                   onUpdate={updateSettings}
                 />
-                <Separator />
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="header" className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <div className="p-3">
                 <HeaderFieldEditor
                   fields={definition.settings.headerFields}
                   onAdd={addHeaderField}


### PR DESCRIPTION
## Summary

- ヘッダー記入欄エディタを「用紙設定」タブから独立した「ヘッダー」タブに移動
- タブ順序: 問題構成 → 用紙設定 → ヘッダー → 罫線 → OMR

Closes #488

## Test plan

- [ ] 「ヘッダー」タブが表示され、記入欄の追加・編集・削除が動作すること
- [ ] 「用紙設定」タブにヘッダー記入欄が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)