### PR TITLE
feat: 個別表示モード模範解答表示 + UserPreference KV移行 + unscored統一

### DIFF
--- a/__tests__/helpers/testPrismaClient.ts
+++ b/__tests__/helpers/testPrismaClient.ts
@@ -76,7 +76,7 @@ export async function cleanupTestDatabase(): Promise<void> {
   await prisma.student.deleteMany()
   await prisma.class.deleteMany()
   await prisma.userKeyboardShortcut.deleteMany()
-  await prisma.userScoringPreference.deleteMany()
+  await prisma.userPreference.deleteMany()
   await prisma.user.deleteMany()
 }
 

--- a/app/settings/components/DisplaySettingsTab.tsx
+++ b/app/settings/components/DisplaySettingsTab.tsx
@@ -50,35 +50,36 @@ export function DisplaySettingsTab() {
     getCurrentPresetId
   )
 
-  // 初期値をロード（カラム別）
+  // 初期値をロード（KV方式）
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) return
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
 
     const loadSettings = async () => {
       if (window.electronAPI?.settings) {
         try {
-          // selectionBorderColorカラムのみ読み込み
-          const result =
-            await window.electronAPI.settings.getScoringPreferenceColumn(
-              userId,
-              "selectionBorderColor"
-            )
-          if (result.success && result.value) {
-            setSelectionBorderColor(result.value)
+          const result = await window.electronAPI.settings.getUserPreference(
+            userId,
+            "selectionBorderColor"
+          )
+          if (result.success && result.value && result.value !== "null") {
+            let parsed = result.value
+            try {
+              parsed = JSON.parse(result.value)
+            } catch {
+              // keep raw
+            }
+            if (parsed) {
+              setSelectionBorderColor(parsed)
+            }
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)
         }
       }
 
-      // 採点状態色をDBから読み込み（scoringStatusColorsは内部でカラム別読み込み）
       await loadScoringStatusColors(userId)
       setScoringColors(getScoringStatusColors())
       setCurrentPresetId(getCurrentPresetId())
@@ -87,7 +88,7 @@ export function DisplaySettingsTab() {
     loadSettings()
   }, [userId])
 
-  // 選択枠色の変更（カラム別・楽観的更新）
+  // 選択枠色の変更（KV方式・楽観的更新）
   const handleSelectionBorderColorChange = useCallback(
     async (color: string) => {
       const upperColor = color.toUpperCase()
@@ -95,10 +96,10 @@ export function DisplaySettingsTab() {
 
       if (userId && window.electronAPI?.settings) {
         try {
-          await window.electronAPI.settings.setScoringPreferenceColumn(
+          await window.electronAPI.settings.setUserPreference(
             userId,
             "selectionBorderColor",
-            upperColor
+            JSON.stringify(upperColor)
           )
           window.dispatchEvent(new CustomEvent("selectionBorderColorChanged"))
           toast.success("選択枠色が変更されました")

--- a/components/exams/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
+++ b/components/exams/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
@@ -30,10 +30,10 @@ export function getDynamicScoreStatusConfig(colors: ScoringStatusColors) {
   return {
     unscored: {
       icon: Circle,
-      bgStyle: { backgroundColor: colors.ungraded.bg },
-      selectedBgStyle: { backgroundColor: colors.ungraded.bg, opacity: 0.8 },
-      textStyle: { color: colors.ungraded.text },
-      iconStyle: { color: colors.ungraded.icon },
+      bgStyle: { backgroundColor: colors.unscored.bg },
+      selectedBgStyle: { backgroundColor: colors.unscored.bg, opacity: 0.8 },
+      textStyle: { color: colors.unscored.text },
+      iconStyle: { color: colors.unscored.icon },
       key: "q",
     },
     correct: {

--- a/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
+++ b/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
@@ -1,14 +1,12 @@
 /**
  * 選択枠の色を取得・監視するフック
- * 機能G: ユーザー設定の永続化
- *
- * カラム別楽観的更新パターン:
- * - selectionBorderColorカラムのみを読み書き
+ * KV方式ユーザー設定の永続化
  */
 
 import { useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
+import { parsePreference } from "@/lib/userPreferences"
 
 const DEFAULT_SELECTION_BORDER_COLOR = "#F97316" // orange-500
 
@@ -18,29 +16,28 @@ export function useSelectionBorder(): string {
   const [color, setColor] = useState(DEFAULT_SELECTION_BORDER_COLOR)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
-  // 設定を読み込む（カラム別）
+  // 設定を読み込む（KV方式）
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
+    if (!userId) return
 
-    // userIdがundefinedの場合は待機（refは更新しない）
-    if (!userId) {
-      return
-    }
-
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
 
     const loadColor = async () => {
       if (window.electronAPI?.settings) {
         try {
-          const result =
-            await window.electronAPI.settings.getScoringPreferenceColumn(
-              userId,
-              "selectionBorderColor"
+          const result = await window.electronAPI.settings.getUserPreference(
+            userId,
+            "selectionBorderColor"
+          )
+          if (result.success) {
+            const parsed = parsePreference(
+              "selectionBorderColor",
+              result.value ?? null
             )
-          if (result.success && result.value) {
-            setColor(result.value)
+            if (parsed) {
+              setColor(parsed)
+            }
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)
@@ -56,13 +53,18 @@ export function useSelectionBorder(): string {
     const handleColorChange = async () => {
       if (userId && window.electronAPI?.settings) {
         try {
-          const result =
-            await window.electronAPI.settings.getScoringPreferenceColumn(
-              userId,
-              "selectionBorderColor"
+          const result = await window.electronAPI.settings.getUserPreference(
+            userId,
+            "selectionBorderColor"
+          )
+          if (result.success) {
+            const parsed = parsePreference(
+              "selectionBorderColor",
+              result.value ?? null
             )
-          if (result.success && result.value) {
-            setColor(result.value)
+            if (parsed) {
+              setColor(parsed)
+            }
           }
         } catch (error) {
           console.error("選択枠色の読み込みに失敗しました:", error)

--- a/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { useParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
 import { getScoringStatusFromArray } from "@/components/exams/07-score-at-once/types"
@@ -43,10 +50,30 @@ export default function AnswerIndividualView({
   onQuestionScoreCreated,
   onAnnotationChanged,
   annotationRefreshKey,
+  masterOverlayImageUrls,
+  masterOverlayOpacity = 50,
+  masterOverlayVisible = false,
+  masterDisplayMode = "overlay",
+  onZoomChanged,
+  scrollContainerRef,
+  onImageSizeChanged,
 }: AnswerIndividualViewProps) {
   // 画像ナビゲーション状態管理（内部管理）
-  const { zoom, position, onZoomChange, onPositionChange } =
-    useImageNavigation()
+  const {
+    zoom,
+    position,
+    onZoomChange: rawOnZoomChange,
+    onPositionChange,
+  } = useImageNavigation()
+
+  // zoom変更をラップして外部にも通知
+  const onZoomChange = useCallback(
+    (newZoom: number) => {
+      rawOnZoomChange(newZoom)
+      onZoomChanged?.(newZoom)
+    },
+    [rawOnZoomChange, onZoomChanged]
+  )
 
   // 印字設定（採点マーク・点数表示のプレビュー用）をDBからロード
   const params = useParams()
@@ -198,6 +225,26 @@ export default function AnswerIndividualView({
     scoringMarkConfig,
   })
 
+  // 画像サイズ通知（split表示のMasterパネルで参照サイズとして使用）
+  useEffect(() => {
+    if (onImageSizeChanged && loadedImages.length > 0) {
+      onImageSizeChanged({
+        width: loadedImages[0].naturalWidth,
+        heights: loadedImages.map((img) => img.naturalHeight),
+      })
+    }
+  }, [loadedImages, onImageSizeChanged])
+
+  // scrollContainerRefの同期（split表示のスクロール同期用）
+  // useLayoutEffectでDOMコミット直後に確実に設定
+  useLayoutEffect(() => {
+    if (scrollContainerRef && containerRef.current) {
+      ;(
+        scrollContainerRef as React.MutableRefObject<HTMLDivElement | null>
+      ).current = containerRef.current
+    }
+  })
+
   // Canvas・V4統合フック
   const {
     canvasWidth,
@@ -226,6 +273,7 @@ export default function AnswerIndividualView({
       loadedImages,
       pageSpacing,
       currentCropRegion,
+      splitMode: null,
     })
 
   // 描画ツールキーボードショートカット
@@ -243,6 +291,7 @@ export default function AnswerIndividualView({
     loadedImages,
     pageSpacing,
     currentCropRegion,
+    splitMode: null,
   })
 
   // イベントハンドリング
@@ -363,6 +412,61 @@ export default function AnswerIndividualView({
     [favoriteElementIds, drawingState]
   )
 
+  // 模範解答オーバーレイ用の画像読み込み（全ページ）
+  const [masterOverlayImages, setMasterOverlayImages] = useState<
+    HTMLImageElement[]
+  >([])
+  useEffect(() => {
+    if (!masterOverlayImageUrls || masterOverlayImageUrls.length === 0) {
+      setMasterOverlayImages([])
+      return
+    }
+    let cancelled = false
+    const loadAll = async () => {
+      const results = await Promise.allSettled(
+        masterOverlayImageUrls.map(
+          (url) =>
+            new Promise<HTMLImageElement>((resolve, reject) => {
+              const img = new Image()
+              img.onload = () => resolve(img)
+              img.onerror = reject
+              img.src = url
+            })
+        )
+      )
+      if (cancelled) return
+      setMasterOverlayImages(
+        results
+          .filter(
+            (r): r is PromiseFulfilledResult<HTMLImageElement> =>
+              r.status === "fulfilled"
+          )
+          .map((r) => r.value)
+      )
+    }
+    loadAll()
+    return () => {
+      cancelled = true
+    }
+  }, [masterOverlayImageUrls])
+
+  // 答案コンテンツの自然サイズ（ズーム前、ピクセル単位）
+  const answerNaturalWidth =
+    loadedImages.length > 0 ? loadedImages[0].naturalWidth : 800
+  const answerNaturalHeight =
+    loadedImages.length > 0
+      ? loadedImages.reduce(
+          (total, img, index) =>
+            total +
+            img.naturalHeight +
+            (index < loadedImages.length - 1 ? pageSpacing || 20 : 0),
+          0
+        )
+      : 600
+
+  // overlay表示判定
+  const isOverlayMode = masterDisplayMode === "overlay"
+
   // 採点データが選択されていない場合の早期リターン
   if (!currentScoringData) {
     return (
@@ -394,24 +498,8 @@ export default function AnswerIndividualView({
         <div
           className="relative grid place-items-center"
           style={{
-            width:
-              loadedImages.length > 0
-                ? `${loadedImages[0].naturalWidth * zoom}px`
-                : `${800 * zoom}px`,
-            height:
-              loadedImages.length > 0
-                ? `${
-                    loadedImages.reduce(
-                      (total, img, index) =>
-                        total +
-                        img.naturalHeight +
-                        (index < loadedImages.length - 1
-                          ? pageSpacing || 20
-                          : 0),
-                      0
-                    ) * zoom
-                  }px`
-                : `${600 * zoom}px`,
+            width: `${answerNaturalWidth * zoom}px`,
+            height: `${answerNaturalHeight * zoom}px`,
             minWidth: "100%",
             minHeight: "100%",
           }}
@@ -538,8 +626,56 @@ export default function AnswerIndividualView({
               transform: "translateZ(0)",
             }}
           />
+          {/* 模範解答オーバーレイ画像（overlay モード時・ページごとに描画） */}
+          {isOverlayMode &&
+            masterOverlayImages.length > 0 &&
+            masterOverlayImages.map((masterImg, pageIndex) => {
+              let pageOffsetY = 0
+              for (let i = 0; i < pageIndex; i++) {
+                const srcImg = loadedImages[i] || masterOverlayImages[i]
+                if (srcImg) {
+                  pageOffsetY += srcImg.naturalHeight + (pageSpacing || 20)
+                }
+              }
+              const pageImg = loadedImages[pageIndex]
+              const pageWidth = pageImg
+                ? pageImg.naturalWidth
+                : masterImg.naturalWidth
+              const pageHeight = pageImg
+                ? pageImg.naturalHeight
+                : masterImg.naturalHeight
+
+              return (
+                <img
+                  key={`master-overlay-${pageIndex}`}
+                  src={masterImg.src}
+                  alt={`模範解答 ページ${pageIndex + 1}`}
+                  className="pointer-events-none absolute left-0 block"
+                  style={{
+                    top: `${pageOffsetY * zoom}px`,
+                    width: `${pageWidth * zoom}px`,
+                    height: `${pageHeight * zoom}px`,
+                    imageRendering: "pixelated",
+                    opacity: masterOverlayVisible
+                      ? masterOverlayOpacity / 100
+                      : 0,
+                    transition: "opacity 0.15s ease-in-out",
+                  }}
+                  draggable={false}
+                />
+              )
+            })}
         </div>
       </div>
+
+      {/* 模範解答ラベル（overlay表示時） */}
+      {isOverlayMode &&
+        masterOverlayVisible &&
+        masterOverlayImages.length > 0 && (
+          <div className="pointer-events-none absolute top-2 left-2 z-10 rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white">
+            模範解答
+          </div>
+        )}
 
       {/* 画像が読み込まれていない場合 */}
       {!imageLoaded && (

--- a/components/exams/07-score-at-once/ScoringIndividual/MasterAnswerView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/MasterAnswerView.tsx
@@ -1,0 +1,250 @@
+"use client"
+
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
+
+interface MasterAnswerViewProps {
+  /** 模範解答の画像URL（単一ページ用、後方互換） */
+  masterImageUrl?: string | null
+  /** 全ページの模範解答画像URL（ページ番号順） */
+  masterImageUrls?: string[]
+  /** ズーム倍率（答案ビューと同期） */
+  zoom: number
+  /** overlay時の不透明度（0-100） */
+  opacity?: number
+  /** overlay時はtrue */
+  isOverlay?: boolean
+  /** overlay時の表示制御 */
+  visible?: boolean
+  /** ページ間隔（答案ビューと一致させる） */
+  pageSpacing?: number
+  /**
+   * 答案側の画像サイズ（参照サイズ）
+   * 模範解答と答案の画素数が異なる場合、答案側のサイズに合わせて描画する
+   */
+  referenceImageSize?: {
+    width: number
+    heights: number[]
+  }
+  /** 答案側のスクロールコンテナRef（wheelイベント転送用） */
+  answerScrollRef?: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * 模範解答画像ビューア（2画面表示用）
+ * 答案ビューとzoom・scrollを同期して並列表示する
+ */
+export const MasterAnswerView = forwardRef<
+  HTMLDivElement,
+  MasterAnswerViewProps
+>(function MasterAnswerView(
+  {
+    masterImageUrl,
+    masterImageUrls,
+    zoom,
+    opacity = 50,
+    isOverlay = false,
+    visible = true,
+    pageSpacing = 20,
+    referenceImageSize,
+    answerScrollRef,
+  },
+  ref
+) {
+  const urls = masterImageUrls ?? (masterImageUrl ? [masterImageUrl] : [])
+  const [loadedImages, setLoadedImages] = useState<HTMLImageElement[]>([])
+  const internalRef = useRef<HTMLDivElement>(null)
+
+  // refを内部refと統合
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      internalRef.current = node
+      if (typeof ref === "function") {
+        ref(node)
+      } else if (ref) {
+        ;(ref as React.MutableRefObject<HTMLDivElement | null>).current = node
+      }
+    },
+    [ref]
+  )
+
+  // 全ページの画像を読み込み
+  useEffect(() => {
+    if (urls.length === 0) {
+      setLoadedImages([])
+      return
+    }
+    let cancelled = false
+    const loadAll = async () => {
+      const results = await Promise.allSettled(
+        urls.map(
+          (url) =>
+            new Promise<HTMLImageElement>((resolve, reject) => {
+              const img = new Image()
+              img.onload = () => resolve(img)
+              img.onerror = reject
+              img.src = url
+            })
+        )
+      )
+      if (cancelled) return
+      setLoadedImages(
+        results
+          .filter(
+            (r): r is PromiseFulfilledResult<HTMLImageElement> =>
+              r.status === "fulfilled"
+          )
+          .map((r) => r.value)
+      )
+    }
+    loadAll()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(urls)])
+
+  // ホイールズーム: Ctrl/Meta + ホイールを答案側コンテナに転送
+  // 答案側の既存のwheelハンドラがzoom計算を行い、onZoomChanged経由で同期される
+  useEffect(() => {
+    const container = internalRef.current
+    if (!container || !answerScrollRef) return
+
+    const handleWheel = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return
+      e.preventDefault()
+
+      const answerEl = answerScrollRef.current
+      if (!answerEl) return
+
+      // 答案側コンテナの対応する位置を計算してwheelイベントを転送
+      const masterRect = container.getBoundingClientRect()
+      const answerRect = answerEl.getBoundingClientRect()
+
+      // マスター側のマウス位置をコンテナ内の相対位置（0-1）に変換
+      const relX = (e.clientX - masterRect.left) / masterRect.width
+      const relY = (e.clientY - masterRect.top) / masterRect.height
+
+      // 答案側コンテナの対応するクライアント座標
+      const answerClientX = answerRect.left + relX * answerRect.width
+      const answerClientY = answerRect.top + relY * answerRect.height
+
+      // 答案側に合成wheelイベントをdispatch
+      const syntheticEvent = new WheelEvent("wheel", {
+        deltaX: e.deltaX,
+        deltaY: e.deltaY,
+        deltaMode: e.deltaMode,
+        clientX: answerClientX,
+        clientY: answerClientY,
+        ctrlKey: e.ctrlKey,
+        metaKey: e.metaKey,
+        bubbles: true,
+      })
+      answerEl.dispatchEvent(syntheticEvent)
+    }
+
+    container.addEventListener("wheel", handleWheel, { passive: false })
+    return () => container.removeEventListener("wheel", handleWheel)
+  }, [answerScrollRef])
+
+  if (urls.length === 0) {
+    if (isOverlay) return null
+    return (
+      <div className="flex h-full items-center justify-center bg-gray-50 text-gray-400">
+        模範解答なし
+      </div>
+    )
+  }
+
+  const refWidth = referenceImageSize?.width
+  const refHeights = referenceImageSize?.heights
+
+  const contentWidth = refWidth ?? (loadedImages[0]?.naturalWidth || 800)
+  const contentHeight =
+    refHeights && refHeights.length > 0
+      ? refHeights.reduce(
+          (total, h, index) =>
+            total + h + (index < refHeights.length - 1 ? pageSpacing : 0),
+          0
+        )
+      : loadedImages.length > 0
+        ? loadedImages.reduce(
+            (total, img, index) =>
+              total +
+              img.naturalHeight +
+              (index < loadedImages.length - 1 ? pageSpacing : 0),
+            0
+          )
+        : 600
+
+  return (
+    <div
+      ref={setRefs}
+      className={`h-full w-full ${isOverlay ? "" : "overflow-auto"}`}
+      style={
+        isOverlay
+          ? {
+              position: "absolute",
+              inset: 0,
+              pointerEvents: "none",
+              opacity: visible ? opacity / 100 : 0,
+              overflow: "auto",
+              scrollbarWidth: "none",
+              transition: "opacity 0.15s ease-in-out",
+            }
+          : {}
+      }
+    >
+      <div
+        className="relative grid place-items-center"
+        style={{
+          width: `${contentWidth * zoom}px`,
+          height: `${contentHeight * zoom}px`,
+          minWidth: "100%",
+          minHeight: "100%",
+        }}
+      >
+        {loadedImages.map((img, pageIndex) => {
+          const displayWidth = refWidth ?? img.naturalWidth
+          const displayHeight =
+            refHeights && refHeights[pageIndex] !== undefined
+              ? refHeights[pageIndex]
+              : img.naturalHeight
+
+          let offsetY = 0
+          for (let i = 0; i < pageIndex; i++) {
+            const h =
+              refHeights && refHeights[i] !== undefined
+                ? refHeights[i]
+                : loadedImages[i]?.naturalHeight || 0
+            offsetY += h + pageSpacing
+          }
+
+          return (
+            <img
+              key={`master-page-${pageIndex}`}
+              src={img.src}
+              alt={`模範解答 ページ${pageIndex + 1}`}
+              className="pointer-events-none absolute left-0 block"
+              style={{
+                top: `${offsetY * zoom}px`,
+                width: `${displayWidth * zoom}px`,
+                height: `${displayHeight * zoom}px`,
+                imageRendering: "pixelated",
+              }}
+              draggable={false}
+            />
+          )
+        })}
+      </div>
+
+      {isOverlay && visible && (
+        <div
+          className="absolute top-2 left-2 rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white"
+          style={{ pointerEvents: "none" }}
+        >
+          模範解答
+        </div>
+      )}
+    </div>
+  )
+})

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useQuestionAutoScroll.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useQuestionAutoScroll.ts
@@ -20,6 +20,8 @@ export interface UseQuestionAutoScrollParams {
   pageSpacing?: number
   /** 現在の設問領域 */
   currentCropRegion?: CropRegionWithExamPage | null
+  /** split表示モード（スクロール中心の補正用） */
+  splitMode?: "horizontal" | "vertical" | null
 }
 
 /**
@@ -39,6 +41,7 @@ export function useQuestionAutoScroll({
   loadedImages,
   pageSpacing = 20,
   currentCropRegion,
+  splitMode,
 }: UseQuestionAutoScrollParams): void {
   useEffect(() => {
     if (
@@ -86,9 +89,17 @@ export function useQuestionAutoScroll({
       const questionCenterScreenX = (questionCenterX + imageOffsetX) * zoom
       const questionCenterScreenY = (questionCenterY + pageOffsetY) * zoom
 
-      // コンテナ中心座標
-      const containerCenterX = container.offsetWidth / 2
-      const containerCenterY = container.offsetHeight / 2
+      // コンテナ中心座標（split時は1セル分の中心）
+      const cellWidth =
+        splitMode === "horizontal"
+          ? (container.offsetWidth - 2) / 2
+          : container.offsetWidth
+      const cellHeight =
+        splitMode === "vertical"
+          ? (container.offsetHeight - 2) / 2
+          : container.offsetHeight
+      const containerCenterX = cellWidth / 2
+      const containerCenterY = cellHeight / 2
 
       // 理想的なスクロール位置（設問を中央に）
       const idealScrollLeft = questionCenterScreenX - containerCenterX
@@ -113,5 +124,6 @@ export function useQuestionAutoScroll({
     loadedImages,
     pageSpacing,
     zoom,
+    splitMode,
   ])
 }

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useZoomAndScroll.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useZoomAndScroll.ts
@@ -24,6 +24,8 @@ export interface UseZoomAndScrollParams {
   pageSpacing?: number
   /** 現在の設問領域 */
   currentCropRegion?: CropRegionWithExamPage | null
+  /** split表示モード（利用可能幅/高さの補正用） */
+  splitMode?: "horizontal" | "vertical" | null
 }
 
 /** ズーム・スクロール操作フックの戻り値 */
@@ -56,6 +58,7 @@ export function useZoomAndScroll({
   loadedImages,
   pageSpacing = 20,
   currentCropRegion,
+  splitMode,
 }: UseZoomAndScrollParams): UseZoomAndScrollReturn {
   // ズームイン（CSS scale + scroll 方式）
   const handleZoomIn = useCallback(() => {
@@ -134,8 +137,15 @@ export function useZoomAndScroll({
       return
 
     const container = containerRef.current
-    const availableWidth = container.offsetWidth
-    const availableHeight = container.offsetHeight
+    // split時は利用可能領域を補正（gridの1セル分）
+    const availableWidth =
+      splitMode === "horizontal"
+        ? (container.offsetWidth - 2) / 2
+        : container.offsetWidth
+    const availableHeight =
+      splitMode === "vertical"
+        ? (container.offsetHeight - 2) / 2
+        : container.offsetHeight
 
     // パディングを考慮
     const padding = 40
@@ -176,7 +186,14 @@ export function useZoomAndScroll({
     requestAnimationFrame(() => {
       container.scrollTo(Math.max(0, scrollLeft), Math.max(0, scrollTop))
     })
-  }, [containerRef, imageLoaded, loadedImages, pageSpacing, onZoomChange])
+  }, [
+    containerRef,
+    imageLoaded,
+    loadedImages,
+    pageSpacing,
+    onZoomChange,
+    splitMode,
+  ])
 
   // 設問表示（CSS scale + scroll 方式）
   const handleCropView = useCallback(() => {
@@ -189,8 +206,15 @@ export function useZoomAndScroll({
       return
 
     const container = containerRef.current
-    const availableWidth = container.offsetWidth
-    const availableHeight = container.offsetHeight
+    // split時は利用可能領域を補正（gridの1セル分）
+    const availableWidth =
+      splitMode === "horizontal"
+        ? (container.offsetWidth - 2) / 2
+        : container.offsetWidth
+    const availableHeight =
+      splitMode === "vertical"
+        ? (container.offsetHeight - 2) / 2
+        : container.offsetHeight
 
     // 余白の比率: 2:6:2（左右/上下に20%ずつの余白、中央60%に設問を表示）
     const marginRatio = 0.2
@@ -251,9 +275,17 @@ export function useZoomAndScroll({
       const questionCenterScreenX = (questionCenterX + imageOffsetX) * newZoom
       const questionCenterScreenY = (questionCenterY + pageOffsetY) * newZoom
 
-      // コンテナ中心座標（現在のコンテナサイズを使用）
-      const containerCenterX = container.offsetWidth / 2
-      const containerCenterY = container.offsetHeight / 2
+      // コンテナ中心座標（split時は1セル分の中心）
+      const cellWidth =
+        splitMode === "horizontal"
+          ? (container.offsetWidth - 2) / 2
+          : container.offsetWidth
+      const cellHeight =
+        splitMode === "vertical"
+          ? (container.offsetHeight - 2) / 2
+          : container.offsetHeight
+      const containerCenterX = cellWidth / 2
+      const containerCenterY = cellHeight / 2
 
       // 設問中心をコンテナ中心に配置するためのスクロール位置
       const scrollLeft = questionCenterScreenX - containerCenterX
@@ -269,6 +301,7 @@ export function useZoomAndScroll({
     loadedImages,
     onZoomChange,
     pageSpacing,
+    splitMode,
   ])
 
   return {

--- a/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -98,6 +98,23 @@ export interface AnswerIndividualViewProps {
   onAnnotationChanged?: () => void
   // 外部からのアノテーション追加後のリフレッシュキー（ブラウザパネル→キャンバス連携用）
   annotationRefreshKey?: number
+
+  // 模範解答表示（ズーム・スクロール同期のため内部で描画）
+  /** 全ページの模範解答画像URL（ページ番号順） */
+  masterOverlayImageUrls?: string[]
+  masterOverlayOpacity?: number
+  masterOverlayVisible?: boolean
+  /** 模範解答表示モード（overlay のみ内部描画） */
+  masterDisplayMode?: "overlay"
+  /** zoom変更通知（split表示のMasterパネルと同期するため） */
+  onZoomChanged?: (zoom: number) => void
+  /** スクロールコンテナのRef公開（split表示のscroll同期用） */
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>
+  /** 読み込み済み画像サイズ通知（split表示のMasterパネルで参照サイズとして使用） */
+  onImageSizeChanged?: (size: {
+    width: number
+    heights: number[]
+  }) => void
 }
 
 // 選択範囲矩形の型定義

--- a/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -1,11 +1,15 @@
 "use client"
 
+import { useCallback, useEffect, useRef, useState } from "react"
+
 import AnswerGridView from "@/components/exams/07-score-at-once/ScoringGrid/AnswerGridView"
 import AnswerIndividualView from "@/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView"
+import { MasterAnswerView } from "@/components/exams/07-score-at-once/ScoringIndividual/MasterAnswerView"
 import type {
   CropRegionWithExamPage,
   GradingMode,
   LayoutDirection,
+  MasterAnswerDisplayMode,
   MasterGridItem,
   QuestionScore,
   ScoringData,
@@ -14,51 +18,32 @@ import type {
 
 interface ScoringContentAreaProps {
   gradingMode: GradingMode
-
-  /** 採点データ管理（両View共通） */
   allScoringData: ScoringData[]
   masterAnswerData: MasterGridItem | null
   filteredScoringDataIds: string[]
   selectedScoringDataIds: Set<string>
-
-  /** 設問情報（Individual表示のみ必要） */
   currentCropRegion?: CropRegionWithExamPage
-  /** 全採点領域（Individual表示の全設問マーク描画用） */
   cropRegions?: CropRegionWithExamPage[]
-
-  /** 操作関数（両View共通） */
   onScoringDataSelect: (dataId: string, isSelected: boolean) => void
   onScoringDataReplace?: (ids: string[]) => void
-
-  /** GridView設定 */
   layoutDirection: LayoutDirection
   itemsPerLine: number[]
   autoScroll: boolean
   showStudentNames: boolean
   expandMargin?: number
-
-  /** IndividualView設定 */
   studentAnswerImages?: StudentAnswerImageWithExamStudents[]
-
-  /** テキスト入力状態変更のコールバック（ショートカット制御用） */
   onTextInputStateChange?: (showTextInput: boolean) => void
-
-  /** QuestionScore自動作成用のコンテキスト情報 */
   currentStudentId?: string
   currentUserId?: string
-
-  /** アノテーション用: QuestionScore配列 */
   questionScores?: QuestionScore[]
-
-  /** QuestionScore自動作成後のコールバック（リストの更新用） */
   onQuestionScoreCreated?: () => void
-
-  /** アノテーション変更通知（キャンバス→ブラウザパネル連携用） */
   onAnnotationChanged?: () => void
-  /** 外部からのアノテーション追加後のリフレッシュキー（ブラウザパネル→キャンバス連携用） */
   annotationRefreshKey?: number
-  /** Grid表示用アノテーションリフレッシュキー */
   gridAnnotationRefreshKey?: number
+  masterAnswerDisplayMode?: MasterAnswerDisplayMode
+  masterAnswerOpacity?: number
+  masterAnswerVisible?: boolean
+  allMasterImageUrls?: string[]
 }
 
 export function ScoringContentArea({
@@ -85,8 +70,11 @@ export function ScoringContentArea({
   onAnnotationChanged,
   annotationRefreshKey,
   gridAnnotationRefreshKey,
+  masterAnswerDisplayMode = "off",
+  masterAnswerOpacity = 50,
+  masterAnswerVisible = false,
+  allMasterImageUrls,
 }: ScoringContentAreaProps) {
-  /** 個別表示時：selectedの最初の要素を利用 */
   const currentScoringDataId =
     gradingMode === "individual"
       ? selectedScoringDataIds.size > 0
@@ -96,9 +84,110 @@ export function ScoringContentArea({
           : null
       : null
 
-  /** Grid layoutでは不要な階層を削除し、直接表示 */
-  return gradingMode === "individual" ? (
-    /** 個別表示はフルサイズ表示 */
+  // ===== split用: zoom同期 + 画像サイズ同期 =====
+  const [syncedZoom, setSyncedZoom] = useState(1)
+  const [answerImageSize, setAnswerImageSize] = useState<{
+    width: number
+    heights: number[]
+  } | null>(null)
+  const answerScrollRef = useRef<HTMLDivElement | null>(null)
+  const masterScrollRef = useRef<HTMLDivElement>(null)
+
+  const handleZoomChanged = useCallback((zoom: number) => {
+    setSyncedZoom(zoom)
+  }, [])
+
+  const handleImageSizeChanged = useCallback(
+    (size: { width: number; heights: number[] }) => {
+      setAnswerImageSize(size)
+    },
+    []
+  )
+
+  const isSplitH = masterAnswerDisplayMode === "split-horizontal"
+  const isSplitV = masterAnswerDisplayMode === "split-vertical"
+  const isSplit = isSplitH || isSplitV
+  const showSplit = masterAnswerVisible && isSplit
+
+  // ===== split用: 双方向スクロール同期（rAFループ） =====
+  const rafIdRef = useRef<number>(0)
+  const prevAnswerRef = useRef({ left: 0, top: 0 })
+  const prevMasterRef = useRef({ left: 0, top: 0 })
+
+  useEffect(() => {
+    if (!showSplit) {
+      // リセット
+      prevAnswerRef.current = { left: 0, top: 0 }
+      prevMasterRef.current = { left: 0, top: 0 }
+      return
+    }
+
+    const sync = () => {
+      const answer = answerScrollRef.current
+      const master = masterScrollRef.current
+
+      if (answer && master) {
+        const aLeft = answer.scrollLeft
+        const aTop = answer.scrollTop
+        const mLeft = master.scrollLeft
+        const mTop = master.scrollTop
+
+        const answerChanged =
+          aLeft !== prevAnswerRef.current.left ||
+          aTop !== prevAnswerRef.current.top
+        const masterChanged =
+          mLeft !== prevMasterRef.current.left ||
+          mTop !== prevMasterRef.current.top
+
+        if (answerChanged) {
+          // 答案側が変化 → 模範解答に同期
+          master.scrollLeft = aLeft
+          master.scrollTop = aTop
+          prevAnswerRef.current = { left: aLeft, top: aTop }
+          prevMasterRef.current = { left: aLeft, top: aTop }
+        } else if (masterChanged) {
+          // 模範解答側が変化 → 答案に同期
+          answer.scrollLeft = mLeft
+          answer.scrollTop = mTop
+          prevAnswerRef.current = { left: mLeft, top: mTop }
+          prevMasterRef.current = { left: mLeft, top: mTop }
+        }
+      }
+
+      rafIdRef.current = requestAnimationFrame(sync)
+    }
+
+    rafIdRef.current = requestAnimationFrame(sync)
+    return () => cancelAnimationFrame(rafIdRef.current)
+  }, [showSplit])
+
+  if (gradingMode !== "individual") {
+    return (
+      <AnswerGridView
+        allScoringData={allScoringData}
+        masterAnswerData={masterAnswerData}
+        filteredScoringDataIds={filteredScoringDataIds}
+        selectedScoringDataIds={selectedScoringDataIds}
+        layoutDirection={layoutDirection}
+        onScoringDataSelect={onScoringDataSelect}
+        onScoringDataReplace={onScoringDataReplace}
+        itemsPerRow={itemsPerLine}
+        autoScroll={autoScroll}
+        showStudentNames={showStudentNames}
+        expandMargin={expandMargin}
+        currentCropRegion={currentCropRegion}
+        currentUserId={currentUserId}
+        annotationRefreshKey={gridAnnotationRefreshKey}
+        className="p-4"
+      />
+    )
+  }
+
+  // 個別表示モード
+  const isOverlay = masterAnswerDisplayMode === "overlay"
+  const showMaster = masterAnswerVisible && masterAnswerDisplayMode !== "off"
+
+  const answerView = (
     <AnswerIndividualView
       scoringDatas={allScoringData}
       currentScoringDataId={currentScoringDataId}
@@ -112,25 +201,59 @@ export function ScoringContentArea({
       onQuestionScoreCreated={onQuestionScoreCreated}
       onAnnotationChanged={onAnnotationChanged}
       annotationRefreshKey={annotationRefreshKey}
+      // overlay
+      masterOverlayImageUrls={isOverlay ? allMasterImageUrls : undefined}
+      masterOverlayOpacity={masterAnswerOpacity}
+      masterOverlayVisible={isOverlay && showMaster}
+      masterDisplayMode={isOverlay ? "overlay" : undefined}
+      // zoom・画像サイズ通知は常に有効
+      onZoomChanged={handleZoomChanged}
+      onImageSizeChanged={handleImageSizeChanged}
+      scrollContainerRef={answerScrollRef}
     />
-  ) : (
-    /** Grid表示：paddingとスクロールを統合 */
-    <AnswerGridView
-      allScoringData={allScoringData}
-      masterAnswerData={masterAnswerData}
-      filteredScoringDataIds={filteredScoringDataIds}
-      selectedScoringDataIds={selectedScoringDataIds}
-      layoutDirection={layoutDirection}
-      onScoringDataSelect={onScoringDataSelect}
-      onScoringDataReplace={onScoringDataReplace}
-      itemsPerRow={itemsPerLine}
-      autoScroll={autoScroll}
-      showStudentNames={showStudentNames}
-      expandMargin={expandMargin}
-      currentCropRegion={currentCropRegion}
-      currentUserId={currentUserId}
-      annotationRefreshKey={gridAnnotationRefreshKey}
-      className="p-4"
-    />
+  )
+
+  // 常に同じ構造（remount防止）
+  return (
+    <div className={`flex h-full w-full ${isSplitV ? "flex-col" : "flex-row"}`}>
+      {/* 答案パネル */}
+      <div
+        className="min-h-0 min-w-0"
+        style={{
+          flex: showSplit ? "1 1 50%" : "1 1 100%",
+          transition: "flex 0.2s ease-in-out",
+        }}
+      >
+        {answerView}
+      </div>
+
+      {/* 模範解答パネル（2画面目） */}
+      {isSplit && (
+        <div
+          className="relative min-h-0 min-w-0 overflow-hidden"
+          style={{
+            flex: showSplit ? "1 1 50%" : "0 0 0%",
+            borderLeft: isSplitH && showSplit ? "2px solid #d1d5db" : "none",
+            borderTop: isSplitV && showSplit ? "2px solid #d1d5db" : "none",
+            transition: "flex 0.2s ease-in-out",
+          }}
+        >
+          {showSplit && (
+            <>
+              <div className="pointer-events-none absolute top-2 left-2 z-10 rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white">
+                模範解答
+              </div>
+              <MasterAnswerView
+                ref={masterScrollRef}
+                masterImageUrls={allMasterImageUrls}
+                zoom={syncedZoom}
+                referenceImageSize={answerImageSize ?? undefined}
+                answerScrollRef={answerScrollRef}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
   )
 }

--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -2,7 +2,7 @@
 
 import Head from "next/head"
 import { useParams } from "next/navigation"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { useContextValue } from "@/components/exams/07-score-at-once/hooks/useContextValue"
 import { OMRAutoScoringModal } from "@/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal"
@@ -64,12 +64,21 @@ function ScoringMainViewContent() {
     showStudentNames,
     layoutDirection,
     expandMargin,
+    masterAnswerDisplayMode,
+    masterAnswerOpacity,
+    masterAnswerKeyBehavior,
     setItemsPerLine,
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
     setExpandMargin,
+    setMasterAnswerDisplayMode,
+    setMasterAnswerOpacity,
+    setMasterAnswerKeyBehavior,
   } = useScoringSettings()
+
+  /** 模範解答表示状態（toggle/hold-to-show制御） */
+  const [masterAnswerVisible, setMasterAnswerVisible] = useState(false)
 
   const [questionChangeVersion, setQuestionChangeVersion] = useState(0)
 
@@ -343,6 +352,52 @@ function ScoringMainViewContent() {
     [setGradingMode]
   )
 
+  /** 模範解答表示トグル */
+  const handleToggleMasterAnswer = useCallback(() => {
+    if (masterAnswerDisplayMode === "off") return
+    if (masterAnswerKeyBehavior === "toggle") {
+      setMasterAnswerVisible((prev) => !prev)
+    } else {
+      // hold-to-show: keydownでon（keyupはネイティブイベントで処理）
+      setMasterAnswerVisible(true)
+    }
+  }, [masterAnswerDisplayMode, masterAnswerKeyBehavior])
+
+  /** 模範解答を直接表示/非表示（hold-to-show用） */
+  const handleMasterAnswerShow = useCallback(() => {
+    setMasterAnswerVisible(true)
+  }, [])
+  const handleMasterAnswerHide = useCallback(() => {
+    setMasterAnswerVisible(false)
+  }, [])
+
+  /** 全ページの模範解答画像URL（ページ番号順） */
+  const allMasterImageUrls = useMemo(() => {
+    if (!exam?.examPages) return []
+    return exam.examPages
+      .slice()
+      .sort((a, b) => a.pageNumber - b.pageNumber)
+      .map((page) => {
+        const masterImage = page.masterImages?.[0]
+        return masterImage?.imagePath
+          ? `appimg:///${masterImage.imagePath}`
+          : null
+      })
+      .filter((url): url is string => url !== null)
+  }, [exam])
+
+  /** hold-to-show用: keyupイベントで模範解答を非表示 */
+  useEffect(() => {
+    if (masterAnswerKeyBehavior !== "hold-to-show") return
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "x" || e.key === "X") {
+        setMasterAnswerVisible(false)
+      }
+    }
+    window.addEventListener("keyup", handleKeyUp)
+    return () => window.removeEventListener("keyup", handleKeyUp)
+  }, [masterAnswerKeyBehavior])
+
   /** コンテキスト値の設定 */
   useContextValue("gradingMode", gradingMode)
   useContextValue("hasSelectedAnswers", selectedStudentAnswerImageIds.size > 0)
@@ -372,6 +427,7 @@ function ScoringMainViewContent() {
     handleToggleFilter,
     handleSelectAll,
     handleToggleViewMode: handleToggleViewMode,
+    handleToggleMasterAnswer,
   })
 
   const currentStudentId = useMemo(() => {
@@ -451,6 +507,10 @@ function ScoringMainViewContent() {
             onAnnotationChanged={handleCanvasAnnotationChanged}
             annotationRefreshKey={annotationVersionForCanvas}
             gridAnnotationRefreshKey={annotationVersionForGrid}
+            masterAnswerDisplayMode={masterAnswerDisplayMode}
+            masterAnswerOpacity={masterAnswerOpacity}
+            masterAnswerVisible={masterAnswerVisible}
+            allMasterImageUrls={allMasterImageUrls}
           />
         </div>
 
@@ -504,6 +564,16 @@ function ScoringMainViewContent() {
               onQuestionScoreCreated={handleQuestionScoreCreated}
               annotationRefreshKey={annotationVersionForBrowser}
               onAnnotationAddedFromBrowser={handleBrowserAnnotationAdded}
+              masterAnswerDisplayMode={masterAnswerDisplayMode}
+              masterAnswerOpacity={masterAnswerOpacity}
+              masterAnswerKeyBehavior={masterAnswerKeyBehavior}
+              onMasterAnswerDisplayModeChange={setMasterAnswerDisplayMode}
+              onMasterAnswerOpacityChange={setMasterAnswerOpacity}
+              onMasterAnswerKeyBehaviorChange={setMasterAnswerKeyBehavior}
+              masterAnswerVisible={masterAnswerVisible}
+              onToggleMasterAnswer={handleToggleMasterAnswer}
+              onMasterAnswerShow={handleMasterAnswerShow}
+              onMasterAnswerHide={handleMasterAnswerHide}
             />
           </div>
         </div>

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
@@ -1,41 +1,34 @@
 /**
  * @fileoverview 自動スクロール設定フック
- * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 
-/** デフォルト値 */
-const DEFAULT_AUTO_SCROLL = true
+const DEFAULT = USER_PREFERENCE_SCHEMA.autoScroll.default
 
-/**
- * 自動スクロール設定を管理するフック
- * @returns autoScroll - 現在の自動スクロール設定
- * @returns setAutoScroll - 設定を更新する関数
- * @returns isLoading - 読み込み中フラグ
- */
 export function useAutoScroll() {
   const { user } = useAuth()
   const userId = user?.id
 
-  const [autoScroll, setAutoScrollState] =
-    useState<boolean>(DEFAULT_AUTO_SCROLL)
+  const [autoScroll, setAutoScrollState] = useState<boolean>(DEFAULT)
   const [isLoading, setIsLoading] = useState(true)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) {
       setIsLoading(false)
       return
     }
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
     setIsLoading(true)
 
@@ -46,13 +39,14 @@ export function useAutoScroll() {
       }
 
       try {
-        const result =
-          await window.electronAPI.settings.getScoringPreferenceColumn(
-            userId,
-            "autoScroll"
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "autoScroll"
+        )
+        if (result.success) {
+          setAutoScrollState(
+            parsePreference("autoScroll", result.value ?? null)
           )
-        if (result.success && result.value !== undefined) {
-          setAutoScrollState(result.value)
         }
       } catch (error) {
         console.error("autoScrollの読み込みに失敗しました:", error)
@@ -63,16 +57,16 @@ export function useAutoScroll() {
     load()
   }, [userId])
 
-  /**
-   * 楽観的更新: UI即時更新 + DB非同期保存
-   * @param value - 新しい自動スクロール設定
-   */
   const setAutoScroll = useCallback(
     (value: boolean) => {
       setAutoScrollState(value)
       if (userId && window.electronAPI?.settings) {
         window.electronAPI.settings
-          .setScoringPreferenceColumn(userId, "autoScroll", value)
+          .setUserPreference(
+            userId,
+            "autoScroll",
+            serializePreference("autoScroll", value)
+          )
           .catch((error) =>
             console.error("autoScrollの保存に失敗しました:", error)
           )
@@ -81,9 +75,5 @@ export function useAutoScroll() {
     [userId]
   )
 
-  return {
-    autoScroll,
-    setAutoScroll,
-    isLoading,
-  }
+  return { autoScroll, setAutoScroll, isLoading }
 }

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
@@ -1,43 +1,34 @@
 /**
  * @fileoverview 表示領域拡張設定フック
- * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 
-/** デフォルト値（0%） */
-const DEFAULT_EXPAND_MARGIN = 0
+const DEFAULT = USER_PREFERENCE_SCHEMA.expandMargin.default
 
-/**
- * 表示領域拡張設定を管理するフック
- * @description Grid表示時に採点領域の外側をn%拡張して表示する
- * @returns expandMargin - 現在の拡張率（0-50%）
- * @returns setExpandMargin - 拡張率を更新する関数
- * @returns isLoading - 読み込み中フラグ
- */
 export function useExpandMargin() {
   const { user } = useAuth()
   const userId = user?.id
 
-  const [expandMargin, setExpandMarginState] = useState<number>(
-    DEFAULT_EXPAND_MARGIN
-  )
+  const [expandMargin, setExpandMarginState] = useState<number>(DEFAULT)
   const [isLoading, setIsLoading] = useState(true)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) {
       setIsLoading(false)
       return
     }
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
     setIsLoading(true)
 
@@ -48,13 +39,14 @@ export function useExpandMargin() {
       }
 
       try {
-        const result =
-          await window.electronAPI.settings.getScoringPreferenceColumn(
-            userId,
-            "expandMargin"
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "expandMargin"
+        )
+        if (result.success) {
+          setExpandMarginState(
+            parsePreference("expandMargin", result.value ?? null)
           )
-        if (result.success && result.value !== undefined) {
-          setExpandMarginState(result.value)
         }
       } catch (error) {
         console.error("expandMarginの読み込みに失敗しました:", error)
@@ -65,16 +57,16 @@ export function useExpandMargin() {
     load()
   }, [userId])
 
-  /**
-   * 楽観的更新: UI即時更新 + DB非同期保存
-   * @param value - 新しい拡張率（0-50の整数）
-   */
   const setExpandMargin = useCallback(
     (value: number) => {
       setExpandMarginState(value)
       if (userId && window.electronAPI?.settings) {
         window.electronAPI.settings
-          .setScoringPreferenceColumn(userId, "expandMargin", value)
+          .setUserPreference(
+            userId,
+            "expandMargin",
+            serializePreference("expandMargin", value)
+          )
           .catch((error) =>
             console.error("expandMarginの保存に失敗しました:", error)
           )
@@ -83,9 +75,5 @@ export function useExpandMargin() {
     [userId]
   )
 
-  return {
-    expandMargin,
-    setExpandMargin,
-    isLoading,
-  }
+  return { expandMargin, setExpandMargin, isLoading }
 }

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
@@ -1,43 +1,34 @@
 /**
  * @fileoverview 1行あたりの表示件数設定フック
- * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 
-/** デフォルト値 */
-const DEFAULT_ITEMS_PER_LINE = 5
+const DEFAULT = USER_PREFERENCE_SCHEMA.itemsPerLine.default
 
-/**
- * 1行あたりの表示件数を管理するフック
- * @returns itemsPerLine - 現在の値（配列形式、Slider互換）
- * @returns setItemsPerLine - 値を更新する関数
- * @returns isLoading - 読み込み中フラグ
- */
 export function useItemsPerLine() {
   const { user } = useAuth()
   const userId = user?.id
 
-  const [itemsPerLine, setItemsPerLineState] = useState<number>(
-    DEFAULT_ITEMS_PER_LINE
-  )
+  const [itemsPerLine, setItemsPerLineState] = useState<number>(DEFAULT)
   const [isLoading, setIsLoading] = useState(true)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
-  // 初期読み込み
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) {
       setIsLoading(false)
       return
     }
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
     setIsLoading(true)
 
@@ -48,13 +39,14 @@ export function useItemsPerLine() {
       }
 
       try {
-        const result =
-          await window.electronAPI.settings.getScoringPreferenceColumn(
-            userId,
-            "itemsPerLine"
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "itemsPerLine"
+        )
+        if (result.success) {
+          setItemsPerLineState(
+            parsePreference("itemsPerLine", result.value ?? null)
           )
-        if (result.success && result.value !== undefined) {
-          setItemsPerLineState(result.value)
         }
       } catch (error) {
         console.error("itemsPerLineの読み込みに失敗しました:", error)
@@ -65,17 +57,17 @@ export function useItemsPerLine() {
     load()
   }, [userId])
 
-  /**
-   * 楽観的更新: UI即時更新 + DB非同期保存
-   * @param value - 新しい値（配列形式、Slider互換）
-   */
   const setItemsPerLine = useCallback(
     (value: number[]) => {
       const newValue = value[0]
       setItemsPerLineState(newValue)
       if (userId && window.electronAPI?.settings) {
         window.electronAPI.settings
-          .setScoringPreferenceColumn(userId, "itemsPerLine", newValue)
+          .setUserPreference(
+            userId,
+            "itemsPerLine",
+            serializePreference("itemsPerLine", newValue)
+          )
           .catch((error) =>
             console.error("itemsPerLineの保存に失敗しました:", error)
           )

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
@@ -1,43 +1,37 @@
 /**
  * @fileoverview レイアウト方向設定フック
- * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import type { LayoutDirection } from "@/components/exams/07-score-at-once/types"
 import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 
-/** デフォルト値 */
-const DEFAULT_LAYOUT_DIRECTION: LayoutDirection = "right-down"
+const DEFAULT = USER_PREFERENCE_SCHEMA.layoutDirection
+  .default as LayoutDirection
 
-/**
- * レイアウト方向設定を管理するフック
- * @returns layoutDirection - 現在のレイアウト方向（"right-down" | "down-right"）
- * @returns setLayoutDirection - レイアウト方向を更新する関数
- * @returns isLoading - 読み込み中フラグ
- */
 export function useLayoutDirection() {
   const { user } = useAuth()
   const userId = user?.id
 
-  const [layoutDirection, setLayoutDirectionState] = useState<LayoutDirection>(
-    DEFAULT_LAYOUT_DIRECTION
-  )
+  const [layoutDirection, setLayoutDirectionState] =
+    useState<LayoutDirection>(DEFAULT)
   const [isLoading, setIsLoading] = useState(true)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) {
       setIsLoading(false)
       return
     }
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
     setIsLoading(true)
 
@@ -48,13 +42,17 @@ export function useLayoutDirection() {
       }
 
       try {
-        const result =
-          await window.electronAPI.settings.getScoringPreferenceColumn(
-            userId,
-            "layoutDirection"
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "layoutDirection"
+        )
+        if (result.success) {
+          setLayoutDirectionState(
+            parsePreference(
+              "layoutDirection",
+              result.value ?? null
+            ) as LayoutDirection
           )
-        if (result.success && result.value !== undefined) {
-          setLayoutDirectionState(result.value as LayoutDirection)
         }
       } catch (error) {
         console.error("layoutDirectionの読み込みに失敗しました:", error)
@@ -65,16 +63,16 @@ export function useLayoutDirection() {
     load()
   }, [userId])
 
-  /**
-   * 楽観的更新: UI即時更新 + DB非同期保存
-   * @param value - 新しいレイアウト方向
-   */
   const setLayoutDirection = useCallback(
     (value: LayoutDirection) => {
       setLayoutDirectionState(value)
       if (userId && window.electronAPI?.settings) {
         window.electronAPI.settings
-          .setScoringPreferenceColumn(userId, "layoutDirection", value)
+          .setUserPreference(
+            userId,
+            "layoutDirection",
+            serializePreference("layoutDirection", value)
+          )
           .catch((error) =>
             console.error("layoutDirectionの保存に失敗しました:", error)
           )
@@ -83,9 +81,5 @@ export function useLayoutDirection() {
     [userId]
   )
 
-  return {
-    layoutDirection,
-    setLayoutDirection,
-    isLoading,
-  }
+  return { layoutDirection, setLayoutDirection, isLoading }
 }

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useMasterAnswerSettings.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useMasterAnswerSettings.ts
@@ -1,0 +1,162 @@
+/**
+ * @fileoverview 模範解答表示設定フック
+ * @description 模範解答の表示モード・透明度・キー動作を管理
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type {
+  MasterAnswerDisplayMode,
+  MasterAnswerKeyBehavior,
+} from "@/components/exams/07-score-at-once/types"
+import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
+
+export function useMasterAnswerSettings() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [displayMode, setDisplayModeState] = useState<MasterAnswerDisplayMode>(
+    USER_PREFERENCE_SCHEMA.masterAnswerDisplayMode
+      .default as MasterAnswerDisplayMode
+  )
+  const [opacity, setOpacityState] = useState<number>(
+    USER_PREFERENCE_SCHEMA.masterAnswerOpacity.default
+  )
+  const [keyBehavior, setKeyBehaviorState] = useState<MasterAnswerKeyBehavior>(
+    USER_PREFERENCE_SCHEMA.masterAnswerKeyBehavior
+      .default as MasterAnswerKeyBehavior
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (initializedUserIdRef.current === userId) return
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    initializedUserIdRef.current = userId
+    setIsLoading(true)
+
+    const load = async () => {
+      if (!window.electronAPI?.settings) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        const [modeResult, opacityResult, behaviorResult] = await Promise.all([
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "masterAnswerDisplayMode"
+          ),
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "masterAnswerOpacity"
+          ),
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "masterAnswerKeyBehavior"
+          ),
+        ])
+
+        if (modeResult.success) {
+          setDisplayModeState(
+            parsePreference(
+              "masterAnswerDisplayMode",
+              modeResult.value ?? null
+            ) as MasterAnswerDisplayMode
+          )
+        }
+        if (opacityResult.success) {
+          setOpacityState(
+            parsePreference("masterAnswerOpacity", opacityResult.value ?? null)
+          )
+        }
+        if (behaviorResult.success) {
+          setKeyBehaviorState(
+            parsePreference(
+              "masterAnswerKeyBehavior",
+              behaviorResult.value ?? null
+            ) as MasterAnswerKeyBehavior
+          )
+        }
+      } catch (error) {
+        console.error("模範解答設定の読み込みに失敗しました:", error)
+      }
+      setIsLoading(false)
+    }
+
+    load()
+  }, [userId])
+
+  const setDisplayMode = useCallback(
+    (value: MasterAnswerDisplayMode) => {
+      setDisplayModeState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "masterAnswerDisplayMode",
+            serializePreference("masterAnswerDisplayMode", value)
+          )
+          .catch((error) =>
+            console.error("masterAnswerDisplayModeの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  const setOpacity = useCallback(
+    (value: number) => {
+      setOpacityState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "masterAnswerOpacity",
+            serializePreference("masterAnswerOpacity", value)
+          )
+          .catch((error) =>
+            console.error("masterAnswerOpacityの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  const setKeyBehavior = useCallback(
+    (value: MasterAnswerKeyBehavior) => {
+      setKeyBehaviorState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "masterAnswerKeyBehavior",
+            serializePreference("masterAnswerKeyBehavior", value)
+          )
+          .catch((error) =>
+            console.error("masterAnswerKeyBehaviorの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    masterAnswerDisplayMode: displayMode,
+    masterAnswerOpacity: opacity,
+    masterAnswerKeyBehavior: keyBehavior,
+    setMasterAnswerDisplayMode: setDisplayMode,
+    setMasterAnswerOpacity: setOpacity,
+    setMasterAnswerKeyBehavior: setKeyBehavior,
+    isLoading,
+  }
+}

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -1,32 +1,15 @@
 /**
  * @fileoverview 採点設定フック（統合版）
- * @description 機能G: ユーザー採点設定の永続化
- *
- * 各設定は独立したフックで管理され、このフックは互換性のために統合して返す。
- * 楽観的更新時のレースコンディションを防ぐため、各設定は独立したstateを持つ。
+ * @description 各設定は独立したフックで管理され、このフックは互換性のために統合して返す。
  */
 
 import { useAutoScroll } from "./useAutoScroll"
 import { useExpandMargin } from "./useExpandMargin"
 import { useItemsPerLine } from "./useItemsPerLine"
 import { useLayoutDirection } from "./useLayoutDirection"
+import { useMasterAnswerSettings } from "./useMasterAnswerSettings"
 import { useShowStudentNames } from "./useShowStudentNames"
 
-/**
- * 全採点設定を統合して返すフック
- * @description 各設定は独立したフックで管理されるため、競合なく楽観的更新が可能
- * @returns itemsPerLine - 1行あたりの表示件数（配列形式）
- * @returns autoScroll - 自動スクロール設定
- * @returns showStudentNames - 生徒名表示設定
- * @returns layoutDirection - レイアウト方向
- * @returns expandMargin - 表示領域拡張率
- * @returns setItemsPerLine - 表示件数更新関数
- * @returns setAutoScroll - 自動スクロール更新関数
- * @returns setShowStudentNames - 生徒名表示更新関数
- * @returns setLayoutDirection - レイアウト方向更新関数
- * @returns setExpandMargin - 拡張率更新関数
- * @returns isLoading - いずれかの設定が読み込み中かどうか
- */
 export function useScoringSettings() {
   const {
     itemsPerLine,
@@ -53,13 +36,23 @@ export function useScoringSettings() {
     setExpandMargin,
     isLoading: isLoadingExpandMargin,
   } = useExpandMargin()
+  const {
+    masterAnswerDisplayMode,
+    masterAnswerOpacity,
+    masterAnswerKeyBehavior,
+    setMasterAnswerDisplayMode,
+    setMasterAnswerOpacity,
+    setMasterAnswerKeyBehavior,
+    isLoading: isLoadingMasterAnswer,
+  } = useMasterAnswerSettings()
 
   const isLoading =
     isLoadingItemsPerLine ||
     isLoadingAutoScroll ||
     isLoadingShowStudentNames ||
     isLoadingLayoutDirection ||
-    isLoadingExpandMargin
+    isLoadingExpandMargin ||
+    isLoadingMasterAnswer
 
   return {
     itemsPerLine,
@@ -67,11 +60,17 @@ export function useScoringSettings() {
     showStudentNames,
     layoutDirection,
     expandMargin,
+    masterAnswerDisplayMode,
+    masterAnswerOpacity,
+    masterAnswerKeyBehavior,
     setItemsPerLine,
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
     setExpandMargin,
+    setMasterAnswerDisplayMode,
+    setMasterAnswerOpacity,
+    setMasterAnswerKeyBehavior,
     isLoading,
   }
 }
@@ -81,4 +80,5 @@ export { useAutoScroll } from "./useAutoScroll"
 export { useExpandMargin } from "./useExpandMargin"
 export { useItemsPerLine } from "./useItemsPerLine"
 export { useLayoutDirection } from "./useLayoutDirection"
+export { useMasterAnswerSettings } from "./useMasterAnswerSettings"
 export { useShowStudentNames } from "./useShowStudentNames"

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -48,6 +48,8 @@ interface ScoringShortcutHandlers {
   handleSelectAll: () => void
   /** 表示モード切り替え（グリッド⇔個別） */
   handleToggleViewMode: () => void
+  /** 模範解答表示トグル（個別モード） */
+  handleToggleMasterAnswer?: () => void
 }
 
 /**
@@ -75,6 +77,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     handleToggleFilter,
     handleSelectAll,
     handleToggleViewMode,
+    handleToggleMasterAnswer,
   } = handlers
 
   // ========================================
@@ -207,6 +210,15 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
       title: "表示モード切り替え",
       category: "表示",
       description: "一覧表示と個別表示を切り替えます",
+    },
+  })
+
+  useCommand("view.toggleMasterAnswer", () => handleToggleMasterAnswer?.(), {
+    when: "!inputFocus && !modalOpen && gradingMode == 'individual'",
+    metadata: {
+      title: "模範解答表示切り替え",
+      category: "表示",
+      description: "模範解答の表示を切り替えます",
     },
   })
 

--- a/components/exams/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
+++ b/components/exams/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
@@ -1,42 +1,35 @@
 /**
  * @fileoverview 生徒名表示設定フック
- * @description 機能G: ユーザー採点設定の永続化（カラム別楽観的更新）
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 
-/** デフォルト値 */
-const DEFAULT_SHOW_STUDENT_NAMES = true
+const DEFAULT = USER_PREFERENCE_SCHEMA.showStudentNames.default
 
-/**
- * 生徒名表示設定を管理するフック
- * @returns showStudentNames - 生徒名を表示するかどうか
- * @returns setShowStudentNames - 設定を更新する関数
- * @returns isLoading - 読み込み中フラグ
- */
 export function useShowStudentNames() {
   const { user } = useAuth()
   const userId = user?.id
 
-  const [showStudentNames, setShowStudentNamesState] = useState<boolean>(
-    DEFAULT_SHOW_STUDENT_NAMES
-  )
+  const [showStudentNames, setShowStudentNamesState] =
+    useState<boolean>(DEFAULT)
   const [isLoading, setIsLoading] = useState(true)
   const initializedUserIdRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    // 同じユーザーで既に初期化済みならスキップ
     if (initializedUserIdRef.current === userId) return
-
-    // userIdがundefinedの場合は待機（refは更新しない）
     if (!userId) {
       setIsLoading(false)
       return
     }
 
-    // 新しいユーザーとして初期化
     initializedUserIdRef.current = userId
     setIsLoading(true)
 
@@ -47,13 +40,14 @@ export function useShowStudentNames() {
       }
 
       try {
-        const result =
-          await window.electronAPI.settings.getScoringPreferenceColumn(
-            userId,
-            "showStudentNames"
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "showStudentNames"
+        )
+        if (result.success) {
+          setShowStudentNamesState(
+            parsePreference("showStudentNames", result.value ?? null)
           )
-        if (result.success && result.value !== undefined) {
-          setShowStudentNamesState(result.value)
         }
       } catch (error) {
         console.error("showStudentNamesの読み込みに失敗しました:", error)
@@ -64,16 +58,16 @@ export function useShowStudentNames() {
     load()
   }, [userId])
 
-  /**
-   * 楽観的更新: UI即時更新 + DB非同期保存
-   * @param value - 新しい生徒名表示設定
-   */
   const setShowStudentNames = useCallback(
     (value: boolean) => {
       setShowStudentNamesState(value)
       if (userId && window.electronAPI?.settings) {
         window.electronAPI.settings
-          .setScoringPreferenceColumn(userId, "showStudentNames", value)
+          .setUserPreference(
+            userId,
+            "showStudentNames",
+            serializePreference("showStudentNames", value)
+          )
           .catch((error) =>
             console.error("showStudentNamesの保存に失敗しました:", error)
           )
@@ -82,9 +76,5 @@ export function useShowStudentNames() {
     [userId]
   )
 
-  return {
-    showStudentNames,
-    setShowStudentNames,
-    isLoading,
-  }
+  return { showStudentNames, setShowStudentNames, isLoading }
 }

--- a/components/exams/07-score-at-once/ScoringSidePanel/MasterAnswerControls.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/MasterAnswerControls.tsx
@@ -1,0 +1,180 @@
+"use client"
+
+import { Eye, EyeOff } from "lucide-react"
+import { useCallback } from "react"
+
+import { useKeyBindings } from "@/components/exams/07-score-at-once/hooks/useKeyBindings"
+import type {
+  MasterAnswerDisplayMode,
+  MasterAnswerKeyBehavior,
+} from "@/components/exams/07-score-at-once/types"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Slider } from "@/components/ui/slider"
+import { Switch } from "@/components/ui/switch"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+import { SidePanelSection } from "./SidePanelSection"
+
+interface MasterAnswerControlsProps {
+  displayMode: MasterAnswerDisplayMode
+  opacity: number
+  keyBehavior: MasterAnswerKeyBehavior
+  masterAnswerVisible: boolean
+  onDisplayModeChange: (mode: MasterAnswerDisplayMode) => void
+  onOpacityChange: (opacity: number) => void
+  onKeyBehaviorChange: (behavior: MasterAnswerKeyBehavior) => void
+  onToggleMasterAnswer: () => void
+  onMasterAnswerShow?: () => void
+  onMasterAnswerHide?: () => void
+}
+
+const DISPLAY_MODE_OPTIONS: {
+  value: MasterAnswerDisplayMode
+  label: string
+}[] = [
+  { value: "off", label: "非表示" },
+  { value: "overlay", label: "オーバーレイ" },
+  { value: "split-horizontal", label: "左右分割" },
+  { value: "split-vertical", label: "上下分割" },
+]
+
+export function MasterAnswerControls({
+  displayMode,
+  opacity,
+  keyBehavior,
+  masterAnswerVisible,
+  onDisplayModeChange,
+  onOpacityChange,
+  onKeyBehaviorChange,
+  onToggleMasterAnswer,
+  onMasterAnswerShow,
+  onMasterAnswerHide,
+}: MasterAnswerControlsProps) {
+  const { keyBindings } = useKeyBindings()
+  const toggleKey = keyBindings["view.toggleMasterAnswer"]?.toUpperCase() || "X"
+
+  // hold-to-show: mousedown で表示、mouseup/mouseleave で非表示
+  const handlePointerDown = useCallback(() => {
+    if (keyBehavior === "hold-to-show") {
+      onMasterAnswerShow?.()
+    }
+  }, [keyBehavior, onMasterAnswerShow])
+
+  const handlePointerUp = useCallback(() => {
+    if (keyBehavior === "hold-to-show") {
+      onMasterAnswerHide?.()
+    }
+  }, [keyBehavior, onMasterAnswerHide])
+
+  const handleClick = useCallback(() => {
+    if (keyBehavior === "toggle") {
+      onToggleMasterAnswer()
+    }
+  }, [keyBehavior, onToggleMasterAnswer])
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <SidePanelSection icon={Eye} title="模範解答">
+        <div className="space-y-3">
+          {/* 表示モード + 表示ボタン（横並び） */}
+          <div className="flex items-end gap-2">
+            <div className="min-w-0 flex-1 space-y-1">
+              <Label className="text-xs">表示モード</Label>
+              <Select
+                value={displayMode}
+                onValueChange={(v) =>
+                  onDisplayModeChange(v as MasterAnswerDisplayMode)
+                }
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DISPLAY_MODE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {displayMode !== "off" && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant={masterAnswerVisible ? "default" : "outline"}
+                    size="sm"
+                    className="h-8 shrink-0 px-3"
+                    onClick={handleClick}
+                    onPointerDown={handlePointerDown}
+                    onPointerUp={handlePointerUp}
+                    onPointerLeave={handlePointerUp}
+                  >
+                    {masterAnswerVisible ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-center">
+                    <div className="font-medium">模範解答の表示切替</div>
+                    <div className="mt-1 text-xs text-gray-400">
+                      キー:{" "}
+                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
+                        {toggleKey}
+                      </kbd>
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+
+          {/* 不透明度スライダー（overlay時のみ） */}
+          {displayMode === "overlay" && (
+            <div className="space-y-1">
+              <Label className="text-xs">不透明度: {opacity}%</Label>
+              <Slider
+                value={[opacity]}
+                onValueChange={([v]) => onOpacityChange(v)}
+                min={5}
+                max={100}
+                step={5}
+                className="py-1"
+              />
+            </div>
+          )}
+
+          {/* キー動作 */}
+          {displayMode !== "off" && (
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">押し続けて表示</Label>
+              <Switch
+                checked={keyBehavior === "hold-to-show"}
+                onCheckedChange={(checked) =>
+                  onKeyBehaviorChange(checked ? "hold-to-show" : "toggle")
+                }
+              />
+            </div>
+          )}
+        </div>
+      </SidePanelSection>
+    </TooltipProvider>
+  )
+}

--- a/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -5,12 +5,15 @@ import { useEffect, useRef } from "react"
 import { QuestionProgress } from "@/components/exams/07-score-at-once/ScoringData/types/scoringDataTypes"
 import { IndividualModePanel } from "@/components/exams/07-score-at-once/ScoringIndividual/IndividualModePanel"
 import ExamProgressCard from "@/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard"
+import { MasterAnswerControls } from "@/components/exams/07-score-at-once/ScoringSidePanel/MasterAnswerControls"
 import NavigationControls from "@/components/exams/07-score-at-once/ScoringSidePanel/NavigationControls"
 import QuestionNavigator from "@/components/exams/07-score-at-once/ScoringSidePanel/QuestionNavigator"
 import ScoringToolbar from "@/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar"
 import type {
   CropRegionWithExamPage,
   LayoutDirection,
+  MasterAnswerDisplayMode,
+  MasterAnswerKeyBehavior,
   ScoringStatus,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
@@ -91,6 +94,17 @@ interface ScoringSidePanelProps {
   annotationRefreshKey?: number
   /** ブラウザの+ボタンでアノテーション追加後のコールバック（キャンバスリロード用） */
   onAnnotationAddedFromBrowser?: () => void
+  // 模範解答表示設定
+  masterAnswerDisplayMode?: MasterAnswerDisplayMode
+  masterAnswerOpacity?: number
+  masterAnswerKeyBehavior?: MasterAnswerKeyBehavior
+  onMasterAnswerDisplayModeChange?: (mode: MasterAnswerDisplayMode) => void
+  onMasterAnswerOpacityChange?: (opacity: number) => void
+  onMasterAnswerKeyBehaviorChange?: (behavior: MasterAnswerKeyBehavior) => void
+  masterAnswerVisible?: boolean
+  onToggleMasterAnswer?: () => void
+  onMasterAnswerShow?: () => void
+  onMasterAnswerHide?: () => void
 }
 
 export function ScoringSidePanel({
@@ -134,6 +148,16 @@ export function ScoringSidePanel({
   onQuestionScoreCreated,
   annotationRefreshKey,
   onAnnotationAddedFromBrowser,
+  masterAnswerDisplayMode,
+  masterAnswerOpacity,
+  masterAnswerKeyBehavior,
+  onMasterAnswerDisplayModeChange,
+  onMasterAnswerOpacityChange,
+  onMasterAnswerKeyBehaviorChange,
+  masterAnswerVisible,
+  onToggleMasterAnswer,
+  onMasterAnswerShow,
+  onMasterAnswerHide,
 }: ScoringSidePanelProps) {
   const annotationBrowser = useAnnotationBrowser()
   const { loadAnnotations: reloadBrowserAnnotations } = annotationBrowser
@@ -207,6 +231,29 @@ export function ScoringSidePanel({
                   onStudentChange={onStudentChange}
                   scoringBehavior={scoringBehavior}
                   onScoringBehaviorChange={onScoringBehaviorChange}
+                />
+              </>
+            )}
+
+          {/* 個別表示モード時：模範解答表示設定 */}
+          {gradingMode === "individual" &&
+            masterAnswerDisplayMode !== undefined &&
+            onMasterAnswerDisplayModeChange && (
+              <>
+                <Separator />
+                <MasterAnswerControls
+                  displayMode={masterAnswerDisplayMode}
+                  opacity={masterAnswerOpacity ?? 50}
+                  keyBehavior={masterAnswerKeyBehavior ?? "toggle"}
+                  masterAnswerVisible={masterAnswerVisible ?? false}
+                  onDisplayModeChange={onMasterAnswerDisplayModeChange}
+                  onOpacityChange={onMasterAnswerOpacityChange ?? (() => {})}
+                  onKeyBehaviorChange={
+                    onMasterAnswerKeyBehaviorChange ?? (() => {})
+                  }
+                  onToggleMasterAnswer={onToggleMasterAnswer ?? (() => {})}
+                  onMasterAnswerShow={onMasterAnswerShow}
+                  onMasterAnswerHide={onMasterAnswerHide}
                 />
               </>
             )}

--- a/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -46,9 +46,9 @@ interface ScoringToolbarProps {
   gradingMode?: "grid" | "individual" // 採点モード
 }
 
-// ScoringStatus -> ScoringStatusType へのマッピング
+// ScoringStatus -> ScoringStatusType へのマッピング（統一済み）
 const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
-  unscored: "ungraded",
+  unscored: "unscored",
   correct: "correct",
   partial: "partial",
   pending: "pending",

--- a/components/exams/07-score-at-once/constants/scoringKeybindings.ts
+++ b/components/exams/07-score-at-once/constants/scoringKeybindings.ts
@@ -74,6 +74,7 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "view.toggleViewMode": "v",
   "view.fullView": "m", // 全体表示（個別モード）
   "view.questionView": "c", // 設問表示（個別モード）
+  "view.toggleMasterAnswer": "x", // 模範解答表示切り替え（個別モード）
 
   // ============================================
   // モーダル (Modal)

--- a/components/exams/07-score-at-once/types/index.ts
+++ b/components/exams/07-score-at-once/types/index.ts
@@ -131,6 +131,20 @@ export interface ScoringData {
   customOrder: number
 }
 
+/**
+ * 模範解答表示モード
+ */
+export type MasterAnswerDisplayMode =
+  | "off"
+  | "overlay"
+  | "split-horizontal"
+  | "split-vertical"
+
+/**
+ * 模範解答キー動作モード
+ */
+export type MasterAnswerKeyBehavior = "toggle" | "hold-to-show"
+
 export type MasterStatus = "master"
 
 export interface MasterGridItem {

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -20,15 +20,11 @@ import {
 } from "../lib/prisma/examSettings"
 import {
   bulkUpsertUserKeyboardShortcuts,
-  getScoringPreferenceColumn,
   getUserKeyboardShortcuts,
-  getUserScoringPreference,
+  getUserPreference,
+  getUserPreferences,
   resetUserKeyboardShortcuts,
-  type ScoringPreferenceColumnName,
-  type ScoringPreferenceColumns,
-  type ScoringPreferenceData,
-  setScoringPreferenceColumn,
-  upsertUserScoringPreference,
+  setUserPreference,
 } from "../lib/prisma/userSettings"
 
 // プロジェクターモード用のpowerSaveBlocker ID
@@ -148,77 +144,43 @@ export function registerSettingsHandlers() {
   )
 
   // =========================================================================
-  // UserScoringPreference
+  // UserPreference（KV方式）
   // =========================================================================
 
   ipcMain.handle(
-    "settings:getUserScoringPreference",
-    async (_event, userId: string) => {
+    "settings:getUserPreference",
+    async (_event, userId: string, key: string) => {
       try {
-        const preference = await getUserScoringPreference(userId)
-        return { success: true, preference }
-      } catch (error) {
-        console.error("Failed to get scoring preference:", error)
-        return { success: false, error: String(error) }
-      }
-    }
-  )
-
-  ipcMain.handle(
-    "settings:upsertUserScoringPreference",
-    async (_event, userId: string, data: ScoringPreferenceData) => {
-      try {
-        const preference = await upsertUserScoringPreference(userId, data)
-        return { success: true, preference }
-      } catch (error) {
-        console.error("Failed to upsert scoring preference:", error)
-        return { success: false, error: String(error) }
-      }
-    }
-  )
-
-  // カラム別取得
-  ipcMain.handle(
-    "settings:getScoringPreferenceColumn",
-    async (
-      _event,
-      userId: string,
-      column: ScoringPreferenceColumnName
-    ): Promise<{
-      success: boolean
-      value?: ScoringPreferenceColumns[typeof column]
-      error?: string
-    }> => {
-      try {
-        const value = await getScoringPreferenceColumn(userId, column)
+        const value = await getUserPreference(userId, key)
         return { success: true, value }
       } catch (error) {
-        console.error(
-          `Failed to get scoring preference column [${column}]:`,
-          error
-        )
+        console.error(`Failed to get user preference [${key}]:`, error)
         return { success: false, error: String(error) }
       }
     }
   )
 
-  // カラム別設定（楽観的更新用）
   ipcMain.handle(
-    "settings:setScoringPreferenceColumn",
-    async (
-      _event,
-      userId: string,
-      column: ScoringPreferenceColumnName,
-      value: ScoringPreferenceColumns[typeof column]
-    ): Promise<{ success: boolean; error?: string }> => {
+    "settings:setUserPreference",
+    async (_event, userId: string, key: string, value: string) => {
       try {
-        await setScoringPreferenceColumn(userId, column, value)
+        await setUserPreference(userId, key, value)
         return { success: true }
       } catch (error) {
-        console.error(
-          `Failed to set scoring preference column [${column}]:`,
-          error
-        )
+        console.error(`Failed to set user preference [${key}]:`, error)
+        return { success: false, error: String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    "settings:getUserPreferences",
+    async (_event, userId: string) => {
+      try {
+        const preferences = await getUserPreferences(userId)
+        return { success: true, preferences }
+      } catch (error) {
+        console.error("Failed to get user preferences:", error)
         return { success: false, error: String(error) }
       }
     }

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -380,20 +380,14 @@ CREATE TABLE "UserKeyboardShortcut" (
 );
 
 -- CreateTable
-CREATE TABLE "UserScoringPreference" (
+CREATE TABLE "UserPreference" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "userId" TEXT NOT NULL,
-    "showStudentNames" BOOLEAN NOT NULL DEFAULT true,
-    "autoScroll" BOOLEAN NOT NULL DEFAULT true,
-    "itemsPerLine" INTEGER NOT NULL DEFAULT 5,
-    "layoutDirection" TEXT NOT NULL DEFAULT 'right-down',
-    "expandMargin" INTEGER NOT NULL DEFAULT 0,
-    "selectionBorderColor" TEXT,
-    "scoringStatusColors" TEXT,
-    "scoringColorPresetId" TEXT,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
-    CONSTRAINT "UserScoringPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT "UserPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- CreateTable
@@ -888,7 +882,10 @@ CREATE UNIQUE INDEX "UserKeyboardShortcut_userId_action_key" ON "UserKeyboardSho
 CREATE INDEX "UserKeyboardShortcut_userId_idx" ON "UserKeyboardShortcut"("userId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "UserScoringPreference_userId_key" ON "UserScoringPreference"("userId");
+CREATE UNIQUE INDEX "UserPreference_userId_key_key" ON "UserPreference"("userId", "key");
+
+-- CreateIndex
+CREATE INDEX "UserPreference_userId_idx" ON "UserPreference"("userId");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "ExamMarkingFormat_examId_markType_key" ON "ExamMarkingFormat"("examId", "markType");

--- a/electron-src/lib/prisma/userSettings.ts
+++ b/electron-src/lib/prisma/userSettings.ts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview ユーザー設定関連のPrisma操作関数
- * @description キーボードショートカット、採点画面設定のDB操作を提供
+ * @description キーボードショートカット、ユーザー設定のDB操作を提供
  */
 
 import prisma from "./client"
@@ -91,126 +91,56 @@ export async function resetUserKeyboardShortcuts(userId: string) {
 }
 
 // =============================================================================
-// UserScoringPreference（採点画面設定）
+// UserPreference（KV方式ユーザー設定）
 // =============================================================================
 
-/** 採点設定の更新用データ型（全カラムオプショナル） */
-export interface ScoringPreferenceData {
-  showStudentNames?: boolean
-  autoScroll?: boolean
-  itemsPerLine?: number
-  layoutDirection?: string
-  expandMargin?: number
-  selectionBorderColor?: string | null
-  scoringStatusColors?: string | null
-  scoringColorPresetId?: string | null
-}
-
 /**
- * カラム別の型定義
- */
-export interface ScoringPreferenceColumns {
-  showStudentNames: boolean
-  autoScroll: boolean
-  itemsPerLine: number
-  layoutDirection: string
-  expandMargin: number
-  selectionBorderColor: string | null
-  scoringStatusColors: string | null
-  scoringColorPresetId: string | null
-}
-
-export type ScoringPreferenceColumnName = keyof ScoringPreferenceColumns
-
-/**
- * ユーザーの採点設定レコードを取得
+ * ユーザー設定を取得（単一キー）
  * @param userId - ユーザーID
- * @returns 採点設定レコード（存在しない場合はnull）
+ * @param key - 設定キー
+ * @returns 設定値（JSON文字列）。存在しない場合はnull
  */
-export async function getUserScoringPreference(userId: string) {
-  return prisma.userScoringPreference.findUnique({
-    where: { userId },
+export async function getUserPreference(
+  userId: string,
+  key: string
+): Promise<string | null> {
+  const record = await prisma.userPreference.findUnique({
+    where: { userId_key: { userId, key } },
   })
+  return record?.value ?? null
 }
 
 /**
- * 採点設定をまとめて追加/更新（レコード単位）
+ * ユーザー設定を保存（単一キー）
  * @param userId - ユーザーID
- * @param data - 更新する設定データ
+ * @param key - 設定キー
+ * @param value - 設定値（JSON文字列）
  */
-export async function upsertUserScoringPreference(
+export async function setUserPreference(
   userId: string,
-  data: ScoringPreferenceData
-) {
-  return prisma.userScoringPreference.upsert({
-    where: { userId },
-    update: data,
-    create: {
-      userId,
-      showStudentNames: data.showStudentNames ?? true,
-      autoScroll: data.autoScroll ?? true,
-      itemsPerLine: data.itemsPerLine ?? 5,
-      layoutDirection: data.layoutDirection ?? "right-down",
-      expandMargin: data.expandMargin ?? 0,
-      selectionBorderColor: data.selectionBorderColor ?? null,
-      scoringStatusColors: data.scoringStatusColors ?? null,
-      scoringColorPresetId: data.scoringColorPresetId ?? null,
-    },
-  })
-}
-
-// =============================================================================
-// カラム別操作（楽観的更新対応）
-// =============================================================================
-
-/** 採点設定のデフォルト値 */
-const SCORING_PREFERENCE_DEFAULTS: ScoringPreferenceColumns = {
-  showStudentNames: true,
-  autoScroll: true,
-  itemsPerLine: 5,
-  layoutDirection: "right-down",
-  expandMargin: 0,
-  selectionBorderColor: null,
-  scoringStatusColors: null,
-  scoringColorPresetId: null,
-}
-
-/**
- * 指定したカラムの値を取得
- */
-export async function getScoringPreferenceColumn<
-  K extends ScoringPreferenceColumnName,
->(userId: string, column: K): Promise<ScoringPreferenceColumns[K]> {
-  const record = await prisma.userScoringPreference.findUnique({
-    where: { userId },
-    select: { [column]: true },
-  })
-
-  if (!record) {
-    return SCORING_PREFERENCE_DEFAULTS[column]
-  }
-
-  // Prismaのselect結果から値を取得
-  return (record as unknown as ScoringPreferenceColumns)[column]
-}
-
-/**
- * 指定したカラムの値を設定（楽観的更新用 - 単一カラムのみ更新）
- */
-export async function setScoringPreferenceColumn<
-  K extends ScoringPreferenceColumnName,
->(
-  userId: string,
-  column: K,
-  value: ScoringPreferenceColumns[K]
+  key: string,
+  value: string
 ): Promise<void> {
-  await prisma.userScoringPreference.upsert({
-    where: { userId },
-    update: { [column]: value },
-    create: {
-      userId,
-      ...SCORING_PREFERENCE_DEFAULTS,
-      [column]: value,
-    },
+  await prisma.userPreference.upsert({
+    where: { userId_key: { userId, key } },
+    update: { value },
+    create: { userId, key, value },
   })
+}
+
+/**
+ * ユーザーの全設定を取得
+ * @param userId - ユーザーID
+ * @returns key -> value のマッピング
+ */
+export async function getUserPreferences(
+  userId: string
+): Promise<Record<string, string>> {
+  const records = await prisma.userPreference.findMany({
+    where: { userId },
+  })
+  return records.reduce<Record<string, string>>((acc, r) => {
+    acc[r.key] = r.value
+    return acc
+  }, {})
 }

--- a/lib/scoringStatusColors.ts
+++ b/lib/scoringStatusColors.ts
@@ -4,13 +4,12 @@
  *
  * - 4つのプリセットパターン（標準、ビビッド、ソフト、色覚多様性対応）
  * - 各状態の個別カスタマイズ
- * - DBに保存（UserScoringPreference.scoringStatusColors, scoringColorPresetId）
- * - カラム別楽観的更新対応
+ * - DBに保存（UserPreference KV方式）
  */
 
-/** 採点状態の種類（DBの値と一致） */
+/** 採点状態の種類（ScoringStatusと統一） */
 export type ScoringStatusType =
-  | "ungraded"
+  | "unscored"
   | "correct"
   | "partial"
   | "pending"
@@ -40,7 +39,7 @@ export interface ScoringColorPreset {
 
 /** 状態のラベル（日本語） */
 export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
-  ungraded: "未採点",
+  unscored: "未採点",
   correct: "正答",
   partial: "部分点",
   pending: "保留",
@@ -50,7 +49,7 @@ export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
 
 /** 状態の表示順序 */
 export const SCORING_STATUS_ORDER: ScoringStatusType[] = [
-  "ungraded",
+  "unscored",
   "correct",
   "partial",
   "pending",
@@ -67,7 +66,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
     name: "標準",
     description: "デフォルトの配色",
     colors: {
-      ungraded: { bg: "#F9FAFB", text: "#4B5563", icon: "#9CA3AF" },
+      unscored: { bg: "#F9FAFB", text: "#4B5563", icon: "#9CA3AF" },
       correct: { bg: "#DCFCE7", text: "#166534", icon: "#16A34A" },
       partial: { bg: "#FEF9C3", text: "#854D0E", icon: "#CA8A04" },
       pending: { bg: "#DBEAFE", text: "#1E40AF", icon: "#2563EB" },
@@ -80,7 +79,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
     name: "ビビッド",
     description: "より鮮やかな配色",
     colors: {
-      ungraded: { bg: "#E5E7EB", text: "#374151", icon: "#6B7280" },
+      unscored: { bg: "#E5E7EB", text: "#374151", icon: "#6B7280" },
       correct: { bg: "#BBF7D0", text: "#14532D", icon: "#22C55E" },
       partial: { bg: "#FDE047", text: "#713F12", icon: "#EAB308" },
       pending: { bg: "#93C5FD", text: "#1E3A8A", icon: "#3B82F6" },
@@ -93,7 +92,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
     name: "ソフト",
     description: "淡い配色で目に優しい",
     colors: {
-      ungraded: { bg: "#FAFAFA", text: "#737373", icon: "#A3A3A3" },
+      unscored: { bg: "#FAFAFA", text: "#737373", icon: "#A3A3A3" },
       correct: { bg: "#ECFCCB", text: "#365314", icon: "#84CC16" },
       partial: { bg: "#FEF3C7", text: "#92400E", icon: "#D97706" },
       pending: { bg: "#E0F2FE", text: "#075985", icon: "#0EA5E9" },
@@ -106,7 +105,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
     name: "色覚多様性対応",
     description: "Wong配色パレット準拠",
     colors: {
-      ungraded: { bg: "#E8E8E8", text: "#4D4D4D", icon: "#999999" },
+      unscored: { bg: "#E8E8E8", text: "#4D4D4D", icon: "#999999" },
       correct: { bg: "#C8EDE0", text: "#005C45", icon: "#009E73" },
       partial: { bg: "#FCF6C8", text: "#6B5A00", icon: "#F0E442" },
       pending: { bg: "#D0EBFA", text: "#0066A0", icon: "#56B4E9" },
@@ -124,32 +123,81 @@ let cachedPresetId: string | null = "default"
 let currentUserId: string | null = null
 
 /**
- * DBから採点状態色を読み込み（初期化用・カラム別）
+ * DBのJSON内の旧キー"ungraded"を"unscored"にマイグレーション
+ */
+function migrateUngradedKey(
+  colors: Record<string, StatusColorConfig>
+): ScoringStatusColors {
+  const result = { ...colors } as Record<string, StatusColorConfig>
+  if ("ungraded" in result && !("unscored" in result)) {
+    result.unscored = result.ungraded
+    delete result.ungraded
+  }
+  return result as ScoringStatusColors
+}
+
+/**
+ * DBから採点状態色を読み込み（初期化用・KV方式）
  */
 export async function loadScoringStatusColors(userId: string): Promise<void> {
   if (typeof window === "undefined" || !window.electronAPI?.settings) return
 
   try {
     currentUserId = userId
-    // カラム別に並列で読み込み
     const [colorsResult, presetIdResult] = await Promise.all([
-      window.electronAPI.settings.getScoringPreferenceColumn(
+      window.electronAPI.settings.getUserPreference(
         userId,
         "scoringStatusColors"
       ),
-      window.electronAPI.settings.getScoringPreferenceColumn(
+      window.electronAPI.settings.getUserPreference(
         userId,
         "scoringColorPresetId"
       ),
     ])
 
-    if (colorsResult.success && colorsResult.value) {
-      cachedColors = JSON.parse(colorsResult.value) as ScoringStatusColors
+    if (
+      colorsResult.success &&
+      colorsResult.value &&
+      colorsResult.value !== "null"
+    ) {
+      let parsed: string | null = colorsResult.value
+      try {
+        parsed = JSON.parse(colorsResult.value)
+      } catch {
+        // value is already the raw JSON string for colors
+      }
+      if (parsed && typeof parsed === "object") {
+        cachedColors = migrateUngradedKey(
+          parsed as unknown as Record<string, StatusColorConfig>
+        )
+      } else if (typeof colorsResult.value === "string") {
+        try {
+          const obj = JSON.parse(colorsResult.value) as Record<
+            string,
+            StatusColorConfig
+          >
+          cachedColors = migrateUngradedKey(obj)
+        } catch {
+          // keep default
+        }
+      }
     }
-    cachedPresetId =
-      presetIdResult.success && presetIdResult.value
-        ? presetIdResult.value
-        : null
+
+    if (
+      presetIdResult.success &&
+      presetIdResult.value &&
+      presetIdResult.value !== "null"
+    ) {
+      let parsed = presetIdResult.value
+      try {
+        parsed = JSON.parse(presetIdResult.value)
+      } catch {
+        // keep raw value
+      }
+      cachedPresetId = parsed
+    } else {
+      cachedPresetId = null
+    }
   } catch (error) {
     console.error("Failed to load scoring status colors:", error)
   }
@@ -163,7 +211,7 @@ export function getScoringStatusColors(): ScoringStatusColors {
 }
 
 /**
- * 採点状態色を保存（カラム別・楽観的更新）
+ * 採点状態色を保存（KV方式・楽観的更新）
  */
 export async function saveScoringStatusColors(
   colors: ScoringStatusColors,
@@ -181,17 +229,16 @@ export async function saveScoringStatusColors(
   if (!targetUserId || !window.electronAPI?.settings) return
 
   try {
-    // カラム別に並列で保存
     await Promise.all([
-      window.electronAPI.settings.setScoringPreferenceColumn(
+      window.electronAPI.settings.setUserPreference(
         targetUserId,
         "scoringStatusColors",
         JSON.stringify(colors)
       ),
-      window.electronAPI.settings.setScoringPreferenceColumn(
+      window.electronAPI.settings.setUserPreference(
         targetUserId,
         "scoringColorPresetId",
-        null
+        "null"
       ),
     ])
   } catch (error) {
@@ -207,7 +254,7 @@ export function getCurrentPresetId(): string | null {
 }
 
 /**
- * プリセットを適用（カラム別・楽観的更新）
+ * プリセットを適用（KV方式・楽観的更新）
  */
 export async function applyScoringColorPreset(
   presetId: string,
@@ -231,17 +278,16 @@ export async function applyScoringColorPreset(
   if (!targetUserId || !window.electronAPI?.settings) return
 
   try {
-    // カラム別に並列で保存
     await Promise.all([
-      window.electronAPI.settings.setScoringPreferenceColumn(
+      window.electronAPI.settings.setUserPreference(
         targetUserId,
         "scoringStatusColors",
         JSON.stringify(preset.colors)
       ),
-      window.electronAPI.settings.setScoringPreferenceColumn(
+      window.electronAPI.settings.setUserPreference(
         targetUserId,
         "scoringColorPresetId",
-        presetId
+        JSON.stringify(presetId)
       ),
     ])
   } catch (error) {

--- a/lib/userPreferences.ts
+++ b/lib/userPreferences.ts
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview ユーザー設定のKVスキーマ定義と型安全アクセス
+ * @description UserPreference KVテーブルの設定キー・デフォルト値・型パースを一元管理
+ */
+
+/** 設定キーごとのスキーマ定義 */
+export const USER_PREFERENCE_SCHEMA = {
+  showStudentNames: { type: "boolean" as const, default: true },
+  autoScroll: { type: "boolean" as const, default: true },
+  itemsPerLine: { type: "number" as const, default: 5 },
+  layoutDirection: {
+    type: "string" as const,
+    default: "right-down",
+    validate: (v: string) =>
+      ["right-down", "left-down", "down-right", "down-left"].includes(v),
+  },
+  expandMargin: { type: "number" as const, default: 0 },
+  selectionBorderColor: {
+    type: "string?" as const,
+    default: null as string | null,
+  },
+  scoringStatusColors: {
+    type: "string?" as const,
+    default: null as string | null,
+  },
+  scoringColorPresetId: {
+    type: "string?" as const,
+    default: null as string | null,
+  },
+  masterAnswerDisplayMode: {
+    type: "string" as const,
+    default: "off",
+    validate: (v: string) =>
+      ["off", "overlay", "split-horizontal", "split-vertical"].includes(v),
+  },
+  masterAnswerOpacity: { type: "number" as const, default: 50 },
+  masterAnswerKeyBehavior: {
+    type: "string" as const,
+    default: "toggle",
+    validate: (v: string) => ["toggle", "hold-to-show"].includes(v),
+  },
+} as const
+
+/** 設定キーの型 */
+export type PreferenceKey = keyof typeof USER_PREFERENCE_SCHEMA
+
+/** 各キーのランタイム型マッピング */
+export type PreferenceValueType = {
+  showStudentNames: boolean
+  autoScroll: boolean
+  itemsPerLine: number
+  layoutDirection: string
+  expandMargin: number
+  selectionBorderColor: string | null
+  scoringStatusColors: string | null
+  scoringColorPresetId: string | null
+  masterAnswerDisplayMode: string
+  masterAnswerOpacity: number
+  masterAnswerKeyBehavior: string
+}
+
+/**
+ * DB文字列値をパースして適切な型に変換
+ */
+export function parsePreference<K extends PreferenceKey>(
+  key: K,
+  raw: string | null
+): PreferenceValueType[K] {
+  const schema = USER_PREFERENCE_SCHEMA[key]
+
+  if (raw === null || raw === undefined) {
+    return schema.default as PreferenceValueType[K]
+  }
+
+  try {
+    switch (schema.type) {
+      case "boolean":
+        return (raw === "true") as PreferenceValueType[K]
+      case "number": {
+        const num = Number(raw)
+        return (isNaN(num) ? schema.default : num) as PreferenceValueType[K]
+      }
+      case "string": {
+        // JSON文字列 → パースしてバリデーション
+        let parsed: string
+        try {
+          parsed = JSON.parse(raw)
+        } catch {
+          parsed = raw
+        }
+        const validate = (schema as { validate?: (v: string) => boolean })
+          .validate
+        if (validate && !validate(parsed)) {
+          return schema.default as PreferenceValueType[K]
+        }
+        return parsed as PreferenceValueType[K]
+      }
+      case "string?": {
+        if (raw === "null") return null as PreferenceValueType[K]
+        try {
+          return JSON.parse(raw) as PreferenceValueType[K]
+        } catch {
+          return raw as PreferenceValueType[K]
+        }
+      }
+    }
+  } catch {
+    // Fallback to default on parse error
+    return USER_PREFERENCE_SCHEMA[key].default as PreferenceValueType[K]
+  }
+}
+
+/**
+ * 値をDB保存用文字列にシリアライズ
+ */
+export function serializePreference<K extends PreferenceKey>(
+  key: K,
+  value: PreferenceValueType[K]
+): string {
+  const schema = USER_PREFERENCE_SCHEMA[key]
+
+  switch (schema.type) {
+    case "boolean":
+      return String(value)
+    case "number":
+      return String(value)
+    case "string":
+      return JSON.stringify(value)
+    case "string?":
+      return value === null ? "null" : JSON.stringify(value)
+  }
+  // Fallback (should be unreachable)
+  return String(value)
+}

--- a/prisma/migrations/20260315000000_migrate_user_preference_kv/migration.sql
+++ b/prisma/migrations/20260315000000_migrate_user_preference_kv/migration.sql
@@ -1,0 +1,103 @@
+-- CreateTable
+CREATE TABLE "UserPreference" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UserPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPreference_userId_key_key" ON "UserPreference"("userId", "key");
+
+-- CreateIndex
+CREATE INDEX "UserPreference_userId_idx" ON "UserPreference"("userId");
+
+-- Migrate existing data from UserScoringPreference to UserPreference
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'showStudentNames',
+    CASE WHEN "showStudentNames" = 1 THEN 'true' ELSE 'false' END,
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference";
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'autoScroll',
+    CASE WHEN "autoScroll" = 1 THEN 'true' ELSE 'false' END,
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference";
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'itemsPerLine',
+    CAST("itemsPerLine" AS TEXT),
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference";
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'layoutDirection',
+    '"' || "layoutDirection" || '"',
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference";
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'expandMargin',
+    CAST("expandMargin" AS TEXT),
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference";
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'selectionBorderColor',
+    CASE WHEN "selectionBorderColor" IS NULL THEN 'null' ELSE '"' || "selectionBorderColor" || '"' END,
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference"
+WHERE "selectionBorderColor" IS NOT NULL;
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'scoringStatusColors',
+    "scoringStatusColors",
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference"
+WHERE "scoringStatusColors" IS NOT NULL;
+
+INSERT INTO "UserPreference" ("id", "userId", "key", "value", "createdAt", "updatedAt")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+    "userId",
+    'scoringColorPresetId',
+    '"' || "scoringColorPresetId" || '"',
+    "createdAt",
+    "updatedAt"
+FROM "UserScoringPreference"
+WHERE "scoringColorPresetId" IS NOT NULL;
+
+-- DropTable
+DROP TABLE "UserScoringPreference";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
   userExams           UserExam[]
   invitedUserExams    UserExam[]             @relation("InvitedByUser")
   keyboardShortcuts   UserKeyboardShortcut[]
-  scoringPreference   UserScoringPreference?
+  preferences         UserPreference[]
   answerSheetDefinitions AsbDefinition[]
 }
 
@@ -343,21 +343,19 @@ model UserKeyboardShortcut {
   @@index([userId])
 }
 
-model UserScoringPreference {
-  id                   String   @id @default(uuid())
-  userId               String   @unique
-  showStudentNames     Boolean  @default(true)
-  autoScroll           Boolean  @default(true)
-  itemsPerLine         Int      @default(5)
-  layoutDirection      String   @default("right-down")
-  expandMargin         Int      @default(0)
-  selectionBorderColor String?
-  scoringStatusColors  String?
-  scoringColorPresetId String?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+model UserPreference {
+  id     String @id @default(uuid())
+  userId String
+  key    String
+  value  String // JSON文字列で保存
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, key])
+  @@index([userId])
 }
 
 model ExamMarkingFormat {


### PR DESCRIPTION
## Summary
- **Issue #564**: 個別表示モードで模範解答を表示する機能を追加（overlay / 左右分割 / 上下分割）
- **UserPreference KV移行**: `UserScoringPreference` カラム方式 → `UserPreference` key-value方式に全面移行
- **unscored統一**: `ScoringStatusType` の `"ungraded"` → `"unscored"` に統一

## 主な変更

### 模範解答表示機能
- **overlay**: 同一スクロールコンテナ内に描画（ズーム・スクロール完全同期）
- **左右/上下分割**: 2画面方式で独立スクロールパネルをrAFループで双方向同期
- 画素数が異なる答案/模範解答の自動スケール補正（`referenceImageSize`）
- ショートカットキー `x` でトグル / hold-to-show対応
- 不透明度スライダー（5-100%）
- 模範解答パネルでのホイールズーム対応（wheelイベント転送）
- サイドパネルに表示モードプルダウン + Eye/EyeOffボタン（tooltip付き）

### UserPreference KV移行
- `UserScoringPreference` テーブル → `UserPreference` (userId, key, value) テーブルに移行
- マイグレーションSQLで既存データを自動移行
- `lib/userPreferences.ts`: 型安全なスキーマ定義 + parse/serialize
- 5つの設定フック + `scoringStatusColors.ts` + `DisplaySettingsTab` を新API対応

### unscored統一
- `ScoringStatusType` の `"ungraded"` → `"unscored"` に変更
- `ScoringToolbar` の `STATUS_MAP`、`scoreStatusConfig` の `colors.ungraded` を修正
- DB保存済みJSONの `"ungraded"` キーをフォールバック読み込み（後方互換）

## Test plan
- [ ] `npx prisma migrate dev` でマイグレーション適用
- [ ] 設定画面で既存設定（itemsPerLine、採点状態色等）が正常に読み書きできること
- [ ] 採点画面 → 個別表示モードで各表示モード（overlay/左右/上下）を切り替え確認
- [ ] `x` キーでトグル / hold-to-show動作確認
- [ ] overlay不透明度スライダー動作確認
- [ ] 分割表示でスクロール・ズーム同期（双方向）確認
- [ ] 分割表示の模範解答側でCtrl+ホイールズーム確認
- [ ] 複数ページ答案での模範解答表示確認
- [ ] Grid表示でunscored表示色が正常に適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)