### PR TITLE
feat: アノテーションのstrokeWidth/fontSizeをmm単位に変更

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -57,6 +57,7 @@ export default function AnswerIndividualView({
   onZoomChanged,
   scrollContainerRef,
   onImageSizeChanged,
+  pageSize = "A4",
 }: AnswerIndividualViewProps) {
   // 画像ナビゲーション状態管理（内部管理）
   const {
@@ -223,6 +224,7 @@ export default function AnswerIndividualView({
     allCropRegionsWithStatus,
     // 印字設定（採点マーク・点数表示のプレビュー用）
     scoringMarkConfig,
+    pageSize,
   })
 
   // 画像サイズ通知（split表示のMasterパネルで参照サイズとして使用）

--- a/components/exams/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/EllipseToolPopover.tsx
@@ -127,13 +127,15 @@ export function EllipseToolPopover({
 
           {/* 線幅 */}
           <div onPointerDown={(e) => e.stopPropagation()}>
-            <Label className="text-xs">線幅: {strokeWidth}px</Label>
+            <Label className="text-xs">線幅: {strokeWidth}mm</Label>
             <Slider
-              min={1}
-              max={10}
-              step={1}
+              min={0.1}
+              max={5.0}
+              step={0.1}
               value={[strokeWidth]}
-              onValueChange={(value) => onStrokeWidthChange(value[0])}
+              onValueChange={(value) =>
+                onStrokeWidthChange(Math.round(value[0] * 10) / 10)
+              }
               className="mt-2"
             />
           </div>

--- a/components/exams/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/LineToolPopover.tsx
@@ -207,13 +207,15 @@ export function LineToolPopover({
 
           {/* 線幅 */}
           <div onPointerDown={(e) => e.stopPropagation()}>
-            <Label className="text-xs">線幅: {strokeWidth}px</Label>
+            <Label className="text-xs">線幅: {strokeWidth}mm</Label>
             <Slider
-              min={1}
-              max={10}
-              step={1}
+              min={0.1}
+              max={5.0}
+              step={0.1}
               value={[strokeWidth]}
-              onValueChange={(value) => onStrokeWidthChange(value[0])}
+              onValueChange={(value) =>
+                onStrokeWidthChange(Math.round(value[0] * 10) / 10)
+              }
               className="mt-2"
             />
           </div>

--- a/components/exams/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
+++ b/components/exams/07-score-at-once/ScoringIndividual/RectangleToolPopover.tsx
@@ -129,13 +129,15 @@ export function RectangleToolPopover({
 
           {/* 線幅 */}
           <div onPointerDown={(e) => e.stopPropagation()}>
-            <Label className="text-xs">線幅: {strokeWidth}px</Label>
+            <Label className="text-xs">線幅: {strokeWidth}mm</Label>
             <Slider
-              min={1}
-              max={10}
-              step={1}
+              min={0.1}
+              max={5.0}
+              step={0.1}
               value={[strokeWidth]}
-              onValueChange={(value) => onStrokeWidthChange(value[0])}
+              onValueChange={(value) =>
+                onStrokeWidthChange(Math.round(value[0] * 10) / 10)
+              }
               className="mt-2"
             />
           </div>

--- a/components/exams/07-score-at-once/ScoringIndividual/constants/drawingConstants.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/constants/drawingConstants.ts
@@ -10,12 +10,12 @@ export const COLOR_PALETTE = [
   "#8000ff", // 紫
 ] as const
 
-// デフォルトの描画設定
+// デフォルトの描画設定（mm単位）
 export const DEFAULT_DRAWING_SETTINGS = {
   strokeColor: "#ef4444",
-  strokeWidth: 3,
+  strokeWidth: 0.5,
   lineStyle: "solid" as const,
-  fontSize: 16,
+  fontSize: 4.0,
 } as const
 
 // 描画時の許容誤差（正規化座標 0-1）

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
@@ -56,6 +56,8 @@ export interface UseImageCanvasProps {
   allCropRegionsWithStatus?: CropRegionWithStatus[]
   // 印字設定（採点マーク・点数表示のプレビュー用）
   scoringMarkConfig?: ScoringMarkConfig | null
+  // 模範解答の用紙サイズ（mm→px変換基準）
+  pageSize?: string
 }
 
 /**

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -173,6 +173,7 @@ interface UseCanvasDrawingProps {
   hoveredElementId?: string | null
   allCropRegionsWithStatus?: CropRegionWithStatus[]
   scoringMarkConfig?: ScoringMarkConfig | null
+  pageSize?: string
 }
 
 /**
@@ -202,6 +203,7 @@ export function useCanvasDrawing({
   hoveredElementId,
   allCropRegionsWithStatus = [],
   scoringMarkConfig,
+  pageSize = "A4",
 }: UseCanvasDrawingProps): void {
   const { convertAnnotationToDrawingElement, drawSingleElement } =
     useDrawingRenderer()
@@ -511,7 +513,8 @@ export function useCanvasDrawing({
               annotOffsetY,
               false,
               false,
-              false
+              false,
+              pageSize
             )
             ctx.globalAlpha = 1.0
           }
@@ -532,7 +535,9 @@ export function useCanvasDrawing({
             currentOffsetX,
             currentOffsetY,
             isSelected,
-            false
+            false,
+            true,
+            pageSize
           )
           ctx.globalAlpha = 1.0
         }
@@ -582,6 +587,7 @@ export function useCanvasDrawing({
       drawSingleElement,
       allCropRegionsWithStatus,
       scoringMarkConfig,
+      pageSize,
     ]
   )
 

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
@@ -8,6 +8,7 @@ import { useCallback } from "react"
 
 import { getTextPositionFromAnchor } from "@/app/textbox-on-canvas-v4/utils/canvasUtils"
 import type { DrawingElement } from "@/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes"
+import { mmToPixels } from "@/lib/paperSize"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
 import { renderTextElementV4 } from "../../utils/canvasTextRendererV4"
@@ -24,7 +25,8 @@ interface UseDrawingRendererReturn {
     offsetY: number,
     isSelected: boolean,
     isDragging: boolean,
-    showAnchor?: boolean
+    showAnchor?: boolean,
+    pageSize?: string
   ) => Promise<void>
 }
 
@@ -69,7 +71,8 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
       offsetY: number,
       isSelected: boolean,
       isDragging: boolean,
-      showAnchor: boolean = true
+      showAnchor: boolean = true,
+      pageSize: string = "A4"
     ) => {
       // テキストボックスの場合、表示用座標があればそれを使用
       const displayX =
@@ -84,13 +87,35 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
       const currentX = displayX * baseImg.naturalWidth + offsetX
       const currentY = displayY * baseImg.naturalHeight + offsetY
 
+      // mm → canvas pixels 変換
+      const strokeWidthPx = mmToPixels(
+        element.strokeWidth,
+        pageSize,
+        baseImg.naturalWidth,
+        baseImg.naturalHeight
+      )
+
+      const fontSizePx = mmToPixels(
+        element.fontSize || 4.0,
+        pageSize,
+        baseImg.naturalWidth,
+        baseImg.naturalHeight
+      )
+
+      // ピクセル変換済みの要素コピー（内部描画関数用）
+      const pxElement = {
+        ...element,
+        strokeWidth: strokeWidthPx,
+        fontSize: fontSizePx,
+      }
+
       ctx.strokeStyle = element.color
       ctx.fillStyle = element.color
-      ctx.lineWidth = element.strokeWidth
+      ctx.lineWidth = strokeWidthPx
 
       // テキスト要素のドラッグ中は軽量描画（長方形のみ）
       if (isDragging && isSelected && element.type === "text") {
-        drawLightweightTextPlaceholder(ctx, element, currentX, currentY)
+        drawLightweightTextPlaceholder(ctx, pxElement, currentX, currentY)
         return
       }
 
@@ -99,7 +124,7 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
         case "text":
           await drawTextElement(
             ctx,
-            element,
+            pxElement,
             baseImg,
             isSelected,
             showAnchor,
@@ -110,7 +135,7 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
         case "line":
           drawLineElement(
             ctx,
-            element,
+            pxElement,
             baseImg,
             offsetX,
             offsetY,
@@ -119,10 +144,10 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
           )
           break
         case "rectangle":
-          drawRectangleElement(ctx, element, baseImg, currentX, currentY)
+          drawRectangleElement(ctx, pxElement, baseImg, currentX, currentY)
           break
         case "ellipse":
-          drawEllipseElement(ctx, element, baseImg, currentX, currentY)
+          drawEllipseElement(ctx, pxElement, baseImg, currentX, currentY)
           break
       }
     },

--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
@@ -38,6 +38,7 @@ export function useImageCanvas({
   hoveredElementId,
   allCropRegionsWithStatus = [],
   scoringMarkConfig,
+  pageSize = "A4",
 }: UseImageCanvasProps): UseImageCanvasReturn {
   // キャンバス参照管理
   const {
@@ -89,6 +90,7 @@ export function useImageCanvas({
     hoveredElementId,
     allCropRegionsWithStatus,
     scoringMarkConfig,
+    pageSize,
   })
 
   return {

--- a/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -111,10 +111,9 @@ export interface AnswerIndividualViewProps {
   /** スクロールコンテナのRef公開（split表示のscroll同期用） */
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>
   /** 読み込み済み画像サイズ通知（split表示のMasterパネルで参照サイズとして使用） */
-  onImageSizeChanged?: (size: {
-    width: number
-    heights: number[]
-  }) => void
+  onImageSizeChanged?: (size: { width: number; heights: number[] }) => void
+  /** 模範解答の用紙サイズ（mm→px変換基準、デフォルト: "A4"） */
+  pageSize?: string
 }
 
 // 選択範囲矩形の型定義

--- a/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -121,6 +121,8 @@ interface PdfCanvasRendererProps {
   ) => void | Promise<void>
   /** エラー発生時のコールバック */
   onError?: (error: Error) => void
+  /** 用紙サイズ（mm→px変換基準） */
+  pageSize?: string
 }
 
 /**
@@ -138,6 +140,7 @@ export function PdfCanvasRenderer({
   onPageComplete,
   onComplete,
   onError,
+  pageSize = "A4",
 }: PdfCanvasRendererProps) {
   const [isRendering, setIsRendering] = useState(false)
   const scoringMarkImagesRef = useRef<Map<string, HTMLImageElement> | null>(
@@ -335,7 +338,8 @@ export function PdfCanvasRenderer({
         markImages,
         subtotalDataForPdf,
         totalScoreDataForPdf,
-        page.pageNumber
+        page.pageNumber,
+        pageSize
       )
 
       const arrayBuffer = await blob.arrayBuffer()

--- a/components/exams/08-export/hooks/useScoredAnswerPreview.ts
+++ b/components/exams/08-export/hooks/useScoredAnswerPreview.ts
@@ -194,7 +194,8 @@ export function useScoredAnswerPreview({
             scoringMarkImagesRef.current!,
             subtotalDataForPdf,
             totalScoreDataForPdf,
-            page.pageNumber
+            page.pageNumber,
+            (page as { pageSize?: string }).pageSize ?? "A4"
           )
 
           if (cancelled) return

--- a/components/exams/08-export/utils/pdfCanvasRenderer.ts
+++ b/components/exams/08-export/utils/pdfCanvasRenderer.ts
@@ -8,6 +8,7 @@
 import type { AnchorDirection } from "@/app/textbox-on-canvas-v4/types"
 import { getTextPositionFromAnchor } from "@/app/textbox-on-canvas-v4/utils/canvasUtils"
 import { convertTextToSvg } from "@/app/textbox-on-canvas-v4/utils/textConversionUtils"
+import { mmToPixels } from "@/lib/paperSize"
 import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
 
 /**
@@ -158,23 +159,37 @@ async function drawElement(
   imageHeight: number,
   offsetX: number = 0,
   offsetY: number = 0,
-  pageOffset: number = 0
+  pageOffset: number = 0,
+  pageSize: string = "A4"
 ): Promise<void> {
   // 座標計算（テキストも含めてelement.x/yを使用 - 一括採点個別表示と同じ）
   // pageOffsetを引くことで、複数ページキャンバスからの座標をページ内座標に変換
   const currentX = element.x * imageWidth + offsetX
   const currentY = (element.y - pageOffset) * imageHeight + offsetY
 
+  // mm → canvas pixels 変換
+  const strokeWidthPx = mmToPixels(
+    element.strokeWidth,
+    pageSize,
+    imageWidth,
+    imageHeight
+  )
+  const fontSizePx = mmToPixels(
+    element.fontSize ?? 4.0,
+    pageSize,
+    imageWidth,
+    imageHeight
+  )
+
   ctx.strokeStyle = element.color
   ctx.fillStyle = element.color
-  ctx.lineWidth = element.strokeWidth
+  ctx.lineWidth = strokeWidthPx
 
   switch (element.type) {
     case "text":
       if (element.text) {
         const anchorDir = (element.anchorDirection ||
           "top-left") as AnchorDirection
-        const fontSize = element.fontSize ?? 16
         const textColor = element.color || "#000000"
 
         try {
@@ -184,7 +199,7 @@ async function drawElement(
             imageHeight,
             "left",
             "top",
-            fontSize,
+            fontSizePx,
             textColor
           )
 
@@ -240,11 +255,11 @@ async function drawElement(
         } catch (error) {
           console.error("MathJaxテキスト描画エラー:", error)
           // フォールバック: シンプルテキスト描画
-          ctx.font = `${fontSize}px sans-serif`
+          ctx.font = `${fontSizePx}px sans-serif`
           ctx.fillStyle = textColor
           ctx.textBaseline = "top"
           const lines = element.text.split("\n")
-          const lineHeight = fontSize * 1.4
+          const lineHeight = fontSizePx * 1.4
           lines.forEach((line, index) => {
             ctx.fillText(line, currentX, currentY + index * lineHeight)
           })
@@ -260,7 +275,7 @@ async function drawElement(
         ctx.save()
         ctx.strokeStyle = element.color
         ctx.fillStyle = element.color
-        ctx.lineWidth = element.strokeWidth
+        ctx.lineWidth = strokeWidthPx
         ctx.setLineDash([])
         ctx.lineCap = "round"
         ctx.lineJoin = "round"
@@ -272,12 +287,12 @@ async function drawElement(
         const angle = Math.atan2(dy, dx)
 
         // 矢印のサイズ
-        const arrowSize = Math.max(element.strokeWidth * 5, 12)
+        const arrowSize = Math.max(strokeWidthPx * 5, 12)
 
         switch (element.lineStyle) {
           case "wave": {
-            const waveAmplitude = element.strokeWidth * 2
-            const waveLength = element.strokeWidth * 4
+            const waveAmplitude = strokeWidthPx * 2
+            const waveLength = strokeWidthPx * 4
             const segments = Math.max(Math.floor(lineLength / waveLength), 1)
 
             ctx.beginPath()
@@ -301,8 +316,8 @@ async function drawElement(
           }
 
           case "zigzag": {
-            const zigHeight = element.strokeWidth * 2
-            const zigLength = element.strokeWidth * 3
+            const zigHeight = strokeWidthPx * 2
+            const zigLength = strokeWidthPx * 3
             const segments = Math.max(Math.floor(lineLength / zigLength), 1)
 
             ctx.beginPath()
@@ -322,7 +337,7 @@ async function drawElement(
           }
 
           case "double": {
-            const offset = element.strokeWidth
+            const offset = strokeWidthPx
             const perpX = -Math.sin(angle) * offset
             const perpY = Math.cos(angle) * offset
 
@@ -730,7 +745,8 @@ export async function renderAnswerSheetToCanvas(
   scoringMarkImages: Map<string, HTMLImageElement>,
   subtotalDataList: SubtotalDataForPdf[] = [],
   totalScoreDataList: TotalScoreDataForPdf[] = [],
-  pageNumber: number = 1
+  pageNumber: number = 1,
+  pageSize: string = "A4"
 ): Promise<Blob> {
   const ctx = canvas.getContext("2d")
   if (!ctx) {
@@ -847,7 +863,16 @@ export async function renderAnswerSheetToCanvas(
     const needsPageOffset =
       element.y >= 1.0 || (element.endY !== undefined && element.endY >= 1.0)
     const pageOffset = needsPageOffset ? basePageOffset : 0
-    await drawElement(ctx, element, imageWidth, imageHeight, 0, 0, pageOffset)
+    await drawElement(
+      ctx,
+      element,
+      imageWidth,
+      imageHeight,
+      0,
+      0,
+      pageOffset,
+      pageSize
+    )
   }
 
   // Canvas結果をBlobとして取得

--- a/electron-src/lib/import/transformers/V1_7_0_to_V1_8_0.ts
+++ b/electron-src/lib/import/transformers/V1_7_0_to_V1_8_0.ts
@@ -3,6 +3,7 @@
  *
  * 変更点:
  * - MasterImage に pageSize フィールドを追加（デフォルト: "A4"）
+ * - DrawingAnnotation の strokeWidth / fontSize をピクセル値からmm値に変換
  */
 
 import type {
@@ -12,6 +13,36 @@ import type {
   VersionTransformer,
 } from "./types"
 
+/**
+ * 用紙サイズ（mm）
+ */
+const PAPER_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  A3: { width: 297, height: 420 },
+  A4: { width: 210, height: 297 },
+  A5: { width: 148, height: 210 },
+  B4: { width: 257, height: 364 },
+  B5: { width: 182, height: 257 },
+}
+
+/**
+ * PDF scale=2.0 を仮定した概算画像幅ピクセル数
+ * 72dpi × 2.0 = 144dpi → 1mm ≈ 5.669px
+ */
+function getEstimatedImageWidthPx(pageSize: string): number {
+  const paper = PAPER_DIMENSIONS[pageSize] ?? PAPER_DIMENSIONS.A4
+  const pxPerMm = (72 * 2) / 25.4
+  return Math.round(paper.width * pxPerMm)
+}
+
+/**
+ * ピクセル値をmm値に概算変換
+ */
+function pxToMm(px: number, pageSize: string): number {
+  const imageWidthPx = getEstimatedImageWidthPx(pageSize)
+  const paper = PAPER_DIMENSIONS[pageSize] ?? PAPER_DIMENSIONS.A4
+  return Math.round(((px * paper.width) / imageWidthPx) * 100) / 100
+}
+
 export class V1_7_0_to_V1_8_0_Transformer implements VersionTransformer {
   readonly fromVersion: ArchiveVersion = "1.7.0"
   readonly toVersion: ArchiveVersion = "1.8.0"
@@ -19,21 +50,42 @@ export class V1_7_0_to_V1_8_0_Transformer implements VersionTransformer {
   transform(data: ArchiveData): TransformResult {
     const warnings: string[] = []
 
-    // v1.7.0 以前のアーカイブには masterImages に pageSize が存在しない
-    // デフォルト値 "A4" を追加
+    // 1. MasterImage に pageSize を追加
     const masterImages = (data.examData.masterImages ?? []).map((img) => ({
       ...img,
       pageSize: img.pageSize ?? "A4",
     }))
+
+    // masterImagesからpageSizeを取得（最初の画像のpageSizeを基準に使用）
+    const pageSize = masterImages[0]?.pageSize ?? "A4"
+
+    // 2. DrawingAnnotation の strokeWidth / fontSize を px→mm 変換
+    const drawingAnnotations = (data.scoresData.drawingAnnotations ?? []).map(
+      (da) => ({
+        ...da,
+        strokeWidth: pxToMm(da.strokeWidth, pageSize),
+        fontSize: pxToMm(da.fontSize, pageSize),
+      })
+    )
 
     const examData = {
       ...data.examData,
       masterImages,
     }
 
+    const scoresData = {
+      ...data.scoresData,
+      drawingAnnotations,
+    }
+
     warnings.push(
       "v1.8.0: MasterImage に pageSize フィールドを追加しました（デフォルト: A4）"
     )
+    if (drawingAnnotations.length > 0) {
+      warnings.push(
+        `v1.8.0: DrawingAnnotation ${drawingAnnotations.length}件の strokeWidth/fontSize をpx→mm変換しました（${pageSize}基準）`
+      )
+    }
 
     return {
       data: {
@@ -43,6 +95,7 @@ export class V1_7_0_to_V1_8_0_Transformer implements VersionTransformer {
           version: this.toVersion,
         },
         examData,
+        scoresData,
       },
       warnings,
     }

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -198,6 +198,7 @@ CREATE TABLE "MasterImage" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "examPageId" TEXT NOT NULL,
     "imagePath" TEXT NOT NULL,
+    "pageSize" TEXT NOT NULL DEFAULT 'A4',
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT "MasterImage_examPageId_fkey" FOREIGN KEY ("examPageId") REFERENCES "ExamPage" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
@@ -312,14 +313,14 @@ CREATE TABLE "DrawingAnnotation" (
     "x" REAL NOT NULL,
     "y" REAL NOT NULL,
     "color" TEXT NOT NULL DEFAULT '#ef4444',
-    "strokeWidth" INTEGER NOT NULL DEFAULT 3,
+    "strokeWidth" REAL NOT NULL DEFAULT 0.5,
     "width" REAL NOT NULL DEFAULT 0.0,
     "height" REAL NOT NULL DEFAULT 0.0,
     "endX" REAL NOT NULL DEFAULT 0.0,
     "endY" REAL NOT NULL DEFAULT 0.0,
     "lineStyle" TEXT NOT NULL DEFAULT 'solid',
     "text" TEXT NOT NULL DEFAULT '',
-    "fontSize" INTEGER NOT NULL DEFAULT 16,
+    "fontSize" REAL NOT NULL DEFAULT 4.0,
     "textBoxWidth" REAL NOT NULL DEFAULT 0.0,
     "textBoxHeight" REAL NOT NULL DEFAULT 0.0,
     "horizontalAlign" TEXT NOT NULL DEFAULT 'left',
@@ -1335,6 +1336,42 @@ export const migrateExistingDatabase = async (): Promise<void> => {
       }
     } catch (error) {
       console.warn("Migration CropRegionOmrChoiceOption table failed:", error)
+    }
+
+    // --- Migration: MasterImage.pageSize (20260316000000) ---
+    try {
+      const miColumns = await getTableColumns(prisma, "MasterImage")
+      if (miColumns.length > 0 && !miColumns.includes("pageSize")) {
+        await prisma.$executeRawUnsafe(
+          `ALTER TABLE "MasterImage" ADD COLUMN "pageSize" TEXT NOT NULL DEFAULT 'A4'`
+        )
+        console.info("Migration: Added pageSize column to MasterImage")
+      }
+    } catch (error) {
+      console.warn("Migration MasterImage.pageSize failed:", error)
+    }
+
+    // --- Migration: DrawingAnnotation strokeWidth/fontSize px→mm変換 (20260316000001) ---
+    // A4 portrait + PDF scale=2.0 基準: 1px ≈ 210mm / 1190px ≈ 0.1765mm
+    // strokeWidth >= 1 のレコードは旧px値と判定し変換
+    try {
+      const result = await prisma.$queryRawUnsafe<{ cnt: number }[]>(
+        `SELECT COUNT(*) as cnt FROM "DrawingAnnotation" WHERE "strokeWidth" >= 1`
+      )
+      const count = result[0]?.cnt ?? 0
+      if (count > 0) {
+        await prisma.$executeRawUnsafe(
+          `UPDATE "DrawingAnnotation" SET "strokeWidth" = ROUND("strokeWidth" * 210.0 / 1190.0, 2), "fontSize" = ROUND("fontSize" * 210.0 / 1190.0, 2) WHERE "strokeWidth" >= 1`
+        )
+        console.info(
+          `Migration: Converted ${count} DrawingAnnotation strokeWidth/fontSize from px to mm`
+        )
+      }
+    } catch (error) {
+      console.warn(
+        "Migration DrawingAnnotation strokeWidth/fontSize conversion failed:",
+        error
+      )
     }
   } catch (error) {
     console.error("Database migration failed:", error)

--- a/lib/paperSize.ts
+++ b/lib/paperSize.ts
@@ -1,0 +1,89 @@
+/**
+ * 用紙サイズ定数とmm⇔ピクセル変換ユーティリティ
+ *
+ * strokeWidth / fontSize をmm単位で管理し、
+ * 描画時に画像ピクセルに変換するための共通関数を提供する。
+ */
+
+/** 用紙サイズ（mm） */
+export const PAPER_DIMENSIONS: Record<
+  string,
+  { width: number; height: number }
+> = {
+  A3: { width: 297, height: 420 },
+  A4: { width: 210, height: 297 },
+  A5: { width: 148, height: 210 },
+  B4: { width: 257, height: 364 },
+  B5: { width: 182, height: 257 },
+}
+
+/**
+ * 用紙サイズと画像ピクセル幅から、mm→ピクセル変換係数を取得
+ *
+ * @param pageSize 用紙サイズ名（"A4"等）
+ * @param imageWidthPx 画像の幅（ピクセル）
+ * @param imageHeightPx 画像の高さ（ピクセル）
+ * @returns 1mmあたりのピクセル数
+ */
+export function getMmToPixelRatio(
+  pageSize: string,
+  imageWidthPx: number,
+  imageHeightPx: number
+): number {
+  const paper = PAPER_DIMENSIONS[pageSize] ?? PAPER_DIMENSIONS.A4
+  // 画像のアスペクト比から縦横を自動判定
+  const isLandscape = imageWidthPx > imageHeightPx
+  const paperWidthMm = isLandscape ? paper.height : paper.width
+  return imageWidthPx / paperWidthMm
+}
+
+/**
+ * mm値をCanvasピクセルに変換
+ */
+export function mmToPixels(
+  mm: number,
+  pageSize: string,
+  imageWidthPx: number,
+  imageHeightPx: number
+): number {
+  return mm * getMmToPixelRatio(pageSize, imageWidthPx, imageHeightPx)
+}
+
+/**
+ * Canvasピクセル値をmmに変換
+ */
+export function pixelsToMm(
+  px: number,
+  pageSize: string,
+  imageWidthPx: number,
+  imageHeightPx: number
+): number {
+  const ratio = getMmToPixelRatio(pageSize, imageWidthPx, imageHeightPx)
+  return ratio > 0 ? px / ratio : 0
+}
+
+/**
+ * PDF scale=2.0を仮定した場合の標準画像幅ピクセル数を返す
+ * （archiveインポート等、画像の実ピクセル数が不明な場合の概算用）
+ *
+ * PDF.js scale=2.0 では 72dpi × 2 = 144dpi 相当
+ * 1mm = 144 / 25.4 ≈ 5.669px
+ */
+export function getEstimatedImageWidthPx(pageSize: string): number {
+  const paper = PAPER_DIMENSIONS[pageSize] ?? PAPER_DIMENSIONS.A4
+  const pxPerMm = (72 * 2) / 25.4
+  return Math.round(paper.width * pxPerMm)
+}
+
+/**
+ * 旧px値をmm値に概算変換（archive transformer用）
+ *
+ * PDF scale=2.0を仮定して変換する。
+ * 実際の画像ピクセル数が不明な場合に使用。
+ */
+export function estimatePxToMm(px: number, pageSize: string): number {
+  const imageWidthPx = getEstimatedImageWidthPx(pageSize)
+  const paper = PAPER_DIMENSIONS[pageSize] ?? PAPER_DIMENSIONS.A4
+  // portrait仮定
+  return (px * paper.width) / imageWidthPx
+}

--- a/prisma/migrations/20260316000000_add_master_image_page_size/migration.sql
+++ b/prisma/migrations/20260316000000_add_master_image_page_size/migration.sql
@@ -1,2 +1,9 @@
--- AlterTable
+-- AlterTable: MasterImage に pageSize を追加
 ALTER TABLE "MasterImage" ADD COLUMN "pageSize" TEXT NOT NULL DEFAULT 'A4';
+
+-- DrawingAnnotation: strokeWidth と fontSize をピクセル値からmm値に概算変換
+-- A4 portrait + PDF scale=2.0 基準: 1px ≈ 210mm / 1190px ≈ 0.1765mm
+-- 小数第2位に丸める
+UPDATE "DrawingAnnotation"
+SET "strokeWidth" = ROUND("strokeWidth" * 210.0 / 1190.0, 2),
+    "fontSize" = ROUND("fontSize" * 210.0 / 1190.0, 2);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -260,14 +260,14 @@ model DrawingAnnotation {
   x               Float
   y               Float
   color           String        @default("#ef4444")
-  strokeWidth     Int           @default(3)
+  strokeWidth     Float         @default(0.5)
   width           Float         @default(0.0)
   height          Float         @default(0.0)
   endX            Float         @default(0.0)
   endY            Float         @default(0.0)
   lineStyle       String        @default("solid")
   text            String        @default("")
-  fontSize        Int           @default(16)
+  fontSize        Float         @default(4.0)
   textBoxWidth    Float         @default(0.0)
   textBoxHeight   Float         @default(0.0)
   horizontalAlign String        @default("left")


### PR DESCRIPTION
## Summary

- 描画アノテーションの`strokeWidth`/`fontSize`をピクセル固定値からmm単位に変更
- `lib/paperSize.ts`に用紙サイズ定数(A3-A5,B4,B5)とmm⇔px変換ユーティリティを追加
- Prismaスキーマ変更: `strokeWidth` Int→Float(0.5mm), `fontSize` Int→Float(4.0mm)
- databaseInitializer: CREATE TABLE更新 + ランタイムマイグレーション(px→mm変換)
- V1_7_0_to_V1_8_0 transformerにDrawingAnnotation px→mm変換を統合
- 描画エンジン・PDF出力にpageSize引数追加、mm→px変換適用
- UIスライダーをmm単位(0.1〜5.0mm)に変更

Closes #622

## Test plan

- [ ] 新規描画時にstrokeWidthのデフォルト値が0.5mmであることを確認
- [ ] 線幅スライダーがmm単位で表示され、0.1〜5.0mmの範囲で動作することを確認
- [ ] 異なるpageSize(A3/A4/B4等)で描画の太さが用紙サイズに対して一定であることを確認
- [ ] 採点済み答案のPDF出力でアノテーションが正しいサイズで描画されることを確認
- [ ] 旧データ(px値)のDBが起動時にmm値に自動変換されることを確認
- [ ] 旧バージョンアーカイブのインポートでstrokeWidth/fontSizeが正しくmm変換されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)