### PR TITLE
個別表示モードにレイアウト方向対応の生徒移動ショートカットを追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/DrawingToolPalette.tsx
@@ -396,7 +396,7 @@ export function DrawingToolPalette({
                     <div className="mt-1 text-xs text-gray-400">
                       キー:{" "}
                       <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
-                        A
+                        {(keyBindings["view.fullView"] || "M").toUpperCase()}
                       </kbd>
                     </div>
                   </div>
@@ -426,7 +426,9 @@ export function DrawingToolPalette({
                     <div className="mt-1 text-xs text-gray-400">
                       キー:{" "}
                       <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs text-gray-800">
-                        C
+                        {(
+                          keyBindings["view.questionView"] || "C"
+                        ).toUpperCase()}
                       </kbd>
                     </div>
                   </div>

--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -154,15 +154,19 @@ function ScoringMainViewContent() {
   })
 
   /** 生徒・答案管理フック */
-  const { students, handleStudentChange, handleIndividualNextStudent } =
-    useStudentAnswerManagement({
-      studentAnswerImages,
-      selectedStudentAnswerImageIds,
-      gradingMode,
-      currentCropRegion,
-      setSelectedPageImageIds,
-      setCurrentStudentIndex,
-    })
+  const {
+    students,
+    handleStudentChange,
+    handleIndividualNextStudent,
+    handleIndividualPrevStudent,
+  } = useStudentAnswerManagement({
+    studentAnswerImages,
+    selectedStudentAnswerImageIds,
+    gradingMode,
+    currentCropRegion,
+    setSelectedPageImageIds,
+    setCurrentStudentIndex,
+  })
 
   /** 採点データ管理hook */
   const {
@@ -239,6 +243,48 @@ function ScoringMainViewContent() {
     cropRegions: cropRegions,
   })
 
+  /**
+   * 個別モード用ナビゲーション
+   * レイアウト方向に応じてWASD/矢印キーを次/前の生徒に変換
+   */
+  const handleIndividualNavigation = useCallback(
+    (key: string) => {
+      // レイアウト方向ごとに「次の生徒」方向のキーを判定
+      let isNext = false
+      let isPrev = false
+
+      switch (layoutDirection) {
+        case "right-down":
+          // 右→下: d/s/ArrowDown = next, a/w/ArrowUp = prev
+          isNext = key === "d" || key === "s" || key === "ArrowDown"
+          isPrev = key === "a" || key === "w" || key === "ArrowUp"
+          break
+        case "left-down":
+          // 左→下: a/s/ArrowDown = next, d/w/ArrowUp = prev
+          isNext = key === "a" || key === "s" || key === "ArrowDown"
+          isPrev = key === "d" || key === "w" || key === "ArrowUp"
+          break
+        case "down-right":
+          // 下→右: s/d/ArrowDown = next, w/a/ArrowUp = prev
+          isNext = key === "s" || key === "d" || key === "ArrowDown"
+          isPrev = key === "w" || key === "a" || key === "ArrowUp"
+          break
+        case "down-left":
+          // 下→左: s/a/ArrowDown = next, w/d/ArrowUp = prev
+          isNext = key === "s" || key === "a" || key === "ArrowDown"
+          isPrev = key === "w" || key === "d" || key === "ArrowUp"
+          break
+      }
+
+      if (isNext) {
+        handleIndividualNextStudent()
+      } else if (isPrev) {
+        handleIndividualPrevStudent()
+      }
+    },
+    [layoutDirection, handleIndividualNextStudent, handleIndividualPrevStudent]
+  )
+
   const { handleBatchScoreWithProgress } = useBatchScoringWithProgress({
     selectedAnswers: selectedStudentAnswerImageIds,
     gradingMode: gradingMode,
@@ -296,6 +342,7 @@ function ScoringMainViewContent() {
     handleNextQuestion,
     handlePrevQuestion,
     handleGridNavigation,
+    handleIndividualNavigation,
     handleZoomIn,
     handleZoomOut,
     handleResetZoom,

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -22,6 +22,8 @@ interface ScoringShortcutHandlers {
   handlePrevQuestion: () => void
   /** グリッドナビゲーション */
   handleGridNavigation: (key: string) => void
+  /** 個別モードナビゲーション（レイアウト方向に応じた次/前の生徒移動） */
+  handleIndividualNavigation: (key: string) => void
   /** ズームイン */
   handleZoomIn: () => void
   /** ズームアウト */
@@ -56,6 +58,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     handleNextQuestion,
     handlePrevQuestion,
     handleGridNavigation,
+    handleIndividualNavigation,
     handleZoomIn,
     handleZoomOut,
     handleResetZoom,
@@ -264,6 +267,70 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
       category: "ナビゲーション",
     },
   })
+
+  // ========================================
+  // 個別モード用ナビゲーション（レイアウト方向対応）
+  // ========================================
+  useCommand("navigation.moveUp", () => handleIndividualNavigation("w"), {
+    when: "!inputFocus && !modalOpen && !textEditorActive && gradingMode == 'individual'",
+    metadata: {
+      title: "前の生徒（上）",
+      category: "ナビゲーション",
+      description: "レイアウト方向に応じて前の生徒に移動します",
+    },
+  })
+
+  useCommand("navigation.moveDown", () => handleIndividualNavigation("s"), {
+    when: "!inputFocus && !modalOpen && !textEditorActive && gradingMode == 'individual'",
+    metadata: {
+      title: "次の生徒（下）",
+      category: "ナビゲーション",
+      description: "レイアウト方向に応じて次の生徒に移動します",
+    },
+  })
+
+  useCommand("navigation.moveLeft", () => handleIndividualNavigation("a"), {
+    when: "!inputFocus && !modalOpen && !textEditorActive && gradingMode == 'individual'",
+    metadata: {
+      title: "前の生徒（左）",
+      category: "ナビゲーション",
+      description: "レイアウト方向に応じて前の生徒に移動します",
+    },
+  })
+
+  useCommand("navigation.moveRight", () => handleIndividualNavigation("d"), {
+    when: "!inputFocus && !modalOpen && !textEditorActive && gradingMode == 'individual'",
+    metadata: {
+      title: "次の生徒（右）",
+      category: "ナビゲーション",
+      description: "レイアウト方向に応じて次の生徒に移動します",
+    },
+  })
+
+  // 矢印キーによる個別モードの生徒移動
+  useCommand(
+    "navigation.nextStudentArrow",
+    () => handleIndividualNavigation("ArrowDown"),
+    {
+      when: "!inputFocus && !modalOpen && gradingMode == 'individual'",
+      metadata: {
+        title: "次の生徒（↓）",
+        category: "ナビゲーション",
+      },
+    }
+  )
+
+  useCommand(
+    "navigation.prevStudentArrow",
+    () => handleIndividualNavigation("ArrowUp"),
+    {
+      when: "!inputFocus && !modalOpen && gradingMode == 'individual'",
+      metadata: {
+        title: "前の生徒（↑）",
+        category: "ナビゲーション",
+      },
+    }
+  )
 
   useCommand("navigation.zoomIn", handleZoomIn, {
     when: "!inputFocus && !modalOpen",

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
@@ -57,6 +57,8 @@ interface UseStudentAnswerManagementReturn {
   handleStudentChange: (studentId: string) => void
   /** 次の生徒へ移動（個別表示用） */
   handleIndividualNextStudent: () => void
+  /** 前の生徒へ移動（個別表示用） */
+  handleIndividualPrevStudent: () => void
 }
 
 /**
@@ -202,9 +204,50 @@ export function useStudentAnswerManagement(
     currentCropRegion,
   ])
 
+  /**
+   * 前の生徒へ移動（個別表示用）
+   */
+  const handleIndividualPrevStudent = useCallback(() => {
+    if (selectedStudentAnswerImageIds.size === 0) return
+
+    const currentAnswerId = Array.from(selectedStudentAnswerImageIds)[0]
+    const currentAnswer = studentAnswerImages.find(
+      (a) => a.id === currentAnswerId
+    )
+    if (!currentAnswer) return
+
+    const sortedStudents = [...students].sort(
+      (a, b) => a.customOrder - b.customOrder
+    )
+    const currentIndex = sortedStudents.findIndex(
+      (s) => s.id === currentAnswer.student?.id
+    )
+    if (currentIndex > 0) {
+      const prevStudent = sortedStudents[currentIndex - 1]
+      const prevStudentSheets = studentAnswerImages.filter(
+        (a) => a.student?.id === prevStudent.id
+      )
+      const prevStudentAnswer = currentCropRegion
+        ? prevStudentSheets.find(
+            (a) => a.examPageId === currentCropRegion.examPageId
+          ) || prevStudentSheets[0]
+        : prevStudentSheets[0]
+      if (prevStudentAnswer) {
+        setSelectedPageImageIds(new Set([prevStudentAnswer.id]))
+      }
+    }
+  }, [
+    students,
+    selectedStudentAnswerImageIds,
+    studentAnswerImages,
+    setSelectedPageImageIds,
+    currentCropRegion,
+  ])
+
   return {
     students,
     handleStudentChange,
     handleIndividualNextStudent,
+    handleIndividualPrevStudent,
   }
 }

--- a/components/exams/07-score-at-once/constants/scoringKeybindings.ts
+++ b/components/exams/07-score-at-once/constants/scoringKeybindings.ts
@@ -66,7 +66,7 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   // ============================================
   "view.toggleStudentNames": "n",
   "view.toggleViewMode": "v",
-  "view.fullView": "a", // 全体表示（個別モード）
+  "view.fullView": "m", // 全体表示（個別モード）
   "view.questionView": "c", // 設問表示（個別モード）
 
   // ============================================


### PR DESCRIPTION
## Summary
- 個別表示モードでWASD/矢印キーによるレイアウト方向対応の生徒間移動を実装
- `view.fullView`キーを`A`→`M`に変更し、`A`をナビゲーションに開放

Closes #508

## 変更内容
- `handleIndividualPrevStudent`を新規追加（前の生徒への移動）
- `handleIndividualNavigation`でレイアウト方向に応じたキーマッピングを実装
- `useScoringShortcuts`に個別モード用WASD/矢印コマンドを登録
- `DrawingToolPalette`の全体表示・設問表示Tooltipをキーバインディングから動的取得に変更

## Test plan
- [ ] 各レイアウト方向でWASDキーが正しく次/前の生徒に移動することを確認
- [ ] 矢印キー（↑/↓）で生徒移動が動作することを確認
- [ ] 全体表示が`M`キーで動作することを確認
- [ ] DrawingToolPaletteのTooltipで`M`が表示されることを確認
- [ ] グリッドモードのWASD移動に影響がないことを確認