### PR TITLE
fix: 採点画面の試験進捗パネルが常に0%になるバグを修正

### DIFF
--- a/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard.tsx
@@ -9,12 +9,12 @@ import { Progress } from "@/components/ui/progress"
 
 // 試験進捗の型定義
 interface ExamProgress {
-  totalAnswerSheets: number
+  totalStudents: number
   totalQuestions: number
   totalItems: number
-  gradedItems: number
+  scoredItems: number
   finalizedItems: number
-  progressPercentage: number
+  scoredPercentage: number
   finalizedPercentage: number
 }
 
@@ -41,25 +41,18 @@ export default function ExamProgressCard({
       setError(null)
       const result = await window.electronAPI.getExamProgress(examId)
 
-      if (result && typeof result.percentage === "number") {
-        setProgress({
-          totalAnswerSheets: result.totalStudentAnswers,
-          totalQuestions: 0,
-          totalItems: result.totalStudentAnswers,
-          gradedItems: result.completedStudentAnswers,
-          finalizedItems: result.completedStudentAnswers,
-          progressPercentage: result.percentage,
-          finalizedPercentage: result.percentage,
-        })
-        onProgressUpdate?.({
-          totalAnswerSheets: result.totalStudentAnswers,
-          totalQuestions: 0,
-          totalItems: result.totalStudentAnswers,
-          gradedItems: result.completedStudentAnswers,
-          finalizedItems: result.completedStudentAnswers,
-          progressPercentage: result.percentage,
-          finalizedPercentage: result.percentage,
-        })
+      if (result && typeof result.totalItems === "number") {
+        const data: ExamProgress = {
+          totalStudents: result.totalStudents,
+          totalQuestions: result.totalQuestions,
+          totalItems: result.totalItems,
+          scoredItems: result.scoredItems,
+          finalizedItems: result.finalizedItems,
+          scoredPercentage: result.scoredPercentage,
+          finalizedPercentage: result.finalizedPercentage,
+        }
+        setProgress(data)
+        onProgressUpdate?.(data)
       } else {
         setError("Failed to fetch progress")
       }
@@ -145,6 +138,9 @@ export default function ExamProgressCard({
     )
   }
 
+  const isComplete =
+    progress.totalItems > 0 && progress.finalizedItems >= progress.totalItems
+
   return (
     <Card>
       <CardHeader className="pb-1">
@@ -152,6 +148,11 @@ export default function ExamProgressCard({
           <CardTitle className="flex items-center text-xs font-medium">
             <Users className="mr-1 h-3 w-3" />
             試験進捗
+            {isComplete && (
+              <span className="ml-1.5 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold text-green-700">
+                完了
+              </span>
+            )}
           </CardTitle>
           <div className="flex items-center space-x-1">
             <Button
@@ -171,9 +172,9 @@ export default function ExamProgressCard({
         <div className="grid grid-cols-3 gap-2 text-center">
           <div>
             <div className="text-sm font-semibold">
-              {progress.totalAnswerSheets}
+              {progress.totalStudents}
             </div>
-            <div className="text-muted-foreground text-xs">答案</div>
+            <div className="text-muted-foreground text-xs">生徒</div>
           </div>
           <div>
             <div className="text-sm font-semibold">
@@ -192,13 +193,13 @@ export default function ExamProgressCard({
           <div className="flex items-center justify-between">
             <span className="text-xs font-medium">採点進捗</span>
             <span className="text-muted-foreground text-xs">
-              {progress.gradedItems}/{progress.totalItems}
+              {progress.scoredItems}/{progress.totalItems}
             </span>
           </div>
-          <Progress value={progress.progressPercentage} className="h-1.5" />
+          <Progress value={progress.scoredPercentage} className="h-1.5" />
           <div className="text-right">
             <span className="text-muted-foreground text-xs">
-              {Math.round(progress.progressPercentage)}%
+              {Math.round(progress.scoredPercentage)}%
             </span>
           </div>
         </div>

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -469,20 +469,12 @@ export const getAnswerSheetProgress = async (_answerSheetId: string) => {
 export const getExamProgress = async (examId: string) => {
   try {
     // 試験に参加している生徒数を取得
-    const totalAnswerSheets = await prisma.examStudent.count({
+    const totalStudents = await prisma.examStudent.count({
       where: { examId },
     })
 
-    if (totalAnswerSheets === 0) {
-      return {
-        totalAnswerSheets: 0,
-        completedAnswerSheets: 0,
-        percentage: 0,
-      }
-    }
-
     // 試験の採点領域数を取得
-    const totalCropRegions = await prisma.cropRegion.count({
+    const totalQuestions = await prisma.cropRegion.count({
       where: {
         examPage: {
           examId,
@@ -491,59 +483,80 @@ export const getExamProgress = async (examId: string) => {
       },
     })
 
-    if (totalCropRegions === 0) {
+    const totalItems = totalStudents * totalQuestions
+
+    if (totalItems === 0) {
       return {
-        totalAnswerSheets,
-        completedAnswerSheets: 0,
-        percentage: 0,
+        totalStudents,
+        totalQuestions,
+        totalItems: 0,
+        scoredItems: 0,
+        finalizedItems: 0,
+        scoredPercentage: 0,
+        finalizedPercentage: 0,
       }
     }
 
-    // 各生徒の採点完了状況を確認
-    const examStudents = await prisma.examStudent.findMany({
-      where: { examId },
-      select: { studentId: true },
+    const cropRegionFilter = {
+      cropRegion: {
+        examPage: { examId },
+        type: "QUESTION_ANSWER" as const,
+      },
+    }
+
+    // 採点済みの項目数を取得
+    // correct/incorrect/no_answer は無条件でカウント
+    // partial/pending は partialScore が null でないもののみカウント
+    const scoredItems = await prisma.questionScore.count({
+      where: {
+        ...cropRegionFilter,
+        OR: [
+          { status: { in: ["correct", "incorrect", "no_answer"] } },
+          {
+            status: { in: ["partial", "pending"] },
+            partialScore: { not: null },
+          },
+        ],
+      },
     })
 
-    let completedAnswerSheets = 0
-
-    for (const examStudent of examStudents) {
-      // この生徒の採点済み設問数を取得
-      const completedQuestions = await prisma.questionScore.count({
-        where: {
-          studentId: examStudent.studentId,
-          cropRegion: {
-            examPage: {
-              examId,
-            },
-            type: "QUESTION_ANSWER",
+    // 最終確定の項目数を取得
+    // correct/incorrect/no_answer は無条件でカウント
+    // partial は partialScore が null でないもののみカウント（pendingは未確定なので除外）
+    const finalizedItems = await prisma.questionScore.count({
+      where: {
+        ...cropRegionFilter,
+        OR: [
+          { status: { in: ["correct", "incorrect", "no_answer"] } },
+          {
+            status: "partial",
+            partialScore: { not: null },
           },
-          OR: [{ status: "final" }, { status: "proposed" }],
-        },
-      })
-
-      // 全設問が採点済みの場合、完了とみなす
-      if (completedQuestions >= totalCropRegions) {
-        completedAnswerSheets++
-      }
-    }
-
-    const percentage =
-      totalAnswerSheets > 0
-        ? (completedAnswerSheets / totalAnswerSheets) * 100
-        : 0
+        ],
+      },
+    })
 
     return {
-      totalAnswerSheets,
-      completedAnswerSheets,
-      percentage: Math.round(percentage * 100) / 100, // 小数点2位まで
+      totalStudents,
+      totalQuestions,
+      totalItems,
+      scoredItems,
+      finalizedItems,
+      scoredPercentage:
+        Math.round((scoredItems / totalItems) * 100 * 100) / 100,
+      finalizedPercentage:
+        Math.round((finalizedItems / totalItems) * 100 * 100) / 100,
     }
   } catch (error) {
     console.error("Error getting exam progress:", error)
     return {
-      totalAnswerSheets: 0,
-      completedAnswerSheets: 0,
-      percentage: 0,
+      totalStudents: 0,
+      totalQuestions: 0,
+      totalItems: 0,
+      scoredItems: 0,
+      finalizedItems: 0,
+      scoredPercentage: 0,
+      finalizedPercentage: 0,
     }
   }
 }


### PR DESCRIPTION
## Summary
- 採点画面の試験進捗パネル（`ExamProgressCard`）が常に0%を表示していたバグを修正
- バックエンドのステータスフィルタを正しい値に修正し、フロントエンドのプロパティマッピングを統一
- `partial`/`pending`は`partialScore`がnullでないもののみ採点済みとしてカウント

## 変更内容
- `electron-src/lib/prisma/questionScore.ts`: `getExamProgress`のクエリを正しいstatus値(`correct`/`incorrect`/`partial`/`pending`/`no_answer`)に修正。N+1クエリも解消
- `components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard.tsx`: バックエンド返却値との正しいマッピング、完了バッジ表示の追加

## Test plan
- [ ] 採点画面で試験進捗パネルが正しいパーセンテージを表示すること
- [ ] 採点操作（正解・不正解・部分点）を行った後にプログレスバーが更新されること
- [ ] 部分点(partial/pending)でpartialScoreがnullの場合は未採点扱いになること
- [ ] 全項目が確定済みの場合に「完了」バッジが表示されること

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)