### PR TITLE
fix: 受験生徒の並び順リセットとcustomOrder/classOrder保存を修正

### DIFF
--- a/components/exams/05-students/components/exam-student-add-modal/hooks/useExamStudentAddModal.ts
+++ b/components/exams/05-students/components/exam-student-add-modal/hooks/useExamStudentAddModal.ts
@@ -96,8 +96,22 @@ export function useExamStudentAddModal({
     try {
       const selectedClasses = availableClasses.filter((cls) => cls.isSelected)
 
-      // 選択された学級の順序で生徒を追加
+      // 既存生徒の最大customOrderを取得して、その後ろに追加する
+      const existingStudentsResult =
+        await window.electronAPI.getStudentsForExam(examId)
       let currentOrder = 0
+      if (existingStudentsResult.success && existingStudentsResult.students) {
+        const maxOrder = existingStudentsResult.students.reduce(
+          (max: number, s: { customOrder?: number | null }) => {
+            if (s.customOrder !== null && s.customOrder !== undefined) {
+              return Math.max(max, s.customOrder)
+            }
+            return max
+          },
+          -1
+        )
+        currentOrder = maxOrder + 1
+      }
 
       for (const classItem of selectedClasses) {
         // 1. ExamClass(administered=true) を作成
@@ -157,7 +171,7 @@ export function useExamStudentAddModal({
           // 生徒の順序を設定（学級順→出席番号順）
           const studentOrders = studentIds.map((studentId, index) => ({
             studentId,
-            customOrder: currentOrder + index + 1,
+            customOrder: currentOrder + index,
           }))
 
           const orderResult = await window.electronAPI.updateStudentOrders(
@@ -205,6 +219,35 @@ export function useExamStudentAddModal({
       if (!result.success) {
         throw new Error(result.error || "Failed to add students")
       }
+
+      // 既存生徒の最大customOrderを取得して、末尾に追加する
+      const existingStudentsResult =
+        await window.electronAPI.getStudentsForExam(examId)
+      let startOrder = 0
+      if (existingStudentsResult.success && existingStudentsResult.students) {
+        // 今追加した生徒以外の最大customOrderを取得
+        const otherStudents = existingStudentsResult.students.filter(
+          (s: { id: string }) => !studentIds.includes(s.id)
+        )
+        const maxOrder = otherStudents.reduce(
+          (max: number, s: { customOrder?: number | null }) => {
+            if (s.customOrder !== null && s.customOrder !== undefined) {
+              return Math.max(max, s.customOrder)
+            }
+            return max
+          },
+          -1
+        )
+        startOrder = maxOrder + 1
+      }
+
+      // 追加した生徒にcustomOrderを設定
+      const studentOrders = studentIds.map((studentId, index) => ({
+        studentId,
+        customOrder: startOrder + index,
+      }))
+
+      await window.electronAPI.updateStudentOrders(examId, studentOrders)
 
       onStudentsAdded()
       handleClose()

--- a/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
+++ b/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
@@ -64,8 +64,14 @@ export function useExamStudentsData({ examId }: UseExamStudentsDataProps) {
           if (a.customOrder !== null && a.customOrder !== undefined) return -1
           if (b.customOrder !== null && b.customOrder !== undefined) return 1
 
-          // customOrderが未設定の場合はデフォルト順序（追加順など）
-          return 0
+          // customOrderが未設定の場合はデフォルト順（学級順→出席番号順）
+          const aClassOrder = a.examClassInfo?.classOrder ?? 99999
+          const bClassOrder = b.examClassInfo?.classOrder ?? 99999
+          if (aClassOrder !== bClassOrder) return aClassOrder - bClassOrder
+
+          const aAttendance = a.examClassInfo?.attendanceNumber ?? 99999
+          const bAttendance = b.examClassInfo?.attendanceNumber ?? 99999
+          return aAttendance - bAttendance
         }
       )
 
@@ -169,7 +175,15 @@ export function useExamStudentsData({ examId }: UseExamStudentsDataProps) {
           }
           if (a.customOrder !== null && a.customOrder !== undefined) return -1
           if (b.customOrder !== null && b.customOrder !== undefined) return 1
-          return 0
+
+          // 両方nullの場合はデフォルト順（学級順→出席番号順）
+          const aClassOrder = a.examClassInfo?.classOrder ?? 99999
+          const bClassOrder = b.examClassInfo?.classOrder ?? 99999
+          if (aClassOrder !== bClassOrder) return aClassOrder - bClassOrder
+
+          const aAttendance = a.examClassInfo?.attendanceNumber ?? 99999
+          const bAttendance = b.examClassInfo?.attendanceNumber ?? 99999
+          return aAttendance - bAttendance
         })
       })
     } catch (error) {

--- a/components/exams/05-students/components/sortable-student-table/hooks/useSortableStudentTable.ts
+++ b/components/exams/05-students/components/sortable-student-table/hooks/useSortableStudentTable.ts
@@ -207,9 +207,9 @@ export function useSortableStudentTable({
     [onSelectAll]
   )
 
-  // リセット実行（統計学級順→出席番号順でcustomOrderを再設定）
+  // リセット実行（学級順→出席番号順でcustomOrderを振り直す）
   const handleResetOrder = useCallback(async () => {
-    // デフォルト順（統計学級順→出席番号順）でソート
+    // デフォルト順（学級順→出席番号順）でソート
     const defaultSorted = [...sortedStudents].sort((a, b) => {
       const aClassOrder = a.examClassInfo?.classOrder ?? 99999
       const bClassOrder = b.examClassInfo?.classOrder ?? 99999
@@ -223,7 +223,7 @@ export function useSortableStudentTable({
       return aAttendance - bAttendance
     })
 
-    // 新しいcustomOrderを割り当て
+    // customOrderを0からの連番で再割り当て
     const newOrders = defaultSorted.map((student, index) => ({
       studentId: student.id,
       customOrder: index,

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -163,12 +163,20 @@ export const addExamClass = async (
   const { examId, classId, administered = false, statistics = false } = options
 
   try {
+    // 現在の最大orderを取得して次の順序を決定
+    const maxOrderResult = await prisma.examClass.aggregate({
+      where: { examId },
+      _max: { order: true },
+    })
+    const nextOrder = (maxOrderResult._max.order ?? -1) + 1
+
     return await prisma.examClass.create({
       data: {
         examId,
         classId,
         administered,
         statistics,
+        order: nextOrder,
       },
       include: {
         class: true,


### PR DESCRIPTION
## Summary
- ExamClass追加時にorderを自動連番で設定するよう修正（全クラスorder=0だった）
- 学級/個別生徒追加時にcustomOrderを既存最大値の後ろから割り当てるよう修正
- 並び順リセット時に学級順→出席番号順でcustomOrderを正しく振り直すよう修正
- null同士のソートロジックをデフォルト順（学級順→出席番号順）に統一

Closes #539

## Test plan
- [ ] 学級を追加して生徒のcustomOrderが正しく連番で保存されることを確認
- [ ] 2つ目の学級を追加した際に末尾に追加されることを確認
- [ ] 個別生徒を追加した際に末尾に追加されることを確認
- [ ] 並び順リセットボタンで学級順→出席番号順に正しく並び直すことを確認
- [ ] リセット後にcustomOrderがDBに保存されていることを確認
- [ ] 答案ステップでcustomOrder順に正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)