### PR TITLE
feat: 解答用紙定義のインポート/エクスポート機能を実装

### DIFF
--- a/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
+++ b/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
@@ -1,14 +1,24 @@
 "use client"
 
-import { Copy, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react"
+import {
+  Copy,
+  Download,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+  Upload,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useState } from "react"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -32,8 +42,13 @@ type SortDir = "asc" | "desc"
 export function AnswerSheetDefinitionList() {
   const { user } = useAuth()
   const router = useRouter()
-  const { definitions, isLoading, deleteDefinition, duplicateDefinition } =
-    useAnswerSheetDefinitions(user?.id)
+  const {
+    definitions,
+    isLoading,
+    loadDefinitions,
+    deleteDefinition,
+    duplicateDefinition,
+  } = useAnswerSheetDefinitions(user?.id)
 
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt")
   const [sortDir, setSortDir] = useState<SortDir>("desc")
@@ -97,6 +112,45 @@ export function AnswerSheetDefinitionList() {
     [deleteDefinition]
   )
 
+  const handleExport = useCallback(async (definitionId: string) => {
+    const api = window.electronAPI?.answerSheetBuilder
+    if (!api) return
+
+    const result = await api.exportDefinition(definitionId)
+    if (result.success) {
+      toast.success("定義を書き出しました")
+    } else if (result.error !== "キャンセルされました") {
+      toast.error(result.error ?? "書き出しに失敗しました")
+    }
+  }, [])
+
+  const handleImport = useCallback(async () => {
+    if (!user?.id) return
+    const api = window.electronAPI?.answerSheetBuilder
+    if (!api) return
+
+    // 1. ファイル選択
+    const fileResult = await api.selectImportFile()
+    if (!fileResult.success || !fileResult.filePath) return
+
+    // 2. インポート実行
+    const importResult = await api.importDefinition(
+      fileResult.filePath,
+      user.id
+    )
+    if (importResult.success) {
+      toast.success("定義を読み込みました")
+      if (importResult.warnings?.length) {
+        for (const w of importResult.warnings) {
+          toast.warning(w)
+        }
+      }
+      await loadDefinitions()
+    } else {
+      toast.error(importResult.error ?? "読み込みに失敗しました")
+    }
+  }, [user?.id, loadDefinitions])
+
   const sortIndicator = (key: SortKey) => {
     if (sortKey !== key) return ""
     return sortDir === "asc" ? " ↑" : " ↓"
@@ -126,10 +180,16 @@ export function AnswerSheetDefinitionList() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">解答用紙定義</h2>
-        <Button size="sm" onClick={handleCreate}>
-          <Plus className="mr-1 h-4 w-4" />
-          新規作成
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={handleImport}>
+            <Download className="mr-1 h-4 w-4" />
+            読み込み
+          </Button>
+          <Button size="sm" onClick={handleCreate}>
+            <Plus className="mr-1 h-4 w-4" />
+            新規作成
+          </Button>
+        </div>
       </div>
 
       {sorted.length === 0 ? (
@@ -220,6 +280,11 @@ export function AnswerSheetDefinitionList() {
                           <Copy className="mr-2 h-4 w-4" />
                           複製
                         </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleExport(def.id)}>
+                          <Upload className="mr-2 h-4 w-4" />
+                          書き出し
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
                         <DropdownMenuItem
                           className="text-destructive"
                           onClick={() => handleDelete(def.id, def.name)}

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -22,6 +22,11 @@ import {
   getAsbImagesDirectory,
   getRelativePathFromData,
 } from "../lib/dataManager"
+import { exportAsbDefinition } from "../lib/export/asb-archive"
+import {
+  analyzeAsbArchive,
+  importAsbDefinition,
+} from "../lib/import/asb-archive"
 import { htmlToPngBuffer } from "../lib/printUtils"
 import {
   deleteAsbDefinition,
@@ -368,4 +373,80 @@ export function setupAnswerSheetBuilderHandlers(): void {
       // tempPdfPath はプレビュー中なので削除しない
     }
   })
+
+  // 定義のインポートファイル選択
+  ipcMain.handle("asb:select-import-file", async () => {
+    try {
+      const result = await dialog.showOpenDialog({
+        title: "解答用紙定義を読み込み",
+        filters: [{ name: "解答用紙定義", extensions: ["asb"] }],
+        properties: ["openFile"],
+      })
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: false, canceled: true }
+      }
+      return { success: true, filePath: result.filePaths[0] }
+    } catch (error) {
+      console.error("asb:select-import-file error:", error)
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "ファイル選択に失敗しました",
+      }
+    }
+  })
+
+  // アーカイブ分析（プレビュー用）
+  ipcMain.handle(
+    "asb:analyze-asb-archive",
+    async (_event, filePath: string) => {
+      try {
+        return await analyzeAsbArchive(filePath)
+      } catch (error) {
+        console.error("asb:analyze-asb-archive error:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "アーカイブ分析に失敗しました",
+        }
+      }
+    }
+  )
+
+  // 定義エクスポート
+  ipcMain.handle(
+    "asb:export-definition",
+    async (_event, definitionId: string) => {
+      try {
+        return await exportAsbDefinition(definitionId)
+      } catch (error) {
+        console.error("asb:export-definition error:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "書き出しに失敗しました",
+        }
+      }
+    }
+  )
+
+  // 定義インポート
+  ipcMain.handle(
+    "asb:import-definition",
+    async (_event, filePath: string, userId: string) => {
+      try {
+        return await importAsbDefinition(filePath, userId)
+      } catch (error) {
+        console.error("asb:import-definition error:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "インポートに失敗しました",
+        }
+      }
+    }
+  )
 }

--- a/electron-src/lib/export/asb-archive/archiveCreator.ts
+++ b/electron-src/lib/export/asb-archive/archiveCreator.ts
@@ -1,0 +1,129 @@
+/**
+ * ASBアーカイブ (.asb) ZIP作成
+ */
+
+import archiver from "archiver"
+import { app } from "electron"
+import * as fs from "fs"
+import * as path from "path"
+
+import type { AsbArchiveManifest } from "../../../../types/asbArchive.types"
+import { ASB_CURRENT_VERSION } from "../../../../types/asbArchive.types"
+import { getDataDirectory } from "../../dataManager"
+import type { CollectedAsbData } from "./dataCollector"
+
+function getAppVersion(): string {
+  try {
+    return app.getVersion()
+  } catch {
+    return "0.0.0"
+  }
+}
+
+function createManifest(collected: CollectedAsbData): AsbArchiveManifest {
+  return {
+    version: ASB_CURRENT_VERSION,
+    appVersion: getAppVersion(),
+    exportedAt: new Date().toISOString(),
+    definitionName: collected.definition.name,
+    paperSize: collected.definition.settings.paperSize,
+    orientation: collected.definition.settings.orientation,
+    counts: collected.counts,
+  }
+}
+
+/**
+ * ASBアーカイブを作成
+ */
+export async function createAsbArchive(
+  collected: CollectedAsbData,
+  outputPath: string
+): Promise<{ success: boolean; outputPath?: string; error?: string }> {
+  return new Promise((resolve) => {
+    try {
+      const outputDir = path.dirname(outputPath)
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true })
+      }
+
+      const output = fs.createWriteStream(outputPath)
+      const archive = archiver("zip", { zlib: { level: 9 } })
+      const missingFiles: string[] = []
+
+      output.on("close", () => {
+        resolve({ success: true, outputPath })
+      })
+
+      archive.on("error", (err) => {
+        console.error("ASB archive error:", err)
+        resolve({
+          success: false,
+          error: `アーカイブ作成エラー: ${err.message}`,
+        })
+      })
+
+      archive.on("warning", (err) => {
+        if (err.code === "ENOENT") {
+          console.warn("ASB archive warning:", err)
+        } else {
+          throw err
+        }
+      })
+
+      archive.pipe(output)
+
+      // manifest.json
+      const manifest = createManifest(collected)
+      archive.append(JSON.stringify(manifest, null, 2), {
+        name: "manifest.json",
+      })
+
+      // definition.json
+      archive.append(JSON.stringify(collected.definition, null, 2), {
+        name: "definition.json",
+      })
+
+      // images/
+      const dataDir = getDataDirectory()
+      for (const relativePath of collected.imagePaths) {
+        const absolutePath = path.join(dataDir, relativePath)
+        if (fs.existsSync(absolutePath)) {
+          archive.file(absolutePath, {
+            name: `images/${path.basename(relativePath)}`,
+          })
+        } else {
+          console.warn(`ASB image not found: ${absolutePath}`)
+          missingFiles.push(path.basename(relativePath))
+        }
+      }
+
+      archive.finalize()
+    } catch (error) {
+      console.error("Error creating ASB archive:", error)
+      resolve({
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "アーカイブ作成に失敗しました",
+      })
+    }
+  })
+}
+
+/**
+ * デフォルトのエクスポートファイル名を生成
+ */
+export function generateAsbExportFileName(definitionName: string): string {
+  const sanitizedName = definitionName.replace(/[<>:"/\\|?*]/g, "_")
+  const now = new Date()
+  const timestamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("-")
+  return `${sanitizedName}-${timestamp}.asb`
+}

--- a/electron-src/lib/export/asb-archive/dataCollector.ts
+++ b/electron-src/lib/export/asb-archive/dataCollector.ts
@@ -1,0 +1,67 @@
+/**
+ * ASB定義エクスポート用データ収集
+ */
+
+import type { AnswerSheetDefinition } from "../../../../types/answerSheetDefinition.types"
+import type { AsbArchiveDataCounts } from "../../../../types/asbArchive.types"
+
+export interface CollectedAsbData {
+  definition: AnswerSheetDefinition
+  counts: AsbArchiveDataCounts
+  imagePaths: string[]
+}
+
+/**
+ * 定義ツリーを走査して画像パスとカウント情報を収集
+ */
+export function collectAsbData(
+  definition: AnswerSheetDefinition
+): CollectedAsbData {
+  const imagePaths: string[] = []
+  let textElements = 0
+  let imageElements = 0
+  let subQuestions = 0
+  let branchQuestions = 0
+  let omrConfigs = 0
+
+  for (const mq of definition.majorQuestions) {
+    for (const sq of mq.subQuestions) {
+      subQuestions++
+      textElements += sq.textElements.length
+      if (sq.imageElements) {
+        imageElements += sq.imageElements.length
+        for (const ie of sq.imageElements) {
+          if (ie.imagePath) imagePaths.push(ie.imagePath)
+        }
+      }
+      if (sq.omrConfig) omrConfigs++
+
+      for (const bq of sq.branchQuestions) {
+        branchQuestions++
+        textElements += bq.textElements.length
+        if (bq.imageElements) {
+          imageElements += bq.imageElements.length
+          for (const ie of bq.imageElements) {
+            if (ie.imagePath) imagePaths.push(ie.imagePath)
+          }
+        }
+        if (bq.omrConfig) omrConfigs++
+      }
+    }
+  }
+
+  return {
+    definition,
+    counts: {
+      headerFields: definition.settings.headerFields.length,
+      majorQuestions: definition.majorQuestions.length,
+      subQuestions,
+      branchQuestions,
+      textElements,
+      imageElements,
+      omrConfigs,
+      images: imagePaths.length,
+    },
+    imagePaths,
+  }
+}

--- a/electron-src/lib/export/asb-archive/index.ts
+++ b/electron-src/lib/export/asb-archive/index.ts
@@ -1,0 +1,51 @@
+/**
+ * ASB定義エクスポート機能
+ */
+
+import { dialog } from "electron"
+
+import { getAsbDefinition } from "../../prisma/asbDefinition"
+import { createAsbArchive, generateAsbExportFileName } from "./archiveCreator"
+import { collectAsbData } from "./dataCollector"
+
+/**
+ * 解答用紙定義をエクスポート
+ */
+export async function exportAsbDefinition(
+  definitionId: string
+): Promise<{ success: boolean; outputPath?: string; error?: string }> {
+  try {
+    // 1. 定義を取得
+    const definition = await getAsbDefinition(definitionId)
+    if (!definition) {
+      return { success: false, error: "定義が見つかりません" }
+    }
+
+    // 2. データ収集
+    const collected = collectAsbData(definition)
+
+    // 3. 保存先を選択
+    const defaultFileName = generateAsbExportFileName(definition.name)
+    const result = await dialog.showSaveDialog({
+      title: "解答用紙定義を書き出し",
+      defaultPath: defaultFileName,
+      filters: [{ name: "解答用紙定義", extensions: ["asb"] }],
+    })
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, error: "キャンセルされました" }
+    }
+
+    // 4. アーカイブを作成
+    return await createAsbArchive(collected, result.filePath)
+  } catch (error) {
+    console.error("Error exporting ASB definition:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "書き出しに失敗しました",
+    }
+  }
+}
+
+export { createAsbArchive, generateAsbExportFileName } from "./archiveCreator"
+export { collectAsbData } from "./dataCollector"

--- a/electron-src/lib/import/asb-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/asb-archive/archiveExtractor.ts
@@ -1,0 +1,144 @@
+/**
+ * ASBアーカイブ展開モジュール
+ */
+
+import AdmZip from "adm-zip"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import type { AnswerSheetDefinition } from "../../../../types/answerSheetDefinition.types"
+import type { AsbArchiveManifest } from "../../../../types/asbArchive.types"
+
+export interface ExtractedAsbData {
+  manifest: AsbArchiveManifest
+  definition: AnswerSheetDefinition
+  tempDir: string
+  imagePaths: string[]
+}
+
+/**
+ * ASBアーカイブを展開してデータを読み込む
+ */
+export async function extractAsbArchive(archivePath: string): Promise<{
+  success: boolean
+  data?: ExtractedAsbData
+  error?: string
+}> {
+  const tempDir = path.join(
+    os.tmpdir(),
+    `asb-archive-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+  )
+
+  try {
+    if (!fs.existsSync(archivePath)) {
+      return { success: false, error: "ファイルが見つかりません" }
+    }
+
+    const zip = new AdmZip(archivePath)
+    zip.extractAllTo(tempDir, true)
+
+    // manifest.json
+    const manifestPath = path.join(tempDir, "manifest.json")
+    if (!fs.existsSync(manifestPath)) {
+      cleanupAsbTempDir(tempDir)
+      return { success: false, error: "マニフェストファイルが見つかりません" }
+    }
+    const manifest: AsbArchiveManifest = JSON.parse(
+      fs.readFileSync(manifestPath, "utf-8")
+    )
+
+    // definition.json
+    const definitionPath = path.join(tempDir, "definition.json")
+    if (!fs.existsSync(definitionPath)) {
+      cleanupAsbTempDir(tempDir)
+      return { success: false, error: "定義ファイルが見つかりません" }
+    }
+    const definition: AnswerSheetDefinition = JSON.parse(
+      fs.readFileSync(definitionPath, "utf-8")
+    )
+
+    // images/
+    const imagesDir = path.join(tempDir, "images")
+    const imagePaths = collectImagePaths(imagesDir)
+
+    return {
+      success: true,
+      data: { manifest, definition, tempDir, imagePaths },
+    }
+  } catch (error) {
+    cleanupAsbTempDir(tempDir)
+    console.error("Error extracting ASB archive:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "アーカイブの展開に失敗しました",
+    }
+  }
+}
+
+/**
+ * マニフェストのみを読み込む（プレビュー用）
+ */
+export async function readAsbManifestOnly(archivePath: string): Promise<{
+  success: boolean
+  manifest?: AsbArchiveManifest
+  error?: string
+}> {
+  try {
+    if (!fs.existsSync(archivePath)) {
+      return { success: false, error: "ファイルが見つかりません" }
+    }
+
+    const zip = new AdmZip(archivePath)
+    const manifestEntry = zip.getEntry("manifest.json")
+    if (!manifestEntry) {
+      return { success: false, error: "マニフェストファイルが見つかりません" }
+    }
+
+    const manifest: AsbArchiveManifest = JSON.parse(
+      zip.readAsText(manifestEntry)
+    )
+    return { success: true, manifest }
+  } catch (error) {
+    console.error("Error reading ASB manifest:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "マニフェストの読み込みに失敗しました",
+    }
+  }
+}
+
+function collectImagePaths(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  const paths: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      paths.push(...collectImagePaths(fullPath))
+    } else if (isImageFile(entry.name)) {
+      paths.push(fullPath)
+    }
+  }
+  return paths
+}
+
+function isImageFile(filename: string): boolean {
+  const ext = path.extname(filename).toLowerCase()
+  return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"].includes(ext)
+}
+
+export function cleanupAsbTempDir(tempDir: string): void {
+  try {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  } catch (error) {
+    console.error("Error cleaning up ASB temp directory:", error)
+  }
+}

--- a/electron-src/lib/import/asb-archive/dataCreator.ts
+++ b/electron-src/lib/import/asb-archive/dataCreator.ts
@@ -1,0 +1,93 @@
+/**
+ * ASBインポートデータ作成
+ *
+ * リマップ済み定義をDBに保存し、画像ファイルをコピーする
+ */
+
+import * as fs from "fs"
+import * as path from "path"
+
+import type { AnswerSheetDefinition } from "../../../../types/answerSheetDefinition.types"
+import {
+  getAsbImagesDirectory,
+  getRelativePathFromData,
+} from "../../dataManager"
+import {
+  listAsbDefinitions,
+  saveAsbDefinition,
+} from "../../prisma/asbDefinition"
+
+/**
+ * 名前の重複を解決するサフィックスを付与
+ */
+export async function resolveNameConflict(
+  name: string,
+  userId: string
+): Promise<string> {
+  const existing = await listAsbDefinitions(userId)
+  const existingNames = new Set(existing.map((d) => d.name))
+
+  if (!existingNames.has(name)) return name
+
+  let suffix = 2
+  while (existingNames.has(`${name} (${suffix})`)) {
+    suffix++
+  }
+  return `${name} (${suffix})`
+}
+
+/**
+ * 画像ファイルをインポート先にコピーし、定義内のimagePathを更新
+ */
+export function copyImagesAndUpdatePaths(
+  definition: AnswerSheetDefinition,
+  tempImagePaths: string[]
+): void {
+  if (tempImagePaths.length === 0) return
+
+  const imagesDir = getAsbImagesDirectory(definition.id)
+  if (!fs.existsSync(imagesDir)) {
+    fs.mkdirSync(imagesDir, { recursive: true })
+  }
+
+  // tempイメージの basename → fullPath マップ
+  const tempImageMap = new Map<string, string>()
+  for (const p of tempImagePaths) {
+    tempImageMap.set(path.basename(p), p)
+  }
+
+  // ツリーを走査して imagePath を更新
+  const updateImageElements = (
+    imageElements?: { imagePath: string; originalName: string }[]
+  ) => {
+    if (!imageElements) return
+    for (const ie of imageElements) {
+      const basename = path.basename(ie.imagePath)
+      const sourcePath = tempImageMap.get(basename)
+      if (sourcePath && fs.existsSync(sourcePath)) {
+        const destPath = path.join(imagesDir, basename)
+        fs.copyFileSync(sourcePath, destPath)
+        ie.imagePath = getRelativePathFromData(destPath)
+      }
+    }
+  }
+
+  for (const mq of definition.majorQuestions) {
+    for (const sq of mq.subQuestions) {
+      updateImageElements(sq.imageElements)
+      for (const bq of sq.branchQuestions) {
+        updateImageElements(bq.imageElements)
+      }
+    }
+  }
+}
+
+/**
+ * インポートした定義をDBに保存
+ */
+export async function createImportedAsbDefinition(
+  definition: AnswerSheetDefinition,
+  userId: string
+): Promise<void> {
+  await saveAsbDefinition(definition, userId)
+}

--- a/electron-src/lib/import/asb-archive/idRemapper.ts
+++ b/electron-src/lib/import/asb-archive/idRemapper.ts
@@ -1,0 +1,122 @@
+/**
+ * ASB定義のID再マッピング
+ *
+ * インポート時に全IDを新UUIDに置換して競合を防ぐ
+ */
+
+import { randomUUID } from "crypto"
+
+import type { AnswerSheetDefinition } from "../../../../types/answerSheetDefinition.types"
+import type { AsbIdMappings } from "../../../../types/asbArchive.types"
+
+/**
+ * 定義ツリー内の全IDに対するマッピングを生成
+ */
+export function generateAsbIdMappings(
+  definition: AnswerSheetDefinition
+): AsbIdMappings {
+  const mappings: AsbIdMappings = {
+    definition: { [definition.id]: randomUUID() },
+    headerField: {},
+    majorQuestion: {},
+    subQuestion: {},
+    branchQuestion: {},
+    textElement: {},
+    imageElement: {},
+    omrConfig: {},
+  }
+
+  for (const hf of definition.settings.headerFields) {
+    mappings.headerField[hf.id] = randomUUID()
+  }
+
+  for (const mq of definition.majorQuestions) {
+    mappings.majorQuestion[mq.id] = randomUUID()
+
+    for (const sq of mq.subQuestions) {
+      mappings.subQuestion[sq.id] = randomUUID()
+
+      for (const te of sq.textElements) {
+        mappings.textElement[te.id] = randomUUID()
+      }
+      if (sq.imageElements) {
+        for (const ie of sq.imageElements) {
+          mappings.imageElement[ie.id] = randomUUID()
+        }
+      }
+      if (sq.omrConfig) {
+        mappings.omrConfig[sq.id] = randomUUID()
+      }
+
+      for (const bq of sq.branchQuestions) {
+        mappings.branchQuestion[bq.id] = randomUUID()
+
+        for (const te of bq.textElements) {
+          mappings.textElement[te.id] = randomUUID()
+        }
+        if (bq.imageElements) {
+          for (const ie of bq.imageElements) {
+            mappings.imageElement[ie.id] = randomUUID()
+          }
+        }
+        if (bq.omrConfig) {
+          mappings.omrConfig[bq.id] = randomUUID()
+        }
+      }
+    }
+  }
+
+  return mappings
+}
+
+/**
+ * 定義のdeep cloneを作成し、全IDを新UUIDに置換
+ */
+export function remapDefinitionIds(
+  definition: AnswerSheetDefinition,
+  mappings: AsbIdMappings
+): AnswerSheetDefinition {
+  const cloned: AnswerSheetDefinition = JSON.parse(JSON.stringify(definition))
+
+  cloned.id = mappings.definition[definition.id]
+
+  for (const hf of cloned.settings.headerFields) {
+    hf.id = mappings.headerField[hf.id] ?? hf.id
+  }
+
+  for (const mq of cloned.majorQuestions) {
+    mq.id = mappings.majorQuestion[mq.id] ?? mq.id
+
+    for (const sq of mq.subQuestions) {
+      sq.id = mappings.subQuestion[sq.id] ?? sq.id
+
+      for (const te of sq.textElements) {
+        te.id = mappings.textElement[te.id] ?? te.id
+      }
+      if (sq.imageElements) {
+        for (const ie of sq.imageElements) {
+          ie.id = mappings.imageElement[ie.id] ?? ie.id
+        }
+      }
+
+      for (const bq of sq.branchQuestions) {
+        bq.id = mappings.branchQuestion[bq.id] ?? bq.id
+
+        for (const te of bq.textElements) {
+          te.id = mappings.textElement[te.id] ?? te.id
+        }
+        if (bq.imageElements) {
+          for (const ie of bq.imageElements) {
+            ie.id = mappings.imageElement[ie.id] ?? ie.id
+          }
+        }
+      }
+    }
+  }
+
+  // createdAt/updatedAt をリセット
+  delete cloned.createdAt
+  delete cloned.updatedAt
+
+  return cloned
+}

--- a/electron-src/lib/import/asb-archive/index.ts
+++ b/electron-src/lib/import/asb-archive/index.ts
@@ -1,0 +1,98 @@
+/**
+ * ASB定義インポート機能
+ */
+
+import type { AsbArchiveManifest } from "../../../../types/asbArchive.types"
+import { transformAsbToLatest } from "../asb-transformers"
+import {
+  cleanupAsbTempDir,
+  extractAsbArchive,
+  readAsbManifestOnly,
+} from "./archiveExtractor"
+import {
+  copyImagesAndUpdatePaths,
+  createImportedAsbDefinition,
+  resolveNameConflict,
+} from "./dataCreator"
+import { generateAsbIdMappings, remapDefinitionIds } from "./idRemapper"
+import { validateAsbManifest } from "./manifestValidator"
+
+/**
+ * ASBアーカイブを分析（プレビュー用）
+ */
+export async function analyzeAsbArchive(filePath: string): Promise<{
+  success: boolean
+  manifest?: AsbArchiveManifest
+  error?: string
+}> {
+  return readAsbManifestOnly(filePath)
+}
+
+/**
+ * ASBアーカイブをインポート
+ */
+export async function importAsbDefinition(
+  filePath: string,
+  userId: string
+): Promise<{
+  success: boolean
+  definitionId?: string
+  warnings?: string[]
+  error?: string
+}> {
+  let tempDir: string | undefined
+
+  try {
+    // 1. 展開
+    const extractResult = await extractAsbArchive(filePath)
+    if (!extractResult.success || !extractResult.data) {
+      return { success: false, error: extractResult.error }
+    }
+    tempDir = extractResult.data.tempDir
+
+    const { manifest, definition, imagePaths } = extractResult.data
+
+    // 2. マニフェスト検証
+    const validation = validateAsbManifest(manifest)
+    if (!validation.valid) {
+      return { success: false, error: validation.error }
+    }
+
+    // 3. バージョン変換
+    const transformResult = transformAsbToLatest({ manifest, definition })
+    const warnings = [...transformResult.warnings]
+    const transformedDefinition = transformResult.data.definition
+
+    // 4. IDリマッピング
+    const mappings = generateAsbIdMappings(transformedDefinition)
+    const remapped = remapDefinitionIds(transformedDefinition, mappings)
+
+    // 5. 名前重複チェック
+    remapped.name = await resolveNameConflict(remapped.name, userId)
+
+    // 6. 画像コピー + パス更新
+    copyImagesAndUpdatePaths(remapped, imagePaths)
+
+    // 7. DB保存
+    await createImportedAsbDefinition(remapped, userId)
+
+    return {
+      success: true,
+      definitionId: remapped.id,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    }
+  } catch (error) {
+    console.error("Error importing ASB definition:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "インポートに失敗しました",
+    }
+  } finally {
+    if (tempDir) {
+      cleanupAsbTempDir(tempDir)
+    }
+  }
+}
+
+export { cleanupAsbTempDir } from "./archiveExtractor"

--- a/electron-src/lib/import/asb-archive/manifestValidator.ts
+++ b/electron-src/lib/import/asb-archive/manifestValidator.ts
@@ -1,0 +1,36 @@
+/**
+ * ASBアーカイブマニフェストのバリデーション
+ */
+
+import type { AsbArchiveManifest } from "../../../../types/asbArchive.types"
+import { detectAsbVersion } from "../asb-transformers"
+
+/**
+ * マニフェストの必須フィールドとバージョン互換性を検証
+ */
+export function validateAsbManifest(manifest: AsbArchiveManifest): {
+  valid: boolean
+  error?: string
+} {
+  // 必須フィールドチェック
+  if (!manifest.version) {
+    return { valid: false, error: "バージョン情報がありません" }
+  }
+  if (!manifest.definitionName) {
+    return { valid: false, error: "定義名がありません" }
+  }
+  if (!manifest.exportedAt) {
+    return { valid: false, error: "エクスポート日時がありません" }
+  }
+
+  // バージョン互換性チェック
+  const detectedVersion = detectAsbVersion(manifest)
+  if (detectedVersion === "unknown") {
+    return {
+      valid: false,
+      error: `未対応のバージョン: ${manifest.version}`,
+    }
+  }
+
+  return { valid: true }
+}

--- a/electron-src/lib/import/asb-transformers/index.ts
+++ b/electron-src/lib/import/asb-transformers/index.ts
@@ -1,0 +1,147 @@
+/**
+ * ASB アーカイブ変換器
+ *
+ * 初期バージョンではtransformerは空。将来バージョン追加時に登録する。
+ */
+
+import type {
+  AsbArchiveData,
+  AsbArchiveManifest,
+  AsbArchiveVersion,
+  AsbChainTransformResult,
+  AsbVersionTransformer,
+} from "../../../../types/asbArchive.types"
+import {
+  ASB_CURRENT_VERSION,
+  ASB_SUPPORTED_VERSIONS,
+} from "../../../../types/asbArchive.types"
+
+// =============================================================================
+// Transformer Registry
+// =============================================================================
+
+const ASB_TRANSFORMERS: AsbVersionTransformer[] = []
+
+// =============================================================================
+// Version Detection
+// =============================================================================
+
+function compareVersions(v1: string, v2: string): number {
+  const parts1 = v1.split(".").map(Number)
+  const parts2 = v2.split(".").map(Number)
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const p1 = parts1[i] || 0
+    const p2 = parts2[i] || 0
+    if (p1 !== p2) return p1 - p2
+  }
+  return 0
+}
+
+export function detectAsbVersion(
+  manifest: AsbArchiveManifest
+): AsbArchiveVersion | "unknown" {
+  const version = manifest.version
+  for (let i = ASB_SUPPORTED_VERSIONS.length - 1; i >= 0; i--) {
+    const supported = ASB_SUPPORTED_VERSIONS[i]
+    const nextVersion = ASB_SUPPORTED_VERSIONS[i + 1]
+    if (nextVersion) {
+      if (
+        compareVersions(version, supported) >= 0 &&
+        compareVersions(version, nextVersion) < 0
+      ) {
+        return supported
+      }
+    } else {
+      if (compareVersions(version, supported) >= 0) {
+        return supported
+      }
+    }
+  }
+  if (
+    ASB_SUPPORTED_VERSIONS.length > 0 &&
+    compareVersions(version, ASB_SUPPORTED_VERSIONS[0]) < 0
+  ) {
+    return ASB_SUPPORTED_VERSIONS[0]
+  }
+  return "unknown"
+}
+
+// =============================================================================
+// Transformation Chain
+// =============================================================================
+
+function buildAsbTransformChain(
+  fromVersion: AsbArchiveVersion,
+  toVersion: AsbArchiveVersion = ASB_CURRENT_VERSION
+): AsbVersionTransformer[] {
+  const chain: AsbVersionTransformer[] = []
+  let currentVersion = fromVersion
+
+  while (currentVersion !== toVersion) {
+    const transformer = ASB_TRANSFORMERS.find(
+      (t) => t.fromVersion === currentVersion
+    )
+    if (!transformer) {
+      throw new Error(
+        `No ASB transformer found for version ${currentVersion}. ` +
+          `Cannot transform from ${fromVersion} to ${toVersion}.`
+      )
+    }
+    chain.push(transformer)
+    currentVersion = transformer.toVersion
+  }
+
+  return chain
+}
+
+export function transformAsbToLatest(
+  data: AsbArchiveData,
+  targetVersion: AsbArchiveVersion = ASB_CURRENT_VERSION
+): AsbChainTransformResult {
+  const originalVersion = detectAsbVersion(data.manifest)
+
+  if (originalVersion === "unknown") {
+    throw new Error(
+      `Unknown ASB archive version: ${data.manifest.version}. ` +
+        `Supported versions: ${ASB_SUPPORTED_VERSIONS.join(", ")}`
+    )
+  }
+
+  if (originalVersion === targetVersion) {
+    return {
+      data,
+      originalVersion,
+      finalVersion: targetVersion,
+      appliedTransformations: [],
+      warnings: [],
+    }
+  }
+
+  const chain = buildAsbTransformChain(originalVersion, targetVersion)
+  let currentData = data
+  const appliedTransformations: {
+    from: AsbArchiveVersion
+    to: AsbArchiveVersion
+  }[] = []
+  const allWarnings: string[] = []
+
+  for (const transformer of chain) {
+    const result = transformer.transform(currentData)
+    currentData = result.data
+    allWarnings.push(...result.warnings)
+    appliedTransformations.push({
+      from: transformer.fromVersion,
+      to: transformer.toVersion,
+    })
+  }
+
+  return {
+    data: currentData,
+    originalVersion,
+    finalVersion: targetVersion,
+    appliedTransformations,
+    warnings: allWarnings,
+  }
+}
+
+export { ASB_CURRENT_VERSION, ASB_SUPPORTED_VERSIONS }

--- a/types/asbArchive.types.ts
+++ b/types/asbArchive.types.ts
@@ -1,0 +1,87 @@
+/**
+ * 解答用紙定義アーカイブ (.asb) の型定義
+ */
+
+import type { AnswerSheetDefinition } from "./answerSheetDefinition.types"
+
+// =============================================================================
+// マニフェスト
+// =============================================================================
+
+export interface AsbArchiveDataCounts {
+  headerFields: number
+  majorQuestions: number
+  subQuestions: number
+  branchQuestions: number
+  textElements: number
+  imageElements: number
+  omrConfigs: number
+  images: number
+}
+
+export interface AsbArchiveManifest {
+  version: string
+  appVersion: string
+  exportedAt: string
+  definitionName: string
+  paperSize: string
+  orientation: string
+  counts: AsbArchiveDataCounts
+}
+
+// =============================================================================
+// アーカイブデータ
+// =============================================================================
+
+export interface AsbArchiveData {
+  manifest: AsbArchiveManifest
+  definition: AnswerSheetDefinition
+}
+
+// =============================================================================
+// Transformer
+// =============================================================================
+
+export interface AsbTransformResult {
+  data: AsbArchiveData
+  warnings: string[]
+}
+
+export interface AsbVersionTransformer {
+  readonly fromVersion: AsbArchiveVersion
+  readonly toVersion: AsbArchiveVersion
+  transform(data: AsbArchiveData): AsbTransformResult
+}
+
+export interface AsbChainTransformResult {
+  data: AsbArchiveData
+  originalVersion: AsbArchiveVersion
+  finalVersion: AsbArchiveVersion
+  appliedTransformations: { from: AsbArchiveVersion; to: AsbArchiveVersion }[]
+  warnings: string[]
+}
+
+// =============================================================================
+// バージョン
+// =============================================================================
+
+export type AsbArchiveVersion = "1.0.0"
+export const ASB_CURRENT_VERSION: AsbArchiveVersion = "1.0.0"
+export const ASB_SUPPORTED_VERSIONS: readonly AsbArchiveVersion[] = [
+  "1.0.0",
+] as const
+
+// =============================================================================
+// IDリマッピング
+// =============================================================================
+
+export interface AsbIdMappings {
+  definition: Record<string, string>
+  headerField: Record<string, string>
+  majorQuestion: Record<string, string>
+  subQuestion: Record<string, string>
+  branchQuestion: Record<string, string>
+  textElement: Record<string, string>
+  imageElement: Record<string, string>
+  omrConfig: Record<string, string>
+}


### PR DESCRIPTION
## Summary

- 解答用紙定義を `.asb` アーカイブ（ZIP形式）で書き出し・読み込みする機能を追加
- バージョン管理付きtransformerチェーンを初期設計に含め、将来のフォーマット変更に対応
- `saveAsbDefinition()` を再利用し、DB書き込みロジックの重複を回避

Closes #587

## 新規ファイル（10ファイル）

| ファイル | 内容 |
|---|---|
| `types/asbArchive.types.ts` | アーカイブ型定義 |
| `electron-src/lib/import/asb-transformers/index.ts` | バージョン変換チェーン |
| `electron-src/lib/export/asb-archive/` (3ファイル) | エクスポート機能 |
| `electron-src/lib/import/asb-archive/` (5ファイル) | インポート機能 |

## 変更ファイル（2ファイル）

| ファイル | 変更内容 |
|---|---|
| `electron-src/ipc-handlers/answerSheetBuilderHandlers.ts` | 4つのIPCハンドラー追加 |
| `components/answer-sheet-builder/AnswerSheetDefinitionList.tsx` | 読み込みボタン + 書き出しメニュー追加 |

## Test plan

- [ ] 解答用紙定義を作成（画像要素・OMR設定含む）して「書き出し」→ `.asb` ファイル生成確認
- [ ] 「読み込み」→ 定義が一覧に追加され、元と一致することを確認
- [ ] 同名定義の2回インポート → 名前にサフィックスが付くことを確認
- [ ] `npm run typecheck` + `npm run lint` パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)