### PR TITLE
feat: 答案アップロード画面のナビゲーションガード

### DIFF
--- a/app/exams/[examId]/06-student-answers/components/index.tsx
+++ b/app/exams/[examId]/06-student-answers/components/index.tsx
@@ -96,6 +96,7 @@ interface StudentAnswersTabContentProps {
   onCloseConfirmModal: () => void
   onApplyChanges: (option: ScoringDataOption) => Promise<void>
   onResetChanges: () => Promise<void>
+  onUploadFileCountChange?: (count: number) => void
 }
 
 export function StudentAnswersTabContent({
@@ -112,6 +113,7 @@ export function StudentAnswersTabContent({
   onCloseConfirmModal,
   onApplyChanges,
   onResetChanges,
+  onUploadFileCountChange,
 }: StudentAnswersTabContentProps) {
   return (
     <>
@@ -123,6 +125,7 @@ export function StudentAnswersTabContent({
           onUploadComplete={onUploadComplete}
           mode="upload"
           existingStudentAnswers={studentAnswers}
+          onUploadFileCountChange={onUploadFileCountChange}
         />
       </TabsContent>
 

--- a/app/exams/[examId]/06-student-answers/page.tsx
+++ b/app/exams/[examId]/06-student-answers/page.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import { FileEdit } from "lucide-react"
-import { useParams, useRouter } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 import { Button } from "@/components/ui/button"
+import type { DirtyDetail } from "@/contexts/NavigationGuardContext"
+import { useNavigationGuard } from "@/hooks/useNavigationGuard"
 
 import {
   LoadingSpinner,
@@ -32,11 +34,11 @@ import { usePendingChanges, useStudentAnswersData } from "./hooks"
 
 export default function StudentAnswersPage() {
   const params = useParams()
-  const router = useRouter()
   const { helpButton } = usePageHelp()
   const examId = params.examId as string
 
   const [activeTab, setActiveTab] = useState<StudentAnswerTab>("new-grid")
+  const [uploadFileCount, setUploadFileCount] = useState(0)
 
   // Data loading hook
   const { students, studentAnswers, modelAnswerCount, isLoading, loadData } =
@@ -53,6 +55,17 @@ export default function StudentAnswersPage() {
     openConfirmModal,
     closeConfirmModal,
   } = usePendingChanges(loadData, students, studentAnswers)
+
+  // Navigation guard
+  const isDirty = uploadFileCount > 0 || pendingChanges.length > 0
+  const dirtyDetails = useMemo<DirtyDetail[]>(
+    () => [
+      { label: "未アップロードの画像", count: uploadFileCount },
+      { label: "配置済み答案の変更", count: pendingChanges.length },
+    ],
+    [uploadFileCount, pendingChanges.length]
+  )
+  const { guardedNavigate } = useNavigationGuard(isDirty, dirtyDetails)
 
   // Reset function will be obtained directly from components
 
@@ -98,7 +111,9 @@ export default function StudentAnswersPage() {
               </Button>
             )}
             <Button
-              onClick={() => router.push(`/exams/${examId}/07-score-at-once`)}
+              onClick={() =>
+                guardedNavigate(`/exams/${examId}/07-score-at-once`)
+              }
             >
               次へ: 一括採点
             </Button>
@@ -124,6 +139,7 @@ export default function StudentAnswersPage() {
               onCloseConfirmModal={closeConfirmModal}
               onApplyChanges={handleApplyChanges}
               onResetChanges={handleResetChanges}
+              onUploadFileCountChange={setUploadFileCount}
             />
           </StudentAnswersTabsNavigation>
         </div>

--- a/app/exams/[examId]/layout.tsx
+++ b/app/exams/[examId]/layout.tsx
@@ -2,10 +2,10 @@
 
 import { Users } from "lucide-react"
 import Head from "next/head"
-import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
 import React, { useEffect, useState } from "react"
 
+import { GuardedLink } from "@/components/common/GuardedLink"
 import { MemberInviteDialog } from "@/components/exams/shared/MemberInviteDialog"
 import {
   Breadcrumb,
@@ -83,7 +83,9 @@ export default function ExamWorkflowLayout({
                         </BreadcrumbPage>
                       ) : (
                         <BreadcrumbLink asChild>
-                          <Link href={linkHref}>{step.label}</Link>
+                          <GuardedLink href={linkHref}>
+                            {step.label}
+                          </GuardedLink>
                         </BreadcrumbLink>
                       )}
                     </BreadcrumbItem>
@@ -110,13 +112,15 @@ export default function ExamWorkflowLayout({
 
             {/* 試験詳細に戻るボタン */}
             <Button variant="outline" size="sm" asChild>
-              <Link href={`/exams/${examId}`}>試験詳細</Link>
+              <GuardedLink href={`/exams/${examId}`}>試験詳細</GuardedLink>
             </Button>
 
             {/* 戻るボタン（採点画面でのみ表示） */}
             {pathname.includes("07-score-at-once") && (
               <Button variant="outline" size="sm" asChild>
-                <Link href={`/exams/${examId}/06-student-answers`}>戻る</Link>
+                <GuardedLink href={`/exams/${examId}/06-student-answers`}>
+                  戻る
+                </GuardedLink>
               </Button>
             )}
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from "next/font/google"
 
 import AppShell from "@/components/layout/AppShell"
 import { AuthProvider } from "@/contexts/AuthContext"
+import { NavigationGuardProvider } from "@/contexts/NavigationGuardContext"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -84,7 +85,9 @@ export default function RootLayout({
       </head>
       <body className={inter.className}>
         <AuthProvider>
-          <AppShell>{children}</AppShell>
+          <NavigationGuardProvider>
+            <AppShell>{children}</AppShell>
+          </NavigationGuardProvider>
         </AuthProvider>
       </body>
     </html>

--- a/components/common/GuardedLink.tsx
+++ b/components/common/GuardedLink.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import Link from "next/link"
+import type { ComponentProps, MouseEvent } from "react"
+
+import { useNavigationGuardContext } from "@/contexts/NavigationGuardContext"
+
+type GuardedLinkProps = ComponentProps<typeof Link>
+
+export function GuardedLink({ onClick, href, ...props }: GuardedLinkProps) {
+  const { requestNavigation } = useNavigationGuardContext()
+
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    const hrefString = typeof href === "string" ? href : (href.pathname ?? "/")
+    if (!requestNavigation(hrefString)) {
+      e.preventDefault()
+    } else if (onClick) {
+      onClick(e)
+    }
+  }
+
+  return <Link href={href} onClick={handleClick} {...props} />
+}

--- a/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -23,6 +23,7 @@ export function StudentAnswerUpload({
   pendingChanges,
   affectedCells,
   onUpdatePendingChanges,
+  onUploadFileCountChange,
 }: StudentAnswerUploadProps) {
   const finalModelAnswerCount = modelAnswerCount
   const finalExistingAnswers = existingStudentAnswers
@@ -64,6 +65,13 @@ export function StudentAnswerUpload({
     fileOrder,
     setFiles,
   ])
+
+  // ナビゲーションガード用: アップロード待ちファイル数の通知
+  useEffect(() => {
+    if (mode === "upload" && onUploadFileCountChange) {
+      onUploadFileCountChange(files.length)
+    }
+  }, [mode, files.length, onUploadFileCountChange])
 
   // 確認モード用の配置戦略変更ハンドラー
   const handleFileOrderChangeInViewMode = useCallback(

--- a/components/exams/06-student-answers/student-answer-management/types/index.ts
+++ b/components/exams/06-student-answers/student-answer-management/types/index.ts
@@ -54,6 +54,9 @@ export interface StudentAnswerUploadProps {
       toState: FileState
     }>
   ) => void
+
+  // ナビゲーションガード用: アップロード待ちファイル数の通知
+  onUploadFileCountChange?: (count: number) => void
 }
 
 export interface FileUploadZoneProps {

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -18,9 +18,9 @@ import {
   User,
   Users,
 } from "lucide-react"
-import Link from "next/link"
 import { usePathname } from "next/navigation"
 
+import { GuardedLink } from "@/components/common/GuardedLink"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
@@ -96,9 +96,9 @@ export default function Navigation({
         )}
       >
         {!isSidebarMinimized && (
-          <Link href="/exams" className="text-lg font-semibold">
+          <GuardedLink href="/exams" className="text-lg font-semibold">
             一括採点
-          </Link>
+          </GuardedLink>
         )}
         <Button
           variant="ghost"
@@ -126,7 +126,7 @@ export default function Navigation({
                   isSidebarMinimized ? (
                     <Tooltip key={item.label}>
                       <TooltipTrigger asChild>
-                        <Link href={item.href} passHref>
+                        <GuardedLink href={item.href} passHref>
                           <Button
                             variant={
                               pathname === item.href ? "secondary" : "ghost"
@@ -137,14 +137,14 @@ export default function Navigation({
                           >
                             <item.icon className="h-5 w-5" />
                           </Button>
-                        </Link>
+                        </GuardedLink>
                       </TooltipTrigger>
                       <TooltipContent side="right" sideOffset={5}>
                         {item.label}
                       </TooltipContent>
                     </Tooltip>
                   ) : (
-                    <Link key={item.label} href={item.href} passHref>
+                    <GuardedLink key={item.label} href={item.href} passHref>
                       <Button
                         variant={pathname === item.href ? "secondary" : "ghost"}
                         className="w-full justify-start"
@@ -152,7 +152,7 @@ export default function Navigation({
                         <item.icon className="mr-3 h-5 w-5" />
                         {item.label}
                       </Button>
-                    </Link>
+                    </GuardedLink>
                   )
                 )}
               </div>
@@ -221,7 +221,7 @@ export default function Navigation({
             {isSidebarMinimized ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Link href="/" passHref>
+                  <GuardedLink href="/" passHref>
                     <Button
                       variant={pathname === "/" ? "secondary" : "ghost"}
                       size="icon"
@@ -230,14 +230,14 @@ export default function Navigation({
                     >
                       <LogIn className="h-5 w-5" />
                     </Button>
-                  </Link>
+                  </GuardedLink>
                 </TooltipTrigger>
                 <TooltipContent side="right" sideOffset={5}>
                   ログイン
                 </TooltipContent>
               </Tooltip>
             ) : (
-              <Link href="/" passHref>
+              <GuardedLink href="/" passHref>
                 <Button
                   variant={pathname === "/" ? "secondary" : "ghost"}
                   className="w-full justify-start"
@@ -245,7 +245,7 @@ export default function Navigation({
                   <LogIn className="mr-3 h-5 w-5" />
                   ログイン
                 </Button>
-              </Link>
+              </GuardedLink>
             )}
           </>
         )}

--- a/contexts/NavigationGuardContext.tsx
+++ b/contexts/NavigationGuardContext.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+export interface DirtyDetail {
+  label: string
+  count: number
+}
+
+interface NavigationGuardContextType {
+  isDirty: boolean
+  setNavigationGuard: (isDirty: boolean, details?: DirtyDetail[]) => void
+  clearNavigationGuard: () => void
+  guardedNavigate: (href: string) => void
+  requestNavigation: (href: string) => boolean
+}
+
+const NavigationGuardContext = createContext<NavigationGuardContextType>({
+  isDirty: false,
+  setNavigationGuard: () => {},
+  clearNavigationGuard: () => {},
+  guardedNavigate: () => {},
+  requestNavigation: () => true,
+})
+
+export function useNavigationGuardContext() {
+  return useContext(NavigationGuardContext)
+}
+
+export function NavigationGuardProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const router = useRouter()
+  const [isDirty, setIsDirty] = useState(false)
+  const [details, setDetails] = useState<DirtyDetail[]>([])
+  const [pendingHref, setPendingHref] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const isDirtyRef = useRef(false)
+
+  const setNavigationGuard = useCallback(
+    (dirty: boolean, newDetails?: DirtyDetail[]) => {
+      setIsDirty(dirty)
+      isDirtyRef.current = dirty
+      if (newDetails) {
+        setDetails(newDetails)
+      }
+    },
+    []
+  )
+
+  const clearNavigationGuard = useCallback(() => {
+    setIsDirty(false)
+    isDirtyRef.current = false
+    setDetails([])
+  }, [])
+
+  const guardedNavigate = useCallback(
+    (href: string) => {
+      if (isDirtyRef.current) {
+        setPendingHref(href)
+        setDialogOpen(true)
+      } else {
+        router.push(href)
+      }
+    },
+    [router]
+  )
+
+  const requestNavigation = useCallback((href: string): boolean => {
+    if (isDirtyRef.current) {
+      setPendingHref(href)
+      setDialogOpen(true)
+      return false
+    }
+    return true
+  }, [])
+
+  // beforeunload handler
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirtyRef.current) {
+        e.preventDefault()
+      }
+    }
+    window.addEventListener("beforeunload", handler)
+    return () => window.removeEventListener("beforeunload", handler)
+  }, [])
+
+  const handleLeave = useCallback(() => {
+    setDialogOpen(false)
+    if (pendingHref) {
+      clearNavigationGuard()
+      router.push(pendingHref)
+      setPendingHref(null)
+    }
+  }, [pendingHref, clearNavigationGuard, router])
+
+  const handleStay = useCallback(() => {
+    setDialogOpen(false)
+    setPendingHref(null)
+  }, [])
+
+  return (
+    <NavigationGuardContext.Provider
+      value={{
+        isDirty,
+        setNavigationGuard,
+        clearNavigationGuard,
+        guardedNavigate,
+        requestNavigation,
+      }}
+    >
+      {children}
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>未保存のデータがあります</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div>
+                {details.length > 0 && (
+                  <ul className="my-2 list-inside list-disc">
+                    {details
+                      .filter((d) => d.count > 0)
+                      .map((d) => (
+                        <li key={d.label}>
+                          {d.label}: {d.count}件
+                        </li>
+                      ))}
+                  </ul>
+                )}
+                <p>このまま画面を離れるとこれらのデータは失われます。</p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleStay}>戻る</AlertDialogCancel>
+            <AlertDialogAction onClick={handleLeave}>離れる</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </NavigationGuardContext.Provider>
+  )
+}

--- a/hooks/useNavigationGuard.ts
+++ b/hooks/useNavigationGuard.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react"
+
+import {
+  type DirtyDetail,
+  useNavigationGuardContext,
+} from "@/contexts/NavigationGuardContext"
+
+export function useNavigationGuard(isDirty: boolean, details: DirtyDetail[]) {
+  const { setNavigationGuard, clearNavigationGuard, guardedNavigate } =
+    useNavigationGuardContext()
+
+  useEffect(() => {
+    setNavigationGuard(isDirty, details)
+  }, [isDirty, details, setNavigationGuard])
+
+  useEffect(() => {
+    return () => {
+      clearNavigationGuard()
+    }
+  }, [clearNavigationGuard])
+
+  return { guardedNavigate }
+}


### PR DESCRIPTION
## Summary
- 06-student-answers画面で未保存データがある状態での画面離脱時に確認ダイアログを表示
- `NavigationGuardProvider` / `GuardedLink` / `useNavigationGuard` による汎用的なナビゲーションガード機構
- パンくずリスト・サイドバー・「次へ」ボタン・ブラウザリロードすべてをガード対象に

Closes #555

## Test plan
- [ ] 06-student-answers画面でファイルをドロップ（アップロード実行しない）→ 各経路で確認ダイアログが表示されること
- [ ] 「戻る」でダイアログが閉じ画面に留まること
- [ ] 「離れる」で遷移すること
- [ ] アップロード実行後、ガードなしで遷移できること
- [ ] 配置変更（ドラッグ&ドロップ）→ 未反映状態でもガードされること
- [ ] ブラウザリロード時にネイティブダイアログが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)