### PR TITLE
feat: 生徒管理・学級管理にExcelエクスポート機能を追加

### DIFF
--- a/components/class/ClassManagementTable.tsx
+++ b/components/class/ClassManagementTable.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { Edit, PlusCircle, Search, Trash2 } from "lucide-react"
+import { Download, Edit, PlusCircle, Search, Trash2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
 
 import ClassModal from "@/components/class/ClassModal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { SortableTableHead } from "@/components/ui/SortableTableHead"
 import {
@@ -64,6 +66,12 @@ export default function ClassManagementTable() {
     null
   )
 
+  // Selection states
+  const [selectedClassIds, setSelectedClassIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [isExporting, setIsExporting] = useState(false)
+
   // Data fetching
   useEffect(() => {
     const fetchClasses = async () => {
@@ -105,6 +113,38 @@ export default function ClassManagementTable() {
     defaultSort: { key: "name", direction: "asc" },
   })
 
+  // Selection handlers
+  const filteredIds = useMemo(() => sortedData.map((d) => d.id), [sortedData])
+
+  const isAllSelected =
+    filteredIds.length > 0 &&
+    filteredIds.every((id) => selectedClassIds.has(id))
+
+  const isSomeSelected =
+    !isAllSelected && filteredIds.some((id) => selectedClassIds.has(id))
+
+  const toggleSelectAll = () => {
+    if (isAllSelected) {
+      const newSet = new Set(selectedClassIds)
+      filteredIds.forEach((id) => newSet.delete(id))
+      setSelectedClassIds(newSet)
+    } else {
+      const newSet = new Set(selectedClassIds)
+      filteredIds.forEach((id) => newSet.add(id))
+      setSelectedClassIds(newSet)
+    }
+  }
+
+  const toggleSelectClass = (classId: string) => {
+    const newSet = new Set(selectedClassIds)
+    if (newSet.has(classId)) {
+      newSet.delete(classId)
+    } else {
+      newSet.add(classId)
+    }
+    setSelectedClassIds(newSet)
+  }
+
   // Event handlers
   const handleAddNewClass = () => {
     setClassToEdit(null)
@@ -121,6 +161,11 @@ export default function ClassManagementTable() {
       try {
         await window.electronAPI.deleteClass(classId)
         setClasses(classes.filter((c) => c.id !== classId))
+        setSelectedClassIds((prev) => {
+          const newSet = new Set(prev)
+          newSet.delete(classId)
+          return newSet
+        })
       } catch (error) {
         console.error("Failed to delete class:", error)
         alert("学級の削除に失敗しました。")
@@ -155,6 +200,28 @@ export default function ClassManagementTable() {
     }
   }
 
+  const handleExportExcel = async () => {
+    if (selectedClassIds.size === 0) return
+    setIsExporting(true)
+    try {
+      const result = await window.electronAPI.exportClassesExcel(
+        Array.from(selectedClassIds)
+      )
+      if (result.success) {
+        toast.success(
+          `${selectedClassIds.size}学級のデータをExcelに出力しました`
+        )
+      } else if (result.error !== "出力がキャンセルされました") {
+        toast.error(`エクスポートに失敗しました: ${result.error}`)
+      }
+    } catch (error) {
+      console.error("Failed to export classes:", error)
+      toast.error("エクスポート中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   return (
     <div className="flex h-full flex-col gap-5">
       {/* Controls */}
@@ -170,13 +237,29 @@ export default function ClassManagementTable() {
             />
           </div>
           <span className="text-muted-foreground text-sm tabular-nums">
+            {selectedClassIds.size > 0
+              ? `${selectedClassIds.size}学級選択中 / `
+              : ""}
             {sortedData.length}学級
           </span>
         </div>
-        <Button onClick={handleAddNewClass} className="rounded-lg">
-          <PlusCircle className="mr-2 h-4 w-4" />
-          学級追加
-        </Button>
+        <div className="flex gap-3">
+          <Button
+            onClick={handleExportExcel}
+            variant="outline"
+            className="rounded-lg"
+            disabled={isExporting || selectedClassIds.size === 0}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            {isExporting
+              ? "出力中..."
+              : `Excel出力${selectedClassIds.size > 0 ? `(${selectedClassIds.size})` : ""}`}
+          </Button>
+          <Button onClick={handleAddNewClass} className="rounded-lg">
+            <PlusCircle className="mr-2 h-4 w-4" />
+            学級追加
+          </Button>
+        </div>
       </div>
 
       {/* Classes Table */}
@@ -185,6 +268,19 @@ export default function ClassManagementTable() {
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-muted/40">
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={
+                      isAllSelected
+                        ? true
+                        : isSomeSelected
+                          ? "indeterminate"
+                          : false
+                    }
+                    onCheckedChange={toggleSelectAll}
+                    aria-label="全選択"
+                  />
+                </TableHead>
                 <SortableTableHead
                   sortKey="name"
                   currentSortKey={sortConfig.key as string | null}
@@ -223,12 +319,25 @@ export default function ClassManagementTable() {
             </TableHeader>
             <TableBody>
               {sortedData.map(({ original: classItem, memberCount }) => {
+                const isSelected = selectedClassIds.has(classItem.id)
+
                 return (
                   <TableRow
                     key={classItem.id}
                     onClick={() => router.push(`/classes/${classItem.id}`)}
                     className="group cursor-pointer"
+                    data-state={isSelected ? "selected" : undefined}
                   >
+                    <TableCell
+                      className="w-10"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={() => toggleSelectClass(classItem.id)}
+                        aria-label={`${classItem.name}を選択`}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium">
                       {classItem.name}
                     </TableCell>
@@ -293,7 +402,7 @@ export default function ClassManagementTable() {
               {sortedData.length === 0 && (
                 <TableRow>
                   <TableCell
-                    colSpan={6}
+                    colSpan={7}
                     className="text-muted-foreground h-32 text-center"
                   >
                     該当する学級が見つかりません。

--- a/components/student/StudentTable.tsx
+++ b/components/student/StudentTable.tsx
@@ -1,14 +1,23 @@
 "use client"
 
 import type { Prisma } from "@prisma/client"
-import { Edit, PlusCircle, Search, Trash2, Upload } from "lucide-react"
+import {
+  Download,
+  Edit,
+  PlusCircle,
+  Search,
+  Trash2,
+  Upload,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
 
 import SpreadsheetImportModal from "@/components/student/SpreadsheetImportModal"
 import StudentModal from "@/components/student/StudentModal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -97,12 +106,18 @@ export default function StudentTable() {
     useState<string>("all")
   const [filterClassId, setFilterClassId] = useState<string>("all")
 
+  // Selection states
+  const [selectedStudentIds, setSelectedStudentIds] = useState<Set<string>>(
+    new Set()
+  )
+
   // Modal states
   const [isStudentModalOpen, setIsStudentModalOpen] = useState(false)
   const [studentToEdit, setStudentToEdit] =
     useState<StudentWithMemberships | null>(null)
   const [isSpreadsheetImportModalOpen, setIsSpreadsheetImportModalOpen] =
     useState(false)
+  const [isExporting, setIsExporting] = useState(false)
 
   // Data fetching
   useEffect(() => {
@@ -176,6 +191,40 @@ export default function StudentTable() {
     defaultSort: { key: "fullName", direction: "asc" },
   })
 
+  // Selection handlers
+  const filteredIds = useMemo(() => sortedData.map((d) => d.id), [sortedData])
+
+  const isAllSelected =
+    filteredIds.length > 0 &&
+    filteredIds.every((id) => selectedStudentIds.has(id))
+
+  const isSomeSelected =
+    !isAllSelected && filteredIds.some((id) => selectedStudentIds.has(id))
+
+  const toggleSelectAll = () => {
+    if (isAllSelected) {
+      // 表示中のものだけ解除
+      const newSet = new Set(selectedStudentIds)
+      filteredIds.forEach((id) => newSet.delete(id))
+      setSelectedStudentIds(newSet)
+    } else {
+      // 表示中のものを全選択
+      const newSet = new Set(selectedStudentIds)
+      filteredIds.forEach((id) => newSet.add(id))
+      setSelectedStudentIds(newSet)
+    }
+  }
+
+  const toggleSelectStudent = (studentId: string) => {
+    const newSet = new Set(selectedStudentIds)
+    if (newSet.has(studentId)) {
+      newSet.delete(studentId)
+    } else {
+      newSet.add(studentId)
+    }
+    setSelectedStudentIds(newSet)
+  }
+
   // Event handlers
   const handleAddNewStudent = () => {
     setStudentToEdit(null)
@@ -192,6 +241,11 @@ export default function StudentTable() {
       try {
         await window.electronAPI.deleteStudent(studentId)
         setStudents(students.filter((s) => s.id !== studentId))
+        setSelectedStudentIds((prev) => {
+          const newSet = new Set(prev)
+          newSet.delete(studentId)
+          return newSet
+        })
       } catch (error) {
         console.error("Failed to delete student:", error)
         alert("生徒の削除に失敗しました。")
@@ -228,6 +282,28 @@ export default function StudentTable() {
     } catch (error) {
       console.error("Failed to update student:", error)
       alert("生徒の更新に失敗しました。")
+    }
+  }
+
+  const handleExportExcel = async () => {
+    if (selectedStudentIds.size === 0) return
+    setIsExporting(true)
+    try {
+      const result = await window.electronAPI.exportStudentsExcel(
+        Array.from(selectedStudentIds)
+      )
+      if (result.success) {
+        toast.success(
+          `${selectedStudentIds.size}名の生徒データをExcelに出力しました`
+        )
+      } else if (result.error !== "出力がキャンセルされました") {
+        toast.error(`エクスポートに失敗しました: ${result.error}`)
+      }
+    } catch (error) {
+      console.error("Failed to export students:", error)
+      toast.error("エクスポート中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
     }
   }
 
@@ -295,10 +371,24 @@ export default function StudentTable() {
             </SelectContent>
           </Select>
           <span className="text-muted-foreground text-sm tabular-nums">
+            {selectedStudentIds.size > 0
+              ? `${selectedStudentIds.size}名選択中 / `
+              : ""}
             {sortedData.length}名
           </span>
         </div>
         <div className="flex gap-3">
+          <Button
+            onClick={handleExportExcel}
+            variant="outline"
+            className="rounded-lg"
+            disabled={isExporting || selectedStudentIds.size === 0}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            {isExporting
+              ? "出力中..."
+              : `Excel出力${selectedStudentIds.size > 0 ? `(${selectedStudentIds.size})` : ""}`}
+          </Button>
           <Button
             onClick={handleAddNewStudent}
             variant="outline"
@@ -322,8 +412,21 @@ export default function StudentTable() {
         <Table wrapperClassName="h-full">
           <TableHeader className="bg-card sticky top-0 z-10 shadow-[0_1px_3px_0_rgba(0,0,0,0.05)]">
             <TableRow className="hover:bg-muted/40">
+              <TableHead className="w-10">
+                <Checkbox
+                  checked={
+                    isAllSelected
+                      ? true
+                      : isSomeSelected
+                        ? "indeterminate"
+                        : false
+                  }
+                  onCheckedChange={toggleSelectAll}
+                  aria-label="全選択"
+                />
+              </TableHead>
               <SortableTableHead
-                sortKey="studentId"
+                sortKey="studentNumber"
                 currentSortKey={sortConfig.key as string | null}
                 currentDirection={sortConfig.direction}
                 onSort={(key) => requestSort(key as keyof StudentSortable)}
@@ -353,13 +456,25 @@ export default function StudentTable() {
           <TableBody>
             {sortedData.map(({ original: student }) => {
               const currentClasses = getCurrentClasses(student)
+              const isSelected = selectedStudentIds.has(student.id)
 
               return (
                 <TableRow
                   key={student.id}
                   onClick={() => router.push(`/students/${student.id}`)}
                   className="group cursor-pointer"
+                  data-state={isSelected ? "selected" : undefined}
                 >
+                  <TableCell
+                    className="w-10"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => toggleSelectStudent(student.id)}
+                      aria-label={`${student.lastName} ${student.firstName}を選択`}
+                    />
+                  </TableCell>
                   <TableCell className="font-mono text-sm">
                     {student.studentNumber}
                   </TableCell>
@@ -421,7 +536,7 @@ export default function StudentTable() {
             {sortedData.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={5}
+                  colSpan={6}
                   className="text-muted-foreground h-32 text-center"
                 >
                   該当する生徒が見つかりません。

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client"
-import { ipcMain } from "electron"
+import { dialog, ipcMain } from "electron"
+import * as ExcelJS from "exceljs"
 
 import {
   addStudentsToExam,
@@ -29,6 +30,10 @@ import {
   getMembershipsByDateRange,
   updateStudentClassMembership,
 } from "../lib/prisma/studentClassMembership"
+import {
+  applyCellStyle,
+  autoFitColumns,
+} from "../lib/shared/utilities/excelUtilities"
 
 export function setupStudentHandlers(): void {
   ipcMain.handle("fetch-students", async () => {
@@ -314,6 +319,169 @@ export function setupStudentHandlers(): void {
       } catch (err) {
         console.error("Error getting student exam results:", err)
         throw err
+      }
+    }
+  )
+
+  // 生徒データExcelエクスポート（選択された生徒のみ）
+  ipcMain.handle(
+    "export-students-excel",
+    async (_event, selectedStudentIds: string[]) => {
+      try {
+        const allStudents = await fetchStudents()
+        const selectedSet = new Set(selectedStudentIds)
+        const students = allStudents.filter((s) => selectedSet.has(s.id))
+
+        if (students.length === 0) {
+          return { success: false, error: "出力する生徒が選択されていません" }
+        }
+
+        const dateStr = new Date().toISOString().slice(0, 10)
+        const result = await dialog.showSaveDialog({
+          title: "生徒一覧のExcel出力先を選択",
+          defaultPath: `生徒一覧_${dateStr}.xlsx`,
+          filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
+        })
+
+        if (result.canceled || !result.filePath) {
+          return { success: false, error: "出力がキャンセルされました" }
+        }
+
+        const workbook = new ExcelJS.Workbook()
+        const worksheet = workbook.addWorksheet("生徒一覧")
+
+        // ヘッダー行（インポートと同じカラム・順序）
+        const headerRow = worksheet.addRow([
+          "学籍番号",
+          "姓",
+          "名",
+          "姓カナ",
+          "名カナ",
+          "入学年度",
+        ])
+        headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
+
+        // データ行（学籍番号順）
+        const sorted = [...students].sort((a, b) =>
+          a.studentNumber.localeCompare(b.studentNumber, "ja")
+        )
+
+        for (const student of sorted) {
+          const row = worksheet.addRow([
+            student.studentNumber,
+            student.lastName,
+            student.firstName,
+            student.lastNameKana,
+            student.firstNameKana,
+            student.enrollmentYear ?? "",
+          ])
+          row.eachCell((cell) => applyCellStyle(cell, "data"))
+        }
+
+        autoFitColumns(worksheet)
+        await workbook.xlsx.writeFile(result.filePath)
+
+        return { success: true, outputPath: result.filePath }
+      } catch (err) {
+        console.error("Error exporting students Excel:", err)
+        return {
+          success: false,
+          error:
+            err instanceof Error ? err.message : "不明なエラーが発生しました",
+        }
+      }
+    }
+  )
+
+  // 学級データExcelエクスポート（選択された学級の所属データ）
+  ipcMain.handle(
+    "export-classes-excel",
+    async (_event, selectedClassIds: string[]) => {
+      try {
+        const { fetchClasses } = await import("../lib/prisma/student")
+        const allClasses = await fetchClasses()
+        const selectedSet = new Set(selectedClassIds)
+        const classes = allClasses.filter((c) => selectedSet.has(c.id))
+
+        if (classes.length === 0) {
+          return { success: false, error: "出力する学級が選択されていません" }
+        }
+
+        const dateStr = new Date().toISOString().slice(0, 10)
+        const result = await dialog.showSaveDialog({
+          title: "学級データのExcel出力先を選択",
+          defaultPath: `学級データ_${dateStr}.xlsx`,
+          filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
+        })
+
+        if (result.canceled || !result.filePath) {
+          return { success: false, error: "出力がキャンセルされました" }
+        }
+
+        // 全生徒を取得（学籍番号逆引き用）
+        const allStudents = await fetchStudents()
+        const studentMap = new Map(allStudents.map((s) => [s.id, s]))
+
+        const workbook = new ExcelJS.Workbook()
+
+        // 学級ごとにシートを作成
+        for (const cls of classes) {
+          const sheetName = cls.name.replace(/[\\/:*?"<>|]/g, "_").slice(0, 31)
+          const worksheet = workbook.addWorksheet(sheetName)
+
+          // ヘッダー行（学級インポートと同じカラム・順序）
+          const headerRow = worksheet.addRow([
+            "学籍番号",
+            "出席番号",
+            "開始日",
+            "終了日",
+          ])
+          headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
+
+          // 所属データ（出席番号順）
+          const sortedMemberships = [...cls.memberships].sort((a, b) => {
+            const aNum = a.attendanceNumber ?? Infinity
+            const bNum = b.attendanceNumber ?? Infinity
+            return aNum - bNum
+          })
+
+          for (const m of sortedMemberships) {
+            const student = studentMap.get(m.student.id)
+            const studentNumber = student?.studentNumber ?? m.student.id
+            const row = worksheet.addRow([
+              studentNumber,
+              m.attendanceNumber ?? "",
+              m.startDate
+                ? new Date(m.startDate).toLocaleDateString("ja-JP", {
+                    year: "numeric",
+                    month: "numeric",
+                    day: "numeric",
+                  })
+                : "",
+              m.endDate
+                ? new Date(m.endDate).toLocaleDateString("ja-JP", {
+                    year: "numeric",
+                    month: "numeric",
+                    day: "numeric",
+                  })
+                : "",
+            ])
+            row.eachCell((cell) => applyCellStyle(cell, "data"))
+          }
+
+          autoFitColumns(worksheet)
+        }
+
+        await workbook.xlsx.writeFile(result.filePath)
+
+        return { success: true, outputPath: result.filePath }
+      } catch (err) {
+        console.error("Error exporting classes Excel:", err)
+        return {
+          success: false,
+          error:
+            err instanceof Error ? err.message : "不明なエラーが発生しました",
+        }
       }
     }
   )

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -167,6 +167,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteStudent: (id: string) => ipcRenderer.invoke("delete-student", id),
   getStudentExamResults: (studentId: string) =>
     ipcRenderer.invoke("get-student-exam-results", studentId),
+  exportStudentsExcel: (selectedStudentIds: string[]) =>
+    ipcRenderer.invoke("export-students-excel", selectedStudentIds) as Promise<{
+      success: boolean
+      outputPath?: string
+      error?: string
+    }>,
+  exportClassesExcel: (selectedClassIds: string[]) =>
+    ipcRenderer.invoke("export-classes-excel", selectedClassIds) as Promise<{
+      success: boolean
+      outputPath?: string
+      error?: string
+    }>,
 
   // Student Class Membership related
   createStudentClassMembership: (

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -380,6 +380,16 @@ export interface MyAPI {
   ) => Promise<StudentWithMemberships>
   deleteStudent: (id: string) => Promise<Student | void>
   getStudentExamResults: (studentId: string) => Promise<StudentExamResult[]>
+  exportStudentsExcel: (selectedStudentIds: string[]) => Promise<{
+    success: boolean
+    outputPath?: string
+    error?: string
+  }>
+  exportClassesExcel: (selectedClassIds: string[]) => Promise<{
+    success: boolean
+    outputPath?: string
+    error?: string
+  }>
 
   // Student Class Membership related
   createStudentClassMembership: (


### PR DESCRIPTION
## Summary
- 生徒管理・学級管理テーブルにチェックボックス列を追加
- 選択したデータをExcelファイルとしてエクスポートする機能を実装
- エクスポートカラムは各インポート形式と同一順序に統一
- 学籍番号ソートキーの誤りを修正

Closes #541

## Test plan
- [ ] 生徒管理ページでチェックボックスが表示され、全選択/個別選択が動作すること
- [ ] 生徒を選択してExcel出力ボタンを押し、正しいカラム順でExcelが生成されること
- [ ] 学級管理ページでチェックボックスが表示され、全選択/個別選択が動作すること
- [ ] 学級を選択してExcel出力ボタンを押し、学級ごとにシート分割されたExcelが生成されること
- [ ] 学籍番号ヘッダーのソートが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)