### PR TITLE
fix: 解答用紙定義の複製時にユニーク制約違反を修正

### DIFF
--- a/components/answer-sheet-builder/hooks/useAnswerSheetDefinitions.ts
+++ b/components/answer-sheet-builder/hooks/useAnswerSheetDefinitions.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import type { ASBDefinitionListItem } from "@/types/answerSheetBuilder.types"
+import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 
 /**
  * 解答用紙定義一覧のCRUDフック。
@@ -62,12 +63,51 @@ export function useAnswerSheetDefinitions(userId: string | undefined) {
         return
       }
 
-      const original = loadResult.data
+      const original: AnswerSheetDefinition = loadResult.data
       const newId = crypto.randomUUID()
+
+      // 全子要素のIDを再生成して一意性を保つ
+      const regeneratedHeaderFields = original.settings.headerFields.map(
+        (hf) => ({ ...hf, id: crypto.randomUUID() })
+      )
+      const regeneratedMajorQuestions = original.majorQuestions.map((mq) => ({
+        ...mq,
+        id: crypto.randomUUID(),
+        subQuestions: mq.subQuestions.map((sq) => ({
+          ...sq,
+          id: crypto.randomUUID(),
+          textElements: sq.textElements.map((te) => ({
+            ...te,
+            id: crypto.randomUUID(),
+          })),
+          imageElements: sq.imageElements?.map((ie) => ({
+            ...ie,
+            id: crypto.randomUUID(),
+          })),
+          branchQuestions: sq.branchQuestions.map((bq) => ({
+            ...bq,
+            id: crypto.randomUUID(),
+            textElements: bq.textElements.map((te) => ({
+              ...te,
+              id: crypto.randomUUID(),
+            })),
+            imageElements: bq.imageElements?.map((ie) => ({
+              ...ie,
+              id: crypto.randomUUID(),
+            })),
+          })),
+        })),
+      }))
+
       const duplicated = {
         ...original,
         id: newId,
         name: `${original.name} (コピー)`,
+        settings: {
+          ...original.settings,
+          headerFields: regeneratedHeaderFields,
+        },
+        majorQuestions: regeneratedMajorQuestions,
         createdAt: undefined,
         updatedAt: undefined,
       }


### PR DESCRIPTION
## Summary
- 解答用紙定義の複製時に全子要素のIDを再生成し、ユニーク制約違反（P2002）を解消
- `original` 変数に `AnswerSheetDefinition` 型を明示付与し、暗黙的anyを解消

Closes #543

## Test plan
- [ ] 解答用紙ビルダーで既存定義の「複製」ボタンを押して正常にコピーが作成されることを確認
- [ ] 複製された定義を開いて内容が正しく引き継がれていることを確認
- [ ] 複製した定義を保存・編集できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)