### PR TITLE
fix: 全エクスポートで採点データ警告を表示 (#549)

### DIFF
--- a/components/exams/08-export/ExportMainView.tsx
+++ b/components/exams/08-export/ExportMainView.tsx
@@ -36,6 +36,9 @@ export default function ExportMainView() {
     unscored: [] as string[],
     missingPartialScore: [] as string[],
   })
+  const [pendingExportType, setPendingExportType] = useState<
+    "scored-answers" | "grading-data" | "individual-reports" | null
+  >(null)
 
   // Canvas描画用の状態
   const [pdfExportPages, setPdfExportPages] = useState<PdfExportPageData[]>([])
@@ -213,6 +216,37 @@ export default function ExportMainView() {
    * Canvas描画ベースのPDF出力（ストリーミング処理フロー）
    * 1. データ取得 → 2. ストリーミングセッション作成 & 保存先選択 → 3. Canvas描画（完了次第PDF埋め込み） → 4. PDF保存
    */
+  /**
+   * 採点データバリデーションを実行し、警告があればモーダルを表示する
+   * @returns true: バリデーション通過（警告なし）、false: 警告あり（モーダル表示）
+   */
+  const validateBeforeExport = async (
+    exportType: "scored-answers" | "grading-data" | "individual-reports"
+  ): Promise<boolean> => {
+    const selectedStudentIds = Array.from(selectedStudents)
+    const result = await window.electronAPI.export.validateScoringData({
+      examId: exam.id,
+      selectedStudentIds,
+    })
+
+    if (!result.success) {
+      throw new Error(result.error || "バリデーションに失敗しました")
+    }
+
+    if (result.hasWarnings && result.warnings) {
+      setWarningData({
+        noScoringData: result.warnings.noScoringData,
+        unscored: result.warnings.ungraded,
+        missingPartialScore: result.warnings.missingPartialScore,
+      })
+      setPendingExportType(exportType)
+      setShowWarningModal(true)
+      return false
+    }
+
+    return true
+  }
+
   const handleExportScoredAnswers = async () => {
     if (selectedStudents.size === 0) {
       alert("出力する生徒を選択してください")
@@ -223,6 +257,21 @@ export default function ExportMainView() {
       return
     }
 
+    try {
+      // バリデーション実行
+      const isValid = await validateBeforeExport("scored-answers")
+      if (!isValid) return
+
+      await executeExportScoredAnswers()
+    } catch (error) {
+      console.error("Export error:", error)
+      alert(
+        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
+      )
+    }
+  }
+
+  const executeExportScoredAnswers = async () => {
     try {
       // 処理開始
       setIsExporting(true)
@@ -566,6 +615,19 @@ export default function ExportMainView() {
       return
     }
 
+    try {
+      // バリデーション実行
+      const isValid = await validateBeforeExport("grading-data")
+      if (!isValid) return
+
+      await executeExportGradingData()
+    } catch (error) {
+      console.error("Export error:", error)
+      alert("出力中にエラーが発生しました")
+    }
+  }
+
+  const executeExportGradingData = async () => {
     setIsExporting(true)
 
     try {
@@ -574,16 +636,13 @@ export default function ExportMainView() {
       const result = await window.electronAPI.exportGradingDataExcel({
         examId: exam.id,
         selectedStudentIds,
+        forceExport: true,
       })
 
       if (result.success) {
         alert(
           `採点データExcelの出力が完了しました。\n保存先: ${result.outputPath}`
         )
-      } else if (result.warnings) {
-        // 警告がある場合は警告モーダルを表示
-        setWarningData(result.warnings)
-        setShowWarningModal(true)
       } else {
         alert(`出力に失敗しました: ${result.error}`)
       }
@@ -597,29 +656,15 @@ export default function ExportMainView() {
 
   const handleContinueExport = async () => {
     setShowWarningModal(false)
-    setIsExporting(true)
+    const exportType = pendingExportType
+    setPendingExportType(null)
 
-    try {
-      const selectedStudentIds = Array.from(selectedStudents)
-
-      const result = await window.electronAPI.exportGradingDataExcel({
-        examId: exam.id,
-        selectedStudentIds,
-        forceExport: true, // 警告を無視して強制実行
-      })
-
-      if (result.success) {
-        alert(
-          `採点データExcelの出力が完了しました。\n保存先: ${result.outputPath}`
-        )
-      } else {
-        alert(`出力に失敗しました: ${result.error}`)
-      }
-    } catch (error) {
-      console.error("Export error:", error)
-      alert("出力中にエラーが発生しました")
-    } finally {
-      setIsExporting(false)
+    if (exportType === "grading-data") {
+      await executeExportGradingData()
+    } else if (exportType === "scored-answers") {
+      await executeExportScoredAnswers()
+    } else if (exportType === "individual-reports") {
+      await executeExportIndividualReports()
     }
   }
 
@@ -634,8 +679,23 @@ export default function ExportMainView() {
     }
 
     try {
-      setIsExporting(true)
+      // バリデーション実行
+      const isValid = await validateBeforeExport("individual-reports")
+      if (!isValid) return
 
+      await executeExportIndividualReports()
+    } catch (error) {
+      console.error("Individual report export error:", error)
+      alert(
+        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
+      )
+    }
+  }
+
+  const executeExportIndividualReports = async () => {
+    setIsExporting(true)
+
+    try {
       const selectedStudentIds = Array.from(selectedStudents)
 
       // 1. データ取得（統計・アドバイス含む）

--- a/components/exams/08-export/components/ExportWarningModal.tsx
+++ b/components/exams/08-export/components/ExportWarningModal.tsx
@@ -112,7 +112,7 @@ export default function ExportWarningModal({
             <p className="text-sm text-gray-600">
               {hasWarnings ? (
                 <>
-                  上記の問題がある状態でExcelファイルを出力すると、該当箇所は適切に表示されない可能性があります。
+                  上記の問題がある状態で出力すると、該当箇所は適切に表示されない可能性があります。
                   それでも続行する場合は「警告を無視して続行」をクリックしてください。
                 </>
               ) : (

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -16,8 +16,42 @@ import {
   finalizeStreamingSession,
   getPdfExportData,
 } from "../lib/prisma/pdfExport"
+import { validateScoringData } from "../lib/shared/utilities/validateScoringData"
 
 export function setupExportHandlers(): void {
+  // 採点データバリデーション（全エクスポート共通）
+  ipcMain.handle(
+    "export:validateScoringData",
+    async (
+      _event,
+      options: {
+        examId: string
+        selectedStudentIds: string[]
+      }
+    ) => {
+      try {
+        const result = await fetchExportData(
+          options.examId,
+          options.selectedStudentIds
+        )
+        if (!result.success || !result.scoringData) {
+          return {
+            success: false,
+            error: result.error || "データ取得に失敗しました",
+          }
+        }
+        const validationResult = validateScoringData(result.scoringData)
+        return { success: true, ...validationResult }
+      } catch (err) {
+        console.error("Error validating scoring data:", err)
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : "Unknown error occurred",
+        }
+      }
+    }
+  )
+
   // Excel Export handlers
   ipcMain.handle(
     "export-grading-data-excel",

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -3,8 +3,8 @@ import * as ExcelJS from "exceljs"
 import {
   ExportGradingDataOptions,
   ExportResult,
-  ScoringData,
 } from "../../shared/types/exportTypes"
+import { validateScoringData } from "../../shared/utilities/validateScoringData"
 import { fetchExportData } from "./dataFetcher"
 import { saveWorkbook } from "./fileSaver"
 import { createItemAnalysisSheet } from "./itemAnalysisSheetCreator"
@@ -95,62 +95,5 @@ export async function exportGradingDataExcel(
       error:
         error instanceof Error ? error.message : "不明なエラーが発生しました",
     }
-  }
-}
-
-/**
- * 採点データの検証結果
- */
-interface ValidationResult {
-  hasWarnings: boolean
-  warnings: {
-    noScoringData: string[]
-    ungraded: string[]
-    missingPartialScore: string[]
-  }
-}
-
-/**
- * 採点データを検証して警告を生成する
- */
-function validateScoringData(scoringData: ScoringData[]): ValidationResult {
-  const warnings = {
-    noScoringData: [] as string[],
-    ungraded: [] as string[],
-    missingPartialScore: [] as string[],
-  }
-
-  for (const studentData of scoringData) {
-    const studentName = studentData.studentName
-
-    for (const score of studentData.scores) {
-      const questionLabel = score.questionLabel
-      const identifier = `${studentName} - ${questionLabel}`
-
-      // 採点データが存在しない
-      if (!score.status || score.status === "unscored") {
-        if (score.score === null) {
-          warnings.noScoringData.push(identifier)
-        } else {
-          warnings.ungraded.push(identifier)
-        }
-      }
-
-      // 部分点・保留で値が入力されていない（0点は有効な値なので除外）
-      if (
-        (score.status === "partial" || score.status === "hold") &&
-        score.score === null
-      ) {
-        warnings.missingPartialScore.push(identifier)
-      }
-    }
-  }
-
-  return {
-    hasWarnings:
-      warnings.noScoringData.length > 0 ||
-      warnings.ungraded.length > 0 ||
-      warnings.missingPartialScore.length > 0,
-    warnings,
   }
 }

--- a/electron-src/lib/shared/utilities/validateScoringData.ts
+++ b/electron-src/lib/shared/utilities/validateScoringData.ts
@@ -1,0 +1,64 @@
+import type { ScoringData } from "../types/exportTypes"
+
+/**
+ * 採点データの検証結果
+ */
+export interface ValidationResult {
+  hasWarnings: boolean
+  warnings: {
+    noScoringData: string[]
+    ungraded: string[]
+    missingPartialScore: string[]
+  }
+}
+
+/**
+ * 採点データを検証して警告を生成する
+ *
+ * - 🔴 noScoringData: 採点データが存在しない（status=unscored, score=null）
+ * - 🟠 ungraded: 未採点（status=unscored, score≠null）
+ * - 🟡 missingPartialScore: 部分点・保留で値が未入力（status=partial|hold, score=null）
+ */
+export function validateScoringData(
+  scoringData: ScoringData[]
+): ValidationResult {
+  const warnings = {
+    noScoringData: [] as string[],
+    ungraded: [] as string[],
+    missingPartialScore: [] as string[],
+  }
+
+  for (const studentData of scoringData) {
+    const studentName = studentData.studentName
+
+    for (const score of studentData.scores) {
+      const questionLabel = score.questionLabel
+      const identifier = `${studentName} - ${questionLabel}`
+
+      // 採点データが存在しない
+      if (!score.status || score.status === "unscored") {
+        if (score.score === null) {
+          warnings.noScoringData.push(identifier)
+        } else {
+          warnings.ungraded.push(identifier)
+        }
+      }
+
+      // 部分点・保留で値が入力されていない（0点は有効な値なので除外）
+      if (
+        (score.status === "partial" || score.status === "hold") &&
+        score.score === null
+      ) {
+        warnings.missingPartialScore.push(identifier)
+      }
+    }
+  }
+
+  return {
+    hasWarnings:
+      warnings.noScoringData.length > 0 ||
+      warnings.ungraded.length > 0 ||
+      warnings.missingPartialScore.length > 0,
+    warnings,
+  }
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -462,6 +462,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Canvas描画エンジン用PDF出力API
   export: {
+    validateScoringData: (options: {
+      examId: string
+      selectedStudentIds: string[]
+    }) => ipcRenderer.invoke("export:validateScoringData", options),
     getPdfExportData: (options: {
       examId: string
       selectedStudentIds: string[]

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -917,9 +917,13 @@ export interface MyAPI {
     percentage: number
   }>
   getExamProgress: (examId: string) => Promise<{
-    totalStudentAnswers: number
-    completedStudentAnswers: number
-    percentage: number
+    totalStudents: number
+    totalQuestions: number
+    totalItems: number
+    scoredItems: number
+    finalizedItems: number
+    scoredPercentage: number
+    finalizedPercentage: number
   }>
   initializeScoringRecords: (examId: string) => Promise<{
     success: boolean
@@ -930,6 +934,21 @@ export interface MyAPI {
 
   // Canvas描画エンジン用PDF出力API
   export: {
+    // 採点データバリデーション（全エクスポート共通）
+    validateScoringData: (options: {
+      examId: string
+      selectedStudentIds: string[]
+    }) => Promise<{
+      success: boolean
+      error?: string
+      hasWarnings?: boolean
+      warnings?: {
+        noScoringData: string[]
+        ungraded: string[]
+        missingPartialScore: string[]
+      }
+    }>
+
     // PDF出力に必要なデータを取得
     getPdfExportData: (options: {
       examId: string


### PR DESCRIPTION
## Summary
- Excel出力時のみ表示されていた採点データ警告を、採点済み答案PDF・個人成績表PDFにも適用
- `validateScoringData` を共有モジュールに抽出し、全エクスポートで共通のバリデーションフローを実現
- `ExportWarningModal` の文言を汎用化

## 変更ファイル
| ファイル | 内容 |
|---------|------|
| `electron-src/lib/shared/utilities/validateScoringData.ts` | 新規: 共有バリデーション関数 |
| `electron-src/lib/export/excel/excelExportMain.ts` | ローカル関数を共有モジュールに置き換え |
| `electron-src/ipc-handlers/exportHandlers.ts` | `export:validateScoringData` ハンドラー追加 |
| `electron-src/preload.ts` | API バインディング追加 |
| `types/electron.d.ts` | 型定義追加 |
| `components/exams/08-export/ExportMainView.tsx` | 全エクスポートに事前バリデーション追加 |
| `components/exams/08-export/components/ExportWarningModal.tsx` | 文言汎用化 |

## Test plan
- [ ] 採点済み答案PDF出力時に、未採点データがある場合に警告モーダルが表示される
- [ ] 個人成績表PDF出力時に、部分点未入力がある場合に警告モーダルが表示される
- [ ] Excel出力時の既存の警告表示が変わらず動作する
- [ ] 警告モーダルで「警告を無視して続行」を選択すると正常に出力される
- [ ] 全データが採点済みの場合は警告なしで直接出力される

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)