### PR TITLE
fix: 原稿用紙使用時のtracking loop高さ計算不一致を修正

### DIFF
--- a/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -625,8 +625,12 @@ export function computeLayoutFromDefinition(
       }
 
       if (isGridHorizontal(mq.subQuestions)) {
-        const gridCells = buildSubGridLayout(mq.subQuestions)
-        const height = gridTotalHeight(gridCells) * baseRowHeight
+        const height = computeMajorHeight(
+          mq,
+          baseRowHeight,
+          contentRight - (majorNumX + majorNumWidth),
+          subNumWidth
+        )
         horizontalMajorRanges.push({ top: trackY, bottom: trackY + height })
         trackY += height
       } else {


### PR DESCRIPTION
## Summary

- tracking loopで `buildSubGridLayout` を `layoutWidth` なしで呼んでいた箇所を `computeMajorHeight()` に置き換え
- 原稿用紙セルの横配置レイアウト幅が正しく反映され、後続大問の小問番号罫線が正しい位置に描画される

Closes #533

## Test plan

- [ ] 原稿用紙を含む大問の後に通常の大問を配置し、小問番号罫線が正しい位置に描画されることを確認
- [ ] 複数の原稿用紙小問が同一行に並ぶケースで罫線位置を確認
- [ ] 原稿用紙を使用しない場合にレイアウトが変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)