### PR TITLE
スクリーンショットテストのディレクトリ構造を統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ temp-notes-*.md
 release-files/
 
 /.claude
+
+# スクリーンショット撮影用
+__tests__/screenshots/data/
+__tests__/screenshots/output/
+__tests__/screenshots/artifacts/

--- a/__tests__/screenshots/helpers/generate-images.ts
+++ b/__tests__/screenshots/helpers/generate-images.ts
@@ -1,0 +1,600 @@
+/**
+ * スクリーンショット用の画像・採点領域定義
+ *
+ * ASBテンプレートから computeMultiPageLayoutFromDefinition でレイアウト計算し、
+ * 正確な正規化座標を取得する。
+ * マスター画像はテスト実行時にASBプレビューからキャプチャして上書きする。
+ */
+
+import * as fs from "fs"
+import * as path from "path"
+import sharp from "sharp"
+
+import { computeMultiPageLayoutFromDefinition } from "@/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout"
+import type {
+  AnswerSheetDefinition,
+  BranchQuestion,
+  SubQuestion,
+} from "@/types/answerSheetDefinition.types"
+
+// 解答用紙（B4, 200dpi相当）の画像サイズ
+export const SHEET_WIDTH = 2024
+export const SHEET_HEIGHT = 2866
+
+interface RegionDef {
+  label: string
+  x: number
+  y: number
+  width: number
+  height: number
+  points: number
+  orderIndex: number
+}
+
+/**
+ * ASBテンプレートJSONから AnswerSheetDefinition を構築
+ */
+function templateToDefinition(
+  template: Record<string, unknown>
+): AnswerSheetDefinition {
+  const t = template as Record<string, unknown>
+  const headerFields = (t.headerFields as Array<Record<string, unknown>>).map(
+    (hf) => ({
+      id: hf.id as string,
+      type: (hf.type as string) ?? "field",
+      label: hf.label as string,
+      widthMm: hf.widthMm as number,
+      heightMm: hf.heightMm as number,
+      gridCount: hf.gridCount as number,
+      lineStyle: hf.lineStyle as string,
+      lineWidth: hf.lineWidth as number,
+      order: hf.order as number,
+      fontSize: (hf.fontSize as number) ?? undefined,
+      linkedRegionType: (hf.linkedRegionType as string) ?? undefined,
+    })
+  )
+
+  const majorQuestions = (
+    t.majorQuestions as Array<Record<string, unknown>>
+  ).map((mq) => ({
+    id: mq.id as string,
+    label: mq.label as string,
+    subQuestions: (mq.subQuestions as Array<Record<string, unknown>>).map(
+      (sq): SubQuestion => {
+        const manuscriptPaper = sq.manuscriptEnabled
+          ? {
+              enabled: true as const,
+              columns: sq.manuscriptColumns as number,
+              rows: sq.manuscriptRows as number,
+            }
+          : undefined
+        return {
+          id: sq.id as string,
+          label: sq.label as string,
+          branchQuestions: (
+            (sq.branchQuestions as Array<Record<string, unknown>>) || []
+          ).map(
+            (bq): BranchQuestion => ({
+              id: bq.id as string,
+              label: bq.label as string,
+              heightMultiplier: bq.heightMultiplier as number,
+              points: bq.points as number,
+              textElements: [],
+              imageElements: [],
+              layoutWidth: (bq.layoutWidth as string) ?? undefined,
+              nextPlacement:
+                (bq.nextPlacement as BranchQuestion["nextPlacement"]) ??
+                undefined,
+              goUp: (bq.goUp as boolean) ?? undefined,
+            })
+          ),
+          heightMultiplier: sq.heightMultiplier as number,
+          points: sq.points as number,
+          textElements: (
+            (sq.textElements as Array<Record<string, unknown>>) || []
+          ).map((te) => ({
+            text: te.text as string,
+            fontSize: te.fontSize as number,
+            horizontalAlign:
+              (te.horizontalAlign as "left" | "center" | "right") ?? "left",
+            verticalAlign:
+              (te.verticalAlign as "top" | "middle" | "bottom") ?? "top",
+            order: (te.order as number) ?? 0,
+          })),
+          imageElements: [],
+          manuscriptPaper,
+          layoutWidth: (sq.layoutWidth as string) ?? undefined,
+          nextPlacement:
+            (sq.nextPlacement as SubQuestion["nextPlacement"]) ?? undefined,
+          goUp: (sq.goUp as boolean) ?? undefined,
+          usesBranchPoints: (sq.usesBranchPoints as boolean) ?? undefined,
+        }
+      }
+    ),
+  }))
+
+  return {
+    id: t.id as string,
+    name: t.name as string,
+    settings: {
+      paperSize: t.paperSize as "B4",
+      orientation: t.orientation as "portrait",
+      baseRowHeight: t.baseRowHeight as number,
+      numberDisplayMode: t.numberDisplayMode as "multirow",
+      margins: {
+        top: t.marginTop as number,
+        bottom: t.marginBottom as number,
+        left: t.marginLeft as number,
+        right: t.marginRight as number,
+      },
+      columnWidths: {
+        majorNumber: t.colWidthMajorNumber as number,
+        subNumber: t.colWidthSubNumber as number,
+        branchNumber: t.colWidthBranchNumber as number,
+      },
+      spacing: {
+        majorQuestionSpacing: t.majorQuestionSpacing as number,
+        headerHeight: t.headerHeight as number,
+      },
+      borderConfig: {
+        outerBorder: t.borderOuterBorder as string,
+        majorDivider: t.borderMajorDivider as string,
+        subDivider: t.borderSubDivider as string,
+        branchDivider: t.borderBranchDivider as string,
+        majorNumberDivider: t.borderMajorNumberDivider as string,
+        subNumberDivider: t.borderSubNumberDivider as string,
+        branchNumberDivider: t.borderBranchNumberDivider as string,
+        outerBorderWidth: (t.borderOuterBorderWidth as number) ?? undefined,
+        majorDividerWidth: (t.borderMajorDividerWidth as number) ?? undefined,
+        subDividerWidth: (t.borderSubDividerWidth as number) ?? undefined,
+        branchDividerWidth: (t.borderBranchDividerWidth as number) ?? undefined,
+        majorNumberDividerWidth:
+          (t.borderMajorNumberDividerWidth as number) ?? undefined,
+        subNumberDividerWidth:
+          (t.borderSubNumberDividerWidth as number) ?? undefined,
+        branchNumberDividerWidth:
+          (t.borderBranchNumberDividerWidth as number) ?? undefined,
+      },
+      omrMarkers: {
+        enabled: t.omrMarkersEnabled as boolean,
+        sizeMm: t.omrMarkersSizeMm as number,
+        offsetMm: t.omrMarkersOffsetMm as number,
+      },
+      fonts: {
+        family: t.fontFamily as string,
+        defaultSize: t.fontDefaultSize as number,
+        majorNumberSize: t.fontMajorNumberSize as number,
+        subNumberSize: t.fontSubNumberSize as number,
+        branchNumberSize: t.fontBranchNumberSize as number,
+      },
+      multiColumn: {
+        enabled: t.multiColumnEnabled as boolean,
+        columnCount: (t.multiColumnCount as 2 | 3) ?? 2,
+        columnGapMm: t.multiColumnGapMm as number,
+        dividerLine: (t.multiColumnDividerLine as string) ?? null,
+        dividerLineWidth: (t.multiColumnDividerLineWidth as number) ?? 0.3,
+      },
+      headerFields,
+    },
+    majorQuestions,
+    renderMode: (t.renderMode as "model-answer") ?? "model-answer",
+    labelPresets: {
+      major: (t.labelPresetMajor as string) ?? undefined,
+      sub: (t.labelPresetSub as string) ?? undefined,
+      branch: (t.labelPresetBranch as string) ?? undefined,
+    },
+  }
+}
+
+/**
+ * ASBテンプレートからレイアウト計算し、answerセルの正規化座標を取得
+ */
+export function computeRegionDefinitions(templatePath: string): RegionDef[] {
+  const template = JSON.parse(fs.readFileSync(templatePath, "utf-8"))
+  const definition = templateToDefinition(template)
+  const layout = computeMultiPageLayoutFromDefinition(definition)
+
+  // ページ0の answer セルのみ取得
+  const page0 = layout.pages[0]
+  if (!page0) return []
+
+  const answerCells = page0.cells.filter((c) => c.cellType === "answer")
+
+  // examConverter と同じロジック: usesBranchPoints === false の枝問は統合
+  const mergedCells: Array<{
+    label: string
+    normalizedX: number
+    normalizedY: number
+    normalizedW: number
+    normalizedH: number
+    points: number
+  }> = []
+  const processedKeys = new Set<string>()
+
+  for (const cell of answerCells) {
+    const [mi, si, bi] = cell.questionPath
+    const isBranch = bi !== undefined
+
+    if (isBranch) {
+      const key = `${mi}-${si}`
+      if (processedKeys.has(key)) continue
+
+      const sub = definition.majorQuestions[mi]?.subQuestions[si]
+      if (sub?.usesBranchPoints === false) {
+        processedKeys.add(key)
+        const siblings = answerCells.filter(
+          (c) =>
+            c.questionPath[0] === mi &&
+            c.questionPath[1] === si &&
+            c.questionPath.length === 3
+        )
+        const minX = Math.min(...siblings.map((c) => c.normalizedX))
+        const minY = Math.min(...siblings.map((c) => c.normalizedY))
+        const maxX = Math.max(
+          ...siblings.map((c) => c.normalizedX + c.normalizedW)
+        )
+        const maxY = Math.max(
+          ...siblings.map((c) => c.normalizedY + c.normalizedH)
+        )
+        mergedCells.push({
+          label: sub.label,
+          normalizedX: minX,
+          normalizedY: minY,
+          normalizedW: maxX - minX,
+          normalizedH: maxY - minY,
+          points: sub.points,
+        })
+        continue
+      }
+    }
+
+    mergedCells.push({
+      label: cell.label,
+      normalizedX: cell.normalizedX,
+      normalizedY: cell.normalizedY,
+      normalizedW: cell.normalizedW,
+      normalizedH: cell.normalizedH,
+      points: cell.points,
+    })
+  }
+
+  return mergedCells.map((cell, i) => ({
+    label: cell.label,
+    x: cell.normalizedX,
+    y: cell.normalizedY,
+    width: cell.normalizedW,
+    height: cell.normalizedH,
+    points: cell.points,
+    orderIndex: i,
+  }))
+}
+
+/**
+ * 配点合計を計算
+ */
+export function computeTotalPoints(regions: RegionDef[]): number {
+  return regions.reduce((sum, r) => sum + r.points, 0)
+}
+
+/**
+ * プレースホルダーマスター画像を生成（白背景）
+ * テスト実行時にASBプレビューで上書きされる
+ */
+export async function generatePlaceholderMasterImage(
+  outputDir: string
+): Promise<string> {
+  fs.mkdirSync(outputDir, { recursive: true })
+  const outputPath = path.join(outputDir, "master-page-1.png")
+
+  await sharp({
+    create: {
+      width: SHEET_WIDTH,
+      height: SHEET_HEIGHT,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .png()
+    .toFile(outputPath)
+
+  return outputPath
+}
+
+// ---------------------------------------------------------------------------
+// 正解データ（各設問の模範解答テキスト）
+// ---------------------------------------------------------------------------
+const CORRECT_ANSWERS: Record<string, string> = {
+  "1-(1)-ア": "3",
+  "1-(1)-イ": "−5",
+  "1-(1)-ウ": "7",
+  "1-(1)-エ": "−2",
+  "1-(2)": "3",
+  "1-(3)": "(2, 3)",
+  "2-(1)": "2x + 3y = 12\nx − y = 1\nを加減法で解く\n3x = 15\nx = 5, y = 4",
+  "2-(2)": "6n − 3",
+  "2-(3)": "1/2",
+  "": "△ABCにおいて\n中点連結定理より\nDE//BC\nDE = 1/2 BC\nよって四角形DBCEは\n台形である",
+  "4-(1)": "辺AD, 辺DC, 辺EH, 辺HG",
+  "4-(2)": "80π",
+  "4-(3)": "12/5",
+  "5-(1)": "0.4",
+  "5-(2)": "ウ",
+  "6-(1)": "(3, 2)",
+  "6-(2)-ア": "y = 2x − 4",
+  "6-(2)-イ":
+    "y = 2x − 4 と\ny = −x + 5 の交点\n2x − 4 = −x + 5\n3x = 9\nx = 3, y = 2\nよって (3, 2)",
+  "7-(1)":
+    "△AOCと△BODにおいて\n半径は等しいから\nOA = OB = OC = OD …①\n①より△OAC, △OBDは\n二等辺三角形だから\n∠OAC = ∠OCA …②\n∠OBD = ∠ODB …③\n仮定より\n∠BAC = ∠ABD\nすなわち\n∠OAC = ∠OBD …④\nよって①②③④より\n△AOC ≡ △BOD",
+  "7-(2)": "108",
+}
+
+// 誤答パターン（各設問に対する典型的な間違い）
+const WRONG_ANSWERS: Record<string, string[]> = {
+  "1-(1)-ア": ["4", "−3", "2"],
+  "1-(1)-イ": ["5", "−3", "4"],
+  "1-(1)-ウ": ["−7", "5", "8"],
+  "1-(1)-エ": ["2", "−4", "3"],
+  "1-(2)": ["−3", "9", "4"],
+  "1-(3)": ["(3, 2)", "(−2, 3)", "(2, −3)"],
+  "2-(1)": ["x + y = 5\nよくわからない", "2x + 3y = 12\nx = 4, y = 2", ""],
+  "2-(2)": ["6n + 3", "3n − 6", "6n"],
+  "2-(3)": ["2", "1/3", "−1/2"],
+  "": ["△ABCで\n中点連結定理？\nよくわからない", "DE = BC\nDE//BC", ""],
+  "4-(1)": ["辺AB, 辺BC", "辺AD, 辺EH", "辺AB, 辺DC, 辺EF"],
+  "4-(2)": ["160π", "40π", "80"],
+  "4-(3)": ["12", "5/12", "2"],
+  "5-(1)": ["0.6", "4", "0.2"],
+  "5-(2)": ["ア", "イ", "エ"],
+  "6-(1)": ["(2, 3)", "(−3, 2)", "(3, −2)"],
+  "6-(2)-ア": ["y = x − 4", "y = −2x + 4", "y = 2x + 4"],
+  "6-(2)-イ": [
+    "y = 2x − 4\ny = −x + 5\nを代入して\n計算ミス…\nx = 2",
+    "わからない",
+    "",
+  ],
+  "7-(1)": [
+    "△AOCと△BODで\nOA = OB …①\n仮定より\n∠BAC = ∠ABD\nよって合同",
+    "△AOCと△BODにおいて\nよくわからない",
+    "",
+  ],
+  "7-(2)": ["120", "72", "144"],
+}
+
+// ---------------------------------------------------------------------------
+// 手書きフォントプール（生徒ごとに異なるフォントを使用）
+// ---------------------------------------------------------------------------
+const HANDWRITE_FONTS = [
+  "Natsume, なつめもじ",
+  "Yomogi",
+  "Klee One, クレー One",
+  "Zen Kurenaido",
+  "GenEi POPle, 源暎ぽっぷる",
+  "Hiragino Maru Gothic ProN, ヒラギノ丸ゴ ProN",
+]
+
+function pickFont(seed: number): string {
+  return HANDWRITE_FONTS[seed % HANDWRITE_FONTS.length]
+}
+
+/**
+ * SVGエスケープ
+ */
+function svgEsc(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+/**
+ * 手書き風テキストSVGを生成
+ */
+function createHandwrittenSvg(
+  text: string,
+  width: number,
+  height: number,
+  color: string = "#1a1a1a",
+  seed: number = 0
+): string {
+  const lines = text.split("\n")
+  const isLargeArea = height > 200
+  const fontFamily = pickFont(seed)
+
+  // フォントサイズ計算: 採点グリッドのカード表示時にも読める大きさ
+  // カードは元画像の約1/3〜1/4に縮小されるため、元画像上で十分大きく描画する
+  let fontSize: number
+  if (isLargeArea) {
+    // 大きい領域（証明等）: 行数に応じたサイズ、最小52px
+    fontSize = Math.max(
+      52,
+      Math.min(80, Math.floor((height / (lines.length + 1)) * 0.9))
+    )
+  } else {
+    // 小さい領域: 高さの80%を目安に、大きめに描画
+    const byHeight = Math.floor(height * 0.8)
+    const maxTextLen = Math.max(...lines.map((l) => l.length), 1)
+    const byWidth = Math.floor((width / maxTextLen) * 1.8)
+    fontSize = Math.max(64, Math.min(byHeight, byWidth, 140))
+  }
+
+  const lineHeight = fontSize * 1.35
+  const startY = isLargeArea
+    ? fontSize + 16
+    : (height - lines.length * lineHeight) / 2 + fontSize * 0.8
+
+  let tspans = ""
+  for (let i = 0; i < lines.length; i++) {
+    const dx = ((seed + i * 3) % 7) - 3
+    const dy = ((seed + i * 7) % 5) - 2
+    const y = startY + i * lineHeight + dy
+    const x = isLargeArea ? 20 + dx : width / 2 + dx
+    tspans += `<tspan x="${x}" y="${y}">${svgEsc(lines[i])}</tspan>`
+  }
+
+  const rotation = ((seed % 7) - 3) * 0.4
+  const anchor = isLargeArea ? "start" : "middle"
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+  <text
+    font-family="${svgEsc(fontFamily)}, sans-serif"
+    font-size="${fontSize}"
+    fill="${color}"
+    text-anchor="${anchor}"
+    transform="rotate(${rotation.toFixed(1)}, ${width / 2}, ${height / 2})"
+  >${tspans}</text>
+</svg>`
+}
+
+/**
+ * 生徒答案画像を生成（マスター画像 + 手書き風解答オーバーレイ）
+ */
+export async function generateStudentAnswerImage(
+  outputDir: string,
+  studentIndex: number,
+  studentId: string,
+  masterDir: string,
+  regions?: RegionDef[],
+  scores?: { regionIndex: number; score: number; status: string }[]
+): Promise<string> {
+  fs.mkdirSync(outputDir, { recursive: true })
+  const masterPath = path.join(masterDir, "master-page-1.png")
+  const outputPath = path.join(outputDir, `${studentId}_page1.png`)
+
+  if (!fs.existsSync(masterPath) || !regions || !scores) {
+    if (fs.existsSync(masterPath)) fs.copyFileSync(masterPath, outputPath)
+    return outputPath
+  }
+
+  const masterMeta = await sharp(masterPath).metadata()
+  const imgW = masterMeta.width || SHEET_WIDTH
+  const imgH = masterMeta.height || SHEET_HEIGHT
+
+  const composites: { input: Buffer; left: number; top: number }[] = []
+
+  for (const s of scores) {
+    const region = regions[s.regionIndex]
+    if (!region) continue
+
+    const rx = Math.round(region.x * imgW)
+    const ry = Math.round(region.y * imgH)
+    const rw = Math.round(region.width * imgW)
+    const rh = Math.round(region.height * imgH)
+
+    if (rw < 5 || rh < 5) continue
+
+    let answerText: string
+    const correctAns = CORRECT_ANSWERS[region.label] ?? ""
+    const wrongPool = WRONG_ANSWERS[region.label] ?? ["?"]
+
+    if (s.status === "correct") {
+      answerText = correctAns
+    } else if (s.status === "partial") {
+      // 部分点: 正解の一部を書く or 途中まで
+      const partial =
+        wrongPool[0] ?? correctAns.split("\n").slice(0, 2).join("\n")
+      answerText = partial
+    } else {
+      // 誤答: 間違った答えをseedに応じて選ぶ
+      const wi = (studentIndex + s.regionIndex) % wrongPool.length
+      answerText = wrongPool[wi]
+    }
+
+    if (!answerText) continue
+
+    const color = s.status === "correct" ? "#1a1a1a" : "#1a1a1a"
+    const svg = createHandwrittenSvg(
+      answerText,
+      rw,
+      rh,
+      color,
+      studentIndex * 7 + s.regionIndex
+    )
+    composites.push({
+      input: Buffer.from(svg),
+      left: rx,
+      top: ry,
+    })
+  }
+
+  if (composites.length > 0) {
+    await sharp(masterPath).composite(composites).png().toFile(outputPath)
+  } else {
+    fs.copyFileSync(masterPath, outputPath)
+  }
+
+  return outputPath
+}
+
+/**
+ * 模範解答画像を生成（マスター画像 + 正答テキストを赤インクでオーバーレイ）
+ * 採点画面の「模範解答」カードに正答が表示されるようにする
+ */
+export async function generateMasterAnswerImage(
+  masterDir: string,
+  regions: RegionDef[]
+): Promise<void> {
+  const masterPath = path.join(masterDir, "master-page-1.png")
+  if (!fs.existsSync(masterPath)) return
+
+  const masterMeta = await sharp(masterPath).metadata()
+  const imgW = masterMeta.width || SHEET_WIDTH
+  const imgH = masterMeta.height || SHEET_HEIGHT
+
+  const composites: { input: Buffer; left: number; top: number }[] = []
+
+  for (const region of regions) {
+    const rx = Math.round(region.x * imgW)
+    const ry = Math.round(region.y * imgH)
+    const rw = Math.round(region.width * imgW)
+    const rh = Math.round(region.height * imgH)
+
+    if (rw < 5 || rh < 5) continue
+
+    const correctAns = CORRECT_ANSWERS[region.label] ?? ""
+    if (!correctAns) continue
+
+    // 模範解答は赤インクで、きれいなフォント（Klee One）で書く
+    const svg = createHandwrittenSvg(
+      correctAns,
+      rw,
+      rh,
+      "#cc0000",
+      region.orderIndex * 3
+    )
+    composites.push({
+      input: Buffer.from(svg),
+      left: rx,
+      top: ry,
+    })
+  }
+
+  if (composites.length > 0) {
+    // 元のマスター画像を一旦バックアップ → 上書き
+    const tempPath = masterPath + ".bak"
+    fs.copyFileSync(masterPath, tempPath)
+    await sharp(tempPath).composite(composites).png().toFile(masterPath)
+    fs.unlinkSync(tempPath)
+  }
+}
+
+/**
+ * 生徒の採点結果を決定的に生成
+ */
+export function generateStudentScores(
+  studentIndex: number,
+  regions: RegionDef[]
+): { regionIndex: number; score: number; status: string }[] {
+  const seed = studentIndex * 7 + 3
+  return regions.map((r) => {
+    const hash = (seed + r.orderIndex * 13) % 100
+    if (hash < 60) {
+      return { regionIndex: r.orderIndex, score: r.points, status: "correct" }
+    } else if (hash < 80) {
+      const partial = Math.max(1, Math.floor(r.points * 0.5))
+      return { regionIndex: r.orderIndex, score: partial, status: "partial" }
+    } else {
+      return { regionIndex: r.orderIndex, score: 0, status: "incorrect" }
+    }
+  })
+}

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -1,0 +1,775 @@
+/**
+ * テスト実行中にデータを段階的に追加するヘルパー
+ *
+ * テストプロセスからPrismaClientを直接操作してデータを追加する。
+ * Electronのメインプロセスは経由しない。
+ */
+
+import { PrismaClient } from "@prisma/client"
+import { randomUUID } from "crypto"
+import * as fs from "fs"
+import * as path from "path"
+import sharp from "sharp"
+
+import {
+  computeRegionDefinitions,
+  computeTotalPoints,
+  generateMasterAnswerImage,
+  generateStudentAnswerImage,
+  generateStudentScores,
+} from "./generate-images"
+
+// ---------------------------------------------------------------------------
+// PrismaClient（テストプロセスから直接DB操作）
+// ---------------------------------------------------------------------------
+const TEST_DATA_DIR = path.join(__dirname, "../data")
+const DB_PATH = path.join(TEST_DATA_DIR, "database.db")
+
+let prisma: PrismaClient
+
+function getPrisma(): PrismaClient {
+  if (!prisma) {
+    prisma = new PrismaClient({
+      datasources: { db: { url: `file:${DB_PATH}` } },
+      log: ["error"],
+    })
+  }
+  return prisma
+}
+
+export async function disconnectPrisma() {
+  if (prisma) await prisma.$disconnect()
+}
+
+// ---------------------------------------------------------------------------
+// 生徒名データ（40名）
+// ---------------------------------------------------------------------------
+export const STUDENT_DATA = [
+  {
+    lastName: "佐藤",
+    firstName: "翔太",
+    lastNameKana: "サトウ",
+    firstNameKana: "ショウタ",
+  },
+  {
+    lastName: "鈴木",
+    firstName: "美咲",
+    lastNameKana: "スズキ",
+    firstNameKana: "ミサキ",
+  },
+  {
+    lastName: "高橋",
+    firstName: "大翔",
+    lastNameKana: "タカハシ",
+    firstNameKana: "ヒロト",
+  },
+  {
+    lastName: "田中",
+    firstName: "結衣",
+    lastNameKana: "タナカ",
+    firstNameKana: "ユイ",
+  },
+  {
+    lastName: "伊藤",
+    firstName: "蓮",
+    lastNameKana: "イトウ",
+    firstNameKana: "レン",
+  },
+  {
+    lastName: "渡辺",
+    firstName: "陽菜",
+    lastNameKana: "ワタナベ",
+    firstNameKana: "ヒナ",
+  },
+  {
+    lastName: "山本",
+    firstName: "悠真",
+    lastNameKana: "ヤマモト",
+    firstNameKana: "ユウマ",
+  },
+  {
+    lastName: "中村",
+    firstName: "さくら",
+    lastNameKana: "ナカムラ",
+    firstNameKana: "サクラ",
+  },
+  {
+    lastName: "小林",
+    firstName: "陸",
+    lastNameKana: "コバヤシ",
+    firstNameKana: "リク",
+  },
+  {
+    lastName: "加藤",
+    firstName: "葵",
+    lastNameKana: "カトウ",
+    firstNameKana: "アオイ",
+  },
+  {
+    lastName: "吉田",
+    firstName: "湊",
+    lastNameKana: "ヨシダ",
+    firstNameKana: "ミナト",
+  },
+  {
+    lastName: "山田",
+    firstName: "芽依",
+    lastNameKana: "ヤマダ",
+    firstNameKana: "メイ",
+  },
+  {
+    lastName: "松本",
+    firstName: "悠人",
+    lastNameKana: "マツモト",
+    firstNameKana: "ユウト",
+  },
+  {
+    lastName: "井上",
+    firstName: "凛",
+    lastNameKana: "イノウエ",
+    firstNameKana: "リン",
+  },
+  {
+    lastName: "木村",
+    firstName: "颯太",
+    lastNameKana: "キムラ",
+    firstNameKana: "ソウタ",
+  },
+  {
+    lastName: "林",
+    firstName: "莉子",
+    lastNameKana: "ハヤシ",
+    firstNameKana: "リコ",
+  },
+  {
+    lastName: "斎藤",
+    firstName: "朝陽",
+    lastNameKana: "サイトウ",
+    firstNameKana: "アサヒ",
+  },
+  {
+    lastName: "清水",
+    firstName: "楓",
+    lastNameKana: "シミズ",
+    firstNameKana: "カエデ",
+  },
+  {
+    lastName: "山口",
+    firstName: "悠斗",
+    lastNameKana: "ヤマグチ",
+    firstNameKana: "ユウト",
+  },
+  {
+    lastName: "森",
+    firstName: "彩花",
+    lastNameKana: "モリ",
+    firstNameKana: "アヤカ",
+  },
+  {
+    lastName: "池田",
+    firstName: "樹",
+    lastNameKana: "イケダ",
+    firstNameKana: "イツキ",
+  },
+  {
+    lastName: "橋本",
+    firstName: "詩織",
+    lastNameKana: "ハシモト",
+    firstNameKana: "シオリ",
+  },
+  {
+    lastName: "阿部",
+    firstName: "颯",
+    lastNameKana: "アベ",
+    firstNameKana: "ハヤテ",
+  },
+  {
+    lastName: "石川",
+    firstName: "花音",
+    lastNameKana: "イシカワ",
+    firstNameKana: "カノン",
+  },
+  {
+    lastName: "前田",
+    firstName: "蒼",
+    lastNameKana: "マエダ",
+    firstNameKana: "アオ",
+  },
+  {
+    lastName: "藤田",
+    firstName: "心春",
+    lastNameKana: "フジタ",
+    firstNameKana: "コハル",
+  },
+  {
+    lastName: "岡田",
+    firstName: "瑛太",
+    lastNameKana: "オカダ",
+    firstNameKana: "エイタ",
+  },
+  {
+    lastName: "後藤",
+    firstName: "杏",
+    lastNameKana: "ゴトウ",
+    firstNameKana: "アン",
+  },
+  {
+    lastName: "長谷川",
+    firstName: "奏太",
+    lastNameKana: "ハセガワ",
+    firstNameKana: "ソウタ",
+  },
+  {
+    lastName: "村上",
+    firstName: "紬",
+    lastNameKana: "ムラカミ",
+    firstNameKana: "ツムギ",
+  },
+  {
+    lastName: "近藤",
+    firstName: "陽翔",
+    lastNameKana: "コンドウ",
+    firstNameKana: "ハルト",
+  },
+  {
+    lastName: "石井",
+    firstName: "美月",
+    lastNameKana: "イシイ",
+    firstNameKana: "ミヅキ",
+  },
+  {
+    lastName: "坂本",
+    firstName: "律",
+    lastNameKana: "サカモト",
+    firstNameKana: "リツ",
+  },
+  {
+    lastName: "遠藤",
+    firstName: "花",
+    lastNameKana: "エンドウ",
+    firstNameKana: "ハナ",
+  },
+  {
+    lastName: "青木",
+    firstName: "太一",
+    lastNameKana: "アオキ",
+    firstNameKana: "タイチ",
+  },
+  {
+    lastName: "藤井",
+    firstName: "琴音",
+    lastNameKana: "フジイ",
+    firstNameKana: "コトネ",
+  },
+  {
+    lastName: "西村",
+    firstName: "海翔",
+    lastNameKana: "ニシムラ",
+    firstNameKana: "カイト",
+  },
+  {
+    lastName: "福田",
+    firstName: "柚希",
+    lastNameKana: "フクダ",
+    firstNameKana: "ユズキ",
+  },
+  {
+    lastName: "太田",
+    firstName: "暖",
+    lastNameKana: "オオタ",
+    firstNameKana: "ダン",
+  },
+  {
+    lastName: "三浦",
+    firstName: "七海",
+    lastNameKana: "ミウラ",
+    firstNameKana: "ナナミ",
+  },
+]
+
+// ---------------------------------------------------------------------------
+// 生徒40名をバルク追加
+// ---------------------------------------------------------------------------
+export async function seedStudents(): Promise<string[]> {
+  const db = getPrisma()
+  const ids: string[] = []
+  for (let i = 0; i < STUDENT_DATA.length; i++) {
+    const s = STUDENT_DATA[i]
+    const student = await db.student.create({
+      data: {
+        id: randomUUID(),
+        studentNumber: `S${String(i + 1).padStart(3, "0")}`,
+        lastName: s.lastName,
+        firstName: s.firstName,
+        lastNameKana: s.lastNameKana,
+        firstNameKana: s.firstNameKana,
+        enrollmentYear: 2025,
+      },
+    })
+    ids.push(student.id)
+  }
+  console.log(`  [SEED] 生徒 ${ids.length}名 追加`)
+  return ids
+}
+
+// ---------------------------------------------------------------------------
+// 学級2クラスを作成し生徒を割り当て
+// ---------------------------------------------------------------------------
+export async function seedClasses(
+  studentIds: string[]
+): Promise<{ classAId: string; classBId: string }> {
+  const db = getPrisma()
+  const classA = await db.class.create({
+    data: { id: randomUUID(), name: "2年A組", grade: 2 },
+  })
+  const classB = await db.class.create({
+    data: { id: randomUUID(), name: "2年B組", grade: 2 },
+  })
+  for (let i = 0; i < 20; i++) {
+    await db.studentClassMembership.create({
+      data: {
+        id: randomUUID(),
+        studentId: studentIds[i],
+        classId: classA.id,
+        attendanceNumber: i + 1,
+      },
+    })
+  }
+  for (let i = 20; i < 40; i++) {
+    await db.studentClassMembership.create({
+      data: {
+        id: randomUUID(),
+        studentId: studentIds[i],
+        classId: classB.id,
+        attendanceNumber: i - 19,
+      },
+    })
+  }
+  console.log(`  [SEED] 学級 2クラス 追加`)
+  return { classAId: classA.id, classBId: classB.id }
+}
+
+// ---------------------------------------------------------------------------
+// 小計グループ + 教科
+// ---------------------------------------------------------------------------
+export async function seedSubtotalAndSubject(): Promise<{
+  subtotalGroupId: string
+  subtotalIds: string[]
+}> {
+  const db = getPrisma()
+  const subtotalGroup = await db.subtotalGroup.create({
+    data: { id: randomUUID(), name: "観点別評価" },
+  })
+  const subtotalNames = [
+    "知識・技能",
+    "思考・判断・表現",
+    "主体的に学習に取り組む態度",
+  ]
+  const subtotalIds: string[] = []
+  for (let i = 0; i < subtotalNames.length; i++) {
+    const st = await db.subtotal.create({
+      data: {
+        id: randomUUID(),
+        name: subtotalNames[i],
+        subtotalGroupId: subtotalGroup.id,
+        order: i,
+      },
+    })
+    subtotalIds.push(st.id)
+  }
+  const subject = await db.subject.create({
+    data: { id: randomUUID(), name: "数学" },
+  })
+  await db.subjectSubtotalGroup.create({
+    data: {
+      id: randomUUID(),
+      subjectId: subject.id,
+      subtotalGroupId: subtotalGroup.id,
+    },
+  })
+  console.log(`  [SEED] 小計グループ: 観点別評価 (3項目)`)
+  return { subtotalGroupId: subtotalGroup.id, subtotalIds }
+}
+
+// ---------------------------------------------------------------------------
+// 試験 + 採点領域 + 受験生徒 + 答案画像 + 採点結果
+// ---------------------------------------------------------------------------
+export async function seedExamWithScoring(
+  userId: string,
+  studentIds: string[],
+  classAId: string,
+  classBId: string,
+  subtotalGroupId: string,
+  subtotalIds: string[],
+  templatePath: string
+): Promise<string> {
+  const db = getPrisma()
+  const REGION_DEFINITIONS = computeRegionDefinitions(templatePath)
+
+  const examId = randomUUID()
+  await db.exam.create({
+    data: {
+      id: examId,
+      examName: "第２回定期テスト 中２数学",
+      examDate: new Date("2025-10-15"),
+      subject: "数学",
+      description: "一次関数・連立方程式",
+    },
+  })
+  await db.userExam.create({
+    data: { id: randomUUID(), userId, examId, role: "OWNER" },
+  })
+  for (const classId of [classAId, classBId]) {
+    await db.examClass.create({
+      data: {
+        id: randomUUID(),
+        examId,
+        classId,
+        administered: true,
+        statistics: true,
+      },
+    })
+  }
+  await db.examSubtotalGroup.create({
+    data: { id: randomUUID(), examId, subtotalGroupId },
+  })
+
+  const examPage = await db.examPage.create({
+    data: { id: randomUUID(), examId, pageNumber: 1 },
+  })
+
+  // マスター画像（プレースホルダー白PNG）
+  const masterDir = path.join(TEST_DATA_DIR, "exams", examId, "master-images")
+  fs.mkdirSync(masterDir, { recursive: true })
+  const masterPath = path.join(masterDir, "master-page-1.png")
+  await sharp({
+    create: {
+      width: 2024,
+      height: 2866,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .png()
+    .toFile(masterPath)
+
+  const relMasterPath = path
+    .relative(TEST_DATA_DIR, masterPath)
+    .replace(/\\/g, "/")
+  await db.masterImage.create({
+    data: {
+      id: randomUUID(),
+      examPageId: examPage.id,
+      imagePath: relMasterPath,
+    },
+  })
+
+  // 採点領域
+  const cropRegionIds: string[] = []
+  for (const region of REGION_DEFINITIONS) {
+    const cr = await db.cropRegion.create({
+      data: {
+        id: randomUUID(),
+        examPageId: examPage.id,
+        label: region.label,
+        type: "QUESTION_ANSWER",
+        x: region.x,
+        y: region.y,
+        width: region.width,
+        height: region.height,
+        points: region.points,
+        orderIndex: region.orderIndex,
+      },
+    })
+    cropRegionIds.push(cr.id)
+
+    // 大問番号に応じて3つの小計に振り分け
+    // Q1-Q3: 知識・技能, Q4-Q5: 思考・判断・表現, Q6-Q7: 主体的に学習に取り組む態度
+    const majorNum = parseInt(region.label.replace(/[^\d].*/, ""), 10) || 1
+    const subtotalIndex = majorNum <= 3 ? 0 : majorNum <= 5 ? 1 : 2
+    await db.cropSubtotal.create({
+      data: {
+        id: randomUUID(),
+        cropRegionId: cr.id,
+        subtotalId: subtotalIds[subtotalIndex],
+        assignmentType: "QUESTION_ASSIGNMENT",
+      },
+    })
+  }
+
+  // 受験生徒 & 答案画像（手書き風解答付き）
+  const answerDir = path.join(TEST_DATA_DIR, "exams", examId, "answer-sheets")
+  fs.mkdirSync(answerDir, { recursive: true })
+
+  // 先に採点結果を計算（答案画像の生成に使う）
+  const allScores: { regionIndex: number; score: number; status: string }[][] =
+    []
+  for (let i = 0; i < studentIds.length; i++) {
+    allScores.push(generateStudentScores(i, REGION_DEFINITIONS))
+  }
+
+  for (let i = 0; i < studentIds.length; i++) {
+    const studentId = studentIds[i]
+    await db.examStudent.create({
+      data: {
+        id: randomUUID(),
+        examId,
+        studentId,
+        status: "PARTICIPATING",
+        customOrder: i + 1,
+      },
+    })
+    // 手書き風の解答をオーバーレイした答案画像を生成
+    await generateStudentAnswerImage(
+      answerDir,
+      i,
+      studentId,
+      masterDir,
+      REGION_DEFINITIONS,
+      allScores[i]
+    )
+    const answerPath = path.join(answerDir, `${studentId}_page1.png`)
+    const relAnswerPath = path
+      .relative(TEST_DATA_DIR, answerPath)
+      .replace(/\\/g, "/")
+    await db.studentAnswerImage.create({
+      data: {
+        id: randomUUID(),
+        examPageId: examPage.id,
+        studentId,
+        imagePath: relAnswerPath,
+      },
+    })
+  }
+
+  // 採点結果
+  for (let i = 0; i < studentIds.length; i++) {
+    const scores = allScores[i]
+    for (const s of scores) {
+      await db.questionScore.create({
+        data: {
+          id: randomUUID(),
+          cropRegionId: cropRegionIds[s.regionIndex],
+          studentId: studentIds[i],
+          partialScore: s.score,
+          status: s.status,
+          userId,
+        },
+      })
+    }
+  }
+
+  console.log(
+    `  [SEED] 試験 + 採点 (examId=${examId}, ${REGION_DEFINITIONS.length}領域)`
+  )
+  return examId
+}
+
+// ---------------------------------------------------------------------------
+// 成績算出プロジェクト
+// ---------------------------------------------------------------------------
+export async function seedGradeProject(
+  examId: string,
+  studentIds: string[],
+  classAId: string,
+  classBId: string,
+  subtotalIds: string[],
+  templatePath: string
+): Promise<string> {
+  const db = getPrisma()
+  const REGION_DEFINITIONS = computeRegionDefinitions(templatePath)
+  const TOTAL_POINTS = computeTotalPoints(REGION_DEFINITIONS)
+
+  const gradeId = randomUUID()
+  await db.grade.create({
+    data: {
+      id: gradeId,
+      name: "第２回定期テスト 数学 成績",
+      description: "成績算出サンプル",
+      referenceDate: new Date("2025-11-01"),
+    },
+  })
+  for (const classId of [classAId, classBId]) {
+    await db.gradeClass.create({
+      data: { id: randomUUID(), gradeId, classId },
+    })
+  }
+  for (let i = 0; i < studentIds.length; i++) {
+    await db.gradeStudent.create({
+      data: {
+        id: randomUUID(),
+        gradeId,
+        studentId: studentIds[i],
+        customOrder: i + 1,
+      },
+    })
+  }
+
+  const subtotalNames = [
+    "知識・技能",
+    "思考・判断・表現",
+    "主体的に学習に取り組む態度",
+  ]
+  // 4つの成績項目: 3つの小計 + 評定（合計点）
+  const gradeItemNames = [
+    "知識・技能",
+    "思考・判断・表現",
+    "主体的に学習に取り組む態度",
+    "評定",
+  ]
+  const gradeItemIds: string[] = []
+  for (let i = 0; i < gradeItemNames.length; i++) {
+    const gi = await db.gradeItem.create({
+      data: { id: randomUUID(), gradeId, name: gradeItemNames[i], order: i },
+    })
+    gradeItemIds.push(gi.id)
+  }
+
+  // 評定 → 合計点データソース
+  await db.gradeDataSource.create({
+    data: {
+      id: randomUUID(),
+      gradeItemId: gradeItemIds[3],
+      type: "exam_total",
+      examId,
+      name: "第２回定期テスト 数学（合計点）",
+      maxScore: TOTAL_POINTS,
+      weight: 1.0,
+    },
+  })
+  // 3つの小計それぞれにデータソースを作成
+  // Q1-Q3: 知識・技能, Q4-Q5: 思考・判断・表現, Q6-Q7: 主体的に学習に取り組む態度
+  for (let si = 0; si < 3; si++) {
+    const maxScore = REGION_DEFINITIONS.filter((r) => {
+      const mn = parseInt(r.label.replace(/[^\d].*/, ""), 10) || 1
+      if (si === 0) return mn <= 3
+      if (si === 1) return mn >= 4 && mn <= 5
+      return mn >= 6
+    }).reduce((sum, r) => sum + r.points, 0)
+    await db.gradeDataSource.create({
+      data: {
+        id: randomUUID(),
+        gradeItemId: gradeItemIds[si],
+        type: "subtotal",
+        examId,
+        subtotalId: subtotalIds[si],
+        name: subtotalNames[si],
+        maxScore,
+        weight: 1.0,
+      },
+    })
+  }
+
+  const boundaryLabels = [
+    { label: "A", minPercentage: 80 },
+    { label: "B", minPercentage: 65 },
+    { label: "C", minPercentage: 50 },
+    { label: "D", minPercentage: 35 },
+    { label: "E", minPercentage: 0 },
+  ]
+  for (const giId of gradeItemIds) {
+    const bs = await db.gradeBoundarySet.create({
+      data: {
+        id: randomUUID(),
+        gradeId,
+        targetType: "grade_item",
+        gradeItemId: giId,
+      },
+    })
+    for (let bi = 0; bi < boundaryLabels.length; bi++) {
+      await db.gradeBoundary.create({
+        data: {
+          id: randomUUID(),
+          gradeBoundarySetId: bs.id,
+          label: boundaryLabels[bi].label,
+          minPercentage: boundaryLabels[bi].minPercentage,
+          order: bi,
+        },
+      })
+    }
+  }
+  const overallBS = await db.gradeBoundarySet.create({
+    data: { id: randomUUID(), gradeId, targetType: "overall" },
+  })
+  for (let bi = 0; bi < boundaryLabels.length; bi++) {
+    await db.gradeBoundary.create({
+      data: {
+        id: randomUUID(),
+        gradeBoundarySetId: overallBS.id,
+        label: boundaryLabels[bi].label,
+        minPercentage: boundaryLabels[bi].minPercentage,
+        order: bi,
+      },
+    })
+  }
+
+  console.log(`  [SEED] 成績算出プロジェクト (gradeId=${gradeId})`)
+  return gradeId
+}
+
+// ---------------------------------------------------------------------------
+// 第2の試験（通常アップロード経路）— マスター画像は後からUIで確認用
+// ---------------------------------------------------------------------------
+export async function seedSimpleExam(
+  userId: string,
+  classAId: string
+): Promise<string> {
+  const db = getPrisma()
+  const examId = randomUUID()
+  await db.exam.create({
+    data: {
+      id: examId,
+      examName: "第１回実力テスト 中２英語",
+      examDate: new Date("2025-07-10"),
+      subject: "英語",
+      description: "Lesson 1-4 まとめ",
+    },
+  })
+  await db.userExam.create({
+    data: { id: randomUUID(), userId, examId, role: "OWNER" },
+  })
+  await db.examClass.create({
+    data: {
+      id: randomUUID(),
+      examId,
+      classId: classAId,
+      administered: true,
+      statistics: true,
+    },
+  })
+  await db.examPage.create({
+    data: { id: randomUUID(), examId, pageNumber: 1 },
+  })
+  console.log(`  [SEED] 通常試験 (examId=${examId})`)
+  return examId
+}
+
+// ---------------------------------------------------------------------------
+// ASBマスター画像ベースで答案画像を再生成
+// ---------------------------------------------------------------------------
+export async function regenerateAnswerImages(
+  examId: string,
+  studentIds: string[],
+  templatePath: string,
+  masterDir: string
+): Promise<void> {
+  const REGION_DEFINITIONS = computeRegionDefinitions(templatePath)
+  const answerDir = path.join(TEST_DATA_DIR, "exams", examId, "answer-sheets")
+  fs.mkdirSync(answerDir, { recursive: true })
+
+  // 模範解答画像に正答テキストをオーバーレイ
+  await generateMasterAnswerImage(masterDir, REGION_DEFINITIONS)
+
+  for (let i = 0; i < studentIds.length; i++) {
+    const scores = generateStudentScores(i, REGION_DEFINITIONS)
+    await generateStudentAnswerImage(
+      answerDir,
+      i,
+      studentIds[i],
+      masterDir,
+      REGION_DEFINITIONS,
+      scores
+    )
+  }
+  console.log(`  [REGEN] 模範解答 + 答案画像 ${studentIds.length}枚を再生成`)
+}

--- a/__tests__/screenshots/setup-data.ts
+++ b/__tests__/screenshots/setup-data.ts
@@ -1,0 +1,236 @@
+/**
+ * スクリーンショット用サンプルデータ生成スクリプト
+ *
+ * 専用の __tests__/screenshots/data/database.db にまっさらな状態からデータを生成する。
+ * 実データ(database.db)には一切触れない。
+ *
+ * Phase 1（テスト前に実行）:
+ *   - ユーザー作成
+ *   - ASBテンプレート定義作成
+ *
+ * Phase 2 以降のデータ（生徒・学級・試験・採点結果等）は
+ * テスト実行中に段階的に追加する。
+ *
+ * 使用方法:
+ *   npx tsx __tests__/screenshots/setup-data.ts
+ */
+
+import { PrismaClient } from "@prisma/client"
+import { randomUUID } from "crypto"
+import * as fs from "fs"
+import * as path from "path"
+
+// ---------------------------------------------------------------------------
+// パス設定
+// ---------------------------------------------------------------------------
+const PROJECT_ROOT = path.resolve(__dirname, "../..")
+const TEST_DATA_DIR = path.join(__dirname, "data")
+const DB_PATH = path.join(TEST_DATA_DIR, "database.db")
+
+// ---------------------------------------------------------------------------
+// Prisma Client（専用DB）
+// ---------------------------------------------------------------------------
+const prisma = new PrismaClient({
+  datasources: { db: { url: `file:${DB_PATH}` } },
+  log: ["error"],
+})
+
+// ---------------------------------------------------------------------------
+// メイン処理
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log("=== スクリーンショット専用データ生成 (Phase 1) ===")
+  console.log(`DB: ${DB_PATH}`)
+  console.log(`Data: ${TEST_DATA_DIR}\n`)
+
+  // 既存DB削除してまっさらに
+  for (const ext of ["", "-shm", "-wal", "-journal"]) {
+    const f = DB_PATH + ext
+    if (fs.existsSync(f)) fs.unlinkSync(f)
+  }
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true })
+
+  // Prisma db push でスキーマ作成
+  console.log("[0/2] スキーマ作成 (prisma db push)...")
+  const { execSync } = await import("child_process")
+  execSync(`npx prisma db push --skip-generate --accept-data-loss`, {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env, DATABASE_URL: `file:${DB_PATH}` },
+    stdio: "pipe",
+  })
+  console.log("  -> スキーマ作成完了")
+
+  // ========== 1. ユーザー ==========
+  console.log("[1/2] ユーザー作成...")
+  const userId = randomUUID()
+  await prisma.user.create({
+    data: {
+      id: userId,
+      username: "yamada-t",
+      name: "山田 太郎",
+      role: "teacher",
+      passcodeType: "none",
+    },
+  })
+  console.log("  -> 山田 太郎 (yamada-t)")
+
+  // ========== 2. 解答用紙ビルダーテンプレート ==========
+  console.log("[2/2] 解答用紙ビルダー定義作成...")
+  const asbTemplateFile = path.join(TEST_DATA_DIR, "asb-template.json")
+  const asbDefId = randomUUID()
+
+  if (fs.existsSync(asbTemplateFile)) {
+    const template = JSON.parse(fs.readFileSync(asbTemplateFile, "utf-8"))
+
+    const defData: Record<string, unknown> = { ...template }
+    defData.id = asbDefId
+    defData.name = "第２回定期テスト 中２数学"
+    defData.userId = userId
+    delete defData.headerFields
+    delete defData.majorQuestions
+    delete defData.createdAt
+    delete defData.updatedAt
+    await prisma.asbDefinition.create({ data: defData as never })
+
+    for (const hf of template.headerFields) {
+      await prisma.asbHeaderField.create({
+        data: { ...hf, id: randomUUID(), definitionId: asbDefId },
+      })
+    }
+
+    for (const mq of template.majorQuestions) {
+      const newMqId = randomUUID()
+      await prisma.asbMajorQuestion.create({
+        data: {
+          id: newMqId,
+          definitionId: asbDefId,
+          label: mq.label,
+          order: mq.order,
+        },
+      })
+      for (const sq of mq.subQuestions) {
+        const newSqId = randomUUID()
+        await prisma.asbSubQuestion.create({
+          data: {
+            id: newSqId,
+            majorQuestionId: newMqId,
+            label: sq.label,
+            order: sq.order,
+            heightMultiplier: sq.heightMultiplier,
+            points: sq.points,
+            usesBranchPoints: sq.usesBranchPoints,
+            layoutWidth: sq.layoutWidth,
+            nextPlacement: sq.nextPlacement,
+            goUp: sq.goUp,
+            manuscriptEnabled: sq.manuscriptEnabled,
+            manuscriptColumns: sq.manuscriptColumns,
+            manuscriptRows: sq.manuscriptRows,
+            manuscriptCellSizeMm: sq.manuscriptCellSizeMm,
+            borderStyleTop: sq.borderStyleTop,
+            borderStyleBottom: sq.borderStyleBottom,
+            borderStyleLeft: sq.borderStyleLeft,
+            borderStyleRight: sq.borderStyleRight,
+          },
+        })
+        for (const te of sq.textElements || []) {
+          await prisma.asbTextElement.create({
+            data: {
+              id: randomUUID(),
+              subQuestionId: newSqId,
+              branchQuestionId: null,
+              text: te.text,
+              fontSize: te.fontSize,
+              horizontalAlign: te.horizontalAlign,
+              verticalAlign: te.verticalAlign,
+              order: te.order,
+            },
+          })
+        }
+        if (sq.omrConfig) {
+          const newOmrId = randomUUID()
+          await prisma.asbOmrConfig.create({
+            data: {
+              id: newOmrId,
+              subQuestionId: newSqId,
+              type: sq.omrConfig.type,
+              numChoices: sq.omrConfig.numChoices,
+              choiceLayout: sq.omrConfig.choiceLayout,
+              numDigits: sq.omrConfig.numDigits,
+              correctAnswer: sq.omrConfig.correctAnswer,
+            },
+          })
+          for (const co of sq.omrConfig.choiceOptions || []) {
+            await prisma.asbOmrChoiceOption.create({
+              data: {
+                id: randomUUID(),
+                omrConfigId: newOmrId,
+                choiceIndex: co.choiceIndex,
+                label: co.label,
+                isCorrect: co.isCorrect,
+              },
+            })
+          }
+        }
+        for (const bq of sq.branchQuestions || []) {
+          await prisma.asbBranchQuestion.create({
+            data: {
+              id: randomUUID(),
+              subQuestionId: newSqId,
+              label: bq.label,
+              order: bq.order,
+              heightMultiplier: bq.heightMultiplier,
+              points: bq.points,
+              layoutWidth: bq.layoutWidth,
+              nextPlacement: bq.nextPlacement,
+              goUp: bq.goUp,
+              borderStyleTop: bq.borderStyleTop,
+              borderStyleBottom: bq.borderStyleBottom,
+              borderStyleLeft: bq.borderStyleLeft,
+              borderStyleRight: bq.borderStyleRight,
+            },
+          })
+        }
+      }
+    }
+    console.log("  -> テンプレートから復元完了")
+  } else {
+    await prisma.asbDefinition.create({
+      data: {
+        id: asbDefId,
+        name: "第２回定期テスト 中２数学",
+        userId,
+        paperSize: "B4",
+        orientation: "portrait",
+        multiColumnEnabled: true,
+        multiColumnCount: 2,
+      },
+    })
+    console.log("  -> シンプル定義を作成")
+  }
+
+  // ========== ID情報をファイルに保存 ==========
+  const ids = {
+    userId,
+    asbDefId,
+  }
+  fs.writeFileSync(
+    path.join(TEST_DATA_DIR, "screenshot-ids.json"),
+    JSON.stringify(ids, null, 2)
+  )
+
+  // ========== サマリー ==========
+  console.log("\n=== Phase 1 セットアップ完了 ===")
+  console.log(`ユーザー: 1名 (山田 太郎)`)
+  console.log(`解答用紙: 第２回定期テスト 中２数学`)
+  console.log(`\n※ 生徒・学級・試験等はテスト実行中に段階的に追加されます。`)
+  console.log(`DB: ${DB_PATH}`)
+  console.log(`IDs: ${path.join(TEST_DATA_DIR, "screenshot-ids.json")}`)
+
+  await prisma.$disconnect()
+}
+
+main().catch((e) => {
+  console.error("Error:", e)
+  prisma.$disconnect()
+  process.exit(1)
+})

--- a/__tests__/screenshots/take-screenshots.spec.ts
+++ b/__tests__/screenshots/take-screenshots.spec.ts
@@ -1,0 +1,967 @@
+/**
+ * 全画面スクリーンショット自動撮影
+ *
+ * 前提:
+ *   1. npx tsx __tests__/screenshots/setup-data.ts を実行済み
+ *   2. Next.js dev server が localhost:3000 で起動中
+ *
+ * 実行:
+ *   npx playwright test --config=playwright.screenshot.config.ts
+ *
+ * 専用DB (__tests__/screenshots/data/database.db) を使用。実データには一切触れない。
+ *
+ * ストーリー:
+ *   空の状態からUIを操作しながら段階的にデータを追加。
+ *   操作 → 結果 が一致するよう撮影する。
+ */
+
+import { test } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+import type { ElectronApplication, Page } from "playwright"
+import { _electron as electron } from "playwright"
+
+import {
+  disconnectPrisma,
+  seedClasses,
+  seedExamWithScoring,
+  seedGradeProject,
+  seedSimpleExam,
+  seedStudents,
+  seedSubtotalAndSubject,
+} from "./helpers/seed-in-test"
+
+// ---------------------------------------------------------------------------
+// 定数
+// ---------------------------------------------------------------------------
+const SCREENSHOTS_DIR = path.resolve(__dirname, "output")
+const PROJECT_ROOT = path.resolve(__dirname, "../..")
+const TEST_DATA_DIR = path.join(__dirname, "data")
+const SCREENSHOT_DB = path.join(TEST_DATA_DIR, "database.db")
+const IDS_FILE = path.join(TEST_DATA_DIR, "screenshot-ids.json")
+const TEMPLATE_PATH = path.join(TEST_DATA_DIR, "asb-template.json")
+const BASE_URL = "http://localhost:3000"
+
+function loadIds(): { userId: string; asbDefId: string } {
+  if (!fs.existsSync(IDS_FILE)) {
+    throw new Error(
+      `${IDS_FILE} が見つかりません。先に npx tsx tests/screenshots/setup-data.ts を実行してください。`
+    )
+  }
+  return JSON.parse(fs.readFileSync(IDS_FILE, "utf-8"))
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+async function waitForReady(page: Page) {
+  await page.waitForLoadState("networkidle")
+  try {
+    await page.waitForSelector(".animate-spin", {
+      state: "hidden",
+      timeout: 5000,
+    })
+  } catch {
+    // なければOK
+  }
+  await page.waitForTimeout(800)
+}
+
+async function ss(page: Page, relativePath: string) {
+  const fullPath = path.join(SCREENSHOTS_DIR, relativePath)
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+  await page.screenshot({
+    path: fullPath,
+    fullPage: false,
+    type: relativePath.endsWith(".jpeg") ? "jpeg" : "png",
+    quality: relativePath.endsWith(".jpeg") ? 90 : undefined,
+  })
+  console.log(`  [OK] ${relativePath}`)
+}
+
+async function nav(page: Page, urlPath: string) {
+  await page.goto(`${BASE_URL}${urlPath}`)
+  await waitForReady(page)
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+let electronApp: ElectronApplication
+let page: Page
+let IDS: ReturnType<typeof loadIds>
+
+// テスト間でIDを共有するための状態
+let studentIds: string[] = []
+let classAId = ""
+let classBId = ""
+let subtotalGroupId = ""
+let subtotalIds: string[] = []
+let examId = ""
+let simpleExamId = ""
+let gradeId = ""
+
+test.beforeAll(async () => {
+  IDS = loadIds()
+  console.log("=== Screenshot Test ===")
+  console.log(`ASB: ${IDS.asbDefId}\n`)
+
+  if (!fs.existsSync(SCREENSHOT_DB)) {
+    throw new Error(
+      "専用DB が見つかりません。setup-data.ts を先に実行してください。"
+    )
+  }
+
+  electronApp = await electron.launch({
+    args: [path.join(PROJECT_ROOT, "main/electron-src/index.js")],
+    cwd: PROJECT_ROOT,
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      SCORE_AT_ONCE_DATA_DIR: TEST_DATA_DIR,
+    },
+    timeout: 60000,
+  })
+
+  page = await electronApp.firstWindow({ timeout: 60000 })
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.waitForLoadState("domcontentloaded", { timeout: 30000 })
+  await page.waitForTimeout(3000)
+
+  // ログイン
+  await page.goto(`${BASE_URL}/login`)
+  await waitForReady(page)
+  try {
+    await page.getByText("山田 太郎").first().click({ timeout: 10000 })
+    await page.waitForTimeout(2000)
+    console.log("Logged in\n")
+  } catch {
+    console.warn("Login warning: user card not found\n")
+  }
+})
+
+test.afterAll(async () => {
+  await disconnectPrisma()
+  if (electronApp) await electronApp.close()
+})
+
+// ===========================
+// 第1章: 初期設定
+// ===========================
+
+test.describe.serial("第1章: 初期設定", () => {
+  test("1-1 ログイン画面", async () => {
+    await nav(page, "/login")
+    await ss(page, "ch1-setup/01-login.png")
+  })
+
+  test("1-2 生徒管理", async () => {
+    // (A) 空の生徒一覧を表示
+    await nav(page, "/students")
+    await ss(page, "ch1-setup/02-student-list.png")
+
+    // (B) 表形式インポートダイアログ（セルにデータ入力）
+    try {
+      await page.getByRole("button", { name: "表形式インポート" }).click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(500)
+
+      const firstInput = page
+        .locator('[role="dialog"] table tbody input')
+        .first()
+      if (await firstInput.isVisible({ timeout: 2000 })) {
+        await firstInput.click()
+        await firstInput.fill("S001")
+        await page.keyboard.press("Tab")
+        await page.keyboard.insertText("佐藤")
+        await page.keyboard.press("Tab")
+        await page.keyboard.insertText("翔太")
+        await page.keyboard.press("Tab")
+        await page.keyboard.insertText("サトウ")
+        await page.keyboard.press("Tab")
+        await page.keyboard.insertText("ショウタ")
+        await page.keyboard.press("Tab")
+        await page.keyboard.insertText("2025")
+      }
+      await page.waitForTimeout(300)
+      await ss(page, "ch1-setup/03-import-dialog.png")
+      await page.keyboard.press("Escape")
+      await page.waitForTimeout(300)
+    } catch (e) {
+      console.warn(
+        "  [SKIP] Import dialog:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+
+    // (C) 生徒追加ダイアログ
+    try {
+      await page.getByRole("button", { name: "生徒追加" }).click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+      const fills: [string, string][] = [
+        ["学籍番号", "S001"],
+        ["姓", "佐藤"],
+        ["名", "翔太"],
+        ["セイ", "サトウ"],
+        ["メイ", "ショウタ"],
+      ]
+      for (const [label, value] of fills) {
+        try {
+          const input = page.getByLabel(label).first()
+          if (await input.isVisible({ timeout: 500 })) await input.fill(value)
+        } catch {
+          // skip
+        }
+      }
+      await page.waitForTimeout(200)
+      await ss(page, "ch1-setup/04-add-student-dialog.png")
+      await page.keyboard.press("Escape")
+      await page.waitForTimeout(300)
+    } catch (e) {
+      console.warn(
+        "  [SKIP] Add student dialog:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+
+    // (D) DB直接操作で40名追加 → 一覧リロード
+    studentIds = await seedStudents()
+    await nav(page, "/students")
+    // 追加後の一覧（スクリーンショットは02で撮影済み、ここでは更新不要）
+  })
+
+  test("1-3 学級管理", async () => {
+    // (A) 空の学級一覧
+    await nav(page, "/classes")
+    await ss(page, "ch1-setup/05-class-list.png")
+
+    // (B) 学級追加ダイアログ（入力あり）
+    try {
+      await page.getByRole("button", { name: "学級追加" }).click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+      const nameInput = page.getByLabel("学級名").first()
+      if (await nameInput.isVisible({ timeout: 1000 })) {
+        await nameInput.fill("2年A組")
+      }
+      try {
+        const gradeInput = page.getByLabel("学年").first()
+        if (await gradeInput.isVisible({ timeout: 500 })) {
+          await gradeInput.fill("2")
+        }
+      } catch {
+        /* skip */
+      }
+      await ss(page, "ch1-setup/06-add-class-dialog.png")
+      await page.keyboard.press("Escape")
+      await page.waitForTimeout(300)
+    } catch (e) {
+      console.warn(
+        "  [SKIP] Add class dialog:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+
+    // (C) DB直接操作で2クラス作成
+    const classResult = await seedClasses(studentIds)
+    classAId = classResult.classAId
+    classBId = classResult.classBId
+
+    // (D) 作成後の学級一覧
+    await nav(page, "/classes")
+    await ss(page, "ch1-setup/07-class-list-updated.png")
+
+    // (E) UIで2年C組を追加（空のクラス）
+    let newClassCreated = false
+    try {
+      await page.getByRole("button", { name: "学級追加" }).click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+      const nameInput = page.getByLabel("学級名").first()
+      if (await nameInput.isVisible({ timeout: 1000 })) {
+        await nameInput.fill("2年C組")
+      }
+      try {
+        const gradeInput = page.getByLabel("学年").first()
+        if (await gradeInput.isVisible({ timeout: 500 })) {
+          await gradeInput.fill("2")
+        }
+      } catch {
+        /* skip */
+      }
+      const saveBtn = page
+        .locator('[role="dialog"]')
+        .getByRole("button", { name: "保存" })
+      if (await saveBtn.isVisible({ timeout: 500 })) {
+        await saveBtn.click()
+        await page.waitForTimeout(1500)
+        newClassCreated = true
+      }
+    } catch (e) {
+      console.warn(
+        "  [SKIP] Create 2年C組:",
+        (e as Error).message?.slice(0, 80)
+      )
+      try {
+        await page.keyboard.press("Escape")
+      } catch {
+        /* */
+      }
+    }
+
+    // (F) 空のクラス詳細
+    if (newClassCreated) {
+      try {
+        await nav(page, "/classes")
+        const newClassLink = page.getByText("2年C組").first()
+        if (await newClassLink.isVisible({ timeout: 2000 })) {
+          await newClassLink.click()
+          await waitForReady(page)
+          await ss(page, "ch1-setup/08-class-empty.png")
+        }
+      } catch (e) {
+        console.warn(
+          "  [SKIP] New class detail:",
+          (e as Error).message?.slice(0, 80)
+        )
+      }
+    }
+
+    // (G) 2年A組の詳細（生徒が20名いる）
+    await nav(page, `/classes/${classAId}`)
+    await ss(page, "ch1-setup/09-class-with-students.png")
+  })
+
+  test("1-4 小計グループ管理", async () => {
+    // (A) 空の小計グループ一覧
+    await nav(page, "/subtotal-groups")
+    await ss(page, "ch1-setup/10-subtotal-groups.png")
+
+    // (B) 新規作成ダイアログ（グループ名 + 項目を入力した状態）
+    try {
+      await page
+        .getByRole("button", { name: "最初のグループを作成" })
+        .first()
+        .click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+
+      const nameInput = page.getByLabel("グループ名").first()
+      if (await nameInput.isVisible({ timeout: 1000 })) {
+        await nameInput.fill("観点別評価")
+      }
+
+      const itemNames = [
+        "知識・技能",
+        "思考・判断・表現",
+        "主体的に学習に取り組む態度",
+      ]
+      for (let i = 0; i < itemNames.length; i++) {
+        try {
+          const addItemBtn = page
+            .locator('[role="dialog"]')
+            .getByRole("button")
+            .filter({ hasText: /項目を追加/ })
+            .first()
+          if (await addItemBtn.isVisible({ timeout: 500 })) {
+            await addItemBtn.click()
+            await page.waitForTimeout(200)
+          }
+          const itemInputs = page.locator(
+            '[role="dialog"] input[placeholder="小計項目名"]'
+          )
+          const lastInput = itemInputs.nth(i)
+          if (await lastInput.isVisible({ timeout: 500 })) {
+            await lastInput.fill(itemNames[i])
+          }
+        } catch {
+          /* skip */
+        }
+      }
+
+      await page.waitForTimeout(300)
+      await ss(page, "ch1-setup/11-add-subtotal-group-dialog.png")
+      await page.keyboard.press("Escape")
+      await page.waitForTimeout(300)
+    } catch (e) {
+      console.warn(
+        "  [SKIP] Add subtotal dialog:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+
+    // (C) DB直接操作で小計グループ + 教科を追加
+    const subtotalResult = await seedSubtotalAndSubject()
+    subtotalGroupId = subtotalResult.subtotalGroupId
+    subtotalIds = subtotalResult.subtotalIds
+
+    // (D) 作成後の一覧
+    await nav(page, "/subtotal-groups")
+    await ss(page, "ch1-setup/12-subtotal-group-created.png")
+  })
+})
+
+// ===========================
+// 第2章: 試験準備
+// ===========================
+
+test.describe.serial("第2章: 試験準備", () => {
+  test("2-1 解答用紙ビルダー", async () => {
+    // テンプレート一覧
+    await nav(page, "/answer-sheet-builder")
+    await ss(page, "ch2-exam-prep/01-asb-list.png")
+
+    // エディタ: 問題構成タブ
+    await nav(page, `/answer-sheet-builder/${IDS.asbDefId}`)
+    await waitForReady(page)
+    await page.waitForTimeout(2000)
+    await ss(page, "ch2-exam-prep/02-asb-editor.png")
+
+    // === ASBのPNG書き出し機能でマスター画像を生成 ===
+    // 注: examIdはまだ無い。一時ディレクトリに保存し、試験作成後にコピー。
+    const tempMasterDir = path.join(TEST_DATA_DIR, "temp-master")
+    fs.mkdirSync(tempMasterDir, { recursive: true })
+    const tempMasterPath = path.join(tempMasterDir, "master-page-1.png")
+
+    try {
+      await electronApp.evaluate(({ ipcMain }, outputPath) => {
+        ipcMain.removeHandler("asb:select-save-path")
+        ipcMain.handle("asb:select-save-path", async () => {
+          return { success: true, filePath: outputPath }
+        })
+      }, tempMasterPath)
+
+      await page.getByRole("button", { name: "出力" }).first().click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+
+      const dpiInput = page.locator('[role="dialog"] input[type="number"]')
+      if (await dpiInput.isVisible({ timeout: 1000 })) {
+        await dpiInput.fill("200")
+      }
+
+      await ss(page, "ch2-exam-prep/03-asb-export-dialog.png")
+
+      const pngBtn = page
+        .locator('[role="dialog"]')
+        .getByText("PNG出力")
+        .first()
+      await pngBtn.click()
+      await page.waitForTimeout(5000)
+
+      if (fs.existsSync(tempMasterPath)) {
+        console.log("  [OK] ASB PNG書き出し → temp-master/ に保存")
+      } else {
+        console.warn("  [WARN] PNG書き出し後にファイルが見つかりません")
+      }
+    } catch (e) {
+      console.warn(
+        "  [WARN] ASB PNG書き出し失敗:",
+        (e as Error).message?.slice(0, 100)
+      )
+    }
+
+    // 用紙設定タブ
+    try {
+      const paperTab = page
+        .getByRole("tab")
+        .filter({ hasText: /用紙設定/ })
+        .first()
+      if (await paperTab.isVisible({ timeout: 1000 })) {
+        await paperTab.click()
+        await page.waitForTimeout(500)
+        await ss(page, "ch2-exam-prep/03-asb-paper-settings.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Paper settings tab")
+    }
+
+    // ヘッダータブ
+    try {
+      const headerTab = page
+        .getByRole("tab")
+        .filter({ hasText: /ヘッダー/ })
+        .first()
+      if (await headerTab.isVisible({ timeout: 1000 })) {
+        await headerTab.click()
+        await page.waitForTimeout(500)
+        await ss(page, "ch2-exam-prep/04-asb-header.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Header tab")
+    }
+
+    // 罫線タブ
+    try {
+      const borderTab = page
+        .getByRole("tab")
+        .filter({ hasText: /罫線/ })
+        .first()
+      if (await borderTab.isVisible({ timeout: 1000 })) {
+        await borderTab.click()
+        await page.waitForTimeout(500)
+        await ss(page, "ch2-exam-prep/05-asb-borders.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Border tab")
+    }
+
+    // OMRタブ
+    try {
+      const omrTab = page.getByRole("tab").filter({ hasText: /OMR/ }).first()
+      if (await omrTab.isVisible({ timeout: 1000 })) {
+        await omrTab.click()
+        await page.waitForTimeout(500)
+        await ss(page, "ch2-exam-prep/06-asb-omr.png")
+      }
+    } catch {
+      console.warn("  [SKIP] OMR tab")
+    }
+  })
+
+  test("2-2 試験作成", async () => {
+    // (A) 空の試験一覧
+    await nav(page, "/exams")
+    await ss(page, "ch2-exam-prep/07-exam-list.png")
+
+    // (B) 新規試験作成ダイアログ（入力あり → 閉じる）
+    try {
+      await page.getByRole("button", { name: "新規試験作成" }).click()
+      await page.waitForSelector('[role="dialog"]', { timeout: 5000 })
+      await page.waitForTimeout(300)
+
+      const examNameInput = page.getByLabel("試験名").first()
+      if (await examNameInput.isVisible({ timeout: 1000 })) {
+        await examNameInput.fill("第２回定期テスト 中２数学")
+      }
+
+      try {
+        const dateInput = page.getByLabel("試験日").first()
+        if (await dateInput.isVisible({ timeout: 500 })) {
+          await dateInput.fill("2025-10-15")
+        }
+      } catch {
+        /* skip */
+      }
+
+      try {
+        const descInput = page.getByLabel("説明").first()
+        if (await descInput.isVisible({ timeout: 500 })) {
+          await descInput.fill("一次関数・連立方程式の範囲")
+        }
+      } catch {
+        /* skip */
+      }
+
+      try {
+        const subjectInput = page.getByPlaceholder("科目を入力").first()
+        if (await subjectInput.isVisible({ timeout: 500 })) {
+          await subjectInput.fill("数学")
+          await page.keyboard.press("Enter")
+          await page.waitForTimeout(200)
+        }
+      } catch {
+        /* skip */
+      }
+
+      await page.waitForTimeout(300)
+      await ss(page, "ch2-exam-prep/08-new-exam-dialog.png")
+      await page.keyboard.press("Escape")
+      await page.waitForTimeout(300)
+    } catch (e) {
+      console.warn(
+        "  [SKIP] New exam dialog:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+
+    // (C) DB直接操作で試験 + 採点領域 + 答案 + 採点結果を追加
+    examId = await seedExamWithScoring(
+      IDS.userId,
+      studentIds,
+      classAId,
+      classBId,
+      subtotalGroupId,
+      subtotalIds,
+      TEMPLATE_PATH
+    )
+
+    // ASBで書き出したマスター画像を試験ディレクトリにコピー & 答案画像を再生成
+    const tempMasterPath = path.join(
+      TEST_DATA_DIR,
+      "temp-master",
+      "master-page-1.png"
+    )
+    if (fs.existsSync(tempMasterPath)) {
+      const masterDir = path.join(
+        TEST_DATA_DIR,
+        "exams",
+        examId,
+        "master-images"
+      )
+      fs.mkdirSync(masterDir, { recursive: true })
+      const destMasterPath = path.join(masterDir, "master-page-1.png")
+      fs.copyFileSync(tempMasterPath, destMasterPath)
+
+      // ASBマスター画像ベースで答案画像を再生成（手書き付き）
+      const { regenerateAnswerImages } = await import("./helpers/seed-in-test")
+      await regenerateAnswerImages(examId, studentIds, TEMPLATE_PATH, masterDir)
+      console.log("  [OK] ASB PNG → マスター画像 + 答案画像を再生成")
+    }
+
+    // (D) 試験詳細
+    await nav(page, `/exams/${examId}`)
+    await ss(page, "ch2-exam-prep/09-exam-detail.png")
+  })
+
+  test("2-3 模範解答アップロード（ASBから変換済み）", async () => {
+    // ASBから変換した試験 → 模範解答は自動セット済み
+    await nav(page, `/exams/${examId}/01-upload`)
+    await ss(page, "ch2-exam-prep/10-master-upload.png")
+  })
+
+  test("2-4 採点領域作成（ASBから自動生成済み）", async () => {
+    await nav(page, `/exams/${examId}/02-template`)
+    await page.waitForTimeout(1500)
+
+    // ヘルプポップアップを閉じる
+    try {
+      const closeHelp = page.getByLabel("ヘルプを閉じる").first()
+      if (await closeHelp.isVisible({ timeout: 1000 })) {
+        await closeHelp.click()
+        await page.waitForTimeout(300)
+      }
+    } catch {
+      /* skip */
+    }
+
+    // imageContainerRef divにtabindexを付与してフォーカス → Ctrl+-でズームアウト
+    try {
+      const imgContainer = page.locator(".cursor-crosshair").first()
+      if (await imgContainer.isVisible({ timeout: 1000 })) {
+        await imgContainer.evaluate((el: HTMLElement) => {
+          el.setAttribute("tabindex", "-1")
+          el.focus()
+        })
+        await page.waitForTimeout(200)
+        for (let i = 0; i < 8; i++) {
+          await page.keyboard.down("Control")
+          await page.keyboard.press("Minus")
+          await page.keyboard.up("Control")
+          await page.waitForTimeout(100)
+        }
+        await page.waitForTimeout(500)
+      }
+    } catch (e) {
+      console.warn("  [WARN] Zoom out:", (e as Error).message?.slice(0, 80))
+    }
+
+    await ss(page, "ch2-exam-prep/11-scoring-regions.png")
+  })
+
+  test("2-5 領域情報", async () => {
+    await nav(page, `/exams/${examId}/03-region-info`)
+    await ss(page, "ch2-exam-prep/12-region-info.png")
+
+    try {
+      const firstLabelCell = page
+        .locator("table tbody tr")
+        .first()
+        .locator("td")
+        .nth(1)
+      if (await firstLabelCell.isVisible()) {
+        await firstLabelCell.dblclick()
+        await page.waitForTimeout(300)
+        await ss(page, "ch2-exam-prep/13-region-editing.png")
+        await page.keyboard.press("Escape")
+      }
+    } catch {
+      console.warn("  [SKIP] Label editing")
+    }
+  })
+
+  test("2-6 小計点設定（試験ごとの設問-小計マッピング）", async () => {
+    // グローバル小計グループの項目と、各設問の対応を設定する画面
+    await nav(page, `/exams/${examId}/04-question-group`)
+    await waitForReady(page)
+    await page.waitForTimeout(1000)
+    await ss(page, "ch2-exam-prep/14-subtotal-matrix.png")
+  })
+
+  test("2-7 受験生徒", async () => {
+    await nav(page, `/exams/${examId}/05-students`)
+    await waitForReady(page)
+    await ss(page, "ch2-exam-prep/15-exam-students.png")
+  })
+
+  test("2-8 通常アップロード経路（ASBを使わない試験作成）", async () => {
+    // 第2の試験を作成（通常のアップロード経路を示す）
+    simpleExamId = await seedSimpleExam(IDS.userId, classAId)
+
+    // 試験一覧（2つの試験が並ぶ）
+    await nav(page, "/exams")
+    await ss(page, "ch2-exam-prep/16-exam-list-two.png")
+
+    // 通常試験の模範解答アップロードページ（空の状態 = ドラッグ&ドロップUI）
+    await nav(page, `/exams/${simpleExamId}/01-upload`)
+    await waitForReady(page)
+    await ss(page, "ch2-exam-prep/17-regular-upload-empty.png")
+
+    // 通常試験の採点領域ページ（空の状態）
+    await nav(page, `/exams/${simpleExamId}/02-template`)
+    await waitForReady(page)
+    await page.waitForTimeout(1000)
+    await ss(page, "ch2-exam-prep/18-regular-template-empty.png")
+  })
+})
+
+// ===========================
+// 第3章: 試験ワークフロー（採点・出力）
+// ===========================
+
+test.describe.serial("第3章: 試験ワークフロー", () => {
+  test("3-1 答案アップロード", async () => {
+    await nav(page, `/exams/${examId}/06-student-answers`)
+    await waitForReady(page)
+    await ss(page, "ch3-scoring/01-answer-sheets.png")
+  })
+
+  test("3-2 一括採点（一覧表示）", async () => {
+    await nav(page, `/exams/${examId}/07-score-at-once`)
+    await waitForReady(page)
+    await page.waitForTimeout(2000)
+
+    // フィルターを全てONにして全答案を表示
+    try {
+      const filterSection = page
+        .locator("text=フィルター")
+        .first()
+        .locator("..")
+        .locator("..")
+      const filterGrid = filterSection.locator(".grid")
+      const filterButtons = filterGrid.getByRole("button")
+      const count = await filterButtons.count()
+      for (let i = 1; i < count; i++) {
+        await filterButtons.nth(i).click()
+        await page.waitForTimeout(150)
+      }
+      await page.waitForTimeout(500)
+    } catch (e) {
+      console.warn(
+        "  [WARN] Filter toggle:",
+        (e as Error).message?.slice(0, 80)
+      )
+    }
+    await ss(page, "ch3-scoring/02-scoring-grid.png")
+  })
+
+  test("3-3 一括採点（個別表示）", async () => {
+    try {
+      const individualBtn = page
+        .getByRole("button")
+        .filter({ hasText: /個別表示/ })
+        .first()
+      if (await individualBtn.isVisible({ timeout: 1000 })) {
+        await individualBtn.click()
+        await page.waitForTimeout(1500)
+        await ss(page, "ch3-scoring/03-individual-view.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Individual view")
+    }
+  })
+
+  test("3-4 一括採点（キーボードモード）", async () => {
+    try {
+      const kbBtn = page
+        .getByRole("button")
+        .filter({ hasText: /キーボード/ })
+        .first()
+      if (await kbBtn.isVisible({ timeout: 1000 })) {
+        await kbBtn.click()
+        await page.waitForTimeout(1500)
+        await ss(page, "ch3-scoring/04-keyboard-mode.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Keyboard mode")
+    }
+  })
+
+  test("3-5 結果", async () => {
+    await nav(page, `/exams/${examId}/08-export`)
+    await waitForReady(page)
+    await ss(page, "ch3-scoring/05-results.png")
+  })
+})
+
+// ===========================
+// 第4章: 成績算出・その他
+// ===========================
+
+test.describe.serial("第4章: 成績算出・その他", () => {
+  test("4-0 成績データ追加", async () => {
+    // DB直接操作で成績算出プロジェクトを追加
+    gradeId = await seedGradeProject(
+      examId,
+      studentIds,
+      classAId,
+      classBId,
+      subtotalIds,
+      TEMPLATE_PATH
+    )
+  })
+
+  test("4-1 成績算出 - 一覧", async () => {
+    await nav(page, "/grades")
+    await ss(page, "ch4-grades/01-grade-list.png")
+  })
+
+  test("4-2 成績算出 - 基本設定", async () => {
+    await nav(page, `/grades/${gradeId}/01-setup`)
+    await ss(page, "ch4-grades/02-setup.png")
+  })
+
+  test("4-3 成績算出 - 対象生徒", async () => {
+    await nav(page, `/grades/${gradeId}/02-students`)
+    await ss(page, "ch4-grades/03-students.png")
+  })
+
+  test("4-4 成績算出 - データソース", async () => {
+    await nav(page, `/grades/${gradeId}/03-data-sources`)
+    await ss(page, "ch4-grades/04-data-sources.png")
+  })
+
+  test("4-5 成績算出 - 外部成績", async () => {
+    await nav(page, `/grades/${gradeId}/04-manual-scores`)
+    await ss(page, "ch4-grades/05-manual-scores.png")
+  })
+
+  test("4-6 成績算出 - 成績境界", async () => {
+    await nav(page, `/grades/${gradeId}/05-boundaries`)
+    await ss(page, "ch4-grades/06-boundaries.png")
+  })
+
+  test("4-7 成績算出 - 結果", async () => {
+    await nav(page, `/grades/${gradeId}/06-results`)
+    await page.waitForTimeout(1500)
+    await ss(page, "ch4-grades/07-results.png")
+
+    try {
+      const boxPlotTab = page
+        .getByRole("tab")
+        .filter({ hasText: /箱ひげ/ })
+        .first()
+      if (await boxPlotTab.isVisible({ timeout: 1000 })) {
+        await boxPlotTab.click()
+        await page.waitForTimeout(800)
+        await ss(page, "ch4-grades/08-box-plot.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Box plot")
+    }
+
+    try {
+      const analysisTab = page
+        .getByRole("tab")
+        .filter({ hasText: /問題分析|分析/ })
+        .first()
+      if (await analysisTab.isVisible({ timeout: 1000 })) {
+        await analysisTab.click()
+        await page.waitForTimeout(800)
+        await ss(page, "ch4-grades/09-question-analysis.png")
+      }
+    } catch {
+      console.warn("  [SKIP] Question analysis")
+    }
+  })
+
+  test("4-8 成績算出 - 出力", async () => {
+    await nav(page, `/grades/${gradeId}/07-export`)
+    await ss(page, "ch4-grades/10-export.png")
+  })
+
+  test("4-9 PDF加工", async () => {
+    await nav(page, "/pdf-tools")
+    await waitForReady(page)
+    await ss(page, "ch4-grades/11-pdf-tools.png")
+  })
+
+  test("4-10 設定", async () => {
+    await nav(page, "/settings")
+    await waitForReady(page)
+    await ss(page, "ch4-grades/12-settings.png")
+
+    const tabNames = ["表示", "ユーザー", "データ"]
+    for (let i = 0; i < tabNames.length; i++) {
+      try {
+        const tab = page
+          .getByRole("tab")
+          .filter({ hasText: new RegExp(tabNames[i]) })
+          .first()
+        if (await tab.isVisible({ timeout: 500 })) {
+          await tab.click()
+          await page.waitForTimeout(500)
+          await ss(page, `ch4-grades/13-settings-${tabNames[i]}.png`)
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  })
+})
+
+// ===========================
+// ヒーロー画像（1920x1080ワイドショット）
+// ===========================
+
+test.describe.serial("ヒーロー画像", () => {
+  test("hero images", async () => {
+    await page.setViewportSize({ width: 1920, height: 1080 })
+
+    // 一括採点ワイドショット
+    await nav(page, `/exams/${examId}/07-score-at-once`)
+    await page.waitForTimeout(2500)
+    // フィルターを全ONにして答案を表示
+    try {
+      const filterSection = page
+        .locator("text=フィルター")
+        .first()
+        .locator("..")
+        .locator("..")
+      const filterGrid = filterSection.locator(".grid")
+      const filterButtons = filterGrid.getByRole("button")
+      const count = await filterButtons.count()
+      for (let i = 1; i < count; i++) {
+        await filterButtons.nth(i).click()
+        await page.waitForTimeout(150)
+      }
+      await page.waitForTimeout(500)
+    } catch {
+      /* skip */
+    }
+    await ss(page, "hero/01-scoring-wide.png")
+
+    // 解答用紙エディタ
+    await nav(page, `/answer-sheet-builder/${IDS.asbDefId}`)
+    await page.waitForTimeout(1500)
+    await ss(page, "hero/02-answer-sheet-builder.png")
+
+    // 成績結果
+    await nav(page, `/grades/${gradeId}/06-results`)
+    await page.waitForTimeout(1500)
+    await ss(page, "hero/03-grade-results.png")
+
+    // 試験一覧
+    await nav(page, "/exams")
+    await ss(page, "hero/04-exam-list.png")
+
+    // 生徒一覧
+    await nav(page, "/students")
+    await ss(page, "hero/05-student-list.png")
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+  })
+})

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -39,7 +39,11 @@ export const getAppRootPath = (): string => {
 }
 
 // データディレクトリのパス
+// 環境変数 SCORE_AT_ONCE_DATA_DIR が設定されている場合はそちらを優先
 export const getDataDirectory = (): string => {
+  if (process.env.SCORE_AT_ONCE_DATA_DIR) {
+    return path.resolve(process.env.SCORE_AT_ONCE_DATA_DIR)
+  }
   const dataPath = path.join(getAppRootPath(), "data")
   return dataPath
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
         "@eslint/eslintrc": "^3.3.3",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -4127,6 +4128,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -18134,6 +18151,52 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "github:prerelease:rc": "node scripts/github-release.js patch rc",
     "postinstall": "prisma generate && node scripts/setup-mathjax-fonts.js",
     "setup-assets": "node scripts/setup-mathjax-fonts.js",
+    "screenshot:setup": "npx tsx __tests__/screenshots/setup-data.ts",
+    "screenshot:test": "npx playwright test --config=playwright.screenshot.config.ts",
+    "screenshot": "npm run screenshot:setup && npm run screenshot:test",
     "db:seed": "node prisma/seed.js",
     "db:setup": "prisma migrate dev && npm run db:seed",
     "db:reset": "prisma migrate reset --force && npm run db:seed"
@@ -129,6 +132,7 @@
     "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@eslint/eslintrc": "^3.3.3",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.screenshot.config.ts
+++ b/playwright.screenshot.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from "@playwright/test"
+
+/**
+ * スクリーンショット自動撮影用 Playwright 設定
+ *
+ * Next.js dev server を自動起動し、Electron アプリ経由で全画面のスクリーンショットを撮影する。
+ *
+ * 使用方法:
+ *   # Electron ビルド済みであること
+ *   npx tsc -p electron-src
+ *   npx playwright test --config=playwright.screenshot.config.ts
+ */
+export default defineConfig({
+  testDir: "./__tests__/screenshots",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [["list"]],
+  timeout: 180 * 1000, // 3分（Electron起動 + ページ遷移を考慮）
+  expect: {
+    timeout: 15 * 1000,
+  },
+  use: {
+    screenshot: "off",
+    video: "off",
+    trace: "off",
+  },
+  outputDir: "__tests__/screenshots/artifacts/",
+  webServer: {
+    command: "npx next dev",
+    port: 3000,
+    reuseExistingServer: true,
+    timeout: 60 * 1000,
+  },
+})


### PR DESCRIPTION
## Summary

- スクリーンショットテスト関連のディレクトリ (`test_data/`, `screenshots/`, `test-results/`, `tests/`) を `__tests__/screenshots/` 配下に統合
- npm scripts追加: `screenshot:setup`, `screenshot:test`, `screenshot`
- 環境変数 `SCORE_AT_ONCE_DATA_DIR` によるデータディレクトリ切替を追加
- 未使用import/変数のlint警告を修正

Closes #523

## Test plan

- [ ] `npm run screenshot:setup` でテストDBが `__tests__/screenshots/data/` に作成されることを確認
- [ ] `npm run screenshot:test` でスクリーンショットが `__tests__/screenshots/output/` に出力されることを確認
- [ ] `npm run lint` が警告なしでパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)