### PR TITLE
refactor: saveAsbDefinitionのdelete+catchをdeleteManyに置換

### DIFF
--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -187,11 +187,7 @@ export async function saveAsbDefinition(
 ): Promise<void> {
   await prisma.$transaction(async (tx) => {
     // 既存があれば子テーブルごと削除（Cascade）
-    await tx.asbDefinition
-      .delete({ where: { id: definition.id } })
-      .catch(() => {
-        // 新規作成時は存在しないので無視
-      })
+    await tx.asbDefinition.deleteMany({ where: { id: definition.id } })
 
     // 定義を作成
     const flat = flattenGlobalSettings(definition.settings)


### PR DESCRIPTION
## Summary

- `saveAsbDefinition` の既存レコード削除を `delete` + `.catch()` から `deleteMany` に変更
- 対象が0件でもエラーにならないため `.catch()` による握りつぶしが不要に

Closes #498

## Test plan

- [ ] ASB定義の新規作成が正常に動作することを確認
- [ ] 既存ASB定義の上書き保存が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)