### PR TITLE
feat: 生徒・学級アーカイブのエクスポート/インポート (#566)

### DIFF
--- a/components/student-import/StudentImportWizardModal.tsx
+++ b/components/student-import/StudentImportWizardModal.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import { AlertCircle, Check, ChevronLeft, X } from "lucide-react"
+import { useEffect } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  STUDENT_IMPORT_STEP_ORDER,
+  useStudentImportWizard,
+} from "@/hooks/student-import/useStudentImportWizard"
+import { cn } from "@/lib/utils"
+import type { StudentImportWizardStep } from "@/types/studentArchive.types"
+
+import { ExecuteStep } from "./steps/ExecuteStep"
+import { FileOverviewStep } from "./steps/FileOverviewStep"
+import { FileSelectStep } from "./steps/FileSelectStep"
+import { FinalConfirmStep } from "./steps/FinalConfirmStep"
+import { IdIntegrationStep } from "./steps/IdIntegrationStep"
+import { UpdateConfirmStep } from "./steps/UpdateConfirmStep"
+
+interface StudentImportWizardModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onComplete?: () => void
+}
+
+const STEP_TITLES: Record<StudentImportWizardStep, string> = {
+  file_select: "ファイル選択",
+  file_overview: "内容確認",
+  id_integration: "紐づけ",
+  update_confirm: "更新",
+  final_confirm: "確認",
+  execute: "実行",
+}
+
+export function StudentImportWizardModal({
+  isOpen,
+  onClose,
+  onComplete,
+}: StudentImportWizardModalProps) {
+  const wizard = useStudentImportWizard()
+  const { state, reset } = wizard
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset()
+    }
+  }, [isOpen, reset])
+
+  const handleClose = () => {
+    if (!state.isProcessing) {
+      onClose()
+    }
+  }
+
+  const currentStepIndex = STUDENT_IMPORT_STEP_ORDER.indexOf(
+    state.currentStep as (typeof STUDENT_IMPORT_STEP_ORDER)[number]
+  )
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="flex max-h-[90vh] min-w-4xl flex-col gap-0 p-0">
+        {/* Header */}
+        <DialogHeader className="bg-muted/30 border-b px-6 py-4">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl font-semibold">
+              生徒データのインポート
+            </DialogTitle>
+          </div>
+
+          {/* Step indicator */}
+          <div className="flex items-center justify-center pt-4">
+            {STUDENT_IMPORT_STEP_ORDER.map((step, index) => {
+              const isActive = step === state.currentStep
+              const isCompleted = index < currentStepIndex
+
+              return (
+                <div key={step} className="flex items-center">
+                  {index > 0 && (
+                    <div
+                      className={cn(
+                        "h-0.5 w-8 transition-colors",
+                        isCompleted ? "bg-primary" : "bg-muted-foreground/20"
+                      )}
+                    />
+                  )}
+                  <div className="flex w-20 flex-col items-center gap-y-2">
+                    <div
+                      className={cn(
+                        "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-all",
+                        isActive &&
+                          "bg-primary text-primary-foreground ring-primary/20 ring-4",
+                        isCompleted && "bg-primary text-primary-foreground",
+                        !isActive &&
+                          !isCompleted &&
+                          "bg-muted text-muted-foreground"
+                      )}
+                    >
+                      {isCompleted ? <Check className="h-4 w-4" /> : index + 1}
+                    </div>
+                    <span
+                      className={cn(
+                        "text-center text-xs font-medium",
+                        isActive && "text-primary",
+                        !isActive && "text-muted-foreground"
+                      )}
+                    >
+                      {STEP_TITLES[step as StudentImportWizardStep]}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </DialogHeader>
+
+        {/* Error display */}
+        {state.error && (
+          <div className="bg-destructive/10 border-destructive/20 mx-6 mt-4 rounded-lg border p-4">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
+              <div className="flex-1">
+                <p className="text-destructive text-sm font-medium">エラー</p>
+                <p className="text-destructive/80 mt-1 text-sm">
+                  {state.error}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={wizard.clearError}
+                className="text-destructive hover:text-destructive hover:bg-destructive/10 -mt-2 -mr-2"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step content */}
+        <div className="min-h-100 flex-1 overflow-y-auto px-6 py-6">
+          {state.currentStep === "file_select" && (
+            <FileSelectStep wizard={wizard} />
+          )}
+          {state.currentStep === "file_overview" && (
+            <FileOverviewStep wizard={wizard} />
+          )}
+          {state.currentStep === "id_integration" && (
+            <IdIntegrationStep wizard={wizard} />
+          )}
+          {state.currentStep === "update_confirm" && (
+            <UpdateConfirmStep wizard={wizard} />
+          )}
+          {state.currentStep === "final_confirm" && (
+            <FinalConfirmStep
+              wizard={wizard}
+              onExecute={() => wizard.goToNextStep()}
+            />
+          )}
+          {state.currentStep === "execute" && (
+            <ExecuteStep
+              wizard={wizard}
+              onComplete={onComplete}
+              onClose={onClose}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="bg-muted/30 flex items-center justify-between border-t px-6 py-4">
+          <Button
+            variant="ghost"
+            onClick={wizard.goBack}
+            disabled={state.currentStep === "file_select" || state.isProcessing}
+            className="gap-2"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            戻る
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleClose}
+            disabled={state.isProcessing}
+          >
+            キャンセル
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/student-import/steps/ExecuteStep.tsx
+++ b/components/student-import/steps/ExecuteStep.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+import type { StudentArchiveImportResult } from "@/types/studentArchive.types"
+
+interface ExecuteStepProps {
+  wizard: StudentImportWizard
+  onComplete?: () => void
+  onClose: () => void
+}
+
+export function ExecuteStep({ wizard, onComplete, onClose }: ExecuteStepProps) {
+  const hasStarted = useRef(false)
+  const [result, setResult] = useState<StudentArchiveImportResult | null>(null)
+
+  useEffect(() => {
+    if (hasStarted.current) return
+    hasStarted.current = true
+
+    const run = async () => {
+      const importResult = await wizard.executeImport()
+      if (importResult) {
+        setResult(importResult)
+      }
+    }
+
+    run()
+  }, [wizard])
+
+  // 実行中
+  if (!result) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 py-16">
+        <Loader2 className="text-primary h-12 w-12 animate-spin" />
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">インポート中...</h3>
+          <p className="text-muted-foreground mt-2 text-sm">
+            データを処理しています。しばらくお待ちください。
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // 失敗
+  if (!result.success) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 py-16">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+          <AlertCircle className="h-8 w-8 text-red-600" />
+        </div>
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">インポートに失敗しました</h3>
+          <p className="text-muted-foreground mt-2 text-sm">{result.error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  // 成功
+  const { summary, warnings } = result
+
+  const handleComplete = () => {
+    onComplete?.()
+    onClose()
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-12">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+        <CheckCircle2 className="h-8 w-8 text-green-600" />
+      </div>
+
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">インポートが完了しました</h3>
+      </div>
+
+      {summary && (
+        <div className="mx-auto grid w-full max-w-md gap-3">
+          <div className="border-border/50 rounded-lg border p-4">
+            <h4 className="mb-2 text-sm font-medium">生徒</h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {summary.created.students > 0 && (
+                <span>新規: {summary.created.students}名</span>
+              )}
+              {summary.updated.students > 0 && (
+                <span>更新: {summary.updated.students}名</span>
+              )}
+              {summary.unchanged.students > 0 && (
+                <span>変更なし: {summary.unchanged.students}名</span>
+              )}
+              {summary.skipped.students > 0 && (
+                <span>スキップ: {summary.skipped.students}名</span>
+              )}
+            </div>
+          </div>
+
+          <div className="border-border/50 rounded-lg border p-4">
+            <h4 className="mb-2 text-sm font-medium">学級</h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {summary.created.classes > 0 && (
+                <span>新規: {summary.created.classes}件</span>
+              )}
+              {summary.updated.classes > 0 && (
+                <span>更新: {summary.updated.classes}件</span>
+              )}
+              {summary.unchanged.classes > 0 && (
+                <span>変更なし: {summary.unchanged.classes}件</span>
+              )}
+              {summary.skipped.classes > 0 && (
+                <span>スキップ: {summary.skipped.classes}件</span>
+              )}
+            </div>
+          </div>
+
+          {summary.created.memberships > 0 && (
+            <div className="text-muted-foreground text-center text-sm">
+              所属関係: {summary.created.memberships}件処理
+            </div>
+          )}
+        </div>
+      )}
+
+      {warnings && warnings.length > 0 && (
+        <div className="w-full max-w-md rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+          <h4 className="mb-2 text-sm font-medium text-amber-700 dark:text-amber-300">
+            注意事項
+          </h4>
+          <ul className="list-inside list-disc space-y-1 text-sm text-amber-600 dark:text-amber-400">
+            {warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <Button onClick={handleComplete} size="lg">
+        閉じる
+      </Button>
+    </div>
+  )
+}

--- a/components/student-import/steps/FileOverviewStep.tsx
+++ b/components/student-import/steps/FileOverviewStep.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { CheckCircle2, ChevronRight, HelpCircle, Users } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+import type { PreMatchingResult } from "@/types/examArchive.types"
+
+interface FileOverviewStepProps {
+  wizard: StudentImportWizard
+}
+
+function CategoryOverviewCard({
+  title,
+  icon: Icon,
+  result,
+}: {
+  title: string
+  icon: React.ElementType
+  result: PreMatchingResult
+}) {
+  const autoMatched = result.byId.length
+  const secondaryMatched =
+    (result.byStudentNumber?.length ?? 0) + (result.byName?.length ?? 0)
+  const noMatch = result.noMatch.length
+  const total = autoMatched + secondaryMatched + noMatch
+
+  return (
+    <div className="border-border/50 rounded-lg border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="text-muted-foreground h-5 w-5" />
+        <h4 className="font-medium">{title}</h4>
+        <span className="text-muted-foreground text-sm">（{total}件）</span>
+      </div>
+
+      <div className="space-y-2 text-sm">
+        {autoMatched > 0 && (
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span>自動で紐づく: {autoMatched}件</span>
+          </div>
+        )}
+        {secondaryMatched > 0 && (
+          <div className="flex items-center gap-2">
+            <HelpCircle className="h-4 w-4 text-amber-500" />
+            <span>確認が必要: {secondaryMatched}件</span>
+          </div>
+        )}
+        {noMatch > 0 && (
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-blue-500" />
+            <span>新規登録: {noMatch}件</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function FileOverviewStep({ wizard }: FileOverviewStepProps) {
+  const { state, goToNextStep } = wizard
+
+  if (!state.fileOverviewData || !state.manifest) {
+    return (
+      <div className="text-muted-foreground py-12 text-center">
+        データを読み込んでいます...
+      </div>
+    )
+  }
+
+  const { student, class: classResult } = state.fileOverviewData
+  const { counts } = state.manifest
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">ファイルの内容</h3>
+        <p className="text-muted-foreground mt-1 text-sm">
+          生徒 {counts.students}名、学級 {counts.classes}件、所属{" "}
+          {counts.memberships}件
+        </p>
+      </div>
+
+      <div className="mx-auto grid max-w-2xl gap-4">
+        <CategoryOverviewCard title="生徒" icon={Users} result={student} />
+        <CategoryOverviewCard title="学級" icon={Users} result={classResult} />
+      </div>
+
+      <div className="flex justify-center pt-4">
+        <Button onClick={goToNextStep} className="gap-2">
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/student-import/steps/FileSelectStep.tsx
+++ b/components/student-import/steps/FileSelectStep.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { FileUp, Loader2, Users } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+
+interface FileSelectStepProps {
+  wizard: StudentImportWizard
+}
+
+export function FileSelectStep({ wizard }: FileSelectStepProps) {
+  const { state, selectFile } = wizard
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-12">
+      <div className="bg-primary/10 flex h-20 w-20 items-center justify-center rounded-full">
+        <Users className="text-primary h-10 w-10" />
+      </div>
+
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">
+          生徒データファイルを選択してください
+        </h3>
+        <p className="text-muted-foreground mt-2 text-sm">
+          .studentsファイルを選択して、生徒・学級データをインポートします
+        </p>
+      </div>
+
+      <Button
+        size="lg"
+        onClick={selectFile}
+        disabled={state.isProcessing}
+        className="gap-2"
+      >
+        {state.isProcessing ? (
+          <>
+            <Loader2 className="h-5 w-5 animate-spin" />
+            読み込み中...
+          </>
+        ) : (
+          <>
+            <FileUp className="h-5 w-5" />
+            ファイルを選択
+          </>
+        )}
+      </Button>
+
+      <div className="bg-muted/50 rounded-lg p-4">
+        <p className="text-muted-foreground text-center text-xs">
+          対応形式: .students（生徒データアーカイブ）
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/student-import/steps/FinalConfirmStep.tsx
+++ b/components/student-import/steps/FinalConfirmStep.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  PlusCircle,
+  SkipForward,
+} from "lucide-react"
+import { useMemo } from "react"
+
+import { Button } from "@/components/ui/button"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+
+interface FinalConfirmStepProps {
+  wizard: StudentImportWizard
+  onExecute: () => void
+}
+
+export function FinalConfirmStep({ wizard, onExecute }: FinalConfirmStepProps) {
+  const { state } = wizard
+
+  const summary = useMemo(() => {
+    if (!state.fileOverviewData) return null
+
+    const { student, class: classResult } = state.fileOverviewData
+    const config = state.idIntegrationConfig
+
+    // 生徒サマリー
+    const studentAutoMatched = student.byId.length
+    const studentSecondaryMatched =
+      (student.byStudentNumber?.length ?? 0) + (student.byName?.length ?? 0)
+    const studentNoMatch = student.noMatch.length
+
+    let studentMerge = studentAutoMatched
+    let studentNew = 0
+    let studentSkip = 0
+
+    if (config.student.strategy === "all_new") {
+      studentNew = studentSecondaryMatched + studentNoMatch
+    } else {
+      studentMerge += studentSecondaryMatched
+      studentNew = studentNoMatch
+    }
+
+    // 個別決定をカウント
+    for (const d of config.student.decisions) {
+      if (d.decisionType === "create_new") studentNew++
+      else if (d.decisionType === "skip") studentSkip++
+    }
+
+    // 学級サマリー
+    const classAutoMatched = classResult.byId.length
+    const classSecondaryMatched = classResult.byName?.length ?? 0
+    const classNoMatch = classResult.noMatch.length
+
+    let classMerge = classAutoMatched
+    let classNew = 0
+    let classSkip = 0
+
+    if (config.class.strategy === "all_new") {
+      classNew = classSecondaryMatched + classNoMatch
+    } else {
+      classMerge += classSecondaryMatched
+      classNew = classNoMatch
+    }
+
+    for (const d of config.class.decisions) {
+      if (d.decisionType === "create_new") classNew++
+      else if (d.decisionType === "skip") classSkip++
+    }
+
+    return {
+      student: { merge: studentMerge, new: studentNew, skip: studentSkip },
+      class: { merge: classMerge, new: classNew, skip: classSkip },
+    }
+  }, [state.fileOverviewData, state.idIntegrationConfig])
+
+  if (!summary) return null
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">最終確認</h3>
+        <p className="text-muted-foreground mt-1 text-sm">
+          以下の内容でインポートを実行します
+        </p>
+      </div>
+
+      <div className="mx-auto grid max-w-lg gap-4">
+        {/* 生徒サマリー */}
+        <div className="border-border/50 rounded-lg border p-4">
+          <h4 className="mb-3 font-medium">生徒</h4>
+          <div className="space-y-2 text-sm">
+            {summary.student.merge > 0 && (
+              <div className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+                <span>既存データと紐づけ: {summary.student.merge}名</span>
+              </div>
+            )}
+            {summary.student.new > 0 && (
+              <div className="flex items-center gap-2">
+                <PlusCircle className="h-4 w-4 text-blue-500" />
+                <span>新規登録: {summary.student.new}名</span>
+              </div>
+            )}
+            {summary.student.skip > 0 && (
+              <div className="flex items-center gap-2">
+                <SkipForward className="h-4 w-4 text-gray-500" />
+                <span>スキップ: {summary.student.skip}名</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 学級サマリー */}
+        <div className="border-border/50 rounded-lg border p-4">
+          <h4 className="mb-3 font-medium">学級</h4>
+          <div className="space-y-2 text-sm">
+            {summary.class.merge > 0 && (
+              <div className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+                <span>既存データと紐づけ: {summary.class.merge}件</span>
+              </div>
+            )}
+            {summary.class.new > 0 && (
+              <div className="flex items-center gap-2">
+                <PlusCircle className="h-4 w-4 text-blue-500" />
+                <span>新規登録: {summary.class.new}件</span>
+              </div>
+            )}
+            {summary.class.skip > 0 && (
+              <div className="flex items-center gap-2">
+                <SkipForward className="h-4 w-4 text-gray-500" />
+                <span>スキップ: {summary.class.skip}件</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 警告 */}
+      <div className="mx-auto max-w-lg rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+        <div className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-500" />
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            この操作は元に戻せません。インポート前にバックアップを取ることをお勧めします。
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-center pt-4">
+        <Button onClick={onExecute} size="lg">
+          インポートを実行
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/student-import/steps/IdIntegrationStep.tsx
+++ b/components/student-import/steps/IdIntegrationStep.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { CheckCircle2, ChevronRight } from "lucide-react"
+import { useState } from "react"
+
+import { ClassIntegrationPanel } from "@/components/import/steps/id-integration/ClassIntegrationPanel"
+import { StudentIntegrationPanel } from "@/components/import/steps/id-integration/StudentIntegrationPanel"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+
+interface IdIntegrationStepProps {
+  wizard: StudentImportWizard
+}
+
+export function IdIntegrationStep({ wizard }: IdIntegrationStepProps) {
+  const { state, goToNextStep } = wizard
+  const [activeTab, setActiveTab] = useState<string>("student")
+
+  if (!state.fileOverviewData) return null
+
+  const { student: studentResult, class: classResult } = state.fileOverviewData
+
+  // 全てID一致で自動照合できる場合はファストパス
+  const studentNeedsDecision =
+    (studentResult.byStudentNumber?.length ?? 0) +
+    (studentResult.byName?.length ?? 0) +
+    studentResult.noMatch.length
+  const classNeedsDecision =
+    (classResult.byName?.length ?? 0) + classResult.noMatch.length
+
+  const allAutoMatched = studentNeedsDecision === 0 && classNeedsDecision === 0
+
+  if (allAutoMatched) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 py-12">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-100">
+          <CheckCircle2 className="h-10 w-10 text-green-600" />
+        </div>
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">
+            すべてのデータが自動で紐づきました
+          </h3>
+          <p className="text-muted-foreground mt-2 text-sm">
+            同じパソコンで作成されたデータのため、手動の設定は不要です
+          </p>
+        </div>
+        <Button onClick={goToNextStep} className="gap-2">
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  // 既存のパネルに渡す互換オブジェクトを作成
+  // StudentIntegrationPanel / ClassIntegrationPanel は
+  // examArchive の useImportWizard を想定しているため、アダプターを作成
+  const wizardAdapter = {
+    state: {
+      ...state,
+      idIntegrationConfig: {
+        ...state.idIntegrationConfig,
+        subtotalGroup: { strategy: "by_name" as const, decisions: [] },
+      },
+      fileOverviewData: {
+        student: studentResult,
+        class: classResult,
+        subtotalGroup: { byId: [], noMatch: [] },
+      },
+    },
+    updateIdIntegrationConfig: (
+      category: string,
+      config: Record<string, unknown>
+    ) => {
+      if (category === "student" || category === "class") {
+        wizard.updateIdIntegrationConfig(category, config)
+      }
+    },
+    updateIdIntegrationDecision: (
+      category: string,
+      importId: string,
+      decision: Record<string, unknown>
+    ) => {
+      if (category === "student" || category === "class") {
+        wizard.updateIdIntegrationDecision(category, importId, decision)
+      }
+    },
+    batchUpdateIdIntegrationDecisions: (
+      category: string,
+      idChoice: "use_import_id" | "use_existing_id"
+    ) => {
+      if (category === "student" || category === "class") {
+        wizard.batchUpdateIdIntegrationDecisions(category, idChoice)
+      }
+    },
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">データの紐づけ</h3>
+        <p className="text-muted-foreground mt-1 text-sm">
+          ファイル内のデータをこのPCのデータとどう紐づけるか設定してください
+        </p>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="student">
+            生徒
+            {studentNeedsDecision > 0 && (
+              <span className="ml-1 text-xs">({studentNeedsDecision})</span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="class">
+            学級
+            {classNeedsDecision > 0 && (
+              <span className="ml-1 text-xs">({classNeedsDecision})</span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="student" className="mt-4">
+          <StudentIntegrationPanel
+            wizard={wizardAdapter as never}
+            onStrategyChange={(strategy) =>
+              wizard.updateIdIntegrationConfig("student", { strategy })
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="class" className="mt-4">
+          <ClassIntegrationPanel
+            wizard={wizardAdapter as never}
+            onStrategyChange={(strategy) =>
+              wizard.updateIdIntegrationConfig("class", { strategy })
+            }
+          />
+        </TabsContent>
+      </Tabs>
+
+      <div className="flex justify-center pt-4">
+        <Button onClick={goToNextStep} className="gap-2">
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/student-import/steps/UpdateConfirmStep.tsx
+++ b/components/student-import/steps/UpdateConfirmStep.tsx
@@ -1,0 +1,276 @@
+"use client"
+
+import { ChevronRight } from "lucide-react"
+import { useEffect, useMemo } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import type { StudentImportWizard } from "@/hooks/student-import/useStudentImportWizard"
+import type { MatchedItem, UpdateStrategy } from "@/types/examArchive.types"
+
+interface UpdateConfirmStepProps {
+  wizard: StudentImportWizard
+}
+
+interface FieldChange {
+  field: string
+  fieldLabel: string
+  currentValue: unknown
+  newValue: unknown
+}
+
+interface UpdateableItem {
+  key: string
+  displayLabel: string
+  importData: Record<string, unknown>
+  existingData: Record<string, unknown>
+  fieldChanges: FieldChange[]
+}
+
+const STUDENT_FIELD_LABELS: Record<string, string> = {
+  studentNumber: "学籍番号",
+  lastName: "姓",
+  firstName: "名",
+  lastNameKana: "姓カナ",
+  firstNameKana: "名カナ",
+  enrollmentYear: "入学年度",
+}
+
+const CLASS_FIELD_LABELS: Record<string, string> = {
+  name: "学級名",
+  classCode: "学級コード",
+  grade: "学年",
+  description: "説明",
+}
+
+function detectFieldChanges(
+  importData: Record<string, unknown>,
+  existingData: Record<string, unknown>,
+  fieldLabels: Record<string, string>
+): FieldChange[] {
+  const changes: FieldChange[] = []
+  for (const [field, label] of Object.entries(fieldLabels)) {
+    const importVal = importData[field]
+    const existingVal = existingData[field]
+    if (importVal !== existingVal && importVal !== undefined) {
+      changes.push({
+        field,
+        fieldLabel: label,
+        currentValue: existingVal,
+        newValue: importVal,
+      })
+    }
+  }
+  return changes
+}
+
+function extractUpdateableItems(
+  matchedItems: MatchedItem[],
+  category: "student" | "class",
+  fieldLabels: Record<string, string>
+): UpdateableItem[] {
+  const items: UpdateableItem[] = []
+  for (const item of matchedItems) {
+    const changes = detectFieldChanges(
+      item.importData,
+      item.existingData,
+      fieldLabels
+    )
+    if (changes.length > 0) {
+      items.push({
+        key: `${category}:${item.importId}`,
+        displayLabel: item.displayLabel,
+        importData: item.importData,
+        existingData: item.existingData,
+        fieldChanges: changes,
+      })
+    }
+  }
+  return items
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "（未設定）"
+  return String(value)
+}
+
+export function UpdateConfirmStep({ wizard }: UpdateConfirmStepProps) {
+  const { state, setFieldUpdateDecision, setBulkUpdateStrategy, goToNextStep } =
+    wizard
+
+  const { student, class: classResult } = state.fileOverviewData ?? {
+    student: { byId: [], noMatch: [] },
+    class: { byId: [], noMatch: [] },
+  }
+
+  // 同一人物と判定されたアイテム（byId + by二次照合で same_person のもの）のフィールド変更を検出
+  const updateableItems = useMemo(() => {
+    const allStudentMatched = [
+      ...student.byId,
+      ...(student.byStudentNumber ?? []),
+      ...(student.byName ?? []),
+    ]
+    const allClassMatched = [...classResult.byId, ...(classResult.byName ?? [])]
+
+    return [
+      ...extractUpdateableItems(
+        allStudentMatched,
+        "student",
+        STUDENT_FIELD_LABELS
+      ),
+      ...extractUpdateableItems(allClassMatched, "class", CLASS_FIELD_LABELS),
+    ]
+  }, [student, classResult])
+
+  // 初期値を設定（keep_existing をデフォルトに）
+  useEffect(() => {
+    for (const item of updateableItems) {
+      for (const change of item.fieldChanges) {
+        if (!state.updateDecisions[item.key]?.[change.field]) {
+          setFieldUpdateDecision(item.key, change.field, "keep_existing")
+        }
+      }
+    }
+  }, [updateableItems, state.updateDecisions, setFieldUpdateDecision])
+
+  if (!state.fileOverviewData) return null
+
+  if (updateableItems.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 py-12">
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">更新するデータはありません</h3>
+          <p className="text-muted-foreground mt-2 text-sm">
+            紐づけたデータに差異はありませんでした
+          </p>
+        </div>
+        <Button onClick={goToNextStep} className="gap-2">
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h3 className="text-lg font-semibold">情報の更新確認</h3>
+        <p className="text-muted-foreground mt-1 text-sm">
+          紐づけたデータに違いがあります。どちらの情報を使うか選んでください
+        </p>
+      </div>
+
+      {/* 一括操作 */}
+      <div className="flex justify-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setBulkUpdateStrategy("keep_existing")}
+        >
+          すべてこのPCの値を使う
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setBulkUpdateStrategy("use_import")}
+        >
+          すべてファイルの値を使う
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setBulkUpdateStrategy("use_newer")}
+        >
+          すべて新しい方を使う
+        </Button>
+      </div>
+
+      {/* アイテム一覧 */}
+      <div className="space-y-4">
+        {updateableItems.map((item) => (
+          <div
+            key={item.key}
+            className="border-border/50 rounded-lg border p-4"
+          >
+            <h4 className="mb-3 font-medium">{item.displayLabel}</h4>
+            <div className="space-y-3">
+              {item.fieldChanges.map((change) => {
+                const currentStrategy =
+                  state.updateDecisions[item.key]?.[change.field] ??
+                  "keep_existing"
+
+                return (
+                  <div
+                    key={change.field}
+                    className="bg-muted/30 rounded-md p-3"
+                  >
+                    <div className="mb-2 text-sm font-medium">
+                      {change.fieldLabel}
+                    </div>
+                    <RadioGroup
+                      value={currentStrategy}
+                      onValueChange={(value: string) =>
+                        setFieldUpdateDecision(
+                          item.key,
+                          change.field,
+                          value as UpdateStrategy
+                        )
+                      }
+                      className="space-y-1"
+                    >
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="keep_existing"
+                          id={`${item.key}-${change.field}-keep`}
+                        />
+                        <Label
+                          htmlFor={`${item.key}-${change.field}-keep`}
+                          className="text-sm"
+                        >
+                          このPC: {formatValue(change.currentValue)}
+                        </Label>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="use_import"
+                          id={`${item.key}-${change.field}-import`}
+                        />
+                        <Label
+                          htmlFor={`${item.key}-${change.field}-import`}
+                          className="text-sm"
+                        >
+                          ファイル: {formatValue(change.newValue)}
+                        </Label>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value="use_newer"
+                          id={`${item.key}-${change.field}-newer`}
+                        />
+                        <Label
+                          htmlFor={`${item.key}-${change.field}-newer`}
+                          className="text-sm"
+                        >
+                          新しい方を使う
+                        </Label>
+                      </div>
+                    </RadioGroup>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-center pt-4">
+        <Button onClick={goToNextStep} className="gap-2">
+          次へ
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/student/StudentArchiveExportDialog.tsx
+++ b/components/student/StudentArchiveExportDialog.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { Download, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ClassInfo {
+  id: string
+  name: string
+}
+
+interface StudentArchiveExportDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  selectedStudentIds: Set<string>
+}
+
+export function StudentArchiveExportDialog({
+  isOpen,
+  onClose,
+  selectedStudentIds,
+}: StudentArchiveExportDialogProps) {
+  const [relatedClasses, setRelatedClasses] = useState<ClassInfo[]>([])
+  const [selectedClassIds, setSelectedClassIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  // 選択生徒に紐づく学級を取得
+  useEffect(() => {
+    if (!isOpen || selectedStudentIds.size === 0) return
+
+    const fetchClasses = async () => {
+      setIsLoading(true)
+      try {
+        const allStudents = await window.electronAPI.fetchStudents()
+        const selectedStudents = allStudents.filter((s: { id: string }) =>
+          selectedStudentIds.has(s.id)
+        )
+
+        // 紐づく学級を収集
+        const classMap = new Map<string, string>()
+        for (const student of selectedStudents) {
+          for (const m of student.memberships || []) {
+            if (m.class && !classMap.has(m.class.id)) {
+              classMap.set(m.class.id, m.class.name)
+            }
+          }
+        }
+
+        const classes = Array.from(classMap.entries())
+          .map(([id, name]) => ({ id, name }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+
+        setRelatedClasses(classes)
+        // デフォルト: 全学級を選択
+        setSelectedClassIds(new Set(classes.map((c) => c.id)))
+      } catch (error) {
+        console.error("Failed to fetch classes:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchClasses()
+  }, [isOpen, selectedStudentIds])
+
+  const toggleClass = (classId: string) => {
+    setSelectedClassIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(classId)) {
+        next.delete(classId)
+      } else {
+        next.add(classId)
+      }
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selectedClassIds.size === relatedClasses.length) {
+      setSelectedClassIds(new Set())
+    } else {
+      setSelectedClassIds(new Set(relatedClasses.map((c) => c.id)))
+    }
+  }
+
+  const handleExport = async () => {
+    setIsExporting(true)
+    try {
+      const result = await window.electronAPI.studentArchive.exportStudents({
+        studentIds: Array.from(selectedStudentIds),
+        classIds:
+          selectedClassIds.size === relatedClasses.length
+            ? undefined
+            : Array.from(selectedClassIds),
+      })
+
+      if (result.success) {
+        toast.success(
+          `${selectedStudentIds.size}名の生徒データをエクスポートしました`
+        )
+        onClose()
+      } else if (result.error !== "キャンセルされました") {
+        toast.error(`エクスポートに失敗しました: ${result.error}`)
+      }
+    } catch (error) {
+      console.error("Failed to export:", error)
+      toast.error("エクスポート中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            生徒データの書き出し（{selectedStudentIds.size}名）
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="py-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+            </div>
+          ) : relatedClasses.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              選択した生徒に紐づく学級はありません。
+              <br />
+              生徒データのみがエクスポートされます。
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm">
+                エクスポートする学級を選択してください。
+                <br />
+                <span className="text-muted-foreground">
+                  学級の情報と所属関係が一緒にエクスポートされます。
+                </span>
+              </p>
+
+              <div className="border-border/50 max-h-60 overflow-y-auto rounded-lg border">
+                {/* 全選択 */}
+                <label className="hover:bg-muted/50 flex items-center gap-3 border-b px-4 py-2.5">
+                  <Checkbox
+                    checked={
+                      selectedClassIds.size === relatedClasses.length
+                        ? true
+                        : selectedClassIds.size > 0
+                          ? "indeterminate"
+                          : false
+                    }
+                    onCheckedChange={toggleAll}
+                  />
+                  <span className="text-sm font-medium">すべて選択</span>
+                </label>
+
+                {relatedClasses.map((cls) => (
+                  <label
+                    key={cls.id}
+                    className="hover:bg-muted/50 flex items-center gap-3 px-4 py-2.5"
+                  >
+                    <Checkbox
+                      checked={selectedClassIds.has(cls.id)}
+                      onCheckedChange={() => toggleClass(cls.id)}
+                    />
+                    <span className="text-sm">{cls.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isExporting}>
+            キャンセル
+          </Button>
+          <Button onClick={handleExport} disabled={isExporting || isLoading}>
+            {isExporting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                書き出し中...
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-4 w-4" />
+                書き出し
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/student/StudentTable.tsx
+++ b/components/student/StudentTable.tsx
@@ -2,8 +2,10 @@
 
 import type { Prisma } from "@prisma/client"
 import {
+  Archive,
   Download,
   Edit,
+  FolderDown,
   PlusCircle,
   Search,
   Trash2,
@@ -14,7 +16,9 @@ import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import SpreadsheetImportModal from "@/components/student/SpreadsheetImportModal"
+import { StudentArchiveExportDialog } from "@/components/student/StudentArchiveExportDialog"
 import StudentModal from "@/components/student/StudentModal"
+import { StudentImportWizardModal } from "@/components/student-import/StudentImportWizardModal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -116,6 +120,10 @@ export default function StudentTable() {
   const [studentToEdit, setStudentToEdit] =
     useState<StudentWithMemberships | null>(null)
   const [isSpreadsheetImportModalOpen, setIsSpreadsheetImportModalOpen] =
+    useState(false)
+  const [isArchiveExportDialogOpen, setIsArchiveExportDialogOpen] =
+    useState(false)
+  const [isArchiveImportModalOpen, setIsArchiveImportModalOpen] =
     useState(false)
   const [isExporting, setIsExporting] = useState(false)
 
@@ -307,6 +315,17 @@ export default function StudentTable() {
     }
   }
 
+  const refreshData = async () => {
+    try {
+      const fetchedStudents = await window.electronAPI.fetchStudents()
+      const fetchedClasses = await window.electronAPI.fetchClasses()
+      setStudents(fetchedStudents || [])
+      setClasses(fetchedClasses || [])
+    } catch (error) {
+      console.error("Failed to refresh data:", error)
+    }
+  }
+
   const onStudentsImported = (importedStudents: StudentWithMemberships[]) => {
     setStudents((prevStudents) => {
       const existingStudentIds = new Set(prevStudents.map((s) => s.id))
@@ -390,12 +409,30 @@ export default function StudentTable() {
               : `Excel出力${selectedStudentIds.size > 0 ? `(${selectedStudentIds.size})` : ""}`}
           </Button>
           <Button
+            onClick={() => setIsArchiveExportDialogOpen(true)}
+            variant="outline"
+            className="rounded-lg"
+            disabled={selectedStudentIds.size === 0}
+          >
+            <Archive className="mr-2 h-4 w-4" />
+            アーカイブ書き出し
+            {selectedStudentIds.size > 0 && `(${selectedStudentIds.size})`}
+          </Button>
+          <Button
             onClick={handleAddNewStudent}
             variant="outline"
             className="rounded-lg"
           >
             <PlusCircle className="mr-2 h-4 w-4" />
             生徒追加
+          </Button>
+          <Button
+            onClick={() => setIsArchiveImportModalOpen(true)}
+            variant="outline"
+            className="rounded-lg"
+          >
+            <FolderDown className="mr-2 h-4 w-4" />
+            アーカイブ読み込み
           </Button>
           <Button
             onClick={() => setIsSpreadsheetImportModalOpen(true)}
@@ -563,6 +600,22 @@ export default function StudentTable() {
           isOpen={isSpreadsheetImportModalOpen}
           onClose={() => setIsSpreadsheetImportModalOpen(false)}
           onImportSuccess={onStudentsImported}
+        />
+      )}
+
+      {isArchiveExportDialogOpen && (
+        <StudentArchiveExportDialog
+          isOpen={isArchiveExportDialogOpen}
+          onClose={() => setIsArchiveExportDialogOpen(false)}
+          selectedStudentIds={selectedStudentIds}
+        />
+      )}
+
+      {isArchiveImportModalOpen && (
+        <StudentImportWizardModal
+          isOpen={isArchiveImportModalOpen}
+          onClose={() => setIsArchiveImportModalOpen(false)}
+          onComplete={refreshData}
         />
       )}
     </div>

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -14,6 +14,7 @@ import { setupPdfToolsHandlers } from "./pdfToolsHandlers"
 import { setupQuestionGroupHandlers } from "./questionGroupHandlers"
 import { setupScoringHandlers } from "./scoringHandlers"
 import { registerSettingsHandlers } from "./settingsHandlers"
+import { registerStudentArchiveHandlers } from "./studentArchiveHandlers"
 import { setupStudentHandlers } from "./studentHandlers"
 import { setupSubjectHandlers } from "./subjectHandlers"
 import { setupSubtotalGroupHandlers } from "./subtotalGroupHandlers"
@@ -40,4 +41,5 @@ export function setupAllIPCHandlers(): void {
   setupAnswerSheetBuilderHandlers()
   setupOMRHandlers()
   setupOmrConfigHandlers()
+  registerStudentArchiveHandlers()
 }

--- a/electron-src/ipc-handlers/studentArchiveHandlers.ts
+++ b/electron-src/ipc-handlers/studentArchiveHandlers.ts
@@ -1,0 +1,170 @@
+/**
+ * 生徒アーカイブ（エクスポート/インポート）IPCハンドラー
+ */
+
+import { dialog, ipcMain } from "electron"
+
+import type { UpdateDecisions } from "../../types/examArchive.types"
+import type {
+  ExportStudentsArchiveOptions,
+  StudentArchiveFileOverviewData,
+  StudentArchiveIdIntegrationConfig,
+} from "../../types/studentArchive.types"
+import { exportStudentsArchive } from "../lib/export/student-archive"
+import {
+  cleanupStudentTempDir,
+  executeStudentImport,
+  extractStudentArchive,
+  performStudentPreMatching,
+} from "../lib/import/student-archive"
+
+/**
+ * 生徒アーカイブ関連のIPCハンドラーを登録
+ */
+export function registerStudentArchiveHandlers(): void {
+  // エクスポート
+  ipcMain.handle(
+    "studentArchive:exportStudents",
+    async (_event, options: ExportStudentsArchiveOptions) => {
+      try {
+        return await exportStudentsArchive(options)
+      } catch (error) {
+        console.error("Error in studentArchive:exportStudents:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "エクスポートに失敗しました",
+        }
+      }
+    }
+  )
+
+  // インポートファイル選択ダイアログ
+  ipcMain.handle("studentArchive:selectImportFile", async () => {
+    try {
+      const result = await dialog.showOpenDialog({
+        title: "生徒データをインポート",
+        filters: [
+          { name: "生徒データ (.students)", extensions: ["students"] },
+          { name: "すべてのファイル", extensions: ["*"] },
+        ],
+        properties: ["openFile"],
+      })
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: true, canceled: true }
+      }
+
+      return { success: true, filePath: result.filePaths[0] }
+    } catch (error) {
+      console.error("Error in studentArchive:selectImportFile:", error)
+      return {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "ダイアログ表示に失敗しました",
+      }
+    }
+  })
+
+  // アーカイブ解析（マニフェスト読み取り）
+  ipcMain.handle(
+    "studentArchive:analyzeArchive",
+    async (_event, options: { archivePath: string }) => {
+      let tempDir: string | null = null
+      try {
+        const extractResult = await extractStudentArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+        return { success: true, manifest: extractResult.data.manifest }
+      } catch (error) {
+        console.error("Error in studentArchive:analyzeArchive:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "アーカイブ解析に失敗しました",
+        }
+      } finally {
+        if (tempDir) cleanupStudentTempDir(tempDir)
+      }
+    }
+  )
+
+  // 事前照合
+  ipcMain.handle(
+    "studentArchive:preMatch",
+    async (_event, options: { archivePath: string }) => {
+      let tempDir: string | null = null
+      try {
+        const extractResult = await extractStudentArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+
+        const fileOverviewData = await performStudentPreMatching(
+          extractResult.data
+        )
+
+        return { success: true, data: fileOverviewData }
+      } catch (error) {
+        console.error("Error in studentArchive:preMatch:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "事前照合に失敗しました",
+        }
+      } finally {
+        if (tempDir) cleanupStudentTempDir(tempDir)
+      }
+    }
+  )
+
+  // インポート実行
+  ipcMain.handle(
+    "studentArchive:import",
+    async (
+      _event,
+      options: {
+        archivePath: string
+        preMatchResult: StudentArchiveFileOverviewData
+        integrationConfig: StudentArchiveIdIntegrationConfig
+        updateDecisions?: UpdateDecisions
+      }
+    ) => {
+      let tempDir: string | null = null
+      try {
+        const extractResult = await extractStudentArchive(options.archivePath)
+        if (!extractResult.success || !extractResult.data) {
+          return { success: false, error: extractResult.error }
+        }
+        tempDir = extractResult.data.tempDir
+
+        const result = await executeStudentImport(
+          extractResult.data,
+          options.preMatchResult,
+          options.integrationConfig,
+          options.updateDecisions
+        )
+
+        return result
+      } catch (error) {
+        console.error("Error in studentArchive:import:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "インポートに失敗しました",
+        }
+      } finally {
+        if (tempDir) cleanupStudentTempDir(tempDir)
+      }
+    }
+  )
+}

--- a/electron-src/lib/export/student-archive/archiveCreator.ts
+++ b/electron-src/lib/export/student-archive/archiveCreator.ts
@@ -1,0 +1,129 @@
+/**
+ * 生徒アーカイブ作成
+ *
+ * 収集した生徒・学級データをZIPアーカイブにパッケージング
+ */
+
+import archiver from "archiver"
+import { app } from "electron"
+import * as fs from "fs"
+import * as path from "path"
+
+import type { StudentArchiveManifest } from "../../../../types/studentArchive.types"
+import type { CollectedStudentArchiveData } from "./dataCollector"
+
+/**
+ * アプリバージョンを取得
+ */
+function getAppVersion(): string {
+  try {
+    return app.getVersion()
+  } catch {
+    return "0.0.0"
+  }
+}
+
+/**
+ * マニフェストを作成
+ */
+function createManifest(
+  counts: CollectedStudentArchiveData["counts"]
+): StudentArchiveManifest {
+  return {
+    archiveType: "students",
+    version: "1.0.0",
+    appVersion: getAppVersion(),
+    exportedAt: new Date().toISOString(),
+    counts,
+  }
+}
+
+/**
+ * ZIPアーカイブを作成
+ */
+export async function createStudentArchive(
+  collectedData: CollectedStudentArchiveData,
+  outputPath: string
+): Promise<{
+  success: boolean
+  outputPath?: string
+  manifest?: StudentArchiveManifest
+  error?: string
+}> {
+  return new Promise((resolve) => {
+    try {
+      const outputDir = path.dirname(outputPath)
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true })
+      }
+
+      const output = fs.createWriteStream(outputPath)
+      const archive = archiver("zip", {
+        zlib: { level: 9 },
+      })
+
+      const manifest = createManifest(collectedData.counts)
+
+      output.on("close", () => {
+        resolve({
+          success: true,
+          outputPath,
+          manifest,
+        })
+      })
+
+      archive.on("error", (err) => {
+        console.error("Student archive error:", err)
+        resolve({
+          success: false,
+          error: `アーカイブ作成エラー: ${err.message}`,
+        })
+      })
+
+      archive.pipe(output)
+
+      // manifest.json
+      archive.append(JSON.stringify(manifest, null, 2), {
+        name: "manifest.json",
+      })
+
+      // students.json
+      archive.append(JSON.stringify(collectedData.studentsData, null, 2), {
+        name: "students.json",
+      })
+
+      // classes.json
+      archive.append(JSON.stringify(collectedData.classesData, null, 2), {
+        name: "classes.json",
+      })
+
+      archive.finalize()
+    } catch (error) {
+      console.error("Error creating student archive:", error)
+      resolve({
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "アーカイブ作成に失敗しました",
+      })
+    }
+  })
+}
+
+/**
+ * デフォルトのエクスポートファイル名を生成
+ */
+export function generateStudentExportFileName(): string {
+  const now = new Date()
+  const timestamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("-")
+
+  return `生徒データ-${timestamp}.students`
+}

--- a/electron-src/lib/export/student-archive/dataCollector.ts
+++ b/electron-src/lib/export/student-archive/dataCollector.ts
@@ -1,0 +1,107 @@
+/**
+ * 生徒アーカイブ データ収集
+ *
+ * 選択された生徒と関連する学級・所属データをPrismaから取得
+ */
+
+import type {
+  ArchiveClassesData,
+  ArchiveStudentsData,
+} from "../../../../types/examArchive.types"
+import type { StudentArchiveDataCounts } from "../../../../types/studentArchive.types"
+import prisma from "../../prisma/client"
+
+export interface CollectedStudentArchiveData {
+  studentsData: ArchiveStudentsData
+  classesData: ArchiveClassesData
+  counts: StudentArchiveDataCounts
+}
+
+/**
+ * 生徒アーカイブ用のデータを収集
+ *
+ * @param studentIds - エクスポート対象の生徒ID
+ * @param classIds - エクスポート対象の学級ID（省略時: 選択生徒に関連する全学級）
+ */
+export async function collectStudentArchiveData(
+  studentIds: string[],
+  classIds?: string[]
+): Promise<CollectedStudentArchiveData> {
+  // 1. 生徒を取得
+  const students = await prisma.student.findMany({
+    where: { id: { in: studentIds } },
+  })
+
+  // 2. 全ての所属を取得
+  const allMemberships = await prisma.studentClassMembership.findMany({
+    where: { studentId: { in: studentIds } },
+  })
+
+  // 3. 関連する学級IDを導出
+  const relatedClassIds = [...new Set(allMemberships.map((m) => m.classId))]
+
+  // classIdsが指定されていればフィルタ
+  const targetClassIds = classIds
+    ? relatedClassIds.filter((id) => classIds.includes(id))
+    : relatedClassIds
+
+  // 4. 学級を取得
+  const classes = await prisma.class.findMany({
+    where: { id: { in: targetClassIds } },
+  })
+
+  // 5. 所属をフィルタ（対象学級のもののみ）
+  const targetClassIdSet = new Set(targetClassIds)
+  const filteredMemberships = allMemberships.filter((m) =>
+    targetClassIdSet.has(m.classId)
+  )
+
+  // 6. アーカイブ形式に整形
+  const studentsData: ArchiveStudentsData = {
+    students: students.map((s) => ({
+      id: s.id,
+      studentNumber: s.studentNumber,
+      lastName: s.lastName,
+      firstName: s.firstName,
+      lastNameKana: s.lastNameKana,
+      firstNameKana: s.firstNameKana,
+      enrollmentYear: s.enrollmentYear,
+      createdAt: s.createdAt.toISOString(),
+      updatedAt: s.updatedAt.toISOString(),
+    })),
+  }
+
+  const classesData: ArchiveClassesData = {
+    classes: classes.map((c) => ({
+      id: c.id,
+      name: c.name,
+      classCode: c.classCode,
+      grade: c.grade,
+      description: c.description,
+      isVisible: c.isVisible,
+      createdAt: c.createdAt.toISOString(),
+      updatedAt: c.updatedAt.toISOString(),
+    })),
+    memberships: filteredMemberships.map((m) => ({
+      id: m.id,
+      studentId: m.studentId,
+      classId: m.classId,
+      startDate: m.startDate.toISOString(),
+      endDate: m.endDate ? m.endDate.toISOString() : null,
+      attendanceNumber: m.attendanceNumber,
+      notes: m.notes,
+      createdAt: m.createdAt.toISOString(),
+      updatedAt: m.updatedAt.toISOString(),
+    })),
+  }
+
+  return {
+    studentsData,
+    classesData,
+    counts: {
+      students: students.length,
+      classes: classes.length,
+      memberships: filteredMemberships.length,
+    },
+  }
+}

--- a/electron-src/lib/export/student-archive/index.ts
+++ b/electron-src/lib/export/student-archive/index.ts
@@ -1,0 +1,79 @@
+/**
+ * 生徒アーカイブ エクスポート機能
+ *
+ * 生徒・学級データをZIPアーカイブとしてエクスポート
+ */
+
+import { dialog } from "electron"
+
+import type {
+  ExportStudentsArchiveOptions,
+  ExportStudentsArchiveResult,
+} from "../../../../types/studentArchive.types"
+import {
+  createStudentArchive,
+  generateStudentExportFileName,
+} from "./archiveCreator"
+import { collectStudentArchiveData } from "./dataCollector"
+
+/**
+ * 生徒をエクスポート
+ */
+export async function exportStudentsArchive(
+  options: ExportStudentsArchiveOptions
+): Promise<ExportStudentsArchiveResult> {
+  const { studentIds, classIds } = options
+
+  try {
+    if (studentIds.length === 0) {
+      return {
+        success: false,
+        error: "エクスポートする生徒が選択されていません",
+      }
+    }
+
+    // 1. データを収集
+    const collectedData = await collectStudentArchiveData(studentIds, classIds)
+
+    // 2. 保存先ダイアログを表示
+    const defaultFileName = generateStudentExportFileName()
+    const result = await dialog.showSaveDialog({
+      title: "生徒データをエクスポート",
+      defaultPath: defaultFileName,
+      filters: [{ name: "生徒データ", extensions: ["students"] }],
+    })
+
+    if (result.canceled || !result.filePath) {
+      return { success: false, error: "キャンセルされました" }
+    }
+
+    // 3. アーカイブを作成
+    const archiveResult = await createStudentArchive(
+      collectedData,
+      result.filePath
+    )
+
+    if (!archiveResult.success) {
+      return { success: false, error: archiveResult.error }
+    }
+
+    return {
+      success: true,
+      outputPath: archiveResult.outputPath,
+      manifest: archiveResult.manifest,
+    }
+  } catch (error) {
+    console.error("Error exporting students archive:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "エクスポートに失敗しました",
+    }
+  }
+}
+
+export {
+  createStudentArchive,
+  generateStudentExportFileName,
+} from "./archiveCreator"
+export { collectStudentArchiveData } from "./dataCollector"

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "crypto"
 
 import type {
+  ArchiveClassesData,
   ArchiveDataCounts,
   FileOverviewData,
   IdIntegrationConfig,
@@ -228,7 +229,7 @@ export async function executeIdIntegrationImport(
         )
 
         // 14. 学級所属
-        await processMemberships(data, idMappings, tx)
+        await processMemberships(data.classesData.memberships, idMappings, tx)
 
         // 15. ID変更処理（「書き出したPCに合わせる」を選んだ場合）
         if (idChangeTargets.length > 0) {
@@ -902,12 +903,19 @@ async function processDrawingAnnotations(
   }
 }
 
-async function processMemberships(
-  data: ExtractedArchiveData,
-  idMappings: IdMappings,
+/**
+ * 学級所属データを処理
+ *
+ * @param memberships - 所属データ配列
+ * @param idMappings - IDマッピング（student, class, membership を使用）
+ * @param tx - Prismaトランザクション
+ */
+export async function processMemberships(
+  memberships: ArchiveClassesData["memberships"],
+  idMappings: Pick<IdMappings, "student" | "class" | "membership">,
   tx: Tx
 ): Promise<void> {
-  for (const m of data.classesData.memberships) {
+  for (const m of memberships) {
     const newStudentId = idMappings.student[m.studentId]
     const newClassId = idMappings.class[m.classId]
 

--- a/electron-src/lib/import/student-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/student-archive/archiveExtractor.ts
@@ -1,0 +1,126 @@
+/**
+ * 生徒アーカイブ展開モジュール
+ *
+ * .studentsファイル（ZIP）を展開し、データを読み込む
+ */
+
+import AdmZip from "adm-zip"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import type {
+  ArchiveClassesData,
+  ArchiveStudentsData,
+} from "../../../../types/examArchive.types"
+import type { StudentArchiveManifest } from "../../../../types/studentArchive.types"
+
+/**
+ * 展開された生徒アーカイブデータ
+ */
+export interface ExtractedStudentArchiveData {
+  manifest: StudentArchiveManifest
+  studentsData: ArchiveStudentsData
+  classesData: ArchiveClassesData
+  tempDir: string
+}
+
+/**
+ * アーカイブを展開してデータを読み込む
+ */
+export async function extractStudentArchive(archivePath: string): Promise<{
+  success: boolean
+  data?: ExtractedStudentArchiveData
+  error?: string
+}> {
+  const tempDir = path.join(
+    os.tmpdir(),
+    `student-archive-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+  )
+
+  try {
+    if (!fs.existsSync(archivePath)) {
+      return { success: false, error: "アーカイブファイルが見つかりません" }
+    }
+
+    const zip = new AdmZip(archivePath)
+    zip.extractAllTo(tempDir, true)
+
+    // manifest.json を読み込み
+    const manifestPath = path.join(tempDir, "manifest.json")
+    if (!fs.existsSync(manifestPath)) {
+      return { success: false, error: "manifest.json が見つかりません" }
+    }
+
+    const manifest: StudentArchiveManifest = JSON.parse(
+      fs.readFileSync(manifestPath, "utf-8")
+    )
+
+    // archiveType を検証
+    if (manifest.archiveType !== "students") {
+      return {
+        success: false,
+        error: `このファイルは生徒データアーカイブではありません（archiveType: ${manifest.archiveType ?? "undefined"}）`,
+      }
+    }
+
+    // students.json を読み込み
+    const studentsPath = path.join(tempDir, "students.json")
+    if (!fs.existsSync(studentsPath)) {
+      return { success: false, error: "students.json が見つかりません" }
+    }
+    const studentsData: ArchiveStudentsData = JSON.parse(
+      fs.readFileSync(studentsPath, "utf-8")
+    )
+
+    // classes.json を読み込み
+    const classesPath = path.join(tempDir, "classes.json")
+    if (!fs.existsSync(classesPath)) {
+      return { success: false, error: "classes.json が見つかりません" }
+    }
+    const classesData: ArchiveClassesData = JSON.parse(
+      fs.readFileSync(classesPath, "utf-8")
+    )
+
+    return {
+      success: true,
+      data: {
+        manifest,
+        studentsData,
+        classesData,
+        tempDir,
+      },
+    }
+  } catch (error) {
+    // エラー時にtempDirをクリーンアップ
+    try {
+      if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true, force: true })
+      }
+    } catch {
+      // ignore cleanup error
+    }
+
+    console.error("Error extracting student archive:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "アーカイブの展開に失敗しました",
+    }
+  }
+}
+
+/**
+ * 一時ディレクトリをクリーンアップ
+ */
+export function cleanupStudentTempDir(tempDir: string): void {
+  try {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  } catch (error) {
+    console.warn("Failed to cleanup temp dir:", error)
+  }
+}

--- a/electron-src/lib/import/student-archive/index.ts
+++ b/electron-src/lib/import/student-archive/index.ts
@@ -1,0 +1,213 @@
+/**
+ * 生徒アーカイブ インポート機能
+ *
+ * .studentsファイルから生徒・学級データをインポート
+ * 既存の試験アーカイブインポートのマッチング・プロセッサーロジックを再利用
+ */
+
+import type { UpdateDecisions } from "../../../../types/examArchive.types"
+import type {
+  StudentArchiveFileOverviewData,
+  StudentArchiveIdIntegrationConfig,
+  StudentArchiveImportResult,
+  StudentArchiveManifest,
+} from "../../../../types/studentArchive.types"
+import prisma from "../../prisma/client"
+import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
+import { executeIdChanges } from "../merge/idChangeExecutor"
+import { processMemberships } from "../merge/idIntegrationImporter"
+import { preMatchClasses } from "../merge/matchers/classMatcher"
+import { preMatchStudents } from "../merge/matchers/studentMatcher"
+import {
+  processClassIdIntegration,
+  processStudentIdIntegration,
+} from "../merge/processors"
+import type { IdChangeTarget, IdMappings } from "../merge/types"
+import type { ExtractedStudentArchiveData } from "./archiveExtractor"
+
+/**
+ * ExtractedStudentArchiveData を ExtractedArchiveData 互換のオブジェクトに変換
+ *
+ * preMatchStudents/preMatchClasses は ExtractedArchiveData を受け取るため、
+ * 必要なフィールドのみを持つ互換オブジェクトを作成する
+ */
+function toCompatibleData(
+  data: ExtractedStudentArchiveData
+): Pick<ExtractedArchiveData, "studentsData" | "classesData"> {
+  return {
+    studentsData: data.studentsData,
+    classesData: data.classesData,
+  }
+}
+
+/**
+ * マニフェストを解析（Step 1）
+ */
+export function analyzeStudentArchive(manifest: StudentArchiveManifest): {
+  success: boolean
+  manifest: StudentArchiveManifest
+} {
+  return { success: true, manifest }
+}
+
+/**
+ * 事前照合を実行（Step 2）
+ */
+export async function performStudentPreMatching(
+  data: ExtractedStudentArchiveData
+): Promise<StudentArchiveFileOverviewData> {
+  const compatData = toCompatibleData(data)
+  const [studentResult, classResult] = await Promise.all([
+    preMatchStudents(compatData as ExtractedArchiveData),
+    preMatchClasses(compatData as ExtractedArchiveData),
+  ])
+
+  return {
+    student: studentResult,
+    class: classResult,
+  }
+}
+
+/**
+ * 生徒アーカイブのインポートを実行（Step 6）
+ */
+export async function executeStudentImport(
+  data: ExtractedStudentArchiveData,
+  preMatchResult: StudentArchiveFileOverviewData,
+  integrationConfig: StudentArchiveIdIntegrationConfig,
+  updateDecisions?: UpdateDecisions
+): Promise<StudentArchiveImportResult> {
+  const warnings: string[] = []
+  const counts = {
+    created: { students: 0, classes: 0, memberships: 0 },
+    updated: { students: 0, classes: 0, memberships: 0 },
+    skipped: { students: 0, classes: 0, memberships: 0 },
+    unchanged: { students: 0, classes: 0, memberships: 0 },
+  }
+
+  // ArchiveDataCounts互換のカウント（プロセッサーが使用）
+  const archiveCounts = {
+    created: createEmptyArchiveCounts(),
+    updated: createEmptyArchiveCounts(),
+    skipped: createEmptyArchiveCounts(),
+    unchanged: createEmptyArchiveCounts(),
+  }
+
+  const idMappings: IdMappings = {
+    student: {},
+    class: {},
+    subtotalGroup: {},
+    subtotal: {},
+    exam: {},
+    examPage: {},
+    cropRegion: {},
+    masterImage: {},
+    studentAnswerImage: {},
+    examStudent: {},
+    userExam: {},
+    examSubtotalGroup: {},
+    cropSubtotal: {},
+    questionScore: {},
+    drawingAnnotation: {},
+    membership: {},
+  }
+
+  const idChangeTargets: IdChangeTarget[] = []
+
+  // FileOverviewData互換に変換（プロセッサーが使用）
+  const compatPreMatch = {
+    student: preMatchResult.student,
+    class: preMatchResult.class,
+    subtotalGroup: { byId: [], noMatch: [] },
+  }
+
+  const compatData = toCompatibleData(data)
+
+  try {
+    await prisma.$transaction(
+      async (tx) => {
+        // 1. 生徒のID統合処理
+        await processStudentIdIntegration(
+          compatData as ExtractedArchiveData,
+          compatPreMatch,
+          integrationConfig.student,
+          idMappings,
+          idChangeTargets,
+          archiveCounts,
+          warnings,
+          tx,
+          updateDecisions
+        )
+
+        // 2. 学級のID統合処理
+        await processClassIdIntegration(
+          compatData as ExtractedArchiveData,
+          compatPreMatch,
+          integrationConfig.class,
+          idMappings,
+          idChangeTargets,
+          archiveCounts,
+          warnings,
+          tx,
+          updateDecisions
+        )
+
+        // 3. 学級所属の処理
+        await processMemberships(data.classesData.memberships, idMappings, tx)
+
+        // 4. ID変更処理
+        if (idChangeTargets.length > 0) {
+          await executeIdChanges(idChangeTargets, idMappings, warnings, tx)
+        }
+      },
+      { timeout: 60000 }
+    )
+
+    // archiveCounts → counts に変換
+    counts.created.students = archiveCounts.created.students
+    counts.created.classes = archiveCounts.created.classes
+    counts.updated.students = archiveCounts.updated.students
+    counts.updated.classes = archiveCounts.updated.classes
+    counts.skipped.students = archiveCounts.skipped.students
+    counts.skipped.classes = archiveCounts.skipped.classes
+    counts.unchanged.students = archiveCounts.unchanged.students
+    counts.unchanged.classes = archiveCounts.unchanged.classes
+
+    // memberships のカウントはprocessMembershipでは集計されないため
+    // idMappings.membership のサイズで推定
+    counts.created.memberships = Object.keys(idMappings.membership).length
+
+    return {
+      success: true,
+      summary: counts,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    }
+  } catch (error) {
+    console.error("Error executing student import:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "インポートに失敗しました",
+    }
+  }
+}
+
+function createEmptyArchiveCounts() {
+  return {
+    students: 0,
+    classes: 0,
+    users: 0,
+    pages: 0,
+    regions: 0,
+    scores: 0,
+    annotations: 0,
+    subtotalGroups: 0,
+    masterImages: 0,
+    answerSheetImages: 0,
+  }
+}
+
+export {
+  cleanupStudentTempDir,
+  extractStudentArchive,
+} from "./archiveExtractor"

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -683,6 +683,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.invoke("archive:convertDatToScore", options),
   },
 
+  // Student Archive (Export/Import) related
+  studentArchive: {
+    exportStudents: (options: { studentIds: string[]; classIds?: string[] }) =>
+      ipcRenderer.invoke("studentArchive:exportStudents", options),
+    selectImportFile: () =>
+      ipcRenderer.invoke("studentArchive:selectImportFile"),
+    analyzeArchive: (options: { archivePath: string }) =>
+      ipcRenderer.invoke("studentArchive:analyzeArchive", options),
+    preMatch: (options: { archivePath: string }) =>
+      ipcRenderer.invoke("studentArchive:preMatch", options),
+    import: (options: {
+      archivePath: string
+      preMatchResult: import("../types/studentArchive.types").StudentArchiveFileOverviewData
+      integrationConfig: import("../types/studentArchive.types").StudentArchiveIdIntegrationConfig
+      updateDecisions?: import("../types/examArchive.types").UpdateDecisions
+    }) => ipcRenderer.invoke("studentArchive:import", options),
+  },
+
   // ExamClass
   examClass: {
     getAll: (examId: string) =>
@@ -782,57 +800,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
     resetUserKeyboardShortcuts: (userId: string) =>
       ipcRenderer.invoke("settings:resetUserKeyboardShortcuts", userId),
 
-    // UserScoringPreference
-    getUserScoringPreference: (userId: string) =>
-      ipcRenderer.invoke("settings:getUserScoringPreference", userId),
-    upsertUserScoringPreference: (
-      userId: string,
-      data: {
-        showStudentNames?: boolean
-        autoScroll?: boolean
-        itemsPerLine?: number
-        layoutDirection?: string
-        expandMargin?: number
-        selectionBorderColor?: string | null
-        scoringStatusColors?: string | null
-        scoringColorPresetId?: string | null
-      }
-    ) =>
-      ipcRenderer.invoke("settings:upsertUserScoringPreference", userId, data),
-
-    // カラム別操作（楽観的更新対応）
-    getScoringPreferenceColumn: (
-      userId: string,
-      column:
-        | "showStudentNames"
-        | "autoScroll"
-        | "itemsPerLine"
-        | "layoutDirection"
-        | "expandMargin"
-        | "selectionBorderColor"
-        | "scoringStatusColors"
-        | "scoringColorPresetId"
-    ) =>
-      ipcRenderer.invoke("settings:getScoringPreferenceColumn", userId, column),
-    setScoringPreferenceColumn: (
-      userId: string,
-      column:
-        | "showStudentNames"
-        | "autoScroll"
-        | "itemsPerLine"
-        | "layoutDirection"
-        | "expandMargin"
-        | "selectionBorderColor"
-        | "scoringStatusColors"
-        | "scoringColorPresetId",
-      value: boolean | number | string | null
-    ) =>
-      ipcRenderer.invoke(
-        "settings:setScoringPreferenceColumn",
-        userId,
-        column,
-        value
-      ),
+    // UserPreference（KV方式）
+    getUserPreference: (userId: string, key: string) =>
+      ipcRenderer.invoke("settings:getUserPreference", userId, key),
+    setUserPreference: (userId: string, key: string, value: string) =>
+      ipcRenderer.invoke("settings:setUserPreference", userId, key, value),
+    getUserPreferences: (userId: string) =>
+      ipcRenderer.invoke("settings:getUserPreferences", userId),
 
     // ExamMarkingFormat
     getExamMarkingFormats: (examId: string) =>

--- a/hooks/student-import/useStudentImportWizard.ts
+++ b/hooks/student-import/useStudentImportWizard.ts
@@ -1,0 +1,310 @@
+"use client"
+
+import { useCallback, useState } from "react"
+
+import type {
+  CategoryIdIntegrationConfig,
+  IdChoice,
+  IdIntegrationDecision,
+  UpdateStrategy,
+} from "@/types/examArchive.types"
+import type {
+  StudentArchiveFileOverviewData,
+  StudentImportWizardState,
+} from "@/types/studentArchive.types"
+import { INITIAL_STUDENT_IMPORT_WIZARD_STATE } from "@/types/studentArchive.types"
+
+export const STUDENT_IMPORT_STEP_ORDER = [
+  "file_select",
+  "file_overview",
+  "id_integration",
+  "update_confirm",
+  "final_confirm",
+  "execute",
+] as const
+
+/**
+ * 生徒インポートウィザードの状態管理フック
+ */
+export function useStudentImportWizard() {
+  const [state, setState] = useState<StudentImportWizardState>(
+    INITIAL_STUDENT_IMPORT_WIZARD_STATE
+  )
+
+  // ファイル選択
+  const selectFile = useCallback(async () => {
+    setState((prev) => ({ ...prev, isProcessing: true, error: null }))
+
+    try {
+      const result = await window.electronAPI.studentArchive.selectImportFile()
+
+      if (!result.success) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          error: result.error || "ファイル選択に失敗しました",
+        }))
+        return false
+      }
+
+      if (result.canceled) {
+        setState((prev) => ({ ...prev, isProcessing: false }))
+        return false
+      }
+
+      const archivePath = result.filePath!
+
+      // アーカイブ解析
+      const analyzeResult =
+        await window.electronAPI.studentArchive.analyzeArchive({ archivePath })
+
+      if (!analyzeResult.success) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          error: analyzeResult.error || "アーカイブの解析に失敗しました",
+        }))
+        return false
+      }
+
+      // 事前照合
+      const preMatchResult = await window.electronAPI.studentArchive.preMatch({
+        archivePath,
+      })
+
+      const fileOverviewData: StudentArchiveFileOverviewData | null =
+        preMatchResult.success ? (preMatchResult.data ?? null) : null
+
+      setState((prev) => ({
+        ...prev,
+        archivePath,
+        manifest: analyzeResult.manifest!,
+        fileOverviewData,
+        isProcessing: false,
+        currentStep: "file_overview",
+      }))
+
+      return true
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isProcessing: false,
+        error: error instanceof Error ? error.message : "エラーが発生しました",
+      }))
+      return false
+    }
+  }, [])
+
+  // ID統合設定を更新
+  const updateIdIntegrationConfig = useCallback(
+    (
+      category: "student" | "class",
+      config: Partial<CategoryIdIntegrationConfig>
+    ) => {
+      setState((prev) => ({
+        ...prev,
+        idIntegrationConfig: {
+          ...prev.idIntegrationConfig,
+          [category]: {
+            ...prev.idIntegrationConfig[category],
+            ...config,
+          },
+        },
+      }))
+    },
+    []
+  )
+
+  // 個別のID統合決定を更新
+  const updateIdIntegrationDecision = useCallback(
+    (
+      category: "student" | "class",
+      importId: string,
+      decision: Partial<IdIntegrationDecision>
+    ) => {
+      setState((prev) => {
+        const currentConfig = prev.idIntegrationConfig[category]
+        const existingIndex = currentConfig.decisions.findIndex(
+          (d) => d.importId === importId
+        )
+        const newDecisions = [...currentConfig.decisions]
+
+        if (existingIndex >= 0) {
+          newDecisions[existingIndex] = {
+            ...newDecisions[existingIndex],
+            ...decision,
+          }
+        } else {
+          newDecisions.push({
+            importId,
+            decisionType: "same_person",
+            ...decision,
+          } as IdIntegrationDecision)
+        }
+
+        return {
+          ...prev,
+          idIntegrationConfig: {
+            ...prev.idIntegrationConfig,
+            [category]: {
+              ...currentConfig,
+              decisions: newDecisions,
+            },
+          },
+        }
+      })
+    },
+    []
+  )
+
+  // 一括ID選択更新
+  const batchUpdateIdIntegrationDecisions = useCallback(
+    (category: "student" | "class", idChoice: IdChoice) => {
+      setState((prev) => {
+        const currentConfig = prev.idIntegrationConfig[category]
+        const newDecisions = currentConfig.decisions.map((d) => ({
+          ...d,
+          idChoice: d.decisionType === "same_person" ? idChoice : d.idChoice,
+        }))
+        return {
+          ...prev,
+          idIntegrationConfig: {
+            ...prev.idIntegrationConfig,
+            [category]: { ...currentConfig, decisions: newDecisions },
+          },
+        }
+      })
+    },
+    []
+  )
+
+  // フィールド更新決定を設定
+  const setFieldUpdateDecision = useCallback(
+    (key: string, field: string, strategy: UpdateStrategy) => {
+      setState((prev) => ({
+        ...prev,
+        updateDecisions: {
+          ...prev.updateDecisions,
+          [key]: {
+            ...(prev.updateDecisions[key] || {}),
+            [field]: strategy,
+          },
+        },
+      }))
+    },
+    []
+  )
+
+  // 一括更新戦略を設定
+  const setBulkUpdateStrategy = useCallback((strategy: UpdateStrategy) => {
+    setState((prev) => {
+      const newDecisions = { ...prev.updateDecisions }
+      for (const key of Object.keys(newDecisions)) {
+        const fields = newDecisions[key]
+        const updatedFields = { ...fields }
+        for (const field of Object.keys(updatedFields)) {
+          updatedFields[field] = strategy
+        }
+        newDecisions[key] = updatedFields
+      }
+      return { ...prev, updateDecisions: newDecisions }
+    })
+  }, [])
+
+  // 次のステップへ
+  const goToNextStep = useCallback(() => {
+    setState((prev) => {
+      const currentIndex = STUDENT_IMPORT_STEP_ORDER.indexOf(
+        prev.currentStep as (typeof STUDENT_IMPORT_STEP_ORDER)[number]
+      )
+      if (currentIndex < STUDENT_IMPORT_STEP_ORDER.length - 1) {
+        return {
+          ...prev,
+          currentStep: STUDENT_IMPORT_STEP_ORDER[currentIndex + 1],
+        }
+      }
+      return prev
+    })
+  }, [])
+
+  // 前のステップへ
+  const goBack = useCallback(() => {
+    setState((prev) => {
+      const currentIndex = STUDENT_IMPORT_STEP_ORDER.indexOf(
+        prev.currentStep as (typeof STUDENT_IMPORT_STEP_ORDER)[number]
+      )
+      if (currentIndex > 0) {
+        return {
+          ...prev,
+          currentStep: STUDENT_IMPORT_STEP_ORDER[currentIndex - 1],
+          error: null,
+        }
+      }
+      return prev
+    })
+  }, [])
+
+  // インポート実行
+  const executeImport = useCallback(async () => {
+    if (!state.archivePath || !state.fileOverviewData) return
+
+    setState((prev) => ({ ...prev, isProcessing: true, error: null }))
+
+    try {
+      const result = await window.electronAPI.studentArchive.import({
+        archivePath: state.archivePath,
+        preMatchResult: state.fileOverviewData,
+        integrationConfig: state.idIntegrationConfig,
+        updateDecisions:
+          Object.keys(state.updateDecisions).length > 0
+            ? state.updateDecisions
+            : undefined,
+      })
+
+      return result
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "インポートに失敗しました"
+      setState((prev) => ({
+        ...prev,
+        isProcessing: false,
+        error: errorMessage,
+      }))
+      return { success: false, error: errorMessage }
+    } finally {
+      setState((prev) => ({ ...prev, isProcessing: false }))
+    }
+  }, [
+    state.archivePath,
+    state.fileOverviewData,
+    state.idIntegrationConfig,
+    state.updateDecisions,
+  ])
+
+  // リセット
+  const reset = useCallback(() => {
+    setState(INITIAL_STUDENT_IMPORT_WIZARD_STATE)
+  }, [])
+
+  // エラーをクリア
+  const clearError = useCallback(() => {
+    setState((prev) => ({ ...prev, error: null }))
+  }, [])
+
+  return {
+    state,
+    selectFile,
+    updateIdIntegrationConfig,
+    updateIdIntegrationDecision,
+    batchUpdateIdIntegrationDecisions,
+    setFieldUpdateDecision,
+    setBulkUpdateStrategy,
+    goToNextStep,
+    goBack,
+    executeImport,
+    reset,
+    clearError,
+  }
+}
+
+export type StudentImportWizard = ReturnType<typeof useStudentImportWizard>

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1387,6 +1387,56 @@ export interface MyAPI {
     }>
   }
 
+  // =============================================================================
+  // 生徒アーカイブ（エクスポート/インポート）関連
+  // =============================================================================
+  studentArchive: {
+    /**
+     * 選択した生徒・学級データを.studentsファイルとしてエクスポート
+     */
+    exportStudents: (
+      options: import("./studentArchive.types").ExportStudentsArchiveOptions
+    ) => Promise<import("./studentArchive.types").ExportStudentsArchiveResult>
+
+    /**
+     * .studentsファイル選択ダイアログ
+     */
+    selectImportFile: () => Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+      error?: string
+    }>
+
+    /**
+     * アーカイブ解析（マニフェスト読み取り）
+     */
+    analyzeArchive: (options: { archivePath: string }) => Promise<{
+      success: boolean
+      manifest?: import("./studentArchive.types").StudentArchiveManifest
+      error?: string
+    }>
+
+    /**
+     * 事前照合を実行
+     */
+    preMatch: (options: { archivePath: string }) => Promise<{
+      success: boolean
+      data?: import("./studentArchive.types").StudentArchiveFileOverviewData
+      error?: string
+    }>
+
+    /**
+     * インポートを実行
+     */
+    import: (options: {
+      archivePath: string
+      preMatchResult: import("./studentArchive.types").StudentArchiveFileOverviewData
+      integrationConfig: import("./studentArchive.types").StudentArchiveIdIntegrationConfig
+      updateDecisions?: import("./examArchive.types").UpdateDecisions
+    }) => Promise<import("./studentArchive.types").StudentArchiveImportResult>
+  }
+
   // データ管理関連
   getDataDirectoryInfo: () => Promise<{
     success: boolean
@@ -1724,45 +1774,26 @@ export interface MyAPI {
       userId: string
     ) => Promise<{ success: boolean; error?: string }>
 
-    // UserScoringPreference
-    getUserScoringPreference: (userId: string) => Promise<{
-      success: boolean
-      preference?: UserScoringPreference | null
-      error?: string
-    }>
-    upsertUserScoringPreference: (
+    // UserPreference（KV方式）
+    getUserPreference: (
       userId: string,
-      data: {
-        showStudentNames?: boolean
-        autoScroll?: boolean
-        itemsPerLine?: number
-        layoutDirection?: string
-        expandMargin?: number
-        selectionBorderColor?: string | null
-        scoringStatusColors?: string | null
-        scoringColorPresetId?: string | null
-      }
+      key: string
     ) => Promise<{
       success: boolean
-      preference?: UserScoringPreference
+      value?: string | null
       error?: string
     }>
-
-    // カラム別操作（楽観的更新対応）
-    getScoringPreferenceColumn: <K extends ScoringPreferenceColumnName>(
+    setUserPreference: (
       userId: string,
-      column: K
+      key: string,
+      value: string
     ) => Promise<{
       success: boolean
-      value?: ScoringPreferenceColumns[K]
       error?: string
     }>
-    setScoringPreferenceColumn: <K extends ScoringPreferenceColumnName>(
-      userId: string,
-      column: K,
-      value: ScoringPreferenceColumns[K]
-    ) => Promise<{
+    getUserPreferences: (userId: string) => Promise<{
       success: boolean
+      preferences?: Record<string, string>
       error?: string
     }>
 
@@ -2532,51 +2563,6 @@ export interface UserExamWithExamDetails {
 // =============================================================================
 // Settings関連型
 // =============================================================================
-
-/**
- * ユーザー採点設定
- */
-export interface UserScoringPreference {
-  id: string
-  userId: string
-  showStudentNames: boolean
-  autoScroll: boolean
-  itemsPerLine: number
-  layoutDirection: string
-  expandMargin: number
-  selectionBorderColor: string | null
-  scoringStatusColors: string | null
-  scoringColorPresetId: string | null
-  createdAt: Date
-  updatedAt: Date
-}
-
-/**
- * UserScoringPreferenceのカラム名
- */
-export type ScoringPreferenceColumnName =
-  | "showStudentNames"
-  | "autoScroll"
-  | "itemsPerLine"
-  | "layoutDirection"
-  | "expandMargin"
-  | "selectionBorderColor"
-  | "scoringStatusColors"
-  | "scoringColorPresetId"
-
-/**
- * カラム別の値の型マッピング
- */
-export interface ScoringPreferenceColumns {
-  showStudentNames: boolean
-  autoScroll: boolean
-  itemsPerLine: number
-  layoutDirection: string
-  expandMargin: number
-  selectionBorderColor: string | null
-  scoringStatusColors: string | null
-  scoringColorPresetId: string | null
-}
 
 /**
  * 試験採点記号設定

--- a/types/studentArchive.types.ts
+++ b/types/studentArchive.types.ts
@@ -1,0 +1,167 @@
+/**
+ * 生徒・学級アーカイブ エクスポート/インポート機能の型定義
+ */
+
+import type {
+  ArchiveClassesData,
+  ArchiveStudentsData,
+  CategoryIdIntegrationConfig,
+  PreMatchingResult,
+  UpdateDecisions,
+} from "./examArchive.types"
+
+// =============================================================================
+// Archive Manifest
+// =============================================================================
+
+/**
+ * 生徒アーカイブのメタ情報
+ */
+export interface StudentArchiveManifest {
+  /** アーカイブ種別（試験アーカイブと区別するため） */
+  archiveType: "students"
+  /** アーカイブ形式バージョン */
+  version: string
+  /** アプリケーションバージョン */
+  appVersion: string
+  /** エクスポート日時 (ISO8601) */
+  exportedAt: string
+  /** データ件数サマリー */
+  counts: StudentArchiveDataCounts
+}
+
+/**
+ * 生徒アーカイブ内のデータ件数
+ */
+export interface StudentArchiveDataCounts {
+  students: number
+  classes: number
+  memberships: number
+}
+
+// =============================================================================
+// Export
+// =============================================================================
+
+/**
+ * エクスポートオプション
+ */
+export interface ExportStudentsArchiveOptions {
+  /** エクスポート対象の生徒ID */
+  studentIds: string[]
+  /** エクスポート対象の学級ID（省略時: 選択生徒に関連する全学級） */
+  classIds?: string[]
+}
+
+/**
+ * エクスポート結果
+ */
+export interface ExportStudentsArchiveResult {
+  success: boolean
+  outputPath?: string
+  manifest?: StudentArchiveManifest
+  error?: string
+}
+
+// =============================================================================
+// Import - File Overview
+// =============================================================================
+
+/**
+ * 生徒アーカイブのファイル概要データ（Step 2 表示用）
+ */
+export interface StudentArchiveFileOverviewData {
+  /** 生徒の照合結果 */
+  student: PreMatchingResult
+  /** 学級の照合結果 */
+  class: PreMatchingResult
+}
+
+// =============================================================================
+// Import - ID Integration
+// =============================================================================
+
+/**
+ * 生徒アーカイブのID統合設定
+ */
+export interface StudentArchiveIdIntegrationConfig {
+  student: CategoryIdIntegrationConfig
+  class: CategoryIdIntegrationConfig
+}
+
+// =============================================================================
+// Import - Result
+// =============================================================================
+
+/**
+ * インポート結果
+ */
+export interface StudentArchiveImportResult {
+  success: boolean
+  summary?: {
+    created: StudentArchiveDataCounts
+    updated: StudentArchiveDataCounts
+    skipped: StudentArchiveDataCounts
+    unchanged: StudentArchiveDataCounts
+  }
+  warnings?: string[]
+  error?: string
+}
+
+// =============================================================================
+// Import Wizard State
+// =============================================================================
+
+/**
+ * ウィザードのステップ
+ */
+export type StudentImportWizardStep =
+  | "file_select"
+  | "file_overview"
+  | "id_integration"
+  | "update_confirm"
+  | "final_confirm"
+  | "execute"
+
+/**
+ * ウィザードの状態
+ */
+export interface StudentImportWizardState {
+  currentStep: StudentImportWizardStep
+  archivePath: string | null
+  manifest: StudentArchiveManifest | null
+  fileOverviewData: StudentArchiveFileOverviewData | null
+  idIntegrationConfig: StudentArchiveIdIntegrationConfig
+  isProcessing: boolean
+  error: string | null
+  updateDecisions: UpdateDecisions
+}
+
+/**
+ * デフォルトのID統合設定
+ */
+export const DEFAULT_STUDENT_ID_INTEGRATION_CONFIG: StudentArchiveIdIntegrationConfig =
+  {
+    student: { strategy: "by_student_number", decisions: [] },
+    class: { strategy: "by_name", decisions: [] },
+  }
+
+/**
+ * 初期ウィザード状態
+ */
+export const INITIAL_STUDENT_IMPORT_WIZARD_STATE: StudentImportWizardState = {
+  currentStep: "file_select",
+  archivePath: null,
+  manifest: null,
+  fileOverviewData: null,
+  idIntegrationConfig: DEFAULT_STUDENT_ID_INTEGRATION_CONFIG,
+  isProcessing: false,
+  error: null,
+  updateDecisions: {},
+}
+
+// =============================================================================
+// Re-export for convenience
+// =============================================================================
+
+export type { ArchiveClassesData, ArchiveStudentsData }


### PR DESCRIPTION
## Summary
- 生徒管理画面から生徒・学級データを `.students` ファイルとして独立エクスポート/インポートできる機能を追加
- 既存の試験アーカイブインポートのマッチング・プロセッサーロジックを最大限再利用
- `processMemberships()` を export 化して `ExtractedArchiveData` への依存を除去

## 変更ファイル（21ファイル）

### 新規（16ファイル）
- `types/studentArchive.types.ts` — 型定義
- `electron-src/lib/export/student-archive/` — エクスポートバックエンド（3ファイル）
- `electron-src/lib/import/student-archive/` — インポートバックエンド（2ファイル）
- `electron-src/ipc-handlers/studentArchiveHandlers.ts` — IPCハンドラー
- `components/student/StudentArchiveExportDialog.tsx` — エクスポートダイアログ
- `components/student-import/` — インポートウィザード（7ファイル）
- `hooks/student-import/useStudentImportWizard.ts` — ウィザードフック

### 修正（5ファイル）
- `electron-src/lib/import/merge/idIntegrationImporter.ts` — `processMemberships` を export + 引数変更
- `electron-src/ipc-handlers/index.ts` — ハンドラー登録追加
- `electron-src/preload.ts` — `studentArchive` API追加
- `types/electron.d.ts` — 型定義追加
- `components/student/StudentTable.tsx` — ボタン・モーダル追加

## Test plan
- [ ] 生徒管理画面で生徒を選択 → 「アーカイブ書き出し」→ `.students` ファイルが作成される
- [ ] 学級チェックボックスで学級を絞り込めること
- [ ] 同一PCへのインポート: UUID一致で自動照合される
- [ ] 別PCへのインポート: 学籍番号・氏名による二次照合が機能する
- [ ] ID統合（use_import_id / use_existing_id）が正常に動作する
- [ ] Membership の重複登録が起こらない
- [ ] 既存の試験アーカイブインポートが影響を受けない（`processMemberships` リファクタの回帰テスト）
- [ ] `npm run typecheck` 通過
- [ ] `npm run lint` 通過

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)