### PR TITLE
fix: 解答用紙一覧の合計点数が完答モード時に正しく計算されないバグを修正

### DIFF
--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -122,6 +122,7 @@ export async function listAsbDefinitions(
           subQuestions: {
             select: {
               points: true,
+              usesBranchPoints: true,
               branchQuestions: {
                 select: { points: true },
               },
@@ -139,8 +140,15 @@ export async function listAsbDefinitions(
     for (const mq of row.majorQuestions) {
       for (const sq of mq.subQuestions) {
         if (sq.branchQuestions.length > 0) {
-          questionCount += sq.branchQuestions.length
-          totalPoints += sq.branchQuestions.reduce((s, b) => s + b.points, 0)
+          if (sq.usesBranchPoints === false) {
+            // 完答モード: 小問の点数を使用
+            questionCount += 1
+            totalPoints += sq.points
+          } else {
+            // 枝問ごとの配点モード: 枝問の点数を合計
+            questionCount += sq.branchQuestions.length
+            totalPoints += sq.branchQuestions.reduce((s, b) => s + b.points, 0)
+          }
         } else {
           questionCount += 1
           totalPoints += sq.points


### PR DESCRIPTION
## Summary

- 解答用紙一覧取得時の `totalPoints` 計算で `usesBranchPoints` フラグを考慮するよう修正
- 完答モード（`usesBranchPoints === false`）では小問の点数を使用し、問題数を1とカウント
- 枝問配点モードでは従来通り枝問の点数を合計

Closes #545

## 変更ファイル

- `electron-src/lib/prisma/asbDefinition.ts`: SELECTに `usesBranchPoints` を追加し、計算ロジックを修正

## Test plan

- [ ] 完答モードの枝問を持つ解答用紙定義を作成し、一覧の点数が作成画面と一致することを確認
- [ ] 枝問配点モードの解答用紙定義で、一覧の点数が正しいことを確認
- [ ] 枝問のない通常の解答用紙定義の点数が影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)