### PR TITLE
refactor: IPCハンドラの重複try-catchパターンをユーティリティに集約

### DIFF
--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -34,64 +34,46 @@ import {
   listAsbDefinitions,
   saveAsbDefinition,
 } from "../lib/prisma/asbDefinition"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupAnswerSheetBuilderHandlers(): void {
   // 定義一覧取得
-  ipcMain.handle("asb:list-definitions", async (_event, userId: string) => {
-    try {
+  registerSafeHandler(
+    "asb:list-definitions",
+    async (userId: string) => {
       const data = await listAsbDefinitions(userId)
       return { success: true, data }
-    } catch (error) {
-      console.error("asb:list-definitions error:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "定義一覧の取得に失敗しました",
-      }
-    }
-  })
+    },
+    "定義一覧の取得に失敗しました"
+  )
 
   // 定義読込
-  ipcMain.handle("asb:load-definition", async (_event, id: string) => {
-    try {
+  registerSafeHandler(
+    "asb:load-definition",
+    async (id: string) => {
       const definition = await getAsbDefinition(id)
       if (!definition) {
         return { success: false, error: "定義が見つかりません" }
       }
       return { success: true, data: definition }
-    } catch (error) {
-      console.error("asb:load-definition error:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "定義の読込に失敗しました",
-      }
-    }
-  })
+    },
+    "定義の読込に失敗しました"
+  )
 
   // 定義保存
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:save-definition",
-    async (_event, definition: AnswerSheetDefinition, userId: string) => {
-      try {
-        await saveAsbDefinition(definition, userId)
-        return { success: true }
-      } catch (error) {
-        console.error("asb:save-definition error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "定義の保存に失敗しました",
-        }
-      }
-    }
+    async (definition: AnswerSheetDefinition, userId: string) => {
+      await saveAsbDefinition(definition, userId)
+      return { success: true }
+    },
+    "定義の保存に失敗しました"
   )
 
   // 定義削除（画像ディレクトリも削除）
-  ipcMain.handle("asb:delete-definition", async (_event, id: string) => {
-    try {
+  registerSafeHandler(
+    "asb:delete-definition",
+    async (id: string) => {
       const deleted = await deleteAsbDefinition(id)
       if (deleted) {
         // 画像ディレクトリの削除
@@ -110,73 +92,50 @@ export function setupAnswerSheetBuilderHandlers(): void {
         }
       }
       return { success: deleted }
-    } catch (error) {
-      console.error("asb:delete-definition error:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "定義の削除に失敗しました",
-      }
-    }
-  })
+    },
+    "定義の削除に失敗しました"
+  )
 
   // 画像アップロード
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:upload-image",
-    async (_event, args: ASBUploadImageArgs) => {
-      try {
-        const imagesDir = getAsbImagesDirectory(args.definitionId)
-        if (!fs.existsSync(imagesDir)) {
-          fs.mkdirSync(imagesDir, { recursive: true })
-        }
-
-        // ユニークなファイル名を生成
-        const ext = path.extname(args.originalName)
-        const baseName = path.basename(args.originalName, ext)
-        const uniqueName = `${baseName}_${Date.now()}${ext}`
-        const destPath = path.join(imagesDir, uniqueName)
-
-        // ファイルコピー
-        fs.copyFileSync(args.filePath, destPath)
-
-        // data/ からの相対パスを返す
-        const relativePath = getRelativePathFromData(destPath)
-        return { success: true, imagePath: relativePath }
-      } catch (error) {
-        console.error("asb:upload-image error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "画像のアップロードに失敗しました",
-        }
+    async (args: ASBUploadImageArgs) => {
+      const imagesDir = getAsbImagesDirectory(args.definitionId)
+      if (!fs.existsSync(imagesDir)) {
+        fs.mkdirSync(imagesDir, { recursive: true })
       }
-    }
+
+      // ユニークなファイル名を生成
+      const ext = path.extname(args.originalName)
+      const baseName = path.basename(args.originalName, ext)
+      const uniqueName = `${baseName}_${Date.now()}${ext}`
+      const destPath = path.join(imagesDir, uniqueName)
+
+      // ファイルコピー
+      fs.copyFileSync(args.filePath, destPath)
+
+      // data/ からの相対パスを返す
+      const relativePath = getRelativePathFromData(destPath)
+      return { success: true, imagePath: relativePath }
+    },
+    "画像のアップロードに失敗しました"
   )
 
   // 画像削除
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:delete-image",
-    async (_event, args: ASBDeleteImageArgs) => {
-      try {
-        const absolutePath = getAbsolutePathFromData(args.imagePath)
-        if (fs.existsSync(absolutePath)) {
-          fs.unlinkSync(absolutePath)
-        }
-        return { success: true }
-      } catch (error) {
-        console.error("asb:delete-image error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "画像の削除に失敗しました",
-        }
+    async (args: ASBDeleteImageArgs) => {
+      const absolutePath = getAbsolutePathFromData(args.imagePath)
+      if (fs.existsSync(absolutePath)) {
+        fs.unlinkSync(absolutePath)
       }
-    }
+      return { success: true }
+    },
+    "画像の削除に失敗しました"
   )
 
   // PDF出力: HTMLを受け取り → 一時ファイル → BrowserWindow → printToPDF
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle("asb:export-pdf", async (_event, args: ASBExportPdfArgs) => {
     let tempHtmlPath: string | null = null
     let win: BrowserWindow | null = null
@@ -210,7 +169,7 @@ export function setupAnswerSheetBuilderHandlers(): void {
 
       return { success: true, filePath: args.outputPath }
     } catch (error) {
-      console.error("asb:export-pdf error:", error)
+      console.error("Error in IPC handler [asb:export-pdf]:", error)
       return {
         success: false,
         error: error instanceof Error ? error.message : "PDF出力に失敗しました",
@@ -228,8 +187,9 @@ export function setupAnswerSheetBuilderHandlers(): void {
   })
 
   // PNG出力: HTML文字列を受け取り → BrowserWindow + capturePage でラスタライズ
-  ipcMain.handle("asb:export-png", async (_event, args: ASBExportPngArgs) => {
-    try {
+  registerSafeHandler(
+    "asb:export-png",
+    async (args: ASBExportPngArgs) => {
       const outputDir = path.dirname(args.outputPath)
       if (!fs.existsSync(outputDir)) {
         fs.mkdirSync(outputDir, { recursive: true })
@@ -259,71 +219,51 @@ export function setupAnswerSheetBuilderHandlers(): void {
       }
 
       return { success: true, filePath: args.outputPath }
-    } catch (error) {
-      console.error("asb:export-png error:", error)
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "PNG出力に失敗しました",
-      }
-    }
-  })
+    },
+    "PNG出力に失敗しました"
+  )
 
   // 保存先ダイアログ
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:select-save-path",
-    async (_event, options: { type: "pdf" | "png"; defaultName?: string }) => {
-      try {
-        const filters =
-          options.type === "pdf"
-            ? [{ name: "PDF", extensions: ["pdf"] }]
-            : [{ name: "PNG", extensions: ["png"] }]
+    async (options: { type: "pdf" | "png"; defaultName?: string }) => {
+      const filters =
+        options.type === "pdf"
+          ? [{ name: "PDF", extensions: ["pdf"] }]
+          : [{ name: "PNG", extensions: ["png"] }]
 
-        const result = await dialog.showSaveDialog({
-          title: `解答用紙を${options.type.toUpperCase()}として保存`,
-          defaultPath: options.defaultName,
-          filters,
-        })
+      const result = await dialog.showSaveDialog({
+        title: `解答用紙を${options.type.toUpperCase()}として保存`,
+        defaultPath: options.defaultName,
+        filters,
+      })
 
-        if (result.canceled || !result.filePath) {
-          return { success: false, canceled: true }
-        }
-        return { success: true, filePath: result.filePath }
-      } catch (error) {
-        console.error("asb:select-save-path error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "保存先選択に失敗しました",
-        }
+      if (result.canceled || !result.filePath) {
+        return { success: false, canceled: true }
       }
-    }
+      return { success: true, filePath: result.filePath }
+    },
+    "保存先選択に失敗しました"
   )
 
   // 試験変換: multiPageLayout + HTML文字列を受け取り
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:convert-to-exam",
-    async (_event, args: ASBConvertToExamArgs) => {
-      try {
-        const result = await convertToExam(
-          args.definition,
-          args.userId,
-          args.multiPageLayout,
-          args.answerSheetHtmlPages,
-          args.modelAnswerHtmlPages
-        )
-        return result
-      } catch (error) {
-        console.error("asb:convert-to-exam error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "試験変換に失敗しました",
-        }
-      }
-    }
+    async (args: ASBConvertToExamArgs) => {
+      const result = await convertToExam(
+        args.definition,
+        args.userId,
+        args.multiPageLayout,
+        args.answerSheetHtmlPages,
+        args.modelAnswerHtmlPages
+      )
+      return result
+    },
+    "試験変換に失敗しました"
   )
 
   // 印刷: HTMLを受け取り → printToPDF → プレビューで開く
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle("asb:print", async (_event, args: ASBPrintArgs) => {
     let tempHtmlPath: string | null = null
     let tempPdfPath: string | null = null
@@ -356,7 +296,7 @@ export function setupAnswerSheetBuilderHandlers(): void {
 
       return { success: true }
     } catch (error) {
-      console.error("asb:print error:", error)
+      console.error("Error in IPC handler [asb:print]:", error)
       return {
         success: false,
         error: error instanceof Error ? error.message : "印刷に失敗しました",
@@ -375,8 +315,9 @@ export function setupAnswerSheetBuilderHandlers(): void {
   })
 
   // 定義のインポートファイル選択
-  ipcMain.handle("asb:select-import-file", async () => {
-    try {
+  registerSafeHandler(
+    "asb:select-import-file",
+    async () => {
       const result = await dialog.showOpenDialog({
         title: "解答用紙定義を読み込み",
         filters: [{ name: "解答用紙定義", extensions: ["asb"] }],
@@ -387,166 +328,125 @@ export function setupAnswerSheetBuilderHandlers(): void {
         return { success: false, canceled: true }
       }
       return { success: true, filePath: result.filePaths[0] }
-    } catch (error) {
-      console.error("asb:select-import-file error:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error ? error.message : "ファイル選択に失敗しました",
-      }
-    }
-  })
+    },
+    "ファイル選択に失敗しました"
+  )
 
   // アーカイブ分析（プレビュー用）
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:analyze-asb-archive",
-    async (_event, filePath: string) => {
-      try {
-        return await analyzeAsbArchive(filePath)
-      } catch (error) {
-        console.error("asb:analyze-asb-archive error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "アーカイブ分析に失敗しました",
-        }
-      }
-    }
+    async (filePath: string) => {
+      return await analyzeAsbArchive(filePath)
+    },
+    "アーカイブ分析に失敗しました"
   )
 
   // 定義エクスポート
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:export-definition",
-    async (_event, definitionId: string) => {
-      try {
-        return await exportAsbDefinition(definitionId)
-      } catch (error) {
-        console.error("asb:export-definition error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "書き出しに失敗しました",
-        }
-      }
-    }
+    async (definitionId: string) => {
+      return await exportAsbDefinition(definitionId)
+    },
+    "書き出しに失敗しました"
   )
 
   // 定義インポート
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:import-definition",
-    async (_event, filePath: string, userId: string) => {
-      try {
-        return await importAsbDefinition(filePath, userId)
-      } catch (error) {
-        console.error("asb:import-definition error:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error ? error.message : "インポートに失敗しました",
-        }
-      }
-    }
+    async (filePath: string, userId: string) => {
+      return await importAsbDefinition(filePath, userId)
+    },
+    "インポートに失敗しました"
   )
 
   // 定義複製（画像ファイルもコピー）
-  ipcMain.handle(
+  registerSafeHandler(
     "asb:duplicate-definition",
-    async (_event, id: string, userId: string) => {
-      try {
-        const definition = await getAsbDefinition(id)
-        if (!definition) {
-          return { success: false, error: "定義が見つかりません" }
-        }
-
-        const newId = crypto.randomUUID()
-
-        // 全子要素のIDを再生成
-        const regeneratedHeaderFields = definition.settings.headerFields.map(
-          (hf) => ({ ...hf, id: crypto.randomUUID() })
-        )
-
-        // 新定義の画像ディレクトリを作成
-        const newImagesDir = getAsbImagesDirectory(newId)
-        fs.mkdirSync(newImagesDir, { recursive: true })
-
-        // 画像コピーとパス更新を行うヘルパー
-        const copyImageElement = <T extends { id: string; imagePath: string }>(
-          ie: T
-        ): T => {
-          let newImagePath = ie.imagePath
-          if (ie.imagePath) {
-            const absoluteSrc = getAbsolutePathFromData(ie.imagePath)
-            if (fs.existsSync(absoluteSrc)) {
-              const filename = path.basename(ie.imagePath)
-              const destPath = path.join(newImagesDir, filename)
-              fs.copyFileSync(absoluteSrc, destPath)
-              newImagePath = getRelativePathFromData(destPath)
-            }
-          }
-          return { ...ie, id: crypto.randomUUID(), imagePath: newImagePath }
-        }
-
-        const regeneratedMajorQuestions = definition.majorQuestions.map(
-          (mq) => ({
-            ...mq,
-            id: crypto.randomUUID(),
-            subQuestions: mq.subQuestions.map((sq) => ({
-              ...sq,
-              id: crypto.randomUUID(),
-              textElements: sq.textElements.map((te) => ({
-                ...te,
-                id: crypto.randomUUID(),
-              })),
-              imageElements: sq.imageElements?.map(copyImageElement),
-              branchQuestions: sq.branchQuestions.map((bq) => ({
-                ...bq,
-                id: crypto.randomUUID(),
-                textElements: bq.textElements.map((te) => ({
-                  ...te,
-                  id: crypto.randomUUID(),
-                })),
-                imageElements: bq.imageElements?.map(copyImageElement),
-              })),
-            })),
-          })
-        )
-
-        // 既存の名前と重複しないようサフィックス付与
-        const existing = await listAsbDefinitions(userId)
-        const existingNames = new Set(existing.map((d) => d.name))
-        let newName = `${definition.name} (コピー)`
-        if (existingNames.has(newName)) {
-          let suffix = 2
-          while (existingNames.has(`${definition.name} (コピー ${suffix})`)) {
-            suffix++
-          }
-          newName = `${definition.name} (コピー ${suffix})`
-        }
-
-        const duplicated: AnswerSheetDefinition = {
-          ...definition,
-          id: newId,
-          name: newName,
-          settings: {
-            ...definition.settings,
-            headerFields: regeneratedHeaderFields,
-          },
-          majorQuestions: regeneratedMajorQuestions,
-          createdAt: undefined as unknown as string,
-          updatedAt: undefined as unknown as string,
-        }
-
-        await saveAsbDefinition(duplicated, userId)
-        return { success: true, definitionId: newId }
-      } catch (error) {
-        console.error("asb:duplicate-definition error:", error)
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "複製に失敗しました",
-        }
+    async (id: string, userId: string) => {
+      const definition = await getAsbDefinition(id)
+      if (!definition) {
+        return { success: false, error: "定義が見つかりません" }
       }
-    }
+
+      const newId = crypto.randomUUID()
+
+      // 全子要素のIDを再生成
+      const regeneratedHeaderFields = definition.settings.headerFields.map(
+        (hf) => ({ ...hf, id: crypto.randomUUID() })
+      )
+
+      // 新定義の画像ディレクトリを作成
+      const newImagesDir = getAsbImagesDirectory(newId)
+      fs.mkdirSync(newImagesDir, { recursive: true })
+
+      // 画像コピーとパス更新を行うヘルパー
+      const copyImageElement = <T extends { id: string; imagePath: string }>(
+        ie: T
+      ): T => {
+        let newImagePath = ie.imagePath
+        if (ie.imagePath) {
+          const absoluteSrc = getAbsolutePathFromData(ie.imagePath)
+          if (fs.existsSync(absoluteSrc)) {
+            const filename = path.basename(ie.imagePath)
+            const destPath = path.join(newImagesDir, filename)
+            fs.copyFileSync(absoluteSrc, destPath)
+            newImagePath = getRelativePathFromData(destPath)
+          }
+        }
+        return { ...ie, id: crypto.randomUUID(), imagePath: newImagePath }
+      }
+
+      const regeneratedMajorQuestions = definition.majorQuestions.map((mq) => ({
+        ...mq,
+        id: crypto.randomUUID(),
+        subQuestions: mq.subQuestions.map((sq) => ({
+          ...sq,
+          id: crypto.randomUUID(),
+          textElements: sq.textElements.map((te) => ({
+            ...te,
+            id: crypto.randomUUID(),
+          })),
+          imageElements: sq.imageElements?.map(copyImageElement),
+          branchQuestions: sq.branchQuestions.map((bq) => ({
+            ...bq,
+            id: crypto.randomUUID(),
+            textElements: bq.textElements.map((te) => ({
+              ...te,
+              id: crypto.randomUUID(),
+            })),
+            imageElements: bq.imageElements?.map(copyImageElement),
+          })),
+        })),
+      }))
+
+      // 既存の名前と重複しないようサフィックス付与
+      const existing = await listAsbDefinitions(userId)
+      const existingNames = new Set(existing.map((d) => d.name))
+      let newName = `${definition.name} (コピー)`
+      if (existingNames.has(newName)) {
+        let suffix = 2
+        while (existingNames.has(`${definition.name} (コピー ${suffix})`)) {
+          suffix++
+        }
+        newName = `${definition.name} (コピー ${suffix})`
+      }
+
+      const duplicated: AnswerSheetDefinition = {
+        ...definition,
+        id: newId,
+        name: newName,
+        settings: {
+          ...definition.settings,
+          headerFields: regeneratedHeaderFields,
+        },
+        majorQuestions: regeneratedMajorQuestions,
+        createdAt: undefined as unknown as string,
+        updatedAt: undefined as unknown as string,
+      }
+
+      await saveAsbDefinition(duplicated, userId)
+      return { success: true, definitionId: newId }
+    },
+    "複製に失敗しました"
   )
 }

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -31,6 +31,7 @@ import {
   performPreMatching,
 } from "../lib/import/merge"
 import { getExamById } from "../lib/prisma/exam"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 /**
  * 一括エクスポートのコアロジック
@@ -99,35 +100,23 @@ export async function executeBulkExport(
  */
 export function registerArchiveHandlers(): void {
   // エクスポート
-  ipcMain.handle(
+  registerSafeHandler(
     "archive:exportExam",
-    async (
-      _event,
-      options: {
-        examId: string
-        userId: string
-        outputPath?: string
-        exportMode?: import("../../src/types/examArchive.types").ExportMode
-      }
-    ) => {
-      try {
-        return await exportExam(options)
-      } catch (error) {
-        console.error("Error in archive:exportExam:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "エクスポートに失敗しました",
-        }
-      }
-    }
+    async (options: {
+      examId: string
+      userId: string
+      outputPath?: string
+      exportMode?: import("../../src/types/examArchive.types").ExportMode
+    }) => {
+      return await exportExam(options)
+    },
+    "エクスポートに失敗しました"
   )
 
   // インポートファイル選択ダイアログ
-  ipcMain.handle("archive:selectImportFile", async () => {
-    try {
+  registerSafeHandler(
+    "archive:selectImportFile",
+    async () => {
       const result = await dialog.showOpenDialog({
         title: "試験をインポート",
         filters: [
@@ -179,76 +168,39 @@ export function registerArchiveHandlers(): void {
       }
 
       return { success: true, filePath, sourceFormat }
-    } catch (error) {
-      console.error("Error in archive:selectImportFile:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "ダイアログ表示に失敗しました",
-      }
-    }
-  })
+    },
+    "ダイアログ表示に失敗しました"
+  )
 
   // .hsz → .score 変換
-  ipcMain.handle(
+  registerSafeHandler(
     "archive:convertHszToScore",
-    async (_event, options: { hszPath: string }) => {
-      try {
-        return await convertHszToScore(options.hszPath)
-      } catch (error) {
-        console.error("Error in archive:convertHszToScore:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : ".hsz ファイルの変換に失敗しました",
-        }
-      }
-    }
+    async (options: { hszPath: string }) => {
+      return await convertHszToScore(options.hszPath)
+    },
+    ".hsz ファイルの変換に失敗しました"
   )
 
   // .dat → .score 変換
-  ipcMain.handle(
+  registerSafeHandler(
     "archive:convertDatToScore",
-    async (_event, options: { datPath: string }) => {
-      try {
-        return await convertDatToScore(options.datPath)
-      } catch (error) {
-        console.error("Error in archive:convertDatToScore:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : ".dat ファイルの変換に失敗しました",
-        }
-      }
-    }
+    async (options: { datPath: string }) => {
+      return await convertDatToScore(options.datPath)
+    },
+    ".dat ファイルの変換に失敗しました"
   )
 
   // アーカイブ解析（プレビュー用）
-  ipcMain.handle(
+  registerSafeHandler(
     "archive:analyzeArchive",
-    async (_event, options: { archivePath: string }) => {
-      try {
-        return await analyzeArchive(options)
-      } catch (error) {
-        console.error("Error in archive:analyzeArchive:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "アーカイブ解析に失敗しました",
-        }
-      }
-    }
+    async (options: { archivePath: string }) => {
+      return await analyzeArchive(options)
+    },
+    "アーカイブ解析に失敗しました"
   )
 
   // 事前照合（Step 2: ファイル概要表示用）
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "archive:preMatch",
     async (_event, options: { archivePath: string }) => {
@@ -267,7 +219,7 @@ export function registerArchiveHandlers(): void {
 
         return { success: true, data: fileOverviewData }
       } catch (error) {
-        console.error("Error in archive:preMatch:", error)
+        console.error("Error in IPC handler [archive:preMatch]:", error)
         return {
           success: false,
           error:
@@ -282,6 +234,7 @@ export function registerArchiveHandlers(): void {
   )
 
   // 競合検出
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "archive:detectConflicts",
     async (
@@ -306,7 +259,7 @@ export function registerArchiveHandlers(): void {
 
         return result
       } catch (error) {
-        console.error("Error in archive:detectConflicts:", error)
+        console.error("Error in IPC handler [archive:detectConflicts]:", error)
         return {
           success: false,
           results: [],
@@ -322,6 +275,7 @@ export function registerArchiveHandlers(): void {
   )
 
   // 採点競合検出（ユーザーの判断に基づく）
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "archive:detectScoringConflicts",
     async (
@@ -351,7 +305,10 @@ export function registerArchiveHandlers(): void {
 
         return { success: true, data: scoringConflicts }
       } catch (error) {
-        console.error("Error in archive:detectScoringConflicts:", error)
+        console.error(
+          "Error in IPC handler [archive:detectScoringConflicts]:",
+          error
+        )
         return {
           success: false,
           error:
@@ -368,6 +325,7 @@ export function registerArchiveHandlers(): void {
   )
 
   // ID統合インポート（新しいフロー）
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "archive:idIntegrationImport",
     async (
@@ -403,7 +361,10 @@ export function registerArchiveHandlers(): void {
 
         return result
       } catch (error) {
-        console.error("Error in archive:idIntegrationImport:", error)
+        console.error(
+          "Error in IPC handler [archive:idIntegrationImport]:",
+          error
+        )
         return {
           success: false,
           error:
@@ -418,44 +379,30 @@ export function registerArchiveHandlers(): void {
   )
 
   // 一括エクスポート
-  ipcMain.handle(
+  registerSafeHandler(
     "archive:bulkExportExams",
-    async (
-      _event,
-      options: {
-        examIds: string[]
-        userId: string
-        exportMode?: ExportMode
-      }
-    ): Promise<BulkExportExamsResult> => {
-      try {
-        // フォルダ選択ダイアログを表示
-        const dialogResult = await dialog.showOpenDialog({
-          title: "一括書き出し先フォルダを選択",
-          properties: ["openDirectory", "createDirectory"],
-        })
+    async (options: {
+      examIds: string[]
+      userId: string
+      exportMode?: ExportMode
+    }): Promise<BulkExportExamsResult> => {
+      // フォルダ選択ダイアログを表示
+      const dialogResult = await dialog.showOpenDialog({
+        title: "一括書き出し先フォルダを選択",
+        properties: ["openDirectory", "createDirectory"],
+      })
 
-        if (dialogResult.canceled || dialogResult.filePaths.length === 0) {
-          return { success: false, results: [], error: "canceled" }
-        }
-
-        return await executeBulkExport(
-          options.examIds,
-          options.userId,
-          dialogResult.filePaths[0],
-          options.exportMode
-        )
-      } catch (error) {
-        console.error("Error in archive:bulkExportExams:", error)
-        return {
-          success: false,
-          results: [],
-          error:
-            error instanceof Error
-              ? error.message
-              : "一括エクスポートに失敗しました",
-        }
+      if (dialogResult.canceled || dialogResult.filePaths.length === 0) {
+        return { success: false, results: [], error: "canceled" }
       }
-    }
+
+      return await executeBulkExport(
+        options.examIds,
+        options.userId,
+        dialogResult.filePaths[0],
+        options.exportMode
+      )
+    },
+    "一括エクスポートに失敗しました"
   )
 }

--- a/electron-src/ipc-handlers/authHandlers.ts
+++ b/electron-src/ipc-handlers/authHandlers.ts
@@ -1,49 +1,44 @@
-import { ipcMain } from "electron"
-
 import { AuthStoreManager } from "../lib/authStore"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupAuthHandlers(): void {
   // 認証トークンを保存
-  ipcMain.handle("auth:saveToken", async (_, token: string) => {
-    try {
+  registerSafeHandler(
+    "auth:saveToken",
+    async (token: string) => {
       AuthStoreManager.saveAuthToken(token)
       return { success: true }
-    } catch (error) {
-      console.error("Failed to save auth token:", error)
-      return { success: false, error: "Failed to save auth token" }
-    }
-  })
+    },
+    "Failed to save auth token"
+  )
 
   // 認証トークンを取得
-  ipcMain.handle("auth:getToken", async () => {
-    try {
+  registerSafeHandler(
+    "auth:getToken",
+    async () => {
       const token = AuthStoreManager.getAuthToken()
       return { success: true, token }
-    } catch (error) {
-      console.error("Failed to get auth token:", error)
-      return { success: false, error: "Failed to get auth token", token: null }
-    }
-  })
+    },
+    "Failed to get auth token"
+  )
 
   // 認証トークンを削除
-  ipcMain.handle("auth:clearToken", async () => {
-    try {
+  registerSafeHandler(
+    "auth:clearToken",
+    async () => {
       AuthStoreManager.clearAuthToken()
       return { success: true }
-    } catch (error) {
-      console.error("Failed to clear auth token:", error)
-      return { success: false, error: "Failed to clear auth token" }
-    }
-  })
+    },
+    "Failed to clear auth token"
+  )
 
   // 認証ストアの状態を取得（デバッグ用）
-  ipcMain.handle("auth:getStoreStatus", async () => {
-    try {
+  registerSafeHandler(
+    "auth:getStoreStatus",
+    async () => {
       const status = AuthStoreManager.getStoreStatus()
       return { success: true, ...status }
-    } catch (error) {
-      console.error("Failed to get store status:", error)
-      return { success: false, error: "Failed to get store status" }
-    }
-  })
+    },
+    "Failed to get store status"
+  )
 }

--- a/electron-src/ipc-handlers/cropRegionHandlers.ts
+++ b/electron-src/ipc-handlers/cropRegionHandlers.ts
@@ -1,5 +1,4 @@
 import { Prisma } from "@prisma/client"
-import { ipcMain } from "electron"
 
 import {
   createCropRegion as dbCreateCropRegion,
@@ -77,306 +76,157 @@ import {
   getSubtotalsByGroupId as dbGetSubtotalsByGroupId,
   updateSubtotal as dbUpdateSubtotal,
 } from "../lib/prisma/subtotal"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupCropRegionHandlers(): void {
   // --- CropRegion Handlers ---
-  ipcMain.handle(
+  registerHandler(
     "create-crop-region",
-    async (_event, data: Prisma.CropRegionUncheckedCreateInput) => {
-      try {
-        const result = await dbCreateCropRegion(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-crop-region error:", error)
-        throw error
-      }
+    async (data: Prisma.CropRegionUncheckedCreateInput) => {
+      return await dbCreateCropRegion(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "create-many-crop-regions",
-    async (_event, data: Prisma.CropRegionCreateManyInput[]) => {
-      try {
-        const result = await dbCreateManyCropRegions(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-many-crop-regions error:", error)
-        throw error
-      }
+    async (data: Prisma.CropRegionCreateManyInput[]) => {
+      return await dbCreateManyCropRegions(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-crop-region",
-    async (_event, id: string, data: Prisma.CropRegionUpdateInput) => {
-      try {
-        const result = await dbUpdateCropRegion(id, data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: update-crop-region error:", error)
-        throw error
-      }
+    async (id: string, data: Prisma.CropRegionUpdateInput) => {
+      return await dbUpdateCropRegion(id, data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-crop-region-orders",
-    async (_event, updates: Array<{ id: string; orderIndex: number }>) => {
-      try {
-        const result = await dbUpdateCropRegionOrders(updates)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: update-crop-region-orders error:", error)
-        throw error
-      }
+    async (updates: Array<{ id: string; orderIndex: number }>) => {
+      return await dbUpdateCropRegionOrders(updates)
     }
   )
 
-  ipcMain.handle("delete-crop-region", async (_event, id: string) => {
-    try {
-      const result = await dbDeleteCropRegion(id)
-      return result
-    } catch (error) {
-      console.error("❌ IPC: delete-crop-region error:", error)
-      throw error
-    }
+  registerHandler("delete-crop-region", async (id: string) => {
+    return await dbDeleteCropRegion(id)
   })
 
-  ipcMain.handle(
-    "get-crop-regions-by-exam-id",
-    async (_event, examId: string) => {
-      try {
-        const result = await dbGetCropRegionsByExamId(examId)
-        // questionScoresのDecimalをnumberに変換
-        return result?.map(serializeCropRegion) || []
-      } catch (error) {
-        console.error("❌ IPC: get-crop-regions-by-exam-id error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("get-crop-regions-by-exam-id", async (examId: string) => {
+    const result = await dbGetCropRegionsByExamId(examId)
+    // questionScoresのDecimalをnumberに変換
+    return result?.map(serializeCropRegion) || []
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "get-question-answer-regions-by-exam-id",
-    async (_event, examId: string) => {
-      try {
-        const result = await dbGetQuestionAnswerRegionsByExamId(examId)
-        // questionScoresのDecimalをnumberに変換
-        return result?.map(serializeCropRegion) || []
-      } catch (error) {
-        console.error(
-          "❌ IPC: get-question-answer-regions-by-exam-id error:",
-          error
-        )
-        throw error
-      }
+    async (examId: string) => {
+      const result = await dbGetQuestionAnswerRegionsByExamId(examId)
+      // questionScoresのDecimalをnumberに変換
+      return result?.map(serializeCropRegion) || []
     }
   )
 
-  ipcMain.handle("get-crop-region-by-id", async (_event, id: string) => {
-    try {
-      const result = await dbGetCropRegionById(id)
-      // questionScoresのDecimalをnumberに変換
-      return result ? serializeCropRegion(result) : null
-    } catch (error) {
-      console.error("❌ IPC: get-crop-region-by-id error:", error)
-      throw error
-    }
+  registerHandler("get-crop-region-by-id", async (id: string) => {
+    const result = await dbGetCropRegionById(id)
+    // questionScoresのDecimalをnumberに変換
+    return result ? serializeCropRegion(result) : null
   })
 
   // --- Subtotal Handlers ---
-  ipcMain.handle(
+  registerHandler(
     "create-subtotal",
-    async (_event, data: Prisma.SubtotalUncheckedCreateInput) => {
-      try {
-        const result = await dbCreateSubtotal(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-subtotal error:", error)
-        throw error
-      }
+    async (data: Prisma.SubtotalUncheckedCreateInput) => {
+      return await dbCreateSubtotal(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "create-many-subtotals",
-    async (_event, data: Prisma.SubtotalUncheckedCreateInput[]) => {
-      try {
-        const result = await dbCreateManySubtotals(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-many-subtotals error:", error)
-        throw error
-      }
+    async (data: Prisma.SubtotalUncheckedCreateInput[]) => {
+      return await dbCreateManySubtotals(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-subtotal",
-    async (_event, id: string, data: Prisma.SubtotalUpdateInput) => {
-      try {
-        const result = await dbUpdateSubtotal(id, data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: update-subtotal error:", error)
-        throw error
-      }
+    async (id: string, data: Prisma.SubtotalUpdateInput) => {
+      return await dbUpdateSubtotal(id, data)
     }
   )
 
-  ipcMain.handle("delete-subtotal", async (_event, id: string) => {
-    try {
-      const result = await dbDeleteSubtotal(id)
-      return result
-    } catch (error) {
-      console.error("❌ IPC: delete-subtotal error:", error)
-      throw error
-    }
+  registerHandler("delete-subtotal", async (id: string) => {
+    return await dbDeleteSubtotal(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "get-subtotals-by-group-id",
-    async (_event, subtotalGroupId: string) => {
-      try {
-        const result = await dbGetSubtotalsByGroupId(subtotalGroupId)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: get-subtotals-by-group-id error:", error)
-        throw error
-      }
+    async (subtotalGroupId: string) => {
+      return await dbGetSubtotalsByGroupId(subtotalGroupId)
     }
   )
 
-  ipcMain.handle("get-subtotal-by-id", async (_event, id: string) => {
-    try {
-      const result = await dbGetSubtotalById(id)
-      return result
-    } catch (error) {
-      console.error("❌ IPC: get-subtotal-by-id error:", error)
-      throw error
-    }
+  registerHandler("get-subtotal-by-id", async (id: string) => {
+    return await dbGetSubtotalById(id)
   })
 
   // --- CropSubtotal Handlers ---
-  ipcMain.handle(
+  registerHandler(
     "create-crop-subtotal",
-    async (_event, data: Prisma.CropSubtotalUncheckedCreateInput) => {
-      try {
-        const result = await dbCreateCropSubtotal(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-crop-subtotal error:", error)
-        throw error
-      }
+    async (data: Prisma.CropSubtotalUncheckedCreateInput) => {
+      return await dbCreateCropSubtotal(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "create-many-crop-subtotals",
-    async (_event, data: Prisma.CropSubtotalUncheckedCreateInput[]) => {
-      try {
-        const result = await dbCreateManyCropSubtotals(data)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: create-many-crop-subtotals error:", error)
-        throw error
-      }
+    async (data: Prisma.CropSubtotalUncheckedCreateInput[]) => {
+      return await dbCreateManyCropSubtotals(data)
     }
   )
 
-  ipcMain.handle("delete-crop-subtotal", async (_event, id: string) => {
-    try {
-      const result = await dbDeleteCropSubtotal(id)
-      return result
-    } catch (error) {
-      console.error("❌ IPC: delete-crop-subtotal error:", error)
-      throw error
-    }
+  registerHandler("delete-crop-subtotal", async (id: string) => {
+    return await dbDeleteCropSubtotal(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "delete-crop-subtotals-by-crop-region-id",
-    async (_event, cropRegionId: string) => {
-      try {
-        const result = await dbDeleteCropSubtotalsByCropRegionId(cropRegionId)
-        return result
-      } catch (error) {
-        console.error(
-          "❌ IPC: delete-crop-subtotals-by-crop-region-id error:",
-          error
-        )
-        throw error
-      }
+    async (cropRegionId: string) => {
+      return await dbDeleteCropSubtotalsByCropRegionId(cropRegionId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-crop-subtotals-by-crop-region-id",
-    async (_event, cropRegionId: string) => {
-      try {
-        const result = await dbGetCropSubtotalsByCropRegionId(cropRegionId)
-        return result
-      } catch (error) {
-        console.error(
-          "❌ IPC: get-crop-subtotals-by-crop-region-id error:",
-          error
-        )
-        throw error
-      }
+    async (cropRegionId: string) => {
+      return await dbGetCropSubtotalsByCropRegionId(cropRegionId)
     }
   )
 
   // 互換性のあるレスポンス形式での取得（QuestionAssignmentMatrix専用）
-  ipcMain.handle(
+  registerSafeHandler(
     "get-assignments-by-question-crop-region-id",
-    async (_event, cropRegionId: string) => {
-      try {
-        const assignments = await dbGetCropSubtotalsByCropRegionId(cropRegionId)
-        return {
-          success: true,
-          assignments: assignments || [],
-        }
-      } catch (error) {
-        console.error(
-          "❌ IPC: get-assignments-by-question-crop-region-id error:",
-          error
-        )
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
-          assignments: [],
-        }
+    async (cropRegionId: string) => {
+      const assignments = await dbGetCropSubtotalsByCropRegionId(cropRegionId)
+      return {
+        success: true,
+        assignments: assignments || [],
       }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-crop-subtotals-by-subtotal-id",
-    async (_event, subtotalId: string) => {
-      try {
-        const result = await dbGetCropSubtotalsBySubtotalId(subtotalId)
-        return result
-      } catch (error) {
-        console.error("❌ IPC: get-crop-subtotals-by-subtotal-id error:", error)
-        throw error
-      }
+    async (subtotalId: string) => {
+      return await dbGetCropSubtotalsBySubtotalId(subtotalId)
     }
   )
 
   // 互換性のためのエイリアス
-  ipcMain.handle(
+  registerHandler(
     "get-subtotal-definitions-by-crop-region-id",
-    async (_event, cropRegionId: string) => {
-      try {
-        const result = await dbGetSubtotalDefsByCropRegionId(cropRegionId)
-        return result
-      } catch (error) {
-        console.error(
-          "❌ IPC: get-subtotal-definitions-by-crop-region-id error:",
-          error
-        )
-        throw error
-      }
+    async (cropRegionId: string) => {
+      return await dbGetSubtotalDefsByCropRegionId(cropRegionId)
     }
   )
 }

--- a/electron-src/ipc-handlers/drawingHandlers.ts
+++ b/electron-src/ipc-handlers/drawingHandlers.ts
@@ -3,14 +3,13 @@
  * @description フロントエンド↔バックエンド間の描画アノテーション通信
  */
 
-import { ipcMain } from "electron"
-
 import type {
   DrawingCreateData,
   DrawingType,
   DrawingUpdateData,
 } from "../../src/types/drawingAnnotation.types"
 import * as drawingService from "../lib/prisma/drawingAnnotation"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 /**
  * 描画アノテーション関連のIPCハンドラーを設定する
@@ -19,332 +18,176 @@ import * as drawingService from "../lib/prisma/drawingAnnotation"
 export function setupDrawingHandlers() {
   // 基本CRUD操作
 
-  /**
-   * 描画アノテーション作成
-   */
-  ipcMain.handle("drawing:create", async (_, data: DrawingCreateData) => {
-    try {
+  /** 描画アノテーション作成 */
+  registerSafeHandler(
+    "drawing:create",
+    async (data: DrawingCreateData) => {
       const result = await drawingService.createDrawingAnnotation(data)
       return { success: true, data: result }
-    } catch (error) {
-      console.error("🚫 描画アノテーション作成エラー:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "描画アノテーション作成に失敗しました",
-      }
-    }
-  })
-
-  /**
-   * QuestionScoreに紐づく描画アノテーション取得
-   */
-  ipcMain.handle(
-    "drawing:getByQuestionScore",
-    async (_, questionScoreId: string, type?: DrawingType, userId?: string) => {
-      try {
-        const result =
-          await drawingService.getDrawingAnnotationsByQuestionScore(
-            questionScoreId,
-            type,
-            userId
-          )
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 描画アノテーション取得エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "描画アノテーション取得に失敗しました",
-        }
-      }
-    }
+    },
+    "描画アノテーション作成に失敗しました"
   )
 
-  /**
-   * 特定の学生・試験の全描画アノテーション取得（透明度制御用）
-   */
-  ipcMain.handle(
+  /** QuestionScoreに紐づく描画アノテーション取得 */
+  registerSafeHandler(
+    "drawing:getByQuestionScore",
+    async (questionScoreId: string, type?: DrawingType, userId?: string) => {
+      const result = await drawingService.getDrawingAnnotationsByQuestionScore(
+        questionScoreId,
+        type,
+        userId
+      )
+      return { success: true, data: result }
+    },
+    "描画アノテーション取得に失敗しました"
+  )
+
+  /** 特定の学生・試験の全描画アノテーション取得（透明度制御用） */
+  registerSafeHandler(
     "drawing:getByStudent",
     async (
-      _,
       studentId: string,
       examId: string,
       type?: DrawingType,
       userId?: string
     ) => {
-      try {
-        const result = await drawingService.getDrawingAnnotationsByStudent(
-          studentId,
-          examId,
-          type,
-          userId
-        )
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 学生別描画アノテーション取得エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "学生別描画アノテーション取得に失敗しました",
-        }
-      }
-    }
+      const result = await drawingService.getDrawingAnnotationsByStudent(
+        studentId,
+        examId,
+        type,
+        userId
+      )
+      return { success: true, data: result }
+    },
+    "学生別描画アノテーション取得に失敗しました"
   )
 
-  /**
-   * 試験全体の描画アノテーション取得（PDF出力用）
-   */
-  ipcMain.handle(
+  /** 試験全体の描画アノテーション取得（PDF出力用） */
+  registerSafeHandler(
     "drawing:getByExam",
-    async (_, examId: string, type?: DrawingType, userId?: string) => {
-      try {
-        const result = await drawingService.getDrawingAnnotationsByExam(
-          examId,
-          type,
-          userId
-        )
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 試験別描画アノテーション取得エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "試験別描画アノテーション取得に失敗しました",
-        }
-      }
-    }
+    async (examId: string, type?: DrawingType, userId?: string) => {
+      const result = await drawingService.getDrawingAnnotationsByExam(
+        examId,
+        type,
+        userId
+      )
+      return { success: true, data: result }
+    },
+    "試験別描画アノテーション取得に失敗しました"
   )
 
-  /**
-   * CropRegion（設問）に紐づく全学生の描画アノテーション取得（Grid表示用）
-   */
-  ipcMain.handle(
+  /** CropRegion（設問）に紐づく全学生の描画アノテーション取得（Grid表示用） */
+  registerSafeHandler(
     "drawing:getByCropRegion",
-    async (_, cropRegionId: string, userId?: string) => {
-      try {
-        const result = await drawingService.getDrawingAnnotationsByCropRegion(
-          cropRegionId,
-          userId
-        )
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 設問別描画アノテーション取得エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "設問別描画アノテーション取得に失敗しました",
-        }
-      }
-    }
+    async (cropRegionId: string, userId?: string) => {
+      const result = await drawingService.getDrawingAnnotationsByCropRegion(
+        cropRegionId,
+        userId
+      )
+      return { success: true, data: result }
+    },
+    "設問別描画アノテーション取得に失敗しました"
   )
 
-  /**
-   * 描画アノテーション更新
-   */
-  ipcMain.handle(
+  /** 描画アノテーション更新 */
+  registerSafeHandler(
     "drawing:update",
-    async (_, id: string, data: DrawingUpdateData) => {
-      try {
-        const result = await drawingService.updateDrawingAnnotation(id, data)
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 描画アノテーション更新エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "描画アノテーション更新に失敗しました",
-        }
-      }
-    }
+    async (id: string, data: DrawingUpdateData) => {
+      const result = await drawingService.updateDrawingAnnotation(id, data)
+      return { success: true, data: result }
+    },
+    "描画アノテーション更新に失敗しました"
   )
 
-  /**
-   * 描画アノテーション削除
-   */
-  ipcMain.handle("drawing:delete", async (_, id: string) => {
-    try {
+  /** 描画アノテーション削除 */
+  registerSafeHandler(
+    "drawing:delete",
+    async (id: string) => {
       await drawingService.deleteDrawingAnnotation(id)
       return { success: true }
-    } catch (error) {
-      console.error("🚫 描画アノテーション削除エラー:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "描画アノテーション削除に失敗しました",
-      }
-    }
-  })
+    },
+    "描画アノテーション削除に失敗しました"
+  )
 
-  /**
-   * QuestionScoreに紐づく描画アノテーション一括削除
-   */
-  ipcMain.handle(
+  /** QuestionScoreに紐づく描画アノテーション一括削除 */
+  registerSafeHandler(
     "drawing:deleteByQuestionScore",
-    async (_, questionScoreId: string, type?: DrawingType) => {
-      try {
-        await drawingService.deleteDrawingAnnotationsByQuestionScore(
-          questionScoreId,
-          type
-        )
-        return { success: true }
-      } catch (error) {
-        console.error("🚫 描画アノテーション一括削除エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "描画アノテーション一括削除に失敗しました",
-        }
-      }
-    }
+    async (questionScoreId: string, type?: DrawingType) => {
+      await drawingService.deleteDrawingAnnotationsByQuestionScore(
+        questionScoreId,
+        type
+      )
+      return { success: true }
+    },
+    "描画アノテーション一括削除に失敗しました"
   )
 
   // バッチ操作
 
-  /**
-   * 描画アノテーション一括作成
-   */
-  ipcMain.handle(
+  /** 描画アノテーション一括作成 */
+  registerSafeHandler(
     "drawing:batchCreate",
-    async (_, annotations: DrawingCreateData[]) => {
-      try {
-        const result =
-          await drawingService.batchCreateDrawingAnnotations(annotations)
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 描画アノテーション一括作成エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "描画アノテーション一括作成に失敗しました",
-        }
-      }
-    }
+    async (annotations: DrawingCreateData[]) => {
+      const result =
+        await drawingService.batchCreateDrawingAnnotations(annotations)
+      return { success: true, data: result }
+    },
+    "描画アノテーション一括作成に失敗しました"
   )
 
-  /**
-   * 描画アノテーション一括更新
-   */
-  ipcMain.handle(
+  /** 描画アノテーション一括更新 */
+  registerSafeHandler(
     "drawing:batchUpdate",
-    async (_, updates: Array<{ id: string; data: DrawingUpdateData }>) => {
-      try {
-        const result =
-          await drawingService.batchUpdateDrawingAnnotations(updates)
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 描画アノテーション一括更新エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "描画アノテーション一括更新に失敗しました",
-        }
-      }
-    }
+    async (updates: Array<{ id: string; data: DrawingUpdateData }>) => {
+      const result = await drawingService.batchUpdateDrawingAnnotations(updates)
+      return { success: true, data: result }
+    },
+    "描画アノテーション一括更新に失敗しました"
   )
 
   // ユーティリティ操作
 
-  /**
-   * 描画アノテーション統計情報取得
-   */
-  ipcMain.handle("drawing:getStats", async (_, questionScoreId: string) => {
-    try {
+  /** 描画アノテーション統計情報取得 */
+  registerSafeHandler(
+    "drawing:getStats",
+    async (questionScoreId: string) => {
       const result =
         await drawingService.getDrawingAnnotationStats(questionScoreId)
       return { success: true, data: result }
-    } catch (error) {
-      console.error("🚫 描画アノテーション統計取得エラー:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "描画アノテーション統計取得に失敗しました",
-      }
-    }
-  })
-
-  /**
-   * アノテーションお気に入り切替
-   */
-  ipcMain.handle(
-    "drawing:toggleFavorite",
-    async (_, id: string, isFavorite: boolean) => {
-      try {
-        const result = await drawingService.toggleAnnotationFavorite(
-          id,
-          isFavorite
-        )
-        return { success: true, data: result }
-      } catch (error) {
-        console.error("🚫 アノテーションお気に入り切替エラー:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "アノテーションお気に入り切替に失敗しました",
-        }
-      }
-    }
+    },
+    "描画アノテーション統計取得に失敗しました"
   )
 
-  /**
-   * ブラウズ用アノテーション取得
-   */
-  ipcMain.handle("drawing:getForBrowse", async (_, examId: string) => {
-    try {
+  /** アノテーションお気に入り切替 */
+  registerSafeHandler(
+    "drawing:toggleFavorite",
+    async (id: string, isFavorite: boolean) => {
+      const result = await drawingService.toggleAnnotationFavorite(
+        id,
+        isFavorite
+      )
+      return { success: true, data: result }
+    },
+    "アノテーションお気に入り切替に失敗しました"
+  )
+
+  /** ブラウズ用アノテーション取得 */
+  registerSafeHandler(
+    "drawing:getForBrowse",
+    async (examId: string) => {
       const result = await drawingService.getAnnotationsForBrowse(examId)
       return { success: true, data: result }
-    } catch (error) {
-      console.error("🚫 ブラウズ用アノテーション取得エラー:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "ブラウズ用アノテーション取得に失敗しました",
-      }
-    }
-  })
+    },
+    "ブラウズ用アノテーション取得に失敗しました"
+  )
 
-  /**
-   * 描画アノテーションID取得
-   */
-  ipcMain.handle("drawing:getById", async (_, id: string) => {
-    try {
+  /** 描画アノテーションID取得 */
+  registerSafeHandler(
+    "drawing:getById",
+    async (id: string) => {
       const result = await drawingService.getDrawingAnnotationById(id)
       return { success: true, data: result }
-    } catch (error) {
-      console.error("🚫 描画アノテーション単体取得エラー:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "描画アノテーション取得に失敗しました",
-      }
-    }
-  })
+    },
+    "描画アノテーション取得に失敗しました"
+  )
 }

--- a/electron-src/ipc-handlers/examClassHandlers.ts
+++ b/electron-src/ipc-handlers/examClassHandlers.ts
@@ -1,5 +1,3 @@
-import { ipcMain } from "electron"
-
 import {
   addExamClass,
   AddExamClassOptions,
@@ -17,155 +15,84 @@ import {
   updateExamClass,
   UpdateExamClassOptions,
 } from "../lib/prisma/examClass"
+import { registerHandler } from "./ipcHandlerUtils"
 
 export function setupExamClassHandlers(): void {
   // Get all classes for a exam
-  ipcMain.handle("exam-class:get-all", async (_event, examId: string) => {
-    try {
-      return await getExamClasses(examId)
-    } catch (error) {
-      console.error("IPC exam-class:get-all error:", error)
-      throw error
-    }
+  registerHandler("exam-class:get-all", async (examId: string) => {
+    return await getExamClasses(examId)
   })
 
   // Get administered classes (for adding students)
-  ipcMain.handle(
-    "exam-class:get-administered",
-    async (_event, examId: string) => {
-      try {
-        return await getAdministeredClasses(examId)
-      } catch (error) {
-        console.error("IPC exam-class:get-administered error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("exam-class:get-administered", async (examId: string) => {
+    return await getAdministeredClasses(examId)
+  })
 
   // Get statistics classes (for aggregation)
-  ipcMain.handle(
-    "exam-class:get-statistics",
-    async (_event, examId: string) => {
-      try {
-        return await getStatisticsClasses(examId)
-      } catch (error) {
-        console.error("IPC exam-class:get-statistics error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("exam-class:get-statistics", async (examId: string) => {
+    return await getStatisticsClasses(examId)
+  })
 
   // Add a class to a exam
-  ipcMain.handle(
-    "exam-class:add",
-    async (_event, options: AddExamClassOptions) => {
-      try {
-        return await addExamClass(options)
-      } catch (error) {
-        console.error("IPC exam-class:add error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("exam-class:add", async (options: AddExamClassOptions) => {
+    return await addExamClass(options)
+  })
 
   // Update a exam class
-  ipcMain.handle(
+  registerHandler(
     "exam-class:update",
-    async (_event, options: UpdateExamClassOptions) => {
-      try {
-        return await updateExamClass(options)
-      } catch (error) {
-        console.error("IPC exam-class:update error:", error)
-        throw error
-      }
+    async (options: UpdateExamClassOptions) => {
+      return await updateExamClass(options)
     }
   )
 
   // Remove a exam class by id
-  ipcMain.handle("exam-class:remove", async (_event, id: string) => {
-    try {
-      return await removeExamClass(id)
-    } catch (error) {
-      console.error("IPC exam-class:remove error:", error)
-      throw error
-    }
+  registerHandler("exam-class:remove", async (id: string) => {
+    return await removeExamClass(id)
   })
 
   // Remove a exam class by examId and classId
-  ipcMain.handle(
+  registerHandler(
     "exam-class:remove-by-ids",
-    async (_event, examId: string, classId: string) => {
-      try {
-        return await removeExamClassByIds(examId, classId)
-      } catch (error) {
-        console.error("IPC exam-class:remove-by-ids error:", error)
-        throw error
-      }
+    async (examId: string, classId: string) => {
+      return await removeExamClassByIds(examId, classId)
     }
   )
 
   // Get available classes (not yet in ExamClass)
-  ipcMain.handle("exam-class:get-available", async (_event, examId: string) => {
-    try {
-      return await getAvailableClassesForExam(examId)
-    } catch (error) {
-      console.error("IPC exam-class:get-available error:", error)
-      throw error
-    }
+  registerHandler("exam-class:get-available", async (examId: string) => {
+    return await getAvailableClassesForExam(examId)
   })
 
   // Add students from class (B案: 統合型フロー)
-  ipcMain.handle(
+  registerHandler(
     "exam-class:add-students-from-class",
-    async (_event, examId: string, classId: string) => {
-      try {
-        return await addStudentsFromClass(examId, classId)
-      } catch (error) {
-        console.error("IPC exam-class:add-students-from-class error:", error)
-        throw error
-      }
+    async (examId: string, classId: string) => {
+      return await addStudentsFromClass(examId, classId)
     }
   )
 
   // Get class info for all students in a exam
-  ipcMain.handle(
+  registerHandler(
     "exam-class:get-student-class-info",
-    async (_event, examId: string) => {
-      try {
-        return await getStudentClassInfoForExam(examId)
-      } catch (error) {
-        console.error("IPC exam-class:get-student-class-info error:", error)
-        throw error
-      }
+    async (examId: string) => {
+      return await getStudentClassInfoForExam(examId)
     }
   )
 
   // Get class info for a single student
-  ipcMain.handle(
+  registerHandler(
     "exam-class:get-student-class-info-single",
-    async (_event, examId: string, studentId: string) => {
-      try {
-        return await getStudentClassInfo(examId, studentId)
-      } catch (error) {
-        console.error(
-          "IPC exam-class:get-student-class-info-single error:",
-          error
-        )
-        throw error
-      }
+    async (examId: string, studentId: string) => {
+      return await getStudentClassInfo(examId, studentId)
     }
   )
 
   // Reorder exam classes
-  ipcMain.handle(
+  registerHandler(
     "exam-class:reorder",
-    async (_event, options: ReorderExamClassesOptions) => {
-      try {
-        return await reorderExamClasses(options)
-      } catch (error) {
-        console.error("IPC exam-class:reorder error:", error)
-        throw error
-      }
+    async (options: ReorderExamClassesOptions) => {
+      return await reorderExamClasses(options)
     }
   )
 }

--- a/electron-src/ipc-handlers/examHandlers.ts
+++ b/electron-src/ipc-handlers/examHandlers.ts
@@ -1,5 +1,4 @@
 import { Prisma } from "@prisma/client"
-import { ipcMain } from "electron"
 
 import {
   createExam as dbCreateExam,
@@ -11,6 +10,7 @@ import {
   updateExam as dbUpdateExam,
 } from "../lib/prisma/exam"
 import { getExamPagesByExamId as dbGetExamPagesByExamId } from "../lib/prisma/examPage"
+import { registerHandler } from "./ipcHandlerUtils"
 
 /**
  * QuestionScoreをIPC用にシリアライズ（DecimalをnumberにDateはそのまま）
@@ -178,182 +178,140 @@ function computeExamStatus(exam: ExamForListPayload) {
 
 export function setupExamHandlers(): void {
   // 試験一覧用の軽量エンドポイント（ステータスをサーバーサイドで計算）
-  ipcMain.handle("fetch-exams-summary", async (_event, userId: string) => {
-    try {
-      const exams = await dbFetchExamsForList(userId)
-      return exams.map((exam) => ({
-        id: exam.id,
-        examName: exam.examName,
-        examDate: exam.examDate,
-        subject: exam.subject,
-        description: exam.description,
-        createdAt: exam.createdAt,
-        updatedAt: exam.updatedAt,
-        status: computeExamStatus(exam),
-      }))
-    } catch (err) {
-      console.error("Error fetching exams summary:", err)
-      throw err
+  registerHandler("fetch-exams-summary", async (userId: string) => {
+    const exams = await dbFetchExamsForList(userId)
+    return exams.map((exam) => ({
+      id: exam.id,
+      examName: exam.examName,
+      examDate: exam.examDate,
+      subject: exam.subject,
+      description: exam.description,
+      createdAt: exam.createdAt,
+      updatedAt: exam.updatedAt,
+      status: computeExamStatus(exam),
+    }))
+  })
+
+  registerHandler("fetch-exams", async (userId: string) => {
+    const exams = await dbFetchExams(userId)
+
+    // Dateオブジェクトをそのまま返す（Structured Clone AlgorithmでDate対応）
+    // Decimalオブジェクトはnumberに変換（Structured Clone非対応のため）
+    const examsWithFlattenedData = exams.map((exam) => ({
+      ...exam,
+      // examPagesのcropRegionsのquestionScoresをシリアライズ
+      examPages:
+        exam.examPages?.map((page) => ({
+          ...page,
+          cropRegions:
+            page.cropRegions?.map((region) => ({
+              ...region,
+              questionScores:
+                region.questionScores?.map(serializeQuestionScore) || [],
+            })) || [],
+        })) || [],
+      // cropRegionsを平坦化（シリアライズ済み）
+      cropRegions:
+        exam.examPages?.flatMap(
+          (page) =>
+            page.cropRegions?.map((region) => ({
+              ...region,
+              questionScores:
+                region.questionScores?.map(serializeQuestionScore) || [],
+            })) || []
+        ) || [],
+      // answerImagesを抽出
+      answerImages:
+        exam.examPages?.flatMap(
+          (page) =>
+            page.studentAnswerImages?.map((image) => ({
+              ...image,
+              pageNumber: page.pageNumber,
+            })) || []
+        ) || [],
+    }))
+
+    return examsWithFlattenedData
+  })
+
+  registerHandler("fetch-exam-by-id", async (examId: string) => {
+    const exam = await dbFetchExamById(examId)
+    if (!exam) {
+      return null
+    }
+
+    // Dateオブジェクトをそのまま返す
+    // Decimalオブジェクトはnumberに変換（Structured Clone非対応のため）
+    return {
+      ...exam,
+      // examPagesのcropRegionsのquestionScoresをシリアライズ
+      examPages:
+        exam.examPages?.map((page) => ({
+          ...page,
+          cropRegions:
+            page.cropRegions?.map((region) => ({
+              ...region,
+              questionScores:
+                region.questionScores?.map(serializeQuestionScore) || [],
+            })) || [],
+        })) || [],
+      // cropRegionsを平坦化（シリアライズ済み）
+      cropRegions:
+        exam.examPages?.flatMap(
+          (page) =>
+            page.cropRegions?.map((region) => ({
+              ...region,
+              questionScores:
+                region.questionScores?.map(serializeQuestionScore) || [],
+            })) || []
+        ) || [],
+      // answerImagesを抽出
+      answerImages:
+        exam.examPages?.flatMap(
+          (page) =>
+            page.studentAnswerImages?.map((image) => ({
+              ...image,
+              pageNumber: page.pageNumber,
+            })) || []
+        ) || [],
     }
   })
 
-  ipcMain.handle("fetch-exams", async (_event, userId: string) => {
-    try {
-      const exams = await dbFetchExams(userId)
-
-      // Dateオブジェクトをそのまま返す（Structured Clone AlgorithmでDate対応）
-      // Decimalオブジェクトはnumberに変換（Structured Clone非対応のため）
-      const examsWithFlattenedData = exams.map((exam) => ({
-        ...exam,
-        // examPagesのcropRegionsのquestionScoresをシリアライズ
-        examPages:
-          exam.examPages?.map((page) => ({
-            ...page,
-            cropRegions:
-              page.cropRegions?.map((region) => ({
-                ...region,
-                questionScores:
-                  region.questionScores?.map(serializeQuestionScore) || [],
-              })) || [],
-          })) || [],
-        // cropRegionsを平坦化（シリアライズ済み）
-        cropRegions:
-          exam.examPages?.flatMap(
-            (page) =>
-              page.cropRegions?.map((region) => ({
-                ...region,
-                questionScores:
-                  region.questionScores?.map(serializeQuestionScore) || [],
-              })) || []
-          ) || [],
-        // answerImagesを抽出
-        answerImages:
-          exam.examPages?.flatMap(
-            (page) =>
-              page.studentAnswerImages?.map((image) => ({
-                ...image,
-                pageNumber: page.pageNumber,
-              })) || []
-          ) || [],
-      }))
-
-      return examsWithFlattenedData
-    } catch (err) {
-      console.error("Error fetching exams:", err)
-      throw err
-    }
-  })
-
-  ipcMain.handle("fetch-exam-by-id", async (_event, examId: string) => {
-    try {
-      const exam = await dbFetchExamById(examId)
-      if (!exam) {
-        return null
-      }
+  registerHandler(
+    "create-exam",
+    async (examData: Omit<Prisma.ExamCreateInput, "user">, userId: string) => {
+      if (!userId) throw new Error("User ID is required to create a exam.")
+      const exam = await dbCreateExam(examData, userId)
 
       // Dateオブジェクトをそのまま返す
-      // Decimalオブジェクトはnumberに変換（Structured Clone非対応のため）
       return {
         ...exam,
-        // examPagesのcropRegionsのquestionScoresをシリアライズ
-        examPages:
-          exam.examPages?.map((page) => ({
-            ...page,
-            cropRegions:
-              page.cropRegions?.map((region) => ({
-                ...region,
-                questionScores:
-                  region.questionScores?.map(serializeQuestionScore) || [],
-              })) || [],
-          })) || [],
-        // cropRegionsを平坦化（シリアライズ済み）
         cropRegions:
           exam.examPages?.flatMap(
-            (page) =>
-              page.cropRegions?.map((region) => ({
-                ...region,
-                questionScores:
-                  region.questionScores?.map(serializeQuestionScore) || [],
-              })) || []
+            (page) => page.cropRegions?.map((region) => region) || []
           ) || [],
-        // answerImagesを抽出
-        answerImages:
-          exam.examPages?.flatMap(
-            (page) =>
-              page.studentAnswerImages?.map((image) => ({
-                ...image,
-                pageNumber: page.pageNumber,
-              })) || []
-          ) || [],
-      }
-    } catch (err) {
-      console.error("Error fetching exam by ID:", err)
-      throw err
-    }
-  })
-
-  ipcMain.handle(
-    "create-exam",
-    async (
-      _event,
-      examData: Omit<Prisma.ExamCreateInput, "user">,
-      userId: string
-    ) => {
-      try {
-        if (!userId) throw new Error("User ID is required to create a exam.")
-        const exam = await dbCreateExam(examData, userId)
-
-        // Dateオブジェクトをそのまま返す
-        return {
-          ...exam,
-          cropRegions:
-            exam.examPages?.flatMap(
-              (page) => page.cropRegions?.map((region) => region) || []
-            ) || [],
-        }
-      } catch (err) {
-        console.error("Error creating exam:", err)
-        throw err
       }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-exam",
-    async (_event, examId: string, data: Prisma.ExamUpdateInput) => {
-      try {
-        const exam = await dbUpdateExam(examId, data)
-        // Dateオブジェクトをそのまま返す
-        return exam
-      } catch (err) {
-        console.error("Error updating exam:", err)
-        throw err
-      }
-    }
-  )
-
-  ipcMain.handle("delete-exam", async (_event, examId: string) => {
-    try {
-      const exam = await dbDeleteExam(examId)
+    async (examId: string, data: Prisma.ExamUpdateInput) => {
+      const exam = await dbUpdateExam(examId, data)
       // Dateオブジェクトをそのまま返す
       return exam
-    } catch (err) {
-      console.error("Error deleting exam:", err)
-      throw err
-    }
-  })
-
-  ipcMain.handle(
-    "get-exam-pages-by-exam-id",
-    async (_event, examId: string) => {
-      try {
-        const examPages = await dbGetExamPagesByExamId(examId)
-        // Dateオブジェクトをそのまま返す
-        return examPages
-      } catch (err) {
-        console.error("Error fetching exam pages by exam ID:", err)
-        throw err
-      }
     }
   )
+
+  registerHandler("delete-exam", async (examId: string) => {
+    const exam = await dbDeleteExam(examId)
+    // Dateオブジェクトをそのまま返す
+    return exam
+  })
+
+  registerHandler("get-exam-pages-by-exam-id", async (examId: string) => {
+    const examPages = await dbGetExamPagesByExamId(examId)
+    // Dateオブジェクトをそのまま返す
+    return examPages
+  })
 }

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -17,228 +17,158 @@ import {
   getPdfExportData,
 } from "../lib/prisma/pdfExport"
 import { validateScoringData } from "../lib/shared/utilities/validateScoringData"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupExportHandlers(): void {
   // 採点データバリデーション（全エクスポート共通）
-  ipcMain.handle(
+  registerSafeHandler(
     "export:validateScoringData",
-    async (
-      _event,
-      options: {
-        examId: string
-        selectedStudentIds: string[]
-      }
-    ) => {
-      try {
-        const result = await fetchExportData(
-          options.examId,
-          options.selectedStudentIds
-        )
-        if (!result.success || !result.scoringData) {
-          return {
-            success: false,
-            error: result.error || "データ取得に失敗しました",
-          }
-        }
-        const validationResult = validateScoringData(result.scoringData)
-        return { success: true, ...validationResult }
-      } catch (err) {
-        console.error("Error validating scoring data:", err)
+    async (options: { examId: string; selectedStudentIds: string[] }) => {
+      const result = await fetchExportData(
+        options.examId,
+        options.selectedStudentIds
+      )
+      if (!result.success || !result.scoringData) {
         return {
           success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
+          error: result.error || "データ取得に失敗しました",
         }
       }
+      const validationResult = validateScoringData(result.scoringData)
+      return { success: true, ...validationResult }
     }
   )
 
   // Excel Export handlers
-  ipcMain.handle(
+  registerSafeHandler(
     "export-grading-data-excel",
-    async (
-      _event,
-      options: {
-        examId: string
-        selectedStudentIds: string[]
-        outputPath?: string
-      }
-    ) => {
-      try {
-        return await exportGradingDataExcel(options)
-      } catch (err) {
-        console.error("Error exporting grading data Excel:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: {
+      examId: string
+      selectedStudentIds: string[]
+      outputPath?: string
+    }) => {
+      return await exportGradingDataExcel(options)
     }
   )
 
   // Excelプレビュー用データ取得
-  ipcMain.handle(
+  registerSafeHandler(
     "export:getExcelPreviewData",
-    async (
-      _event,
-      options: {
-        examId: string
-        selectedStudentIds: string[]
+    async (options: { examId: string; selectedStudentIds: string[] }) => {
+      const result = await fetchExportData(
+        options.examId,
+        options.selectedStudentIds
+      )
+      if (!result.success) {
+        return { success: false, error: result.error }
       }
-    ) => {
-      try {
-        const result = await fetchExportData(
-          options.examId,
-          options.selectedStudentIds
-        )
-        if (!result.success) {
-          return { success: false, error: result.error }
-        }
-        // Prismaの Decimal/Date 型はIPC経由でcloneできないため、
-        // プレーンなJSオブジェクトに変換して返す
-        const questionRegions = result.questionRegions?.map((r) => ({
-          id: r.id,
-          label: r.label,
-          points: r.points != null ? Number(r.points) : null,
-          orderIndex: r.orderIndex != null ? Number(r.orderIndex) : null,
-        }))
+      // Prismaの Decimal/Date 型はIPC経由でcloneできないため、
+      // プレーンなJSオブジェクトに変換して返す
+      const questionRegions = result.questionRegions?.map((r) => ({
+        id: r.id,
+        label: r.label,
+        points: r.points != null ? Number(r.points) : null,
+        orderIndex: r.orderIndex != null ? Number(r.orderIndex) : null,
+      }))
 
-        const scoringData = result.scoringData?.map((sd) => ({
-          studentId: sd.studentId,
-          studentName: sd.studentName,
-          studentNumber: sd.studentNumber,
-          grade: sd.grade,
-          className: sd.className,
-          attendanceNumber:
-            sd.attendanceNumber != null ? Number(sd.attendanceNumber) : null,
-          status: sd.status,
-          scores: sd.scores.map((s) => ({
-            questionId: s.questionId,
-            questionLabel: s.questionLabel,
-            score: s.score != null ? Number(s.score) : null,
-            maxScore: Number(s.maxScore),
-            status: s.status,
-          })),
-          totalScore: sd.totalScore != null ? Number(sd.totalScore) : null,
-          totalMaxScore: Number(sd.totalMaxScore),
-          subtotalScores: sd.subtotalScores.map((ss) => ({
-            subtotalId: ss.subtotalId,
-            subtotalLabel: ss.subtotalLabel,
-            score: ss.score != null ? Number(ss.score) : null,
-            maxScore: Number(ss.maxScore),
-          })),
-        }))
+      const scoringData = result.scoringData?.map((sd) => ({
+        studentId: sd.studentId,
+        studentName: sd.studentName,
+        studentNumber: sd.studentNumber,
+        grade: sd.grade,
+        className: sd.className,
+        attendanceNumber:
+          sd.attendanceNumber != null ? Number(sd.attendanceNumber) : null,
+        status: sd.status,
+        scores: sd.scores.map((s) => ({
+          questionId: s.questionId,
+          questionLabel: s.questionLabel,
+          score: s.score != null ? Number(s.score) : null,
+          maxScore: Number(s.maxScore),
+          status: s.status,
+        })),
+        totalScore: sd.totalScore != null ? Number(sd.totalScore) : null,
+        totalMaxScore: Number(sd.totalMaxScore),
+        subtotalScores: sd.subtotalScores.map((ss) => ({
+          subtotalId: ss.subtotalId,
+          subtotalLabel: ss.subtotalLabel,
+          score: ss.score != null ? Number(ss.score) : null,
+          maxScore: Number(ss.maxScore),
+        })),
+      }))
 
-        return {
-          success: true,
-          questionRegions,
-          subtotalColumns: result.subtotalColumns,
-          scoringData,
-        }
-      } catch (err) {
-        console.error("Error getting Excel preview data:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
+      return {
+        success: true,
+        questionRegions,
+        subtotalColumns: result.subtotalColumns,
+        scoringData,
       }
     }
   )
 
   // Canvas描画用PDF出力データ取得
-  ipcMain.handle(
+  registerSafeHandler(
     "export:getPdfExportData",
-    async (
-      _event,
-      options: {
-        examId: string
-        selectedStudentIds: string[]
-      }
-    ) => {
-      try {
-        return await getPdfExportData(options)
-      } catch (err) {
-        console.error("Error getting PDF export data:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: { examId: string; selectedStudentIds: string[] }) => {
+      return await getPdfExportData(options)
     }
   )
 
   // Canvas描画済み画像からPDF作成
-  ipcMain.handle(
+  registerSafeHandler(
     "export:createPdfFromRenderedImages",
-    async (
-      _event,
-      options: {
-        examId: string
-        renderedPages: Array<{
-          studentId: string
-          pageNumber: number
-          imageData: ArrayBuffer
-        }>
-        pdfOrientation?: "portrait" | "landscape"
-      }
-    ) => {
-      try {
-        // プログレスコールバックは渡さない（React側で管理するため）
-        // Electron側のprogressCallbackはReact側のプログレス更新と競合し、
-        // プログレスバーが0%にリセットされて2周するように見える問題を引き起こしていた
-        return await createPdfFromRenderedImages({
-          ...options,
-        })
-      } catch (err) {
-        console.error("Error creating PDF from rendered images:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: {
+      examId: string
+      renderedPages: Array<{
+        studentId: string
+        pageNumber: number
+        imageData: ArrayBuffer
+      }>
+      pdfOrientation?: "portrait" | "landscape"
+    }) => {
+      // プログレスコールバックは渡さない（React側で管理するため）
+      // Electron側のprogressCallbackはReact側のプログレス更新と競合し、
+      // プログレスバーが0%にリセットされて2周するように見える問題を引き起こしていた
+      return await createPdfFromRenderedImages({
+        ...options,
+      })
     }
   )
 
   // PDF保存先選択ダイアログ（Canvas描画前に呼び出す）
-  ipcMain.handle(
+  registerSafeHandler(
     "export:selectPdfSavePath",
-    async (
-      _event,
-      options: {
-        examName?: string
+    async (options: {
+      examName?: string
+    }): Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+    }> => {
+      const dateStr = new Date().toISOString().split("T")[0]
+      const safeExamName = options.examName
+        ? options.examName.replace(/[<>:"/\\|?*]/g, "_")
+        : null
+      const defaultFileName = safeExamName
+        ? `採点済み答案_${safeExamName}_${dateStr}.pdf`
+        : `採点済み答案_${dateStr}.pdf`
+
+      const result = await dialog.showSaveDialog({
+        title: "採点済み答案PDFの保存先",
+        defaultPath: defaultFileName,
+        filters: [{ name: "PDF Files", extensions: ["pdf"] }],
+      })
+
+      if (result.canceled || !result.filePath) {
+        return { success: false, canceled: true }
       }
-    ): Promise<{ success: boolean; filePath?: string; canceled?: boolean }> => {
-      try {
-        const { dialog } = require("electron")
-        const dateStr = new Date().toISOString().split("T")[0]
-        const safeExamName = options.examName
-          ? options.examName.replace(/[<>:"/\\|?*]/g, "_")
-          : null
-        const defaultFileName = safeExamName
-          ? `採点済み答案_${safeExamName}_${dateStr}.pdf`
-          : `採点済み答案_${dateStr}.pdf`
 
-        const result = await dialog.showSaveDialog({
-          title: "採点済み答案PDFの保存先",
-          defaultPath: defaultFileName,
-          filters: [{ name: "PDF Files", extensions: ["pdf"] }],
-        })
-
-        if (result.canceled || !result.filePath) {
-          return { success: false, canceled: true }
-        }
-
-        return { success: true, filePath: result.filePath }
-      } catch (err) {
-        console.error("Error selecting PDF save path:", err)
-        return {
-          success: false,
-          canceled: false,
-        }
-      }
+      return { success: true, filePath: result.filePath }
     }
   )
 
   // SVG→PNG変換ハンドラ（MathJaxテキストのtaint問題回避用）
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "export:convertSvgToPng",
     async (
@@ -316,7 +246,7 @@ export function setupExportHandlers(): void {
           win.destroy()
         }
       } catch (err) {
-        console.error("Error converting SVG to PNG:", err)
+        console.error("Error in IPC handler [export:convertSvgToPng]:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "Unknown error occurred",
@@ -330,86 +260,42 @@ export function setupExportHandlers(): void {
   // ============================================================
 
   // ストリーミングセッション作成
-  ipcMain.handle(
+  registerSafeHandler(
     "export:createPdfStreamingSession",
-    async (
-      _event,
-      options: {
-        totalPages: number
-        pdfOrientation?: "portrait" | "landscape"
-      }
-    ) => {
-      try {
-        return await createPdfStreamingSession(options)
-      } catch (err) {
-        console.error("Error creating PDF streaming session:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: {
+      totalPages: number
+      pdfOrientation?: "portrait" | "landscape"
+    }) => {
+      return await createPdfStreamingSession(options)
     }
   )
 
   // ストリーミングセッションにページを追加
-  ipcMain.handle(
+  registerSafeHandler(
     "export:addPageToStreamingSession",
-    async (
-      _event,
-      options: {
-        sessionId: string
-        pageIndex: number
-        imageData: ArrayBuffer
-      }
-    ) => {
-      try {
-        return await addPageToStreamingSession(options)
-      } catch (err) {
-        console.error("Error adding page to streaming session:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: {
+      sessionId: string
+      pageIndex: number
+      imageData: ArrayBuffer
+    }) => {
+      return await addPageToStreamingSession(options)
     }
   )
 
   // ストリーミングセッションを完了してPDF保存
-  ipcMain.handle(
+  registerSafeHandler(
     "export:finalizeStreamingSession",
-    async (
-      _event,
-      options: {
-        sessionId: string
-        outputPath: string
-      }
-    ) => {
-      try {
-        return await finalizeStreamingSession(options)
-      } catch (err) {
-        console.error("Error finalizing streaming session:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: { sessionId: string; outputPath: string }) => {
+      return await finalizeStreamingSession(options)
     }
   )
 
   // ストリーミングセッションをキャンセル
-  ipcMain.handle(
+  registerSafeHandler(
     "export:cancelStreamingSession",
-    async (_event, sessionId: string) => {
-      try {
-        cancelStreamingSession(sessionId)
-        return { success: true }
-      } catch (err) {
-        console.error("Error canceling streaming session:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (sessionId: string) => {
+      cancelStreamingSession(sessionId)
+      return { success: true }
     }
   )
 
@@ -418,102 +304,69 @@ export function setupExportHandlers(): void {
   // ============================================================
 
   // 個人成績表用データ取得
-  ipcMain.handle(
+  registerSafeHandler(
     "export:getIndividualReportData",
-    async (_event, options: GetIndividualReportDataOptions) => {
-      try {
-        return await fetchIndividualReportData(options)
-      } catch (err) {
-        console.error("Error getting individual report data:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (options: GetIndividualReportDataOptions) => {
+      return await fetchIndividualReportData(options)
     }
   )
 
   // 個人成績表用小計点グループ一覧取得
-  ipcMain.handle(
+  registerSafeHandler(
     "export:getSubtotalGroupsForReport",
-    async (_event, examId: string) => {
-      try {
-        return await fetchSubtotalGroupsForReport(examId)
-      } catch (err) {
-        console.error("Error getting subtotal groups for report:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error occurred",
-        }
-      }
+    async (examId: string) => {
+      return await fetchSubtotalGroupsForReport(examId)
     }
   )
 
   // 個人成績表PDF保存先選択ダイアログ
-  ipcMain.handle(
+  registerSafeHandler(
     "export:selectIndividualReportSavePath",
-    async (
-      _event,
-      options: {
-        examName?: string
+    async (options: {
+      examName?: string
+    }): Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+    }> => {
+      const dateStr = new Date().toISOString().split("T")[0]
+      const safeExamName = options.examName
+        ? options.examName.replace(/[<>:"/\\|?*]/g, "_")
+        : null
+      const defaultFileName = safeExamName
+        ? `個人成績表_${safeExamName}_${dateStr}.pdf`
+        : `個人成績表_${dateStr}.pdf`
+
+      const result = await dialog.showSaveDialog({
+        title: "個人成績表PDFの保存先",
+        defaultPath: defaultFileName,
+        filters: [{ name: "PDF Files", extensions: ["pdf"] }],
+      })
+
+      if (result.canceled || !result.filePath) {
+        return { success: false, canceled: true }
       }
-    ): Promise<{ success: boolean; filePath?: string; canceled?: boolean }> => {
-      try {
-        const dateStr = new Date().toISOString().split("T")[0]
-        const safeExamName = options.examName
-          ? options.examName.replace(/[<>:"/\\|?*]/g, "_")
-          : null
-        const defaultFileName = safeExamName
-          ? `個人成績表_${safeExamName}_${dateStr}.pdf`
-          : `個人成績表_${dateStr}.pdf`
 
-        const result = await dialog.showSaveDialog({
-          title: "個人成績表PDFの保存先",
-          defaultPath: defaultFileName,
-          filters: [{ name: "PDF Files", extensions: ["pdf"] }],
-        })
-
-        if (result.canceled || !result.filePath) {
-          return { success: false, canceled: true }
-        }
-
-        return { success: true, filePath: result.filePath }
-      } catch (err) {
-        console.error("Error selecting individual report save path:", err)
-        return {
-          success: false,
-          canceled: false,
-        }
-      }
+      return { success: true, filePath: result.filePath }
     }
   )
 
   // 個人成績表PDFバッファを保存
-  ipcMain.handle(
+  registerSafeHandler(
     "export:saveIndividualReportPdf",
-    async (
-      _event,
-      options: {
-        filePath: string
-        pdfBuffer: ArrayBuffer
-      }
-    ): Promise<{ success: boolean; error?: string }> => {
-      try {
-        const fs = require("fs").promises
-        await fs.writeFile(options.filePath, Buffer.from(options.pdfBuffer))
-        return { success: true }
-      } catch (err) {
-        console.error("Error saving individual report PDF:", err)
-        return {
-          success: false,
-          error:
-            err instanceof Error ? err.message : "ファイル保存に失敗しました",
-        }
-      }
-    }
+    async (options: {
+      filePath: string
+      pdfBuffer: ArrayBuffer
+    }): Promise<{ success: boolean; error?: string }> => {
+      const fs = require("fs").promises
+      await fs.writeFile(options.filePath, Buffer.from(options.pdfBuffer))
+      return { success: true }
+    },
+    "ファイル保存に失敗しました"
   )
 
   // HTMLからPDFを生成（ブラウザ印刷機能を使用）
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "export:printHtmlToPdf",
     async (
@@ -594,7 +447,7 @@ export function setupExportHandlers(): void {
 
         return { success: true }
       } catch (err) {
-        console.error("Error printing HTML to PDF:", err)
+        console.error("Error in IPC handler [export:printHtmlToPdf]:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "PDF生成に失敗しました",
@@ -612,6 +465,7 @@ export function setupExportHandlers(): void {
   )
 
   // 複数のHTMLページからPDFを生成（バッチ処理）
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "export:printMultipleHtmlToPdf",
     async (
@@ -686,7 +540,10 @@ export function setupExportHandlers(): void {
 
         return { success: true }
       } catch (err) {
-        console.error("Error printing multiple HTML to PDF:", err)
+        console.error(
+          "Error in IPC handler [export:printMultipleHtmlToPdf]:",
+          err
+        )
         return {
           success: false,
           error: err instanceof Error ? err.message : "PDF生成に失敗しました",
@@ -702,6 +559,7 @@ export function setupExportHandlers(): void {
   // ============================================================
 
   // HTMLからPDFを生成してプレビューで開く
+  // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "export:openPrintDialog",
     async (
@@ -780,7 +638,7 @@ export function setupExportHandlers(): void {
 
         return { success: true }
       } catch (err) {
-        console.error("Error generating PDF:", err)
+        console.error("Error in IPC handler [export:openPrintDialog]:", err)
         return {
           success: false,
           error: err instanceof Error ? err.message : "PDF生成に失敗しました",

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -2,7 +2,7 @@
  * Grade（成績算出）IPC ハンドラー
  */
 
-import { dialog, ipcMain } from "electron"
+import { dialog } from "electron"
 
 import { createGradeArchive } from "../lib/export/grade-archive"
 import { exportGradeExcel } from "../lib/export/gradeExcel"
@@ -65,38 +65,35 @@ import {
   getManualScoresByDataSourceId,
 } from "../lib/prisma/manualScore"
 import { calculateGrades } from "../lib/shared/calculations/gradeCalculator"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupGradeHandlers(): void {
   // =====================================================================
   // Grade CRUD
   // =====================================================================
 
-  ipcMain.handle("grade:getAll", async () => {
+  registerHandler("grade:getAll", async () => {
     return getAllGrades()
   })
 
-  ipcMain.handle("grade:getById", async (_event, id: string) => {
+  registerHandler("grade:getById", async (id: string) => {
     return getGradeById(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:create",
-    async (
-      _event,
-      data: {
-        name: string
-        description?: string
-        referenceDate?: string | null
-      }
-    ) => {
+    async (data: {
+      name: string
+      description?: string
+      referenceDate?: string | null
+    }) => {
       return createGrade(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:update",
     async (
-      _event,
       id: string,
       data: {
         name?: string
@@ -108,34 +105,20 @@ export function setupGradeHandlers(): void {
     }
   )
 
-  ipcMain.handle("grade:delete", async (_event, id: string) => {
+  registerHandler("grade:delete", async (id: string) => {
     return deleteGrade(id)
   })
 
-  ipcMain.handle("grade:getExportSettings", async (_event, gradeId: string) => {
-    try {
-      const settings = await getGradeExportSettings(gradeId)
-      return { success: true, settings }
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
-      }
-    }
+  registerSafeHandler("grade:getExportSettings", async (gradeId: string) => {
+    const settings = await getGradeExportSettings(gradeId)
+    return { success: true, settings }
   })
 
-  ipcMain.handle(
+  registerSafeHandler(
     "grade:saveExportSettings",
-    async (_event, gradeId: string, settings: Record<string, unknown>) => {
-      try {
-        await upsertGradeExportSettings(gradeId, settings)
-        return { success: true }
-      } catch (error) {
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
-        }
-      }
+    async (gradeId: string, settings: Record<string, unknown>) => {
+      await upsertGradeExportSettings(gradeId, settings)
+      return { success: true }
     }
   )
 
@@ -143,39 +126,35 @@ export function setupGradeHandlers(): void {
   // Grade 生徒・学級管理
   // =====================================================================
 
-  ipcMain.handle("grade:getStudents", async (_event, gradeId: string) => {
+  registerHandler("grade:getStudents", async (gradeId: string) => {
     return getStudentsByGradeId(gradeId)
   })
 
-  ipcMain.handle("grade:getClasses", async (_event, gradeId: string) => {
+  registerHandler("grade:getClasses", async (gradeId: string) => {
     return getGradeClasses(gradeId)
   })
 
-  ipcMain.handle(
-    "grade:getAvailableClasses",
-    async (_event, gradeId: string) => {
-      return getAvailableClassesForGrade(gradeId)
-    }
-  )
+  registerHandler("grade:getAvailableClasses", async (gradeId: string) => {
+    return getAvailableClassesForGrade(gradeId)
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:addStudentsFromClass",
-    async (_event, gradeId: string, classId: string) => {
+    async (gradeId: string, classId: string) => {
       return addStudentsFromClassToGrade(gradeId, classId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:removeClass",
-    async (_event, gradeId: string, classId: string) => {
+    async (gradeId: string, classId: string) => {
       return removeClassFromGrade(gradeId, classId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:updateStudentOrders",
     async (
-      _event,
       gradeId: string,
       studentOrders: { studentId: string; customOrder: number }[]
     ) => {
@@ -187,31 +166,31 @@ export function setupGradeHandlers(): void {
   // GradeItem
   // =====================================================================
 
-  ipcMain.handle("grade:getGradeItems", async (_event, gradeId: string) => {
+  registerHandler("grade:getGradeItems", async (gradeId: string) => {
     return getGradeItemsByExamId(gradeId)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:createGradeItem",
-    async (_event, data: { gradeId: string; name: string }) => {
+    async (data: { gradeId: string; name: string }) => {
       return createGradeItem(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:updateGradeItem",
-    async (_event, id: string, data: { name?: string }) => {
+    async (id: string, data: { name?: string }) => {
       return updateGradeItem(id, data)
     }
   )
 
-  ipcMain.handle("grade:deleteGradeItem", async (_event, id: string) => {
+  registerHandler("grade:deleteGradeItem", async (id: string) => {
     return deleteGradeItem(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:reorderGradeItems",
-    async (_event, items: { id: string; order: number }[]) => {
+    async (items: { id: string; order: number }[]) => {
       return reorderGradeItems(items)
     }
   )
@@ -220,35 +199,31 @@ export function setupGradeHandlers(): void {
   // GradeDataSource
   // =====================================================================
 
-  ipcMain.handle(
+  registerHandler(
     "grade:createDataSource",
-    async (
-      _event,
-      data: {
-        gradeItemId: string
-        type: string
-        examId?: string
-        subtotalId?: string
-        cropRegionId?: string
-        name: string
-        maxScore: number
-        weight: number
-        absentMethod?: string
-        absentRatio?: number
-        absentOffset?: number
-        treatExpectedAsMissing?: boolean
-        estimationMode?: string
-        estimationSourceIds?: string[]
-      }
-    ) => {
+    async (data: {
+      gradeItemId: string
+      type: string
+      examId?: string
+      subtotalId?: string
+      cropRegionId?: string
+      name: string
+      maxScore: number
+      weight: number
+      absentMethod?: string
+      absentRatio?: number
+      absentOffset?: number
+      treatExpectedAsMissing?: boolean
+      estimationMode?: string
+      estimationSourceIds?: string[]
+    }) => {
       return createDataSource(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:updateDataSource",
     async (
-      _event,
       id: string,
       data: {
         name?: string
@@ -266,21 +241,20 @@ export function setupGradeHandlers(): void {
     }
   )
 
-  ipcMain.handle("grade:deleteDataSource", async (_event, id: string) => {
+  registerHandler("grade:deleteDataSource", async (id: string) => {
     return deleteDataSource(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:reorderDataSources",
-    async (_event, items: { id: string; order: number }[]) => {
+    async (items: { id: string; order: number }[]) => {
       return reorderDataSources(items)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:batchUpdateAbsentPolicy",
     async (
-      _event,
       dataSourceIds: string[],
       policy: {
         absentMethod: string
@@ -299,32 +273,26 @@ export function setupGradeHandlers(): void {
   // 補助: 候補取得・計算
   // =====================================================================
 
-  ipcMain.handle("grade:getExamCandidates", async () => {
+  registerHandler("grade:getExamCandidates", async () => {
     return getExamCandidates()
   })
 
-  ipcMain.handle(
-    "grade:getExamSubtotalGroups",
-    async (_event, examId: string) => {
-      return getExamSubtotalGroups(examId)
-    }
-  )
+  registerHandler("grade:getExamSubtotalGroups", async (examId: string) => {
+    return getExamSubtotalGroups(examId)
+  })
 
-  ipcMain.handle("grade:getExamCropRegions", async (_event, examId: string) => {
+  registerHandler("grade:getExamCropRegions", async (examId: string) => {
     return getExamCropRegions(examId)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:calculateSourceMaxScore",
-    async (
-      _event,
-      data: {
-        type: string
-        examId?: string
-        subtotalId?: string
-        cropRegionId?: string
-      }
-    ) => {
+    async (data: {
+      type: string
+      examId?: string
+      subtotalId?: string
+      cropRegionId?: string
+    }) => {
       return calculateSourceMaxScore(data)
     }
   )
@@ -333,17 +301,16 @@ export function setupGradeHandlers(): void {
   // ManualScore
   // =====================================================================
 
-  ipcMain.handle(
+  registerHandler(
     "grade:getManualScores",
-    async (_event, gradeDataSourceId: string) => {
+    async (gradeDataSourceId: string) => {
       return getManualScoresByDataSourceId(gradeDataSourceId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:batchUpsertManualScores",
     async (
-      _event,
       scores: {
         gradeDataSourceId: string
         studentId: string
@@ -358,26 +325,23 @@ export function setupGradeHandlers(): void {
   // GradeBoundary
   // =====================================================================
 
-  ipcMain.handle("grade:getBoundarySets", async (_event, gradeId: string) => {
+  registerHandler("grade:getBoundarySets", async (gradeId: string) => {
     return getBoundarySetsByGradeId(gradeId)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:upsertBoundarySet",
-    async (
-      _event,
-      data: {
-        gradeId: string
-        targetType: string
-        gradeItemId: string | null
-        boundaries: { label: string; minPercentage: number; order: number }[]
-      }
-    ) => {
+    async (data: {
+      gradeId: string
+      targetType: string
+      gradeItemId: string | null
+      boundaries: { label: string; minPercentage: number; order: number }[]
+    }) => {
       return upsertBoundarySet(data)
     }
   )
 
-  ipcMain.handle("grade:deleteBoundarySet", async (_event, id: string) => {
+  registerHandler("grade:deleteBoundarySet", async (id: string) => {
     return deleteBoundarySet(id)
   })
 
@@ -385,33 +349,27 @@ export function setupGradeHandlers(): void {
   // GradeOverride
   // =====================================================================
 
-  ipcMain.handle(
+  registerHandler(
     "grade:upsertGradeOverride",
-    async (
-      _event,
-      data: {
-        gradeId: string
-        studentId: string
-        targetType: string
-        gradeItemId: string | null
-        overrideLabel: string
-      }
-    ) => {
+    async (data: {
+      gradeId: string
+      studentId: string
+      targetType: string
+      gradeItemId: string | null
+      overrideLabel: string
+    }) => {
       return upsertGradeOverride(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:deleteGradeOverride",
-    async (
-      _event,
-      data: {
-        gradeId: string
-        studentId: string
-        targetType: string
-        gradeItemId: string | null
-      }
-    ) => {
+    async (data: {
+      gradeId: string
+      studentId: string
+      targetType: string
+      gradeItemId: string | null
+    }) => {
       return deleteGradeOverride(data)
     }
   )
@@ -420,32 +378,25 @@ export function setupGradeHandlers(): void {
   // GradeItemExclusion
   // =====================================================================
 
-  ipcMain.handle(
-    "grade:getGradeItemExclusions",
-    async (_event, gradeId: string) => {
-      return getGradeItemExclusions(gradeId)
-    }
-  )
+  registerHandler("grade:getGradeItemExclusions", async (gradeId: string) => {
+    return getGradeItemExclusions(gradeId)
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:setGradeItemExclusion",
-    async (
-      _event,
-      data: {
-        gradeId: string
-        studentId: string
-        gradeItemId: string
-        excluded: boolean
-      }
-    ) => {
+    async (data: {
+      gradeId: string
+      studentId: string
+      gradeItemId: string
+      excluded: boolean
+    }) => {
       return setGradeItemExclusion(data)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "grade:batchUpdateGradeItemExclusions",
     async (
-      _event,
       gradeId: string,
       updates: { studentId: string; gradeItemId: string; excluded: boolean }[]
     ) => {
@@ -457,7 +408,7 @@ export function setupGradeHandlers(): void {
   // 成績算出
   // =====================================================================
 
-  ipcMain.handle("grade:calculateGrades", async (_event, gradeId: string) => {
+  registerHandler("grade:calculateGrades", async (gradeId: string) => {
     return calculateGrades(gradeId)
   })
 
@@ -465,9 +416,9 @@ export function setupGradeHandlers(): void {
   // Excel出力
   // =====================================================================
 
-  ipcMain.handle(
+  registerHandler(
     "grade:exportExcel",
-    async (_event, gradeId: string, options?: { studentIds?: string[] }) => {
+    async (gradeId: string, options?: { studentIds?: string[] }) => {
       return exportGradeExcel(gradeId, {
         studentIds: options?.studentIds,
       })
@@ -478,7 +429,7 @@ export function setupGradeHandlers(): void {
   // アーカイブ Export/Import
   // =====================================================================
 
-  ipcMain.handle("grade:exportArchive", async (_event, gradeId: string) => {
+  registerHandler("grade:exportArchive", async (gradeId: string) => {
     const result = await dialog.showSaveDialog({
       title: "成績アーカイブの保存先",
       defaultPath: `grade-exam.grade`,
@@ -490,7 +441,7 @@ export function setupGradeHandlers(): void {
     return createGradeArchive(gradeId, result.filePath)
   })
 
-  ipcMain.handle("grade:importArchive", async (_event) => {
+  registerHandler("grade:importArchive", async () => {
     const result = await dialog.showOpenDialog({
       title: "成績アーカイブを選択",
       filters: [{ name: "成績アーカイブ", extensions: ["grade"] }],
@@ -509,10 +460,9 @@ export function setupGradeHandlers(): void {
     return { success: true, preview, archiveData: extractResult.data }
   })
 
-  ipcMain.handle(
+  registerHandler(
     "grade:executeImport",
     async (
-      _event,
       archiveData: Parameters<typeof importGradeArchive>[0],
       examMapping?: Record<string, string>
     ) => {

--- a/electron-src/ipc-handlers/ipcHandlerUtils.ts
+++ b/electron-src/ipc-handlers/ipcHandlerUtils.ts
@@ -1,0 +1,49 @@
+/**
+ * IPC ハンドラーのボイラープレートを削減するユーティリティ
+ */
+
+import { ipcMain } from "electron"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type HandlerFunction = (...args: any[]) => any
+
+/**
+ * IPC ハンドラーを登録し、try-catch + エラーログを自動適用する。
+ * エラー時は例外をそのまま再スローする（呼び出し元でハンドリングされる）。
+ */
+export function registerHandler(
+  channel: string,
+  handler: HandlerFunction
+): void {
+  ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
+    try {
+      return await handler(...args)
+    } catch (err) {
+      console.error(`Error in IPC handler [${channel}]:`, err)
+      throw err
+    }
+  })
+}
+
+/**
+ * IPC ハンドラーを登録し、try-catch + エラーログを自動適用する。
+ * エラー時は例外をスローせず、{ success: false, error: message } を返す。
+ */
+export function registerSafeHandler(
+  channel: string,
+  handler: HandlerFunction,
+  fallbackError?: string
+): void {
+  ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
+    try {
+      return await handler(...args)
+    } catch (err) {
+      console.error(`Error in IPC handler [${channel}]:`, err)
+      return {
+        success: false,
+        error:
+          err instanceof Error ? err.message : fallbackError || "Unknown error",
+      }
+    }
+  })
+}

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -1,5 +1,4 @@
 import { Prisma } from "@prisma/client"
-import { ipcMain } from "electron"
 import * as fs from "fs/promises"
 
 import { getAbsolutePathFromData } from "../lib/dataManager"
@@ -35,163 +34,103 @@ import {
   uploadStudentAnswers,
 } from "../lib/prisma/studentAnswer"
 import { fetchUsers, getCurrentUser } from "../lib/prisma/user"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupMiscHandlers(): void {
   // User handlers
-  ipcMain.handle("fetch-users", async () => {
-    try {
-      return await fetchUsers()
-    } catch (err) {
-      console.error("Error fetching users:", err)
-      throw err
-    }
+  registerHandler("fetch-users", async () => {
+    return await fetchUsers()
   })
 
-  ipcMain.handle("get-current-user", async () => {
-    try {
-      return await getCurrentUser()
-    } catch (err) {
-      console.error("Error getting current user:", err)
-      throw err
-    }
+  registerHandler("get-current-user", async () => {
+    return await getCurrentUser()
   })
 
   // Authentication handlers
-  ipcMain.handle(
-    "login-user",
-    async (_event, username: string, password: string) => {
-      try {
-        return await loginUser(username, password)
-      } catch (err) {
-        console.error("Error logging in user:", err)
-        throw err
-      }
-    }
-  )
-
-  ipcMain.handle(
-    "create-user",
-    async (
-      _event,
-      userData: {
-        username: string
-        name: string
-        passcode?: string
-        passcodeType?: "none" | "4digit" | "6digit" | "alphanumeric"
-        password?: string // Legacy support
-        role?: string
-      }
-    ) => {
-      try {
-        if (
-          userData.passcode !== undefined ||
-          userData.passcodeType !== undefined
-        ) {
-          // New passcode-based user creation
-          const { createUser: createUserWithPasscode } =
-            await import("../lib/prisma/user")
-          return await createUserWithPasscode({
-            username: userData.username,
-            name: userData.name,
-            passcode: userData.passcode,
-            passcodeType: userData.passcodeType,
-          })
-        } else if (userData.password) {
-          // Legacy password-based user creation
-          return await createUser({
-            username: userData.username,
-            password: userData.password,
-            name: userData.name,
-            role: userData.role,
-          })
-        } else {
-          throw new Error("Either passcode or password must be provided")
-        }
-      } catch (err) {
-        console.error("Error creating user:", err)
-        throw err
-      }
-    }
-  )
-
-  ipcMain.handle("get-user-by-token", async (_event, token: string) => {
-    try {
-      return await getUserByToken(token)
-    } catch (err) {
-      console.error("Error getting user by token:", err)
-      throw err
-    }
+  registerHandler("login-user", async (username: string, password: string) => {
+    return await loginUser(username, password)
   })
 
-  ipcMain.handle(
+  registerHandler(
+    "create-user",
+    async (userData: {
+      username: string
+      name: string
+      passcode?: string
+      passcodeType?: "none" | "4digit" | "6digit" | "alphanumeric"
+      password?: string // Legacy support
+      role?: string
+    }) => {
+      if (
+        userData.passcode !== undefined ||
+        userData.passcodeType !== undefined
+      ) {
+        // New passcode-based user creation
+        const { createUser: createUserWithPasscode } =
+          await import("../lib/prisma/user")
+        return await createUserWithPasscode({
+          username: userData.username,
+          name: userData.name,
+          passcode: userData.passcode,
+          passcodeType: userData.passcodeType,
+        })
+      } else if (userData.password) {
+        // Legacy password-based user creation
+        return await createUser({
+          username: userData.username,
+          password: userData.password,
+          name: userData.name,
+          role: userData.role,
+        })
+      } else {
+        throw new Error("Either passcode or password must be provided")
+      }
+    }
+  )
+
+  registerHandler("get-user-by-token", async (token: string) => {
+    return await getUserByToken(token)
+  })
+
+  registerHandler(
     "update-user-password",
-    async (_event, userId: string, newPassword: string) => {
-      try {
-        return await updateUserPassword(userId, newPassword)
-      } catch (err) {
-        console.error("Error updating user password:", err)
-        throw err
-      }
+    async (userId: string, newPassword: string) => {
+      return await updateUserPassword(userId, newPassword)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "verify-passcode",
-    async (_event, userId: string, passcode: string) => {
-      try {
-        const { verifyPasscode } = await import("../lib/prisma/user")
-        return await verifyPasscode(userId, passcode)
-      } catch (err) {
-        console.error("Error verifying passcode:", err)
-        throw err
-      }
+    async (userId: string, passcode: string) => {
+      const { verifyPasscode } = await import("../lib/prisma/user")
+      return await verifyPasscode(userId, passcode)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-user",
-    async (
-      _event,
-      userId: string,
-      userData: { username?: string; name?: string }
-    ) => {
-      try {
-        const { updateUser } = await import("../lib/prisma/user")
-        return await updateUser(userId, userData)
-      } catch (err) {
-        console.error("Error updating user:", err)
-        throw err
-      }
+    async (userId: string, userData: { username?: string; name?: string }) => {
+      const { updateUser } = await import("../lib/prisma/user")
+      return await updateUser(userId, userData)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-user-passcode",
-    async (
-      _event,
-      userId: string,
-      passcode?: string,
-      passcodeType?: string
-    ) => {
-      try {
-        const { updateUserPasscode } = await import("../lib/prisma/user")
-        return await updateUserPasscode(
-          userId,
-          passcode,
-          passcodeType as "none" | "4digit" | "6digit" | "alphanumeric"
-        )
-      } catch (err) {
-        console.error("Error updating user passcode:", err)
-        throw err
-      }
+    async (userId: string, passcode?: string, passcodeType?: string) => {
+      const { updateUserPasscode } = await import("../lib/prisma/user")
+      return await updateUserPasscode(
+        userId,
+        passcode,
+        passcodeType as "none" | "4digit" | "6digit" | "alphanumeric"
+      )
     }
   )
 
   // Answer sheet handlers
-  ipcMain.handle(
+  registerHandler(
     "upload-answer-sheets",
     async (
-      _event,
       examId: string,
       filesData: {
         name: string
@@ -203,172 +142,113 @@ export function setupMiscHandlers(): void {
         correctWithMarkers?: boolean
       }[]
     ) => {
-      try {
-        return await uploadStudentAnswers(examId, filesData)
-      } catch (err) {
-        console.error("Error uploading answer sheets:", err)
-        throw err
-      }
+      return await uploadStudentAnswers(examId, filesData)
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "get-answer-sheets-by-exam-id",
-    async (_event, examId: string) => {
-      try {
-        const result = await getStudentAnswersByExamId(examId)
-        if (!result.success) {
-          return { success: false, error: result.error }
-        }
-        return {
-          success: true,
-          studentAnswerImages: result.studentAnswerImages ?? [],
-        }
-      } catch (err) {
-        console.error("Error fetching student answer images:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
+    async (examId: string) => {
+      const result = await getStudentAnswersByExamId(examId)
+      if (!result.success) {
+        return { success: false, error: result.error }
+      }
+      return {
+        success: true,
+        studentAnswerImages: result.studentAnswerImages ?? [],
       }
     }
   )
 
-  ipcMain.handle(
-    "delete-answer-sheet",
-    async (_event, answerSheetId: string) => {
-      try {
-        return await deleteStudentAnswer(answerSheetId)
-      } catch (err) {
-        console.error("Error deleting answer sheet:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("delete-answer-sheet", async (answerSheetId: string) => {
+    return await deleteStudentAnswer(answerSheetId)
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "associate-answer-sheet-with-student",
-    async (_event, answerSheetId: string, studentId: string) => {
-      try {
-        return await associateStudentAnswerWithStudent(answerSheetId, studentId)
-      } catch (err) {
-        console.error("Error associating answer sheet with student:", err)
-        throw err
-      }
+    async (answerSheetId: string, studentId: string) => {
+      return await associateStudentAnswerWithStudent(answerSheetId, studentId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "set-answer-sheet-absent",
-    async (_event, answerSheetId: string, isAbsent: boolean) => {
-      try {
-        return await setStudentAnswerAbsent(answerSheetId, isAbsent)
-      } catch (err) {
-        console.error("Error setting answer sheet absent status:", err)
-        throw err
-      }
+    async (answerSheetId: string, isAbsent: boolean) => {
+      return await setStudentAnswerAbsent(answerSheetId, isAbsent)
     }
   )
 
-  ipcMain.handle(
-    "get-answer-sheet-by-id",
-    async (_event, answerSheetId: string) => {
-      try {
-        const result = await getStudentAnswerById(answerSheetId)
-        if (!result.success) {
-          throw new Error(result.error)
-        }
-        if (!result.answerSheet) return null
-        return {
-          ...result.answerSheet,
-        }
-      } catch (err) {
-        console.error("Error fetching answer sheet by ID:", err)
-        throw err
-      }
+  registerHandler("get-answer-sheet-by-id", async (answerSheetId: string) => {
+    const result = await getStudentAnswerById(answerSheetId)
+    if (!result.success) {
+      throw new Error(result.error)
     }
-  )
+    if (!result.answerSheet) return null
+    return {
+      ...result.answerSheet,
+    }
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "update-answer-sheet-placement",
     async (
-      _event,
       answerSheetId: string,
       studentId: string | null,
       pageNumber: number
     ) => {
-      try {
-        const result = await updateStudentAnswerPlacement(
-          answerSheetId,
-          studentId,
-          pageNumber
-        )
-        if (!result.success) {
-          throw new Error(result.error)
-        }
-        return {
-          ...result.answerSheet,
-        }
-      } catch (err) {
-        console.error("Error updating answer sheet placement:", err)
-        throw err
+      const result = await updateStudentAnswerPlacement(
+        answerSheetId,
+        studentId,
+        pageNumber
+      )
+      if (!result.success) {
+        throw new Error(result.error)
+      }
+      return {
+        ...result.answerSheet,
       }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "swap-answer-sheet-placements",
-    async (_event, answerSheetId1: string, answerSheetId2: string) => {
-      try {
-        const result = await swapStudentAnswerPlacements(
-          answerSheetId1,
-          answerSheetId2
-        )
-        if (!result.success) {
-          throw new Error(result.error)
-        }
-        return (result.answerSheets || [])
-          .filter((sheet) => sheet !== null)
-          .map((sheet) => ({
-            ...sheet,
-          }))
-      } catch (err) {
-        console.error("Error swapping answer sheet placements:", err)
-        throw err
+    async (answerSheetId1: string, answerSheetId2: string) => {
+      const result = await swapStudentAnswerPlacements(
+        answerSheetId1,
+        answerSheetId2
+      )
+      if (!result.success) {
+        throw new Error(result.error)
       }
+      return (result.answerSheets || [])
+        .filter((sheet) => sheet !== null)
+        .map((sheet) => ({
+          ...sheet,
+        }))
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "swap-answer-sheet-placements-with-scoring",
-    async (_event, answerSheetId1: string, answerSheetId2: string) => {
-      try {
-        const result = await swapStudentAnswerPlacementsWithScoring(
-          answerSheetId1,
-          answerSheetId2
-        )
-        if (!result.success) {
-          throw new Error(result.error)
-        }
-        return (result.answerSheets || [])
-          .filter((sheet) => sheet !== null)
-          .map((sheet) => ({
-            ...sheet,
-          }))
-      } catch (err) {
-        console.error(
-          "Error swapping answer sheet placements with scoring:",
-          err
-        )
-        throw err
+    async (answerSheetId1: string, answerSheetId2: string) => {
+      const result = await swapStudentAnswerPlacementsWithScoring(
+        answerSheetId1,
+        answerSheetId2
+      )
+      if (!result.success) {
+        throw new Error(result.error)
       }
+      return (result.answerSheets || [])
+        .filter((sheet) => sheet !== null)
+        .map((sheet) => ({
+          ...sheet,
+        }))
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "batch-update-answer-sheet-placements",
     async (
-      _event,
       moves: Array<{
         fileId: string
         finalStudentId: string | null
@@ -376,72 +256,45 @@ export function setupMiscHandlers(): void {
       }>,
       withScoring: boolean = false
     ) => {
-      try {
-        const result = await batchUpdateStudentAnswerPlacements(
-          moves,
-          withScoring
-        )
-        if (!result.success) {
-          const errorMessage =
-            "error" in result ? result.error : "Unknown error"
-          throw new Error(errorMessage)
-        }
-        return result
-      } catch (err) {
-        console.error("Error in batch update answer sheet placements:", err)
-        throw err
+      const result = await batchUpdateStudentAnswerPlacements(
+        moves,
+        withScoring
+      )
+      if (!result.success) {
+        const errorMessage = "error" in result ? result.error : "Unknown error"
+        throw new Error(errorMessage)
       }
+      return result
     }
   )
 
   // Class handlers
-  ipcMain.handle("fetch-classes", async () => {
-    try {
-      return await fetchClasses()
-    } catch (err) {
-      console.error("Error fetching classes:", err)
-      throw err
-    }
+  registerHandler("fetch-classes", async () => {
+    return await fetchClasses()
   })
 
-  ipcMain.handle(
+  registerHandler(
     "create-class",
-    async (_event, classData: Prisma.ClassCreateInput) => {
-      try {
-        return await createClass(classData)
-      } catch (err) {
-        console.error("Error creating class:", err)
-        throw err
-      }
+    async (classData: Prisma.ClassCreateInput) => {
+      return await createClass(classData)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-class",
-    async (_event, classData: Prisma.ClassUpdateInput & { id: string }) => {
-      try {
-        return await updateClass(classData)
-      } catch (err) {
-        console.error("Error updating class:", err)
-        throw err
-      }
+    async (classData: Prisma.ClassUpdateInput & { id: string }) => {
+      return await updateClass(classData)
     }
   )
 
-  ipcMain.handle("delete-class", async (_event, classId: string) => {
-    try {
-      return await deleteClass(classId)
-    } catch (err) {
-      console.error("Error deleting class:", err)
-      throw err
-    }
+  registerHandler("delete-class", async (classId: string) => {
+    return await deleteClass(classId)
   })
 
   // Master image handlers
-  ipcMain.handle(
+  registerHandler(
     "upload-master-answers",
     async (
-      _event,
       examId: string,
       filesData: {
         name: string
@@ -450,262 +303,182 @@ export function setupMiscHandlers(): void {
         path?: string
       }[]
     ) => {
-      try {
-        return await uploadMasterAnswers(examId, filesData)
-      } catch (err) {
-        console.error("Error in IPC upload-master-images:", err)
-        throw err
-      }
+      return await uploadMasterAnswers(examId, filesData)
     }
   )
 
-  ipcMain.handle("delete-master-answer", async (_event, answerId: string) => {
-    try {
-      return await deleteMasterAnswer(answerId)
-    } catch (err) {
-      console.error("Error in IPC delete-master-answer:", err)
-      throw err
-    }
+  registerHandler("delete-master-answer", async (answerId: string) => {
+    return await deleteMasterAnswer(answerId)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "update-master-answers-order",
-    async (_event, answerOrders: { id: string; pageNumber: number }[]) => {
-      try {
-        return await updateMasterAnswersOrder(answerOrders)
-      } catch (err) {
-        console.error("Error in IPC update-master-answers-order:", err)
-        throw err
-      }
+    async (answerOrders: { id: string; pageNumber: number }[]) => {
+      return await updateMasterAnswersOrder(answerOrders)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-master-image-page-size",
-    async (_event, id: string, pageSize: string) => {
-      try {
-        return await updateMasterImagePageSize(id, pageSize)
-      } catch (err) {
-        console.error("Error in IPC update-master-image-page-size:", err)
-        throw err
-      }
+    async (id: string, pageSize: string) => {
+      return await updateMasterImagePageSize(id, pageSize)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "resolve-file-protocol-path",
-    async (_event, relativePath: string) => {
-      try {
-        // パスを適切にエンコード
-        // appimg:/// (スラッシュ3つ) にすることで、URLパース時にpathname全体が取得できる
-        const encodedPath = encodeURI(relativePath)
-        const result = `appimg:///${encodedPath}`
+    async (relativePath: string) => {
+      // パスを適切にエンコード
+      // appimg:/// (スラッシュ3つ) にすることで、URLパース時にpathname全体が取得できる
+      const encodedPath = encodeURI(relativePath)
+      const result = `appimg:///${encodedPath}`
 
-        return result
-      } catch (err) {
-        console.error("Error in IPC resolve-file-protocol-path:", err)
-        throw err
-      }
+      return result
     }
   )
 
-  ipcMain.handle("read-file-as-base64", async (_event, filePath: string) => {
+  registerSafeHandler("read-file-as-base64", async (filePath: string) => {
+    const fs = await import("fs/promises")
+    const path = await import("path")
+    const { getDataDirectory } = await import("../lib/dataManager")
+
+    // 相対パスの場合はdataディレクトリからの相対パスとして解決
+    const resolvedPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.join(getDataDirectory(), filePath)
+
+    // ファイルの存在確認
     try {
-      const fs = await import("fs/promises")
-      const path = await import("path")
-      const { getDataDirectory } = await import("../lib/dataManager")
-
-      // 相対パスの場合はdataディレクトリからの相対パスとして解決
-      const resolvedPath = path.isAbsolute(filePath)
-        ? filePath
-        : path.join(getDataDirectory(), filePath)
-
-      // ファイルの存在確認
-      try {
-        await fs.access(resolvedPath)
-      } catch {
-        return {
-          success: false,
-          error: "File not found",
-        }
-      }
-
-      // ファイルを読み込んでBase64に変換
-      const buffer = await fs.readFile(resolvedPath)
-      const base64Data = buffer.toString("base64")
-
-      // MIMEタイプを推定
-      const ext = path.extname(resolvedPath).toLowerCase()
-      const mimeType =
-        ext === ".png"
-          ? "image/png"
-          : ext === ".jpg" || ext === ".jpeg"
-            ? "image/jpeg"
-            : ext === ".gif"
-              ? "image/gif"
-              : ext === ".webp"
-                ? "image/webp"
-                : "application/octet-stream"
-
-      return {
-        success: true,
-        data: `data:${mimeType};base64,${base64Data}`,
-        mimeType,
-      }
-    } catch (err) {
-      console.error("Error reading file as base64:", err)
+      await fs.access(resolvedPath)
+    } catch {
       return {
         success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
+        error: "File not found",
       }
+    }
+
+    // ファイルを読み込んでBase64に変換
+    const buffer = await fs.readFile(resolvedPath)
+    const base64Data = buffer.toString("base64")
+
+    // MIMEタイプを推定
+    const ext = path.extname(resolvedPath).toLowerCase()
+    const mimeType =
+      ext === ".png"
+        ? "image/png"
+        : ext === ".jpg" || ext === ".jpeg"
+          ? "image/jpeg"
+          : ext === ".gif"
+            ? "image/gif"
+            : ext === ".webp"
+              ? "image/webp"
+              : "application/octet-stream"
+
+    return {
+      success: true,
+      data: `data:${mimeType};base64,${base64Data}`,
+      mimeType,
     }
   })
 
-  ipcMain.handle(
-    "get-master-images-by-exam-id",
-    async (_event, examId: string) => {
-      try {
-        const masterAnswers = await getMasterAnswersByExamId(examId)
-        // Dateオブジェクトをそのまま返す
-        return masterAnswers
-      } catch (err) {
-        console.error("Error getting master images by exam ID:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("get-master-images-by-exam-id", async (examId: string) => {
+    const masterAnswers = await getMasterAnswersByExamId(examId)
+    // Dateオブジェクトをそのまま返す
+    return masterAnswers
+  })
 
   // Data management handlers
-  ipcMain.handle("get-data-directory-info", async (_event) => {
-    try {
-      const { getDataDirectory, calculateDataSize } =
-        await import("../lib/dataManager")
+  registerSafeHandler("get-data-directory-info", async () => {
+    const { getDataDirectory, calculateDataSize } =
+      await import("../lib/dataManager")
 
-      const dataDirectory = getDataDirectory()
-      const size = await calculateDataSize()
+    const dataDirectory = getDataDirectory()
+    const size = await calculateDataSize()
 
-      return {
-        success: true,
-        directory: dataDirectory,
-        size,
-      }
-    } catch (err) {
-      console.error("Error getting data directory info:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
+    return {
+      success: true,
+      directory: dataDirectory,
+      size,
     }
   })
 
-  ipcMain.handle("open-data-directory", async (_event) => {
-    try {
-      const { shell } = await import("electron")
-      const { getDataDirectory } = await import("../lib/dataManager")
+  registerSafeHandler("open-data-directory", async () => {
+    const { shell } = await import("electron")
+    const { getDataDirectory } = await import("../lib/dataManager")
 
-      const dataDirectory = getDataDirectory()
-      await shell.openPath(dataDirectory)
+    const dataDirectory = getDataDirectory()
+    await shell.openPath(dataDirectory)
 
-      return { success: true }
-    } catch (err) {
-      console.error("Error opening data directory:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
-    }
+    return { success: true }
   })
 
-  ipcMain.handle("delete-all-data", async (_event) => {
-    try {
-      const { getDataDirectory } = await import("../lib/dataManager")
-      const fs = await import("fs/promises")
+  registerSafeHandler("delete-all-data", async () => {
+    const { getDataDirectory } = await import("../lib/dataManager")
+    const fs = await import("fs/promises")
 
-      const dataDirectory = getDataDirectory()
+    const dataDirectory = getDataDirectory()
 
-      // データフォルダを完全削除
-      await fs.rm(dataDirectory, { recursive: true, force: true })
+    // データフォルダを完全削除
+    await fs.rm(dataDirectory, { recursive: true, force: true })
 
-      // データディレクトリを再作成
-      await fs.mkdir(dataDirectory, { recursive: true })
+    // データディレクトリを再作成
+    await fs.mkdir(dataDirectory, { recursive: true })
 
-      return { success: true }
-    } catch (err) {
-      console.error("Error deleting all data:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
-    }
+    return { success: true }
   })
 
   // 画像ファイル読み込みハンドラー
-  ipcMain.handle("get-image-data", async (_event, relativePath: string) => {
-    try {
-      const absolutePath = getAbsolutePathFromData(relativePath)
-      const imageBuffer = await fs.readFile(absolutePath)
-      const base64 = imageBuffer.toString("base64")
+  registerSafeHandler("get-image-data", async (relativePath: string) => {
+    const absolutePath = getAbsolutePathFromData(relativePath)
+    const imageBuffer = await fs.readFile(absolutePath)
+    const base64 = imageBuffer.toString("base64")
 
-      // MIMEタイプを推定
-      const ext = relativePath.split(".").pop()?.toLowerCase()
-      let mimeType = "image/png" // デフォルト
-      if (ext === "jpg" || ext === "jpeg") {
-        mimeType = "image/jpeg"
-      } else if (ext === "gif") {
-        mimeType = "image/gif"
-      } else if (ext === "webp") {
-        mimeType = "image/webp"
-      }
+    // MIMEタイプを推定
+    const ext = relativePath.split(".").pop()?.toLowerCase()
+    let mimeType = "image/png" // デフォルト
+    if (ext === "jpg" || ext === "jpeg") {
+      mimeType = "image/jpeg"
+    } else if (ext === "gif") {
+      mimeType = "image/gif"
+    } else if (ext === "webp") {
+      mimeType = "image/webp"
+    }
 
-      return {
-        success: true,
-        data: `data:${mimeType};base64,${base64}`,
-      }
-    } catch (err) {
-      console.error("Error reading image file:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
+    return {
+      success: true,
+      data: `data:${mimeType};base64,${base64}`,
     }
   })
 
   // ファイル存在確認ハンドラー
-  ipcMain.handle("check-file-exists", async (_event, relativePath: string) => {
+  registerSafeHandler("check-file-exists", async (relativePath: string) => {
+    const absolutePath = getAbsolutePathFromData(relativePath)
     try {
-      const absolutePath = getAbsolutePathFromData(relativePath)
       await fs.access(absolutePath)
       return { success: true, exists: true, path: absolutePath }
     } catch (err) {
       return {
         success: true,
         exists: false,
-        path: getAbsolutePathFromData(relativePath),
+        path: absolutePath,
         error: err instanceof Error ? err.message : "Unknown error",
       }
     }
   })
 
   // アセットパス解決ハンドラー
-  ipcMain.handle("get-asset-path", async (_event, assetPath: string) => {
-    try {
-      const { app } = require("electron")
-      const path = require("path")
+  registerSafeHandler("get-asset-path", async (assetPath: string) => {
+    const { app } = require("electron")
+    const path = require("path")
 
-      // パッケージ化されたアプリかどうかで分岐
-      const publicDir = app.isPackaged
-        ? path.join(app.getAppPath(), "public")
-        : path.join(process.cwd(), "public")
+    // パッケージ化されたアプリかどうかで分岐
+    const publicDir = app.isPackaged
+      ? path.join(app.getAppPath(), "public")
+      : path.join(process.cwd(), "public")
 
-      const fullPath = path.join(publicDir, assetPath)
+    const fullPath = path.join(publicDir, assetPath)
 
-      // appimg:/// プロトコルを使用してパスを返す（webSecurity有効時のローカルファイルアクセス用）
-      return { success: true, path: `appimg:///${fullPath}` }
-    } catch (err) {
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
-    }
+    // appimg:/// プロトコルを使用してパスを返す（webSecurity有効時のローカルファイルアクセス用）
+    return { success: true, path: `appimg:///${fullPath}` }
   })
 }

--- a/electron-src/ipc-handlers/omrConfigHandlers.ts
+++ b/electron-src/ipc-handlers/omrConfigHandlers.ts
@@ -2,64 +2,39 @@
  * CropRegionOmrConfig IPC ハンドラー
  */
 
-import { ipcMain } from "electron"
-
 import {
   deleteOmrConfig,
   getOmrConfigsByExamId,
   upsertOmrConfig,
   type UpsertOmrConfigData,
 } from "../lib/prisma/cropRegionOmrConfig"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupOmrConfigHandlers(): void {
-  ipcMain.handle(
+  registerSafeHandler(
     "omr-config:upsert",
-    async (_event, data: UpsertOmrConfigData) => {
-      try {
-        const config = await upsertOmrConfig(data)
-        return { success: true, config }
-      } catch (error) {
-        console.error("Error upserting OMR config:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "OMR設定の保存に失敗しました",
-        }
-      }
-    }
+    async (data: UpsertOmrConfigData) => {
+      const config = await upsertOmrConfig(data)
+      return { success: true, config }
+    },
+    "OMR設定の保存に失敗しました"
   )
 
-  ipcMain.handle("omr-config:delete", async (_event, cropRegionId: string) => {
-    try {
+  registerSafeHandler(
+    "omr-config:delete",
+    async (cropRegionId: string) => {
       await deleteOmrConfig(cropRegionId)
       return { success: true }
-    } catch (error) {
-      console.error("Error deleting OMR config:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "OMR設定の削除に失敗しました",
-      }
-    }
-  })
+    },
+    "OMR設定の削除に失敗しました"
+  )
 
-  ipcMain.handle("omr-config:get-by-exam", async (_event, examId: string) => {
-    try {
+  registerSafeHandler(
+    "omr-config:get-by-exam",
+    async (examId: string) => {
       const configs = await getOmrConfigsByExamId(examId)
       return { success: true, configs }
-    } catch (error) {
-      console.error("Error getting OMR configs:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "OMR設定の取得に失敗しました",
-      }
-    }
-  })
+    },
+    "OMR設定の取得に失敗しました"
+  )
 }

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -21,6 +21,7 @@ import {
   recognizeCells,
 } from "../lib/omr"
 import prisma from "../lib/prisma/client"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 /** マスターマーカー検出キャッシュ (キー: "examId:pageNumber") */
 const masterMarkerCache = new Map<string, MarkerDetectionResult>()
@@ -38,10 +39,9 @@ export function setupOMRHandlers(): void {
   // ────────────────────────────────────────
   // 単一画像のコーナーマーカー検出
   // ────────────────────────────────────────
-  ipcMain.handle(
+  registerHandler(
     "omr:detect-markers",
     async (
-      _event,
       imagePath: string,
       colorThreshold?: number
     ): Promise<MarkerDetectionResult> => {
@@ -51,6 +51,7 @@ export function setupOMRHandlers(): void {
 
   // ────────────────────────────────────────
   // 1枚の答案シート認識
+  // NOTE: Has custom error return format (OMRSheetResult), kept as manual ipcMain.handle
   // ────────────────────────────────────────
   ipcMain.handle(
     "omr:recognize-sheet",
@@ -127,6 +128,7 @@ export function setupOMRHandlers(): void {
           cellResults,
         }
       } catch (error) {
+        console.error("Error in IPC handler [omr:recognize-sheet]:", error)
         return {
           success: false,
           pageIndex: args.pageIndex ?? 0,
@@ -147,6 +149,7 @@ export function setupOMRHandlers(): void {
 
   // ────────────────────────────────────────
   // バッチ認識（試験全答案）
+  // NOTE: Has complex loop with progress reporting via BrowserWindow.send, kept as manual ipcMain.handle
   // ────────────────────────────────────────
   ipcMain.handle(
     "omr:batch-recognize",
@@ -278,10 +281,9 @@ export function setupOMRHandlers(): void {
   // ────────────────────────────────────────
   // マスター画像のコーナーマーカー一括検出
   // ────────────────────────────────────────
-  ipcMain.handle(
+  registerSafeHandler(
     "omr:detect-master-markers",
     async (
-      _event,
       examId: string,
       colorThreshold?: number
     ): Promise<{
@@ -289,71 +291,61 @@ export function setupOMRHandlers(): void {
       pages: Array<{ pageNumber: number; result: MarkerDetectionResult }>
       error?: string
     }> => {
-      try {
-        // マスター画像を取得
-        const masterImages = await prisma.masterImage.findMany({
-          where: {
-            examPage: { examId },
-          },
-          include: { examPage: true },
-          orderBy: { examPage: { pageNumber: "asc" } },
-        })
+      // マスター画像を取得
+      const masterImages = await prisma.masterImage.findMany({
+        where: {
+          examPage: { examId },
+        },
+        include: { examPage: true },
+        orderBy: { examPage: { pageNumber: "asc" } },
+      })
 
-        if (masterImages.length === 0) {
-          return {
-            success: false,
-            pages: [],
-            error: "マスター画像が見つかりません",
-          }
-        }
-
-        const pages: Array<{
-          pageNumber: number
-          result: MarkerDetectionResult
-        }> = []
-
-        const dataDir = getDataDirectory()
-
-        for (const mi of masterImages) {
-          const pageNumber = mi.examPage.pageNumber
-          const cacheKey = `${examId}:${pageNumber}`
-
-          // キャッシュチェック
-          const cached = masterMarkerCache.get(cacheKey)
-          if (cached) {
-            pages.push({ pageNumber, result: cached })
-            continue
-          }
-
-          // 画像パスを解決してマーカー検出
-          const imagePath = path.join(dataDir, mi.imagePath)
-          const result = await detectCornerMarkers(imagePath, colorThreshold)
-
-          // キャッシュに保存
-          masterMarkerCache.set(cacheKey, result)
-          pages.push({ pageNumber, result })
-        }
-
-        // 全ページで4マーカー検出できたか
-        const allSuccess = pages.every((p) => p.result.success)
-
-        return {
-          success: allSuccess,
-          pages,
-          error: allSuccess
-            ? undefined
-            : "一部のページでマーカーを検出できませんでした",
-        }
-      } catch (error) {
+      if (masterImages.length === 0) {
         return {
           success: false,
           pages: [],
-          error:
-            error instanceof Error
-              ? error.message
-              : "マスターマーカー検出に失敗しました",
+          error: "マスター画像が見つかりません",
         }
       }
-    }
+
+      const pages: Array<{
+        pageNumber: number
+        result: MarkerDetectionResult
+      }> = []
+
+      const dataDir = getDataDirectory()
+
+      for (const mi of masterImages) {
+        const pageNumber = mi.examPage.pageNumber
+        const cacheKey = `${examId}:${pageNumber}`
+
+        // キャッシュチェック
+        const cached = masterMarkerCache.get(cacheKey)
+        if (cached) {
+          pages.push({ pageNumber, result: cached })
+          continue
+        }
+
+        // 画像パスを解決してマーカー検出
+        const imagePath = path.join(dataDir, mi.imagePath)
+        const result = await detectCornerMarkers(imagePath, colorThreshold)
+
+        // キャッシュに保存
+        masterMarkerCache.set(cacheKey, result)
+        pages.push({ pageNumber, result })
+      }
+
+      // 全ページで4マーカー検出できたか
+      const allSuccess = pages.every((p) => p.result.success)
+
+      return {
+        success: allSuccess,
+        pages,
+        error: allSuccess
+          ? undefined
+          : "一部のページでマーカーを検出できませんでした",
+      }
+    },
+    "マスターマーカー検出に失敗しました"
   )
 }

--- a/electron-src/ipc-handlers/pdfToolsHandlers.ts
+++ b/electron-src/ipc-handlers/pdfToolsHandlers.ts
@@ -20,41 +20,36 @@ import {
 } from "../lib/pdf-tools/pdfRotator"
 import { splitPdf } from "../lib/pdf-tools/pdfSplitter"
 import { exportPagesToPng } from "../lib/pdf-tools/pdfToPng"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupPdfToolsHandlers(): void {
   // PDF結合
-  ipcMain.handle(
+  registerHandler(
     "pdf-tools:merge-pdfs",
-    async (
-      _event,
-      options: {
-        pages: MergePageInput[]
-        outputPath: string
-      }
-    ): Promise<PdfToolsResult> => {
+    async (options: {
+      pages: MergePageInput[]
+      outputPath: string
+    }): Promise<PdfToolsResult> => {
       return await mergePdfs(options.pages, options.outputPath)
     }
   )
 
   // PDF分割
-  ipcMain.handle(
+  registerHandler(
     "pdf-tools:split-pdf",
-    async (
-      _event,
-      options: {
-        filePath: string
-        outputDir: string
-        prefix?: string
-      }
-    ): Promise<PdfToolsResult> => {
+    async (options: {
+      filePath: string
+      outputDir: string
+      prefix?: string
+    }): Promise<PdfToolsResult> => {
       return await splitPdf(options.filePath, options.outputDir, options.prefix)
     }
   )
 
   // 2-in-1変換
-  ipcMain.handle(
+  registerHandler(
     "pdf-tools:apply-nup",
-    async (_event, options: NUpOptions): Promise<PdfToolsResult> => {
+    async (options: NUpOptions): Promise<PdfToolsResult> => {
       return await applyNUp(
         options.filePath,
         options.layout,
@@ -65,16 +60,13 @@ export function setupPdfToolsHandlers(): void {
   )
 
   // ページ回転
-  ipcMain.handle(
+  registerHandler(
     "pdf-tools:rotate-pages",
-    async (
-      _event,
-      options: {
-        filePath: string
-        rotations: RotatePageInput[]
-        outputPath: string
-      }
-    ): Promise<PdfToolsResult> => {
+    async (options: {
+      filePath: string
+      rotations: RotatePageInput[]
+      outputPath: string
+    }): Promise<PdfToolsResult> => {
       return await rotatePdfPages(
         options.filePath,
         options.rotations,
@@ -84,24 +76,22 @@ export function setupPdfToolsHandlers(): void {
   )
 
   // PNG書き出し
-  ipcMain.handle(
+  registerHandler(
     "pdf-tools:export-as-png",
-    async (
-      _event,
-      options: {
-        imageBuffers: {
-          buffer: Buffer
-          name: string
-          rotation?: RotationDegree
-        }[]
-        outputDir: string
-      }
-    ): Promise<PdfToolsResult> => {
+    async (options: {
+      imageBuffers: {
+        buffer: Buffer
+        name: string
+        rotation?: RotationDegree
+      }[]
+      outputDir: string
+    }): Promise<PdfToolsResult> => {
       return await exportPagesToPng(options.imageBuffers, options.outputDir)
     }
   )
 
   // ファイル選択ダイアログ（インポート用）
+  // NOTE: Uses BrowserWindow.getFocusedWindow(), kept as manual ipcMain.handle
   ipcMain.handle(
     "pdf-tools:select-files",
     async (): Promise<{
@@ -123,17 +113,16 @@ export function setupPdfToolsHandlers(): void {
 
         return { success: true, filePaths: result.filePaths }
       } catch (error) {
-        console.error("File select dialog error:", error)
+        console.error("Error in IPC handler [pdf-tools:select-files]:", error)
         return { success: false }
       }
     }
   )
 
   // PDFファイル情報を取得
-  ipcMain.handle(
+  registerSafeHandler(
     "pdf-tools:get-pdf-info",
     async (
-      _event,
       filePath: string
     ): Promise<{
       success: boolean
@@ -141,28 +130,21 @@ export function setupPdfToolsHandlers(): void {
       name?: string
       error?: string
     }> => {
-      try {
-        if (!fs.existsSync(filePath)) {
-          return { success: false, error: `File not found: ${filePath}` }
-        }
-
-        const fileBuffer = fs.readFileSync(filePath)
-        const pdfDoc = await PDFDocument.load(fileBuffer)
-        const pageCount = pdfDoc.getPageCount()
-        const name = path.basename(filePath)
-
-        return { success: true, pageCount, name }
-      } catch (error) {
-        console.error("PDF info error:", error)
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
-        }
+      if (!fs.existsSync(filePath)) {
+        return { success: false, error: `File not found: ${filePath}` }
       }
+
+      const fileBuffer = fs.readFileSync(filePath)
+      const pdfDoc = await PDFDocument.load(fileBuffer)
+      const pageCount = pdfDoc.getPageCount()
+      const name = path.basename(filePath)
+
+      return { success: true, pageCount, name }
     }
   )
 
   // 保存パス選択ダイアログ
+  // NOTE: Uses BrowserWindow.getFocusedWindow(), kept as manual ipcMain.handle
   ipcMain.handle(
     "pdf-tools:select-save-path",
     async (
@@ -200,7 +182,10 @@ export function setupPdfToolsHandlers(): void {
           return { success: true, path: result.filePaths[0] }
         }
       } catch (error) {
-        console.error("Dialog error:", error)
+        console.error(
+          "Error in IPC handler [pdf-tools:select-save-path]:",
+          error
+        )
         return {
           success: false,
           canceled: false,

--- a/electron-src/ipc-handlers/questionGroupHandlers.ts
+++ b/electron-src/ipc-handlers/questionGroupHandlers.ts
@@ -30,6 +30,7 @@ import {
   deleteSubtotalDefinitionsByCropRegionId,
   getSubtotalDefinitionsByQuestionGroupItemId,
 } from "../lib/prisma/subtotalDefinition"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupQuestionGroupHandlers(): void {
   // 既存のハンドラーをクリア（重複登録を防ぐ）
@@ -60,258 +61,124 @@ export function setupQuestionGroupHandlers(): void {
   ipcMain.removeHandler("get-subtotal-definitions-by-question-group-item-id")
 
   // QuestionGroup handlers
-  ipcMain.handle("create-question-group", async (_event, data) => {
-    try {
-      return await createQuestionGroup(data)
-    } catch (err) {
-      console.error("Error creating question group:", err)
-      throw err
-    }
+  registerHandler("create-question-group", async (data) => {
+    return await createQuestionGroup(data)
   })
 
-  ipcMain.handle("update-question-group", async (_event, id, data) => {
-    try {
-      return await updateQuestionGroup(id, data)
-    } catch (err) {
-      console.error("Error updating question group:", err)
-      throw err
-    }
+  registerHandler("update-question-group", async (id, data) => {
+    return await updateQuestionGroup(id, data)
   })
 
-  ipcMain.handle("delete-question-group", async (_event, id) => {
-    try {
-      return await deleteQuestionGroup(id)
-    } catch (err) {
-      console.error("Error deleting question group:", err)
-      throw err
-    }
+  registerHandler("delete-question-group", async (id) => {
+    return await deleteQuestionGroup(id)
   })
 
-  ipcMain.handle("get-question-groups-by-exam-id", async (_event, examId) => {
-    try {
-      return await getQuestionGroupsByExamId(examId)
-    } catch (err) {
-      console.error("Error getting question groups by exam id:", err)
-      throw err
-    }
+  registerHandler("get-question-groups-by-exam-id", async (examId) => {
+    return await getQuestionGroupsByExamId(examId)
   })
 
-  ipcMain.handle("get-question-group-by-id", async (_event, id) => {
-    try {
-      return await getQuestionGroupById(id)
-    } catch (err) {
-      console.error("Error getting question group by id:", err)
-      throw err
-    }
+  registerHandler("get-question-group-by-id", async (id) => {
+    return await getQuestionGroupById(id)
   })
 
   // QuestionGroupItem handlers
-  ipcMain.handle("create-question-group-item", async (_event, data) => {
-    try {
-      return await createQuestionGroupItem(data)
-    } catch (err) {
-      console.error("Error creating question group item:", err)
-      throw err
-    }
+  registerHandler("create-question-group-item", async (data) => {
+    return await createQuestionGroupItem(data)
   })
 
-  ipcMain.handle("create-many-question-group-items", async (_event, items) => {
-    try {
-      return await createManyQuestionGroupItems(items)
-    } catch (err) {
-      console.error("Error creating many question group items:", err)
-      throw err
-    }
+  registerHandler("create-many-question-group-items", async (items) => {
+    return await createManyQuestionGroupItems(items)
   })
 
-  ipcMain.handle("update-question-group-item", async (_event, id, data) => {
-    try {
-      return await updateQuestionGroupItem(id, data)
-    } catch (err) {
-      console.error("Error updating question group item:", err)
-      throw err
-    }
+  registerHandler("update-question-group-item", async (id, data) => {
+    return await updateQuestionGroupItem(id, data)
   })
 
-  ipcMain.handle("delete-question-group-item", async (_event, id) => {
-    try {
-      return await deleteQuestionGroupItem(id)
-    } catch (err) {
-      console.error("Error deleting question group item:", err)
-      throw err
-    }
+  registerHandler("delete-question-group-item", async (id) => {
+    return await deleteQuestionGroupItem(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "get-question-group-items-by-group-id",
-    async (_event, questionGroupId) => {
-      try {
-        return await getQuestionGroupItemsByGroupId(questionGroupId)
-      } catch (err) {
-        console.error("Error getting question group items by group id:", err)
-        throw err
-      }
+    async (questionGroupId) => {
+      return await getQuestionGroupItemsByGroupId(questionGroupId)
     }
   )
 
-  ipcMain.handle("get-question-group-item-by-id", async (_event, id) => {
-    try {
-      return await getQuestionGroupItemById(id)
-    } catch (err) {
-      console.error("Error getting question group item by id:", err)
-      throw err
-    }
+  registerHandler("get-question-group-item-by-id", async (id) => {
+    return await getQuestionGroupItemById(id)
   })
 
-  ipcMain.handle(
-    "update-question-group-item-orders",
-    async (_event, orders) => {
-      try {
-        const result = await updateQuestionGroupItemOrders(orders)
-        return result
-      } catch (err) {
-        console.error("Error updating question group item orders:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("update-question-group-item-orders", async (orders) => {
+    const result = await updateQuestionGroupItemOrders(orders)
+    return result
+  })
 
   // QuestionSubtotalAssignment handlers
-  ipcMain.handle(
-    "create-question-subtotal-assignment",
-    async (_event, data) => {
-      try {
-        return await createQuestionSubtotalAssignment(data)
-      } catch (err) {
-        console.error("Error creating question subtotal assignment:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("create-question-subtotal-assignment", async (data) => {
+    return await createQuestionSubtotalAssignment(data)
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "create-many-question-subtotal-assignments",
-    async (_event, assignments) => {
-      try {
-        return await createManyQuestionSubtotalAssignments(assignments)
-      } catch (err) {
-        console.error("Error creating many question subtotal assignments:", err)
-        throw err
-      }
+    async (assignments) => {
+      return await createManyQuestionSubtotalAssignments(assignments)
     }
   )
 
-  ipcMain.handle("delete-question-subtotal-assignment", async (_event, id) => {
-    try {
-      return await deleteQuestionSubtotalAssignment(id)
-    } catch (err) {
-      console.error("Error deleting question subtotal assignment:", err)
-      throw err
-    }
+  registerHandler("delete-question-subtotal-assignment", async (id) => {
+    return await deleteQuestionSubtotalAssignment(id)
   })
 
   // Note: delete-assignments-by-question-crop-region-id handler moved to crop-region-handlers.ts
 
-  ipcMain.handle(
+  registerHandler(
     "delete-assignments-by-question-group-item-id",
-    async (_event, questionGroupItemId) => {
-      try {
-        return await deleteAssignmentsByQuestionGroupItemId(questionGroupItemId)
-      } catch (err) {
-        console.error(
-          "Error deleting assignments by question group item id:",
-          err
-        )
-        throw err
-      }
+    async (questionGroupItemId) => {
+      return await deleteAssignmentsByQuestionGroupItemId(questionGroupItemId)
     }
   )
 
   // Note: get-assignments-by-question-crop-region-id handler moved to crop-region-handlers.ts
 
-  ipcMain.handle(
+  registerSafeHandler(
     "get-assignments-by-question-group-item-id",
-    async (_event, questionGroupItemId) => {
-      try {
-        const assignments =
-          await getAssignmentsByQuestionGroupItemId(questionGroupItemId)
-        return {
-          success: true,
-          assignments,
-        }
-      } catch (err) {
-        console.error(
-          "Error getting assignments by question group item id:",
-          err
-        )
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
+    async (questionGroupItemId) => {
+      const assignments =
+        await getAssignmentsByQuestionGroupItemId(questionGroupItemId)
+      return {
+        success: true,
+        assignments,
       }
     }
   )
 
   // SubtotalDefinition handlers
-  ipcMain.handle("create-subtotal-definition", async (_event, data) => {
-    try {
-      return await createSubtotalDefinition(data)
-    } catch (err) {
-      console.error("Error creating subtotal definition:", err)
-      throw err
-    }
+  registerHandler("create-subtotal-definition", async (data) => {
+    return await createSubtotalDefinition(data)
   })
 
-  ipcMain.handle(
-    "create-many-subtotal-definitions",
-    async (_event, definitions) => {
-      try {
-        return await createManySubtotalDefinitions(definitions)
-      } catch (err) {
-        console.error("Error creating many subtotal definitions:", err)
-        throw err
-      }
-    }
-  )
-
-  ipcMain.handle("delete-subtotal-definition", async (_event, id) => {
-    try {
-      return await deleteSubtotalDefinition(id)
-    } catch (err) {
-      console.error("Error deleting subtotal definition:", err)
-      throw err
-    }
+  registerHandler("create-many-subtotal-definitions", async (definitions) => {
+    return await createManySubtotalDefinitions(definitions)
   })
 
-  ipcMain.handle(
+  registerHandler("delete-subtotal-definition", async (id) => {
+    return await deleteSubtotalDefinition(id)
+  })
+
+  registerHandler(
     "delete-subtotal-definitions-by-crop-region-id",
-    async (_event, cropRegionId) => {
-      try {
-        return await deleteSubtotalDefinitionsByCropRegionId(cropRegionId)
-      } catch (err) {
-        console.error(
-          "Error deleting subtotal definitions by layout region id:",
-          err
-        )
-        throw err
-      }
+    async (cropRegionId) => {
+      return await deleteSubtotalDefinitionsByCropRegionId(cropRegionId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-subtotal-definitions-by-question-group-item-id",
-    async (_event, questionGroupItemId) => {
-      try {
-        return await getSubtotalDefinitionsByQuestionGroupItemId(
-          questionGroupItemId
-        )
-      } catch (err) {
-        console.error(
-          "Error getting subtotal definitions by question group item id:",
-          err
-        )
-        throw err
-      }
+    async (questionGroupItemId) => {
+      return await getSubtotalDefinitionsByQuestionGroupItemId(
+        questionGroupItemId
+      )
     }
   )
 }

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -1,5 +1,3 @@
-import { ipcMain } from "electron"
-
 import {
   type BatchScoreEntry,
   batchUpdateQuestionScores,
@@ -17,6 +15,7 @@ import {
   UpdateQuestionScoreData,
 } from "../lib/prisma/questionScore"
 import { initializeScoringRecords } from "../lib/prisma/scoringInitializer"
+import { registerHandler } from "./ipcHandlerUtils"
 
 /**
  * QuestionScoreをIPC用に変換（DecimalをnumberにDateはそのまま）
@@ -45,125 +44,88 @@ function serializeScore(score: {
 
 export function setupScoringHandlers(): void {
   // QuestionScore 関連のハンドラー
-  ipcMain.handle(
+  registerHandler(
     "get-question-scores-for-exam",
-    async (_event, examId: string, userId?: string) => {
-      try {
-        const result = await getQuestionScoresForExam(examId, userId)
+    async (examId: string, userId?: string) => {
+      const result = await getQuestionScoresForExam(examId, userId)
 
-        if (!result.success) {
-          return result
-        }
-
-        const scores = result.scores?.map(serializeScore) || []
-        return { success: true, scores }
-      } catch (err) {
-        console.error("Error getting question scores for exam:", err)
-        throw err
+      if (!result.success) {
+        return result
       }
+
+      const scores = result.scores?.map(serializeScore) || []
+      return { success: true, scores }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-question-scores-for-student",
-    async (_event, studentId: string, userId?: string) => {
-      try {
-        const result = await getQuestionScoresForStudent(studentId, userId)
+    async (studentId: string, userId?: string) => {
+      const result = await getQuestionScoresForStudent(studentId, userId)
 
-        if (!result.success) {
-          return result
-        }
-
-        const scores = result.scores?.map(serializeScore) || []
-        return { success: true, scores }
-      } catch (err) {
-        console.error("Error getting question scores for student:", err)
-        throw err
+      if (!result.success) {
+        return result
       }
+
+      const scores = result.scores?.map(serializeScore) || []
+      return { success: true, scores }
     }
   )
 
-  ipcMain.handle("get-question-score", async (_event, id: string) => {
-    try {
-      const result = await getQuestionScoreById(id)
+  registerHandler("get-question-score", async (id: string) => {
+    const result = await getQuestionScoreById(id)
+
+    if (!result.success || !result.score) {
+      return result
+    }
+
+    return { success: true, score: serializeScore(result.score) }
+  })
+
+  registerHandler(
+    "create-question-score",
+    async (data: CreateQuestionScoreData) => {
+      const result = await createQuestionScore(data)
 
       if (!result.success || !result.score) {
         return result
       }
 
       return { success: true, score: serializeScore(result.score) }
-    } catch (err) {
-      console.error("Error getting question score:", err)
-      throw err
-    }
-  })
-
-  ipcMain.handle(
-    "create-question-score",
-    async (_event, data: CreateQuestionScoreData) => {
-      try {
-        const result = await createQuestionScore(data)
-
-        if (!result.success || !result.score) {
-          return result
-        }
-
-        return { success: true, score: serializeScore(result.score) }
-      } catch (err) {
-        console.error("Error creating question score:", err)
-        throw err
-      }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-question-score",
     async (
-      _event,
       id: string,
       data: UpdateQuestionScoreData,
       expectedVersion?: number
     ) => {
-      try {
-        const result = await updateQuestionScore(id, data, expectedVersion)
+      const result = await updateQuestionScore(id, data, expectedVersion)
 
-        if (!result.success || !result.score) {
-          return result
-        }
-
-        return { success: true, score: serializeScore(result.score) }
-      } catch (err) {
-        console.error("Error updating question score:", err)
-        throw err
+      if (!result.success || !result.score) {
+        return result
       }
+
+      return { success: true, score: serializeScore(result.score) }
     }
   )
 
-  ipcMain.handle("delete-question-score", async (_event, id: string) => {
-    try {
-      return await deleteQuestionScore(id)
-    } catch (err) {
-      console.error("Error deleting question score:", err)
-      throw err
-    }
+  registerHandler("delete-question-score", async (id: string) => {
+    return await deleteQuestionScore(id)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "get-question-score-comparison",
-    async (_event, studentId: string, cropRegionId: string) => {
-      try {
-        return await getQuestionScoreComparison(studentId, cropRegionId)
-      } catch (err) {
-        console.error("Error getting question score comparison:", err)
-        throw err
-      }
+    async (studentId: string, cropRegionId: string) => {
+      return await getQuestionScoreComparison(studentId, cropRegionId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "finalize-question-score",
     async (
-      _event,
       studentId: string,
       cropRegionId: string,
       userId: string,
@@ -173,70 +135,42 @@ export function setupScoringHandlers(): void {
         comment?: string
       }
     ) => {
-      try {
-        const result = await finalizeQuestionScore(
-          studentId,
-          cropRegionId,
-          userId,
-          scoreData
-        )
+      const result = await finalizeQuestionScore(
+        studentId,
+        cropRegionId,
+        userId,
+        scoreData
+      )
 
-        if (!result.success || !("score" in result)) {
-          return result
-        }
-
-        return { success: true, score: serializeScore(result.score) }
-      } catch (err) {
-        console.error("Error finalizing question score:", err)
-        throw err
+      if (!result.success || !("score" in result)) {
+        return result
       }
+
+      return { success: true, score: serializeScore(result.score) }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-answer-sheet-progress",
-    async (_event, answerSheetId: string) => {
-      try {
-        return await getAnswerSheetProgress(answerSheetId)
-      } catch (err) {
-        console.error("Error getting answer sheet progress:", err)
-        throw err
-      }
+    async (answerSheetId: string) => {
+      return await getAnswerSheetProgress(answerSheetId)
     }
   )
 
-  ipcMain.handle("get-exam-progress", async (_event, examId: string) => {
-    try {
-      return await getExamProgress(examId)
-    } catch (err) {
-      console.error("Error getting exam progress:", err)
-      throw err
-    }
+  registerHandler("get-exam-progress", async (examId: string) => {
+    return await getExamProgress(examId)
   })
 
   // QuestionScore 一括更新（OMR自動採点結果反映）
-  ipcMain.handle(
+  registerHandler(
     "batch-update-question-scores",
-    async (_event, entries: BatchScoreEntry[]) => {
-      try {
-        return await batchUpdateQuestionScores(entries)
-      } catch (err) {
-        console.error("Error batch updating question scores:", err)
-        throw err
-      }
+    async (entries: BatchScoreEntry[]) => {
+      return await batchUpdateQuestionScores(entries)
     }
   )
 
   // Scoring initialization handler
-  ipcMain.handle(
-    "initialize-scoring-records",
-    async (_event, examId: string) => {
-      try {
-        return await initializeScoringRecords(examId)
-      } catch (err) {
-        console.error("Error initializing scoring records:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("initialize-scoring-records", async (examId: string) => {
+    return await initializeScoringRecords(examId)
+  })
 }

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -26,6 +26,7 @@ import {
   resetUserKeyboardShortcuts,
   setUserPreference,
 } from "../lib/prisma/userSettings"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 // プロジェクターモード用のpowerSaveBlocker ID
 let projectorModeBlockerId: number | null = null
@@ -35,39 +36,29 @@ export function registerSettingsHandlers() {
   // プロジェクターモード（スクリーンセーバー無効化）
   // =========================================================================
 
-  ipcMain.handle(
-    "settings:setProjectorMode",
-    async (_event, enabled: boolean) => {
-      try {
-        if (enabled) {
-          if (
-            projectorModeBlockerId !== null &&
-            powerSaveBlocker.isStarted(projectorModeBlockerId)
-          ) {
-            return { success: true, active: true }
-          }
-          projectorModeBlockerId = powerSaveBlocker.start(
-            "prevent-display-sleep"
-          )
-          return { success: true, active: true }
-        } else {
-          if (
-            projectorModeBlockerId !== null &&
-            powerSaveBlocker.isStarted(projectorModeBlockerId)
-          ) {
-            powerSaveBlocker.stop(projectorModeBlockerId)
-          }
-          projectorModeBlockerId = null
-          return { success: true, active: false }
-        }
-      } catch (error) {
-        console.error("Failed to set projector mode:", error)
-        return { success: false, error: String(error) }
+  registerSafeHandler("settings:setProjectorMode", async (enabled: boolean) => {
+    if (enabled) {
+      if (
+        projectorModeBlockerId !== null &&
+        powerSaveBlocker.isStarted(projectorModeBlockerId)
+      ) {
+        return { success: true, active: true }
       }
+      projectorModeBlockerId = powerSaveBlocker.start("prevent-display-sleep")
+      return { success: true, active: true }
+    } else {
+      if (
+        projectorModeBlockerId !== null &&
+        powerSaveBlocker.isStarted(projectorModeBlockerId)
+      ) {
+        powerSaveBlocker.stop(projectorModeBlockerId)
+      }
+      projectorModeBlockerId = null
+      return { success: true, active: false }
     }
-  )
+  })
 
-  ipcMain.handle("settings:getProjectorMode", async () => {
+  registerSafeHandler("settings:getProjectorMode", async () => {
     const active =
       projectorModeBlockerId !== null &&
       powerSaveBlocker.isStarted(projectorModeBlockerId)
@@ -76,6 +67,8 @@ export function registerSettingsHandlers() {
 
   // =========================================================================
   // フルスクリーン制御
+  // NOTE: These handlers use event.sender to get the BrowserWindow,
+  //       so they cannot use the registerHandler wrapper.
   // =========================================================================
 
   ipcMain.handle("settings:getFullScreen", async (event) => {
@@ -95,7 +88,7 @@ export function registerSettingsHandlers() {
       }
       return { success: true }
     } catch (error) {
-      console.error("Failed to set fullscreen:", error)
+      console.error("Error in IPC handler [settings:setFullScreen]:", error)
       return { success: false, error: String(error) }
     }
   })
@@ -104,42 +97,27 @@ export function registerSettingsHandlers() {
   // UserKeyboardShortcut
   // =========================================================================
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getUserKeyboardShortcuts",
-    async (_event, userId: string) => {
-      try {
-        const shortcuts = await getUserKeyboardShortcuts(userId)
-        return { success: true, shortcuts }
-      } catch (error) {
-        console.error("Failed to get keyboard shortcuts:", error)
-        return { success: false, error: String(error) }
-      }
+    async (userId: string) => {
+      const shortcuts = await getUserKeyboardShortcuts(userId)
+      return { success: true, shortcuts }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:saveUserKeyboardShortcuts",
-    async (_event, userId: string, shortcuts: Record<string, string>) => {
-      try {
-        await bulkUpsertUserKeyboardShortcuts(userId, shortcuts)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to save keyboard shortcuts:", error)
-        return { success: false, error: String(error) }
-      }
+    async (userId: string, shortcuts: Record<string, string>) => {
+      await bulkUpsertUserKeyboardShortcuts(userId, shortcuts)
+      return { success: true }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:resetUserKeyboardShortcuts",
-    async (_event, userId: string) => {
-      try {
-        await resetUserKeyboardShortcuts(userId)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to reset keyboard shortcuts:", error)
-        return { success: false, error: String(error) }
-      }
+    async (userId: string) => {
+      await resetUserKeyboardShortcuts(userId)
+      return { success: true }
     }
   )
 
@@ -147,72 +125,44 @@ export function registerSettingsHandlers() {
   // UserPreference（KV方式）
   // =========================================================================
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getUserPreference",
-    async (_event, userId: string, key: string) => {
-      try {
-        const value = await getUserPreference(userId, key)
-        return { success: true, value }
-      } catch (error) {
-        console.error(`Failed to get user preference [${key}]:`, error)
-        return { success: false, error: String(error) }
-      }
+    async (userId: string, key: string) => {
+      const value = await getUserPreference(userId, key)
+      return { success: true, value }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:setUserPreference",
-    async (_event, userId: string, key: string, value: string) => {
-      try {
-        await setUserPreference(userId, key, value)
-        return { success: true }
-      } catch (error) {
-        console.error(`Failed to set user preference [${key}]:`, error)
-        return { success: false, error: String(error) }
-      }
+    async (userId: string, key: string, value: string) => {
+      await setUserPreference(userId, key, value)
+      return { success: true }
     }
   )
 
-  ipcMain.handle(
-    "settings:getUserPreferences",
-    async (_event, userId: string) => {
-      try {
-        const preferences = await getUserPreferences(userId)
-        return { success: true, preferences }
-      } catch (error) {
-        console.error("Failed to get user preferences:", error)
-        return { success: false, error: String(error) }
-      }
-    }
-  )
+  registerSafeHandler("settings:getUserPreferences", async (userId: string) => {
+    const preferences = await getUserPreferences(userId)
+    return { success: true, preferences }
+  })
 
   // =========================================================================
   // ExamMarkingFormat
   // =========================================================================
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getExamMarkingFormats",
-    async (_event, examId: string) => {
-      try {
-        const formats = await getExamMarkingFormats(examId)
-        return { success: true, formats }
-      } catch (error) {
-        console.error("Failed to get marking formats:", error)
-        return { success: false, error: String(error) }
-      }
+    async (examId: string) => {
+      const formats = await getExamMarkingFormats(examId)
+      return { success: true, formats }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:saveExamMarkingFormats",
-    async (_event, examId: string, formats: MarkingFormatData[]) => {
-      try {
-        await bulkUpsertExamMarkingFormats(examId, formats)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to save marking formats:", error)
-        return { success: false, error: String(error) }
-      }
+    async (examId: string, formats: MarkingFormatData[]) => {
+      await bulkUpsertExamMarkingFormats(examId, formats)
+      return { success: true }
     }
   )
 
@@ -220,29 +170,19 @@ export function registerSettingsHandlers() {
   // ExamExportSettings
   // =========================================================================
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getExamExportSettings",
-    async (_event, examId: string) => {
-      try {
-        const settings = await getExamExportSettings(examId)
-        return { success: true, settings }
-      } catch (error) {
-        console.error("Failed to get export settings:", error)
-        return { success: false, error: String(error) }
-      }
+    async (examId: string) => {
+      const settings = await getExamExportSettings(examId)
+      return { success: true, settings }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:saveExamExportSettings",
-    async (_event, examId: string, settings: Record<string, unknown>) => {
-      try {
-        await upsertExamExportSettings(examId, settings)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to save export settings:", error)
-        return { success: false, error: String(error) }
-      }
+    async (examId: string, settings: Record<string, unknown>) => {
+      await upsertExamExportSettings(examId, settings)
+      return { success: true }
     }
   )
 
@@ -250,55 +190,35 @@ export function registerSettingsHandlers() {
   // CropRegionMarkingOverride (機能H)
   // =========================================================================
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getCropRegionMarkingOverrides",
-    async (_event, cropRegionId: string) => {
-      try {
-        const overrides = await getCropRegionMarkingOverrides(cropRegionId)
-        return { success: true, overrides }
-      } catch (error) {
-        console.error("Failed to get marking overrides:", error)
-        return { success: false, error: String(error) }
-      }
+    async (cropRegionId: string) => {
+      const overrides = await getCropRegionMarkingOverrides(cropRegionId)
+      return { success: true, overrides }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:saveCropRegionMarkingOverrides",
-    async (_event, cropRegionId: string, overrides: MarkingOverrideData[]) => {
-      try {
-        await bulkUpsertCropRegionMarkingOverrides(cropRegionId, overrides)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to save marking overrides:", error)
-        return { success: false, error: String(error) }
-      }
+    async (cropRegionId: string, overrides: MarkingOverrideData[]) => {
+      await bulkUpsertCropRegionMarkingOverrides(cropRegionId, overrides)
+      return { success: true }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:resetCropRegionMarkingOverrides",
-    async (_event, cropRegionId: string) => {
-      try {
-        await resetCropRegionMarkingOverrides(cropRegionId)
-        return { success: true }
-      } catch (error) {
-        console.error("Failed to reset marking overrides:", error)
-        return { success: false, error: String(error) }
-      }
+    async (cropRegionId: string) => {
+      await resetCropRegionMarkingOverrides(cropRegionId)
+      return { success: true }
     }
   )
 
-  ipcMain.handle(
+  registerSafeHandler(
     "settings:getExamCropRegionMarkingOverrides",
-    async (_event, examId: string) => {
-      try {
-        const overrides = await getExamCropRegionMarkingOverrides(examId)
-        return { success: true, overrides }
-      } catch (error) {
-        console.error("Failed to get exam marking overrides:", error)
-        return { success: false, error: String(error) }
-      }
+    async (examId: string) => {
+      const overrides = await getExamCropRegionMarkingOverrides(examId)
+      return { success: true, overrides }
     }
   )
 }

--- a/electron-src/ipc-handlers/studentArchiveHandlers.ts
+++ b/electron-src/ipc-handlers/studentArchiveHandlers.ts
@@ -17,33 +17,25 @@ import {
   extractStudentArchive,
   performStudentPreMatching,
 } from "../lib/import/student-archive"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 /**
  * 生徒アーカイブ関連のIPCハンドラーを登録
  */
 export function registerStudentArchiveHandlers(): void {
   // エクスポート
-  ipcMain.handle(
+  registerSafeHandler(
     "studentArchive:exportStudents",
-    async (_event, options: ExportStudentsArchiveOptions) => {
-      try {
-        return await exportStudentsArchive(options)
-      } catch (error) {
-        console.error("Error in studentArchive:exportStudents:", error)
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "エクスポートに失敗しました",
-        }
-      }
-    }
+    async (options: ExportStudentsArchiveOptions) => {
+      return await exportStudentsArchive(options)
+    },
+    "エクスポートに失敗しました"
   )
 
   // インポートファイル選択ダイアログ
-  ipcMain.handle("studentArchive:selectImportFile", async () => {
-    try {
+  registerSafeHandler(
+    "studentArchive:selectImportFile",
+    async () => {
       const result = await dialog.showOpenDialog({
         title: "生徒データをインポート",
         filters: [
@@ -58,19 +50,12 @@ export function registerStudentArchiveHandlers(): void {
       }
 
       return { success: true, filePath: result.filePaths[0] }
-    } catch (error) {
-      console.error("Error in studentArchive:selectImportFile:", error)
-      return {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "ダイアログ表示に失敗しました",
-      }
-    }
-  })
+    },
+    "ダイアログ表示に失敗しました"
+  )
 
   // アーカイブ解析（マニフェスト読み取り）
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "studentArchive:analyzeArchive",
     async (_event, options: { archivePath: string }) => {
@@ -83,7 +68,10 @@ export function registerStudentArchiveHandlers(): void {
         tempDir = extractResult.data.tempDir
         return { success: true, manifest: extractResult.data.manifest }
       } catch (error) {
-        console.error("Error in studentArchive:analyzeArchive:", error)
+        console.error(
+          "Error in IPC handler [studentArchive:analyzeArchive]:",
+          error
+        )
         return {
           success: false,
           error:
@@ -98,6 +86,7 @@ export function registerStudentArchiveHandlers(): void {
   )
 
   // 事前照合
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "studentArchive:preMatch",
     async (_event, options: { archivePath: string }) => {
@@ -115,7 +104,7 @@ export function registerStudentArchiveHandlers(): void {
 
         return { success: true, data: fileOverviewData }
       } catch (error) {
-        console.error("Error in studentArchive:preMatch:", error)
+        console.error("Error in IPC handler [studentArchive:preMatch]:", error)
         return {
           success: false,
           error:
@@ -128,6 +117,7 @@ export function registerStudentArchiveHandlers(): void {
   )
 
   // インポート実行
+  // NOTE: Uses finally block for tempDir cleanup, kept as manual ipcMain.handle
   ipcMain.handle(
     "studentArchive:import",
     async (
@@ -156,7 +146,7 @@ export function registerStudentArchiveHandlers(): void {
 
         return result
       } catch (error) {
-        console.error("Error in studentArchive:import:", error)
+        console.error("Error in IPC handler [studentArchive:import]:", error)
         return {
           success: false,
           error:

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client"
-import { dialog, ipcMain } from "electron"
+import { dialog } from "electron"
 import * as ExcelJS from "exceljs"
 
 import {
@@ -34,455 +34,314 @@ import {
   applyCellStyle,
   autoFitColumns,
 } from "../lib/shared/utilities/excelUtilities"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupStudentHandlers(): void {
-  ipcMain.handle("fetch-students", async () => {
-    try {
-      return await fetchStudents()
-    } catch (err) {
-      console.error("Error fetching students:", err)
-      throw err
-    }
+  registerHandler("fetch-students", async () => {
+    return await fetchStudents()
   })
 
-  ipcMain.handle(
+  registerHandler(
     "create-student",
-    async (_event, studentData: Prisma.StudentCreateInput) => {
-      try {
-        return await createStudent(studentData)
-      } catch (err) {
-        console.error("Error creating student:", err)
-        throw err
-      }
+    async (studentData: Prisma.StudentCreateInput) => {
+      return await createStudent(studentData)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-student",
-    async (_event, id: string, studentData: Prisma.StudentUpdateInput) => {
-      try {
-        return await updateStudent(id, studentData)
-      } catch (err) {
-        console.error("Error updating student:", err)
-        throw err
-      }
+    async (id: string, studentData: Prisma.StudentUpdateInput) => {
+      return await updateStudent(id, studentData)
     }
   )
 
-  ipcMain.handle("delete-student", async (_event, id: string) => {
-    try {
-      return await deleteStudent(id)
-    } catch (err) {
-      console.error("Error deleting student:", err)
-      throw err
-    }
+  registerHandler("delete-student", async (id: string) => {
+    return await deleteStudent(id)
   })
 
   // Student Class Membership handlers
-  ipcMain.handle(
+  registerHandler(
     "create-student-class-membership",
-    async (
-      _event,
-      membershipData: Prisma.StudentClassMembershipCreateInput
-    ) => {
-      try {
-        return await createStudentClassMembership(membershipData)
-      } catch (err) {
-        console.error("Error creating student class membership:", err)
-        throw err
-      }
+    async (membershipData: Prisma.StudentClassMembershipCreateInput) => {
+      return await createStudentClassMembership(membershipData)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-student-class-membership",
     async (
-      _event,
       id: string,
       membershipData: Prisma.StudentClassMembershipUpdateInput
     ) => {
-      try {
-        return await updateStudentClassMembership(id, membershipData)
-      } catch (err) {
-        console.error("Error updating student class membership:", err)
-        throw err
-      }
+      return await updateStudentClassMembership(id, membershipData)
     }
   )
 
-  ipcMain.handle(
-    "delete-student-class-membership",
-    async (_event, id: string) => {
-      try {
-        return await deleteStudentClassMembership(id)
-      } catch (err) {
-        console.error("Error deleting student class membership:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("delete-student-class-membership", async (id: string) => {
+    return await deleteStudentClassMembership(id)
+  })
 
-  ipcMain.handle(
+  registerHandler(
     "get-current-memberships-by-student-id",
-    async (_event, studentId: string) => {
-      try {
-        return await getCurrentMembershipsByStudentId(studentId)
-      } catch (err) {
-        console.error("Error getting current memberships by student ID:", err)
-        throw err
-      }
+    async (studentId: string) => {
+      return await getCurrentMembershipsByStudentId(studentId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-all-memberships-by-student-id",
-    async (_event, studentId: string) => {
-      try {
-        return await getAllMembershipsByStudentId(studentId)
-      } catch (err) {
-        console.error("Error getting all memberships by student ID:", err)
-        throw err
-      }
+    async (studentId: string) => {
+      return await getAllMembershipsByStudentId(studentId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-current-memberships-by-class-id",
-    async (_event, classId: string) => {
-      try {
-        return await getCurrentMembershipsByClassId(classId)
-      } catch (err) {
-        console.error("Error getting current memberships by class ID:", err)
-        throw err
-      }
+    async (classId: string) => {
+      return await getCurrentMembershipsByClassId(classId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "add-student-to-class",
     async (
-      _event,
       studentId: string,
       classId: string,
       startDate?: Date,
       attendanceNumber?: number,
       notes?: string
     ) => {
-      try {
-        const dateToUse = startDate ? new Date(startDate) : new Date()
+      const dateToUse = startDate ? new Date(startDate) : new Date()
 
-        const result = await addStudentToClass(
-          studentId,
-          classId,
-          dateToUse,
-          attendanceNumber,
-          notes
-        )
-        return result
-      } catch (err) {
-        console.error("Error adding student to class:", err)
-        throw err
-      }
+      const result = await addStudentToClass(
+        studentId,
+        classId,
+        dateToUse,
+        attendanceNumber,
+        notes
+      )
+      return result
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "end-student-membership",
-    async (_event, membershipId: string, endDate?: Date) => {
-      try {
-        return await endStudentMembership(membershipId, endDate)
-      } catch (err) {
-        console.error("Error ending student membership:", err)
-        throw err
-      }
+    async (membershipId: string, endDate?: Date) => {
+      return await endStudentMembership(membershipId, endDate)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "get-memberships-by-date-range",
-    async (_event, startDate: Date, endDate?: Date) => {
-      try {
-        return await getMembershipsByDateRange(startDate, endDate)
-      } catch (err) {
-        console.error("Error getting memberships by date range:", err)
-        throw err
-      }
+    async (startDate: Date, endDate?: Date) => {
+      return await getMembershipsByDateRange(startDate, endDate)
     }
   )
 
   // Exam-Student relationship handlers
-  ipcMain.handle("get-students-for-exam", async (_event, examId: string) => {
-    try {
-      return await getStudentsForExam(examId)
-    } catch (err) {
-      console.error("Error getting students for exam:", err)
-      throw err
-    }
+  registerHandler("get-students-for-exam", async (examId: string) => {
+    return await getStudentsForExam(examId)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "add-students-to-exam",
-    async (_event, examId: string, studentIds: string[]) => {
-      try {
-        return await addStudentsToExam(examId, studentIds)
-      } catch (err) {
-        console.error("Error adding students to exam:", err)
-        throw err
-      }
+    async (examId: string, studentIds: string[]) => {
+      return await addStudentsToExam(examId, studentIds)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "remove-students-from-exam",
-    async (_event, examId: string, studentIds: string[]) => {
-      try {
-        return await removeStudentsFromExam(examId, studentIds)
-      } catch (err) {
-        console.error("Error removing students from exam:", err)
-        throw err
-      }
+    async (examId: string, studentIds: string[]) => {
+      return await removeStudentsFromExam(examId, studentIds)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-student-exam-status",
     async (
-      _event,
       examId: string,
       studentId: string,
       status: "participating" | "expected" | "absent"
     ) => {
-      try {
-        return await updateStudentExamStatus(examId, studentId, status)
-      } catch (err) {
-        console.error("Error updating student exam status:", err)
-        throw err
-      }
+      return await updateStudentExamStatus(examId, studentId, status)
     }
   )
 
-  ipcMain.handle("get-classes-not-in-exam", async (_event, examId: string) => {
-    try {
-      return await getClassesNotInExam(examId)
-    } catch (err) {
-      console.error("Error getting classes not in exam:", err)
-      throw err
-    }
+  registerHandler("get-classes-not-in-exam", async (examId: string) => {
+    return await getClassesNotInExam(examId)
   })
 
-  ipcMain.handle("get-students-not-in-exam", async (_event, examId: string) => {
-    try {
-      return await getStudentsNotInExam(examId)
-    } catch (err) {
-      console.error("Error getting students not in exam:", err)
-      throw err
-    }
+  registerHandler("get-students-not-in-exam", async (examId: string) => {
+    return await getStudentsNotInExam(examId)
   })
 
-  ipcMain.handle(
+  registerSafeHandler(
     "check-grading-data-for-students",
-    async (_event, examId: string, studentIds: string[]) => {
-      try {
-        const result = await checkGradingDataForStudents(examId, studentIds)
-        return { success: true, ...result }
-      } catch (err) {
-        console.error("Error checking grading data for students:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+    async (examId: string, studentIds: string[]) => {
+      const result = await checkGradingDataForStudents(examId, studentIds)
+      return { success: true, ...result }
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "update-student-orders",
     async (
-      _event,
       examId: string,
       studentOrders: { studentId: string; customOrder: number }[]
     ) => {
-      try {
-        return await updateStudentOrders(examId, studentOrders)
-      } catch (err) {
-        console.error("Error updating student orders:", err)
-        throw err
-      }
+      return await updateStudentOrders(examId, studentOrders)
     }
   )
 
-  ipcMain.handle(
-    "get-student-exam-results",
-    async (_event, studentId: string) => {
-      try {
-        return await getStudentExamResults(studentId)
-      } catch (err) {
-        console.error("Error getting student exam results:", err)
-        throw err
-      }
-    }
-  )
+  registerHandler("get-student-exam-results", async (studentId: string) => {
+    return await getStudentExamResults(studentId)
+  })
 
   // 生徒データExcelエクスポート（選択された生徒のみ）
-  ipcMain.handle(
+  registerSafeHandler(
     "export-students-excel",
-    async (_event, selectedStudentIds: string[]) => {
-      try {
-        const allStudents = await fetchStudents()
-        const selectedSet = new Set(selectedStudentIds)
-        const students = allStudents.filter((s) => selectedSet.has(s.id))
+    async (selectedStudentIds: string[]) => {
+      const allStudents = await fetchStudents()
+      const selectedSet = new Set(selectedStudentIds)
+      const students = allStudents.filter((s) => selectedSet.has(s.id))
 
-        if (students.length === 0) {
-          return { success: false, error: "出力する生徒が選択されていません" }
-        }
+      if (students.length === 0) {
+        return { success: false, error: "出力する生徒が選択されていません" }
+      }
 
-        const dateStr = new Date().toISOString().slice(0, 10)
-        const result = await dialog.showSaveDialog({
-          title: "生徒一覧のExcel出力先を選択",
-          defaultPath: `生徒一覧_${dateStr}.xlsx`,
-          filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
-        })
+      const dateStr = new Date().toISOString().slice(0, 10)
+      const result = await dialog.showSaveDialog({
+        title: "生徒一覧のExcel出力先を選択",
+        defaultPath: `生徒一覧_${dateStr}.xlsx`,
+        filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
+      })
 
-        if (result.canceled || !result.filePath) {
-          return { success: false, error: "出力がキャンセルされました" }
-        }
+      if (result.canceled || !result.filePath) {
+        return { success: false, error: "出力がキャンセルされました" }
+      }
 
-        const workbook = new ExcelJS.Workbook()
-        const worksheet = workbook.addWorksheet("生徒一覧")
+      const workbook = new ExcelJS.Workbook()
+      const worksheet = workbook.addWorksheet("生徒一覧")
 
-        // ヘッダー行（インポートと同じカラム・順序）
+      // ヘッダー行（インポートと同じカラム・順序）
+      const headerRow = worksheet.addRow([
+        "学籍番号",
+        "姓",
+        "名",
+        "姓カナ",
+        "名カナ",
+        "入学年度",
+      ])
+      headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
+
+      // データ行（学籍番号順）
+      const sorted = [...students].sort((a, b) =>
+        a.studentNumber.localeCompare(b.studentNumber, "ja")
+      )
+
+      for (const student of sorted) {
+        const row = worksheet.addRow([
+          student.studentNumber,
+          student.lastName,
+          student.firstName,
+          student.lastNameKana,
+          student.firstNameKana,
+          student.enrollmentYear ?? "",
+        ])
+        row.eachCell((cell) => applyCellStyle(cell, "data"))
+      }
+
+      autoFitColumns(worksheet)
+      await workbook.xlsx.writeFile(result.filePath)
+
+      return { success: true, outputPath: result.filePath }
+    },
+    "不明なエラーが発生しました"
+  )
+
+  // 学級データExcelエクスポート（選択された学級の所属データ）
+  registerSafeHandler(
+    "export-classes-excel",
+    async (selectedClassIds: string[]) => {
+      const { fetchClasses } = await import("../lib/prisma/student")
+      const allClasses = await fetchClasses()
+      const selectedSet = new Set(selectedClassIds)
+      const classes = allClasses.filter((c) => selectedSet.has(c.id))
+
+      if (classes.length === 0) {
+        return { success: false, error: "出力する学級が選択されていません" }
+      }
+
+      const dateStr = new Date().toISOString().slice(0, 10)
+      const result = await dialog.showSaveDialog({
+        title: "学級データのExcel出力先を選択",
+        defaultPath: `学級データ_${dateStr}.xlsx`,
+        filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
+      })
+
+      if (result.canceled || !result.filePath) {
+        return { success: false, error: "出力がキャンセルされました" }
+      }
+
+      // 全生徒を取得（学籍番号逆引き用）
+      const allStudents = await fetchStudents()
+      const studentMap = new Map(allStudents.map((s) => [s.id, s]))
+
+      const workbook = new ExcelJS.Workbook()
+
+      // 学級ごとにシートを作成
+      for (const cls of classes) {
+        const sheetName = cls.name.replace(/[\\/:*?"<>|]/g, "_").slice(0, 31)
+        const worksheet = workbook.addWorksheet(sheetName)
+
+        // ヘッダー行（学級インポートと同じカラム・順序）
         const headerRow = worksheet.addRow([
           "学籍番号",
-          "姓",
-          "名",
-          "姓カナ",
-          "名カナ",
-          "入学年度",
+          "出席番号",
+          "開始日",
+          "終了日",
         ])
         headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
 
-        // データ行（学籍番号順）
-        const sorted = [...students].sort((a, b) =>
-          a.studentNumber.localeCompare(b.studentNumber, "ja")
-        )
+        // 所属データ（出席番号順）
+        const sortedMemberships = [...cls.memberships].sort((a, b) => {
+          const aNum = a.attendanceNumber ?? Infinity
+          const bNum = b.attendanceNumber ?? Infinity
+          return aNum - bNum
+        })
 
-        for (const student of sorted) {
+        for (const m of sortedMemberships) {
+          const student = studentMap.get(m.student.id)
+          const studentNumber = student?.studentNumber ?? m.student.id
           const row = worksheet.addRow([
-            student.studentNumber,
-            student.lastName,
-            student.firstName,
-            student.lastNameKana,
-            student.firstNameKana,
-            student.enrollmentYear ?? "",
+            studentNumber,
+            m.attendanceNumber ?? "",
+            m.startDate
+              ? new Date(m.startDate).toLocaleDateString("ja-JP", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                })
+              : "",
+            m.endDate
+              ? new Date(m.endDate).toLocaleDateString("ja-JP", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                })
+              : "",
           ])
           row.eachCell((cell) => applyCellStyle(cell, "data"))
         }
 
         autoFitColumns(worksheet)
-        await workbook.xlsx.writeFile(result.filePath)
-
-        return { success: true, outputPath: result.filePath }
-      } catch (err) {
-        console.error("Error exporting students Excel:", err)
-        return {
-          success: false,
-          error:
-            err instanceof Error ? err.message : "不明なエラーが発生しました",
-        }
       }
-    }
-  )
 
-  // 学級データExcelエクスポート（選択された学級の所属データ）
-  ipcMain.handle(
-    "export-classes-excel",
-    async (_event, selectedClassIds: string[]) => {
-      try {
-        const { fetchClasses } = await import("../lib/prisma/student")
-        const allClasses = await fetchClasses()
-        const selectedSet = new Set(selectedClassIds)
-        const classes = allClasses.filter((c) => selectedSet.has(c.id))
+      await workbook.xlsx.writeFile(result.filePath)
 
-        if (classes.length === 0) {
-          return { success: false, error: "出力する学級が選択されていません" }
-        }
-
-        const dateStr = new Date().toISOString().slice(0, 10)
-        const result = await dialog.showSaveDialog({
-          title: "学級データのExcel出力先を選択",
-          defaultPath: `学級データ_${dateStr}.xlsx`,
-          filters: [{ name: "Excelファイル", extensions: ["xlsx"] }],
-        })
-
-        if (result.canceled || !result.filePath) {
-          return { success: false, error: "出力がキャンセルされました" }
-        }
-
-        // 全生徒を取得（学籍番号逆引き用）
-        const allStudents = await fetchStudents()
-        const studentMap = new Map(allStudents.map((s) => [s.id, s]))
-
-        const workbook = new ExcelJS.Workbook()
-
-        // 学級ごとにシートを作成
-        for (const cls of classes) {
-          const sheetName = cls.name.replace(/[\\/:*?"<>|]/g, "_").slice(0, 31)
-          const worksheet = workbook.addWorksheet(sheetName)
-
-          // ヘッダー行（学級インポートと同じカラム・順序）
-          const headerRow = worksheet.addRow([
-            "学籍番号",
-            "出席番号",
-            "開始日",
-            "終了日",
-          ])
-          headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
-
-          // 所属データ（出席番号順）
-          const sortedMemberships = [...cls.memberships].sort((a, b) => {
-            const aNum = a.attendanceNumber ?? Infinity
-            const bNum = b.attendanceNumber ?? Infinity
-            return aNum - bNum
-          })
-
-          for (const m of sortedMemberships) {
-            const student = studentMap.get(m.student.id)
-            const studentNumber = student?.studentNumber ?? m.student.id
-            const row = worksheet.addRow([
-              studentNumber,
-              m.attendanceNumber ?? "",
-              m.startDate
-                ? new Date(m.startDate).toLocaleDateString("ja-JP", {
-                    year: "numeric",
-                    month: "numeric",
-                    day: "numeric",
-                  })
-                : "",
-              m.endDate
-                ? new Date(m.endDate).toLocaleDateString("ja-JP", {
-                    year: "numeric",
-                    month: "numeric",
-                    day: "numeric",
-                  })
-                : "",
-            ])
-            row.eachCell((cell) => applyCellStyle(cell, "data"))
-          }
-
-          autoFitColumns(worksheet)
-        }
-
-        await workbook.xlsx.writeFile(result.filePath)
-
-        return { success: true, outputPath: result.filePath }
-      } catch (err) {
-        console.error("Error exporting classes Excel:", err)
-        return {
-          success: false,
-          error:
-            err instanceof Error ? err.message : "不明なエラーが発生しました",
-        }
-      }
-    }
+      return { success: true, outputPath: result.filePath }
+    },
+    "不明なエラーが発生しました"
   )
 }

--- a/electron-src/ipc-handlers/subjectHandlers.ts
+++ b/electron-src/ipc-handlers/subjectHandlers.ts
@@ -2,8 +2,6 @@
  * Subject/SubjectSubtotalGroup IPC ハンドラー
  */
 
-import { ipcMain } from "electron"
-
 import {
   createSubject,
   deleteSubject,
@@ -16,48 +14,49 @@ import {
   deleteSubjectSubtotalGroup,
   getSubjectSubtotalGroups,
 } from "../lib/prisma/subjectSubtotalGroup"
+import { registerHandler } from "./ipcHandlerUtils"
 
 export function setupSubjectHandlers(): void {
   // Subject CRUD
-  ipcMain.handle("subject:getAll", async () => {
+  registerHandler("subject:getAll", async () => {
     return getAllSubjects()
   })
 
-  ipcMain.handle("subject:getById", async (_event, id: string) => {
+  registerHandler("subject:getById", async (id: string) => {
     return getSubjectById(id)
   })
 
-  ipcMain.handle("subject:create", async (_event, data: { name: string }) => {
+  registerHandler("subject:create", async (data: { name: string }) => {
     return createSubject(data)
   })
 
-  ipcMain.handle(
+  registerHandler(
     "subject:update",
-    async (_event, id: string, data: { name: string }) => {
+    async (id: string, data: { name: string }) => {
       return updateSubject(id, data)
     }
   )
 
-  ipcMain.handle("subject:delete", async (_event, id: string) => {
+  registerHandler("subject:delete", async (id: string) => {
     return deleteSubject(id)
   })
 
   // SubjectSubtotalGroup CRUD
-  ipcMain.handle(
+  registerHandler(
     "subjectSubtotalGroup:getBySubjectId",
-    async (_event, subjectId: string) => {
+    async (subjectId: string) => {
       return getSubjectSubtotalGroups(subjectId)
     }
   )
 
-  ipcMain.handle(
+  registerHandler(
     "subjectSubtotalGroup:create",
-    async (_event, data: { subjectId: string; subtotalGroupId: string }) => {
+    async (data: { subjectId: string; subtotalGroupId: string }) => {
       return createSubjectSubtotalGroup(data)
     }
   )
 
-  ipcMain.handle("subjectSubtotalGroup:delete", async (_event, id: string) => {
+  registerHandler("subjectSubtotalGroup:delete", async (id: string) => {
     return deleteSubjectSubtotalGroup(id)
   })
 }

--- a/electron-src/ipc-handlers/subtotalGroupHandlers.ts
+++ b/electron-src/ipc-handlers/subtotalGroupHandlers.ts
@@ -1,5 +1,3 @@
-import { ipcMain } from "electron"
-
 import {
   addSubtotalGroupToExam,
   createSubtotalGroup,
@@ -10,51 +8,32 @@ import {
   removeSubtotalGroupFromExam,
   updateSubtotalGroup,
 } from "../lib/prisma/subtotalGroup"
+import { registerSafeHandler } from "./ipcHandlerUtils"
 
 export function setupSubtotalGroupHandlers(): void {
   // 小計点グループ一覧取得
-  ipcMain.handle("get-subtotal-groups", async () => {
-    try {
-      return await getSubtotalGroups()
-    } catch (err) {
-      console.error("Error getting subtotal groups:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
-    }
+  registerSafeHandler("get-subtotal-groups", async () => {
+    return await getSubtotalGroups()
   })
 
   // 小計点グループ作成
-  ipcMain.handle(
+  registerSafeHandler(
     "create-subtotal-group",
-    async (
-      _event,
-      data: {
+    async (data: {
+      name: string
+      subtotals: {
         name: string
-        subtotals: {
-          name: string
-          order: number
-        }[]
-      }
-    ) => {
-      try {
-        return await createSubtotalGroup(data)
-      } catch (err) {
-        console.error("Error creating subtotal group:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+        order: number
+      }[]
+    }) => {
+      return await createSubtotalGroup(data)
     }
   )
 
   // 小計点グループ更新
-  ipcMain.handle(
+  registerSafeHandler(
     "update-subtotal-group",
     async (
-      _event,
       id: string,
       data: {
         name: string
@@ -64,92 +43,44 @@ export function setupSubtotalGroupHandlers(): void {
         }[]
       }
     ) => {
-      try {
-        return await updateSubtotalGroup(id, data)
-      } catch (err) {
-        console.error("Error updating subtotal group:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+      return await updateSubtotalGroup(id, data)
     }
   )
 
   // 小計点グループ削除
-  ipcMain.handle("delete-subtotal-group", async (_event, id: string) => {
-    try {
-      return await deleteSubtotalGroup(id)
-    } catch (err) {
-      console.error("Error deleting subtotal group:", err)
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      }
-    }
+  registerSafeHandler("delete-subtotal-group", async (id: string) => {
+    return await deleteSubtotalGroup(id)
   })
 
   // 試験で利用可能な小計点グループ取得
-  ipcMain.handle(
+  registerSafeHandler(
     "get-available-subtotal-groups-for-exam",
-    async (_event, examId: string) => {
-      try {
-        return await getAvailableSubtotalGroupsForExam(examId)
-      } catch (err) {
-        console.error("Error getting available subtotal groups for exam:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+    async (examId: string) => {
+      return await getAvailableSubtotalGroupsForExam(examId)
     }
   )
 
   // 試験で有効化されている小計点グループ取得
-  ipcMain.handle(
+  registerSafeHandler(
     "get-active-subtotal-groups-for-exam",
-    async (_event, examId: string) => {
-      try {
-        return await getActiveSubtotalGroupsForExam(examId)
-      } catch (err) {
-        console.error("Error getting active subtotal groups for exam:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+    async (examId: string) => {
+      return await getActiveSubtotalGroupsForExam(examId)
     }
   )
 
   // 試験に小計点グループを追加
-  ipcMain.handle(
+  registerSafeHandler(
     "add-subtotal-group-to-exam",
-    async (_event, examId: string, subtotalGroupId: string) => {
-      try {
-        return await addSubtotalGroupToExam(examId, subtotalGroupId)
-      } catch (err) {
-        console.error("Error adding subtotal group to exam:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+    async (examId: string, subtotalGroupId: string) => {
+      return await addSubtotalGroupToExam(examId, subtotalGroupId)
     }
   )
 
   // 試験から小計点グループを削除
-  ipcMain.handle(
+  registerSafeHandler(
     "remove-subtotal-group-from-exam",
-    async (_event, examId: string, subtotalGroupId: string) => {
-      try {
-        return await removeSubtotalGroupFromExam(examId, subtotalGroupId)
-      } catch (err) {
-        console.error("Error removing subtotal group from exam:", err)
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : "Unknown error",
-        }
-      }
+    async (examId: string, subtotalGroupId: string) => {
+      return await removeSubtotalGroupFromExam(examId, subtotalGroupId)
     }
   )
 }

--- a/electron-src/ipc-handlers/userExamHandlers.ts
+++ b/electron-src/ipc-handlers/userExamHandlers.ts
@@ -1,5 +1,3 @@
-import { ipcMain } from "electron"
-
 import {
   getExamMembers,
   getExamOwner,
@@ -15,144 +13,79 @@ import {
   SetOwnerOptions,
   transferOwnership,
 } from "../lib/prisma/userExam"
+import { registerHandler } from "./ipcHandlerUtils"
 
 export function setupUserExamHandlers(): void {
   // Get all members of a exam
-  ipcMain.handle("user-exam:get-members", async (_event, examId: string) => {
-    try {
-      return await getExamMembers(examId)
-    } catch (error) {
-      console.error("IPC user-exam:get-members error:", error)
-      throw error
-    }
+  registerHandler("user-exam:get-members", async (examId: string) => {
+    return await getExamMembers(examId)
   })
 
   // Get user's role in a exam
-  ipcMain.handle(
+  registerHandler(
     "user-exam:get-role",
-    async (_event, userId: string, examId: string) => {
-      try {
-        return await getUserRoleInExam(userId, examId)
-      } catch (error) {
-        console.error("IPC user-exam:get-role error:", error)
-        throw error
-      }
+    async (userId: string, examId: string) => {
+      return await getUserRoleInExam(userId, examId)
     }
   )
 
   // Check if user is exam owner
-  ipcMain.handle(
+  registerHandler(
     "user-exam:is-owner",
-    async (_event, userId: string, examId: string) => {
-      try {
-        return await isExamOwner(userId, examId)
-      } catch (error) {
-        console.error("IPC user-exam:is-owner error:", error)
-        throw error
-      }
+    async (userId: string, examId: string) => {
+      return await isExamOwner(userId, examId)
     }
   )
 
   // Check if user is exam member
-  ipcMain.handle(
+  registerHandler(
     "user-exam:is-member",
-    async (_event, userId: string, examId: string) => {
-      try {
-        return await isExamMember(userId, examId)
-      } catch (error) {
-        console.error("IPC user-exam:is-member error:", error)
-        throw error
-      }
+    async (userId: string, examId: string) => {
+      return await isExamMember(userId, examId)
     }
   )
 
   // Set exam owner (when creating exam)
-  ipcMain.handle(
-    "user-exam:set-owner",
-    async (_event, options: SetOwnerOptions) => {
-      try {
-        return await setExamOwner(options)
-      } catch (error) {
-        console.error("IPC user-exam:set-owner error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("user-exam:set-owner", async (options: SetOwnerOptions) => {
+    return await setExamOwner(options)
+  })
 
   // Invite a member to exam
-  ipcMain.handle(
-    "user-exam:invite",
-    async (_event, options: InviteMemberOptions) => {
-      try {
-        return await inviteExamMember(options)
-      } catch (error) {
-        console.error("IPC user-exam:invite error:", error)
-        throw error
-      }
-    }
-  )
+  registerHandler("user-exam:invite", async (options: InviteMemberOptions) => {
+    return await inviteExamMember(options)
+  })
 
   // Remove a member from exam
-  ipcMain.handle(
+  registerHandler(
     "user-exam:remove",
-    async (_event, examId: string, userId: string, removedBy: string) => {
-      try {
-        return await removeExamMember(examId, userId, removedBy)
-      } catch (error) {
-        console.error("IPC user-exam:remove error:", error)
-        throw error
-      }
+    async (examId: string, userId: string, removedBy: string) => {
+      return await removeExamMember(examId, userId, removedBy)
     }
   )
 
   // Transfer exam ownership
-  ipcMain.handle(
+  registerHandler(
     "user-exam:transfer-ownership",
-    async (
-      _event,
-      examId: string,
-      newOwnerId: string,
-      currentOwnerId: string
-    ) => {
-      try {
-        return await transferOwnership(examId, newOwnerId, currentOwnerId)
-      } catch (error) {
-        console.error("IPC user-exam:transfer-ownership error:", error)
-        throw error
-      }
+    async (examId: string, newOwnerId: string, currentOwnerId: string) => {
+      return await transferOwnership(examId, newOwnerId, currentOwnerId)
     }
   )
 
   // Get all exams for a user
-  ipcMain.handle("user-exam:get-user-exams", async (_event, userId: string) => {
-    try {
-      return await getUserExams(userId)
-    } catch (error) {
-      console.error("IPC user-exam:get-user-exams error:", error)
-      throw error
-    }
+  registerHandler("user-exam:get-user-exams", async (userId: string) => {
+    return await getUserExams(userId)
   })
 
   // Get exam owner
-  ipcMain.handle("user-exam:get-owner", async (_event, examId: string) => {
-    try {
-      return await getExamOwner(examId)
-    } catch (error) {
-      console.error("IPC user-exam:get-owner error:", error)
-      throw error
-    }
+  registerHandler("user-exam:get-owner", async (examId: string) => {
+    return await getExamOwner(examId)
   })
 
   // Search users for invitation
-  ipcMain.handle(
+  registerHandler(
     "user-exam:search-users",
-    async (_event, examId: string, query: string) => {
-      try {
-        return await searchUsersForInvitation(examId, query)
-      } catch (error) {
-        console.error("IPC user-exam:search-users error:", error)
-        throw error
-      }
+    async (examId: string, query: string) => {
+      return await searchUsersForInvitation(examId, query)
     }
   )
 }


### PR DESCRIPTION
## Summary
- `registerHandler` / `registerSafeHandler` の2つのラッパー関数を `ipcHandlerUtils.ts` に作成
- 20ファイル・約250箇所のtry-catchボイラープレートを集約
- リソースクリーンアップやBrowserWindowライフサイクル管理が必要な約16箇所は手動のまま維持

## Test plan
- [ ] `npm run check-all` パス確認済み
- [ ] Electronアプリ起動して各IPC通信が正常に動作することを確認
- [ ] エラー発生時のログ出力形式が統一されていることを確認

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)