### PR TITLE
描画ツールパレットにショートカットキー表示を統一追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
+import { useKeyBindings } from "@/components/exams/07-score-at-once/hooks/useKeyBindings"
 import type { CropRegionWithExamPage } from "@/components/exams/07-score-at-once/types"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
@@ -233,6 +234,9 @@ export function DrawingToolPalette({
     },
     [selectedTexts, onUpdateSelectedElements, onStrokeColorChange]
   )
+  // キーバインディング取得
+  const { keyBindings } = useKeyBindings()
+
   const [isVisible, setIsVisible] = useState(true)
   const [isHovered, setIsHovered] = useState(false)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
@@ -453,6 +457,12 @@ export function DrawingToolPalette({
                   <div className="text-center">
                     <div className="font-medium">ハンドツール</div>
                     <div className="text-xs text-gray-400">ドラッグで移動</div>
+                    <div className="mt-1 text-xs text-gray-400">
+                      キー:{" "}
+                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                        {(keyBindings["tool.hand"] || "H").toUpperCase()}
+                      </kbd>
+                    </div>
                   </div>
                 </TooltipPrimitive.Content>
               </TooltipPrimitive.Portal>
@@ -479,6 +489,12 @@ export function DrawingToolPalette({
                     <div className="text-xs text-gray-400">
                       図形を選択・移動・削除
                     </div>
+                    <div className="mt-1 text-xs text-gray-400">
+                      キー:{" "}
+                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                        {(keyBindings["tool.select"] || "G").toUpperCase()}
+                      </kbd>
+                    </div>
                   </div>
                 </TooltipPrimitive.Content>
               </TooltipPrimitive.Portal>
@@ -500,6 +516,7 @@ export function DrawingToolPalette({
                 selectedTexts.length > 0
               }
               onClearSelection={onClearSelection}
+              shortcutKey={keyBindings["tool.line"] || "L"}
             />
 
             <RectangleToolPopover
@@ -516,6 +533,7 @@ export function DrawingToolPalette({
                 selectedTexts.length > 0
               }
               onClearSelection={onClearSelection}
+              shortcutKey={keyBindings["tool.rectangle"] || "B"}
             />
 
             <EllipseToolPopover
@@ -532,6 +550,7 @@ export function DrawingToolPalette({
                 selectedTexts.length > 0
               }
               onClearSelection={onClearSelection}
+              shortcutKey={keyBindings["tool.ellipse"] || "Y"}
             />
 
             <TextToolPopover
@@ -546,6 +565,7 @@ export function DrawingToolPalette({
                 selectedEllipses.length > 0
               }
               onClearSelection={onClearSelection}
+              shortcutKey={keyBindings["tool.text"] || "T"}
             />
 
             {/* お気に入り登録ボタン（要素選択時のみ表示） */}

--- a/components/exams/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { Circle } from "lucide-react"
 import { useState } from "react"
 
@@ -11,6 +12,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { Slider } from "@/components/ui/slider"
+import { cn } from "@/lib/utils"
 
 import { COLOR_PALETTE } from "./constants/drawingConstants"
 import type { DrawingTool } from "./types/answerIndividualTypes"
@@ -25,6 +27,7 @@ interface EllipseToolPopoverProps {
   hasSelectedElement?: boolean // 選択中の楕円があるかどうか
   hasOtherTypeSelected?: boolean // 他のタイプの要素が選択されているか
   onClearSelection?: () => void
+  shortcutKey?: string
 }
 
 export function EllipseToolPopover({
@@ -37,6 +40,7 @@ export function EllipseToolPopover({
   hasSelectedElement = false,
   hasOtherTypeSelected = false,
   onClearSelection,
+  shortcutKey,
 }: EllipseToolPopoverProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -65,30 +69,56 @@ export function EllipseToolPopover({
   // ボタンがアクティブ状態かどうか
   const isActive = currentTool === "ellipse" || hasSelectedElement
 
+  const tooltipContentClass = cn(
+    "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+    "data-[side=right]:slide-in-from-left-2",
+    "z-50 w-fit rounded-md px-3 py-1.5 text-xs"
+  )
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          size="sm"
-          variant={isActive ? "default" : "ghost"}
-          onClick={handleClick}
-          onPointerDown={(e) => e.stopPropagation()}
-          title={
-            hasSelectedElement
-              ? "選択中の楕円を編集"
-              : "楕円ツール - Shift+ドラッグで正円"
-          }
-          style={{
-            backgroundColor: isActive ? strokeColor : undefined,
-            borderColor: isActive ? strokeColor : undefined,
-          }}
-        >
-          <Circle
-            className="h-4 w-4"
-            style={{ color: isActive ? "white" : undefined }}
-          />
-        </Button>
-      </PopoverTrigger>
+      <TooltipPrimitive.Root open={isOpen ? false : undefined}>
+        <TooltipPrimitive.Trigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              size="sm"
+              variant={isActive ? "default" : "ghost"}
+              onClick={handleClick}
+              onPointerDown={(e) => e.stopPropagation()}
+              style={{
+                backgroundColor: isActive ? strokeColor : undefined,
+                borderColor: isActive ? strokeColor : undefined,
+              }}
+            >
+              <Circle
+                className="h-4 w-4"
+                style={{ color: isActive ? "white" : undefined }}
+              />
+            </Button>
+          </PopoverTrigger>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side="right"
+            sideOffset={5}
+            className={tooltipContentClass}
+          >
+            <div className="text-center">
+              <div className="font-medium">楕円ツール</div>
+              <div className="text-xs text-gray-400">Shift+ドラッグで正円</div>
+              {shortcutKey && (
+                <div className="mt-1 text-xs text-gray-400">
+                  キー:{" "}
+                  <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                    {shortcutKey.toUpperCase()}
+                  </kbd>
+                </div>
+              )}
+            </div>
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
       <PopoverContent className="w-64" side="right">
         <div className="space-y-3">
           <h4 className="text-sm font-medium">

--- a/components/exams/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { Ruler } from "lucide-react"
 import { useState } from "react"
 
@@ -11,6 +12,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { Slider } from "@/components/ui/slider"
+import { cn } from "@/lib/utils"
 
 import { COLOR_PALETTE } from "./constants/drawingConstants"
 import type { DrawingTool } from "./types/answerIndividualTypes"
@@ -27,6 +29,7 @@ interface LineToolPopoverProps {
   hasSelectedElement?: boolean // 選択中の線があるかどうか
   hasOtherTypeSelected?: boolean // 他のタイプの要素が選択されているか
   onClearSelection?: () => void
+  shortcutKey?: string
 }
 
 export function LineToolPopover({
@@ -41,6 +44,7 @@ export function LineToolPopover({
   hasSelectedElement = false,
   hasOtherTypeSelected = false,
   onClearSelection,
+  shortcutKey,
 }: LineToolPopoverProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -70,30 +74,58 @@ export function LineToolPopover({
   // ボタンがアクティブ状態かどうか（線ツール選択中 または 線を選択中）
   const isActive = currentTool === "line" || hasSelectedElement
 
+  const tooltipContentClass = cn(
+    "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+    "data-[side=right]:slide-in-from-left-2",
+    "z-50 w-fit rounded-md px-3 py-1.5 text-xs"
+  )
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          size="sm"
-          variant={isActive ? "default" : "ghost"}
-          onClick={handleClick}
-          onPointerDown={(e) => e.stopPropagation()}
-          title={
-            hasSelectedElement
-              ? "選択中の線を編集"
-              : "自由線ツール - Shift+ドラッグで鉛直・水平線"
-          }
-          style={{
-            backgroundColor: isActive ? strokeColor : undefined,
-            borderColor: isActive ? strokeColor : undefined,
-          }}
-        >
-          <Ruler
-            className="h-4 w-4"
-            style={{ color: isActive ? "white" : undefined }}
-          />
-        </Button>
-      </PopoverTrigger>
+      <TooltipPrimitive.Root open={isOpen ? false : undefined}>
+        <TooltipPrimitive.Trigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              size="sm"
+              variant={isActive ? "default" : "ghost"}
+              onClick={handleClick}
+              onPointerDown={(e) => e.stopPropagation()}
+              style={{
+                backgroundColor: isActive ? strokeColor : undefined,
+                borderColor: isActive ? strokeColor : undefined,
+              }}
+            >
+              <Ruler
+                className="h-4 w-4"
+                style={{ color: isActive ? "white" : undefined }}
+              />
+            </Button>
+          </PopoverTrigger>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side="right"
+            sideOffset={5}
+            className={tooltipContentClass}
+          >
+            <div className="text-center">
+              <div className="font-medium">線ツール</div>
+              <div className="text-xs text-gray-400">
+                Shift+ドラッグで鉛直・水平線
+              </div>
+              {shortcutKey && (
+                <div className="mt-1 text-xs text-gray-400">
+                  キー:{" "}
+                  <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                    {shortcutKey.toUpperCase()}
+                  </kbd>
+                </div>
+              )}
+            </div>
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
       <PopoverContent className="w-64" side="right">
         <div className="space-y-3">
           <h4 className="text-sm font-medium">

--- a/components/exams/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { RectangleHorizontal } from "lucide-react"
 import { useState } from "react"
 
@@ -11,6 +12,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { Slider } from "@/components/ui/slider"
+import { cn } from "@/lib/utils"
 
 import { COLOR_PALETTE } from "./constants/drawingConstants"
 import type { DrawingTool } from "./types/answerIndividualTypes"
@@ -25,6 +27,7 @@ interface RectangleToolPopoverProps {
   hasSelectedElement?: boolean // 選択中の長方形があるかどうか
   hasOtherTypeSelected?: boolean // 他のタイプの要素が選択されているか
   onClearSelection?: () => void
+  shortcutKey?: string
 }
 
 export function RectangleToolPopover({
@@ -37,6 +40,7 @@ export function RectangleToolPopover({
   hasSelectedElement = false,
   hasOtherTypeSelected = false,
   onClearSelection,
+  shortcutKey,
 }: RectangleToolPopoverProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -65,30 +69,58 @@ export function RectangleToolPopover({
   // ボタンがアクティブ状態かどうか
   const isActive = currentTool === "rectangle" || hasSelectedElement
 
+  const tooltipContentClass = cn(
+    "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+    "data-[side=right]:slide-in-from-left-2",
+    "z-50 w-fit rounded-md px-3 py-1.5 text-xs"
+  )
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          size="sm"
-          variant={isActive ? "default" : "ghost"}
-          onClick={handleClick}
-          onPointerDown={(e) => e.stopPropagation()}
-          title={
-            hasSelectedElement
-              ? "選択中の長方形を編集"
-              : "矩形ツール - Shift+ドラッグで正方形"
-          }
-          style={{
-            backgroundColor: isActive ? strokeColor : undefined,
-            borderColor: isActive ? strokeColor : undefined,
-          }}
-        >
-          <RectangleHorizontal
-            className="h-4 w-4"
-            style={{ color: isActive ? "white" : undefined }}
-          />
-        </Button>
-      </PopoverTrigger>
+      <TooltipPrimitive.Root open={isOpen ? false : undefined}>
+        <TooltipPrimitive.Trigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              size="sm"
+              variant={isActive ? "default" : "ghost"}
+              onClick={handleClick}
+              onPointerDown={(e) => e.stopPropagation()}
+              style={{
+                backgroundColor: isActive ? strokeColor : undefined,
+                borderColor: isActive ? strokeColor : undefined,
+              }}
+            >
+              <RectangleHorizontal
+                className="h-4 w-4"
+                style={{ color: isActive ? "white" : undefined }}
+              />
+            </Button>
+          </PopoverTrigger>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side="right"
+            sideOffset={5}
+            className={tooltipContentClass}
+          >
+            <div className="text-center">
+              <div className="font-medium">矩形ツール</div>
+              <div className="text-xs text-gray-400">
+                Shift+ドラッグで正方形
+              </div>
+              {shortcutKey && (
+                <div className="mt-1 text-xs text-gray-400">
+                  キー:{" "}
+                  <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                    {shortcutKey.toUpperCase()}
+                  </kbd>
+                </div>
+              )}
+            </div>
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
       <PopoverContent className="w-64" side="right">
         <div className="space-y-3">
           <h4 className="text-sm font-medium">

--- a/components/exams/07-score-at-once/ScoringIndividual/TextToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/TextToolPopover.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { Type } from "lucide-react"
 import { useState } from "react"
 
@@ -10,6 +11,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
 
 import { COLOR_PALETTE } from "./constants/drawingConstants"
 import type { DrawingTool } from "./types/answerIndividualTypes"
@@ -22,6 +24,7 @@ interface TextToolPopoverProps {
   hasSelectedElement?: boolean // 選択中のテキストがあるかどうか
   hasOtherTypeSelected?: boolean // 他のタイプの要素が選択されているか
   onClearSelection?: () => void
+  shortcutKey?: string
 }
 
 export function TextToolPopover({
@@ -32,6 +35,7 @@ export function TextToolPopover({
   hasSelectedElement = false,
   hasOtherTypeSelected = false,
   onClearSelection,
+  shortcutKey,
 }: TextToolPopoverProps) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -60,30 +64,58 @@ export function TextToolPopover({
   // ボタンがアクティブ状態かどうか
   const isActive = currentTool === "text" || hasSelectedElement
 
+  const tooltipContentClass = cn(
+    "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+    "data-[side=right]:slide-in-from-left-2",
+    "z-50 w-fit rounded-md px-3 py-1.5 text-xs"
+  )
+
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          size="sm"
-          variant={isActive ? "default" : "ghost"}
-          onClick={handleClick}
-          onPointerDown={(e) => e.stopPropagation()}
-          title={
-            hasSelectedElement
-              ? "選択中のテキストを編集"
-              : "テキストアンカー - クリックでテキスト配置"
-          }
-          style={{
-            backgroundColor: isActive ? textColor : undefined,
-            borderColor: isActive ? textColor : undefined,
-          }}
-        >
-          <Type
-            className="h-4 w-4"
-            style={{ color: isActive ? "white" : undefined }}
-          />
-        </Button>
-      </PopoverTrigger>
+      <TooltipPrimitive.Root open={isOpen ? false : undefined}>
+        <TooltipPrimitive.Trigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              size="sm"
+              variant={isActive ? "default" : "ghost"}
+              onClick={handleClick}
+              onPointerDown={(e) => e.stopPropagation()}
+              style={{
+                backgroundColor: isActive ? textColor : undefined,
+                borderColor: isActive ? textColor : undefined,
+              }}
+            >
+              <Type
+                className="h-4 w-4"
+                style={{ color: isActive ? "white" : undefined }}
+              />
+            </Button>
+          </PopoverTrigger>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side="right"
+            sideOffset={5}
+            className={tooltipContentClass}
+          >
+            <div className="text-center">
+              <div className="font-medium">テキストツール</div>
+              <div className="text-xs text-gray-400">
+                クリックでテキスト配置
+              </div>
+              {shortcutKey && (
+                <div className="mt-1 text-xs text-gray-400">
+                  キー:{" "}
+                  <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
+                    {shortcutKey.toUpperCase()}
+                  </kbd>
+                </div>
+              )}
+            </div>
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
       <PopoverContent className="w-64" side="right">
         <div className="space-y-3">
           <h4 className="text-sm font-medium">

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
@@ -84,7 +84,7 @@ export function useTextboxV4Integration({
   // モーダル表示状態
   const [showV4Modal, setShowV4Modal] = useState(false)
   const [currentTextValue, setCurrentTextValue] = useState("")
-  const [currentTextColor, setCurrentTextColor] = useState("#000000")
+  const [currentTextColor, setCurrentTextColor] = useState("#ef4444")
   const [currentPosition, setCurrentPosition] = useState({ x: 0.5, y: 0.5 })
   const [currentFontSize, setCurrentFontSize] = useState(16)
   const [currentAnchorDirection, setCurrentAnchorDirection] =


### PR DESCRIPTION
## Summary
- 描画ツールパレットの全ボタンに統一UIでショートカットキー表示を追加
- テキストツールのデフォルト色を他ツールと統一（赤）

Closes #504

## 変更内容
- ハンド・選択ツール: 既存Tooltipにキーバインディングのショートカットキーを追加
- 線・矩形・楕円・テキストツール: `TooltipPrimitive`でスタイル付きTooltipを新規追加（Popover非表示時のみ表示）
- テキストツールのデフォルト色: `#000000` → `#ef4444`

## Test plan
- [ ] 個別採点モードで各描画ツールボタンにホバーし、統一されたTooltip（ツール名+説明+ショートカットキー）が表示されることを確認
- [ ] 線・矩形・楕円・テキストツールのPopover表示中にTooltipが出ないことを確認
- [ ] テキストツールで新規テキスト作成時、デフォルト色が赤であることを確認
- [ ] ショートカットキーで各ツールが正常に切り替わることを確認