### PR TITLE
feat: グリッドモードで全選択（Ctrl+A）機能を追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -224,6 +224,11 @@ function ScoringMainViewContent() {
     [replaceSelection]
   )
 
+  /** 全選択：表示中（フィルタ適用後）の答案をすべて選択 */
+  const handleSelectAll = useCallback(() => {
+    replaceSelection(filteredScoringDataIds)
+  }, [replaceSelection, filteredScoringDataIds])
+
   const {
     handleNextQuestion,
     handlePrevQuestion,
@@ -355,6 +360,7 @@ function ScoringMainViewContent() {
     handlePartialScoreBackspace,
     handleScore: handleBatchScoreWithProgress,
     handleToggleFilter,
+    handleSelectAll,
   })
 
   const currentStudentId = useMemo(() => {

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -44,6 +44,8 @@ interface ScoringShortcutHandlers {
   handleScore: (status: ScoringStatus) => void
   /** フィルタトグル（サイドパネル非表示でも有効にするため） */
   handleToggleFilter: (key: string) => void
+  /** 全選択（表示中の答案をすべて選択） */
+  handleSelectAll: () => void
 }
 
 /**
@@ -69,7 +71,20 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     handlePartialScoreBackspace,
     handleScore,
     handleToggleFilter,
+    handleSelectAll,
   } = handlers
+
+  // ========================================
+  // 選択コマンド
+  // ========================================
+  useCommand("selection.selectAll", handleSelectAll, {
+    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    metadata: {
+      title: "全選択",
+      category: "選択",
+      description: "表示中の答案をすべて選択します",
+    },
+  })
 
   // ========================================
   // 採点コマンド（サイドパネル非表示でも有効）

--- a/components/exams/07-score-at-once/constants/scoringKeybindings.ts
+++ b/components/exams/07-score-at-once/constants/scoringKeybindings.ts
@@ -61,6 +61,12 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "filter.refresh": "r",
 
   // ============================================
+  // 選択 (Selection)
+  // 答案の選択操作
+  // ============================================
+  "selection.selectAll": "Ctrl+a",
+
+  // ============================================
   // 表示 (View)
   // 表示モードの切り替え
   // ============================================
@@ -124,6 +130,7 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
  */
 export const KEYBINDING_CATEGORIES = {
   scoring: "採点",
+  selection: "選択",
   navigation: "ナビゲーション",
   filter: "フィルタ",
   view: "表示",


### PR DESCRIPTION
## Summary
- グリッドモードで `Ctrl+A`（macOS: `Cmd+A`）による全選択機能を追加
- フィルタ適用後の表示中答案を一括選択可能に
- `selection.selectAll` コマンドとして設定画面からカスタマイズ可能

Closes #562

## 変更ファイル
- `scoringKeybindings.ts` — `selection.selectAll: "Ctrl+a"` 追加、カテゴリ追加
- `useScoringShortcuts.ts` — `handleSelectAll` ハンドラー登録
- `ScoringMainView.tsx` — `filteredScoringDataIds` を使った全選択ロジック

## Test plan
- [ ] グリッドモードで `Ctrl+A` を押して全答案が選択されることを確認
- [ ] フィルタ適用後に `Ctrl+A` で表示中の答案のみ選択されることを確認
- [ ] 個別モードでは `Ctrl+A` が無効であることを確認
- [ ] 入力フォーカス中・モーダル中は `Ctrl+A` が通常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)