### PR TITLE
fix: 波線・ジグザグ線の振幅/波長調整と全パラメータの線幅比例化

### DIFF
--- a/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
+++ b/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
@@ -269,7 +269,7 @@ function drawLineElement(
   const dy = currentEndY - currentY
   const lineLength = Math.sqrt(dx * dx + dy * dy)
   const angle = Math.atan2(dy, dx)
-  const arrowSize = Math.max(element.strokeWidth * 5, 12)
+  const arrowSize = element.strokeWidth * 5
 
   switch (element.lineStyle) {
     case "wave":
@@ -356,8 +356,8 @@ function drawWaveLine(
   angle: number,
   strokeWidth: number
 ): void {
-  const waveAmplitude = strokeWidth * 3
-  const waveHalfPeriod = strokeWidth * 6
+  const waveAmplitude = strokeWidth * 1.5
+  const waveHalfPeriod = strokeWidth * 10
 
   // 半周期の数を計算（偶数にして始点と終点が直線上に来るようにする）
   let numHalves = Math.max(Math.round(lineLength / waveHalfPeriod), 2)
@@ -412,8 +412,8 @@ function drawZigzagLine(
   _endY: number,
   strokeWidth: number
 ): void {
-  const zigAmplitude = strokeWidth * 3
-  const zigPitch = strokeWidth * 5
+  const zigAmplitude = strokeWidth * 1.5
+  const zigPitch = strokeWidth * 8
 
   // 頂点（山・谷）の数を計算
   const numPeaks = Math.max(Math.round(lineLength / zigPitch), 2)

--- a/components/exams/08-export/utils/pdfCanvasRenderer.ts
+++ b/components/exams/08-export/utils/pdfCanvasRenderer.ts
@@ -287,12 +287,12 @@ async function drawElement(
         const angle = Math.atan2(dy, dx)
 
         // 矢印のサイズ
-        const arrowSize = Math.max(strokeWidthPx * 5, 12)
+        const arrowSize = strokeWidthPx * 5
 
         switch (element.lineStyle) {
           case "wave": {
-            const waveAmplitude = strokeWidthPx * 2
-            const waveLength = strokeWidthPx * 4
+            const waveAmplitude = strokeWidthPx * 1.5
+            const waveLength = strokeWidthPx * 20
             const segments = Math.max(Math.floor(lineLength / waveLength), 1)
 
             ctx.beginPath()
@@ -316,8 +316,8 @@ async function drawElement(
           }
 
           case "zigzag": {
-            const zigHeight = strokeWidthPx * 2
-            const zigLength = strokeWidthPx * 3
+            const zigHeight = strokeWidthPx * 1.5
+            const zigLength = strokeWidthPx * 8
             const segments = Math.max(Math.floor(lineLength / zigLength), 1)
 
             ctx.beginPath()


### PR DESCRIPTION
## Summary

- 波線: 振幅 sw×3→sw×1.5、半周期 sw×6→sw×10（控えめで緩やかな波形に）
- ジグザグ: 振幅 sw×3→sw×1.5、ピッチ sw×5→sw×8
- 矢印: 固定下限(12px)を削除し、完全にstrokeWidth比例(sw×5)に統一
- 採点画面(useDrawingRenderer)とPDF出力(pdfCanvasRenderer)の両方を修正

Closes #624

## Test plan

- [ ] 波線が以前より控えめ（小振幅・長波長）に描画されることを確認
- [ ] strokeWidthを変更した際、波線・ジグザグ・矢印が全て比例してスケーリングされることを確認
- [ ] PDF出力でも同じ波形パラメータが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)