### PR TITLE
fix: DB初期化・アーカイブ機能の整合性修正

### DIFF
--- a/electron-src/lib/export/exam-archive/archiveCreator.ts
+++ b/electron-src/lib/export/exam-archive/archiveCreator.ts
@@ -108,9 +108,12 @@ function getDataDir(): string {
  * @param options - アーカイブ作成オプション
  * @returns 作成されたアーカイブのパス
  */
-export async function createArchive(
-  options: CreateArchiveOptions
-): Promise<{ success: boolean; outputPath?: string; error?: string }> {
+export async function createArchive(options: CreateArchiveOptions): Promise<{
+  success: boolean
+  outputPath?: string
+  error?: string
+  warnings?: string[]
+}> {
   const {
     collectedData,
     examName,
@@ -134,8 +137,14 @@ export async function createArchive(
         zlib: { level: 9 }, // 最高圧縮率
       })
 
+      const missingFiles: string[] = []
+
       output.on("close", () => {
-        resolve({ success: true, outputPath })
+        resolve({
+          success: true,
+          outputPath,
+          ...(missingFiles.length > 0 ? { warnings: missingFiles } : {}),
+        })
       })
 
       archive.on("error", (err) => {
@@ -203,6 +212,7 @@ export async function createArchive(
           archive.file(absolutePath, { name: archivePath })
         } else {
           console.warn(`Master image not found: ${absolutePath}`)
+          missingFiles.push(`模範解答画像: ${path.basename(relativePath)}`)
         }
       }
 
@@ -215,6 +225,7 @@ export async function createArchive(
           archive.file(absolutePath, { name: archivePath })
         } else {
           console.warn(`Answer sheet not found: ${absolutePath}`)
+          missingFiles.push(`答案画像: ${path.basename(relativePath)}`)
         }
       }
 

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -74,6 +74,12 @@ export async function collectGradeArchiveData(
           gradeItem: { select: { name: true } },
         },
       },
+      gradeOverrides: {
+        include: {
+          student: { select: { studentNumber: true } },
+          gradeItem: { select: { name: true } },
+        },
+      },
     },
   })
 
@@ -178,6 +184,13 @@ export async function collectGradeArchiveData(
     gradeItemName: ex.gradeItem.name,
   }))
 
+  const gradeOverrides = gp.gradeOverrides.map((ov) => ({
+    studentNumber: ov.student.studentNumber,
+    targetType: ov.targetType,
+    gradeItemName: ov.gradeItem?.name ?? null,
+    overrideLabel: ov.overrideLabel,
+  }))
+
   return {
     gradeData: {
       grade: {
@@ -190,6 +203,7 @@ export async function collectGradeArchiveData(
       studentRefs,
       gradeItemExclusions:
         gradeItemExclusions.length > 0 ? gradeItemExclusions : undefined,
+      gradeOverrides: gradeOverrides.length > 0 ? gradeOverrides : undefined,
     },
     manualScoresData: { manualScores },
     boundariesData: { boundarySets },

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -292,6 +292,38 @@ export async function importGradeArchive(
         }
       }
 
+      // 8. GradeOverride挿入（後方互換: optionalフィールド）
+      if (gradeData.gradeOverrides && gradeData.gradeOverrides.length > 0) {
+        for (const ov of gradeData.gradeOverrides) {
+          const student = await tx.student.findUnique({
+            where: { studentNumber: ov.studentNumber },
+          })
+          if (!student) continue
+
+          let gradeItemId: string | null = null
+          if (ov.gradeItemName) {
+            const gradeItem = await tx.gradeItem.findFirst({
+              where: {
+                gradeId: gp.id,
+                name: ov.gradeItemName,
+              },
+            })
+            if (!gradeItem) continue
+            gradeItemId = gradeItem.id
+          }
+
+          await tx.gradeOverride.create({
+            data: {
+              gradeId: gp.id,
+              studentId: student.id,
+              targetType: ov.targetType,
+              gradeItemId,
+              overrideLabel: ov.overrideLabel,
+            },
+          })
+        }
+      }
+
       return { success: true, gradeId: gp.id }
     })
   } catch (error) {

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -431,6 +431,341 @@ CREATE TABLE "CropRegionMarkingOverride" (
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "CropRegionMarkingOverride_cropRegionId_fkey" FOREIGN KEY ("cropRegionId") REFERENCES "CropRegion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+-- CreateTable (Grade)
+CREATE TABLE "Grade" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "referenceDate" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "GradeItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeItem_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeClass" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeClass_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeClass_classId_fkey" FOREIGN KEY ("classId") REFERENCES "classes" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeStudent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "customOrder" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeStudent_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeStudent_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeDataSource" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeItemId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "examId" TEXT,
+    "subtotalId" TEXT,
+    "cropRegionId" TEXT,
+    "name" TEXT NOT NULL,
+    "maxScore" DECIMAL NOT NULL,
+    "weight" DECIMAL NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "absentMethod" TEXT NOT NULL DEFAULT 'null',
+    "absentRatio" DECIMAL NOT NULL DEFAULT 1.0,
+    "absentOffset" DECIMAL NOT NULL DEFAULT 0,
+    "treatExpectedAsMissing" BOOLEAN NOT NULL DEFAULT false,
+    "estimationMode" TEXT NOT NULL DEFAULT 'all',
+    "estimationSourceIds" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeDataSource_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeDataSource_examId_fkey" FOREIGN KEY ("examId") REFERENCES "Exam" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "GradeDataSource_subtotalId_fkey" FOREIGN KEY ("subtotalId") REFERENCES "Subtotal" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeDataSource_cropRegionId_fkey" FOREIGN KEY ("cropRegionId") REFERENCES "CropRegion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ManualScore" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeDataSourceId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "score" DECIMAL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ManualScore_gradeDataSourceId_fkey" FOREIGN KEY ("gradeDataSourceId") REFERENCES "GradeDataSource" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ManualScore_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeItemExclusion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeItemExclusion_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeItemExclusion_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeItemExclusion_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeBoundarySet" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "gradeItemId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeBoundarySet_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeBoundarySet_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeOverride" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "gradeItemId" TEXT,
+    "overrideLabel" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeOverride_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeOverride_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeOverride_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeBoundary" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeBoundarySetId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "minPercentage" DECIMAL NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeBoundary_gradeBoundarySetId_fkey" FOREIGN KEY ("gradeBoundarySetId") REFERENCES "GradeBoundarySet" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "GradeExportSettings" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "settingsJson" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeExportSettings_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable (ASB)
+CREATE TABLE "AsbDefinition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL DEFAULT '新しい解答用紙',
+    "renderMode" TEXT NOT NULL DEFAULT 'answer-sheet',
+    "labelPresetMajor" TEXT,
+    "labelPresetSub" TEXT,
+    "labelPresetBranch" TEXT,
+    "paperSize" TEXT NOT NULL DEFAULT 'A4',
+    "orientation" TEXT NOT NULL DEFAULT 'portrait',
+    "baseRowHeight" REAL NOT NULL DEFAULT 12,
+    "numberDisplayMode" TEXT NOT NULL DEFAULT 'multirow',
+    "marginTop" REAL NOT NULL DEFAULT 15,
+    "marginBottom" REAL NOT NULL DEFAULT 15,
+    "marginLeft" REAL NOT NULL DEFAULT 10,
+    "marginRight" REAL NOT NULL DEFAULT 10,
+    "colWidthMajorNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthSubNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthBranchNumber" REAL NOT NULL DEFAULT 10,
+    "majorQuestionSpacing" REAL NOT NULL DEFAULT 5,
+    "headerHeight" REAL NOT NULL DEFAULT 0,
+    "borderOuterBorder" TEXT NOT NULL DEFAULT 'solid',
+    "borderMajorDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderMajorNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderOuterBorderWidth" REAL DEFAULT 0.7,
+    "borderMajorDividerWidth" REAL DEFAULT 0.5,
+    "borderSubDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchDividerWidth" REAL DEFAULT 0.3,
+    "borderMajorNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderSubNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchNumberDividerWidth" REAL DEFAULT 0.3,
+    "omrMarkersEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "omrMarkersSizeMm" REAL NOT NULL DEFAULT 5,
+    "omrMarkersOffsetMm" REAL NOT NULL DEFAULT 3,
+    "fontFamily" TEXT NOT NULL DEFAULT 'Noto Sans JP',
+    "fontDefaultSize" REAL NOT NULL DEFAULT 6,
+    "fontMajorNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontSubNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontBranchNumberSize" REAL NOT NULL DEFAULT 5,
+    "multiColumnEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "multiColumnCount" INTEGER NOT NULL DEFAULT 2,
+    "multiColumnGapMm" REAL NOT NULL DEFAULT 5,
+    "multiColumnDividerLine" TEXT,
+    "multiColumnDividerLineWidth" REAL NOT NULL DEFAULT 0.3,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "AsbDefinition_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbHeaderField" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "definitionId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'field',
+    "label" TEXT NOT NULL,
+    "widthMm" REAL NOT NULL DEFAULT 30,
+    "heightMm" REAL NOT NULL DEFAULT 8,
+    "gridCount" INTEGER NOT NULL DEFAULT 0,
+    "lineStyle" TEXT NOT NULL DEFAULT 'solid',
+    "lineWidth" REAL NOT NULL DEFAULT 0.4,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "fontSize" REAL,
+    "linkedRegionType" TEXT,
+    CONSTRAINT "AsbHeaderField_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "AsbDefinition" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbMajorQuestion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "definitionId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbMajorQuestion_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "AsbDefinition" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbSubQuestion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "majorQuestionId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "heightMultiplier" REAL NOT NULL DEFAULT 1,
+    "points" REAL NOT NULL DEFAULT 1,
+    "usesBranchPoints" BOOLEAN,
+    "layoutWidth" TEXT,
+    "nextPlacement" TEXT,
+    "goUp" INTEGER,
+    "manuscriptEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "manuscriptColumns" INTEGER NOT NULL DEFAULT 20,
+    "manuscriptRows" INTEGER NOT NULL DEFAULT 10,
+    "manuscriptCellSizeMm" REAL NOT NULL DEFAULT 8,
+    "borderStyleTop" TEXT,
+    "borderStyleBottom" TEXT,
+    "borderStyleLeft" TEXT,
+    "borderStyleRight" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbSubQuestion_majorQuestionId_fkey" FOREIGN KEY ("majorQuestionId") REFERENCES "AsbMajorQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbBranchQuestion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subQuestionId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "heightMultiplier" REAL NOT NULL DEFAULT 1,
+    "points" REAL NOT NULL DEFAULT 1,
+    "layoutWidth" TEXT,
+    "nextPlacement" TEXT,
+    "goUp" INTEGER,
+    "borderStyleTop" TEXT,
+    "borderStyleBottom" TEXT,
+    "borderStyleLeft" TEXT,
+    "borderStyleRight" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbBranchQuestion_subQuestionId_fkey" FOREIGN KEY ("subQuestionId") REFERENCES "AsbSubQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbTextElement" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subQuestionId" TEXT,
+    "branchQuestionId" TEXT,
+    "text" TEXT NOT NULL,
+    "fontSize" REAL NOT NULL,
+    "horizontalAlign" TEXT NOT NULL DEFAULT 'left',
+    "verticalAlign" TEXT NOT NULL DEFAULT 'top',
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbTextElement_subQuestionId_fkey" FOREIGN KEY ("subQuestionId") REFERENCES "AsbSubQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AsbTextElement_branchQuestionId_fkey" FOREIGN KEY ("branchQuestionId") REFERENCES "AsbBranchQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbImageElement" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subQuestionId" TEXT,
+    "branchQuestionId" TEXT,
+    "imagePath" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "objectFit" TEXT NOT NULL DEFAULT 'contain',
+    "horizontalAlign" TEXT NOT NULL DEFAULT 'center',
+    "verticalAlign" TEXT NOT NULL DEFAULT 'middle',
+    "opacity" REAL NOT NULL DEFAULT 1,
+    "visibility" TEXT NOT NULL DEFAULT 'both',
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbImageElement_subQuestionId_fkey" FOREIGN KEY ("subQuestionId") REFERENCES "AsbSubQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AsbImageElement_branchQuestionId_fkey" FOREIGN KEY ("branchQuestionId") REFERENCES "AsbBranchQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbOmrConfig" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "subQuestionId" TEXT,
+    "branchQuestionId" TEXT,
+    "type" TEXT NOT NULL,
+    "numChoices" INTEGER,
+    "choiceLayout" TEXT,
+    "numDigits" INTEGER,
+    "correctAnswer" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbOmrConfig_subQuestionId_fkey" FOREIGN KEY ("subQuestionId") REFERENCES "AsbSubQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "AsbOmrConfig_branchQuestionId_fkey" FOREIGN KEY ("branchQuestionId") REFERENCES "AsbBranchQuestion" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "AsbOmrChoiceOption" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "omrConfigId" TEXT NOT NULL,
+    "choiceIndex" INTEGER NOT NULL,
+    "label" TEXT NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbOmrChoiceOption_omrConfigId_fkey" FOREIGN KEY ("omrConfigId") REFERENCES "AsbOmrConfig" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
         `
 
         // 現在のスキーマに完全準拠したインデックス作成SQL（最新マイグレーションに基づく）
@@ -485,6 +820,9 @@ CREATE INDEX "DrawingAnnotation_type_idx" ON "DrawingAnnotation"("type");
 
 -- CreateIndex
 CREATE INDEX "DrawingAnnotation_createdAt_idx" ON "DrawingAnnotation"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "DrawingAnnotation_isFavorite_idx" ON "DrawingAnnotation"("isFavorite");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "UserExam_userId_examId_key" ON "UserExam"("userId", "examId");
@@ -545,6 +883,132 @@ CREATE INDEX "StudentAnswerImage_examPageId_idx" ON "StudentAnswerImage"("examPa
 
 -- CreateIndex
 CREATE INDEX "StudentAnswerImage_studentId_idx" ON "StudentAnswerImage"("studentId");
+
+-- CreateIndex (Grade)
+CREATE INDEX "GradeItem_gradeId_idx" ON "GradeItem"("gradeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeClass_gradeId_classId_key" ON "GradeClass"("gradeId", "classId");
+
+-- CreateIndex
+CREATE INDEX "GradeClass_gradeId_idx" ON "GradeClass"("gradeId");
+
+-- CreateIndex
+CREATE INDEX "GradeClass_classId_idx" ON "GradeClass"("classId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeStudent_gradeId_studentId_key" ON "GradeStudent"("gradeId", "studentId");
+
+-- CreateIndex
+CREATE INDEX "GradeStudent_gradeId_idx" ON "GradeStudent"("gradeId");
+
+-- CreateIndex
+CREATE INDEX "GradeStudent_studentId_idx" ON "GradeStudent"("studentId");
+
+-- CreateIndex
+CREATE INDEX "GradeStudent_gradeId_customOrder_idx" ON "GradeStudent"("gradeId", "customOrder");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSource_gradeItemId_idx" ON "GradeDataSource"("gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSource_examId_idx" ON "GradeDataSource"("examId");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSource_subtotalId_idx" ON "GradeDataSource"("subtotalId");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSource_cropRegionId_idx" ON "GradeDataSource"("cropRegionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ManualScore_gradeDataSourceId_studentId_key" ON "ManualScore"("gradeDataSourceId", "studentId");
+
+-- CreateIndex
+CREATE INDEX "ManualScore_gradeDataSourceId_idx" ON "ManualScore"("gradeDataSourceId");
+
+-- CreateIndex
+CREATE INDEX "ManualScore_studentId_idx" ON "ManualScore"("studentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeItemExclusion_gradeId_studentId_gradeItemId_key" ON "GradeItemExclusion"("gradeId", "studentId", "gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeItemExclusion_gradeId_idx" ON "GradeItemExclusion"("gradeId");
+
+-- CreateIndex
+CREATE INDEX "GradeItemExclusion_studentId_idx" ON "GradeItemExclusion"("studentId");
+
+-- CreateIndex
+CREATE INDEX "GradeItemExclusion_gradeItemId_idx" ON "GradeItemExclusion"("gradeItemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeBoundarySet_gradeId_targetType_gradeItemId_key" ON "GradeBoundarySet"("gradeId", "targetType", "gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeBoundarySet_gradeId_idx" ON "GradeBoundarySet"("gradeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeOverride_gradeId_studentId_targetType_gradeItemId_key" ON "GradeOverride"("gradeId", "studentId", "targetType", "gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeOverride_gradeId_idx" ON "GradeOverride"("gradeId");
+
+-- CreateIndex
+CREATE INDEX "GradeOverride_studentId_idx" ON "GradeOverride"("studentId");
+
+-- CreateIndex
+CREATE INDEX "GradeOverride_gradeItemId_idx" ON "GradeOverride"("gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeBoundary_gradeBoundarySetId_idx" ON "GradeBoundary"("gradeBoundarySetId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeExportSettings_gradeId_key" ON "GradeExportSettings"("gradeId");
+
+-- CreateIndex (ASB)
+CREATE INDEX "AsbDefinition_userId_idx" ON "AsbDefinition"("userId");
+
+-- CreateIndex
+CREATE INDEX "AsbHeaderField_definitionId_idx" ON "AsbHeaderField"("definitionId");
+
+-- CreateIndex
+CREATE INDEX "AsbMajorQuestion_definitionId_idx" ON "AsbMajorQuestion"("definitionId");
+
+-- CreateIndex
+CREATE INDEX "AsbSubQuestion_majorQuestionId_idx" ON "AsbSubQuestion"("majorQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbBranchQuestion_subQuestionId_idx" ON "AsbBranchQuestion"("subQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbTextElement_subQuestionId_idx" ON "AsbTextElement"("subQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbTextElement_branchQuestionId_idx" ON "AsbTextElement"("branchQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbImageElement_subQuestionId_idx" ON "AsbImageElement"("subQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbImageElement_branchQuestionId_idx" ON "AsbImageElement"("branchQuestionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AsbOmrConfig_subQuestionId_key" ON "AsbOmrConfig"("subQuestionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AsbOmrConfig_branchQuestionId_key" ON "AsbOmrConfig"("branchQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbOmrConfig_subQuestionId_idx" ON "AsbOmrConfig"("subQuestionId");
+
+-- CreateIndex
+CREATE INDEX "AsbOmrConfig_branchQuestionId_idx" ON "AsbOmrConfig"("branchQuestionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AsbOmrChoiceOption_omrConfigId_choiceIndex_key" ON "AsbOmrChoiceOption"("omrConfigId", "choiceIndex");
+
+-- CreateIndex
+CREATE INDEX "AsbOmrChoiceOption_omrConfigId_idx" ON "AsbOmrChoiceOption"("omrConfigId");
         `
 
         // SQLを複数のステートメントに分割して実行

--- a/electron-src/lib/prisma/scoringInitializer.ts
+++ b/electron-src/lib/prisma/scoringInitializer.ts
@@ -30,26 +30,34 @@ export const initializeScoringRecords = async (examId: string) => {
         throw new Error("No default user found for scoring initialization")
       }
 
+      const studentIds = examStudents.map((es) => es.studentId)
+      const regionIds = questionRegions.map((r) => r.id)
+
+      // 既存レコードを一括取得してSetで管理
+      const existingScores = await tx.questionScore.findMany({
+        where: {
+          studentId: { in: studentIds },
+          cropRegionId: { in: regionIds },
+          userId: defaultUser.id,
+        },
+        select: { studentId: true, cropRegionId: true },
+      })
+      const existingSet = new Set(
+        existingScores.map((s) => `${s.studentId}#${s.cropRegionId}`)
+      )
+
       const scoringRecords = []
 
       // 全ての生徒×採点領域の組み合わせを作成
       for (const examStudent of examStudents) {
         for (const region of questionRegions) {
-          // 既存レコードをチェック
-          const existing = await tx.questionScore.findFirst({
-            where: {
-              studentId: examStudent.studentId,
-              cropRegionId: region.id,
-              userId: defaultUser.id,
-            },
-          })
-
-          if (!existing) {
+          const key = `${examStudent.studentId}#${region.id}`
+          if (!existingSet.has(key)) {
             scoringRecords.push({
               studentId: examStudent.studentId,
               cropRegionId: region.id,
               partialScore: null,
-              status: "ungraded",
+              status: "unscored",
               userId: defaultUser.id,
             })
           }

--- a/types/gradeArchive.types.ts
+++ b/types/gradeArchive.types.ts
@@ -48,6 +48,13 @@ export interface ArchiveGradeData {
     studentNumber: string
     gradeItemName: string
   }[]
+  /** 成績ラベル手動上書き（後方互換: optional） */
+  gradeOverrides?: {
+    studentNumber: string
+    targetType: string
+    gradeItemName: string | null
+    overrideLabel: string
+  }[]
 }
 
 export interface ArchiveGradeItem {


### PR DESCRIPTION
## Summary

Closes #512

- databaseInitializerにGrade関連11テーブル・ASB関連9テーブルのCREATE TABLEと38個のインデックスを追加
- scoringInitializerのステータス値を"unscored"に修正し、N+1クエリをfindMany一括取得に改善
- GradeOverridesのエクスポート・インポート対応を追加（データ喪失防止）
- archiveCreatorに欠損ファイル警告のwarnings返却を追加

## 変更ファイル

| ファイル | 修正内容 |
|---------|---------|
| `databaseInitializer.ts` | Grade×11 + ASB×9テーブル、インデックス38個追加 |
| `scoringInitializer.ts` | ステータス値修正 + N+1クエリ解消 |
| `gradeArchive.types.ts` | GradeOverrides型追加 |
| `gradeArchiveDataCollector.ts` | GradeOverrides収集追加 |
| `gradeArchiveImporter.ts` | GradeOverridesインポート追加 |
| `archiveCreator.ts` | 欠損ファイルwarnings返却追加 |

## Test plan

- [ ] 新規DBで全テーブル・インデックスが作成されることを確認
- [ ] 採点初期化で"unscored"ステータスが設定されることを確認
- [ ] GradeOverridesを含む成績アーカイブのエクスポート→インポートが正常動作することを確認
- [ ] 画像欠損時にwarningsが返却されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)