### PR TITLE
feat: マーカー補正ステータスUI表示 & 自動有効化

### DIFF
--- a/app/exams/[examId]/06-student-answers/components/index.tsx
+++ b/app/exams/[examId]/06-student-answers/components/index.tsx
@@ -97,6 +97,8 @@ interface StudentAnswersTabContentProps {
   onApplyChanges: (option: ScoringDataOption) => Promise<void>
   onResetChanges: () => Promise<void>
   onUploadFileCountChange?: (count: number) => void
+  correctionStatusMap?: Map<string, "corrected" | "skipped">
+  onCorrectionStatusUpdate?: (map: Map<string, "corrected" | "skipped">) => void
 }
 
 export function StudentAnswersTabContent({
@@ -114,6 +116,8 @@ export function StudentAnswersTabContent({
   onApplyChanges,
   onResetChanges,
   onUploadFileCountChange,
+  correctionStatusMap,
+  onCorrectionStatusUpdate,
 }: StudentAnswersTabContentProps) {
   return (
     <>
@@ -126,6 +130,7 @@ export function StudentAnswersTabContent({
           mode="upload"
           existingStudentAnswers={studentAnswers}
           onUploadFileCountChange={onUploadFileCountChange}
+          onCorrectionStatusUpdate={onCorrectionStatusUpdate}
         />
       </TabsContent>
 
@@ -140,6 +145,7 @@ export function StudentAnswersTabContent({
           pendingChanges={pendingChanges}
           affectedCells={affectedCells}
           onUpdatePendingChanges={onUpdatePendingChanges}
+          correctionStatusMap={correctionStatusMap}
         />
       </TabsContent>
 

--- a/app/exams/[examId]/06-student-answers/page.tsx
+++ b/app/exams/[examId]/06-student-answers/page.tsx
@@ -39,6 +39,9 @@ export default function StudentAnswersPage() {
 
   const [activeTab, setActiveTab] = useState<StudentAnswerTab>("new-grid")
   const [uploadFileCount, setUploadFileCount] = useState(0)
+  const [correctionStatusMap, setCorrectionStatusMap] = useState<
+    Map<string, "corrected" | "skipped">
+  >(new Map())
 
   // Data loading hook
   const { students, studentAnswers, modelAnswerCount, isLoading, loadData } =
@@ -73,6 +76,20 @@ export default function StudentAnswersPage() {
   useEffect(() => {
     loadData()
   }, [examId, loadData])
+
+  /**
+   * Handles correction status updates from upload
+   */
+  const handleCorrectionStatusUpdate = useCallback(
+    (map: Map<string, "corrected" | "skipped">) => {
+      setCorrectionStatusMap((prev) => {
+        const merged = new Map(prev)
+        map.forEach((value, key) => merged.set(key, value))
+        return merged
+      })
+    },
+    []
+  )
 
   /**
    * Handles upload completion for new uploads
@@ -140,6 +157,8 @@ export default function StudentAnswersPage() {
               onApplyChanges={handleApplyChanges}
               onResetChanges={handleResetChanges}
               onUploadFileCountChange={setUploadFileCount}
+              correctionStatusMap={correctionStatusMap}
+              onCorrectionStatusUpdate={handleCorrectionStatusUpdate}
             />
           </StudentAnswersTabsNavigation>
         </div>

--- a/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -24,6 +24,8 @@ export function StudentAnswerUpload({
   affectedCells,
   onUpdatePendingChanges,
   onUploadFileCountChange,
+  correctionStatusMap,
+  onCorrectionStatusUpdate,
 }: StudentAnswerUploadProps) {
   const finalModelAnswerCount = modelAnswerCount
   const finalExistingAnswers = existingStudentAnswers
@@ -42,18 +44,31 @@ export function StudentAnswerUpload({
     setFileOrder,
     handleDrop,
     handleUpload,
-  } = useStudentAnswerUpload(examId, onUploadComplete)
+  } = useStudentAnswerUpload(examId, onUploadComplete, onCorrectionStatusUpdate)
 
   // 確認モード用の初期化処理
   useEffect(() => {
     if (mode === "view" && finalExistingAnswers && files.length === 0) {
       // 初回のみ既存答案を配置戦略に基づいて配列構築
-      const initialFiles = buildOrderedFileArrayFromStudentAnswers(
+      let initialFiles = buildOrderedFileArrayFromStudentAnswers(
         finalExistingAnswers,
         students,
         finalModelAnswerCount,
         fileOrder
       )
+      // correctionStatusMapから補正ステータスを注入
+      if (correctionStatusMap && correctionStatusMap.size > 0) {
+        initialFiles = initialFiles.map((file) => {
+          if (file.studentId) {
+            const key = `${file.studentId}-${file.pageNumber}`
+            const status = correctionStatusMap.get(key)
+            if (status) {
+              return { ...file, correctionStatus: status }
+            }
+          }
+          return file
+        })
+      }
       setFiles(initialFiles)
     }
   }, [
@@ -64,6 +79,7 @@ export function StudentAnswerUpload({
     finalModelAnswerCount,
     fileOrder,
     setFiles,
+    correctionStatusMap,
   ])
 
   // ナビゲーションガード用: アップロード待ちファイル数の通知

--- a/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
+++ b/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
@@ -10,7 +10,8 @@ import { type ConvertedImage, convertPdfToImages } from "@/lib/pdfConverter"
 
 export function useStudentAnswerUpload(
   examId: string,
-  onUploadComplete?: () => void
+  onUploadComplete?: () => void,
+  onCorrectionStatusUpdate?: (map: Map<string, "corrected" | "skipped">) => void
 ) {
   // State管理
   const [isUploading, setIsUploading] = useState(false)
@@ -224,6 +225,7 @@ export function useStudentAnswerUpload(
       try {
         let successCount = 0
         let overwriteCount = 0
+        const correctionMap = new Map<string, "corrected" | "skipped">()
 
         for (let i = 0; i < uploadData.length; i++) {
           const data = uploadData[i]
@@ -233,10 +235,20 @@ export function useStudentAnswerUpload(
 
           if (result.success) {
             successCount++
-            // 上書きフラグをチェック
-            // if (result.answerSheets?.[0]?.isOverwrite) {
-            //   overwriteCount++
-            // }
+            // correctionStatus収集
+            const sheet = result.studentAnswers?.[0] as
+              | (Record<string, unknown> & { correctionStatus?: string })
+              | undefined
+            if (
+              sheet?.correctionStatus &&
+              sheet.correctionStatus !== "not_requested"
+            ) {
+              const key = `${data.studentId}-${data.pageNumber}`
+              correctionMap.set(
+                key,
+                sheet.correctionStatus as "corrected" | "skipped"
+              )
+            }
           } else {
             console.error(`Upload failed for ${data.name}:`, result.error)
           }
@@ -252,6 +264,9 @@ export function useStudentAnswerUpload(
             toast.success(`${successCount}件の答案をアップロードしました`)
           }
           setFiles([]) // アップロード成功後にファイルリストをクリア
+          if (correctionMap.size > 0) {
+            onCorrectionStatusUpdate?.(correctionMap)
+          }
           onUploadComplete?.()
         }
 
@@ -267,7 +282,7 @@ export function useStudentAnswerUpload(
         setIsUploading(false)
       }
     },
-    [onUploadComplete, examId]
+    [onUploadComplete, onCorrectionStatusUpdate, examId]
   )
 
   return {

--- a/components/exams/06-student-answers/student-answer-management/types/index.ts
+++ b/components/exams/06-student-answers/student-answer-management/types/index.ts
@@ -57,6 +57,10 @@ export interface StudentAnswerUploadProps {
 
   // ナビゲーションガード用: アップロード待ちファイル数の通知
   onUploadFileCountChange?: (count: number) => void
+
+  // マーカー補正ステータス
+  correctionStatusMap?: Map<string, "corrected" | "skipped">
+  onCorrectionStatusUpdate?: (map: Map<string, "corrected" | "skipped">) => void
 }
 
 export interface FileUploadZoneProps {

--- a/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
+++ b/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
@@ -248,6 +248,13 @@ export function FilePreviewCell({
         <div className="pointer-events-none absolute inset-0 z-30 border-2 border-orange-500 bg-orange-500/20" />
       )}
 
+      {file.correctionStatus === "corrected" && (
+        <div className="pointer-events-none absolute inset-0 z-20 border-2 border-green-500" />
+      )}
+      {file.correctionStatus === "skipped" && (
+        <div className="pointer-events-none absolute inset-0 z-20 border-2 border-red-500" />
+      )}
+
       {renderLoadingState()}
     </div>
   )

--- a/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -148,7 +148,9 @@ export function useStudentAnswerTableLogic({
         const result = await window.electronAPI.omr.detectMasterMarkers(examId)
         if (!cancelled) {
           setMarkerCorrectionAvailable(result.success)
-          if (!result.success) {
+          if (result.success) {
+            setMarkerCorrectionEnabled(true)
+          } else {
             setMarkerCorrectionEnabled(false)
           }
         }

--- a/components/exams/06-student-answers/types.ts
+++ b/components/exams/06-student-answers/types.ts
@@ -45,6 +45,7 @@ export interface UnifiedFile {
   color?: string // 表示色（テスト・デバッグ用）
   position?: number // table内の位置（studentIndex * maxPages + pageNumber - 1）
   imagePath?: string | null // 既存画像ファイルのパス（遅延読み込み用）
+  correctionStatus?: "corrected" | "skipped" | "not_requested" // マーカー補正結果
 }
 
 // ============================================================================

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -84,6 +84,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
       studentId?: string
       pageNumber?: number
       overwrite?: boolean
+      correctWithMarkers?: boolean
     }[]
   ) => ipcRenderer.invoke("upload-answer-sheets", examId, filesData),
   getStudentAnswersByExamId: (examId: string) =>


### PR DESCRIPTION
## Summary

- マーカー補正結果をセッション内で管理し、答案セルに緑枠（成功）/赤枠（失敗）で可視化
- マーカー検出成功時にマーカー補正トグルを自動ONに変更
- preload.tsの型定義に`correctWithMarkers`を追加

Closes #613

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `electron-src/preload.ts` | 型修正（1行） |
| `.../hooks/useStudentAnswerTableLogic.ts` | 自動有効化（1行） |
| `.../types.ts` | UnifiedFileにフィールド追加（1行） |
| `.../hooks/useStudentAnswerUpload.ts` | correctionStatus収集・コールバック |
| `app/.../06-student-answers/page.tsx` | correctionStatusMap state |
| `app/.../06-student-answers/components/index.tsx` | props伝搬 |
| `.../components/StudentAnswerUpload.tsx` | props伝搬 + view時の注入 |
| `.../types/index.ts` | StudentAnswerUploadProps型追加 |
| `.../components/FilePreviewCell.tsx` | 緑枠/赤枠表示 |

## Test plan

- [ ] マーカー付き模範解答の試験で答案アップロード画面を開く → トグルが自動ON
- [ ] 答案をアップロード → 「配置済み答案の確認」タブに切り替え → 補正成功セルに緑枠、失敗セルに赤枠
- [ ] ページリロード → 枠なし（セッション内のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)