### PR TITLE
fix: アノテーション重複チェックの改善（3層防御）

### DIFF
--- a/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
+++ b/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
@@ -8,7 +8,8 @@ import {
   Star,
   Type,
 } from "lucide-react"
-import { useCallback, useEffect, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -24,6 +25,7 @@ import type { AnnotationWithContext } from "@/types/drawingAnnotation.types"
 import type { CropRegionWithExamPage } from "../types"
 import type {
   AddToTargetsParams,
+  AddToTargetsResult,
   AnnotationDisplayItem,
   AnnotationFilters,
 } from "./hooks/useAnnotationBrowser"
@@ -42,7 +44,7 @@ interface AnnotationBrowserPanelProps {
   onFiltersChange: (partial: Partial<AnnotationFilters>) => void
   onLoadAnnotations: (examId: string) => Promise<void>
   onToggleFavorite: (id: string, currentFavorite: boolean) => Promise<void>
-  onAddToTargets: (params: AddToTargetsParams) => Promise<void>
+  onAddToTargets: (params: AddToTargetsParams) => Promise<AddToTargetsResult>
   // QuestionScore確保用
   questionScores: Array<{
     id: string
@@ -175,64 +177,85 @@ export function AnnotationBrowserPanel({
     [questionScores, currentUserId, onQuestionScoreCreated]
   )
 
+  // 連打防止用フラグ
+  const isAddingRef = useRef(false)
+
   // 「追加」ボタンハンドラ
   const handleAdd = useCallback(
     async (item: AnnotationDisplayItem) => {
       if (!currentUserId) return
+      if (isAddingRef.current) return
+      isAddingRef.current = true
 
-      const source = item.representative
-      const sourceCropRegionId = source.questionScore?.cropRegionId ?? ""
+      try {
+        const source = item.representative
+        const sourceCropRegionId = source.questionScore?.cropRegionId ?? ""
 
-      if (gradingMode === "individual") {
-        // 個別モード: 現在の生徒+設問に追加
-        if (!currentStudentId || !currentCropRegionId) return
-        const qsId = await ensureQuestionScore(
-          currentStudentId,
-          currentCropRegionId
-        )
-        if (!qsId) return
+        let result: AddToTargetsResult | undefined
 
-        await onAddToTargets({
-          sourceAnnotation: source,
-          targetQuestionScoreIds: [qsId],
-          targetCropRegionId: currentCropRegionId,
-          sourceCropRegionId,
-          userId: currentUserId,
-        })
-      } else {
-        // 一覧モード: 選択中の全生徒に追加
-        if (selectedScoringDataIds.length === 0 || !currentCropRegionId) return
+        if (gradingMode === "individual") {
+          // 個別モード: 現在の生徒+設問に追加
+          if (!currentStudentId || !currentCropRegionId) return
+          const qsId = await ensureQuestionScore(
+            currentStudentId,
+            currentCropRegionId
+          )
+          if (!qsId) return
 
-        // selectedScoringDataIdsからstudentIdをマッピング
-        const targetStudentIds = selectedScoringDataIds
-          .map((sdId) => {
-            const sd = allScoringData.find((s) => s.id === sdId)
-            return sd?.studentId
+          result = await onAddToTargets({
+            sourceAnnotation: source,
+            targetQuestionScoreIds: [qsId],
+            targetCropRegionId: currentCropRegionId,
+            sourceCropRegionId,
+            userId: currentUserId,
           })
-          .filter((id): id is string => !!id)
+        } else {
+          // 一覧モード: 選択中の全生徒に追加
+          if (selectedScoringDataIds.length === 0 || !currentCropRegionId)
+            return
 
-        // 各生徒のQuestionScoreを確保
-        const targetQsIds: string[] = []
-        for (const studentId of targetStudentIds) {
-          const qsId = await ensureQuestionScore(studentId, currentCropRegionId)
-          if (qsId) targetQsIds.push(qsId)
+          // selectedScoringDataIdsからstudentIdをマッピング
+          const targetStudentIds = selectedScoringDataIds
+            .map((sdId) => {
+              const sd = allScoringData.find((s) => s.id === sdId)
+              return sd?.studentId
+            })
+            .filter((id): id is string => !!id)
+
+          // 各生徒のQuestionScoreを確保
+          const targetQsIds: string[] = []
+          for (const studentId of targetStudentIds) {
+            const qsId = await ensureQuestionScore(
+              studentId,
+              currentCropRegionId
+            )
+            if (qsId) targetQsIds.push(qsId)
+          }
+
+          if (targetQsIds.length === 0) return
+
+          result = await onAddToTargets({
+            sourceAnnotation: source,
+            targetQuestionScoreIds: targetQsIds,
+            targetCropRegionId: currentCropRegionId,
+            sourceCropRegionId,
+            userId: currentUserId,
+          })
         }
 
-        if (targetQsIds.length === 0) return
+        // 結果に応じたフィードバック
+        if (result && result.created === 0 && result.skipped > 0) {
+          toast.info("既に追加済みのアノテーションです")
+          return
+        }
 
-        await onAddToTargets({
-          sourceAnnotation: source,
-          targetQuestionScoreIds: targetQsIds,
-          targetCropRegionId: currentCropRegionId,
-          sourceCropRegionId,
-          userId: currentUserId,
-        })
+        // 追加後にアノテーション一覧を再ロード
+        await onLoadAnnotations(examId)
+        // キャンバスプレビューにも即時反映
+        onAnnotationAddedFromBrowser?.()
+      } finally {
+        isAddingRef.current = false
       }
-
-      // 追加後にアノテーション一覧を再ロード
-      await onLoadAnnotations(examId)
-      // キャンバスプレビューにも即時反映
-      onAnnotationAddedFromBrowser?.()
     },
     [
       currentUserId,

--- a/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
+++ b/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
@@ -90,6 +90,14 @@ function centerPosition(
   }
 }
 
+// addToTargetsの結果
+export interface AddToTargetsResult {
+  /** 実際に作成されたアノテーション数 */
+  created: number
+  /** 重複としてスキップされた数 */
+  skipped: number
+}
+
 export interface UseAnnotationBrowserReturn {
   allAnnotations: AnnotationWithContext[]
   displayItems: AnnotationDisplayItem[]
@@ -98,7 +106,7 @@ export interface UseAnnotationBrowserReturn {
   setFilters: (partial: Partial<AnnotationFilters>) => void
   loadAnnotations: (examId: string) => Promise<void>
   toggleFavorite: (id: string, currentFavorite: boolean) => Promise<void>
-  addToTargets: (params: AddToTargetsParams) => Promise<void>
+  addToTargets: (params: AddToTargetsParams) => Promise<AddToTargetsResult>
 }
 
 export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
@@ -214,23 +222,79 @@ export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
     []
   )
 
-  const addToTargets = useCallback(async (params: AddToTargetsParams) => {
-    const {
-      sourceAnnotation,
-      targetQuestionScoreIds,
-      targetCropRegionId,
-      sourceCropRegionId,
-      userId,
-    } = params
+  const addToTargets = useCallback(
+    async (params: AddToTargetsParams): Promise<AddToTargetsResult> => {
+      const {
+        sourceAnnotation,
+        targetQuestionScoreIds,
+        targetCropRegionId,
+        sourceCropRegionId,
+        userId,
+      } = params
 
-    // 位置計算: 同一設問→同位置、異設問→中央配置
-    const isSameQuestion = sourceCropRegionId === targetCropRegionId
-    const positionOverride = isSameQuestion
-      ? {}
-      : centerPosition(sourceAnnotation)
+      // 位置計算: 同一設問→同位置、異設問→中央配置
+      const isSameQuestion = sourceCropRegionId === targetCropRegionId
+      const positionOverride = isSameQuestion
+        ? {}
+        : centerPosition(sourceAnnotation)
 
-    const createDataList: DrawingCreateData[] = targetQuestionScoreIds.map(
-      (qsId) => ({
+      // フロントエンド側重複チェック: allAnnotationsを使ってローカルで判定
+      // 既に同一プロパティのアノテーションが存在するquestionScoreIdを除外する
+      const newQsIds = targetQuestionScoreIds.filter((qsId) => {
+        // このqsIdに紐づく既存アノテーションの中で、ソースと同一のものがあるか
+        return !allAnnotations.some((existing) => {
+          if (existing.questionScore?.id !== qsId) return false
+          // 位置はpositionOverrideを適用した値と比較
+          const targetX =
+            (positionOverride as { x?: number }).x ?? sourceAnnotation.x
+          const targetY =
+            (positionOverride as { y?: number }).y ?? sourceAnnotation.y
+          const targetEndX =
+            (positionOverride as { endX?: number }).endX ??
+            sourceAnnotation.endX
+          const targetEndY =
+            (positionOverride as { endY?: number }).endY ??
+            sourceAnnotation.endY
+          const targetDisplayX =
+            (positionOverride as { displayX?: number }).displayX ??
+            sourceAnnotation.displayX
+          const targetDisplayY =
+            (positionOverride as { displayY?: number }).displayY ??
+            sourceAnnotation.displayY
+
+          return (
+            existing.type === sourceAnnotation.type &&
+            existing.x === targetX &&
+            existing.y === targetY &&
+            existing.color === sourceAnnotation.color &&
+            existing.strokeWidth === sourceAnnotation.strokeWidth &&
+            existing.width === sourceAnnotation.width &&
+            existing.height === sourceAnnotation.height &&
+            existing.endX === targetEndX &&
+            existing.endY === targetEndY &&
+            existing.lineStyle === sourceAnnotation.lineStyle &&
+            existing.text === sourceAnnotation.text &&
+            existing.fontSize === sourceAnnotation.fontSize &&
+            existing.textBoxWidth === sourceAnnotation.textBoxWidth &&
+            existing.textBoxHeight === sourceAnnotation.textBoxHeight &&
+            existing.horizontalAlign === sourceAnnotation.horizontalAlign &&
+            existing.verticalAlign === sourceAnnotation.verticalAlign &&
+            existing.anchorDirection === sourceAnnotation.anchorDirection &&
+            existing.displayX === targetDisplayX &&
+            existing.displayY === targetDisplayY &&
+            existing.userId === userId
+          )
+        })
+      })
+
+      const skipped = targetQuestionScoreIds.length - newQsIds.length
+
+      // 全て重複の場合はIPCリクエストを送らない
+      if (newQsIds.length === 0) {
+        return { created: 0, skipped }
+      }
+
+      const createDataList: DrawingCreateData[] = newQsIds.map((qsId) => ({
         questionScoreId: qsId,
         type: sourceAnnotation.type,
         x: sourceAnnotation.x,
@@ -253,34 +317,37 @@ export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
         displayY: sourceAnnotation.displayY,
         userId,
         ...positionOverride,
-      })
-    )
+      }))
 
-    try {
-      if (createDataList.length === 1) {
-        const result = await window.electronAPI.drawing.create(
-          createDataList[0]
-        )
-        if (result.success && result.data) {
-          setAllAnnotations((prev) => [
-            result.data as AnnotationWithContext,
-            ...prev,
-          ])
+      try {
+        if (createDataList.length === 1) {
+          const result = await window.electronAPI.drawing.create(
+            createDataList[0]
+          )
+          if (result.success && result.data) {
+            setAllAnnotations((prev) => [
+              result.data as AnnotationWithContext,
+              ...prev,
+            ])
+          }
+        } else if (createDataList.length > 1) {
+          const result =
+            await window.electronAPI.drawing.batchCreate(createDataList)
+          if (result.success && result.data) {
+            setAllAnnotations((prev) => [
+              ...(result.data as AnnotationWithContext[]),
+              ...prev,
+            ])
+          }
         }
-      } else if (createDataList.length > 1) {
-        const result =
-          await window.electronAPI.drawing.batchCreate(createDataList)
-        if (result.success && result.data) {
-          setAllAnnotations((prev) => [
-            ...(result.data as AnnotationWithContext[]),
-            ...prev,
-          ])
-        }
+        return { created: createDataList.length, skipped }
+      } catch (error) {
+        console.error("アノテーション追加エラー:", error)
+        return { created: 0, skipped }
       }
-    } catch (error) {
-      console.error("アノテーション追加エラー:", error)
-    }
-  }, [])
+    },
+    [allAnnotations]
+  )
 
   return {
     allAnnotations,

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -53,37 +53,89 @@ export async function createDrawingAnnotation(
       throw new Error(`User not found: ${data.userId}`)
     }
 
+    const createData = {
+      questionScoreId: data.questionScoreId,
+      type: data.type,
+      x: data.x,
+      y: data.y,
+      color: data.color || "#ef4444",
+      strokeWidth: data.strokeWidth || 3,
+      width: data.width || 0.0,
+      height: data.height || 0.0,
+      endX: data.endX || 0.0,
+      endY: data.endY || 0.0,
+      lineStyle: data.lineStyle || "solid",
+      text: data.text || "",
+      fontSize: data.fontSize || 16,
+      textBoxWidth: data.textBoxWidth || 0.0,
+      textBoxHeight: data.textBoxHeight || 0.0,
+      horizontalAlign: data.horizontalAlign || "left",
+      verticalAlign: data.verticalAlign || "top",
+      anchorDirection: data.anchorDirection || "top-left",
+      displayX: data.displayX || 0.0,
+      displayY: data.displayY || 0.0,
+      userId: data.userId,
+    }
+
+    // 重複チェック: 全プロパティが完全一致するアノテーションが既に存在する場合はそれを返す。
+    // アノテーションのコピー時は値を直接コピーするため、浮動小数点の丸め誤差は発生しない。
+    // SQLite (IEEE 754 double) と JavaScript (IEEE 754 double) 間で値は保持される。
+    const duplicate = await prisma.drawingAnnotation.findFirst({
+      where: {
+        questionScoreId: createData.questionScoreId,
+        type: createData.type,
+        x: createData.x,
+        y: createData.y,
+        color: createData.color,
+        strokeWidth: createData.strokeWidth,
+        width: createData.width,
+        height: createData.height,
+        endX: createData.endX,
+        endY: createData.endY,
+        lineStyle: createData.lineStyle,
+        text: createData.text,
+        fontSize: createData.fontSize,
+        textBoxWidth: createData.textBoxWidth,
+        textBoxHeight: createData.textBoxHeight,
+        horizontalAlign: createData.horizontalAlign,
+        verticalAlign: createData.verticalAlign,
+        anchorDirection: createData.anchorDirection,
+        displayX: createData.displayX,
+        displayY: createData.displayY,
+        userId: createData.userId,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            name: true,
+          },
+        },
+        questionScore: {
+          select: {
+            id: true,
+            cropRegionId: true,
+            cropRegion: {
+              select: {
+                id: true,
+                label: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    if (duplicate) {
+      return duplicate as DrawingAnnotation
+    }
+
     const result = await prisma.drawingAnnotation.create({
       data: {
         // フロントエンドで生成したIDがあれば使用、なければPrismaが自動生成
         ...(data.id && { id: data.id }),
-        questionScoreId: data.questionScoreId,
-        type: data.type,
-        x: data.x,
-        y: data.y,
-        color: data.color || "#ef4444",
-        strokeWidth: data.strokeWidth || 3,
-        // サイズプロパティ
-        width: data.width || 0.0,
-        height: data.height || 0.0,
-        // 直線プロパティ
-        endX: data.endX || 0.0,
-        endY: data.endY || 0.0,
-        lineStyle: data.lineStyle || "solid",
-        // テキストプロパティ
-        text: data.text || "",
-        fontSize: data.fontSize || 16,
-        textBoxWidth: data.textBoxWidth || 0.0,
-        textBoxHeight: data.textBoxHeight || 0.0,
-        horizontalAlign: data.horizontalAlign || "left",
-        verticalAlign: data.verticalAlign || "top",
-        // V4統合フィールド
-        anchorDirection: data.anchorDirection || "top-left",
-        // 表示プロパティ
-        displayX: data.displayX || 0.0,
-        displayY: data.displayY || 0.0,
-        // メタデータ
-        userId: data.userId,
+        ...createData,
       },
       // 透明度制御に必要なquestionScore情報を含める
       include: {


### PR DESCRIPTION
## Summary

Closes #639

- Prisma層: epsilon比較を除去し、`findFirst`で全フィールド完全一致検索に簡素化
- フロントエンド: `allAnnotations`を使ったローカル重複判定を追加（重複時はIPCリクエストを送らない）
- UI: `isAddingRef`による連打防止＋重複時の「既に追加済み」トースト通知

## Test plan

- [ ] 生徒A設問aのアノテーションを、同じ生徒A設問aに追加 → 「既に追加済み」トーストが表示され、アノテーションが増えないこと
- [ ] 生徒A設問aのアノテーションを、生徒A-E設問aに追加 → Aはスキップ、B-Eに追加されること
- [ ] 生徒A設問aのアノテーションを、生徒A-E設問bに追加 → 全員に中央配置で追加されること
- [ ] 「+」ボタンを連打しても、アノテーションが1件のみ追加されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)