### PR TITLE
feat: 採点入力の楽観的UI更新でキー連打時の入力飲み込みを解消

### DIFF
--- a/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -1,5 +1,5 @@
 // import { checkForAutoFinalization } from "@/components/exams/07-score-at-once/hooks/scoring-data/utils/auto-finalization"
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
 import { toast } from "sonner"
 
 import type {
@@ -29,8 +29,47 @@ export function useBatchScoring({
   questionScores,
   setQuestionScores,
 }: UseBatchScoringProps) {
+  // questionScoresの最新値をrefで保持（useCallbackの依存配列から除去するため）
+  const questionScoresRef = useRef(questionScores)
+  questionScoresRef.current = questionScores
+
+  const rollbackUpdate = useCallback(
+    async (scoreId: string) => {
+      try {
+        const result = await window.electronAPI.getQuestionScore(scoreId)
+        if (result.success && result.score) {
+          const dbScore = result.score
+          setQuestionScores((prev) =>
+            prev.map((s) =>
+              s.id === scoreId
+                ? {
+                    ...s,
+                    partialScore: dbScore.partialScore,
+                    status: dbScore.status,
+                    updatedAt: new Date(dbScore.updatedAt),
+                  }
+                : s
+            )
+          )
+        }
+      } catch {
+        // ロールバック自体が失敗 → Shift+Rでの再読み込みに委ねる
+      }
+      toast.error("採点の保存に失敗しました")
+    },
+    [setQuestionScores]
+  )
+
+  const rollbackCreate = useCallback(
+    (tempId: string) => {
+      setQuestionScores((prev) => prev.filter((s) => s.id !== tempId))
+      toast.error("採点の保存に失敗しました")
+    },
+    [setQuestionScores]
+  )
+
   const handleBatchScore = useCallback(
-    async (
+    (
       statusOrAnswerIds: ScoringStatus | string | string[],
       statusOrPartialScore?: ScoringStatus | number | null,
       partialScore?: number | null,
@@ -71,11 +110,8 @@ export function useBatchScoring({
       let effectiveUserId: string
       if (!currentUserId) {
         console.warn("No current user ID available, using default")
-        // デフォルトユーザーIDを設定（実際の実装では適切なユーザー管理が必要）
         const defaultUserId = "default-user-id"
         setCurrentUserId(defaultUserId)
-
-        // 一時的にdefaultUserIdを使用
         effectiveUserId = defaultUserId
       } else {
         effectiveUserId = currentUserId
@@ -94,36 +130,34 @@ export function useBatchScoring({
         )
         if (!studentAnswerImage) continue
 
-        if (!studentAnswerImage.studentId) continue // studentIdがnullの場合はスキップ
+        if (!studentAnswerImage.studentId) continue
 
+        // refから最新のquestionScoresを取得
         const currentScore = findQuestionScore(
-          questionScores,
+          questionScoresRef.current,
           studentAnswerImage.studentId,
           currentCropRegion.id
         )
 
         let newScore: number | null = 0
-        // Use the actual status type from the scoring action
         let scoringStatus: ScoringStatus = status
 
         switch (status) {
           case "unscored":
-            newScore = null // partialScoreはnullに設定
+            newScore = null
             scoringStatus = "unscored"
             break
           case "correct":
-            newScore = null // partialScoreはnullに設定
+            newScore = null
             break
           case "incorrect":
           case "no_answer":
-            newScore = null // partialScoreはnullに設定
+            newScore = null
             break
           case "partial":
-            // モーダルで入力された場合は具体的な値、モーダル無しの場合は現在の値を維持（ステータスのみ変更）
             if (inputPartialScore !== null && inputPartialScore !== undefined) {
               newScore = inputPartialScore
             } else {
-              // nullの場合は現在のpartialScoreを維持（ステータスのみ変更）
               newScore =
                 currentScore?.partialScore !== undefined &&
                 currentScore?.partialScore !== null
@@ -132,11 +166,9 @@ export function useBatchScoring({
             }
             break
           case "pending":
-            // モーダルで入力された場合は具体的な値、モーダル無しの場合は現在の値を維持（ステータスのみ変更）
             if (inputPartialScore !== null && inputPartialScore !== undefined) {
               newScore = inputPartialScore
             } else {
-              // nullの場合は現在のpartialScoreを維持（ステータスのみ変更）
               newScore =
                 currentScore?.partialScore !== undefined &&
                 currentScore?.partialScore !== null
@@ -146,85 +178,121 @@ export function useBatchScoring({
             break
         }
 
-        // Save to database
-        try {
-          if (currentScore?.id) {
-            // Update existing score
-            const updateData = {
-              partialScore: newScore !== null ? newScore : undefined,
-              status: scoringStatus,
-            }
-            const result = await window.electronAPI.updateQuestionScore(
-              currentScore.id,
-              updateData
+        if (currentScore?.id) {
+          // Update: 楽観的にUI更新
+          const scoreId = currentScore.id
+          const optimisticPartialScore =
+            newScore !== null
+              ? (newScore as unknown as QuestionScore["partialScore"])
+              : null
+          setQuestionScores((prev) =>
+            prev.map((s) =>
+              s.id === scoreId
+                ? {
+                    ...s,
+                    partialScore: optimisticPartialScore,
+                    status: scoringStatus,
+                  }
+                : s
             )
-
-            if (result.success && result.score) {
-              const updatedScore = result.score
-              setQuestionScores((prev) =>
-                prev.map((score) =>
-                  score.id === currentScore.id
-                    ? {
-                        ...score,
-                        partialScore: updatedScore.partialScore,
-                        status: scoringStatus,
-                        updatedAt: new Date(updatedScore.updatedAt),
-                      }
-                    : score
-                )
-              )
-            }
-          } else {
-            // Create new score
-            const scoreData = {
-              studentId: studentAnswerImage.studentId,
-              cropRegionId: currentCropRegion.id,
-              partialScore: newScore !== null ? newScore : undefined,
-              status: scoringStatus,
-              userId: effectiveUserId,
-            }
-            const result =
-              await window.electronAPI.createQuestionScore(scoreData)
-
-            if (result.success && result.score) {
-              const createdScore = result.score
-              const newQuestionScore: QuestionScore = {
-                id: createdScore.id,
-                cropRegionId: createdScore.cropRegionId,
-                studentId: createdScore.studentId,
-                partialScore: createdScore.partialScore,
-                status: createdScore.status,
-                userId: createdScore.userId,
-                createdAt: createdScore.createdAt,
-                updatedAt: createdScore.updatedAt,
-              }
-
-              setQuestionScores((prev) => [...prev, newQuestionScore])
-            }
-          }
-
-          // TODO: Check for auto-finalization in collaborative mode
-          // Temporarily disabled during QuestionScore array migration
-          // if (scoringStatus === "pending" && studentAnswerImage.studentId) {
-          //   await checkForAutoFinalization(
-          //     studentAnswerImage.studentId,
-          //     currentCropRegion.id,
-          //     currentUserId,
-          //     setQuestionScores,
-          //   )
-          // }
-
-          // TODO: Add subtotal score recalculation here
-          // After individual question scoring, we should:
-          // 1. Identify all subtotal regions that depend on this question
-          // 2. Recalculate those subtotal scores
-          // 3. Save the updated subtotal scores to database
-          // 4. Update the local scoring data state
-        } catch (error) {
-          console.error("Error in batch scoring:", error)
-          toast.error(
-            `採点中にエラーが発生しました: ${studentAnswerImage.student?.lastName || "不明な生徒"}`
           )
+          // refも同期してループ内の次の反復で最新値が見えるようにする
+          questionScoresRef.current = questionScoresRef.current.map((s) =>
+            s.id === scoreId
+              ? {
+                  ...s,
+                  partialScore: optimisticPartialScore,
+                  status: scoringStatus,
+                }
+              : s
+          )
+
+          // DB保存をfire-and-forget
+          const updateData = {
+            partialScore: newScore !== null ? newScore : undefined,
+            status: scoringStatus,
+          }
+          window.electronAPI
+            .updateQuestionScore(scoreId, updateData)
+            .then((result) => {
+              if (result.success && result.score) {
+                // 成功時: updatedAtを反映
+                const updatedScore = result.score
+                setQuestionScores((prev) =>
+                  prev.map((s) =>
+                    s.id === scoreId
+                      ? {
+                          ...s,
+                          updatedAt: new Date(updatedScore.updatedAt),
+                        }
+                      : s
+                  )
+                )
+              } else {
+                // DB保存失敗 → ロールバック
+                rollbackUpdate(scoreId)
+              }
+            })
+            .catch(() => {
+              rollbackUpdate(scoreId)
+            })
+        } else {
+          // Create: 仮IDで楽観的にUI追加
+          const tempId = crypto.randomUUID()
+          const now = new Date()
+          const optimisticScore: QuestionScore = {
+            id: tempId,
+            cropRegionId: currentCropRegion.id,
+            studentId: studentAnswerImage.studentId,
+            partialScore:
+              newScore !== null
+                ? (newScore as unknown as QuestionScore["partialScore"])
+                : null,
+            status: scoringStatus,
+            userId: effectiveUserId,
+            createdAt: now,
+            updatedAt: now,
+          }
+          setQuestionScores((prev) => [...prev, optimisticScore])
+          // refも同期してループ内の次の反復で最新値が見えるようにする
+          questionScoresRef.current = [
+            ...questionScoresRef.current,
+            optimisticScore,
+          ]
+
+          // DB保存をfire-and-forget
+          const scoreData = {
+            studentId: studentAnswerImage.studentId,
+            cropRegionId: currentCropRegion.id,
+            partialScore: newScore !== null ? newScore : undefined,
+            status: scoringStatus,
+            userId: effectiveUserId,
+          }
+          window.electronAPI
+            .createQuestionScore(scoreData)
+            .then((result) => {
+              if (result.success && result.score) {
+                // 成功時: 仮IDを本物のIDに差し替え
+                const createdScore = result.score
+                setQuestionScores((prev) =>
+                  prev.map((s) =>
+                    s.id === tempId
+                      ? {
+                          ...s,
+                          id: createdScore.id,
+                          createdAt: new Date(createdScore.createdAt),
+                          updatedAt: new Date(createdScore.updatedAt),
+                        }
+                      : s
+                  )
+                )
+              } else {
+                rollbackCreate(tempId)
+              }
+            })
+            .catch(() => {
+              rollbackCreate(tempId)
+            })
         }
       }
     },
@@ -234,8 +302,9 @@ export function useBatchScoring({
       setCurrentUserId,
       currentCropRegionId,
       studentAnswerImages,
-      questionScores,
       setQuestionScores,
+      rollbackUpdate,
+      rollbackCreate,
     ]
   )
 

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
@@ -22,7 +22,7 @@ interface UseBatchScoringWithProgressParams {
     statusOrPartialScore?: ScoringStatus | number | null,
     partialScore?: number | null,
     selectedAnswers?: Set<string>
-  ) => Promise<void>
+  ) => void
   getGridAnswerData: () => ScoringDataWithSelection[]
   setSelectedAnswers: (answers: Set<string>) => void
   handleNextStudent: () => void
@@ -42,7 +42,7 @@ export function useBatchScoringWithProgress({
 }: UseBatchScoringWithProgressParams) {
   // 自動進行機能付きのhandleBatchScore（ラッパー）
   const handleBatchScoreWithProgress = useCallback(
-    async (
+    (
       statusOrAnswerIds: ScoringStatus | string | string[],
       statusOrPartialScore?: ScoringStatus | number | null,
       partialScore?: number | null
@@ -57,8 +57,8 @@ export function useBatchScoringWithProgress({
         return newSet
       })
 
-      // その後で採点実行
-      await handleBatchScore(
+      // その後で採点実行（楽観的UI更新のため同期的に完了）
+      handleBatchScore(
         statusOrAnswerIds,
         statusOrPartialScore,
         partialScore,

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -7,6 +7,7 @@ import {
   finalizeQuestionScore,
   getAnswerSheetProgress,
   getExamProgress,
+  getQuestionScoreById,
   getQuestionScoreComparison,
   getQuestionScoresForExam,
   getQuestionScoresForStudent,
@@ -79,6 +80,21 @@ export function setupScoringHandlers(): void {
       }
     }
   )
+
+  ipcMain.handle("get-question-score", async (_event, id: string) => {
+    try {
+      const result = await getQuestionScoreById(id)
+
+      if (!result.success || !result.score) {
+        return result
+      }
+
+      return { success: true, score: serializeScore(result.score) }
+    } catch (err) {
+      console.error("Error getting question score:", err)
+      throw err
+    }
+  })
 
   ipcMain.handle(
     "create-question-score",

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -148,6 +148,35 @@ export const getQuestionScoresForStudent = async (
 }
 
 /**
+ * 単一の採点データをIDで取得
+ * @param id QuestionScoreのID
+ */
+export const getQuestionScoreById = async (id: string) => {
+  try {
+    const score = await prisma.questionScore.findUnique({
+      where: { id },
+      include: {
+        student: true,
+        cropRegion: true,
+        user: true,
+      },
+    })
+
+    if (!score) {
+      return { success: false, error: "Question score not found" }
+    }
+
+    return { success: true, score }
+  } catch (error) {
+    console.error("Failed to get question score by id:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
  * 採点データを作成
  */
 export const createQuestionScore = async (data: CreateQuestionScoreData) => {

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -283,6 +283,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   ) => ipcRenderer.invoke("update-student-orders", examId, studentOrders),
 
   // QuestionScore related functions
+  getQuestionScore: (id: string) =>
+    ipcRenderer.invoke("get-question-score", id),
   getQuestionScoresForExam: (examId: string, userId?: string) =>
     ipcRenderer.invoke("get-question-scores-for-exam", examId, userId),
   getQuestionScoresForAnswerSheet: (answerSheetId: string) =>

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -816,6 +816,7 @@ export interface MyAPI {
   }>
 
   // QuestionScore関連のAPI
+  getQuestionScore: (id: string) => Promise<QuestionScoreOperationResult>
   getQuestionScoresForExam: (
     examId: string,
     userId?: string


### PR DESCRIPTION
## Summary
- 採点画面でキー連打時にDB保存完了を待ってからUI更新していたため入力が「飲まれる」問題を修正
- `handleBatchScore` を同期関数化し、DB保存を fire-and-forget に変更
- `questionScoresRef` で最新値を保持してレースコンディションを防止しつつ `useCallback` 依存配列を最適化

## 変更内容
| ファイル | 変更内容 |
|---|---|
| `useBatchScoring.ts` | 楽観的UI更新化、ref同期、fire-and-forget DB保存、ロールバック処理 |
| `useBatchScoringWithProgress.ts` | `handleBatchScore` の型を `Promise<void>` → `void` に変更 |
| `questionScore.ts` | `getQuestionScoreById` 関数を追加 |
| `scoringHandlers.ts` | `get-question-score` IPCハンドラを追加 |
| `preload.ts` | `getQuestionScore` ブリッジを追加 |
| `electron.d.ts` | `getQuestionScore` 型定義を追加 |

## Test plan
- [ ] 採点画面でキー連打して即座にUI反映されることを確認
- [ ] DB保存失敗時にtoast通知が表示されロールバックされることを確認
- [ ] Shift+R後にDBと整合していることを確認
- [ ] `npm run typecheck` で型エラーがないことを確認
- [ ] `npm run lint` でlintエラーがないことを確認

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)