### PR TITLE
feat: OMRマーク形状を共通テスト準拠の縦長楕円に変更 (#580)

### DIFF
--- a/__tests__/omr/unit/imageProcessor.test.ts
+++ b/__tests__/omr/unit/imageProcessor.test.ts
@@ -1,0 +1,222 @@
+/**
+ * 画像処理ユーティリティ テスト
+ *
+ * computeCircularFillRatio / computeEllipticalFillRatio の
+ * 塗りつぶし判定を検証する。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  computeCircularFillRatio,
+  computeEllipticalFillRatio,
+} from "../../../electron-src/lib/omr/imageProcessor"
+import type { RawImageData } from "../../../types/omr.types"
+
+/** 白背景のRawImageDataを作成 */
+function createWhiteImage(width: number, height: number): RawImageData {
+  const channels = 3
+  const data = Buffer.alloc(width * height * channels, 255)
+  return { data, width, height, channels }
+}
+
+/** 楕円領域を黒く塗った画像を作成 */
+function createImageWithFilledEllipse(
+  imgWidth: number,
+  imgHeight: number,
+  cx: number,
+  cy: number,
+  halfW: number,
+  halfH: number
+): RawImageData {
+  const channels = 3
+  const data = Buffer.alloc(imgWidth * imgHeight * channels, 255)
+
+  for (let py = 0; py < imgHeight; py++) {
+    for (let px = 0; px < imgWidth; px++) {
+      const dx = (px - cx) / halfW
+      const dy = (py - cy) / halfH
+      if (dx * dx + dy * dy <= 1) {
+        const idx = (py * imgWidth + px) * channels
+        data[idx] = 0 // R
+        data[idx + 1] = 0 // G
+        data[idx + 2] = 0 // B
+      }
+    }
+  }
+
+  return { data, width: imgWidth, height: imgHeight, channels }
+}
+
+/** 円領域を黒く塗った画像を作成 */
+function createImageWithFilledCircle(
+  imgWidth: number,
+  imgHeight: number,
+  cx: number,
+  cy: number,
+  radius: number
+): RawImageData {
+  return createImageWithFilledEllipse(
+    imgWidth,
+    imgHeight,
+    cx,
+    cy,
+    radius,
+    radius
+  )
+}
+
+describe("computeCircularFillRatio", () => {
+  it("完全に白い画像では塗りつぶし率が0", () => {
+    const img = createWhiteImage(100, 100)
+    const ratio = computeCircularFillRatio(img, 50, 50, 20, 128)
+    expect(ratio).toBe(0)
+  })
+
+  it("円を完全に塗りつぶした画像では塗りつぶし率が1に近い", () => {
+    const img = createImageWithFilledCircle(200, 200, 100, 100, 30)
+    const ratio = computeCircularFillRatio(img, 100, 100, 30, 128)
+    expect(ratio).toBeGreaterThan(0.95)
+  })
+
+  it("半分だけ塗った場合は0.5付近", () => {
+    const imgWidth = 200
+    const imgHeight = 200
+    const channels = 3
+    const data = Buffer.alloc(imgWidth * imgHeight * channels, 255)
+
+    // 円の上半分だけ黒く塗る
+    const cx = 100
+    const cy = 100
+    const radius = 30
+    for (let py = 0; py < imgHeight; py++) {
+      for (let px = 0; px < imgWidth; px++) {
+        const dx = px - cx
+        const dy = py - cy
+        if (dx * dx + dy * dy <= radius * radius && py <= cy) {
+          const idx = (py * imgWidth + px) * channels
+          data[idx] = 0
+          data[idx + 1] = 0
+          data[idx + 2] = 0
+        }
+      }
+    }
+    const img: RawImageData = {
+      data,
+      width: imgWidth,
+      height: imgHeight,
+      channels,
+    }
+
+    const ratio = computeCircularFillRatio(img, cx, cy, radius, 128)
+    expect(ratio).toBeGreaterThan(0.4)
+    expect(ratio).toBeLessThan(0.6)
+  })
+})
+
+describe("computeEllipticalFillRatio", () => {
+  it("完全に白い画像では塗りつぶし率が0", () => {
+    const img = createWhiteImage(200, 200)
+    const ratio = computeEllipticalFillRatio(img, 100, 100, 20, 30, 128)
+    expect(ratio).toBe(0)
+  })
+
+  it("楕円を完全に塗りつぶした場合は1に近い", () => {
+    const halfW = 15
+    const halfH = 25
+    const img = createImageWithFilledEllipse(200, 200, 100, 100, halfW, halfH)
+    const ratio = computeEllipticalFillRatio(img, 100, 100, halfW, halfH, 128)
+    expect(ratio).toBeGreaterThan(0.95)
+  })
+
+  it("縦長楕円（共通テスト形状）が正しく認識される", () => {
+    // 共通テスト風: 幅4mm、高さ6.4mm相当（300dpiでの近似ピクセル値）
+    const halfW = 24 // ~4mm/2 at 300dpi
+    const halfH = 38 // ~6.4mm/2 at 300dpi
+    const img = createImageWithFilledEllipse(200, 200, 100, 100, halfW, halfH)
+    const ratio = computeEllipticalFillRatio(img, 100, 100, halfW, halfH, 128)
+    expect(ratio).toBeGreaterThan(0.95)
+  })
+
+  it("楕円外に塗りがある場合はカウントしない", () => {
+    const imgWidth = 200
+    const imgHeight = 200
+    const channels = 3
+    const data = Buffer.alloc(imgWidth * imgHeight * channels, 255)
+
+    // 楕円の外側だけ黒く塗る
+    const halfW = 20
+    const halfH = 30
+    for (let py = 0; py < imgHeight; py++) {
+      for (let px = 0; px < imgWidth; px++) {
+        const dx = (px - 100) / halfW
+        const dy = (py - 100) / halfH
+        if (dx * dx + dy * dy > 1 && dx * dx + dy * dy < 4) {
+          const idx = (py * imgWidth + px) * channels
+          data[idx] = 0
+          data[idx + 1] = 0
+          data[idx + 2] = 0
+        }
+      }
+    }
+    const img: RawImageData = {
+      data,
+      width: imgWidth,
+      height: imgHeight,
+      channels,
+    }
+
+    const ratio = computeEllipticalFillRatio(img, 100, 100, halfW, halfH, 128)
+    expect(ratio).toBe(0)
+  })
+
+  it("閾値の変更が反映される", () => {
+    const imgWidth = 200
+    const imgHeight = 200
+    const channels = 3
+    // グレー(128)で楕円を塗る
+    const data = Buffer.alloc(imgWidth * imgHeight * channels, 255)
+    const halfW = 20
+    const halfH = 30
+    for (let py = 0; py < imgHeight; py++) {
+      for (let px = 0; px < imgWidth; px++) {
+        const dx = (px - 100) / halfW
+        const dy = (py - 100) / halfH
+        if (dx * dx + dy * dy <= 1) {
+          const idx = (py * imgWidth + px) * channels
+          data[idx] = 128
+          data[idx + 1] = 128
+          data[idx + 2] = 128
+        }
+      }
+    }
+    const img: RawImageData = {
+      data,
+      width: imgWidth,
+      height: imgHeight,
+      channels,
+    }
+
+    // 閾値128では「暗い」にならない（128 < 128 は false）
+    const ratioLow = computeEllipticalFillRatio(
+      img,
+      100,
+      100,
+      halfW,
+      halfH,
+      128
+    )
+    expect(ratioLow).toBe(0)
+
+    // 閾値200なら「暗い」になる
+    const ratioHigh = computeEllipticalFillRatio(
+      img,
+      100,
+      100,
+      halfW,
+      halfH,
+      200
+    )
+    expect(ratioHigh).toBeGreaterThan(0.95)
+  })
+})

--- a/__tests__/omr/unit/markRecognizer.test.ts
+++ b/__tests__/omr/unit/markRecognizer.test.ts
@@ -1,0 +1,699 @@
+/**
+ * マーク認識エンジン テスト
+ *
+ * 楕円形バブルの塗りつぶし判定→選択肢認識→自動採点の
+ * パイプラインをテスト画像で検証する。
+ *
+ * 理想的なケースに加え、実際のスキャンで発生するリアルなケースも検証:
+ * - 鉛筆の濃淡（薄塗り・しっかり塗り）
+ * - 消しゴム跡（消し残し）
+ * - はみ出し塗り
+ * - ダブルマーク（微妙な塗り残し）
+ * - 楕円の一部だけ塗る（チェックマーク的な塗り方）
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { recognizeCell } from "../../../electron-src/lib/omr/markRecognizer"
+import type { ComputedCell } from "../../../types/answerSheetLayout.types"
+import type {
+  ComputedOMRBubble,
+  CoordinateTransform,
+  OMRCellConfig,
+  OMRRecognitionParams,
+  RawImageData,
+} from "../../../types/omr.types"
+
+// =====================
+// テストヘルパー
+// =====================
+
+function createIdentityTransform(
+  width: number,
+  height: number
+): CoordinateTransform {
+  return {
+    detectedCorners: [
+      { x: 0, y: 0 },
+      { x: width, y: 0 },
+      { x: 0, y: height },
+      { x: width, y: height },
+    ],
+    expectedCorners: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ],
+    imageWidth: width,
+    imageHeight: height,
+  }
+}
+
+const DEFAULT_PARAMS: OMRRecognitionParams = {
+  colorThreshold: 128,
+  areaThreshold: 0.4,
+}
+
+/**
+ * バブル内の楕円ピクセルを指定グレー値・充填率で塗る
+ *
+ * @param data    RGBバッファ（直接変更）
+ * @param width   画像幅
+ * @param bubble  対象バブル
+ * @param gray    塗りの明度（0=真っ黒, 255=白）
+ * @param coverage 楕円領域のうち塗る割合（0-1, 1=全域）
+ * @param pattern 塗りパターン
+ *   - "solid": 全域を均一に塗る（デフォルト）
+ *   - "center": 中心部のみ塗る（楕円の内側coverage比率の領域）
+ *   - "random": ランダムに散らす（鉛筆の粗い塗りシミュレーション）
+ *   - "top-half": 上半分だけ塗る（チェックマーク風のずさんな塗り）
+ */
+function paintBubble(
+  data: Buffer,
+  width: number,
+  height: number,
+  bubble: ComputedOMRBubble,
+  gray: number,
+  coverage: number = 1,
+  pattern: "solid" | "center" | "random" | "top-half" = "solid"
+): void {
+  const channels = 3
+  const cx = bubble.normalizedCx * width
+  const cy = bubble.normalizedCy * height
+  const halfW = (bubble.normalizedWidth * width) / 2
+  const halfH = (bubble.normalizedHeight * height) / 2
+
+  // 固定シードの簡易PRNG（テスト再現性のため）
+  let seed = 12345
+  function nextRand(): number {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff
+    return seed / 0x7fffffff
+  }
+
+  for (let py = 0; py < height; py++) {
+    for (let px = 0; px < width; px++) {
+      const dx = (px - cx) / halfW
+      const dy = (py - cy) / halfH
+      const dist2 = dx * dx + dy * dy
+      if (dist2 > 1) continue
+
+      let shouldPaint = false
+      switch (pattern) {
+        case "solid":
+          shouldPaint = true
+          break
+        case "center":
+          // 楕円の内側 coverage^2 比率（面積=πab, 内側楕円=π(a*r)(b*r) → r^2 = coverage）
+          shouldPaint = dist2 <= coverage
+          break
+        case "random":
+          shouldPaint = nextRand() < coverage
+          break
+        case "top-half":
+          shouldPaint = dy < 0 // 上半分のみ
+          break
+      }
+
+      if (shouldPaint) {
+        const pidx = (py * width + px) * channels
+        data[pidx] = gray
+        data[pidx + 1] = gray
+        data[pidx + 2] = gray
+      }
+    }
+  }
+}
+
+/**
+ * テスト用画像を生成: 白背景に指定バブルを黒楕円で塗りつぶす（基本版）
+ */
+function createTestImage(
+  width: number,
+  height: number,
+  bubbles: ComputedOMRBubble[],
+  filledIndices: number[]
+): RawImageData {
+  const channels = 3
+  const data = Buffer.alloc(width * height * channels, 255)
+
+  for (const idx of filledIndices) {
+    const bubble = bubbles[idx]
+    if (!bubble) continue
+    paintBubble(data, width, height, bubble, 0, 1, "solid")
+  }
+
+  return { data, width, height, channels }
+}
+
+/**
+ * テスト用画像を生成: 各バブルに個別の塗り設定を適用
+ */
+function createRealisticTestImage(
+  width: number,
+  height: number,
+  bubbles: ComputedOMRBubble[],
+  fills: {
+    index: number
+    gray: number
+    coverage?: number
+    pattern?: "solid" | "center" | "random" | "top-half"
+  }[]
+): RawImageData {
+  const channels = 3
+  const data = Buffer.alloc(width * height * channels, 255)
+
+  for (const fill of fills) {
+    const bubble = bubbles[fill.index]
+    if (!bubble) continue
+    paintBubble(
+      data,
+      width,
+      height,
+      bubble,
+      fill.gray,
+      fill.coverage ?? 1,
+      fill.pattern ?? "solid"
+    )
+  }
+
+  return { data, width, height, channels }
+}
+
+/** 共通テスト風の縦長楕円バブル4択を生成 */
+function create4ChoiceBubbles(
+  imgWidth: number,
+  imgHeight: number
+): ComputedOMRBubble[] {
+  const bubbleW = 30 / imgWidth
+  const bubbleH = 48 / imgHeight
+  const n = 4
+  const spacing = 1 / (n + 1)
+
+  return Array.from({ length: n }, (_, i) => ({
+    normalizedCx: spacing * (i + 1),
+    normalizedCy: 0.5,
+    normalizedWidth: bubbleW,
+    normalizedHeight: bubbleH,
+    choiceIndex: i,
+    label: ["①", "②", "③", "④"][i],
+  }))
+}
+
+describe("markRecognizer", () => {
+  const imgWidth = 400
+  const imgHeight = 100
+  const transform = createIdentityTransform(imgWidth, imgHeight)
+  const bubbles = create4ChoiceBubbles(imgWidth, imgHeight)
+
+  const config: OMRCellConfig & { type: "choice" } = {
+    type: "choice",
+    numChoices: 4,
+    labels: ["①", "②", "③", "④"],
+    correctAnswers: [1], // ②が正解
+    layout: "horizontal",
+  }
+
+  function makeCell(omrBubbles: ComputedOMRBubble[]): ComputedCell {
+    return {
+      questionPath: [0, 0],
+      x: 0,
+      y: 0,
+      width: imgWidth,
+      height: imgHeight,
+      normalizedX: 0,
+      normalizedY: 0,
+      normalizedW: 1,
+      normalizedH: 1,
+      label: "1",
+      points: 5,
+      textElements: [],
+      cellType: "answer",
+      pageIndex: 0,
+      omrBubbles,
+    }
+  }
+
+  it("塗りつぶしなし → no_answer", async () => {
+    const img = createTestImage(imgWidth, imgHeight, bubbles, [])
+    const cell = makeCell(bubbles)
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("no_answer")
+    expect(result.recognizedValues).toEqual([])
+    expect(result.confidence).toBeGreaterThan(0.5)
+  })
+
+  it("正解のバブルを塗りつぶし → correct", async () => {
+    const img = createTestImage(imgWidth, imgHeight, bubbles, [1]) // ②を塗る
+    const cell = makeCell(bubbles)
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("correct")
+    expect(result.recognizedValues).toEqual(["②"])
+    expect(result.confidence).toBeGreaterThan(0.5)
+  })
+
+  it("不正解のバブルを塗りつぶし → incorrect", async () => {
+    const img = createTestImage(imgWidth, imgHeight, bubbles, [2]) // ③を塗る
+    const cell = makeCell(bubbles)
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("incorrect")
+    expect(result.recognizedValues).toEqual(["③"])
+  })
+
+  it("複数バブルを塗りつぶし（正解数より多い） → ambiguous", async () => {
+    const img = createTestImage(imgWidth, imgHeight, bubbles, [0, 1]) // ①②を塗る
+    const cell = makeCell(bubbles)
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("ambiguous")
+    expect(result.recognizedValues).toHaveLength(2)
+  })
+
+  it("fillRatiosが各バブルの値を返す", async () => {
+    const img = createTestImage(imgWidth, imgHeight, bubbles, [1])
+    const cell = makeCell(bubbles)
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.fillRatios).toHaveLength(4)
+    // 塗ったバブルは高い塗りつぶし率
+    expect(result.fillRatios![1]).toBeGreaterThan(0.8)
+    // 塗っていないバブルは低い塗りつぶし率
+    expect(result.fillRatios![0]).toBeLessThan(0.1)
+    expect(result.fillRatios![2]).toBeLessThan(0.1)
+    expect(result.fillRatios![3]).toBeLessThan(0.1)
+  })
+
+  it("omrBubblesが空の場合は no_answer", async () => {
+    const img = createTestImage(imgWidth, imgHeight, [], [])
+    const cell = makeCell([])
+    const result = await recognizeCell(
+      cell,
+      config,
+      img,
+      transform,
+      DEFAULT_PARAMS
+    )
+
+    expect(result.autoScoreStatus).toBe("no_answer")
+    expect(result.recognizedValues).toEqual([])
+  })
+
+  describe("複数正解対応", () => {
+    const multiConfig: OMRCellConfig & { type: "choice" } = {
+      type: "choice",
+      numChoices: 4,
+      labels: ["①", "②", "③", "④"],
+      correctAnswers: [0, 2], // ①③が正解
+      layout: "horizontal",
+    }
+
+    it("複数正解を全て選択 → correct", async () => {
+      const img = createTestImage(imgWidth, imgHeight, bubbles, [0, 2])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        multiConfig,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.recognizedValues).toEqual(["①", "③"])
+    })
+
+    it("正解を一部だけ選択 → incorrect", async () => {
+      const img = createTestImage(imgWidth, imgHeight, bubbles, [0])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        multiConfig,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("incorrect")
+    })
+  })
+
+  describe("0〜9数値解答（10択）", () => {
+    const digitBubbles: ComputedOMRBubble[] = Array.from(
+      { length: 10 },
+      (_, i) => ({
+        normalizedCx: (i + 1) / 11,
+        normalizedCy: 0.5,
+        normalizedWidth: 20 / imgWidth,
+        normalizedHeight: 32 / imgHeight,
+        choiceIndex: i,
+        label: String(i),
+      })
+    )
+
+    const digitConfig: OMRCellConfig & { type: "choice" } = {
+      type: "choice",
+      numChoices: 10,
+      labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+      correctAnswers: [7], // 7が正解
+      layout: "horizontal",
+    }
+
+    it("数字7を塗りつぶし → correct + 認識値は '7'", async () => {
+      const img = createTestImage(imgWidth, imgHeight, digitBubbles, [7])
+      const cell = makeCell(digitBubbles)
+      const result = await recognizeCell(
+        cell,
+        digitConfig,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.recognizedValues).toEqual(["7"])
+    })
+  })
+
+  // =====================
+  // リアルケース: 鉛筆の濃淡・消しゴム跡・ダブルマーク
+  // =====================
+
+  describe("鉛筆の濃淡", () => {
+    it("しっかり濃く塗った鉛筆マーク（gray=30）→ 認識される", async () => {
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 30, coverage: 0.9, pattern: "solid" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.recognizedValues).toEqual(["②"])
+    })
+
+    it("薄く塗った鉛筆マーク（gray=100）→ 認識される", async () => {
+      // gray=100 は colorThreshold=128 より暗いので「暗い」判定
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 100, coverage: 0.85, pattern: "random" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.fillRatios![1]).toBeGreaterThan(0.4)
+    })
+
+    it("非常に薄い塗り（gray=140）→ 閾値以上なので認識されない", async () => {
+      // gray=140 > colorThreshold=128 なので「暗くない」判定
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 140, coverage: 1, pattern: "solid" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("no_answer")
+      expect(result.fillRatios![1]).toBe(0)
+    })
+  })
+
+  describe("消しゴム跡（消し残し）", () => {
+    it("消しゴムで消した跡（gray=180, 20%残り）→ 認識しない", async () => {
+      // 消しゴムで消したが20%程度のピクセルが薄く残っている
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 0, gray: 80, coverage: 0.2, pattern: "random" },
+        { index: 1, gray: 10, coverage: 0.95, pattern: "solid" }, // 本命の塗り
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      // 消し残しはareaThreshold(0.4)未満なのでマークと判定しない
+      expect(result.fillRatios![0]).toBeLessThan(0.4)
+      // 本命は認識される
+      expect(result.fillRatios![1]).toBeGreaterThan(0.8)
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.recognizedValues).toEqual(["②"])
+    })
+
+    it("消しゴム跡が35%残り → ギリギリ認識しない", async () => {
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 0, gray: 60, coverage: 0.35, pattern: "random" },
+        { index: 1, gray: 0, coverage: 1, pattern: "solid" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.fillRatios![0]).toBeLessThan(0.4)
+      expect(result.autoScoreStatus).toBe("correct")
+    })
+  })
+
+  describe("ダブルマーク（怪しいケース）", () => {
+    it("2つのバブルを均等にしっかり塗り → ambiguous", async () => {
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 1, pattern: "solid" },
+        { index: 2, gray: 0, coverage: 1, pattern: "solid" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.autoScoreStatus).toBe("ambiguous")
+      expect(result.recognizedValues).toHaveLength(2)
+      expect(result.confidence).toBeLessThanOrEqual(0.3) // ダブルマークは低信頼度
+    })
+
+    it("本命しっかり + 別の微妙な塗り(45%) → ダブルマーク判定", async () => {
+      // 1つはしっかり塗り、もう1つが閾値ギリギリ超え
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 1, pattern: "solid" },
+        { index: 3, gray: 50, coverage: 0.5, pattern: "random" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      // ③の塗りが閾値を超えたかどうかで結果が分かれる
+      if (result.fillRatios![3]! >= 0.4) {
+        expect(result.autoScoreStatus).toBe("ambiguous")
+        expect(result.recognizedValues).toHaveLength(2)
+      } else {
+        expect(result.autoScoreStatus).toBe("correct")
+        expect(result.recognizedValues).toEqual(["②"])
+      }
+    })
+
+    it("本命しっかり + 別の薄塗り(30%) → 本命のみ認識", async () => {
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 1, pattern: "solid" },
+        { index: 3, gray: 80, coverage: 0.3, pattern: "random" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.fillRatios![3]).toBeLessThan(0.4)
+      expect(result.autoScoreStatus).toBe("correct")
+      expect(result.recognizedValues).toEqual(["②"])
+    })
+  })
+
+  describe("雑な塗り方", () => {
+    it("楕円の上半分だけ塗る → 約50%で閾値超えなら認識", async () => {
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 1, pattern: "top-half" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      // 上半分 ≈ 50%の塗り → areaThreshold(0.4)を超えるので認識される
+      expect(result.fillRatios![1]).toBeGreaterThan(0.4)
+      expect(result.autoScoreStatus).toBe("correct")
+    })
+
+    it("中心部だけ塗る（coverage=0.6）→ 認識される", async () => {
+      // 楕円の中心60%の面積だけ塗る
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 0.6, pattern: "center" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.fillRatios![1]).toBeGreaterThan(0.4)
+      expect(result.autoScoreStatus).toBe("correct")
+    })
+
+    it("中心の小さな点だけ（coverage=0.15）→ 認識されない", async () => {
+      // ちょっとだけ点を打った程度
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 0.15, pattern: "center" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        DEFAULT_PARAMS
+      )
+
+      expect(result.fillRatios![1]).toBeLessThan(0.4)
+      expect(result.autoScoreStatus).toBe("no_answer")
+    })
+  })
+
+  describe("閾値パラメータの影響", () => {
+    it("areaThresholdを下げると薄塗りでも認識される", async () => {
+      const looseParams: OMRRecognitionParams = {
+        colorThreshold: 128,
+        areaThreshold: 0.2, // 通常0.4 → 0.2に緩和
+      }
+      // 30%しか塗っていない
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 0.3, pattern: "random" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        looseParams
+      )
+
+      expect(result.fillRatios![1]).toBeGreaterThan(0.2)
+      expect(result.autoScoreStatus).toBe("correct")
+    })
+
+    it("areaThresholdを上げると普通の塗りでも認識されにくくなる", async () => {
+      const strictParams: OMRRecognitionParams = {
+        colorThreshold: 128,
+        areaThreshold: 0.9, // 90%以上塗らないと認識しない
+      }
+      // 70%塗り
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 0, coverage: 0.7, pattern: "random" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        strictParams
+      )
+
+      expect(result.autoScoreStatus).toBe("no_answer")
+    })
+
+    it("colorThresholdを下げると濃い鉛筆のみ認識", async () => {
+      const darkOnlyParams: OMRRecognitionParams = {
+        colorThreshold: 50, // gray < 50 のみ「暗い」
+        areaThreshold: 0.4,
+      }
+      // gray=80（中程度の鉛筆）で塗る
+      const img = createRealisticTestImage(imgWidth, imgHeight, bubbles, [
+        { index: 1, gray: 80, coverage: 1, pattern: "solid" },
+      ])
+      const cell = makeCell(bubbles)
+      const result = await recognizeCell(
+        cell,
+        config,
+        img,
+        transform,
+        darkOnlyParams
+      )
+
+      // gray=80 > colorThreshold=50 なので認識されない
+      expect(result.autoScoreStatus).toBe("no_answer")
+    })
+  })
+})

--- a/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
+++ b/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { Scan } from "lucide-react"
-import { useCallback } from "react"
+import { useCallback, useMemo, useState } from "react"
 
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -14,23 +15,110 @@ import {
 import { Switch } from "@/components/ui/switch"
 import type { OMRCellConfig, OMRChoiceConfig } from "@/types/omr.types"
 
-/** 選択肢ラベルプリセット */
-const CHOICE_LABEL_PRESETS: { value: string; labels: string[] }[] = [
+/**
+ * 選択肢ラベルプリセット
+ *
+ * 共通テストで実際に使用される全パターンを網羅:
+ *
+ * ■ 数学（数値解答欄）
+ *   - 0〜9: 数値解答（全年度共通）
+ *   - −: 負の符号（令和7年度〜、符号はマイナスのみ）
+ *   - ±: 符号（〜令和6年度の数学①で使用、令和7年度〜廃止）
+ *   - a,b,c,d: 文字選択（〜令和6年度の数学②で使用、令和7年度〜廃止）
+ *
+ * ■ 全科目共通（選択肢番号）
+ *   - ①〜⑨: 選択肢番号（4〜9択、科目・問題により異なる）
+ *
+ * その他汎用プリセット・カスタム入力も対応。
+ */
+const CHOICE_LABEL_PRESETS: {
+  value: string
+  displayName: string
+  labels: string[]
+  /** 共通テストで使用されるプリセットかどうか */
+  isCommonTest?: boolean
+}[] = [
+  // ── 共通テスト準拠：数学 数値解答欄 ──
+  {
+    value: "digit",
+    displayName: "0〜9（数値解答）",
+    labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    isCommonTest: true,
+  },
+  {
+    value: "minus",
+    displayName: "−（負の符号）",
+    labels: ["−"],
+    isCommonTest: true,
+  },
+  {
+    value: "digit-minus",
+    displayName: "0〜9,−（数値+符号）",
+    labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "−"],
+    isCommonTest: true,
+  },
+  {
+    value: "plus-minus",
+    displayName: "+,−（符号）",
+    labels: ["+", "−"],
+    isCommonTest: true,
+  },
+  {
+    value: "plus-minus-zero",
+    displayName: "+,−,0（符号+ゼロ）",
+    labels: ["+", "−", "0"],
+    isCommonTest: true,
+  },
+  // ── 共通テスト準拠：全科目 選択肢番号 ──
+  {
+    value: "circled",
+    displayName: "①〜⑨（選択肢番号）",
+    labels: ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨"],
+    isCommonTest: true,
+  },
+  // ── 共通テスト準拠：旧課程・特定科目 ──
+  {
+    value: "alphabet-lower",
+    displayName: "a〜d（数学②〜R6）",
+    labels: ["a", "b", "c", "d"],
+    isCommonTest: true,
+  },
+  {
+    value: "plus-minus-pm",
+    displayName: "+,−,±（数学①〜R6）",
+    labels: ["+", "−", "±"],
+    isCommonTest: true,
+  },
+  // ── 汎用プリセット ──
   {
     value: "katakana",
+    displayName: "ア〜コ",
     labels: ["ア", "イ", "ウ", "エ", "オ", "カ", "キ", "ク", "ケ", "コ"],
   },
   {
-    value: "alphabet",
+    value: "alphabet-upper",
+    displayName: "A〜J",
     labels: ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"],
   },
   {
-    value: "circled",
-    labels: ["①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩"],
+    value: "number",
+    displayName: "1〜10",
+    labels: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
   },
   {
-    value: "number",
-    labels: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+    value: "true-false",
+    displayName: "正,誤",
+    labels: ["正", "誤"],
+  },
+  {
+    value: "maru-batsu",
+    displayName: "○,×",
+    labels: ["○", "×"],
+  },
+  {
+    value: "custom",
+    displayName: "カスタム（コンマ区切り）",
+    labels: [],
   },
 ]
 
@@ -136,6 +224,20 @@ export function OMRCellConfigForm({
   )
 }
 
+/** 現在のラベルに一致するプリセットを検出 */
+function detectPreset(labels: string[]): string {
+  for (const p of CHOICE_LABEL_PRESETS) {
+    if (p.value === "custom") continue
+    if (
+      p.labels.length >= labels.length &&
+      labels.every((l, i) => p.labels[i] === l)
+    ) {
+      return p.value
+    }
+  }
+  return "custom"
+}
+
 function ChoiceConfigFields({
   config,
   onChange,
@@ -143,69 +245,120 @@ function ChoiceConfigFields({
   config: OMRChoiceConfig
   onChange: (config: OMRCellConfig) => void
 }) {
+  const currentPresetValue = useMemo(
+    () => detectPreset(config.labels),
+    [config.labels]
+  )
+  const isCustom = currentPresetValue === "custom"
+
+  // カスタム入力用のローカルステート
+  const [customInput, setCustomInput] = useState(() =>
+    isCustom ? config.labels.join(",") : ""
+  )
+
   return (
     <>
-      {/* 選択肢数 */}
-      <div className="flex items-center gap-1.5">
-        <Label className="text-muted-foreground min-w-[3rem] text-xs">
-          選択肢数
-        </Label>
-        <input
-          type="number"
-          className="border-input h-7 w-14 [appearance:textfield] rounded border px-1.5 text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-          value={config.numChoices}
-          min={2}
-          max={10}
-          onChange={(e) => {
-            const n = Math.max(2, Math.min(10, Number(e.target.value) || 4))
-            const currentPreset = CHOICE_LABEL_PRESETS.find(
-              (p) => p.labels[0] === config.labels[0]
-            )
-            const labels = (
-              currentPreset?.labels ?? CHOICE_LABEL_PRESETS[0].labels
-            ).slice(0, n)
-            onChange({
-              ...config,
-              numChoices: n,
-              labels,
-              correctAnswers: config.correctAnswers.filter((i) => i < n),
-            })
-          }}
-        />
-      </div>
-
       {/* ラベルプリセット */}
       <div className="flex items-center gap-1.5">
         <Label className="text-muted-foreground min-w-[3rem] text-xs">
           ラベル
         </Label>
         <Select
-          value={
-            CHOICE_LABEL_PRESETS.find((p) => p.labels[0] === config.labels[0])
-              ?.value ?? "katakana"
-          }
+          value={currentPresetValue}
           onValueChange={(preset) => {
+            if (preset === "custom") {
+              setCustomInput(config.labels.join(","))
+              return
+            }
             const p = CHOICE_LABEL_PRESETS.find((pr) => pr.value === preset)
             if (p) {
+              const labels = p.labels.slice(0, Math.max(2, p.labels.length))
               onChange({
                 ...config,
-                labels: p.labels.slice(0, config.numChoices),
+                numChoices: labels.length,
+                labels,
+                correctAnswers: config.correctAnswers.filter(
+                  (i) => i < labels.length
+                ),
               })
             }
           }}
         >
-          <SelectTrigger className="h-7 w-32 text-xs">
+          <SelectTrigger className="h-7 w-44 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             {CHOICE_LABEL_PRESETS.map((p) => (
               <SelectItem key={p.value} value={p.value}>
-                {p.labels.slice(0, 4).join(",")}...
+                {p.displayName}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
+
+      {/* カスタムラベル入力 */}
+      {isCustom && (
+        <div className="flex items-center gap-1.5">
+          <Label className="text-muted-foreground min-w-[3rem] text-xs">
+            入力
+          </Label>
+          <Input
+            className="h-7 w-44 text-xs"
+            value={customInput}
+            placeholder="例: +,-,±"
+            onChange={(e) => {
+              const val = e.target.value
+              setCustomInput(val)
+              const labels = val
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0)
+              if (labels.length >= 2) {
+                onChange({
+                  ...config,
+                  numChoices: labels.length,
+                  labels,
+                  correctAnswers: config.correctAnswers.filter(
+                    (i) => i < labels.length
+                  ),
+                })
+              }
+            }}
+          />
+        </div>
+      )}
+
+      {/* 選択肢数（プリセット時のみ調整可能） */}
+      {!isCustom && (
+        <div className="flex items-center gap-1.5">
+          <Label className="text-muted-foreground min-w-[3rem] text-xs">
+            選択肢数
+          </Label>
+          <input
+            type="number"
+            className="border-input h-7 w-14 [appearance:textfield] rounded border px-1.5 text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            value={config.numChoices}
+            min={2}
+            max={10}
+            onChange={(e) => {
+              const n = Math.max(2, Math.min(10, Number(e.target.value) || 4))
+              const preset = CHOICE_LABEL_PRESETS.find(
+                (p) => p.value === currentPresetValue
+              )
+              const labels = (
+                preset?.labels ?? CHOICE_LABEL_PRESETS[0].labels
+              ).slice(0, n)
+              onChange({
+                ...config,
+                numChoices: n,
+                labels,
+                correctAnswers: config.correctAnswers.filter((i) => i < n),
+              })
+            }}
+          />
+        </div>
+      )}
 
       {/* 配置方向 */}
       <div className="flex items-center gap-1.5">
@@ -218,7 +371,7 @@ function ChoiceConfigFields({
             onChange({ ...config, layout: v })
           }
         >
-          <SelectTrigger className="h-7 w-32 text-xs">
+          <SelectTrigger className="h-7 w-44 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -403,31 +403,33 @@ export function AnswerSheetSVGRenderer({
             })
         )}
 
-      {/* OMRバブル */}
+      {/* OMRバブル（共通テスト準拠：楕円＋内部ラベル） */}
       {cells
         .filter((c) => c.cellType === "answer" && c.omrBubbles?.length)
         .flatMap((cell, cellIdx) =>
           cell.omrBubbles!.map((bubble, bi) => {
             const cx = bubble.normalizedCx * pageWidthMm
             const cy = bubble.normalizedCy * pageHeightMm
-            const r = bubble.normalizedRadius * pageWidthMm
+            const rx = (bubble.normalizedWidth * pageWidthMm) / 2
+            const ry = (bubble.normalizedHeight * pageHeightMm) / 2
             return (
               <g key={`omr-bubble-${cellIdx}-${cell.label}-${bi}`}>
-                <circle
+                <ellipse
                   cx={cx}
                   cy={cy}
-                  r={r}
+                  rx={rx}
+                  ry={ry}
                   fill="none"
                   stroke="black"
                   strokeWidth={0.3}
                 />
                 <text
                   x={cx}
-                  y={cy + r + 2}
-                  fontSize={2.5}
+                  y={cy}
+                  fontSize={ry * 1.1}
                   fontFamily="'Noto Sans JP', sans-serif"
                   textAnchor="middle"
-                  dominantBaseline="hanging"
+                  dominantBaseline="central"
                   fill="#333"
                 >
                   {bubble.label}

--- a/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
+++ b/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
@@ -39,6 +39,9 @@ export function computeSubHeight(
 
 /**
  * OMR choiceセルのバブル位置を計算（0-1正規化座標）
+ *
+ * 共通テスト準拠の横長楕円（角丸長方形）形状。
+ * ラベルは楕円内部に配置される。
  */
 export function computeOMRBubbles(
   cellX: number,
@@ -52,8 +55,10 @@ export function computeOMRBubbles(
   const bubbles: ComputedOMRBubble[] = []
   const n = config.numChoices
 
-  const maxRadiusMm = Math.min(cellHeight * 0.25, cellWidth / (n * 2.5 + 1))
-  const radiusMm = Math.max(1.5, maxRadiusMm)
+  // 共通テスト準拠: 縦長楕円のサイズ計算
+  // 幅はセル幅ベースで計算、高さは幅の1.6倍（縦長楕円）
+  const bubbleWidthMm = Math.max(2.5, Math.min(cellHeight * 0.35, 4))
+  const bubbleHeightMm = Math.max(4, bubbleWidthMm * 1.6)
 
   if (config.layout === "horizontal") {
     const spacing = cellWidth / (n + 1)
@@ -64,7 +69,8 @@ export function computeOMRBubbles(
       bubbles.push({
         normalizedCx: cx / paperWidth,
         normalizedCy: cy / paperHeight,
-        normalizedRadius: radiusMm / paperWidth,
+        normalizedWidth: bubbleWidthMm / paperWidth,
+        normalizedHeight: bubbleHeightMm / paperHeight,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
       })
@@ -78,7 +84,8 @@ export function computeOMRBubbles(
       bubbles.push({
         normalizedCx: cx / paperWidth,
         normalizedCy: cy / paperHeight,
-        normalizedRadius: radiusMm / paperWidth,
+        normalizedWidth: bubbleWidthMm / paperWidth,
+        normalizedHeight: bubbleHeightMm / paperHeight,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
       })

--- a/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -283,12 +283,13 @@ function renderOMRBubbles(
   for (const bubble of cell.omrBubbles) {
     const cx = bubble.normalizedCx * pageWidthMm
     const cy = bubble.normalizedCy * pageHeightMm
-    const r = bubble.normalizedRadius * pageWidthMm
+    const rx = (bubble.normalizedWidth * pageWidthMm) / 2
+    const ry = (bubble.normalizedHeight * pageHeightMm) / 2
     parts.push(
-      `<circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="black" stroke-width="0.3"/>`
+      `<ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" fill="none" stroke="black" stroke-width="0.3"/>`
     )
     parts.push(
-      `<text x="${cx}" y="${cy + r + 2}" font-size="2.5" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="hanging" fill="#333">${escapeXml(bubble.label)}</text>`
+      `<text x="${cx}" y="${cy}" font-size="${ry * 1.1}" font-family="'Noto Sans JP', sans-serif" text-anchor="middle" dominant-baseline="central" fill="#333">${escapeXml(bubble.label)}</text>`
     )
   }
   return parts

--- a/electron-src/lib/omr/imageProcessor.ts
+++ b/electron-src/lib/omr/imageProcessor.ts
@@ -148,3 +148,44 @@ export function computeCircularFillRatio(
 
   return totalPixels === 0 ? 0 : darkCount / totalPixels
 }
+
+/**
+ * 楕円形領域のピクセルの塗りつぶし率を計算
+ *
+ * 共通テスト風の横長楕円マーク認識用。
+ * (x/rx)^2 + (y/ry)^2 <= 1 の楕円内のピクセルのみを対象とする。
+ */
+export function computeEllipticalFillRatio(
+  rawData: RawImageData,
+  centerX: number,
+  centerY: number,
+  halfWidth: number,
+  halfHeight: number,
+  threshold: number
+): number {
+  const { data, width, height, channels } = rawData
+
+  let totalPixels = 0
+  let darkCount = 0
+
+  const x0 = Math.max(0, Math.floor(centerX - halfWidth))
+  const x1 = Math.min(width - 1, Math.ceil(centerX + halfWidth))
+  const y0 = Math.max(0, Math.floor(centerY - halfHeight))
+  const y1 = Math.min(height - 1, Math.ceil(centerY + halfHeight))
+
+  for (let py = y0; py <= y1; py++) {
+    for (let px = x0; px <= x1; px++) {
+      const dx = (px - centerX) / halfWidth
+      const dy = (py - centerY) / halfHeight
+      if (dx * dx + dy * dy <= 1) {
+        totalPixels++
+        const idx = (py * width + px) * channels
+        if (data[idx] < threshold) {
+          darkCount++
+        }
+      }
+    }
+  }
+
+  return totalPixels === 0 ? 0 : darkCount / totalPixels
+}

--- a/electron-src/lib/omr/markRecognizer.ts
+++ b/electron-src/lib/omr/markRecognizer.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../../types/omr.types"
 import { normalizedToPixel } from "./coordinateTransform"
 import { recognizeDigitCell } from "./digitRecognizer"
-import { computeCircularFillRatio } from "./imageProcessor"
+import { computeEllipticalFillRatio } from "./imageProcessor"
 
 /**
  * 1つのセルのマーク認識を実行
@@ -66,14 +66,15 @@ function recognizeChoiceCell(
       bubble.normalizedCy,
       transform
     )
-    const radiusPx = bubble.normalizedRadius * rawImage.width
 
-    // 塗りつぶし率を計算
-    const ratio = computeCircularFillRatio(
+    const halfWidthPx = (bubble.normalizedWidth * rawImage.width) / 2
+    const halfHeightPx = (bubble.normalizedHeight * rawImage.height) / 2
+    const ratio = computeEllipticalFillRatio(
       rawImage,
       center.x,
       center.y,
-      radiusPx,
+      halfWidthPx,
+      halfHeightPx,
       params.colorThreshold
     )
     fillRatios.push(ratio)

--- a/types/omr.types.ts
+++ b/types/omr.types.ts
@@ -151,8 +151,10 @@ export interface ComputedOMRBubble {
   normalizedCx: number
   /** バブル中心Y（0-1正規化） */
   normalizedCy: number
-  /** バブル半径（0-1正規化） */
-  normalizedRadius: number
+  /** バブル幅（0-1正規化）— 共通テスト準拠の横長楕円 */
+  normalizedWidth: number
+  /** バブル高さ（0-1正規化）— 共通テスト準拠の横長楕円 */
+  normalizedHeight: number
   /** 選択肢インデックス */
   choiceIndex: number
   /** ラベル（"ア", "イ" など） */


### PR DESCRIPTION
## Summary
- OMRマーク形状を円形から共通テスト準拠の縦長楕円に変更
- ラベルプリセットを共通テスト全パターン（0-9, −, ±, ①-⑨, a-d等）に拡充し、カスタム入力にも対応
- 認識エンジンに楕円形塗りつぶし率計算を追加し、リアルケース（鉛筆濃淡、消しゴム跡、ダブルマーク等）のテストを網羅

Closes #580

## 変更ファイル
- `types/omr.types.ts` — ComputedOMRBubbleにnormalizedWidth/Height追加（normalizedRadius削除）
- `cellBuilder.ts` — 縦長楕円のサイズ計算に変更
- `AnswerSheetSVGRenderer.tsx` / `renderSvgStrings.ts` — `<ellipse>` + 内部ラベル描画
- `imageProcessor.ts` — `computeEllipticalFillRatio` 追加
- `markRecognizer.ts` — 楕円形認識対応
- `OMRCellConfigForm.tsx` — プリセット拡充 + カスタム入力UI
- テスト2ファイル新規追加（48テスト全通過）

## Test plan
- [x] `npm run typecheck` — 型チェック通過
- [x] `npm run lint` — lint通過
- [x] `npx vitest run __tests__/omr` — 全48テスト通過
- [ ] 解答用紙ビルダーでOMRバブルの表示を確認
- [ ] PDF出力で楕円マークが正しく描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)