### PR TITLE
perf: 試験一覧ページの読み込み速度を最適化

### DIFF
--- a/components/exams/list/ExamList.tsx
+++ b/components/exams/list/ExamList.tsx
@@ -49,15 +49,14 @@ import {
 } from "@/components/ui/table"
 import { useAuth } from "@/contexts/AuthContext"
 import { SortDirection, useTableSort } from "@/hooks/useTableSort"
-import { ExamWithDetails, isValidExam } from "@/types/common.types"
+import type { ExamListItem } from "@/types/common.types"
 import type { ExportMode } from "@/types/examArchive.types"
-import { getExamStatus } from "@/utils/examStatus"
 
 interface ExamSortable {
   id: string
   examName: string
   examDate: string | null
-  original: ExamWithDetails
+  original: ExamListItem
 }
 
 const SORT_OPTIONS = [
@@ -100,7 +99,7 @@ const File = () => {
 
   // ソート用データに変換
   const sortableData = useMemo<ExamSortable[]>(() => {
-    return exams.filter(isValidExam).map((exam) => ({
+    return exams.map((exam) => ({
       id: exam.id,
       examName: exam.examName,
       examDate: exam.examDate ? new Date(exam.examDate).toISOString() : null,
@@ -132,13 +131,12 @@ const File = () => {
     }
   }
 
-  const handleStartScoring = (exam: ExamWithDetails) => {
+  const handleStartScoring = (exam: ExamListItem) => {
     router.push(`/exams/${exam.id}`)
   }
 
-  const handleNextStep = (exam: ExamWithDetails) => {
-    const status = getExamStatus(exam)
-    router.push(status.url)
+  const handleNextStep = (exam: ExamListItem) => {
+    router.push(exam.status.url)
   }
 
   const handleImportComplete = (examId: string) => {
@@ -332,8 +330,6 @@ const File = () => {
               </TableHeader>
               <TableBody>
                 {sortedData.map(({ original: exam }) => {
-                  const status = getExamStatus(exam)
-
                   return (
                     <TableRow key={exam.id} className="group">
                       <TableCell className="text-center">
@@ -348,13 +344,9 @@ const File = () => {
                           <div className="font-medium">{exam.examName}</div>
                           <div className="text-muted-foreground text-sm tabular-nums">
                             {exam.examDate
-                              ? typeof exam.examDate === "string"
-                                ? new Date(exam.examDate).toLocaleDateString(
-                                    "ja-JP"
-                                  )
-                                : new Date(exam.examDate).toLocaleDateString(
-                                    "ja-JP"
-                                  )
+                              ? new Date(exam.examDate).toLocaleDateString(
+                                  "ja-JP"
+                                )
                               : "実施日未設定"}
                           </div>
                         </div>
@@ -378,31 +370,31 @@ const File = () => {
                           onClick={() => handleNextStep(exam)}
                           className="w-48 justify-start rounded-lg text-left"
                         >
-                          {status.step === 1 && (
+                          {exam.status.step === 1 && (
                             <FileImage className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 2 && (
+                          {exam.status.step === 2 && (
                             <Settings className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 3 && (
+                          {exam.status.step === 3 && (
                             <Edit className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 4 && (
+                          {exam.status.step === 4 && (
                             <Calculator className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 5 && (
+                          {exam.status.step === 5 && (
                             <Users className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 6 && (
+                          {exam.status.step === 6 && (
                             <Upload className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 7 && (
+                          {exam.status.step === 7 && (
                             <PlayCircle className="mr-1 h-4 w-4" />
                           )}
-                          {status.step === 8 && (
+                          {exam.status.step === 8 && (
                             <Download className="mr-1 h-4 w-4" />
                           )}
-                          <span className="text-xs">{status.text}</span>
+                          <span className="text-xs">{exam.status.text}</span>
                         </Button>
                       </TableCell>
                     </TableRow>

--- a/components/hooks/useExams.ts
+++ b/components/hooks/useExams.ts
@@ -3,11 +3,11 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
-import type { ExamWithDetails } from "@/types/electron"
+import type { ExamListItem } from "@/types/electron"
 
 export const useExams = () => {
   const { user } = useAuth()
-  const [exams, setExams] = useState<ExamWithDetails[]>([])
+  const [exams, setExams] = useState<ExamListItem[]>([])
 
   const loadExams = useCallback(async () => {
     if (!user) {
@@ -15,7 +15,7 @@ export const useExams = () => {
       return
     }
     try {
-      const fetchedExams = await window.electronAPI.fetchExams(user.id)
+      const fetchedExams = await window.electronAPI.fetchExamsSummary(user.id)
       if (fetchedExams) {
         setExams(fetchedExams)
       } else {

--- a/electron-src/ipc-handlers/examHandlers.ts
+++ b/electron-src/ipc-handlers/examHandlers.ts
@@ -4,8 +4,10 @@ import { ipcMain } from "electron"
 import {
   createExam as dbCreateExam,
   deleteExam as dbDeleteExam,
+  type ExamForListPayload,
   getExamById as dbFetchExamById,
   getExams as dbFetchExams,
+  getExamsForList as dbFetchExamsForList,
   updateExam as dbUpdateExam,
 } from "../lib/prisma/exam"
 import { getExamPagesByExamId as dbGetExamPagesByExamId } from "../lib/prisma/examPage"
@@ -39,7 +41,162 @@ function serializeQuestionScore(score: {
   }
 }
 
+/**
+ * 軽量クエリ結果からExamProgressを計算し、ExamStatusを返す
+ */
+function computeExamStatus(exam: ExamForListPayload) {
+  const hasImages = exam.examPages.length > 0
+
+  const allCropRegions = exam.examPages.flatMap((p) => p.cropRegions)
+  const hasLayout = allCropRegions.length > 0
+  const hasRegionInfo = hasLayout
+
+  const hasSubtotalRegions = allCropRegions.some(
+    (r) => r.type === "SUBTOTAL_SCORE"
+  )
+  const hasSubtotalGroupSetting =
+    !hasSubtotalRegions || exam.examSubtotalGroups.length > 0
+
+  const hasStudents = exam.examStudents.length > 0
+
+  const allAnswerImages = exam.examPages.flatMap((p) => p.studentAnswerImages)
+  const hasAnswers = allAnswerImages.length > 0
+
+  // 採点進捗の計算
+  const questionAnswerRegions = allCropRegions.filter(
+    (r) => r.type === "QUESTION_ANSWER"
+  )
+  const questionAnswerCount = questionAnswerRegions.length
+
+  const participatingStudentIds = new Set(
+    exam.examStudents
+      .filter((ps) => ps.status === "PARTICIPATING" || ps.status === "EXPECTED")
+      .map((ps) => ps.studentId)
+  )
+
+  const answerSheetCount = new Set(
+    allAnswerImages
+      .filter(
+        (img) => img.studentId && participatingStudentIds.has(img.studentId)
+      )
+      .map((img) => img.studentId)
+  ).size
+
+  const expectedScoringCount = questionAnswerCount * answerSheetCount
+
+  const actualScoringCount = questionAnswerRegions.reduce((total, region) => {
+    const validScores = region.questionScores.filter(
+      (score) =>
+        score.status !== "unscored" &&
+        score.studentId !== null &&
+        participatingStudentIds.has(score.studentId) &&
+        !(
+          (score.status === "partial" || score.status === "pending") &&
+          score.partialScore === null
+        )
+    )
+    return total + validScores.length
+  }, 0)
+
+  const hasScoring =
+    expectedScoringCount > 0 && actualScoringCount >= expectedScoringCount
+
+  // ステップ判定（examStatus.ts の getExamStatus と同等のロジック）
+  if (!hasImages)
+    return {
+      step: 1,
+      action: "upload",
+      text: "模範解答画像の管理",
+      url: `/exams/${exam.id}/01-upload`,
+      isCompleted: false,
+      canStart: true,
+    }
+  if (!hasLayout)
+    return {
+      step: 2,
+      action: "template",
+      text: "答案の採点領域作成",
+      url: `/exams/${exam.id}/02-template`,
+      isCompleted: false,
+      canStart: hasImages,
+    }
+  if (!hasRegionInfo)
+    return {
+      step: 3,
+      action: "region-info",
+      text: "採点領域の詳細情報設定",
+      url: `/exams/${exam.id}/03-region-info`,
+      isCompleted: false,
+      canStart: hasLayout,
+    }
+  if (!hasSubtotalGroupSetting)
+    return {
+      step: 4,
+      action: "question-group",
+      text: "小計点の設定",
+      url: `/exams/${exam.id}/04-question-group`,
+      isCompleted: false,
+      canStart: hasRegionInfo,
+    }
+  if (!hasStudents)
+    return {
+      step: 5,
+      action: "students",
+      text: "受験生徒の管理",
+      url: `/exams/${exam.id}/05-students`,
+      isCompleted: false,
+      canStart: hasSubtotalGroupSetting,
+    }
+  if (!hasAnswers)
+    return {
+      step: 6,
+      action: "student-answers",
+      text: "生徒答案の追加と関連付け",
+      url: `/exams/${exam.id}/06-student-answers`,
+      isCompleted: false,
+      canStart: hasStudents,
+    }
+  if (!hasScoring)
+    return {
+      step: 7,
+      action: "score-at-once",
+      text: "一括採点",
+      url: `/exams/${exam.id}/07-score-at-once`,
+      isCompleted: false,
+      canStart: hasAnswers && hasRegionInfo,
+    }
+
+  return {
+    step: 8,
+    action: "export",
+    text: "採点結果のファイル出力",
+    url: `/exams/${exam.id}/08-export`,
+    isCompleted: false,
+    canStart: hasScoring,
+  }
+}
+
 export function setupExamHandlers(): void {
+  // 試験一覧用の軽量エンドポイント（ステータスをサーバーサイドで計算）
+  ipcMain.handle("fetch-exams-summary", async (_event, userId: string) => {
+    try {
+      const exams = await dbFetchExamsForList(userId)
+      return exams.map((exam) => ({
+        id: exam.id,
+        examName: exam.examName,
+        examDate: exam.examDate,
+        subject: exam.subject,
+        description: exam.description,
+        createdAt: exam.createdAt,
+        updatedAt: exam.updatedAt,
+        status: computeExamStatus(exam),
+      }))
+    } catch (err) {
+      console.error("Error fetching exams summary:", err)
+      throw err
+    }
+  })
+
   ipcMain.handle("fetch-exams", async (_event, userId: string) => {
     try {
       const exams = await dbFetchExams(userId)

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -2,7 +2,63 @@ import type { Prisma as PrismaTypes } from "@prisma/client"
 
 import prisma from "./client"
 
-// Exam一覧を取得 (ユーザーでフィルタリング)
+// Exam一覧用の軽量クエリ（ステップ判定に必要な最小限のデータのみ取得）
+export const getExamsForList = async (userId: string) => {
+  return prisma.exam.findMany({
+    where: {
+      userExams: {
+        some: {
+          userId,
+        },
+      },
+    },
+    select: {
+      id: true,
+      examName: true,
+      examDate: true,
+      subject: true,
+      description: true,
+      createdAt: true,
+      updatedAt: true,
+      examPages: {
+        select: {
+          id: true,
+          studentAnswerImages: {
+            select: { studentId: true },
+          },
+          cropRegions: {
+            select: {
+              type: true,
+              questionScores: {
+                select: {
+                  status: true,
+                  studentId: true,
+                  partialScore: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      examSubtotalGroups: {
+        select: { id: true },
+      },
+      examStudents: {
+        select: { studentId: true, status: true },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  })
+}
+
+// getExamsForList の戻り値の型
+export type ExamForListPayload = Awaited<
+  ReturnType<typeof getExamsForList>
+>[number]
+
+// Exam一覧を取得 (ユーザーでフィルタリング) - 詳細ページ用
 export const getExams = async (userId: string) => {
   return prisma.exam.findMany({
     where: {

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -21,6 +21,8 @@ declare global {
 
 contextBridge.exposeInMainWorld("electronAPI", {
   fetchExams: (userId: string) => ipcRenderer.invoke("fetch-exams", userId),
+  fetchExamsSummary: (userId: string) =>
+    ipcRenderer.invoke("fetch-exams-summary", userId),
   fetchExamById: (examId: string) =>
     ipcRenderer.invoke("fetch-exam-by-id", examId),
   createExam: (props: CreateExamArgs, userId: string) => {

--- a/types/common.types.ts
+++ b/types/common.types.ts
@@ -51,6 +51,28 @@ export type ExamWithDetails = Prisma.ExamGetPayload<{
 /** @deprecated Use ExamWithDetails instead */
 export type SerializedExam = ExamWithDetails
 
+/**
+ * 試験一覧表示用の軽量型
+ * ステータスはメインプロセスで事前計算済み
+ */
+export interface ExamListItem {
+  id: string
+  examName: string
+  examDate: Date | null
+  subject: string | null
+  description: string | null
+  createdAt: Date
+  updatedAt: Date
+  status: {
+    step: number
+    action: string
+    text: string
+    url: string
+    isCompleted: boolean
+    canStart: boolean
+  }
+}
+
 // =============================================================================
 // 型ガード関数
 // =============================================================================

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -15,7 +15,11 @@ import type {
   UserExam,
 } from "@prisma/client"
 
-export type { ExamWithDetails, SerializedExam } from "./common.types"
+export type {
+  ExamListItem,
+  ExamWithDetails,
+  SerializedExam,
+} from "./common.types"
 export type {
   ClassWithMemberships,
   ClassWithStudents,
@@ -193,6 +197,7 @@ export interface MasterAnswerDeletionResult {
 
 export interface MyAPI {
   fetchExams: (userId: string) => Promise<ExamWithDetails[]>
+  fetchExamsSummary: (userId: string) => Promise<ExamListItem[]>
   fetchExamById: (examId: string) => Promise<ExamWithDetails | null>
   createExam: (
     examData: CreateExamArgs,


### PR DESCRIPTION
## Summary

- 試験一覧用の軽量クエリ `getExamsForList()` を新設（`select` で最小限のフィールドのみ取得）
- ステータス判定（`computeExamStatus`）をメインプロセスで事前計算し、`ExamListItem` 型で返却
- フロントエンドの `getExamStatus()` 呼び出しを廃止、事前計算済みの `exam.status` を直接参照

Closes #635

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `electron-src/lib/prisma/exam.ts` | `getExamsForList()` 追加 |
| `electron-src/ipc-handlers/examHandlers.ts` | `fetch-exams-summary` ハンドラー + `computeExamStatus()` 追加 |
| `types/common.types.ts` | `ExamListItem` 型追加 |
| `types/electron.d.ts` | `fetchExamsSummary` API定義追加 |
| `electron-src/preload.ts` | `fetchExamsSummary` API追加 |
| `components/hooks/useExams.ts` | `fetchExamsSummary` を使用 |
| `components/exams/list/ExamList.tsx` | `ExamListItem` 型 + `exam.status` 直接参照に変更 |

## Test plan

- [ ] 試験一覧ページが正常に表示されること
- [ ] 各試験の「次のステップ」ボタンが正しいステップを表示すること
- [ ] 「次のステップ」クリックで正しいURLに遷移すること
- [ ] 試験作成後に一覧が更新されること
- [ ] 既存の `fetch-exams` エンドポイントが影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)