### PR TITLE
feat: MasterImageに用紙サイズ(pageSize)フィールドを追加

### DIFF
--- a/components/exams/01-upload/components/MasterAnswerCard.tsx
+++ b/components/exams/01-upload/components/MasterAnswerCard.tsx
@@ -28,6 +28,8 @@ import { Button } from "@/components/ui/button"
  * @param onMoveRight - 右移動のコールバック関数
  * @returns 模範解答画像カードコンポーネント
  */
+const PAGE_SIZE_OPTIONS = ["A3", "A4", "A5", "B4", "B5"] as const
+
 const MasterAnswerCard = React.memo<MasterAnswerCardProps>(
   ({
     answer,
@@ -39,6 +41,7 @@ const MasterAnswerCard = React.memo<MasterAnswerCardProps>(
     onDelete,
     onMoveLeft,
     onMoveRight,
+    onPageSizeChange,
   }) => {
     // 移動可能性の判定
     const canMoveLeft = index > 0
@@ -89,6 +92,22 @@ const MasterAnswerCard = React.memo<MasterAnswerCardProps>(
           <p className="text-sm font-semibold text-white">
             ページ {answer.pageNumber}
           </p>
+          <select
+            className="mt-1 rounded bg-white/20 px-1.5 py-0.5 text-xs text-white backdrop-blur-sm"
+            value={answer.pageSize ?? "A4"}
+            onChange={(e) => {
+              e.stopPropagation()
+              onPageSizeChange(e.target.value)
+            }}
+            onClick={(e) => e.stopPropagation()}
+            disabled={isDisabled}
+          >
+            {PAGE_SIZE_OPTIONS.map((size) => (
+              <option key={size} value={size} className="text-black">
+                {size}
+              </option>
+            ))}
+          </select>
           <div className="mt-2 flex space-x-1">
             <Button
               size="icon"

--- a/components/exams/01-upload/components/MasterAnswerGallery.tsx
+++ b/components/exams/01-upload/components/MasterAnswerGallery.tsx
@@ -30,6 +30,7 @@ export function MasterAnswerGallery({
   isMoving,
   onDeleteAnswer,
   onMoveAnswer,
+  onPageSizeChange,
 }: MasterAnswerGalleryProps) {
   // 画像がない場合は何も表示しない
   if (answers.length === 0) {
@@ -62,6 +63,9 @@ export function MasterAnswerGallery({
                   onDelete={() => onDeleteAnswer(answer.id)}
                   onMoveLeft={() => onMoveAnswer(index, "left")}
                   onMoveRight={() => onMoveAnswer(index, "right")}
+                  onPageSizeChange={(pageSize) =>
+                    onPageSizeChange(answer.id, pageSize)
+                  }
                 />
               ) : (
                 <div

--- a/components/exams/01-upload/components/MasterAnswerManager.tsx
+++ b/components/exams/01-upload/components/MasterAnswerManager.tsx
@@ -38,6 +38,7 @@ export function MasterAnswerManager({
     uploadAnswers,
     deleteAnswer,
     moveAnswer,
+    updatePageSize,
     handlePasswordSubmit,
     handlePasswordCancel,
   } = useMasterAnswers(examId, initialMasterAnswers, onMasterAnswersChange)
@@ -61,6 +62,7 @@ export function MasterAnswerManager({
         isMoving={isMoving}
         onDeleteAnswer={deleteAnswer}
         onMoveAnswer={moveAnswer}
+        onPageSizeChange={updatePageSize}
       />
 
       {/* パスワード入力ダイアログ */}

--- a/components/exams/01-upload/hooks/useMasterAnswers.ts
+++ b/components/exams/01-upload/hooks/useMasterAnswers.ts
@@ -344,11 +344,34 @@ export function useMasterAnswers(
     [state.answers, onAnswersChange]
   )
 
+  const updatePageSize = useCallback(
+    async (answerId: string, pageSize: string) => {
+      try {
+        await window.electronAPI.updateMasterImagePageSize(answerId, pageSize)
+        setState((prev) => ({
+          ...prev,
+          answers: prev.answers.map((a) =>
+            a.id === answerId ? { ...a, pageSize } : a
+          ),
+        }))
+        onAnswersChange(
+          state.answers.map((a) => (a.id === answerId ? { ...a, pageSize } : a))
+        )
+        toast.success("用紙サイズを変更しました")
+      } catch (error) {
+        console.error("Failed to update page size:", error)
+        toast.error("用紙サイズの変更に失敗しました")
+      }
+    },
+    [state.answers, onAnswersChange]
+  )
+
   return {
     ...state,
     uploadAnswers,
     deleteAnswer,
     moveAnswer,
+    updatePageSize,
     handlePasswordSubmit,
     handlePasswordCancel,
   }

--- a/components/exams/01-upload/types/index.ts
+++ b/components/exams/01-upload/types/index.ts
@@ -7,6 +7,7 @@ export type MasterAnswer = {
   examId: string
   imagePath: string
   pageNumber: number
+  pageSize: string
   createdAt: Date
   updatedAt: Date
 }
@@ -41,6 +42,7 @@ export interface MasterAnswerGalleryProps {
   isMoving: boolean
   onDeleteAnswer: (answerId: string) => void
   onMoveAnswer: (fromIndex: number, direction: "left" | "right") => void
+  onPageSizeChange: (answerId: string, pageSize: string) => void
 }
 
 /**
@@ -66,6 +68,7 @@ export interface MasterAnswerCardProps {
   onDelete: () => void
   onMoveLeft: () => void
   onMoveRight: () => void
+  onPageSizeChange: (pageSize: string) => void
 }
 
 /**

--- a/components/exams/01-upload/utils/imageUtils.ts
+++ b/components/exams/01-upload/utils/imageUtils.ts
@@ -143,6 +143,7 @@ type MinimalPageImage = {
 type MinimalMasterImage = {
   id: string
   imagePath: string
+  pageSize?: string
   createdAt: Date
   updatedAt: Date
 }
@@ -178,6 +179,8 @@ export const convertExamPagesToMasterAnswers = <T extends MinimalExamPage>(
       examId: page.examId,
       imagePath: masterImage.imagePath,
       pageNumber: page.pageNumber,
+      pageSize:
+        "pageSize" in masterImage ? (masterImage.pageSize ?? "A4") : "A4",
       createdAt: masterImage.createdAt,
       updatedAt: masterImage.updatedAt,
     }))

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -19,6 +19,7 @@ import {
   deleteMasterAnswer,
   getMasterAnswersByExamId,
   updateMasterAnswersOrder,
+  updateMasterImagePageSize,
   uploadMasterAnswers,
 } from "../lib/prisma/masterAnswer"
 import {
@@ -474,6 +475,18 @@ export function setupMiscHandlers(): void {
         return await updateMasterAnswersOrder(answerOrders)
       } catch (err) {
         console.error("Error in IPC update-master-answers-order:", err)
+        throw err
+      }
+    }
+  )
+
+  ipcMain.handle(
+    "update-master-image-page-size",
+    async (_event, id: string, pageSize: string) => {
+      try {
+        return await updateMasterImagePageSize(id, pageSize)
+      } catch (err) {
+        console.error("Error in IPC update-master-image-page-size:", err)
         throw err
       }
     }

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -113,6 +113,7 @@ export async function convertToExam(
         data: {
           examPageId: examPage.id,
           imagePath: relativeMasterPath,
+          pageSize: definition.settings.paperSize ?? "A4",
         },
       })
 

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -374,6 +374,7 @@ export async function collectExamData(
           id: img.id,
           examPageId: img.examPageId,
           imagePath: img.imagePath,
+          pageSize: img.pageSize,
           createdAt: img.createdAt.toISOString(),
           updatedAt: img.updatedAt.toISOString(),
         }))

--- a/electron-src/lib/import/exam-archive/imageHandler.ts
+++ b/electron-src/lib/import/exam-archive/imageHandler.ts
@@ -80,6 +80,7 @@ export async function createImageRecords(
           id: remapIdRequired(img.id, mappings.masterImage),
           examPageId: newExamPageId,
           imagePath: newImagePath,
+          pageSize: img.pageSize ?? "A4",
         },
       })
     }

--- a/electron-src/lib/import/merge/imageImporter.ts
+++ b/electron-src/lib/import/merge/imageImporter.ts
@@ -107,6 +107,7 @@ async function createMasterImageRecords(
           id: img.id,
           examPageId: newExamPageId,
           imagePath: newImagePath,
+          pageSize: img.pageSize ?? "A4",
         },
       })
     }

--- a/electron-src/lib/import/transformers/V1_7_0_to_V1_8_0.ts
+++ b/electron-src/lib/import/transformers/V1_7_0_to_V1_8_0.ts
@@ -1,0 +1,50 @@
+/**
+ * V1.7.0 → V1.8.0 変換器
+ *
+ * 変更点:
+ * - MasterImage に pageSize フィールドを追加（デフォルト: "A4"）
+ */
+
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  TransformResult,
+  VersionTransformer,
+} from "./types"
+
+export class V1_7_0_to_V1_8_0_Transformer implements VersionTransformer {
+  readonly fromVersion: ArchiveVersion = "1.7.0"
+  readonly toVersion: ArchiveVersion = "1.8.0"
+
+  transform(data: ArchiveData): TransformResult {
+    const warnings: string[] = []
+
+    // v1.7.0 以前のアーカイブには masterImages に pageSize が存在しない
+    // デフォルト値 "A4" を追加
+    const masterImages = (data.examData.masterImages ?? []).map((img) => ({
+      ...img,
+      pageSize: img.pageSize ?? "A4",
+    }))
+
+    const examData = {
+      ...data.examData,
+      masterImages,
+    }
+
+    warnings.push(
+      "v1.8.0: MasterImage に pageSize フィールドを追加しました（デフォルト: A4）"
+    )
+
+    return {
+      data: {
+        ...data,
+        manifest: {
+          ...data.manifest,
+          version: this.toVersion,
+        },
+        examData,
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/transformers/index.ts
+++ b/electron-src/lib/import/transformers/index.ts
@@ -20,6 +20,7 @@ import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 import { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
 import { V1_5_0_to_V1_6_0_Transformer } from "./V1_5_0_to_V1_6_0"
 import { V1_6_0_to_V1_7_0_Transformer } from "./V1_6_0_to_V1_7_0"
+import { V1_7_0_to_V1_8_0_Transformer } from "./V1_7_0_to_V1_8_0"
 
 // =============================================================================
 // Transformer Registry
@@ -38,6 +39,7 @@ const TRANSFORMERS: VersionTransformer[] = [
   new V1_4_0_to_V1_5_0_Transformer(),
   new V1_5_0_to_V1_6_0_Transformer(),
   new V1_6_0_to_V1_7_0_Transformer(),
+  new V1_7_0_to_V1_8_0_Transformer(),
 ]
 
 /**
@@ -242,3 +244,4 @@ export { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 export { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
 export { V1_5_0_to_V1_6_0_Transformer } from "./V1_5_0_to_V1_6_0"
 export { V1_6_0_to_V1_7_0_Transformer } from "./V1_6_0_to_V1_7_0"
+export { V1_7_0_to_V1_8_0_Transformer } from "./V1_7_0_to_V1_8_0"

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -31,6 +31,7 @@ import type {
  * - 1.5.0: v0.6.x (Project→Exam, GradeProject→Grade リネーム、DBスキーマ変更)
  * - 1.6.0: v0.7.x (DrawingAnnotation.isFavorite 追加)
  * - 1.7.0: v0.8.x (CropRegionOmrConfig, CropRegionOmrChoiceOption 追加)
+ * - 1.8.0: v0.9.x (MasterImage.pageSize 追加)
  */
 export type ArchiveVersion =
   | "1.0.0"
@@ -41,9 +42,10 @@ export type ArchiveVersion =
   | "1.5.0"
   | "1.6.0"
   | "1.7.0"
+  | "1.8.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.7.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.8.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -55,6 +57,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.5.0",
   "1.6.0",
   "1.7.0",
+  "1.8.0",
 ] as const
 
 // =============================================================================

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -429,6 +429,17 @@ export const getMasterAnswerByPage = async (
   return null
 }
 
+export const updateMasterImagePageSize = async (
+  id: string,
+  pageSize: string
+) => {
+  return prisma.masterImage.update({
+    where: { id },
+    data: { pageSize },
+    include: { examPage: true },
+  })
+}
+
 // For compatibility with existing code
 export type MasterAnswerPayload = MasterImage & {
   pageNumber: number

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -228,6 +228,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   updateMasterAnswersOrder: (
     answerOrders: { id: string; pageNumber: number }[]
   ) => ipcRenderer.invoke("update-master-answers-order", answerOrders),
+  updateMasterImagePageSize: (id: string, pageSize: string) =>
+    ipcRenderer.invoke("update-master-image-page-size", id, pageSize),
 
   // New API to resolve file path for display
   resolveFileProtocolPath: (relativePath: string) =>

--- a/prisma/migrations/20260316000000_add_master_image_page_size/migration.sql
+++ b/prisma/migrations/20260316000000_add_master_image_page_size/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MasterImage" ADD COLUMN "pageSize" TEXT NOT NULL DEFAULT 'A4';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,7 @@ model MasterImage {
   id         String   @id @default(uuid())
   examPageId String
   imagePath  String
+  pageSize   String   @default("A4")
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
   examPage   ExamPage @relation(fields: [examPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -477,6 +477,10 @@ export interface MyAPI {
   updateMasterAnswersOrder: (
     answerOrders: { id: string; pageNumber: number }[]
   ) => Promise<Prisma.BatchPayload>
+  updateMasterImagePageSize: (
+    id: string,
+    pageSize: string
+  ) => Promise<MasterImage & { examPage: ExamPage }>
   getMasterAnswersByExamId: (examId: string) => Promise<ExamPageWithDetails[]>
   getExamPagesByExamId: (examId: string) => Promise<ExamPageWithDetails[]>
 

--- a/types/examArchive.types.ts
+++ b/types/examArchive.types.ts
@@ -649,6 +649,8 @@ export interface ArchiveExamData {
     id: string
     examPageId: string
     imagePath: string
+    /** v1.8.0+ 用紙サイズ */
+    pageSize?: string
     createdAt: string
     updatedAt: string
   }>


### PR DESCRIPTION
## Summary

- MasterImageモデルに`pageSize`フィールド（デフォルト: "A4"）を追加
- 模範解答アップロード画面にMasterImageごとの用紙サイズ選択UIを追加
- 解答用紙ビルダーからの試験変換時に`paperSize`を引き継ぐように対応
- Archive export/importでpageSizeの保存・復元に対応（v1.8.0）

## 変更ファイル (20ファイル)

**スキーマ・マイグレーション:**
- `prisma/schema.prisma` — `pageSize String @default("A4")` 追加
- マイグレーションSQL追加

**バックエンド:**
- `masterAnswer.ts` — `updateMasterImagePageSize`関数追加
- `miscHandlers.ts` — IPCハンドラ追加
- `preload.ts` — API公開

**フロントエンド:**
- `MasterAnswerCard.tsx` — 用紙サイズ選択`<select>`追加
- `useMasterAnswers.ts` — `updatePageSize`関数追加
- 型定義・Gallery・Managerの配線

**Archive (v1.8.0):**
- `V1_7_0_to_V1_8_0.ts` — 旧アーカイブにデフォルト値付与
- export/import両方で`pageSize`を保存・復元

Closes #620

## Test plan

- [ ] 模範解答アップロード画面で用紙サイズがA4で表示されることを確認
- [ ] 用紙サイズをA3やB4に変更して保存されることを確認
- [ ] 解答用紙ビルダーからの試験変換でpaperSizeが引き継がれることを確認
- [ ] 試験のエクスポート→インポートでpageSizeが保持されることを確認
- [ ] 旧バージョン(v1.7.0以前)のアーカイブインポートでA4がデフォルト設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)