### PR TITLE
fix: 個別表示切替時のアノテーション非表示バグを修正

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -148,6 +148,7 @@ export default function AnswerIndividualView({
     currentStudentId,
     currentCropRegion,
     currentUserId,
+    refreshKey: annotationRefreshKey,
   })
 
   // テキスト入力状態変更の通知

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -909,6 +909,12 @@ export function useCanvasDrawing({
   const isDrawingTextCanvasRef = useRef(false)
   const needsTextRedrawRef = useRef(false)
 
+  // 最新のdrawTextCanvasをrefで保持（stale closure防止）
+  // executeTextCanvasDrawのfinally内で再帰呼び出しする際、
+  // 古いクロージャのdrawTextCanvasではなく最新版を使用する
+  const latestDrawTextCanvasRef = useRef(drawTextCanvas)
+  latestDrawTextCanvasRef.current = drawTextCanvas
+
   const executeTextCanvasDraw = useCallback(async () => {
     if (isDrawingTextCanvasRef.current) {
       needsTextRedrawRef.current = true
@@ -919,16 +925,19 @@ export function useCanvasDrawing({
     needsTextRedrawRef.current = false
 
     try {
-      await drawTextCanvas()
+      // refから最新のdrawTextCanvasを取得（stale closure防止）
+      await latestDrawTextCanvasRef.current()
     } finally {
       isDrawingTextCanvasRef.current = false
 
       if (needsTextRedrawRef.current) {
         needsTextRedrawRef.current = false
+        // 再帰呼び出しもrefを通じて最新版を使用するため、
+        // 安定した参照（deps: []）のまま正しく動作する
         executeTextCanvasDraw()
       }
     }
-  }, [drawTextCanvas])
+  }, []) // deps不要: drawTextCanvasはrefから取得
 
   // テキストドラッグ終了時の再描画
   useEffect(() => {

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
@@ -169,7 +169,18 @@ export function useDrawingState(
   // CRUD操作時はsetAnnotationsによるuseEffect発火をスキップし、
   // 楽観的更新（addDrawingElement/updateDrawingElement/removeDrawingElement）に依存する
   // これにより、まだDBに保存されていない楽観的更新が上書きされることを防ぐ
+  //
+  // 注意: 初回マウント時、useEffect([annotations])はannotations=[]で即座に発火するが、
+  // loadAnnotationsはまだ非同期完了していない。この初回発火でisLoadTriggeredRefが
+  // 消費されると、実際のデータ到着時にスキップされてしまう。
+  // isInitialMountRefで初回発火をスキップすることでこの問題を回避する。
+  const isInitialMountRef = useRef(true)
+
   useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false
+      return
+    }
     if (!isLoadTriggeredRef.current) {
       return
     }

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
@@ -15,6 +15,8 @@ export interface UseAllStudentAnnotationsParams {
   currentCropRegion?: CropRegionWithExamPage | null
   /** 現在のユーザーID（アノテーション取得のフィルタリング用） */
   currentUserId?: string
+  /** 外部からのアノテーション変更通知キー（変更時にリロード） */
+  refreshKey?: number
 }
 
 /** 全設問アノテーション読み込みフックの戻り値 */
@@ -38,6 +40,7 @@ export function useAllStudentAnnotations({
   currentStudentId,
   currentCropRegion,
   currentUserId,
+  refreshKey,
 }: UseAllStudentAnnotationsParams): UseAllStudentAnnotationsReturn {
   const [allStudentAnnotations, setAllStudentAnnotations] = useState<
     DrawingAnnotation[]
@@ -88,6 +91,7 @@ export function useAllStudentAnnotations({
     currentCropRegion?.examPage?.examId,
     currentCropRegion?.id,
     currentUserId,
+    refreshKey,
   ])
 
   return { allStudentAnnotations }


### PR DESCRIPTION
## Summary

Closes #506

- **useDrawingState**: `isInitialMountRef`で初回マウント時の`useEffect`発火をスキップし、`isLoadTriggeredRef`が`loadAnnotations`完了前に消費されるレースコンディションを修正
- **useCanvasDrawing**: `latestDrawTextCanvasRef`パターンで`executeTextCanvasDraw`内のstale closureを修正
- **useAllStudentAnnotations**: `refreshKey`パラメータ追加でパレットからのアノテーション追加後のリロードを実現

## Test plan

- [ ] 一覧表示から個別表示に切り替えた際、アノテーションが正しく表示されることを確認
- [ ] 個別表示内で生徒を切り替えた際、テキストアノテーションが正しく再描画されることを確認
- [ ] 一覧表示でパレットからアノテーション追加後、個別表示で操作（ドラッグ等）可能なことを確認
- [ ] テキスト編集後にアノテーションが消えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)