### PR TITLE
波線・ジグザグの描画をcos波・中央揃えに統一

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
@@ -1,0 +1,592 @@
+/**
+ * 描画要素レンダリングフック
+ * - 単一要素の描画
+ * - 線種別描画（矢印、波線、ジグザグ等）
+ * - アノテーション変換
+ */
+import { useCallback } from "react"
+
+import { getTextPositionFromAnchor } from "@/app/textbox-on-canvas-v4/utils/canvasUtils"
+import type { DrawingElement } from "@/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes"
+import { mmToPixels } from "@/lib/paperSize"
+import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
+
+import { renderTextElementV4 } from "../../utils/canvasTextRendererV4"
+
+interface UseDrawingRendererReturn {
+  convertAnnotationToDrawingElement: (
+    annotation: DrawingAnnotationWithQuestionScore
+  ) => DrawingElement
+  drawSingleElement: (
+    ctx: CanvasRenderingContext2D,
+    element: DrawingElement,
+    baseImg: HTMLImageElement,
+    offsetX: number,
+    offsetY: number,
+    isSelected: boolean,
+    isDragging: boolean,
+    showAnchor?: boolean,
+    pageSize?: string
+  ) => Promise<void>
+}
+
+/**
+ * 描画要素のレンダリングを管理するフック
+ */
+export function useDrawingRenderer(): UseDrawingRendererReturn {
+  // アノテーションをDrawingElement形式に変換する関数
+  const convertAnnotationToDrawingElement = useCallback(
+    (annotation: DrawingAnnotationWithQuestionScore): DrawingElement => {
+      return {
+        id: annotation.id,
+        type: annotation.type as DrawingElement["type"],
+        x: annotation.x,
+        y: annotation.y,
+        color: annotation.color,
+        strokeWidth: annotation.strokeWidth,
+        width: annotation.width,
+        height: annotation.height,
+        endX: annotation.endX,
+        endY: annotation.endY,
+        lineStyle: annotation.lineStyle,
+        text: annotation.text,
+        fontSize: annotation.fontSize,
+        textBoxWidth: annotation.textBoxWidth,
+        textBoxHeight: annotation.textBoxHeight,
+        displayX: annotation.displayX,
+        displayY: annotation.displayY,
+        anchorDirection: annotation.anchorDirection,
+      }
+    },
+    []
+  )
+
+  // 単一要素を描画するヘルパー関数
+  const drawSingleElement = useCallback(
+    async (
+      ctx: CanvasRenderingContext2D,
+      element: DrawingElement,
+      baseImg: HTMLImageElement,
+      offsetX: number,
+      offsetY: number,
+      isSelected: boolean,
+      isDragging: boolean,
+      showAnchor: boolean = true,
+      pageSize: string = "A4"
+    ) => {
+      // テキストボックスの場合、表示用座標があればそれを使用
+      const displayX =
+        element.type === "text" && element.displayX !== undefined
+          ? element.displayX
+          : element.x
+      const displayY =
+        element.type === "text" && element.displayY !== undefined
+          ? element.displayY
+          : element.y
+
+      const currentX = displayX * baseImg.naturalWidth + offsetX
+      const currentY = displayY * baseImg.naturalHeight + offsetY
+
+      // mm → canvas pixels 変換
+      const strokeWidthPx = mmToPixels(
+        element.strokeWidth,
+        pageSize,
+        baseImg.naturalWidth,
+        baseImg.naturalHeight
+      )
+
+      const fontSizePx = mmToPixels(
+        element.fontSize || 4.0,
+        pageSize,
+        baseImg.naturalWidth,
+        baseImg.naturalHeight
+      )
+
+      // ピクセル変換済みの要素コピー（内部描画関数用）
+      const pxElement = {
+        ...element,
+        strokeWidth: strokeWidthPx,
+        fontSize: fontSizePx,
+      }
+
+      ctx.strokeStyle = element.color
+      ctx.fillStyle = element.color
+      ctx.lineWidth = strokeWidthPx
+
+      // テキスト要素のドラッグ中は軽量描画（長方形のみ）
+      if (isDragging && isSelected && element.type === "text") {
+        drawLightweightTextPlaceholder(ctx, pxElement, currentX, currentY)
+        return
+      }
+
+      // 通常描画
+      switch (element.type) {
+        case "text":
+          await drawTextElement(
+            ctx,
+            pxElement,
+            baseImg,
+            isSelected,
+            showAnchor,
+            currentX,
+            currentY
+          )
+          break
+        case "line":
+          drawLineElement(
+            ctx,
+            pxElement,
+            baseImg,
+            offsetX,
+            offsetY,
+            currentX,
+            currentY
+          )
+          break
+        case "rectangle":
+          drawRectangleElement(ctx, pxElement, baseImg, currentX, currentY)
+          break
+        case "ellipse":
+          drawEllipseElement(ctx, pxElement, baseImg, currentX, currentY)
+          break
+      }
+    },
+    []
+  )
+
+  return {
+    convertAnnotationToDrawingElement,
+    drawSingleElement,
+  }
+}
+
+/**
+ * 軽量テキストプレースホルダーを描画
+ */
+function drawLightweightTextPlaceholder(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  currentX: number,
+  currentY: number
+): void {
+  ctx.save()
+  ctx.strokeStyle = element.color
+  ctx.setLineDash([5, 5])
+  ctx.lineWidth = 2
+  ctx.globalAlpha = 0.7
+
+  const boundingWidth = element.text
+    ? Math.max(element.text.length * (element.fontSize || 16) * 0.6, 50)
+    : 50
+  const boundingHeight = Math.max((element.fontSize || 16) * 1.2, 20)
+
+  const anchorDir = element.anchorDirection || "top-left"
+  const textPos = getTextPositionFromAnchor(
+    currentX,
+    currentY,
+    boundingWidth,
+    boundingHeight,
+    anchorDir
+  )
+
+  ctx.strokeRect(textPos.x, textPos.y, boundingWidth, boundingHeight)
+
+  ctx.font = "12px sans-serif"
+  ctx.fillStyle = element.color
+  ctx.globalAlpha = 0.8
+  const shortText = element.text
+    ? element.text.length > 10
+      ? element.text.substring(0, 10) + "..."
+      : element.text
+    : "Text"
+  ctx.fillText(shortText, textPos.x + 5, textPos.y + 15)
+
+  ctx.restore()
+}
+
+/**
+ * テキスト要素を描画
+ */
+async function drawTextElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  baseImg: HTMLImageElement,
+  isSelected: boolean,
+  showAnchor: boolean,
+  currentX: number,
+  currentY: number
+): Promise<void> {
+  if (!element.text) return
+
+  try {
+    await renderTextElementV4(
+      ctx,
+      element,
+      baseImg.naturalWidth,
+      baseImg.naturalHeight,
+      isSelected,
+      showAnchor
+    )
+  } catch (error) {
+    console.error("V4テキスト描画エラー:", error)
+    // フォールバック: シンプルテキスト描画
+    ctx.font = `${element.fontSize || 16}px sans-serif`
+    ctx.fillStyle = element.color
+    const lines = element.text.split("\n")
+    const lineHeight = (element.fontSize || 16) * 1.4
+    lines.forEach((line, index) => {
+      ctx.fillText(line, currentX, currentY + index * lineHeight)
+    })
+  }
+}
+
+/**
+ * 線要素を描画
+ */
+function drawLineElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  baseImg: HTMLImageElement,
+  offsetX: number,
+  offsetY: number,
+  currentX: number,
+  currentY: number
+): void {
+  if (element.endX === undefined || element.endY === undefined) return
+
+  const currentEndX = element.endX * baseImg.naturalWidth + offsetX
+  const currentEndY = element.endY * baseImg.naturalHeight + offsetY
+
+  ctx.save()
+  ctx.strokeStyle = element.color
+  ctx.fillStyle = element.color
+  ctx.lineWidth = element.strokeWidth
+  ctx.setLineDash([])
+  ctx.lineCap = "round"
+  ctx.lineJoin = "round"
+
+  const dx = currentEndX - currentX
+  const dy = currentEndY - currentY
+  const lineLength = Math.sqrt(dx * dx + dy * dy)
+  const angle = Math.atan2(dy, dx)
+  const arrowSize = element.strokeWidth * 5
+
+  switch (element.lineStyle) {
+    case "wave":
+      drawWaveLine(
+        ctx,
+        currentX,
+        currentY,
+        dx,
+        dy,
+        lineLength,
+        angle,
+        element.strokeWidth
+      )
+      break
+    case "zigzag":
+      drawZigzagLine(
+        ctx,
+        currentX,
+        currentY,
+        dx,
+        dy,
+        lineLength,
+        angle,
+        currentEndX,
+        currentEndY,
+        element.strokeWidth
+      )
+      break
+    case "double":
+      drawDoubleLine(
+        ctx,
+        currentX,
+        currentY,
+        currentEndX,
+        currentEndY,
+        angle,
+        element.strokeWidth
+      )
+      break
+    case "arrow":
+      drawArrowLine(
+        ctx,
+        currentX,
+        currentY,
+        currentEndX,
+        currentEndY,
+        angle,
+        arrowSize
+      )
+      break
+    case "both_arrow":
+      drawBothArrowLine(
+        ctx,
+        currentX,
+        currentY,
+        currentEndX,
+        currentEndY,
+        angle,
+        arrowSize
+      )
+      break
+    default:
+      // solid - 通常の直線
+      ctx.beginPath()
+      ctx.moveTo(currentX, currentY)
+      ctx.lineTo(currentEndX, currentEndY)
+      ctx.stroke()
+      break
+  }
+
+  ctx.restore()
+}
+
+/**
+ * 波線を描画（cos波、中央揃え）
+ *
+ * 線分の中央が波の頂点になるcos波を描画する。
+ * 始点・終点は波の途中で切れてもよい（偶数制約なし）。
+ */
+function drawWaveLine(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  dx: number,
+  dy: number,
+  lineLength: number,
+  angle: number,
+  strokeWidth: number
+): void {
+  const waveAmplitude = strokeWidth * 1.5
+  const wavelength = strokeWidth * 10 * 2
+
+  const perpX = -Math.sin(angle)
+  const perpY = Math.cos(angle)
+
+  const steps = Math.max(Math.ceil((lineLength / wavelength) * 32), 64)
+
+  ctx.beginPath()
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps
+    const pos = t * lineLength
+    const theta = (2 * Math.PI * (pos - lineLength / 2)) / wavelength
+    const offset = waveAmplitude * Math.cos(theta)
+
+    const x = startX + dx * t + perpX * offset
+    const y = startY + dy * t + perpY * offset
+
+    if (i === 0) ctx.moveTo(x, y)
+    else ctx.lineTo(x, y)
+  }
+  ctx.stroke()
+}
+
+/**
+ * ジグザグ線を描画（cos位相、中央揃え）
+ *
+ * 線分の中央が頂点(+A)になるよう、中央から左右対称に頂点を配置する。
+ * 始点・終点は直線上で、端の頂点が途中で切れることはないが、
+ * 端のセグメント長は中央部分と異なる場合がある。
+ */
+function drawZigzagLine(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  dx: number,
+  dy: number,
+  lineLength: number,
+  angle: number,
+  _endX: number,
+  _endY: number,
+  strokeWidth: number
+): void {
+  const zigAmplitude = strokeWidth * 1.5
+  const zigPitch = strokeWidth * 8
+
+  const perpX = -Math.sin(angle)
+  const perpY = Math.cos(angle)
+
+  // 中央基準で頂点を配置（中央が+A、左右にzigPitch間隔で交互）
+  const center = lineLength / 2
+  const peaks: { pos: number; amp: number }[] = []
+
+  // 中央の頂点
+  peaks.push({ pos: center, amp: zigAmplitude })
+
+  // 中央から左右に展開
+  for (let i = 1; center + i * zigPitch < lineLength; i++) {
+    const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+    peaks.push({ pos: center + i * zigPitch, amp })
+  }
+  for (let i = 1; center - i * zigPitch > 0; i++) {
+    const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+    peaks.push({ pos: center - i * zigPitch, amp })
+  }
+
+  // 位置順にソート
+  peaks.sort((a, b) => a.pos - b.pos)
+
+  ctx.beginPath()
+  ctx.moveTo(startX, startY)
+
+  for (const peak of peaks) {
+    const t = peak.pos / lineLength
+    const baseX = startX + dx * t
+    const baseY = startY + dy * t
+    ctx.lineTo(baseX + perpX * peak.amp, baseY + perpY * peak.amp)
+  }
+
+  ctx.lineTo(startX + dx, startY + dy)
+  ctx.stroke()
+}
+
+/**
+ * 二重線を描画
+ */
+function drawDoubleLine(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  angle: number,
+  strokeWidth: number
+): void {
+  const offset = strokeWidth
+  const perpX = -Math.sin(angle) * offset
+  const perpY = Math.cos(angle) * offset
+
+  ctx.beginPath()
+  ctx.moveTo(startX + perpX, startY + perpY)
+  ctx.lineTo(endX + perpX, endY + perpY)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(startX - perpX, startY - perpY)
+  ctx.lineTo(endX - perpX, endY - perpY)
+  ctx.stroke()
+}
+
+/**
+ * 矢印線を描画
+ */
+function drawArrowLine(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  angle: number,
+  arrowSize: number
+): void {
+  ctx.beginPath()
+  ctx.moveTo(startX, startY)
+  ctx.lineTo(endX, endY)
+  ctx.stroke()
+
+  ctx.beginPath()
+  ctx.moveTo(endX, endY)
+  ctx.lineTo(
+    endX - arrowSize * Math.cos(angle - Math.PI / 6),
+    endY - arrowSize * Math.sin(angle - Math.PI / 6)
+  )
+  ctx.lineTo(
+    endX - arrowSize * Math.cos(angle + Math.PI / 6),
+    endY - arrowSize * Math.sin(angle + Math.PI / 6)
+  )
+  ctx.closePath()
+  ctx.fill()
+}
+
+/**
+ * 両矢印線を描画
+ */
+function drawBothArrowLine(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  angle: number,
+  arrowSize: number
+): void {
+  ctx.beginPath()
+  ctx.moveTo(startX, startY)
+  ctx.lineTo(endX, endY)
+  ctx.stroke()
+
+  // 終点の矢印
+  ctx.beginPath()
+  ctx.moveTo(endX, endY)
+  ctx.lineTo(
+    endX - arrowSize * Math.cos(angle - Math.PI / 6),
+    endY - arrowSize * Math.sin(angle - Math.PI / 6)
+  )
+  ctx.lineTo(
+    endX - arrowSize * Math.cos(angle + Math.PI / 6),
+    endY - arrowSize * Math.sin(angle + Math.PI / 6)
+  )
+  ctx.closePath()
+  ctx.fill()
+
+  // 始点の矢印（反対方向）
+  ctx.beginPath()
+  ctx.moveTo(startX, startY)
+  ctx.lineTo(
+    startX + arrowSize * Math.cos(angle - Math.PI / 6),
+    startY + arrowSize * Math.sin(angle - Math.PI / 6)
+  )
+  ctx.lineTo(
+    startX + arrowSize * Math.cos(angle + Math.PI / 6),
+    startY + arrowSize * Math.sin(angle + Math.PI / 6)
+  )
+  ctx.closePath()
+  ctx.fill()
+}
+
+/**
+ * 矩形要素を描画
+ */
+function drawRectangleElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  baseImg: HTMLImageElement,
+  currentX: number,
+  currentY: number
+): void {
+  if (element.width === undefined || element.height === undefined) return
+
+  const rectWidth = element.width * baseImg.naturalWidth
+  const rectHeight = element.height * baseImg.naturalHeight
+  ctx.strokeRect(currentX, currentY, rectWidth, rectHeight)
+}
+
+/**
+ * 楕円要素を描画
+ */
+function drawEllipseElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  baseImg: HTMLImageElement,
+  currentX: number,
+  currentY: number
+): void {
+  if (element.width === undefined || element.height === undefined) return
+
+  const rectWidth = element.width * baseImg.naturalWidth
+  const rectHeight = element.height * baseImg.naturalHeight
+
+  ctx.beginPath()
+  ctx.ellipse(
+    currentX + rectWidth / 2,
+    currentY + rectHeight / 2,
+    Math.abs(rectWidth) / 2,
+    Math.abs(rectHeight) / 2,
+    0,
+    0,
+    2 * Math.PI
+  )
+  ctx.stroke()
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -1,0 +1,588 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+import type { CropRegionWithExamPage } from "@/components/exams/07-score-at-once/types"
+import { PAPER_DIMENSIONS } from "@/lib/paperSize"
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+
+import type { DrawingElement } from "../ScoringIndividual/types/answerIndividualTypes"
+import { renderTextElementV4 } from "../ScoringIndividual/utils/canvasTextRendererV4"
+
+/**
+ * 画像表示について：
+ * このコンポーネントでは標準の<img>要素を使用しています。
+ * Next.js Image コンポーネントを使用しない理由：
+ *
+ * 1. Canvas描画での直接操作が必要
+ *    - 画像データを直接Canvasに描画するため、HTMLImageElementへの直接アクセスが必要
+ *
+ * 2. naturalWidth/naturalHeightの取得
+ *    - 画像の実際のサイズ情報が必要で、Next.js Imageでは取得が困難
+ *
+ * 3. refの互換性問題
+ *    - Next.js Imageコンポーネントのrefは実際の<img>要素を直接参照しない場合がある
+ *
+ * 4. onLoadイベントの確実な発火
+ *    - 画像読み込み完了の検出が確実に必要
+ *
+ * 5. Electronアプリでの制限
+ *    - Next.jsの画像最適化機能がElectronアプリで正常に動作しない場合がある
+ */
+
+interface CroppedAnswerImageProps {
+  imageUrl: string
+  cropRegion: CropRegionWithExamPage // not null（呼び出し元で保証）
+  alt: string
+  className?: string
+  isColumnLayout?: boolean
+  calculatedCellHeight?: number // 親から渡された計算済みセル高さ
+  isSelected?: boolean
+  expandMargin?: number // 表示領域拡張率 (0-50%)
+  annotations?: DrawingAnnotation[] // Grid表示用アノテーション
+  pageSize?: string // 用紙サイズ（mm→px変換基準）
+}
+
+// セル内の固定オフセット（padding + gap + footer）
+const CELL_CONTENT_OFFSET = 32 // p-2(16px) + gap-1(4px) + footer(~12px)
+
+// 採点領域をクロップして表示するコンポーネント
+export default function CroppedAnswerImage({
+  imageUrl,
+  cropRegion,
+  alt,
+  className = "",
+  isColumnLayout = false,
+  calculatedCellHeight = 0,
+  isSelected = false,
+  expandMargin = 0,
+  annotations,
+  pageSize,
+}: CroppedAnswerImageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const imageRef = useRef<HTMLImageElement>(null)
+  const [imageLoaded, setImageLoaded] = useState(false)
+
+  // imageUrl変更時にimageLoadedをリセット
+  // リセットしないと、新画像のonLoadでsetImageLoaded(true)がno-opとなり
+  // キャンバスの再描画が発火しない
+  const prevImageUrlRef = useRef(imageUrl)
+  if (prevImageUrlRef.current !== imageUrl) {
+    prevImageUrlRef.current = imageUrl
+    if (imageLoaded) {
+      setImageLoaded(false)
+    }
+  }
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const imageElement = imageRef.current
+    if (!canvas || !imageElement || !imageLoaded) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    // 表示領域拡張の計算
+    const expandRatio = (expandMargin ?? 0) / 100
+    const expandX = cropRegion.width * expandRatio
+    const expandY = cropRegion.height * expandRatio
+
+    // 拡張後の座標（画像端でクリップ）
+    const newX = Math.max(0, cropRegion.x - expandX)
+    const newY = Math.max(0, cropRegion.y - expandY)
+    // 右端・下端がはみ出さないように制限
+    const newWidth = Math.min(1 - newX, cropRegion.width + expandX * 2)
+    const newHeight = Math.min(1 - newY, cropRegion.height + expandY * 2)
+
+    // 採点領域のアスペクト比を計算（拡張後の領域で計算）
+    const sourceWidth = newWidth * imageElement.naturalWidth
+    const sourceHeight = newHeight * imageElement.naturalHeight
+    const aspectRatio = sourceWidth / sourceHeight
+
+    let canvasWidth: number
+    let canvasHeight: number
+
+    if (isColumnLayout && calculatedCellHeight > 0) {
+      // 列表示: 計算済みセル高さからcanvas高さを算出
+      canvasHeight = Math.max(10, calculatedCellHeight - CELL_CONTENT_OFFSET)
+      canvasWidth = canvasHeight * aspectRatio
+    } else {
+      // 行表示: 親要素の幅を基準に計算
+      const parent = canvas.parentElement
+      if (!parent) return
+      const containerWidth = parent.offsetWidth
+      canvasWidth = Math.max(10, containerWidth)
+      canvasHeight = canvasWidth / aspectRatio
+    }
+
+    canvas.width = canvasWidth
+    canvas.height = canvasHeight
+
+    // canvas の CSS サイズを直接設定（ピクセルバッファサイズと一致させる）
+    if (isColumnLayout) {
+      canvas.style.width = `${canvasWidth}px`
+      canvas.style.height = `${canvasHeight}px`
+      canvas.style.flexShrink = "0"
+    } else {
+      canvas.style.width = "100%"
+      canvas.style.height = ""
+      canvas.style.flexShrink = ""
+    }
+
+    // 拡張後の座標でクロップして描画
+    const sourceX = newX * imageElement.naturalWidth
+    const sourceY = newY * imageElement.naturalHeight
+
+    // 拡張した採点領域を直接Canvas全体に描画（アスペクト比は既に調整済み）
+    ctx.drawImage(
+      imageElement,
+      sourceX,
+      sourceY,
+      sourceWidth,
+      sourceHeight,
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    )
+
+    // アノテーション描画（非同期: MathJaxテキスト変換を含む）
+    if (annotations && annotations.length > 0) {
+      let cancelled = false
+      const drawAsync = async () => {
+        await drawAnnotations(
+          ctx,
+          annotations,
+          newX,
+          newY,
+          newWidth,
+          newHeight,
+          canvas.width,
+          canvas.height,
+          imageElement.naturalWidth,
+          imageElement.naturalHeight,
+          () => cancelled,
+          pageSize
+        )
+      }
+      drawAsync()
+      return () => {
+        cancelled = true
+      }
+    }
+  }, [
+    imageLoaded,
+    imageUrl,
+    cropRegion,
+    isColumnLayout,
+    calculatedCellHeight,
+    expandMargin,
+    annotations,
+    pageSize,
+  ])
+
+  const handleImageLoad = () => {
+    setImageLoaded(true)
+  }
+
+  // 行表示: 幅100%、高さは自動
+  // 列表示: 明示的にサイズ指定（useEffect内で直接設定）
+  const containerClass = isColumnLayout ? "" : "w-full"
+
+  return (
+    <div
+      className={`relative ${containerClass} ${isSelected ? "ring-2 ring-blue-500 ring-inset" : ""} ${className}`}
+    >
+      {/* Canvas描画用の画像データ取得のため、Next.js Imageではなく通常のimgタグを使用 */}
+      {}
+      <img
+        ref={imageRef}
+        src={imageUrl}
+        alt={alt}
+        className="hidden"
+        onLoad={handleImageLoad}
+        draggable={false}
+      />
+      <canvas
+        ref={canvasRef}
+        style={{ display: imageLoaded ? "block" : "none" }}
+      />
+      {!imageLoaded && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
+          <div className="text-xs text-gray-500">読み込み中...</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Grid表示用アノテーション描画
+ * アノテーションの0-1相対座標をクロップ領域→Canvasピクセル座標に変換して描画
+ * テキストはrenderTextElementV4を使用してMathJax対応
+ */
+async function drawAnnotations(
+  ctx: CanvasRenderingContext2D,
+  annotations: DrawingAnnotation[],
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  imageNaturalWidth: number,
+  imageNaturalHeight: number,
+  isCancelled: () => boolean,
+  pageSize?: string
+) {
+  // mm→用紙幅比率→canvasピクセルに変換するためのスケール
+  // anno.strokeWidth (mm) → anno.strokeWidth / paperWidthMm → × canvasWidth / visibleWidth
+  const paper = PAPER_DIMENSIONS[pageSize ?? "A4"] ?? PAPER_DIMENSIONS.A4
+  const isLandscape =
+    imageNaturalWidth > (imageNaturalHeight ?? imageNaturalWidth)
+  const paperWidthMm = isLandscape ? paper.height : paper.width
+  const scaleFactor = canvasWidth / (visibleWidth * paperWidthMm)
+
+  for (const anno of annotations) {
+    if (isCancelled()) return
+
+    ctx.save()
+    ctx.strokeStyle = anno.color
+    ctx.fillStyle = anno.color
+    ctx.lineWidth = Math.max(1, anno.strokeWidth * scaleFactor)
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+
+    switch (anno.type) {
+      case "text":
+        await drawGridTextV4(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight,
+          scaleFactor
+        )
+        break
+      case "line":
+        drawGridLine(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight,
+          scaleFactor
+        )
+        break
+      case "rectangle":
+        drawGridRectangle(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight
+        )
+        break
+      case "ellipse":
+        drawGridEllipse(
+          ctx,
+          anno,
+          visibleX,
+          visibleY,
+          visibleWidth,
+          visibleHeight,
+          canvasWidth,
+          canvasHeight
+        )
+        break
+    }
+
+    ctx.restore()
+  }
+}
+
+/** 0-1相対座標→Canvasピクセル座標に変換 */
+function toCanvasX(
+  annoX: number,
+  visibleX: number,
+  visibleWidth: number,
+  canvasWidth: number
+): number {
+  return ((annoX - visibleX) / visibleWidth) * canvasWidth
+}
+
+function toCanvasY(
+  annoY: number,
+  visibleY: number,
+  visibleHeight: number,
+  canvasHeight: number
+): number {
+  return ((annoY - visibleY) / visibleHeight) * canvasHeight
+}
+
+/**
+ * テキスト描画（V4レンダラー使用: MathJax/SVG対応）
+ * DrawingAnnotationをDrawingElementに変換し、renderTextElementV4で描画
+ */
+async function drawGridTextV4(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  scaleFactor: number
+) {
+  if (!anno.text) return
+
+  // DrawingAnnotation → DrawingElement に変換
+  // renderTextElementV4は element.x * canvasWidth でアンカーピクセル位置を計算するため、
+  // Grid Canvas空間での0-1座標に変換する
+  const element: DrawingElement = {
+    id: `grid-${anno.id}`,
+    type: "text",
+    x: (anno.x - visibleX) / visibleWidth,
+    y: (anno.y - visibleY) / visibleHeight,
+    color: anno.color,
+    strokeWidth: anno.strokeWidth,
+    text: anno.text,
+    fontSize: Math.max(2, anno.fontSize * scaleFactor),
+    anchorDirection: anno.anchorDirection || "top-left",
+  }
+
+  await renderTextElementV4(
+    ctx,
+    element,
+    canvasWidth,
+    canvasHeight,
+    false, // isSelected
+    false, // showAnchor
+    1.0 // opacity
+  )
+}
+
+/** 線描画（全lineStyle対応） */
+function drawGridLine(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number,
+  scaleFactor: number
+) {
+  const startX = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const startY = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const endX = toCanvasX(anno.endX, visibleX, visibleWidth, canvasWidth)
+  const endY = toCanvasY(anno.endY, visibleY, visibleHeight, canvasHeight)
+
+  const dx = endX - startX
+  const dy = endY - startY
+  const lineLength = Math.sqrt(dx * dx + dy * dy)
+  const angle = Math.atan2(dy, dx)
+  const sw = Math.max(1, anno.strokeWidth * scaleFactor)
+  const arrowSize = Math.max(sw * 5, 8)
+
+  ctx.lineWidth = sw
+  ctx.setLineDash([])
+
+  switch (anno.lineStyle) {
+    case "wave": {
+      // cos波（中央揃え）: 線分の中央が波の頂点
+      const waveAmplitude = sw * 1.5
+      const wavelength = sw * 10 * 2
+
+      const perpX = -Math.sin(angle)
+      const perpY = Math.cos(angle)
+
+      const steps = Math.max(Math.ceil((lineLength / wavelength) * 32), 64)
+
+      ctx.beginPath()
+      for (let i = 0; i <= steps; i++) {
+        const t = i / steps
+        const pos = t * lineLength
+        const theta = (2 * Math.PI * (pos - lineLength / 2)) / wavelength
+        const waveOffset = waveAmplitude * Math.cos(theta)
+
+        const x = startX + dx * t + perpX * waveOffset
+        const y = startY + dy * t + perpY * waveOffset
+
+        if (i === 0) ctx.moveTo(x, y)
+        else ctx.lineTo(x, y)
+      }
+      ctx.stroke()
+      break
+    }
+    case "zigzag": {
+      // ジグザグ（cos位相、中央揃え）: 中央が+A頂点
+      const zigAmplitude = sw * 1.5
+      const zigPitch = sw * 8
+
+      const perpX = -Math.sin(angle)
+      const perpY = Math.cos(angle)
+
+      const center = lineLength / 2
+      const peaks: { pos: number; amp: number }[] = []
+
+      peaks.push({ pos: center, amp: zigAmplitude })
+
+      for (let i = 1; center + i * zigPitch < lineLength; i++) {
+        const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+        peaks.push({ pos: center + i * zigPitch, amp })
+      }
+      for (let i = 1; center - i * zigPitch > 0; i++) {
+        const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+        peaks.push({ pos: center - i * zigPitch, amp })
+      }
+
+      peaks.sort((a, b) => a.pos - b.pos)
+
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+
+      for (const peak of peaks) {
+        const t = peak.pos / lineLength
+        const baseX = startX + dx * t
+        const baseY = startY + dy * t
+        ctx.lineTo(baseX + perpX * peak.amp, baseY + perpY * peak.amp)
+      }
+
+      ctx.lineTo(startX + dx, startY + dy)
+      ctx.stroke()
+      break
+    }
+    case "double": {
+      const offset = sw
+      const perpX = -Math.sin(angle) * offset
+      const perpY = Math.cos(angle) * offset
+      ctx.beginPath()
+      ctx.moveTo(startX + perpX, startY + perpY)
+      ctx.lineTo(endX + perpX, endY + perpY)
+      ctx.stroke()
+      ctx.beginPath()
+      ctx.moveTo(startX - perpX, startY - perpY)
+      ctx.lineTo(endX - perpX, endY - perpY)
+      ctx.stroke()
+      break
+    }
+    case "arrow": {
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      ctx.beginPath()
+      ctx.moveTo(endX, endY)
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle - Math.PI / 6),
+        endY - arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle + Math.PI / 6),
+        endY - arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      break
+    }
+    case "both_arrow": {
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      // 終点矢印
+      ctx.beginPath()
+      ctx.moveTo(endX, endY)
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle - Math.PI / 6),
+        endY - arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        endX - arrowSize * Math.cos(angle + Math.PI / 6),
+        endY - arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      // 始点矢印
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(
+        startX + arrowSize * Math.cos(angle - Math.PI / 6),
+        startY + arrowSize * Math.sin(angle - Math.PI / 6)
+      )
+      ctx.lineTo(
+        startX + arrowSize * Math.cos(angle + Math.PI / 6),
+        startY + arrowSize * Math.sin(angle + Math.PI / 6)
+      )
+      ctx.closePath()
+      ctx.fill()
+      break
+    }
+    default: {
+      // solid
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      ctx.lineTo(endX, endY)
+      ctx.stroke()
+      break
+    }
+  }
+}
+
+/** 矩形描画 */
+function drawGridRectangle(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  const cx = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const cy = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const w = (anno.width / visibleWidth) * canvasWidth
+  const h = (anno.height / visibleHeight) * canvasHeight
+  ctx.strokeRect(cx, cy, w, h)
+}
+
+/** 楕円描画 */
+function drawGridEllipse(
+  ctx: CanvasRenderingContext2D,
+  anno: DrawingAnnotation,
+  visibleX: number,
+  visibleY: number,
+  visibleWidth: number,
+  visibleHeight: number,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  const cx = toCanvasX(anno.x, visibleX, visibleWidth, canvasWidth)
+  const cy = toCanvasY(anno.y, visibleY, visibleHeight, canvasHeight)
+  const w = (anno.width / visibleWidth) * canvasWidth
+  const h = (anno.height / visibleHeight) * canvasHeight
+  ctx.beginPath()
+  ctx.ellipse(
+    cx + w / 2,
+    cy + h / 2,
+    Math.abs(w) / 2,
+    Math.abs(h) / 2,
+    0,
+    0,
+    2 * Math.PI
+  )
+  ctx.stroke()
+}

--- a/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
+++ b/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
@@ -1,0 +1,974 @@
+/**
+ * PDF出力用Canvas描画ユーティリティ
+ *
+ * 一括採点個別表示のCanvas描画エンジン（useImageCanvas.ts）を流用し、
+ * PDF出力に適した形式でCanvas上に描画を行う。
+ */
+
+import type { AnchorDirection } from "@/app/textbox-on-canvas-v4/types"
+import { getTextPositionFromAnchor } from "@/app/textbox-on-canvas-v4/utils/canvasUtils"
+import { convertTextToSvg } from "@/app/textbox-on-canvas-v4/utils/textConversionUtils"
+import { mmToPixels } from "@/lib/paperSize"
+import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+
+/**
+ * 採点データ（PDF出力用）
+ */
+export interface ScoringDataForPdf {
+  questionScoreId: string
+  status: string // "unscored" | "correct" | "partial" | "pending" | "incorrect" | "no_answer"
+  partialScore?: number | null
+  cropRegion: {
+    id: string
+    x: number
+    y: number
+    width: number
+    height: number
+    label: string
+    maxScore?: number | null // 配点
+    examPage?: {
+      pageNumber: number
+    }
+  }
+}
+
+/**
+ * 採点マーク設定
+ */
+export interface ScoringMarkConfigForPdf {
+  markPosition: string
+  markSize: number
+  useTransparent: boolean
+  showPartialScore: boolean
+  partialScorePosition: string
+  partialScoreSize: number
+  partialScoreOffsetX: number
+  partialScoreOffsetY: number
+  // 小計点用設定
+  subtotalScorePosition: string
+  subtotalScoreSize: number
+  subtotalScoreOffsetX: number
+  subtotalScoreOffsetY: number
+  // 合計点用設定
+  totalScorePosition: string
+  totalScoreSize: number
+  totalScoreOffsetX: number
+  totalScoreOffsetY: number
+  // ステータスごとの表示設定
+  showMarkForStatus?: Record<string, boolean>
+  showScoreForStatus?: Record<string, boolean>
+}
+
+/**
+ * 小計点データ（PDF出力用）
+ */
+export interface SubtotalDataForPdf {
+  regionId: string
+  label: string
+  score: number
+  x: number
+  y: number
+  width: number
+  height: number
+  pageNumber: number
+}
+
+/**
+ * 合計点データ（PDF出力用）
+ */
+export interface TotalScoreDataForPdf {
+  regionId: string
+  score: number
+  maxScore: number
+  x: number
+  y: number
+  width: number
+  height: number
+  pageNumber: number
+}
+
+/**
+ * 描画要素（内部用、DrawingAnnotationから変換）
+ */
+interface DrawingElement {
+  id: string
+  type: "text" | "line" | "rectangle" | "ellipse"
+  x: number
+  y: number
+  color: string
+  strokeWidth: number
+  width?: number
+  height?: number
+  endX?: number
+  endY?: number
+  lineStyle?: string
+  text?: string
+  fontSize?: number
+  displayX?: number
+  displayY?: number
+  anchorDirection?: string
+}
+
+/**
+ * DrawingAnnotationをDrawingElementに変換
+ */
+function convertAnnotationToDrawingElement(
+  annotation: DrawingAnnotation
+): DrawingElement {
+  return {
+    id: annotation.id,
+    type: annotation.type as "text" | "line" | "rectangle" | "ellipse",
+    x: annotation.x,
+    y: annotation.y,
+    color: annotation.color,
+    strokeWidth: annotation.strokeWidth,
+    width: annotation.width,
+    height: annotation.height,
+    endX: annotation.endX,
+    endY: annotation.endY,
+    lineStyle: annotation.lineStyle,
+    text: annotation.text,
+    fontSize: annotation.fontSize,
+    displayX: annotation.displayX,
+    displayY: annotation.displayY,
+    anchorDirection: annotation.anchorDirection,
+  }
+}
+
+/**
+ * 単一の描画要素をCanvas上に描画
+ *
+ * useImageCanvas.ts の drawSingleElement を純粋関数として抽出
+ *
+ * @param ctx - Canvas 2D コンテキスト
+ * @param element - 描画要素
+ * @param imageWidth - 画像の幅
+ * @param imageHeight - 画像の高さ
+ * @param offsetX - X座標オフセット
+ * @param offsetY - Y座標オフセット
+ * @param pageOffset - ページオフセット（複数ページ対応用、デフォルト0）
+ *                     UI側で複数ページが縦に結合されたキャンバス上で描画された場合、
+ *                     アノテーションのy座標は1ページ目の高さで正規化されるため
+ *                     2ページ目以降のアノテーションはy > 1.0になる。
+ *                     このオフセットを引くことで正しいページ内座標に変換する。
+ */
+async function drawElement(
+  ctx: CanvasRenderingContext2D,
+  element: DrawingElement,
+  imageWidth: number,
+  imageHeight: number,
+  offsetX: number = 0,
+  offsetY: number = 0,
+  pageOffset: number = 0,
+  pageSize: string = "A4"
+): Promise<void> {
+  // 座標計算（テキストも含めてelement.x/yを使用 - 一括採点個別表示と同じ）
+  // pageOffsetを引くことで、複数ページキャンバスからの座標をページ内座標に変換
+  const currentX = element.x * imageWidth + offsetX
+  const currentY = (element.y - pageOffset) * imageHeight + offsetY
+
+  // mm → canvas pixels 変換
+  const strokeWidthPx = mmToPixels(
+    element.strokeWidth,
+    pageSize,
+    imageWidth,
+    imageHeight
+  )
+  const fontSizePx = mmToPixels(
+    element.fontSize ?? 4.0,
+    pageSize,
+    imageWidth,
+    imageHeight
+  )
+
+  ctx.strokeStyle = element.color
+  ctx.fillStyle = element.color
+  ctx.lineWidth = strokeWidthPx
+
+  switch (element.type) {
+    case "text":
+      if (element.text) {
+        const anchorDir = (element.anchorDirection ||
+          "top-left") as AnchorDirection
+        const textColor = element.color || "#000000"
+
+        try {
+          const svgElement = await convertTextToSvg(
+            element.text,
+            imageWidth,
+            imageHeight,
+            "left",
+            "top",
+            fontSizePx,
+            textColor
+          )
+
+          if (svgElement) {
+            let svgData = new XMLSerializer().serializeToString(svgElement)
+
+            // MathJax defsを埋め込み
+            const hasMathJaxElements =
+              svgData.includes("mjx-container") || svgData.includes("<use")
+            if (hasMathJaxElements) {
+              const globalDefs = document.querySelector(
+                "#MJX-SVG-global-cache defs"
+              )
+              if (globalDefs && globalDefs.innerHTML.length > 10) {
+                const defsContent = globalDefs.outerHTML
+                svgData = svgData.replace(/(<svg[^>]*>)/, `$1${defsContent}`)
+              }
+            }
+
+            // SVG→PNG変換（Canvas taint問題を回避するためmainプロセスで実行）
+            const result = await window.electronAPI.export.convertSvgToPng({
+              svgString: svgData,
+            })
+
+            if (result.success && result.dataUrl) {
+              const img = new Image()
+              await new Promise<void>((resolve, reject) => {
+                img.onload = () => resolve()
+                img.onerror = () =>
+                  reject(new Error("Failed to load converted PNG"))
+                img.src = result.dataUrl!
+              })
+
+              // 論理サイズで描画（Retinaではimg.width/heightが2倍になるため）
+              const width = result.width ?? img.width
+              const height = result.height ?? img.height
+
+              const textPosition = getTextPositionFromAnchor(
+                currentX,
+                currentY,
+                width,
+                height,
+                anchorDir
+              )
+
+              ctx.drawImage(img, textPosition.x, textPosition.y, width, height)
+            } else {
+              throw new Error(result.error || "SVG to PNG conversion failed")
+            }
+          } else {
+            throw new Error("Failed to generate SVG")
+          }
+        } catch (error) {
+          console.error("MathJaxテキスト描画エラー:", error)
+          // フォールバック: シンプルテキスト描画
+          ctx.font = `${fontSizePx}px sans-serif`
+          ctx.fillStyle = textColor
+          ctx.textBaseline = "top"
+          const lines = element.text.split("\n")
+          const lineHeight = fontSizePx * 1.4
+          lines.forEach((line, index) => {
+            ctx.fillText(line, currentX, currentY + index * lineHeight)
+          })
+        }
+      }
+      break
+
+    case "line":
+      if (element.endX !== undefined && element.endY !== undefined) {
+        const currentEndX = element.endX * imageWidth + offsetX
+        const currentEndY = (element.endY - pageOffset) * imageHeight + offsetY
+
+        ctx.save()
+        ctx.strokeStyle = element.color
+        ctx.fillStyle = element.color
+        ctx.lineWidth = strokeWidthPx
+        ctx.setLineDash([])
+        ctx.lineCap = "round"
+        ctx.lineJoin = "round"
+
+        // 線の長さと角度を計算
+        const dx = currentEndX - currentX
+        const dy = currentEndY - currentY
+        const lineLength = Math.sqrt(dx * dx + dy * dy)
+        const angle = Math.atan2(dy, dx)
+
+        // 矢印のサイズ
+        const arrowSize = strokeWidthPx * 5
+
+        switch (element.lineStyle) {
+          case "wave": {
+            // cos波（中央揃え）: 線分の中央が波の頂点
+            const waveAmplitude = strokeWidthPx * 1.5
+            const wavelength = strokeWidthPx * 10 * 2
+
+            const perpX = -Math.sin(angle)
+            const perpY = Math.cos(angle)
+
+            const steps = Math.max(
+              Math.ceil((lineLength / wavelength) * 32),
+              64
+            )
+
+            ctx.beginPath()
+            for (let i = 0; i <= steps; i++) {
+              const t = i / steps
+              const pos = t * lineLength
+              const theta = (2 * Math.PI * (pos - lineLength / 2)) / wavelength
+              const waveOffset = waveAmplitude * Math.cos(theta)
+
+              const x = currentX + dx * t + perpX * waveOffset
+              const y = currentY + dy * t + perpY * waveOffset
+
+              if (i === 0) ctx.moveTo(x, y)
+              else ctx.lineTo(x, y)
+            }
+            ctx.stroke()
+            break
+          }
+
+          case "zigzag": {
+            // ジグザグ（cos位相、中央揃え）: 中央が+A頂点
+            const zigAmplitude = strokeWidthPx * 1.5
+            const zigPitch = strokeWidthPx * 8
+
+            const perpX = -Math.sin(angle)
+            const perpY = Math.cos(angle)
+
+            const center = lineLength / 2
+            const peaks: { pos: number; amp: number }[] = []
+
+            peaks.push({ pos: center, amp: zigAmplitude })
+
+            for (let i = 1; center + i * zigPitch < lineLength; i++) {
+              const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+              peaks.push({
+                pos: center + i * zigPitch,
+                amp,
+              })
+            }
+            for (let i = 1; center - i * zigPitch > 0; i++) {
+              const amp = (i % 2 === 0 ? 1 : -1) * zigAmplitude
+              peaks.push({
+                pos: center - i * zigPitch,
+                amp,
+              })
+            }
+
+            peaks.sort((a, b) => a.pos - b.pos)
+
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+
+            for (const peak of peaks) {
+              const t = peak.pos / lineLength
+              const baseX = currentX + dx * t
+              const baseY = currentY + dy * t
+              ctx.lineTo(baseX + perpX * peak.amp, baseY + perpY * peak.amp)
+            }
+
+            ctx.lineTo(currentX + dx, currentY + dy)
+            ctx.stroke()
+            break
+          }
+
+          case "double": {
+            const offset = strokeWidthPx
+            const perpX = -Math.sin(angle) * offset
+            const perpY = Math.cos(angle) * offset
+
+            ctx.beginPath()
+            ctx.moveTo(currentX + perpX, currentY + perpY)
+            ctx.lineTo(currentEndX + perpX, currentEndY + perpY)
+            ctx.stroke()
+
+            ctx.beginPath()
+            ctx.moveTo(currentX - perpX, currentY - perpY)
+            ctx.lineTo(currentEndX - perpX, currentEndY - perpY)
+            ctx.stroke()
+            break
+          }
+
+          case "arrow": {
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+
+            ctx.beginPath()
+            ctx.moveTo(currentEndX, currentEndY)
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle - Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle - Math.PI / 6)
+            )
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle + Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle + Math.PI / 6)
+            )
+            ctx.closePath()
+            ctx.fill()
+            break
+          }
+
+          case "both_arrow": {
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+
+            // 終点の矢印
+            ctx.beginPath()
+            ctx.moveTo(currentEndX, currentEndY)
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle - Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle - Math.PI / 6)
+            )
+            ctx.lineTo(
+              currentEndX - arrowSize * Math.cos(angle + Math.PI / 6),
+              currentEndY - arrowSize * Math.sin(angle + Math.PI / 6)
+            )
+            ctx.closePath()
+            ctx.fill()
+
+            // 始点の矢印
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(
+              currentX + arrowSize * Math.cos(angle - Math.PI / 6),
+              currentY + arrowSize * Math.sin(angle - Math.PI / 6)
+            )
+            ctx.lineTo(
+              currentX + arrowSize * Math.cos(angle + Math.PI / 6),
+              currentY + arrowSize * Math.sin(angle + Math.PI / 6)
+            )
+            ctx.closePath()
+            ctx.fill()
+            break
+          }
+
+          default:
+            // solid - 通常の直線
+            ctx.beginPath()
+            ctx.moveTo(currentX, currentY)
+            ctx.lineTo(currentEndX, currentEndY)
+            ctx.stroke()
+            break
+        }
+
+        ctx.restore()
+      }
+      break
+
+    case "rectangle":
+      if (element.width !== undefined && element.height !== undefined) {
+        const rectWidth = element.width * imageWidth
+        const rectHeight = element.height * imageHeight
+        ctx.strokeRect(currentX, currentY, rectWidth, rectHeight)
+      }
+      break
+
+    case "ellipse":
+      if (element.width !== undefined && element.height !== undefined) {
+        const rectWidth = element.width * imageWidth
+        const rectHeight = element.height * imageHeight
+
+        ctx.beginPath()
+        ctx.ellipse(
+          currentX + rectWidth / 2,
+          currentY + rectHeight / 2,
+          Math.abs(rectWidth) / 2,
+          Math.abs(rectHeight) / 2,
+          0,
+          0,
+          2 * Math.PI
+        )
+        ctx.stroke()
+      }
+      break
+  }
+}
+
+/**
+ * 採点マークの位置を計算
+ */
+function calculateMarkPosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  markSize: number,
+  position: string
+): { x: number; y: number } {
+  const padding = 5
+
+  switch (position) {
+    case "top-left":
+      return { x: regionX + padding, y: regionY + padding }
+    case "top-center":
+      return { x: regionX + (regionWidth - markSize) / 2, y: regionY + padding }
+    case "top-right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + padding,
+      }
+    case "middle-left":
+      return {
+        x: regionX + padding,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "middle-center":
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "middle-right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+    case "bottom-left":
+      return {
+        x: regionX + padding,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    case "bottom-center":
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    case "bottom-right":
+      return {
+        x: regionX + regionWidth - markSize - padding,
+        y: regionY + regionHeight - markSize - padding,
+      }
+    default:
+      // デフォルトは中央
+      return {
+        x: regionX + (regionWidth - markSize) / 2,
+        y: regionY + (regionHeight - markSize) / 2,
+      }
+  }
+}
+
+/**
+ * 部分点テキストの位置を計算
+ */
+function calculatePartialScorePosition(
+  regionX: number,
+  regionY: number,
+  regionWidth: number,
+  regionHeight: number,
+  position: string,
+  offsetX: number,
+  offsetY: number
+): { x: number; y: number } {
+  let baseX: number
+  let baseY: number
+
+  switch (position) {
+    case "top-left":
+      baseX = regionX
+      baseY = regionY
+      break
+    case "top-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY
+      break
+    case "top-right":
+      baseX = regionX + regionWidth
+      baseY = regionY
+      break
+    case "middle-left":
+      baseX = regionX
+      baseY = regionY + regionHeight / 2
+      break
+    case "middle-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight / 2
+      break
+    case "middle-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight / 2
+      break
+    case "bottom-left":
+      baseX = regionX
+      baseY = regionY + regionHeight
+      break
+    case "bottom-center":
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight
+      break
+    case "bottom-right":
+      baseX = regionX + regionWidth
+      baseY = regionY + regionHeight
+      break
+    default:
+      // デフォルトは中央
+      baseX = regionX + regionWidth / 2
+      baseY = regionY + regionHeight / 2
+      break
+  }
+
+  return {
+    x: baseX + offsetX,
+    y: baseY + offsetY,
+  }
+}
+
+/**
+ * 採点マーク画像を描画
+ */
+function drawScoringMark(
+  ctx: CanvasRenderingContext2D,
+  markImage: HTMLImageElement,
+  region: ScoringDataForPdf["cropRegion"],
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number
+): void {
+  const regionX = region.x * imageWidth
+  const regionY = region.y * imageHeight
+  const regionWidth = region.width * imageWidth
+  const regionHeight = region.height * imageHeight
+
+  const markSize = Math.min(
+    config.markSize,
+    regionWidth * 0.8,
+    regionHeight * 0.8
+  )
+  const { x, y } = calculateMarkPosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    markSize,
+    config.markPosition
+  )
+
+  ctx.drawImage(markImage, x, y, markSize, markSize)
+}
+
+/**
+ * 点数テキストを描画（赤色）
+ * @param score - 表示する点数
+ */
+function drawScoreText(
+  ctx: CanvasRenderingContext2D,
+  score: number,
+  region: ScoringDataForPdf["cropRegion"],
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number
+): void {
+  if (!config.showPartialScore) return
+
+  const regionX = region.x * imageWidth
+  const regionY = region.y * imageHeight
+  const regionWidth = region.width * imageWidth
+  const regionHeight = region.height * imageHeight
+
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.partialScorePosition,
+    config.partialScoreOffsetX,
+    config.partialScoreOffsetY
+  )
+
+  ctx.save()
+  ctx.font = `bold ${config.partialScoreSize}px sans-serif`
+  ctx.fillStyle = "#ef4444" // 点数は全て赤色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 小計点テキストを描画（青色）
+ */
+function drawSubtotalScoreText(
+  ctx: CanvasRenderingContext2D,
+  subtotalData: SubtotalDataForPdf,
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number
+): void {
+  const regionX = subtotalData.x * imageWidth
+  const regionY = subtotalData.y * imageHeight
+  const regionWidth = subtotalData.width * imageWidth
+  const regionHeight = subtotalData.height * imageHeight
+
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.subtotalScorePosition,
+    config.subtotalScoreOffsetX,
+    config.subtotalScoreOffsetY
+  )
+
+  ctx.save()
+  ctx.font = `bold ${config.subtotalScoreSize}px sans-serif`
+  ctx.fillStyle = "#2563eb" // 小計点は青色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(subtotalData.score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 合計点テキストを描画（青色）
+ */
+function drawTotalScoreText(
+  ctx: CanvasRenderingContext2D,
+  totalScoreData: TotalScoreDataForPdf,
+  config: ScoringMarkConfigForPdf,
+  imageWidth: number,
+  imageHeight: number
+): void {
+  const regionX = totalScoreData.x * imageWidth
+  const regionY = totalScoreData.y * imageHeight
+  const regionWidth = totalScoreData.width * imageWidth
+  const regionHeight = totalScoreData.height * imageHeight
+
+  const { x, y } = calculatePartialScorePosition(
+    regionX,
+    regionY,
+    regionWidth,
+    regionHeight,
+    config.totalScorePosition,
+    config.totalScoreOffsetX,
+    config.totalScoreOffsetY
+  )
+
+  ctx.save()
+  ctx.font = `bold ${config.totalScoreSize}px sans-serif`
+  ctx.fillStyle = "#2563eb" // 合計点も青色
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(String(totalScoreData.score), x, y)
+  ctx.restore()
+}
+
+/**
+ * 答案シート1枚分をCanvas上に描画
+ *
+ * @param canvas - 描画先のCanvas要素
+ * @param image - 答案画像
+ * @param scoringDataList - 採点データのリスト（設問ごと）
+ * @param annotations - 全アノテーション
+ * @param config - 採点マーク設定
+ * @param scoringMarkImages - 採点マーク画像のMap
+ * @param subtotalDataList - 小計点データのリスト
+ * @param totalScoreDataList - 合計点データのリスト
+ * @param pageNumber - ページ番号（1-indexed、複数ページ対応用）
+ *                     UI側で複数ページが縦に結合されたキャンバス上で描画された場合、
+ *                     アノテーションのy座標は1ページ目の高さで正規化されるため
+ *                     2ページ目以降のアノテーションはy > 1.0になる。
+ *                     このページ番号を使ってオフセットを計算し正しい座標に変換する。
+ * @returns PNG Blob
+ */
+export async function renderAnswerSheetToCanvas(
+  canvas: HTMLCanvasElement,
+  image: HTMLImageElement,
+  scoringDataList: ScoringDataForPdf[],
+  annotations: DrawingAnnotation[],
+  config: ScoringMarkConfigForPdf,
+  scoringMarkImages: Map<string, HTMLImageElement>,
+  subtotalDataList: SubtotalDataForPdf[] = [],
+  totalScoreDataList: TotalScoreDataForPdf[] = [],
+  pageNumber: number = 1,
+  pageSize: string = "A4"
+): Promise<Blob> {
+  const ctx = canvas.getContext("2d")
+  if (!ctx) {
+    throw new Error("Canvas context not available")
+  }
+
+  const imageWidth = image.naturalWidth
+  const imageHeight = image.naturalHeight
+
+  // Canvasサイズを画像サイズに設定
+  canvas.width = imageWidth
+  canvas.height = imageHeight
+
+  // Canvasをクリア
+  ctx.clearRect(0, 0, imageWidth, imageHeight)
+
+  // Canvas Context設定
+  ctx.globalCompositeOperation = "source-over"
+  ctx.globalAlpha = 1.0
+  ctx.lineCap = "butt"
+  ctx.lineJoin = "miter"
+  ctx.miterLimit = 10
+  ctx.setLineDash([])
+
+  // 1. 答案画像を描画
+  ctx.drawImage(image, 0, 0)
+
+  // 2. 各設問に対して採点マークと部分点を描画
+  for (const scoringData of scoringDataList) {
+    // ステータスごとのマーク表示判定
+    const shouldShowMark = config.showMarkForStatus
+      ? (config.showMarkForStatus[scoringData.status] ?? true)
+      : scoringData.status !== "unscored"
+    if (!shouldShowMark) {
+      // マークは非表示でも点数テキストは別途判定するため、マーク描画だけスキップ
+    } else {
+      // 採点マーク画像の取得
+      const markKey =
+        scoringData.status === "pending"
+          ? "hold"
+          : scoringData.status === "no_answer"
+            ? "incorrect"
+            : scoringData.status
+      const markImage = scoringMarkImages.get(markKey)
+
+      if (markImage) {
+        drawScoringMark(
+          ctx,
+          markImage,
+          scoringData.cropRegion,
+          config,
+          imageWidth,
+          imageHeight
+        )
+      }
+    }
+
+    // 点数テキストの描画
+    // showScoreForStatusがある場合はステータスごとに判定、ない場合は後方互換性のためpartialのみ
+    const shouldShowScore = config.showScoreForStatus
+      ? (config.showScoreForStatus[scoringData.status] ?? false)
+      : scoringData.status === "partial"
+
+    if (shouldShowScore) {
+      // ステータスに応じた点数を決定
+      let scoreToDisplay: number | null = null
+      if (scoringData.status === "correct") {
+        // 正解: 配点を表示
+        scoreToDisplay = scoringData.cropRegion.maxScore ?? null
+      } else if (scoringData.status === "partial") {
+        // 部分点: 部分点を表示
+        scoreToDisplay = scoringData.partialScore ?? null
+      } else if (
+        scoringData.status === "incorrect" ||
+        scoringData.status === "no_answer"
+      ) {
+        // 誤答/無答: 0点を表示
+        scoreToDisplay = 0
+      }
+
+      if (scoreToDisplay !== null) {
+        drawScoreText(
+          ctx,
+          scoreToDisplay,
+          scoringData.cropRegion,
+          config,
+          imageWidth,
+          imageHeight
+        )
+      }
+    }
+  }
+
+  // 3. 小計点を描画（青色）
+  for (const subtotalData of subtotalDataList) {
+    drawSubtotalScoreText(ctx, subtotalData, config, imageWidth, imageHeight)
+  }
+
+  // 4. 合計点を描画（青色）
+  for (const totalScoreData of totalScoreDataList) {
+    drawTotalScoreText(ctx, totalScoreData, config, imageWidth, imageHeight)
+  }
+
+  // 5. 全アノテーションを描画
+  // 座標系の互換性処理:
+  // - 旧データ: y座標がキャンバス全体に対する相対座標（2ページ目以降はy > 1.0）
+  // - 新データ: y座標がページ内の相対座標（常に0.0 - 1.0）
+  // y >= 1.0の場合は旧データとみなし、pageOffsetを引いて変換する
+  // y < 1.0の場合は新データとみなし、そのまま使用する
+  const basePageOffset = pageNumber - 1
+  for (const annotation of annotations) {
+    const element = convertAnnotationToDrawingElement(annotation)
+    // y座標が1.0以上の場合のみpageOffsetを適用（旧座標系の互換性対応）
+    const needsPageOffset =
+      element.y >= 1.0 || (element.endY !== undefined && element.endY >= 1.0)
+    const pageOffset = needsPageOffset ? basePageOffset : 0
+    await drawElement(
+      ctx,
+      element,
+      imageWidth,
+      imageHeight,
+      0,
+      0,
+      pageOffset,
+      pageSize
+    )
+  }
+
+  // Canvas結果をBlobとして取得
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+        } else {
+          reject(new Error("Failed to create blob from canvas"))
+        }
+      },
+      "image/png",
+      1.0
+    )
+  })
+}
+
+/**
+ * 採点マーク画像をプリロード
+ *
+ * fetchしてBlobからObjectURLを作成することで、Canvasのtainted問題を回避
+ */
+export async function preloadScoringMarkImages(
+  useTransparent: boolean
+): Promise<Map<string, HTMLImageElement>> {
+  const prefix = useTransparent ? "tp_" : ""
+  const markTypes = ["correct", "partial", "hold", "incorrect"]
+  const images = new Map<string, HTMLImageElement>()
+
+  await Promise.all(
+    markTypes.map(async (type) => {
+      try {
+        // fetchしてBlobとして取得
+        const response = await fetch(`/score-assets/${prefix}${type}.png`)
+        const blob = await response.blob()
+        const objectUrl = URL.createObjectURL(blob)
+
+        const img = new Image()
+        img.src = objectUrl
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => {
+            // ObjectURLを解放（画像は既にメモリにロード済み）
+            URL.revokeObjectURL(objectUrl)
+            resolve()
+          }
+          img.onerror = () => {
+            URL.revokeObjectURL(objectUrl)
+            reject(new Error(`Failed to load ${type} mark image`))
+          }
+        })
+        images.set(type, img)
+      } catch (error) {
+        console.error(`Failed to fetch ${type} mark image:`, error)
+        // フォールバック: 直接読み込み
+        const img = new Image()
+        img.crossOrigin = "anonymous"
+        img.src = `/score-assets/${prefix}${type}.png`
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve()
+          img.onerror = () =>
+            reject(new Error(`Failed to load ${type} mark image`))
+        })
+        images.set(type, img)
+      }
+    })
+  )
+
+  return images
+}


### PR DESCRIPTION
## Summary
- 波線をcos波（線分中央が頂点）に変更し、ジグザグも中央基準で頂点を対称配置するロジックに統一
- 3ファイル間で異なっていた描画ロジック（quadraticCurveTo vs sin点列等）を完全統一
- 偶数制約を撤廃し、端が波の途中で切れることを許容する自然な描画に改善

## 係数（変更なし）
| | 波線振幅 | 波線波長 | ジグザグ振幅 | ジグザグピッチ |
|--|---------|---------|------------|-------------|
| 全ファイル共通 | `sw × 1.5` | `sw × 20` | `sw × 1.5` | `sw × 8` |

## Test plan
- [ ] 個別採点画面で波線・ジグザグが中央揃えで描画されることを確認
- [ ] 一括採点グリッド画面で同じ見た目になることを確認
- [ ] PDF出力で同じ見た目になることを確認
- [ ] 各strokeWidth（1pt, 2pt, 4pt, 8pt）で振幅が適切にスケールすることを確認

Closes #653
Related: #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)