### PR TITLE
サイドバー動作のデフォルト修正とセクション内遷移の再適用防止

### DIFF
--- a/app/settings/components/ScreenControlTab.tsx
+++ b/app/settings/components/ScreenControlTab.tsx
@@ -27,7 +27,7 @@ export function ScreenControlTab() {
   // サイドバー動作（セクション別）
   const [sidebarBehaviors, setSidebarBehaviors] = useState<
     Record<string, SidebarBehavior>
-  >(() => Object.fromEntries(SIDEBAR_SECTIONS.map((s) => [s.key, "collapse"])))
+  >(() => Object.fromEntries(SIDEBAR_SECTIONS.map((s) => [s.key, "none"])))
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -64,7 +64,7 @@ export function ScreenControlTab() {
           ) {
             loaded[section.key] = stored
           } else {
-            loaded[section.key] = "collapse"
+            loaded[section.key] = "none"
           }
         }
         setSidebarBehaviors(loaded)

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { usePathname } from "next/navigation"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 
 import { ScreenBlackout } from "@/components/common/ScreenBlackout"
 import { ToastProvider } from "@/components/common/ToastProvider"
@@ -64,18 +64,30 @@ function getSidebarBehaviorForPath(pathname: string): SidebarBehavior | null {
   } catch {
     // ignore
   }
-  return "collapse"
+  return "none"
+}
+
+function getCurrentSectionKey(pathname: string): string | null {
+  const section = SIDEBAR_SECTIONS.find((s) => s.pathMatch(pathname))
+  return section?.key ?? null
 }
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [isSidebarMinimized, setIsSidebarMinimized] = useState(false)
   const pathname = usePathname()
+  const prevSectionRef = useRef<string | null>(null)
 
   const toggleSidebar = () => {
     setIsSidebarMinimized((prev) => !prev)
   }
 
   useEffect(() => {
+    const currentSection = getCurrentSectionKey(pathname)
+
+    // 同じセクション内の遷移では何もしない
+    if (currentSection === prevSectionRef.current) return
+    prevSectionRef.current = currentSection
+
     const behavior = getSidebarBehaviorForPath(pathname)
     if (behavior === null || behavior === "none") return
 


### PR DESCRIPTION
## Summary

- デフォルト値を「縮小する」から「変更しない」に変更
- 同一セクション内のページ遷移ではサイドバー設定を再適用しないよう `prevSectionRef` で制御

Closes #601

## Test plan

- [ ] 設定未変更の状態で各セクションに遷移し、サイドバーが変化しないことを確認
- [ ] セクション内のページ遷移（例: 試験詳細→採点画面）でサイドバーが勝手に変わらないことを確認
- [ ] 異なるセクション間の遷移で設定が正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)