### PR TITLE
feat: 小問ラベルプリセットに「問1, 問2…」形式を追加

### DIFF
--- a/components/answer-sheet-builder/constants.ts
+++ b/components/answer-sheet-builder/constants.ts
@@ -279,6 +279,7 @@ export const SUB_QUESTION_LABEL_PRESETS = [
   Array.from({ length: N }, (_, i) => `(${i + 1})`).join(""),
   Array.from({ length: N }, (_, i) => getCircledNumber(i + 1)).join(""),
   Array.from({ length: N }, (_, i) => `〔問${toFullWidth(i + 1)}〕`).join(""),
+  Array.from({ length: N }, (_, i) => `問${i + 1}`).join(","),
   "abcdefghijklmnopqrstuvwxyz",
 ]
 


### PR DESCRIPTION
## Summary
- 解答用紙ビルダーの小問プリセットに `問1, 問2, 問3…` 形式（カギカッコなし・半角数字）を追加

Closes #556

## 変更ファイル
- `components/answer-sheet-builder/constants.ts`

## 補足
プリセット以外にも、各設問ごとにラベルを個別に変更することが可能です。  
詳しくは [解答用紙ビルダーガイド](https://score.keppy.jp/blog/answer-sheet-builder-guide) をご参照ください。

## Test plan
- [ ] 解答用紙ビルダーで小問プリセット一覧に「問1, 問2…」が表示されることを確認
- [ ] プリセット選択時に正しくラベルが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)