### PR TITLE
fix: テキストアノテーションの3つのバグを修正

### DIFF
--- a/app/textbox-on-canvas-v4/utils/textConversionUtils.ts
+++ b/app/textbox-on-canvas-v4/utils/textConversionUtils.ts
@@ -156,10 +156,19 @@ function parseDiscordMarkdown(text: string): string {
   let result = text
 
   // Discord Markdown → HTML変換（数式コンテキストを考慮）
-  result = safeReplace(result, /\*\*(.+?)\*\*/g, "<strong>$1</strong>") // 太字
-  result = safeReplace(result, /(?<!\*)\*([^*\n]+?)\*(?!\*)/g, "<em>$1</em>") // 斜体
-  result = safeReplace(result, /__(.+?)__/g, "<u>$1</u>") // 下線
-  result = safeReplace(result, /~~(.+?)~~/g, "<del>$1</del>") // 取り消し線
+  // 注意: safeReplaceの文字列置換では$1がリテラル扱いされるため、関数置換を使用
+  result = safeReplace(
+    result,
+    /\*\*(.+?)\*\*/g,
+    (_m, p1) => `<strong>${p1}</strong>`
+  ) // 太字
+  result = safeReplace(
+    result,
+    /(?<!\*)\*([^*\n]+?)\*(?!\*)/g,
+    (_m, p1) => `<em>${p1}</em>`
+  ) // 斜体
+  result = safeReplace(result, /__(.+?)__/g, (_m, p1) => `<u>${p1}</u>`) // 下線
+  result = safeReplace(result, /~~(.+?)~~/g, (_m, p1) => `<del>${p1}</del>`) // 取り消し線
 
   return result
 }

--- a/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModalV4.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModalV4.tsx
@@ -191,7 +191,7 @@ export function RichTextEditorModalV4({
   }, [insertFormatting])
 
   const handleUnderline = useCallback(() => {
-    insertFormatting("<u>", "</u>")
+    insertFormatting("__", "__")
     setIsUnderline(true)
     setTimeout(() => setIsUnderline(false), 200)
   }, [insertFormatting])

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
@@ -140,7 +140,10 @@ export function useDrawingState(
 
   // questionScoreIdが変更された時にDBから自動読み込み
   const prevQuestionScoreIdRef = useRef<string | null | undefined>(undefined)
-  const isInitialLoadRef = useRef(true)
+
+  // ロード操作（設問変更時）でannotationsが変わった場合のみdrawingElementsを同期する
+  // CRUD操作時のannotations変更では楽観的更新に依存し、上書きしない
+  const isLoadTriggeredRef = useRef(false)
 
   // 設問変更時の同期的クリア（useLayoutEffectで描画前に確実にクリア）
   // useLayoutEffectは描画effectの前に実行されるため、古いデータで描画されることを防ぐ
@@ -156,17 +159,21 @@ export function useDrawingState(
 
       // DB読み込みは非同期なので、ここでは開始のみ
       if (enablePersistence && questionScoreId) {
+        isLoadTriggeredRef.current = true
         loadAnnotations(questionScoreId)
       }
     }
   }, [enablePersistence, questionScoreId, loadAnnotations])
 
-  // annotationsが更新されたらdrawingElementsに反映
+  // annotationsが更新されたらdrawingElementsに反映（ロード時のみ）
+  // CRUD操作時はsetAnnotationsによるuseEffect発火をスキップし、
+  // 楽観的更新（addDrawingElement/updateDrawingElement/removeDrawingElement）に依存する
+  // これにより、まだDBに保存されていない楽観的更新が上書きされることを防ぐ
   useEffect(() => {
-    if (isInitialLoadRef.current) {
-      isInitialLoadRef.current = false
+    if (!isLoadTriggeredRef.current) {
       return
     }
+    isLoadTriggeredRef.current = false
 
     // annotationsをdrawingElementsに変換（同期的に更新）
     const elements = annotations.map(convertAnnotationToElement)
@@ -444,8 +451,10 @@ export function useDrawingState(
     if (!enablePersistence || !questionScoreId) return
 
     try {
+      isLoadTriggeredRef.current = true
       await loadAnnotations(questionScoreId)
     } catch (error) {
+      isLoadTriggeredRef.current = false
       console.error("データベース読み込みエラー:", error)
     }
   }, [enablePersistence, questionScoreId, loadAnnotations])


### PR DESCRIPTION
## Summary

Closes #500

- 下線ボタンの挿入記法を `<u></u>` から `__` に変更（パーサーと統一）
- `safeReplace` の文字列置換で `$1` がリテラル扱いされるバグを関数置換で修正
- CRUD操作時の `annotations` → `drawingElements` 同期によるレースコンディションを修正（ロード時のみ同期に限定）

## Test plan

- [ ] テキストエディタで太字 (`**text**`) を入力し、`$1` ではなく正しく太字表示されることを確認
- [ ] 下線ボタンを押して `__` 記法が挿入されることを確認
- [ ] テキスト編集後に他のアノテーション（線、矩形等）が消えないことを確認
- [ ] 設問切替時にアノテーションが正しくロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)