### PR TITLE
fix: 解答用紙のPNGキャプチャでコンテンツが縮小表示される問題を修正

### DIFF
--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -225,16 +225,18 @@ export function setupAnswerSheetBuilderHandlers(): void {
   // PNG出力: HTML文字列を受け取り → BrowserWindow + capturePage でラスタライズ
   ipcMain.handle("asb:export-png", async (_event, args: ASBExportPngArgs) => {
     try {
-      const widthPx = Math.round((args.pageWidthMm / 25.4) * args.dpi)
-      const heightPx = Math.round((args.pageHeightMm / 25.4) * args.dpi)
-
       const outputDir = path.dirname(args.outputPath)
       if (!fs.existsSync(outputDir)) {
         fs.mkdirSync(outputDir, { recursive: true })
       }
 
       if (args.htmlPages.length === 1) {
-        const buf = await htmlToPngBuffer(args.htmlPages[0], widthPx, heightPx)
+        const buf = await htmlToPngBuffer(
+          args.htmlPages[0],
+          args.pageWidthMm,
+          args.pageHeightMm,
+          args.dpi
+        )
         fs.writeFileSync(args.outputPath, buf)
       } else {
         const ext = path.extname(args.outputPath)
@@ -243,8 +245,9 @@ export function setupAnswerSheetBuilderHandlers(): void {
           const pagePath = `${base}-${i + 1}${ext}`
           const buf = await htmlToPngBuffer(
             args.htmlPages[i],
-            widthPx,
-            heightPx
+            args.pageWidthMm,
+            args.pageHeightMm,
+            args.dpi
           )
           fs.writeFileSync(pagePath, buf)
         }

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -65,18 +65,17 @@ export async function convertToExam(
 
     // 2. HTML → PNG Buffer 生成（BrowserWindow + capturePage）
     const dpi = 300
-    const widthPx = Math.round((multiPageLayout.pageWidthMm / 25.4) * dpi)
-    const heightPx = Math.round((multiPageLayout.pageHeightMm / 25.4) * dpi)
+    const { pageWidthMm, pageHeightMm } = multiPageLayout
 
     const templateBuffers: Buffer[] = []
     for (const html of answerSheetHtmlPages) {
-      const buf = await htmlToPngBuffer(html, widthPx, heightPx)
+      const buf = await htmlToPngBuffer(html, pageWidthMm, pageHeightMm, dpi)
       templateBuffers.push(buf)
     }
 
     const modelBuffers: Buffer[] = []
     for (const html of modelAnswerHtmlPages) {
-      const buf = await htmlToPngBuffer(html, widthPx, heightPx)
+      const buf = await htmlToPngBuffer(html, pageWidthMm, pageHeightMm, dpi)
       modelBuffers.push(buf)
     }
 

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -44,12 +44,24 @@ export function resolveMathJaxSrc(html: string): string {
 /**
  * HTML文字列をオフスクリーンBrowserWindowでロードし、capturePageでPNGバッファに変換。
  * 解答用紙のPNG出力・試験変換の模範解答画像生成で共通使用。
+ *
+ * HTMLはCSSの mm 単位で .page をレイアウトしているが、BrowserWindowは目的の
+ * 出力ピクセルサイズに設定し、.page をビューポート全体に引き伸ばす CSS を注入する。
+ * SVGの viewBox により自然にスケールされ、目的の解像度でラスタライズされる。
  */
 export async function htmlToPngBuffer(
   html: string,
-  widthPx: number,
-  heightPx: number
+  pageWidthMm: number,
+  pageHeightMm: number,
+  dpi: number = 300
 ): Promise<Buffer> {
+  const widthPx = Math.round((pageWidthMm / 25.4) * dpi)
+  const heightPx = Math.round((pageHeightMm / 25.4) * dpi)
+
+  // .page を固定 mm サイズからビューポート全体に拡張する CSS を注入
+  const overrideCss = `<style>.page { width: 100vw !important; height: 100vh !important; }</style>`
+  const modifiedHtml = html.replace("</head>", `${overrideCss}\n</head>`)
+
   let tempHtmlPath: string | null = null
   let win: BrowserWindow | null = null
   try {
@@ -57,7 +69,7 @@ export async function htmlToPngBuffer(
       os.tmpdir(),
       `asb-capture-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.html`
     )
-    fs.writeFileSync(tempHtmlPath, html, "utf-8")
+    fs.writeFileSync(tempHtmlPath, modifiedHtml, "utf-8")
 
     win = new BrowserWindow({
       show: false,


### PR DESCRIPTION
## Summary

- `htmlToPngBuffer`のシグネチャを`(html, widthPx, heightPx)`から`(html, pageWidthMm, pageHeightMm, dpi)`に変更
- `.page`をビューポート全体に引き伸ばすCSS注入で、SVGのviewBoxスケーリングを活用
- 呼び出し元（`examConverter.ts`, `answerSheetBuilderHandlers.ts`）を新シグネチャに対応

Closes #492

## Test plan

- [ ] 解答用紙ビルダーから試験変換後、模範解答画像がページ全体に正しく表示されること
- [ ] PNG出力が正しい解像度で生成されること
- [ ] CropRegionの位置が画像と一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)