### PR TITLE
fix: 個別表示モードで数字キーによる部分点モーダルが発火しない問題を修正

### DIFF
--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -451,60 +451,60 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   // ========================================
-  // グリッドモードでの部分点入力ショートカット
+  // 部分点入力ショートカット（グリッド・個別共通）
   // ========================================
   useCommand("scoring.openPartialWith0", () => handlePartialScoreInput("0"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "0キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith1", () => handlePartialScoreInput("1"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "1キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith2", () => handlePartialScoreInput("2"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "2キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith3", () => handlePartialScoreInput("3"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "3キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith4", () => handlePartialScoreInput("4"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "4キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith5", () => handlePartialScoreInput("5"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "5キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith6", () => handlePartialScoreInput("6"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "6キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith7", () => handlePartialScoreInput("7"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "7キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith8", () => handlePartialScoreInput("8"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "8キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith9", () => handlePartialScoreInput("9"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "9キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWithDot", () => handlePartialScoreInput("."), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers && gradingMode == 'grid'",
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: ".キーで部分点入力", category: "採点" },
   })
 }


### PR DESCRIPTION
## Summary

- 部分点入力ショートカット(0-9, .)の`when`条件から`gradingMode == 'grid'`を削除し、個別表示モードでも発火するように修正
- テキストエディタとの競合防止のため`!textEditorActive`条件を追加

Closes #548

## 変更ファイル

- `components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts`

## Test plan

- [ ] グリッド表示モードで数字キーによる部分点モーダルが従来通り動作すること
- [ ] 個別表示モードで数字キーによる部分点モーダルが発火すること
- [ ] テキストエディタ内では数字キーが通常入力として動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)