### PR TITLE
fix: 採点領域タブでのプレビュー表示ズレを修正

### DIFF
--- a/components/answer-sheet-builder/utils/generatePrintHtml.ts
+++ b/components/answer-sheet-builder/utils/generatePrintHtml.ts
@@ -45,6 +45,7 @@ async function renderPageSvgHtmls(
           width: pageWidthMm,
           height: pageHeightMm,
           viewBox: `0 0 ${pageWidthMm} ${pageHeightMm}`,
+          preserveAspectRatio: "xMinYMin meet",
         },
         React.createElement(AnswerSheetSVGRenderer, {
           layout: {

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -75,6 +75,8 @@ export async function htmlToPngBuffer(
       show: false,
       width: widthPx,
       height: heightPx,
+      frame: false,
+      useContentSize: true,
       webPreferences: { offscreen: true },
     })
     await win.loadFile(tempHtmlPath)


### PR DESCRIPTION
## Summary
- `htmlToPngBuffer`のBrowserWindowに`frame: false`と`useContentSize: true`を追加し、Windows環境でのコンテンツ領域圧縮を解消
- SVGの`preserveAspectRatio`を`xMinYMin meet`に明示指定し、中央寄せによる座標ズレを防止

Closes #612

## Test plan
- [ ] Windows環境で解答用紙作成→試験変換後、02-template（採点領域タブ）で領域枠が画像と一致するか確認
- [ ] 07-score-at-once（採点タブ）で引き続き正しく表示されるか確認
- [ ] macOS環境でリグレッションがないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)