### PR TITLE
fix: アノテーション描画にMasterImageのpageSizeを伝播

### DIFF
--- a/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -47,6 +47,8 @@ export interface AnswerGridViewProps {
   currentUserId?: string
   /** アノテーションリフレッシュキー（変更検知用） */
   annotationRefreshKey?: number
+  /** 用紙サイズ（mm→px変換基準） */
+  pageSize?: string
   className?: string
 }
 
@@ -65,6 +67,7 @@ export default function AnswerGridView({
   currentCropRegion,
   currentUserId,
   annotationRefreshKey,
+  pageSize,
   className = "",
 }: AnswerGridViewProps) {
   /** フィルタリングされた採点データ（模範解答 + 学生データ） */
@@ -250,6 +253,7 @@ export default function AnswerGridView({
               scoringColors={scoringColors}
               expandMargin={expandMargin}
               annotations={annotationsByStudent.get(answer.studentId)}
+              pageSize={pageSize}
               onMouseDown={onCellMouseDown}
             />
           )

--- a/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -32,6 +32,7 @@ interface GridCellProps {
   scoringColors: ScoringStatusColors
   expandMargin?: number
   annotations?: DrawingAnnotation[]
+  pageSize?: string
   onMouseDown: (e: React.MouseEvent, answerId: string) => void
 }
 
@@ -45,6 +46,7 @@ export function GridCell({
   scoringColors,
   expandMargin,
   annotations,
+  pageSize,
   onMouseDown,
 }: GridCellProps) {
   const statusConfig = getDynamicScoreStatusConfig(scoringColors)
@@ -132,6 +134,7 @@ export function GridCell({
         isSelected={isSelected}
         expandMargin={expandMargin}
         annotations={annotations}
+        pageSize={pageSize}
       />
 
       {/* 学生情報と採点状況 */}

--- a/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react"
 
 import type { CropRegionWithExamPage } from "@/components/exams/07-score-at-once/types"
+import { PAPER_DIMENSIONS } from "@/lib/paperSize"
 import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
 
 import type { DrawingElement } from "../ScoringIndividual/types/answerIndividualTypes"
@@ -39,6 +40,7 @@ interface CroppedAnswerImageProps {
   isSelected?: boolean
   expandMargin?: number // 表示領域拡張率 (0-50%)
   annotations?: DrawingAnnotation[] // Grid表示用アノテーション
+  pageSize?: string // 用紙サイズ（mm→px変換基準）
 }
 
 // セル内の固定オフセット（padding + gap + footer）
@@ -55,6 +57,7 @@ export default function CroppedAnswerImage({
   isSelected = false,
   expandMargin = 0,
   annotations,
+  pageSize,
 }: CroppedAnswerImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
@@ -146,7 +149,9 @@ export default function CroppedAnswerImage({
           canvas.width,
           canvas.height,
           imageElement.naturalWidth,
-          () => cancelled
+          imageElement.naturalHeight,
+          () => cancelled,
+          pageSize
         )
       }
       drawAsync()
@@ -161,6 +166,7 @@ export default function CroppedAnswerImage({
     calculatedCellHeight,
     expandMargin,
     annotations,
+    pageSize,
   ])
 
   const handleImageLoad = () => {
@@ -213,9 +219,17 @@ async function drawAnnotations(
   canvasWidth: number,
   canvasHeight: number,
   imageNaturalWidth: number,
-  isCancelled: () => boolean
+  imageNaturalHeight: number,
+  isCancelled: () => boolean,
+  pageSize?: string
 ) {
-  const scaleFactor = canvasWidth / (visibleWidth * imageNaturalWidth)
+  // mm→用紙幅比率→canvasピクセルに変換するためのスケール
+  // anno.strokeWidth (mm) → anno.strokeWidth / paperWidthMm → × canvasWidth / visibleWidth
+  const paper = PAPER_DIMENSIONS[pageSize ?? "A4"] ?? PAPER_DIMENSIONS.A4
+  const isLandscape =
+    imageNaturalWidth > (imageNaturalHeight ?? imageNaturalWidth)
+  const paperWidthMm = isLandscape ? paper.height : paper.width
+  const scaleFactor = canvasWidth / (visibleWidth * paperWidthMm)
 
   for (const anno of annotations) {
     if (isCancelled()) return

--- a/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -44,6 +44,7 @@ interface ScoringContentAreaProps {
   masterAnswerOpacity?: number
   masterAnswerVisible?: boolean
   allMasterImageUrls?: string[]
+  pageSize?: string
 }
 
 export function ScoringContentArea({
@@ -74,6 +75,7 @@ export function ScoringContentArea({
   masterAnswerOpacity = 50,
   masterAnswerVisible = false,
   allMasterImageUrls,
+  pageSize = "A4",
 }: ScoringContentAreaProps) {
   const currentScoringDataId =
     gradingMode === "individual"
@@ -178,6 +180,7 @@ export function ScoringContentArea({
         currentCropRegion={currentCropRegion}
         currentUserId={currentUserId}
         annotationRefreshKey={gridAnnotationRefreshKey}
+        pageSize={pageSize}
         className="p-4"
       />
     )
@@ -210,6 +213,7 @@ export function ScoringContentArea({
       onZoomChanged={handleZoomChanged}
       onImageSizeChanged={handleImageSizeChanged}
       scrollContainerRef={answerScrollRef}
+      pageSize={pageSize}
     />
   )
 

--- a/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -371,6 +371,20 @@ function ScoringMainViewContent() {
     setMasterAnswerVisible(false)
   }, [])
 
+  /** 用紙サイズ（MasterImageのpageSizeフィールドから取得、デフォルトA4） */
+  const pageSize = useMemo(() => {
+    if (!exam?.examPages) return "A4"
+    for (const page of exam.examPages) {
+      const masterImage = page.masterImages?.[0]
+      if (masterImage?.pageSize) {
+        console.log(`[pageSize] MasterImageから取得: "${masterImage.pageSize}"`)
+        return masterImage.pageSize
+      }
+    }
+    console.log("[pageSize] デフォルト: A4")
+    return "A4"
+  }, [exam])
+
   /** 全ページの模範解答画像URL（ページ番号順） */
   const allMasterImageUrls = useMemo(() => {
     if (!exam?.examPages) return []
@@ -511,6 +525,7 @@ function ScoringMainViewContent() {
             masterAnswerOpacity={masterAnswerOpacity}
             masterAnswerVisible={masterAnswerVisible}
             allMasterImageUrls={allMasterImageUrls}
+            pageSize={pageSize}
           />
         </div>
 

--- a/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -351,7 +351,7 @@ export function PdfCanvasRenderer({
         imageData: arrayBuffer,
       }
     },
-    [loadImage, scoringMarkConfig]
+    [loadImage, scoringMarkConfig, pageSize]
   )
 
   /**


### PR DESCRIPTION
## Summary
- MasterImage.pageSizeが採点画面に伝播されず常にA4デフォルトだった問題を修正
- CroppedAnswerImageのscaleFactorを画像ピクセル依存からpageSize依存に変更
- 採点画面（個別・グリッド）と書き出しの全描画箇所にpageSizeを伝播

## Test plan
- [ ] B4用紙の試験でアノテーション（線・テキスト・矩形等）の太さ・サイズが正しく表示されることを確認
- [ ] グリッド表示でアノテーションが正しい位置・サイズで表示されることを確認
- [ ] 個別表示でアノテーションが正しく表示されることを確認
- [ ] PDF出力でアノテーションが正しく描画されることを確認
- [ ] コンソールに`[pageSize]`ログが出力され、正しい用紙サイズが表示されることを確認

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)