### PR TITLE
feat: 答案画像のマーカー補正機能を追加

### DIFF
--- a/components/exams/06-student-answers/student-answer-table/components/MarkerCorrectionToggle.tsx
+++ b/components/exams/06-student-answers/student-answer-table/components/MarkerCorrectionToggle.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Crosshair } from "lucide-react"
+
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+interface MarkerCorrectionToggleProps {
+  enabled: boolean
+  available: boolean
+  onChange: (enabled: boolean) => void
+}
+
+export function MarkerCorrectionToggle({
+  enabled,
+  available,
+  onChange,
+}: MarkerCorrectionToggleProps) {
+  const toggle = (
+    <div className="flex items-center gap-2">
+      <Switch
+        id="marker-correction-toggle"
+        checked={enabled}
+        onCheckedChange={onChange}
+        disabled={!available}
+      />
+      <Label
+        htmlFor="marker-correction-toggle"
+        className={`flex items-center gap-1 text-sm ${
+          !available ? "text-gray-400" : ""
+        }`}
+      >
+        <Crosshair
+          className={`h-3 w-3 transition-opacity ${
+            enabled && available
+              ? "text-blue-500 opacity-100"
+              : "text-gray-400 opacity-30"
+          }`}
+        />
+        マーカー補正
+      </Label>
+    </div>
+  )
+
+  if (!available) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{toggle}</TooltipTrigger>
+          <TooltipContent>
+            <p>模範解答にマーカーが検出できません</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  return toggle
+}

--- a/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
+++ b/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
@@ -39,6 +39,9 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
     handleDragEnd,
     allowOverwrite,
     setAllowOverwrite,
+    markerCorrectionEnabled,
+    markerCorrectionAvailable,
+    setMarkerCorrectionEnabled,
     previewMode,
     uploadModalState,
     handlePreviewModeChange,
@@ -92,6 +95,9 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
             hasNameRegion={hasNameRegion}
             allowOverwrite={allowOverwrite}
             onAllowOverwriteChange={setAllowOverwrite}
+            markerCorrectionEnabled={markerCorrectionEnabled}
+            markerCorrectionAvailable={markerCorrectionAvailable}
+            onMarkerCorrectionChange={setMarkerCorrectionEnabled}
           />
 
           <CardContent className="p-4">

--- a/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
+++ b/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/popover"
 import { Separator } from "@/components/ui/separator"
 
+import { MarkerCorrectionToggle } from "./MarkerCorrectionToggle"
 import { OverwriteToggle } from "./OverwriteToggle"
 import { PlacementStrategySelector } from "./PlacementStrategySelector"
 import { PreviewModeToggle } from "./PreviewModeToggle"
@@ -33,6 +34,9 @@ export function TableHeader({
   hasNameRegion,
   allowOverwrite = false,
   onAllowOverwriteChange,
+  markerCorrectionEnabled = false,
+  markerCorrectionAvailable = false,
+  onMarkerCorrectionChange,
 }: TableHeaderProps) {
   const [isTrashOpen, setIsTrashOpen] = useState(false)
 
@@ -63,6 +67,15 @@ export function TableHeader({
             onPreviewModeChange={onPreviewModeChange}
             hasNameRegion={hasNameRegion}
           />
+
+          {/* マーカー補正トグル（アップロードモードのみ） */}
+          {mode === "upload" && onMarkerCorrectionChange && (
+            <MarkerCorrectionToggle
+              enabled={markerCorrectionEnabled}
+              available={markerCorrectionAvailable}
+              onChange={onMarkerCorrectionChange}
+            />
+          )}
 
           {/* 既存答案上書きトグル（アップロードモードのみ） */}
           {mode === "upload" && onAllowOverwriteChange && (

--- a/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -91,6 +91,9 @@ export function useStudentAnswerTableLogic({
   const [uploadModalState, setUploadModalState] = useState<UploadModalState>({
     isOpen: false,
   })
+  const [markerCorrectionEnabled, setMarkerCorrectionEnabled] = useState(false)
+  const [markerCorrectionAvailable, setMarkerCorrectionAvailable] =
+    useState(false)
 
   // ============================================================================
   // 削除処理
@@ -135,6 +138,32 @@ export function useStudentAnswerTableLogic({
     initializeStudentsWithoutAnswers(students)
   }, [students, initializeStudentsWithoutAnswers])
 
+  // マスター画像のマーカー検出（マーカー補正の利用可否判定）
+  useEffect(() => {
+    if (mode !== "upload" || !examId) return
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const result = await window.electronAPI.omr.detectMasterMarkers(examId)
+        if (!cancelled) {
+          setMarkerCorrectionAvailable(result.success)
+          if (!result.success) {
+            setMarkerCorrectionEnabled(false)
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setMarkerCorrectionAvailable(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [examId, mode])
+
   // ============================================================================
   // イベントハンドラー
   // ============================================================================
@@ -164,6 +193,7 @@ export function useStudentAnswerTableLogic({
             studentId: cell.student.id,
             pageNumber: cell.pageNumber,
             overwrite: allowOverwrite,
+            correctWithMarkers: markerCorrectionEnabled,
           })
         }
       })
@@ -228,6 +258,9 @@ export function useStudentAnswerTableLogic({
     handleDragEnd,
     allowOverwrite,
     setAllowOverwrite,
+    markerCorrectionEnabled,
+    markerCorrectionAvailable,
+    setMarkerCorrectionEnabled,
 
     // ローカル状態
     previewMode,

--- a/components/exams/06-student-answers/student-answer-table/types/index.ts
+++ b/components/exams/06-student-answers/student-answer-table/types/index.ts
@@ -100,6 +100,9 @@ export interface TableHeaderProps {
   hasNameRegion: boolean
   allowOverwrite?: boolean
   onAllowOverwriteChange?: (allow: boolean) => void
+  markerCorrectionEnabled?: boolean
+  markerCorrectionAvailable?: boolean
+  onMarkerCorrectionChange?: (enabled: boolean) => void
 }
 
 export interface PlacementStrategySelectorProps {

--- a/components/exams/06-student-answers/types.ts
+++ b/components/exams/06-student-answers/types.ts
@@ -95,6 +95,7 @@ export interface UploadData {
   studentId: string // 受験生徒ID
   pageNumber: number // ページ番号
   overwrite: boolean // 上書きフラグ
+  correctWithMarkers?: boolean // マーカー補正フラグ
 }
 
 /**

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -199,6 +199,7 @@ export function setupMiscHandlers(): void {
         studentId?: string
         pageNumber?: number
         overwrite?: boolean
+        correctWithMarkers?: boolean
       }[]
     ) => {
       try {

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -22,6 +22,19 @@ import {
   loadImageRaw,
   recognizeCells,
 } from "../lib/omr"
+import prisma from "../lib/prisma/client"
+
+/** マスターマーカー検出キャッシュ (キー: "examId:pageNumber") */
+const masterMarkerCache = new Map<string, MarkerDetectionResult>()
+
+/** キャッシュ無効化（マスター画像変更時に呼び出す） */
+export function invalidateMasterMarkerCache(examId: string): void {
+  for (const key of masterMarkerCache.keys()) {
+    if (key.startsWith(`${examId}:`)) {
+      masterMarkerCache.delete(key)
+    }
+  }
+}
 
 export function setupOMRHandlers(): void {
   // ────────────────────────────────────────
@@ -261,6 +274,88 @@ export function setupOMRHandlers(): void {
       }
 
       return results
+    }
+  )
+
+  // ────────────────────────────────────────
+  // マスター画像のコーナーマーカー一括検出
+  // ────────────────────────────────────────
+  ipcMain.handle(
+    "omr:detect-master-markers",
+    async (
+      _event,
+      examId: string,
+      colorThreshold?: number
+    ): Promise<{
+      success: boolean
+      pages: Array<{ pageNumber: number; result: MarkerDetectionResult }>
+      error?: string
+    }> => {
+      try {
+        // マスター画像を取得
+        const masterImages = await prisma.masterImage.findMany({
+          where: {
+            examPage: { examId },
+          },
+          include: { examPage: true },
+          orderBy: { examPage: { pageNumber: "asc" } },
+        })
+
+        if (masterImages.length === 0) {
+          return {
+            success: false,
+            pages: [],
+            error: "マスター画像が見つかりません",
+          }
+        }
+
+        const pages: Array<{
+          pageNumber: number
+          result: MarkerDetectionResult
+        }> = []
+
+        const dataDir = getDataDirectory()
+
+        for (const mi of masterImages) {
+          const pageNumber = mi.examPage.pageNumber
+          const cacheKey = `${examId}:${pageNumber}`
+
+          // キャッシュチェック
+          const cached = masterMarkerCache.get(cacheKey)
+          if (cached) {
+            pages.push({ pageNumber, result: cached })
+            continue
+          }
+
+          // 画像パスを解決してマーカー検出
+          const imagePath = path.join(dataDir, mi.imagePath)
+          const result = await detectCornerMarkers(imagePath, colorThreshold)
+
+          // キャッシュに保存
+          masterMarkerCache.set(cacheKey, result)
+          pages.push({ pageNumber, result })
+        }
+
+        // 全ページで4マーカー検出できたか
+        const allSuccess = pages.every((p) => p.result.success)
+
+        return {
+          success: allSuccess,
+          pages,
+          error: allSuccess
+            ? undefined
+            : "一部のページでマーカーを検出できませんでした",
+        }
+      } catch (error) {
+        return {
+          success: false,
+          pages: [],
+          error:
+            error instanceof Error
+              ? error.message
+              : "マスターマーカー検出に失敗しました",
+        }
+      }
     }
   )
 

--- a/electron-src/lib/omr/imageCorrector.ts
+++ b/electron-src/lib/omr/imageCorrector.ts
@@ -1,0 +1,194 @@
+/**
+ * 答案画像の補正エンジン
+ *
+ * マスター画像のコーナーマーカー位置を基準に、
+ * 答案画像のズレ・傾き・拡大縮小を類似変換で補正する。
+ */
+
+import sharp from "sharp"
+
+import type {
+  DetectedCornerMarker,
+  MarkerDetectionResult,
+  Point,
+} from "../../../types/omr.types"
+import { detectCornerMarkersFromRaw } from "./cornerMarkerDetector"
+import { loadImageRawFromBuffer } from "./imageProcessor"
+
+export interface SimilarityTransformParams {
+  a: number // cos(θ) * scale
+  b: number // sin(θ) * scale
+  tx: number // x平行移動
+  ty: number // y平行移動
+}
+
+export interface ImageCorrectionResult {
+  success: boolean
+  correctedBuffer?: Buffer
+  error?: string
+  /** 算出されたスケール係数 */
+  scale?: number
+  /** 算出された回転角(度) */
+  rotationDeg?: number
+}
+
+/**
+ * 4点ペアから最小二乗法で類似変換パラメータを算出
+ *
+ * 類似変換: X = a*x - b*y + tx, Y = b*x + a*y + ty
+ * 4点(8方程式)で4未知数(a, b, tx, ty)を解く
+ */
+export function computeSimilarityTransform(
+  src: Point[],
+  dst: Point[]
+): SimilarityTransformParams {
+  if (src.length !== dst.length || src.length < 2) {
+    throw new Error("src と dst は同数かつ2点以上必要です")
+  }
+
+  const n = src.length
+
+  // 正規方程式の係数を蓄積
+  // [a, b, tx, ty] を解く
+  // X_i = a * x_i - b * y_i + tx
+  // Y_i = b * x_i + a * y_i + ty
+  let sumXx = 0,
+    sumXy = 0,
+    sumX = 0,
+    sumY = 0
+  let sumXX = 0,
+    sumXY_dst = 0,
+    sumYY_dst = 0
+
+  for (let i = 0; i < n; i++) {
+    const { x, y } = src[i]
+    const { x: X, y: Y } = dst[i]
+
+    sumXx += x * X + y * Y
+    sumXy += x * Y - y * X
+    sumX += X
+    sumY += Y
+    sumXX += x * x + y * y
+    sumXY_dst += x
+    sumYY_dst += y
+  }
+
+  // 4x4の正規方程式を解く
+  // | sumXX    0     sumXY_dst  sumYY_dst | | a  |   | sumXx |
+  // |   0    sumXX  -sumYY_dst  sumXY_dst | | b  | = | sumXy |
+  // | sumXY_dst -sumYY_dst  n      0      | | tx |   | sumX  |
+  // | sumYY_dst  sumXY_dst  0      n      | | ty |   | sumY  |
+
+  // 解析解（ブロック行列の逆行列を利用）
+  const det = n * sumXX - sumXY_dst * sumXY_dst - sumYY_dst * sumYY_dst
+  if (Math.abs(det) < 1e-10) {
+    throw new Error("変換パラメータの算出に失敗しました（退化した入力）")
+  }
+
+  const a = (n * sumXx - sumXY_dst * sumX - sumYY_dst * sumY) / det
+  const b = (n * sumXy + sumYY_dst * sumX - sumXY_dst * sumY) / det
+  const tx = (sumX - a * sumXY_dst + b * sumYY_dst) / n
+  const ty = (sumY - b * sumXY_dst - a * sumYY_dst) / n
+
+  return { a, b, tx, ty }
+}
+
+/**
+ * 答案画像をマスター画像のマーカー位置に合わせて補正
+ */
+export async function correctImage(
+  imageBuffer: Buffer,
+  masterMarkers: DetectedCornerMarker[],
+  masterWidth: number,
+  masterHeight: number,
+  colorThreshold: number = 128
+): Promise<ImageCorrectionResult> {
+  try {
+    // 1. 答案画像のマーカー検出
+    const rawImage = await loadImageRawFromBuffer(imageBuffer)
+    const answerResult: MarkerDetectionResult = detectCornerMarkersFromRaw(
+      rawImage,
+      colorThreshold
+    )
+
+    if (!answerResult.success) {
+      return {
+        success: false,
+        error: `答案マーカー検出失敗: ${answerResult.error ?? `${answerResult.markers.length}/4検出`}`,
+      }
+    }
+
+    // 2. マーカーをコーナー順にソート (TL, TR, BL, BR)
+    const cornerOrder: Array<"TL" | "TR" | "BL" | "BR"> = [
+      "TL",
+      "TR",
+      "BL",
+      "BR",
+    ]
+    const srcPoints: Point[] = []
+    const dstPoints: Point[] = []
+
+    for (const corner of cornerOrder) {
+      const answerMarker = answerResult.markers.find((m) => m.corner === corner)
+      const masterMarker = masterMarkers.find((m) => m.corner === corner)
+
+      if (!answerMarker || !masterMarker) {
+        return {
+          success: false,
+          error: `${corner}マーカーのペアリングに失敗`,
+        }
+      }
+
+      srcPoints.push({ x: answerMarker.centerX, y: answerMarker.centerY })
+      dstPoints.push({ x: masterMarker.centerX, y: masterMarker.centerY })
+    }
+
+    // 3. 類似変換パラメータ算出
+    const params = computeSimilarityTransform(srcPoints, dstPoints)
+    const scale = Math.sqrt(params.a * params.a + params.b * params.b)
+    const rotationDeg = (Math.atan2(params.b, params.a) * 180) / Math.PI
+
+    // 4. スケール妥当性検証
+    if (scale < 0.8 || scale > 1.2) {
+      return {
+        success: false,
+        error: `スケール係数 ${scale.toFixed(3)} が許容範囲外(0.8〜1.2)`,
+        scale,
+        rotationDeg,
+      }
+    }
+
+    // 5. sharp.affine() で画像変換
+    // affine の matrix は [[a, -b], [b, a]] (答案→マスター座標系)
+    const correctedBuffer = await sharp(imageBuffer)
+      .affine(
+        [
+          [params.a, -params.b],
+          [params.b, params.a],
+        ],
+        {
+          odx: params.tx,
+          ody: params.ty,
+          background: "#FFFFFF",
+        }
+      )
+      .resize(masterWidth, masterHeight)
+      .png()
+      .toBuffer()
+
+    return {
+      success: true,
+      correctedBuffer,
+      scale,
+      rotationDeg,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "画像補正中に不明なエラーが発生",
+    }
+  }
+}

--- a/electron-src/lib/omr/index.ts
+++ b/electron-src/lib/omr/index.ts
@@ -13,6 +13,8 @@ export {
   detectCornerMarkersFromRaw,
 } from "./cornerMarkerDetector"
 export { recognizeDigitCell } from "./digitRecognizer"
+export type { ImageCorrectionResult } from "./imageCorrector"
+export { computeSimilarityTransform, correctImage } from "./imageCorrector"
 export {
   computeCircularFillRatio,
   computeFillRatio,

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -5,12 +5,72 @@
 import * as fs from "fs/promises"
 import * as path from "path"
 
+import type {
+  DetectedCornerMarker,
+  MarkerDetectionResult,
+} from "../../../../types/omr.types"
 import {
   getAbsolutePathFromData,
   getAnswerSheetsDirectory,
+  getDataDirectory,
   getRelativePathFromData,
 } from "../../dataManager"
+import { detectCornerMarkers } from "../../omr/cornerMarkerDetector"
+import { correctImage } from "../../omr/imageCorrector"
 import prisma from "../client"
+
+/** ページごとのマスターマーカーキャッシュ */
+type MasterMarkerInfo = {
+  markers: DetectedCornerMarker[]
+  width: number
+  height: number
+}
+
+/**
+ * マスター画像のマーカーを取得（ページごとにキャッシュ）
+ */
+async function getMasterMarkersForPage(
+  examId: string,
+  pageNumber: number,
+  cache: Map<number, MasterMarkerInfo | null>,
+  colorThreshold: number = 128
+): Promise<MasterMarkerInfo | null> {
+  if (cache.has(pageNumber)) {
+    return cache.get(pageNumber) ?? null
+  }
+
+  const masterImage = await prisma.masterImage.findFirst({
+    where: {
+      examPage: { examId, pageNumber },
+    },
+    include: { examPage: true },
+  })
+
+  if (!masterImage) {
+    cache.set(pageNumber, null)
+    return null
+  }
+
+  const dataDir = getDataDirectory()
+  const imagePath = path.join(dataDir, masterImage.imagePath)
+  const result: MarkerDetectionResult = await detectCornerMarkers(
+    imagePath,
+    colorThreshold
+  )
+
+  if (!result.success) {
+    cache.set(pageNumber, null)
+    return null
+  }
+
+  const info: MasterMarkerInfo = {
+    markers: result.markers,
+    width: result.imageWidth,
+    height: result.imageHeight,
+  }
+  cache.set(pageNumber, info)
+  return info
+}
 
 /**
  * 答案画像のアップロード
@@ -24,6 +84,7 @@ export async function uploadStudentAnswers(
     studentId?: string
     pageNumber?: number
     overwrite?: boolean
+    correctWithMarkers?: boolean
   }[]
 ) {
   try {
@@ -32,7 +93,16 @@ export async function uploadStudentAnswers(
     // 試験ディレクトリを作成
     await fs.mkdir(examDir, { recursive: true })
 
-    const uploadedSheets = []
+    const uploadedSheets: Array<{
+      id: string
+      imagePath: string
+      isOverwrite: boolean
+      correctionStatus: "corrected" | "skipped" | "not_requested"
+      correctionError?: string
+    }> = []
+
+    // 補正用のマスターマーカーキャッシュ（ページ番号→マーカー情報）
+    const masterMarkerCache = new Map<number, MasterMarkerInfo | null>()
 
     for (const fileData of filesData) {
       // studentIdが必須
@@ -72,10 +142,44 @@ export async function uploadStudentAnswers(
       const filePath = path.join(examDir, fileName)
       const relativePath = getRelativePathFromData(filePath)
 
+      // 画像バッファを準備（補正の可能性あり）
+      let buffer = Buffer.from(fileData.buffer)
+      let correctionStatus: "corrected" | "skipped" | "not_requested" =
+        "not_requested"
+      let correctionError: string | undefined
+
+      if (fileData.correctWithMarkers) {
+        const masterInfo = await getMasterMarkersForPage(
+          examId,
+          fileData.pageNumber || 1,
+          masterMarkerCache
+        )
+
+        if (masterInfo) {
+          const result = await correctImage(
+            buffer,
+            masterInfo.markers,
+            masterInfo.width,
+            masterInfo.height
+          )
+
+          if (result.success && result.correctedBuffer) {
+            buffer = Buffer.from(result.correctedBuffer)
+            correctionStatus = "corrected"
+          } else {
+            correctionStatus = "skipped"
+            correctionError = result.error
+            console.warn(`画像補正スキップ (${fileData.name}): ${result.error}`)
+          }
+        } else {
+          correctionStatus = "skipped"
+          correctionError = "マスター画像のマーカーが検出できませんでした"
+        }
+      }
+
       if (existingRecord) {
         if (fileData.overwrite) {
           // ファイルを保存
-          const buffer = Buffer.from(fileData.buffer)
           await fs.writeFile(filePath, buffer)
 
           // 古いファイルを削除
@@ -94,14 +198,22 @@ export async function uploadStudentAnswers(
             data: { imagePath: relativePath },
           })
 
-          uploadedSheets.push({ ...answerSheet, isOverwrite: true })
+          uploadedSheets.push({
+            ...answerSheet,
+            isOverwrite: true,
+            correctionStatus,
+            correctionError,
+          })
         } else {
           // 上書き無効: スキップ（既存レコードをそのまま返す）
-          uploadedSheets.push({ ...existingRecord, isOverwrite: false })
+          uploadedSheets.push({
+            ...existingRecord,
+            isOverwrite: false,
+            correctionStatus: "not_requested",
+          })
         }
       } else {
         // ファイルを保存
-        const buffer = Buffer.from(fileData.buffer)
         await fs.writeFile(filePath, buffer)
 
         // 新規作成
@@ -113,7 +225,12 @@ export async function uploadStudentAnswers(
           },
         })
 
-        uploadedSheets.push({ ...answerSheet, isOverwrite: false })
+        uploadedSheets.push({
+          ...answerSheet,
+          isOverwrite: false,
+          correctionStatus,
+          correctionError,
+        })
       }
     }
 

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -1143,6 +1143,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       params: { colorThreshold: number; areaThreshold: number }
       pageIndex?: number
     }) => ipcRenderer.invoke("omr:batch-recognize", args),
+    detectMasterMarkers: (examId: string, colorThreshold?: number) =>
+      ipcRenderer.invoke("omr:detect-master-markers", examId, colorThreshold),
     saveTemplate: (examId: string, template: unknown) =>
       ipcRenderer.invoke("omr:save-template", examId, template),
     loadTemplate: (examId: string) =>

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -103,6 +103,7 @@ export interface UploadStudentAnswerFileData {
   studentId: string
   pageNumber: number
   overwrite: boolean
+  correctWithMarkers?: boolean
 }
 
 // Student exam result type
@@ -2257,6 +2258,17 @@ export interface MyAPI {
       examId: string,
       template: import("./omr.types").OMRTemplate
     ) => Promise<{ success: boolean; error?: string }>
+    detectMasterMarkers: (
+      examId: string,
+      colorThreshold?: number
+    ) => Promise<{
+      success: boolean
+      pages: Array<{
+        pageNumber: number
+        result: import("./omr.types").MarkerDetectionResult
+      }>
+      error?: string
+    }>
     loadTemplate: (examId: string) => Promise<{
       success: boolean
       template?: import("./omr.types").OMRTemplate


### PR DESCRIPTION
## Summary

Closes #514

OMRコーナーマーカーを基準とした類似変換により、答案画像のズレ・傾き・拡大縮小を自動補正する機能を実装。

### 変更ファイル

**新規:**
- `electron-src/lib/omr/imageCorrector.ts` — コア補正エンジン（類似変換算出 + sharp.affine()）
- `components/.../MarkerCorrectionToggle.tsx` — 補正ON/OFFトグルUI

**変更:**
- `omrHandlers.ts` — `omr:detect-master-markers` IPCハンドラー + キャッシュ
- `crud.ts` — アップロード時の補正ロジック統合
- `preload.ts` / `electron.d.ts` — API・型定義追加
- UI層 — TableHeader, useStudentAnswerTableLogic, types等

### 設計ポイント
- 補正はアップロード時に実施し、補正済み画像を保存 → 下流の採点・PDF出力は変更不要
- マーカー検出失敗時は元画像をそのまま保存（非破壊的フォールバック）
- スケール係数0.8〜1.2の妥当性検証

## Test plan

- [ ] マーカー付きマスター画像をアップロード → `omr:detect-master-markers` で4点検出確認
- [ ] トグルUIがenabled/disabledになることを確認
- [ ] 傾いた答案画像をアップロード(補正ON) → 保存された画像が補正されていることを目視確認
- [ ] マーカーなし答案 → 元画像がそのまま保存されることを確認
- [ ] 補正ON/OFFでアップロードし、採点画面で領域クロップ位置の精度を比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)