### PR TITLE
feat: 画面制御機能を追加（プロジェクターモード・画面消灯・ロック）

### DIFF
--- a/app/settings/components/DisplaySettingsTab.tsx
+++ b/app/settings/components/DisplaySettingsTab.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { RotateCcw } from "lucide-react"
+import { Monitor, RotateCcw } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { ColorPicker } from "@/components/ui/color-picker"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/contexts/AuthContext"
 import {
   applyScoringColorPreset,
@@ -23,6 +25,7 @@ import {
 import { cn } from "@/lib/utils"
 
 const DEFAULT_SELECTION_BORDER_COLOR = "#F97316"
+const BLACKOUT_SETTINGS_KEY = "screenBlackoutSettings"
 const SELECTION_BORDER_PRESETS = [
   "#F97316", // オレンジ
   "#3B82F6", // 青
@@ -49,6 +52,14 @@ export function DisplaySettingsTab() {
   const [currentPresetId, setCurrentPresetId] = useState<string | null>(
     getCurrentPresetId
   )
+
+  // プロジェクターモード
+  const [projectorMode, setProjectorMode] = useState(false)
+
+  // 画面消灯
+  const [blackoutEnabled, setBlackoutEnabled] = useState(false)
+  const [blackoutMinutes, setBlackoutMinutes] = useState(5)
+  const [autoFullScreen, setAutoFullScreen] = useState(false)
 
   // 初期値をロード（カラム別）
   useEffect(() => {
@@ -82,6 +93,27 @@ export function DisplaySettingsTab() {
       await loadScoringStatusColors(userId)
       setScoringColors(getScoringStatusColors())
       setCurrentPresetId(getCurrentPresetId())
+
+      // プロジェクターモードの現在状態を取得
+      if (window.electronAPI?.settings?.getProjectorMode) {
+        const pmResult = await window.electronAPI.settings.getProjectorMode()
+        if (pmResult.success) {
+          setProjectorMode(pmResult.active ?? false)
+        }
+      }
+
+      // 画面消灯の設定を読み込み
+      try {
+        const stored = localStorage.getItem(BLACKOUT_SETTINGS_KEY)
+        if (stored) {
+          const parsed = JSON.parse(stored)
+          setBlackoutEnabled(parsed.enabled ?? false)
+          setBlackoutMinutes(parsed.timeoutMinutes ?? 5)
+          setAutoFullScreen(parsed.autoFullScreen ?? false)
+        }
+      } catch {
+        // ignore
+      }
     }
 
     loadSettings()
@@ -148,10 +180,168 @@ export function DisplaySettingsTab() {
     await handlePresetSelect("default")
   }, [handlePresetSelect])
 
+  // プロジェクターモードの切り替え
+  const handleProjectorModeToggle = useCallback(async (enabled: boolean) => {
+    setProjectorMode(enabled)
+    if (window.electronAPI?.settings?.setProjectorMode) {
+      try {
+        const result =
+          await window.electronAPI.settings.setProjectorMode(enabled)
+        if (result.success) {
+          toast.success(
+            enabled
+              ? "プロジェクターモードを有効にしました"
+              : "プロジェクターモードを無効にしました"
+          )
+        } else {
+          setProjectorMode(!enabled)
+          toast.error("プロジェクターモードの切り替えに失敗しました")
+        }
+      } catch {
+        setProjectorMode(!enabled)
+        toast.error("プロジェクターモードの切り替えに失敗しました")
+      }
+    }
+  }, [])
+
+  // 画面消灯設定の保存
+  const saveBlackoutSettings = useCallback(
+    (enabled: boolean, minutes: number, fullScreen: boolean) => {
+      const settings = {
+        enabled,
+        timeoutMinutes: minutes,
+        autoFullScreen: fullScreen,
+      }
+      localStorage.setItem(BLACKOUT_SETTINGS_KEY, JSON.stringify(settings))
+      window.dispatchEvent(new CustomEvent("screenBlackoutSettingsChanged"))
+    },
+    []
+  )
+
+  const handleBlackoutToggle = useCallback(
+    (enabled: boolean) => {
+      setBlackoutEnabled(enabled)
+      saveBlackoutSettings(enabled, blackoutMinutes, autoFullScreen)
+      toast.success(
+        enabled ? "画面消灯を有効にしました" : "画面消灯を無効にしました"
+      )
+    },
+    [blackoutMinutes, autoFullScreen, saveBlackoutSettings]
+  )
+
+  const handleBlackoutMinutesChange = useCallback(
+    (value: string) => {
+      const minutes = Math.max(1, Math.min(60, parseInt(value) || 1))
+      setBlackoutMinutes(minutes)
+      saveBlackoutSettings(blackoutEnabled, minutes, autoFullScreen)
+    },
+    [blackoutEnabled, autoFullScreen, saveBlackoutSettings]
+  )
+
+  const handleAutoFullScreenToggle = useCallback(
+    (enabled: boolean) => {
+      setAutoFullScreen(enabled)
+      saveBlackoutSettings(blackoutEnabled, blackoutMinutes, enabled)
+      toast.success(
+        enabled
+          ? "消灯時の自動フルスクリーンを有効にしました"
+          : "消灯時の自動フルスクリーンを無効にしました"
+      )
+    },
+    [blackoutEnabled, blackoutMinutes, saveBlackoutSettings]
+  )
+
   const isPresetSelected = (presetId: string) => currentPresetId === presetId
 
   return (
     <div className="space-y-8">
+      {/* プロジェクターモード・画面消灯 */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">
+            <Monitor className="mr-2 inline-block h-5 w-5" />
+            画面制御
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            スクリーンセーバーの無効化や、一定時間後の画面消灯を設定できます。
+            <kbd className="mx-1 rounded border border-gray-300 px-1 py-0.5 text-xs">
+              Ctrl+L
+            </kbd>
+            で手動消灯できます（パスコード設定時はロック付き）
+          </p>
+        </div>
+
+        <div className="space-y-4 rounded-lg border p-4">
+          {/* プロジェクターモード */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label className="text-sm font-medium">
+                プロジェクターモード
+              </Label>
+              <p className="text-muted-foreground text-xs">
+                スクリーンセーバーとスリープを無効化します
+              </p>
+            </div>
+            <Switch
+              checked={projectorMode}
+              onCheckedChange={handleProjectorModeToggle}
+            />
+          </div>
+
+          <div className="border-t" />
+
+          {/* 画面消灯 */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label className="text-sm font-medium">画面消灯</Label>
+              <p className="text-muted-foreground text-xs">
+                操作がない場合、画面を黒くします。パスコード設定時はロック解除が必要です
+              </p>
+            </div>
+            <Switch
+              checked={blackoutEnabled}
+              onCheckedChange={handleBlackoutToggle}
+            />
+          </div>
+
+          {/* 消灯までの時間 */}
+          <div className="flex items-center gap-3 pl-4">
+            <Label className="text-muted-foreground text-sm">
+              消灯までの時間
+            </Label>
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="number"
+                min={1}
+                max={60}
+                value={blackoutMinutes}
+                onChange={(e) => handleBlackoutMinutesChange(e.target.value)}
+                className="w-16"
+              />
+              <span className="text-muted-foreground text-sm">分</span>
+            </div>
+          </div>
+
+          <div className="border-t" />
+
+          {/* 自動フルスクリーン */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label className="text-sm font-medium">
+                消灯時に自動フルスクリーン
+              </Label>
+              <p className="text-muted-foreground text-xs">
+                消灯・ロック時にウィンドウをフルスクリーンにします
+              </p>
+            </div>
+            <Switch
+              checked={autoFullScreen}
+              onCheckedChange={handleAutoFullScreenToggle}
+            />
+          </div>
+        </div>
+      </section>
+
       {/* 選択枠の色 */}
       <section className="space-y-4">
         <div>

--- a/components/common/ScreenBlackout.tsx
+++ b/components/common/ScreenBlackout.tsx
@@ -1,0 +1,400 @@
+"use client"
+
+import { Lock } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/contexts/AuthContext"
+
+const BLACKOUT_SETTINGS_KEY = "screenBlackoutSettings"
+const FADE_TIMEOUT_MS = 3000
+
+interface BlackoutSettings {
+  enabled: boolean
+  timeoutMinutes: number
+  autoFullScreen: boolean
+}
+
+function getBlackoutSettings(): BlackoutSettings {
+  try {
+    const stored = localStorage.getItem(BLACKOUT_SETTINGS_KEY)
+    if (stored) return JSON.parse(stored)
+  } catch {
+    // ignore
+  }
+  return { enabled: false, timeoutMinutes: 5, autoFullScreen: false }
+}
+
+export function ScreenBlackout() {
+  const { user } = useAuth()
+  const [isBlackout, setIsBlackout] = useState(false)
+  const [isLocked, setIsLocked] = useState(false)
+  const [settings, setSettings] = useState<BlackoutSettings>({
+    enabled: false,
+    timeoutMinutes: 5,
+    autoFullScreen: false,
+  })
+  const [passcode, setPasscode] = useState("")
+  const [passcodeType, setPasscodeType] = useState<string | null>(null)
+  const [error, setError] = useState("")
+  const [uiVisible, setUiVisible] = useState(true)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hiddenInputRef = useRef<HTMLInputElement>(null)
+  const wasFullScreenBeforeRef = useRef(false)
+
+  // ユーザーのパスコードタイプを取得
+  useEffect(() => {
+    if (!user?.id) return
+    const loadPasscodeType = async () => {
+      try {
+        const users = await window.electronAPI.fetchUsers()
+        const currentUser = users.find((u: { id: string }) => u.id === user.id)
+        setPasscodeType(currentUser?.passcodeType ?? "none")
+      } catch {
+        setPasscodeType("none")
+      }
+    }
+    loadPasscodeType()
+  }, [user?.id])
+
+  const hasPasscode = passcodeType && passcodeType !== "none"
+  const maxLength =
+    passcodeType === "4digit" ? 4 : passcodeType === "6digit" ? 6 : undefined
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // フェードUI制御
+  const startFadeTimer = useCallback(() => {
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
+    fadeTimerRef.current = setTimeout(() => {
+      setUiVisible(false)
+    }, FADE_TIMEOUT_MS)
+  }, [])
+
+  const showUi = useCallback(() => {
+    setUiVisible(true)
+    startFadeTimer()
+  }, [startFadeTimer])
+
+  const enterFullScreenIfNeeded = useCallback(() => {
+    const current = getBlackoutSettings()
+    if (current.autoFullScreen && window.electronAPI?.settings?.setFullScreen) {
+      wasFullScreenBeforeRef.current = !!document.fullscreenElement
+      window.electronAPI.settings.setFullScreen(true)
+    }
+  }, [])
+
+  const restoreFullScreenIfNeeded = useCallback(() => {
+    const current = getBlackoutSettings()
+    if (
+      current.autoFullScreen &&
+      !wasFullScreenBeforeRef.current &&
+      window.electronAPI?.settings?.setFullScreen
+    ) {
+      window.electronAPI.settings.setFullScreen(false)
+    }
+  }, [])
+
+  const startTimer = useCallback(
+    (minutes: number) => {
+      clearTimer()
+      timerRef.current = setTimeout(
+        () => {
+          enterFullScreenIfNeeded()
+          setIsBlackout(true)
+          if (hasPasscode) {
+            setIsLocked(true)
+            setUiVisible(true)
+            startFadeTimer()
+          }
+        },
+        minutes * 60 * 1000
+      )
+    },
+    [clearTimer, hasPasscode, enterFullScreenIfNeeded, startFadeTimer]
+  )
+
+  const unlock = useCallback(() => {
+    restoreFullScreenIfNeeded()
+    setIsBlackout(false)
+    setIsLocked(false)
+    setUiVisible(true)
+    setPasscode("")
+    setError("")
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
+    const current = getBlackoutSettings()
+    if (current.enabled) {
+      startTimer(current.timeoutMinutes)
+    }
+  }, [startTimer, restoreFullScreenIfNeeded])
+
+  // 手動ロック（Ctrl/Cmd + L）
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "l") {
+        e.preventDefault()
+        enterFullScreenIfNeeded()
+        setIsBlackout(true)
+        clearTimer()
+        if (hasPasscode) {
+          setIsLocked(true)
+          setUiVisible(true)
+          startFadeTimer()
+        }
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [hasPasscode, clearTimer, enterFullScreenIfNeeded, startFadeTimer])
+
+  // 設定変更を監視
+  useEffect(() => {
+    const handleSettingsChange = () => {
+      const newSettings = getBlackoutSettings()
+      setSettings(newSettings)
+      clearTimer()
+      if (newSettings.enabled && !isLocked) {
+        startTimer(newSettings.timeoutMinutes)
+      }
+      if (!isLocked) {
+        setIsBlackout(false)
+      }
+    }
+
+    handleSettingsChange()
+
+    window.addEventListener(
+      "screenBlackoutSettingsChanged",
+      handleSettingsChange
+    )
+    return () => {
+      window.removeEventListener(
+        "screenBlackoutSettingsChanged",
+        handleSettingsChange
+      )
+      clearTimer()
+    }
+  }, [clearTimer, startTimer, isLocked])
+
+  // ユーザー操作でタイマーリセット（ロック中は無視）
+  useEffect(() => {
+    if (!settings.enabled || isLocked) return
+
+    const events = ["mousemove", "mousedown", "keydown", "touchstart", "scroll"]
+
+    const handleActivity = () => {
+      if (isBlackout && !isLocked) {
+        if (!hasPasscode) {
+          unlock()
+          return
+        }
+        return
+      }
+      clearTimer()
+      if (settings.enabled) {
+        startTimer(settings.timeoutMinutes)
+      }
+    }
+
+    events.forEach((event) => {
+      window.addEventListener(event, handleActivity, { passive: true })
+    })
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, handleActivity)
+      })
+    }
+  }, [
+    settings.enabled,
+    settings.timeoutMinutes,
+    isBlackout,
+    isLocked,
+    hasPasscode,
+    unlock,
+    clearTimer,
+    startTimer,
+  ])
+
+  // ロック画面でのユーザー操作→フェード復帰＋隠しinputにフォーカス
+  useEffect(() => {
+    if (!isLocked) return
+
+    const handleLockActivity = (e: Event) => {
+      showUi()
+      // キーイベント以外（マウス/トラックパッド）の場合もinputにフォーカス
+      if (e.type !== "keydown") {
+        setTimeout(() => hiddenInputRef.current?.focus(), 0)
+      }
+    }
+
+    const events = ["mousemove", "mousedown", "keydown", "touchstart"]
+    events.forEach((event) => {
+      window.addEventListener(event, handleLockActivity, { passive: true })
+    })
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, handleLockActivity)
+      })
+    }
+  }, [isLocked, showUi])
+
+  // ロック表示時に隠しinputへフォーカス
+  useEffect(() => {
+    if (isLocked && uiVisible) {
+      setTimeout(() => hiddenInputRef.current?.focus(), 50)
+    }
+  }, [isLocked, uiVisible])
+
+  // パスコードリセット（input要素を直接操作してフォーカス・入力を途切れさせない）
+  const resetPasscodeInput = useCallback(() => {
+    setPasscode("")
+    if (hiddenInputRef.current) {
+      hiddenInputRef.current.value = ""
+      hiddenInputRef.current.focus()
+    }
+  }, [])
+
+  // パスコード検証
+  const verifyPasscode = useCallback(
+    async (code: string) => {
+      if (!user?.id || !code) return
+      setError("")
+      try {
+        const isValid = await window.electronAPI.verifyPasscode(user.id, code)
+        if (isValid) {
+          unlock()
+        } else {
+          setError("パスコードが正しくありません")
+          resetPasscodeInput()
+        }
+      } catch {
+        setError("検証に失敗しました")
+        resetPasscodeInput()
+      }
+    },
+    [user?.id, unlock, resetPasscodeInput]
+  )
+
+  // 入力ハンドラー
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      let value = e.target.value
+      // 数字パスコードの場合は数字のみ
+      if (passcodeType === "4digit" || passcodeType === "6digit") {
+        value = value.replace(/\D/g, "")
+      }
+      if (maxLength && value.length > maxLength) {
+        value = value.slice(0, maxLength)
+      }
+      setPasscode(value)
+      setError("")
+
+      // 桁数一致で自動検証
+      if (maxLength && value.length === maxLength) {
+        verifyPasscode(value)
+      }
+    },
+    [passcodeType, maxLength, verifyPasscode]
+  )
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && passcodeType === "alphanumeric") {
+        e.preventDefault()
+        verifyPasscode(passcode)
+      }
+    },
+    [passcode, passcodeType, verifyPasscode]
+  )
+
+  if (!isBlackout) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black"
+      onClick={() => {
+        if (!isLocked && !hasPasscode) {
+          unlock()
+        } else if (isLocked) {
+          showUi()
+          setTimeout(() => hiddenInputRef.current?.focus(), 0)
+        }
+      }}
+      role="presentation"
+    >
+      {isLocked && (
+        <>
+          {/* 隠しinput: 常にDOMに存在しフォーカスを受ける */}
+          <input
+            ref={hiddenInputRef}
+            type={passcodeType === "alphanumeric" ? "text" : "tel"}
+            value={passcode}
+            onChange={handleInputChange}
+            onKeyDown={handleInputKeyDown}
+            className="fixed -top-20 left-0 opacity-0"
+            autoFocus
+            inputMode={passcodeType === "alphanumeric" ? "text" : "numeric"}
+            autoComplete="off"
+            aria-label="パスコード入力"
+          />
+
+          {/* フェード表示UI */}
+          <div
+            className="flex flex-col items-center gap-6 transition-opacity duration-500"
+            style={{ opacity: uiVisible ? 1 : 0 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Lock className="h-8 w-8 text-gray-500" />
+            <p className="text-sm text-gray-400">
+              パスコードを入力してロック解除
+            </p>
+
+            {/* ドット表示 */}
+            {(passcodeType === "4digit" || passcodeType === "6digit") && (
+              <div className="flex gap-3">
+                {Array.from({ length: maxLength! }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="flex h-4 w-4 items-center justify-center"
+                  >
+                    {i < passcode.length ? (
+                      <div className="h-3 w-3 rounded-full bg-white" />
+                    ) : (
+                      <div className="h-3 w-3 rounded-full border border-gray-600" />
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {passcodeType === "alphanumeric" && (
+              <div className="flex min-h-[28px] items-center gap-1">
+                {passcode.length > 0 ? (
+                  Array.from({ length: passcode.length }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="h-2.5 w-2.5 rounded-full bg-white"
+                    />
+                  ))
+                ) : (
+                  <p className="text-sm text-gray-600">
+                    キーボードで入力してください
+                  </p>
+                )}
+              </div>
+            )}
+
+            {error && <p className="text-sm text-red-400">{error}</p>}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation"
 import React, { useEffect, useState } from "react"
 
+import { ScreenBlackout } from "@/components/common/ScreenBlackout"
 import { ToastProvider } from "@/components/common/ToastProvider"
 import Navigation from "@/components/layout/Navigation"
 import { cn } from "@/lib/utils"
@@ -46,6 +47,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         {children}
       </main>
       <ToastProvider />
+      <ScreenBlackout />
     </div>
   )
 }

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -2,7 +2,7 @@
  * 設定関連のIPCハンドラー
  */
 
-import { ipcMain } from "electron"
+import { BrowserWindow, ipcMain, powerSaveBlocker } from "electron"
 
 import {
   bulkUpsertCropRegionMarkingOverrides,
@@ -31,7 +31,70 @@ import {
   upsertUserScoringPreference,
 } from "../lib/prisma/userSettings"
 
+// プロジェクターモード用のpowerSaveBlocker ID
+let projectorModeBlockerId: number | null = null
+
 export function registerSettingsHandlers() {
+  // =========================================================================
+  // プロジェクターモード（スクリーンセーバー無効化）
+  // =========================================================================
+
+  ipcMain.handle(
+    "settings:setProjectorMode",
+    async (_event, enabled: boolean) => {
+      try {
+        if (enabled) {
+          if (
+            projectorModeBlockerId !== null &&
+            powerSaveBlocker.isStarted(projectorModeBlockerId)
+          ) {
+            return { success: true, active: true }
+          }
+          projectorModeBlockerId = powerSaveBlocker.start(
+            "prevent-display-sleep"
+          )
+          return { success: true, active: true }
+        } else {
+          if (
+            projectorModeBlockerId !== null &&
+            powerSaveBlocker.isStarted(projectorModeBlockerId)
+          ) {
+            powerSaveBlocker.stop(projectorModeBlockerId)
+          }
+          projectorModeBlockerId = null
+          return { success: true, active: false }
+        }
+      } catch (error) {
+        console.error("Failed to set projector mode:", error)
+        return { success: false, error: String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle("settings:getProjectorMode", async () => {
+    const active =
+      projectorModeBlockerId !== null &&
+      powerSaveBlocker.isStarted(projectorModeBlockerId)
+    return { success: true, active }
+  })
+
+  // =========================================================================
+  // フルスクリーン制御
+  // =========================================================================
+
+  ipcMain.handle("settings:setFullScreen", async (event, enabled: boolean) => {
+    try {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (win) {
+        win.setFullScreen(enabled)
+      }
+      return { success: true }
+    } catch (error) {
+      console.error("Failed to set fullscreen:", error)
+      return { success: false, error: String(error) }
+    }
+  })
+
   // =========================================================================
   // UserKeyboardShortcut
   // =========================================================================

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -749,6 +749,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Settings
   settings: {
+    // プロジェクターモード（スクリーンセーバー無効化）
+    setProjectorMode: (enabled: boolean) =>
+      ipcRenderer.invoke("settings:setProjectorMode", enabled),
+    getProjectorMode: () => ipcRenderer.invoke("settings:getProjectorMode"),
+    setFullScreen: (enabled: boolean) =>
+      ipcRenderer.invoke("settings:setFullScreen", enabled),
+
     // UserKeyboardShortcut
     getUserKeyboardShortcuts: (userId: string) =>
       ipcRenderer.invoke("settings:getUserKeyboardShortcuts", userId),
@@ -1215,6 +1222,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
     deleteImage: (
       args: import("../types/answerSheetBuilder.types").ASBDeleteImageArgs
     ) => ipcRenderer.invoke("asb:delete-image", args),
+    selectImportFile: () => ipcRenderer.invoke("asb:select-import-file"),
+    analyzeAsbArchive: (filePath: string) =>
+      ipcRenderer.invoke("asb:analyze-asb-archive", filePath),
+    exportDefinition: (definitionId: string) =>
+      ipcRenderer.invoke("asb:export-definition", definitionId),
+    importDefinition: (filePath: string, userId: string) =>
+      ipcRenderer.invoke("asb:import-definition", filePath, userId),
   },
 })
 

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1677,6 +1677,21 @@ export interface MyAPI {
 
   // Settings
   settings: {
+    // プロジェクターモード（スクリーンセーバー無効化）
+    setProjectorMode: (enabled: boolean) => Promise<{
+      success: boolean
+      active?: boolean
+      error?: string
+    }>
+    getProjectorMode: () => Promise<{
+      success: boolean
+      active?: boolean
+      error?: string
+    }>
+    setFullScreen: (
+      enabled: boolean
+    ) => Promise<{ success: boolean; error?: string }>
+
     // UserKeyboardShortcut
     getUserKeyboardShortcuts: (userId: string) => Promise<{
       success: boolean
@@ -2247,6 +2262,29 @@ export interface MyAPI {
     deleteImage: (
       args: import("./answerSheetBuilder.types").ASBDeleteImageArgs
     ) => Promise<{ success: boolean; error?: string }>
+    selectImportFile: () => Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+      error?: string
+    }>
+    analyzeAsbArchive: (filePath: string) => Promise<{
+      success: boolean
+      manifest?: import("./asbArchive.types").AsbArchiveManifest
+      error?: string
+    }>
+    exportDefinition: (
+      definitionId: string
+    ) => Promise<{ success: boolean; outputPath?: string; error?: string }>
+    importDefinition: (
+      filePath: string,
+      userId: string
+    ) => Promise<{
+      success: boolean
+      definitionId?: string
+      warnings?: string[]
+      error?: string
+    }>
   }
 
   // =============================================================================


### PR DESCRIPTION
## Summary

Closes #585

- プロジェクターモード: `powerSaveBlocker`によるスクリーンセーバー/スリープ無効化
- 画面消灯: 一定時間操作なしで黒画面表示（1〜60分設定可能）
- 画面ロック: パスコード設定済みユーザーは消灯時にロック解除が必要
- 手動ロック: `Ctrl/Cmd+L`で即時消灯（パスコード有無問わず）
- 自動フルスクリーン: 消灯時にウィンドウを自動フルスクリーン化するオプション
- ロック解除UI: フェードイン/アウトするパスコード入力画面（白ドット表示、エラー後即再入力可能）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `electron-src/ipc-handlers/settingsHandlers.ts` | powerSaveBlocker・フルスクリーンのIPCハンドラー追加 |
| `electron-src/preload.ts` | `setProjectorMode`, `getProjectorMode`, `setFullScreen` API追加 |
| `types/electron.d.ts` | 新規API型定義追加 |
| `components/common/ScreenBlackout.tsx` | 画面消灯・ロックオーバーレイ（新規） |
| `components/layout/AppShell.tsx` | ScreenBlackoutコンポーネントのマウント |
| `app/settings/components/DisplaySettingsTab.tsx` | 画面制御セクションUI追加 |

## Test plan

- [ ] 設定 > 表示タブで「画面制御」セクションが表示される
- [ ] プロジェクターモードのON/OFFが切り替わる
- [ ] 画面消灯を有効にし、指定時間後に黒画面になる
- [ ] パスコード未設定: クリックで即復帰
- [ ] パスコード設定済み: パスコード入力でロック解除
- [ ] `Ctrl+L`（Mac: `Cmd+L`）で即時黒画面
- [ ] 自動フルスクリーンON時、消灯でフルスクリーン化・解除で復帰
- [ ] パスコードエラー後に即座に再入力可能
- [ ] ロック画面UIが3秒後にフェードアウト、操作でフェードイン

🤖 Generated with [Claude Code](https://claude.com/claude-code)