### PR TITLE
サイドバー動作設定をセクション別に分離

### DIFF
--- a/app/settings/components/ScreenControlTab.tsx
+++ b/app/settings/components/ScreenControlTab.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import {
-  SIDEBAR_BEHAVIOR_KEY,
+  SIDEBAR_SECTIONS,
   type SidebarBehavior,
 } from "@/components/layout/AppShell"
 import { Button } from "@/components/ui/button"
@@ -24,9 +24,10 @@ export function ScreenControlTab() {
   const [blackoutMinutes, setBlackoutMinutes] = useState(5)
   const [autoFullScreen, setAutoFullScreen] = useState(false)
 
-  // サイドバー動作
-  const [sidebarBehavior, setSidebarBehavior] =
-    useState<SidebarBehavior>("collapse")
+  // サイドバー動作（セクション別）
+  const [sidebarBehaviors, setSidebarBehaviors] = useState<
+    Record<string, SidebarBehavior>
+  >(() => Object.fromEntries(SIDEBAR_SECTIONS.map((s) => [s.key, "collapse"])))
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -51,16 +52,22 @@ export function ScreenControlTab() {
         // ignore
       }
 
-      // サイドバー動作の設定を読み込み
+      // サイドバー動作の設定を読み込み（セクション別）
       try {
-        const storedBehavior = localStorage.getItem(SIDEBAR_BEHAVIOR_KEY)
-        if (
-          storedBehavior === "collapse" ||
-          storedBehavior === "expand" ||
-          storedBehavior === "none"
-        ) {
-          setSidebarBehavior(storedBehavior)
+        const loaded: Record<string, SidebarBehavior> = {}
+        for (const section of SIDEBAR_SECTIONS) {
+          const stored = localStorage.getItem(section.storageKey)
+          if (
+            stored === "collapse" ||
+            stored === "expand" ||
+            stored === "none"
+          ) {
+            loaded[section.key] = stored
+          } else {
+            loaded[section.key] = "collapse"
+          }
         }
+        setSidebarBehaviors(loaded)
       } catch {
         // ignore
       }
@@ -140,17 +147,23 @@ export function ScreenControlTab() {
     [blackoutEnabled, blackoutMinutes, saveBlackoutSettings]
   )
 
-  // サイドバー動作の変更
+  // サイドバー動作の変更（セクション別）
   const handleSidebarBehaviorChange = useCallback(
-    (behavior: SidebarBehavior) => {
-      setSidebarBehavior(behavior)
-      localStorage.setItem(SIDEBAR_BEHAVIOR_KEY, behavior)
+    (sectionKey: string, behavior: SidebarBehavior) => {
+      setSidebarBehaviors((prev) => ({ ...prev, [sectionKey]: behavior }))
+      const section = SIDEBAR_SECTIONS.find((s) => s.key === sectionKey)
+      if (section) {
+        localStorage.setItem(section.storageKey, behavior)
+      }
       const labels: Record<SidebarBehavior, string> = {
         collapse: "縮小する",
         expand: "展開する",
         none: "変更しない",
       }
-      toast.success(`サイドバー動作を「${labels[behavior]}」に設定しました`)
+      const sectionLabel = section?.label ?? ""
+      toast.success(
+        `${sectionLabel}のサイドバー動作を「${labels[behavior]}」に設定しました`
+      )
     },
     []
   )
@@ -252,31 +265,43 @@ export function ScreenControlTab() {
             サイドバー動作
           </h2>
           <p className="text-muted-foreground text-sm">
-            採点・解答用紙作成画面を開いた際のサイドバーの動作を設定します
+            各画面を開いた際のサイドバーの動作をセクションごとに設定します
           </p>
         </div>
 
-        <div className="rounded-lg border p-4">
-          <div className="flex items-center gap-2">
-            {(
-              [
-                { value: "collapse", label: "縮小する" },
-                { value: "expand", label: "展開する" },
-                { value: "none", label: "変更しない" },
-              ] as const
-            ).map((option) => (
-              <Button
-                key={option.value}
-                variant={
-                  sidebarBehavior === option.value ? "default" : "outline"
-                }
-                size="sm"
-                onClick={() => handleSidebarBehaviorChange(option.value)}
-              >
-                {option.label}
-              </Button>
-            ))}
-          </div>
+        <div className="space-y-3 rounded-lg border p-4">
+          {SIDEBAR_SECTIONS.map((section, index) => (
+            <div key={section.key}>
+              {index > 0 && <div className="my-3 border-t" />}
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">{section.label}</Label>
+                <div className="flex items-center gap-1.5">
+                  {(
+                    [
+                      { value: "collapse", label: "縮小する" },
+                      { value: "expand", label: "展開する" },
+                      { value: "none", label: "変更しない" },
+                    ] as const
+                  ).map((option) => (
+                    <Button
+                      key={option.value}
+                      variant={
+                        sidebarBehaviors[section.key] === option.value
+                          ? "default"
+                          : "outline"
+                      }
+                      size="sm"
+                      onClick={() =>
+                        handleSidebarBehaviorChange(section.key, option.value)
+                      }
+                    >
+                      {option.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
       </section>
     </div>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -8,14 +8,58 @@ import { ToastProvider } from "@/components/common/ToastProvider"
 import Navigation from "@/components/layout/Navigation"
 import { cn } from "@/lib/utils"
 
-export const SIDEBAR_BEHAVIOR_KEY = "sidebarBehaviorOnWorkPage"
 export type SidebarBehavior = "collapse" | "expand" | "none"
 
-function getSidebarBehavior(): SidebarBehavior {
+export interface SidebarSectionConfig {
+  key: string
+  label: string
+  storageKey: string
+  pathMatch: (pathname: string) => boolean
+}
+
+export const SIDEBAR_SECTIONS: SidebarSectionConfig[] = [
+  {
+    key: "exams",
+    label: "試験一覧",
+    storageKey: "sidebarBehavior_exams",
+    pathMatch: (p) => p.startsWith("/exams"),
+  },
+  {
+    key: "answerSheetBuilder",
+    label: "解答用紙作成",
+    storageKey: "sidebarBehavior_answerSheetBuilder",
+    pathMatch: (p) => p.startsWith("/answer-sheet-builder"),
+  },
+  {
+    key: "pdfTools",
+    label: "PDF加工",
+    storageKey: "sidebarBehavior_pdfTools",
+    pathMatch: (p) => p.startsWith("/pdf-tools"),
+  },
+  {
+    key: "grades",
+    label: "成績算出",
+    storageKey: "sidebarBehavior_grades",
+    pathMatch: (p) => p.startsWith("/grades"),
+  },
+]
+
+// 旧キーからの移行用
+const LEGACY_SIDEBAR_BEHAVIOR_KEY = "sidebarBehaviorOnWorkPage"
+
+function getSidebarBehaviorForPath(pathname: string): SidebarBehavior | null {
+  const section = SIDEBAR_SECTIONS.find((s) => s.pathMatch(pathname))
+  if (!section) return null
+
   try {
-    const stored = localStorage.getItem(SIDEBAR_BEHAVIOR_KEY)
+    const stored = localStorage.getItem(section.storageKey)
     if (stored === "collapse" || stored === "expand" || stored === "none") {
       return stored
+    }
+    // 旧設定からの移行: セクション別設定がなければ旧設定を参照
+    const legacy = localStorage.getItem(LEGACY_SIDEBAR_BEHAVIOR_KEY)
+    if (legacy === "collapse" || legacy === "expand" || legacy === "none") {
+      return legacy
     }
   } catch {
     // ignore
@@ -32,15 +76,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   useEffect(() => {
-    if (
-      !pathname.includes("/score") &&
-      !pathname.includes("/answer-sheet-builder")
-    ) {
-      return
-    }
-
-    const behavior = getSidebarBehavior()
-    if (behavior === "none") return
+    const behavior = getSidebarBehaviorForPath(pathname)
+    if (behavior === null || behavior === "none") return
 
     const frame = requestAnimationFrame(() => {
       setIsSidebarMinimized(behavior === "collapse")


### PR DESCRIPTION
## Summary

- サイドバーの動作設定を試験一覧・解答用紙作成・PDF加工・成績算出の4セクションごとに個別設定可能に変更
- 旧設定（`sidebarBehaviorOnWorkPage`）からの自動移行に対応
- 設定UIを各セクション横並びのボタン群に刷新

Closes #599

## Test plan

- [ ] 設定画面で4セクションそれぞれの動作を変更し、トーストが表示されることを確認
- [ ] 各セクションの画面に遷移し、設定した動作（縮小/展開/変更しない）が正しく反映されることを確認
- [ ] 旧設定のみ存在する場合にフォールバックが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)