### PR TITLE
feat: OMRマーカー設定UIをスライダー+隠しinputboxに変更

### DIFF
--- a/components/answer-sheet-builder/components/form/OMRMarkerSettings.tsx
+++ b/components/answer-sheet-builder/components/form/OMRMarkerSettings.tsx
@@ -1,13 +1,85 @@
 "use client"
 
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
 import type { OMRMarkerConfig } from "@/types/answerSheetDefinition.types"
 
 interface OMRMarkerSettingsProps {
   config: OMRMarkerConfig
   onUpdate: (config: Partial<OMRMarkerConfig>) => void
+}
+
+function EditableValue({
+  value,
+  min,
+  max,
+  step,
+  decimals = 1,
+  onChange,
+}: {
+  value: number
+  min: number
+  max: number
+  step: number
+  decimals?: number
+  onChange: (v: number) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editing])
+
+  const handleChange = useCallback(
+    (raw: string) => {
+      setEditValue(raw)
+      const parsed = parseFloat(raw)
+      if (!isNaN(parsed) && parsed >= min && parsed <= max) {
+        onChange(parsed)
+      }
+    },
+    [min, max, onChange]
+  )
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="number"
+        aria-label="値を入力"
+        className="border-input bg-background box-border h-5 w-10 shrink-0 rounded border text-center text-[10px] outline-none"
+        value={editValue}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => handleChange(e.target.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === "Escape") setEditing(false)
+        }}
+      />
+    )
+  }
+
+  return (
+    <span
+      className="text-muted-foreground inline-flex h-5 w-10 shrink-0 cursor-pointer items-center justify-end text-[10px] select-none hover:underline"
+      onDoubleClick={() => {
+        setEditValue(value.toFixed(decimals))
+        setEditing(true)
+      }}
+      title="ダブルクリックで直接入力"
+    >
+      {value.toFixed(decimals)}
+    </span>
+  )
 }
 
 export function OMRMarkerSettings({
@@ -27,39 +99,45 @@ export function OMRMarkerSettings({
       </div>
 
       {config.enabled && (
-        <div className="grid grid-cols-2 gap-2">
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              サイズ (mm)
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
-              value={config.sizeMm}
-              min={1}
+        <div className="space-y-1.5">
+          <div className="flex min-h-6 items-center gap-2">
+            <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
+              サイズ
+            </span>
+            <Slider
+              className="min-w-12 flex-1"
+              value={[config.sizeMm]}
+              min={1.5}
               max={15}
               step={0.5}
-              onChange={(e) => onUpdate({ sizeMm: Number(e.target.value) })}
-              onBlur={(e) => {
-                e.target.value = String(Number(e.target.value))
-              }}
+              onValueChange={([v]) => onUpdate({ sizeMm: v })}
+            />
+            <EditableValue
+              value={config.sizeMm}
+              min={0.5}
+              max={15}
+              step={0.5}
+              onChange={(v) => onUpdate({ sizeMm: v })}
             />
           </div>
-          <div>
-            <Label className="text-muted-foreground text-[10px]">
-              オフセット (mm)
-            </Label>
-            <Input
-              type="number"
-              className="h-7 text-xs"
+          <div className="flex min-h-6 items-center gap-2">
+            <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
+              余白
+            </span>
+            <Slider
+              className="min-w-12 flex-1"
+              value={[config.offsetMm]}
+              min={5}
+              max={20}
+              step={0.5}
+              onValueChange={([v]) => onUpdate({ offsetMm: v })}
+            />
+            <EditableValue
               value={config.offsetMm}
               min={0}
               max={20}
               step={0.5}
-              onChange={(e) => onUpdate({ offsetMm: Number(e.target.value) })}
-              onBlur={(e) => {
-                e.target.value = String(Number(e.target.value))
-              }}
+              onChange={(v) => onUpdate({ offsetMm: v })}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- OMRマーカー設定UIを罫線設定UIと同様のスライダー+ダブルクリック入力パターンに統一
- サイズのスライダー最小値を1.5mm（OMR検出安全ライン）に設定、inputboxでは0.5mmまで許容
- 余白のスライダー最小値を5mmに設定、inputboxでは0mmまで許容
- 「オフセット」→「余白」にラベル変更（内部ロジックは変更なし）

Closes #631

## Test plan
- [ ] OMRマーカーを有効にしてスライダーが正しく動作することを確認
- [ ] ダブルクリックでinputboxが表示され、スライダー範囲外の値が入力可能なことを確認
- [ ] サイズ: スライダー1.5〜15mm、inputbox 0.5〜15mmの範囲を確認
- [ ] 余白: スライダー5〜20mm、inputbox 0〜20mmの範囲を確認
- [ ] 既定値（サイズ5mm、余白6mm）が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)