### PR TITLE
fix: 試験進捗の生徒数を答案画像ベースに変更（欠席生徒除外）

### DIFF
--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -468,10 +468,15 @@ export const getAnswerSheetProgress = async (_answerSheetId: string) => {
  */
 export const getExamProgress = async (examId: string) => {
   try {
-    // 試験に参加している生徒数を取得
-    const totalStudents = await prisma.examStudent.count({
-      where: { examId },
+    // 答案画像が存在する生徒数を取得（設問一覧の進捗計算と同じロジック）
+    const studentsWithAnswers = await prisma.studentAnswerImage.findMany({
+      where: {
+        examPage: { examId },
+      },
+      select: { studentId: true },
+      distinct: ["studentId"],
     })
+    const totalStudents = studentsWithAnswers.length
 
     // 試験の採点領域数を取得
     const totalQuestions = await prisma.cropRegion.count({


### PR DESCRIPTION
## Summary
- 試験進捗パネルの生徒数カウントを`ExamStudent.count`から`StudentAnswerImage`のdistinct studentIdに変更
- 欠席生徒や答案未アップロードの生徒が進捗計算から自動的に除外される
- 設問一覧の採点完了バッジ（`progressCalculator.ts`）と同じロジックに統一

## Test plan
- [ ] 欠席生徒がいる試験で、進捗パネルの生徒数から除外されていること
- [ ] 答案未アップロードの生徒がいる試験で、進捗パネルの生徒数から除外されていること
- [ ] 全生徒に答案がある場合、従来と同じ進捗が表示されること

Related #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)