### PR TITLE
feat: 一括採点画面にVキーによる表示モード切り替えショートカットを追加

### DIFF
--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -333,6 +333,12 @@ function ScoringMainViewContent() {
     onBatchScore: handleBatchScoreWithProgress,
   })
 
+  /** 表示モード切り替え（グリッド⇔個別） */
+  const handleToggleViewMode = useCallback(
+    () => setGradingMode((prev) => (prev === "grid" ? "individual" : "grid")),
+    [setGradingMode]
+  )
+
   /** コンテキスト値の設定 */
   useContextValue("gradingMode", gradingMode)
   useContextValue("hasSelectedAnswers", selectedStudentAnswerImageIds.size > 0)
@@ -361,6 +367,7 @@ function ScoringMainViewContent() {
     handleScore: handleBatchScoreWithProgress,
     handleToggleFilter,
     handleSelectAll,
+    handleToggleViewMode: handleToggleViewMode,
   })
 
   const currentStudentId = useMemo(() => {

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -46,6 +46,8 @@ interface ScoringShortcutHandlers {
   handleToggleFilter: (key: string) => void
   /** 全選択（表示中の答案をすべて選択） */
   handleSelectAll: () => void
+  /** 表示モード切り替え（グリッド⇔個別） */
+  handleToggleViewMode: () => void
 }
 
 /**
@@ -72,6 +74,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     handleScore,
     handleToggleFilter,
     handleSelectAll,
+    handleToggleViewMode,
   } = handlers
 
   // ========================================
@@ -198,6 +201,15 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   // ========================================
   // 表示関連ショートカット
   // ========================================
+  useCommand("view.toggleViewMode", handleToggleViewMode, {
+    when: "!inputFocus && !modalOpen",
+    metadata: {
+      title: "表示モード切り替え",
+      category: "表示",
+      description: "一覧表示と個別表示を切り替えます",
+    },
+  })
+
   useCommand("view.toggleStudentNames", handleToggleStudentNames, {
     when: "!inputFocus && !modalOpen",
     metadata: {


### PR DESCRIPTION
## Summary
- 一括採点画面でVキーによるグリッド表示⇔個別表示のトグル切り替えを実装
- 既存のキーバインディング定義 `view.toggleViewMode` に対して `useCommand` ハンドラーを登録
- キーボードヘルプにも自動的に表示される

Closes #582

## 変更ファイル
- `components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts`: ハンドラー型定義追加 + `useCommand` 登録
- `components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx`: `handleToggleViewMode` コールバック追加

## Test plan
- [ ] 一括採点画面でVキーを押してグリッド⇔個別表示が切り替わることを確認
- [ ] モーダル表示中・入力フォーカス中はVキーが無効であることを確認
- [ ] キーボードヘルプに「表示モード切り替え」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)