### PR TITLE
ci: GitHub ActionsランタイムをNode.js 24に早期オプトイン

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,6 +21,8 @@ permissions:
 env:
   # Node.js version to use
   NODE_VERSION: "22"
+  # Opt into Node.js 24 for GitHub Actions runtime
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -2,6 +2,9 @@ name: Discord Notifications
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   issues:
     types: [opened]

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -28,6 +28,7 @@ permissions:
 
 env:
   NODE_VERSION: "22"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   create-release:


### PR DESCRIPTION
## Summary

- 全ワークフローに `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を追加
- 2026年6月のNode.js 20廃止に先行して対応
- 問題発生時は環境変数を削除するだけで戻せる

Closes #607

## 対象ファイル

- `.github/workflows/build-and-release.yml`
- `.github/workflows/manual-release.yml`
- `.github/workflows/discord-notify.yml`

## Test plan

- [ ] ワークフローがNode.js 24ランタイムで正常に動作すること
- [ ] build-and-releaseワークフローのビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)