### PR TITLE
fix: 交互挿入モードのpagesPerGroup実装（2-in-1併用時の不均等配分修正）

### DIFF
--- a/components/pdf-tools/export-panel/ExportPanel.tsx
+++ b/components/pdf-tools/export-panel/ExportPanel.tsx
@@ -222,12 +222,22 @@ function generateOutputPages(
       filePageGroups.push(group)
     }
 
-    // インターリーブ
-    const maxLength = Math.max(...filePageGroups.map((g) => g.length), 0)
-    for (let i = 0; i < maxLength; i++) {
-      for (const group of filePageGroups) {
-        if (group[i]) {
-          pages.push(group[i])
+    // pagesPerGroupに基づいてグループ化してインターリーブ
+    const groupedPages: OutputPage[][][] = filePageGroups.map((group, idx) => {
+      const transform = interleaveConfig.transforms[idx]
+      const perGroup = transform?.pagesPerGroup || 1
+      const chunks: OutputPage[][] = []
+      for (let i = 0; i < group.length; i += perGroup) {
+        chunks.push(group.slice(i, i + perGroup))
+      }
+      return chunks
+    })
+
+    const maxChunks = Math.max(...groupedPages.map((g) => g.length), 0)
+    for (let i = 0; i < maxChunks; i++) {
+      for (const chunks of groupedPages) {
+        if (chunks[i]) {
+          pages.push(...chunks[i])
         }
       }
     }

--- a/components/pdf-tools/export-panel/InterleaveSettings.tsx
+++ b/components/pdf-tools/export-panel/InterleaveSettings.tsx
@@ -3,6 +3,7 @@
 import { RotateCw, Settings2 } from "lucide-react"
 import { useEffect, useRef } from "react"
 
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -129,7 +130,7 @@ export default function InterleaveSettings({
                     {file.name}
                   </span>
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   <Select
                     value={
                       transform.nUp.enabled ? transform.nUp.layout : "1in1"
@@ -174,6 +175,28 @@ export default function InterleaveSettings({
                       <SelectItem value="270">270°</SelectItem>
                     </SelectContent>
                   </Select>
+
+                  <div className="flex items-center gap-1">
+                    <Input
+                      type="number"
+                      min={1}
+                      max={99}
+                      value={transform.pagesPerGroup}
+                      onChange={(e) => {
+                        const val = parseInt(e.target.value)
+                        if (val >= 1) {
+                          handleTransformChange(transform.fileId, {
+                            pagesPerGroup: val,
+                          })
+                        }
+                      }}
+                      className="h-8 w-14 text-center"
+                      disabled={disabled}
+                    />
+                    <span className="text-muted-foreground text-xs whitespace-nowrap">
+                      頁/組
+                    </span>
+                  </div>
                 </div>
               </div>
             )


### PR DESCRIPTION
## Summary

- 交互挿入のインターリーブロジックで`pagesPerGroup`によるチャンク化を実装
- InterleaveSettingsに「頁/組」数値入力UIを追加
- 2-in-1併用時のページ配分が均等になるよう修正

Closes #537

## Test plan

- [ ] PDF-A(4p, 2-in-1) + PDF-B(4p, 1-in-1)で交互挿入し、PDF-BのpagesPerGroup=2で均等配分されることを確認
- [ ] pagesPerGroup=1（デフォルト）で従来通りの1ページずつラウンドロビンになることを確認
- [ ] 3ファイル以上のインターリーブでも正しく動作することを確認
- [ ] 結合・分割モードに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)