### PR TITLE
feat: 箱ひげ図に合計点表示とスケール修正

### DIFF
--- a/components/exams/08-export/components/IndividualReportSettings.tsx
+++ b/components/exams/08-export/components/IndividualReportSettings.tsx
@@ -245,6 +245,19 @@ export function IndividualReportSettings({
           >
             {options.graphOptions.showBoxPlot && (
               <div className="mt-2 flex flex-col gap-4">
+                <div className="flex flex-wrap gap-2">
+                  <OptionCard
+                    label="合計点"
+                    checked={options.graphOptions.showOverallBoxPlot ?? false}
+                    onChange={(v) =>
+                      updateOption("graphOptions", {
+                        ...options.graphOptions,
+                        showOverallBoxPlot: v,
+                      })
+                    }
+                    variant="sub"
+                  />
+                </div>
                 <SubtotalGroupSelector
                   examId={examId}
                   selection={options.boxPlotSubtotalGroupSelection}

--- a/components/exams/08-export/components/individual-report/BoxPlotChart.tsx
+++ b/components/exams/08-export/components/individual-report/BoxPlotChart.tsx
@@ -19,6 +19,7 @@ import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
 import {
   type BoxPlotIncludeStatuses,
   type ComputedSubtotalStat,
+  computeFilteredOverallStat,
   computeFilteredSubtotalStats,
 } from "./computeReportData"
 
@@ -44,6 +45,7 @@ interface BoxPlotChartProps {
   boxPlotIncludeStatuses?: BoxPlotIncludeStatuses
   boxPlotFontSize?: number
   boxPlotItemHeight?: number
+  showOverallBoxPlot?: boolean
 }
 
 /**
@@ -65,6 +67,7 @@ export function BoxPlotChart({
   boxPlotIncludeStatuses = DEFAULT_INCLUDE_STATUSES,
   boxPlotFontSize = 11,
   boxPlotItemHeight = 50,
+  showOverallBoxPlot = false,
 }: BoxPlotChartProps) {
   // renderer側で統計を再計算（受験状態フィルタ対応）
   const computedStats = useMemo(() => {
@@ -113,19 +116,43 @@ export function BoxPlotChart({
     scoringData.subtotalScores,
   ])
 
-  if (subtotalStats.length === 0) return null
-
-  // 各小計の得点を取得
-  const getStudentScore = (subtotalId: string): number => {
-    const subtotal = scoringData.subtotalScores.find(
-      (s) => s.subtotalId === subtotalId
+  // 合計点の箱ひげ図データ
+  const overallStat = useMemo(() => {
+    if (!showOverallBoxPlot) return null
+    return computeFilteredOverallStat(
+      statistics.rawTotalScores || [],
+      scoringData.totalMaxScore,
+      boxPlotIncludeStatuses
     )
+  }, [
+    showOverallBoxPlot,
+    statistics.rawTotalScores,
+    scoringData.totalMaxScore,
+    boxPlotIncludeStatuses,
+  ])
+
+  // 全項目を合成: [合計点] + [小計別]
+  const allStats = useMemo(() => {
+    const items: ComputedSubtotalStat[] = []
+    if (overallStat) items.push(overallStat)
+    items.push(...subtotalStats)
+    return items
+  }, [overallStat, subtotalStats])
+
+  if (allStats.length === 0) return null
+
+  // 各項目の得点を取得
+  const getStudentScore = (id: string): number => {
+    if (id === "__overall__") {
+      return scoringData.totalScore ?? 0
+    }
+    const subtotal = scoringData.subtotalScores.find((s) => s.subtotalId === id)
     return subtotal?.score ?? 0
   }
 
   return (
     <BoxPlotChartView
-      subtotalStats={subtotalStats}
+      subtotalStats={allStats}
       getStudentScore={getStudentScore}
       fontScale={fontScale}
       showMin={showMin}
@@ -261,7 +288,7 @@ export function BoxPlotChartView({
       {subtotalStats.map((stat, index) => {
         const y = marginTop + index * rowHeight
         const boxPlot = stat.boxPlot
-        const maxScore = boxPlot.max || 100
+        const maxScore = stat.maxScore || boxPlot.max || 100
 
         const toPercent = (score: number) => (score / maxScore) * 100
         const toX = (percent: number) =>

--- a/components/exams/08-export/components/individual-report/IndividualReportPreview.tsx
+++ b/components/exams/08-export/components/individual-report/IndividualReportPreview.tsx
@@ -200,7 +200,7 @@ export function IndividualReportPreview({
                 borderBottom: "1px solid #ddd",
               }}
             >
-              小計別分布
+              得点分布
             </h2>
             <BoxPlotChart
               statistics={report.statistics}
@@ -218,6 +218,7 @@ export function IndividualReportPreview({
               boxPlotIncludeStatuses={options.boxPlotIncludeStatuses}
               boxPlotFontSize={options.graphOptions.boxPlotFontSize}
               boxPlotItemHeight={options.graphOptions.boxPlotItemHeight}
+              showOverallBoxPlot={options.graphOptions.showOverallBoxPlot}
             />
           </section>
         ) : null

--- a/components/exams/08-export/components/individual-report/computeReportData.ts
+++ b/components/exams/08-export/components/individual-report/computeReportData.ts
@@ -218,6 +218,41 @@ export function computeFilteredSubtotalStats(
   })
 }
 
+/**
+ * 合計点箱ひげ図の統計を受験状態フィルタ付きで計算
+ */
+export function computeFilteredOverallStat(
+  rawTotalScores: {
+    studentId: string
+    totalScore: number | null
+    status: "participating" | "expected" | "absent"
+  }[],
+  totalMaxScore: number,
+  includeStatuses: BoxPlotIncludeStatuses
+): ComputedSubtotalStat {
+  const filteredScores = rawTotalScores
+    .filter((s) => {
+      if (s.status === "participating") return includeStatuses.participating
+      if (s.status === "expected") return includeStatuses.expected
+      if (s.status === "absent") return includeStatuses.absent
+      return true
+    })
+    .map((s) => s.totalScore)
+    .filter((s): s is number => s !== null)
+
+  return {
+    subtotalId: "__overall__",
+    subtotalLabel: "合計点",
+    subtotalGroupId: "__overall__",
+    boxPlot:
+      filteredScores.length > 0
+        ? calculateBoxPlotData(filteredScores)
+        : { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
+    average: calculateAverage(filteredScores),
+    maxScore: totalMaxScore,
+  }
+}
+
 // ============================
 // 小計点テーブル計算
 // ============================

--- a/components/exams/08-export/components/individual-report/generatePrintHtml.ts
+++ b/components/exams/08-export/components/individual-report/generatePrintHtml.ts
@@ -15,6 +15,7 @@ import { BoxPlotChartView } from "./BoxPlotChart"
 import {
   allocateColumnsDHondt,
   buildStatsItems,
+  computeFilteredOverallStat,
   computeFilteredStats,
   computeFilteredSubtotalStats,
   filterSubtotalScores,
@@ -269,12 +270,32 @@ function renderSectionElement(
         )
       }
 
-      if (subtotalStats.length === 0) return null
-
       const graphOptions = options.graphOptions
-      const getStudentScore = (subtotalId: string): number => {
+
+      // 合計点を合成
+      type ComputedStat = (typeof subtotalStats)[number]
+      const allStats: ComputedStat[] = []
+
+      if (graphOptions.showOverallBoxPlot) {
+        allStats.push(
+          computeFilteredOverallStat(
+            report.statistics.rawTotalScores || [],
+            report.scoringData.totalMaxScore,
+            includeStatuses
+          )
+        )
+      }
+
+      allStats.push(...subtotalStats)
+
+      if (allStats.length === 0) return null
+
+      const getStudentScore = (id: string): number => {
+        if (id === "__overall__") {
+          return report.scoringData.totalScore ?? 0
+        }
         const subtotal = report.scoringData.subtotalScores.find(
-          (s) => s.subtotalId === subtotalId
+          (s) => s.subtotalId === id
         )
         return subtotal?.score ?? 0
       }
@@ -294,10 +315,10 @@ function renderSectionElement(
               borderBottom: "1px solid #ddd",
             },
           },
-          "小計別分布"
+          "得点分布"
         ),
         React.createElement(BoxPlotChartView, {
-          subtotalStats,
+          subtotalStats: allStats,
           getStudentScore,
           fontScale,
           showMin: graphOptions.showBoxPlotMin,

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -37,6 +37,8 @@ export interface GraphOptions {
   showBarChart: boolean
   showRadarChart: boolean
   showBoxPlot: boolean
+  // 箱ひげ図の表示対象
+  showOverallBoxPlot: boolean // 合計点の箱ひげ図を表示
   // 箱ひげ図の詳細オプション
   showBoxPlotMin: boolean // 最小値のヒゲを表示
   showBoxPlotQ1: boolean // Q1（第1四分位数）を表示
@@ -288,6 +290,7 @@ export const DEFAULT_GRAPH_OPTIONS: GraphOptions = {
   showBarChart: true,
   showRadarChart: true,
   showBoxPlot: true,
+  showOverallBoxPlot: false,
   showBoxPlotMin: true,
   showBoxPlotQ1: true,
   showBoxPlotMedian: true,


### PR DESCRIPTION
## Summary

Closes #510

- 箱ひげ図に「合計点」のワンクリック表示オプションを追加（小計別の前に表示）
- `computeFilteredOverallStat`で受験状態フィルタ付き合計点統計を計算
- 箱ひげ図のスケール計算を`boxPlot.max`（最高得点）→`stat.maxScore`（配点）に修正
- プレビュー・PDF出力の両方に対応

## Test plan

- [ ] 箱ひげ図の「合計点」チェックボックスをON/OFFして、合計点が正しく追加・削除されることを確認
- [ ] 合計点の箱ひげ図が配点に対する正しいスケールで表示されることを確認
- [ ] 小計点の箱ひげ図も配点基準のスケールに変更されていることを確認
- [ ] 受験状態フィルタが合計点にも適用されることを確認
- [ ] PDF出力でも正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)