### PR TITLE
feat: 採点領域作成画面に配点の初期値設定を追加

### DIFF
--- a/app/exams/[examId]/02-template/page.tsx
+++ b/app/exams/[examId]/02-template/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from "next/navigation"
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import CropRegionEditor from "@/components/exams/02-template/components/CropRegionEditor"
 import { PageNavigation } from "@/components/exams/02-template/components/PageNavigation"
@@ -27,6 +27,8 @@ export default function TemplateStepPage() {
   const paramsExamId = params.examId
   const examId =
     typeof paramsExamId === "string" ? paramsExamId : paramsExamId?.[0]
+
+  const [defaultPoints, setDefaultPoints] = useState(10)
 
   // カスタムフックの使用
   const {
@@ -103,7 +105,8 @@ export default function TemplateStepPage() {
         type,
         coords,
         initialData.selectedMasterImage.id,
-        initialData.cropRegions
+        initialData.cropRegions,
+        defaultPoints
       )
 
       if (newRegion) {
@@ -117,6 +120,7 @@ export default function TemplateStepPage() {
       createRegion,
       updateCropRegions,
       updateLayoutId,
+      defaultPoints,
     ]
   )
 
@@ -193,6 +197,8 @@ export default function TemplateStepPage() {
             backgroundImageUrl={initialData.backgroundImageUrl}
             imageDimensions={initialData.imageDimensions}
             examPageId={initialData.selectedMasterImage?.id || null}
+            defaultPoints={defaultPoints}
+            onDefaultPointsChange={setDefaultPoints}
           />
         </div>
       </div>

--- a/components/exams/02-template/components/CropRegionEditor.tsx
+++ b/components/exams/02-template/components/CropRegionEditor.tsx
@@ -27,6 +27,8 @@ type CropRegionEditorProps = {
   backgroundImageUrl: string | null
   imageDimensions: { width: number; height: number } | null
   examPageId: string | null
+  defaultPoints: number
+  onDefaultPointsChange: (points: number) => void
 }
 
 const CropRegionEditor = ({
@@ -38,6 +40,8 @@ const CropRegionEditor = ({
   backgroundImageUrl,
   imageDimensions,
   examPageId,
+  defaultPoints,
+  onDefaultPointsChange,
 }: CropRegionEditorProps) => {
   const [selectedAreaIndex, setSelectedAreaIndex] = useState<number | null>(
     null
@@ -173,7 +177,7 @@ const CropRegionEditor = ({
               areas.filter((a) => a.type === "QUESTION_ANSWER").length + 1
             }`,
             type: "QUESTION_ANSWER",
-            points: 10, // デフォルトポイント
+            points: defaultPoints,
           }
           break
         case "TOTAL_SCORE":
@@ -248,6 +252,22 @@ const CropRegionEditor = ({
               検出枠: {detectedRects.length}個
             </div>
           )}
+          <div className="flex items-center gap-2">
+            <label className="text-xs whitespace-nowrap text-gray-600">
+              配点の初期値
+            </label>
+            <input
+              type="number"
+              min={0}
+              value={defaultPoints}
+              onChange={(e) => {
+                const v = parseInt(e.target.value)
+                if (!isNaN(v) && v >= 0) onDefaultPointsChange(v)
+              }}
+              className="h-7 w-16 rounded border px-2 text-right text-sm"
+            />
+            <span className="text-xs text-gray-500">点</span>
+          </div>
         </div>
 
         <CropRegionList

--- a/components/exams/02-template/hooks/useCropRegionSave.ts
+++ b/components/exams/02-template/hooks/useCropRegionSave.ts
@@ -174,7 +174,8 @@ export function useCropRegionSave(
       type: AreaType,
       coords: RegionCoordinates,
       examPageId: string,
-      existingRegions: CropRegionArea[]
+      existingRegions: CropRegionArea[],
+      defaultPoints?: number
     ): Promise<CropRegionArea | null> => {
       // タイプに応じたラベルと配点を設定
       let label = ""
@@ -192,7 +193,7 @@ export function useCropRegionSave(
             existingRegions.filter((a) => a.type === "QUESTION_ANSWER").length +
             1
           }`
-          points = "10" // デフォルトポイント
+          points = String(defaultPoints ?? 10)
           break
         case "TOTAL_SCORE":
           label = "合計点"


### PR DESCRIPTION
## Summary
- 採点領域作成画面（02-template）の右パネルに「配点の初期値」入力欄を追加
- 新しい採点領域を追加する際、ハードコードの10点ではなく入力欄の値がデフォルト配点として使用される
- DB変更不要（React stateのみで管理）

Closes #565

## Test plan
- [ ] 02-template画面で右パネルに「配点の初期値」入力欄が表示されることを確認
- [ ] 初期値を変更してから採点領域を追加し、変更後の値が配点に反映されることを確認
- [ ] 0以上の整数のみ入力可能であることを確認
- [ ] 既存の検出モード・設定パネルとの表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)