### PR TITLE
fix: 枝問配点オフ時の合計点計算が不正確だった問題を修正

### DIFF
--- a/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -116,12 +116,23 @@ export function AnswerSheetBuilderMainView({
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [examDialogOpen, setExamDialogOpen] = useState(false)
 
-  // 問題統計（全ページのセルから集計）
+  // 問題統計（定義データから集計）
   const allCells = multiPageLayout.pages.flatMap((p) => p.cells)
   const totalQuestions = allCells.filter((c) => c.cellType === "answer").length
-  const totalPoints = allCells
-    .filter((c) => c.cellType === "answer")
-    .reduce((sum, c) => sum + c.points, 0)
+  let totalPoints = 0
+  for (const mq of definition.majorQuestions) {
+    for (const sq of mq.subQuestions) {
+      if (sq.branchQuestions.length > 0) {
+        if (sq.usesBranchPoints === false) {
+          totalPoints += sq.points
+        } else {
+          totalPoints += sq.branchQuestions.reduce((s, b) => s + b.points, 0)
+        }
+      } else {
+        totalPoints += sq.points
+      }
+    }
+  }
 
   const handleRenderModeChange = useCallback(
     (mode: RenderMode) => {

--- a/components/answer-sheet-builder/hooks/layout/lineRenderer.ts
+++ b/components/answer-sheet-builder/hooks/layout/lineRenderer.ts
@@ -284,6 +284,7 @@ export function renderBranchQuestions(
         })
       }
 
+      const branchPoints = sub.usesBranchPoints === false ? 0 : gc.item.points
       cells.push(
         createCell(
           [mi, si, gc.itemIndex],
@@ -293,7 +294,7 @@ export function renderBranchQuestions(
           cellHeight,
           paper,
           `${majorLabel}-${sub.label}-${gc.item.label}`,
-          gc.item.points,
+          branchPoints,
           gc.item.textElements,
           "answer",
           pageIndex,
@@ -380,6 +381,7 @@ export function renderBranchQuestions(
         })
       }
 
+      const branchPoints = sub.usesBranchPoints === false ? 0 : branch.points
       cells.push(
         createCell(
           [mi, si, bi],
@@ -389,7 +391,7 @@ export function renderBranchQuestions(
           branchHeight,
           paper,
           `${majorLabel}-${sub.label}-${branch.label}`,
-          branch.points,
+          branchPoints,
           branch.textElements,
           "answer",
           pageIndex,


### PR DESCRIPTION
## Summary

- `lineRenderer.ts`: 枝問配点オフ時に枝問セルの`points`を0に設定（横配置・縦配置両方）
- `AnswerSheetBuilderMainView.tsx`: フッター合計点を定義データから直接計算し、枝問配点オフ時は小問のpointsを使用

Closes #494

## Test plan

- [ ] 枝問配点オフの小問で、フッターの合計点が小問の配点を反映すること
- [ ] 枝問配点オンの場合は従来通り各枝問の配点合計が表示されること
- [ ] 枝問なしの小問の配点が正しく反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)