### PR TITLE
chore: 開発用テストページをproductionナビゲーションから除外

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -39,6 +39,22 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>
 }
 
+const devNavGroup: NavItem[] = [
+  { href: "/dnd-kit-test", label: "DnD テスト", icon: TestTube2 },
+  { href: "/simple-dnd-kit-test", label: "シンプル DnD", icon: TestTube2 },
+  { href: "/table-dnd-kit-test", label: "テーブル DnD", icon: TestTube2 },
+  {
+    href: "/textbox-on-canvas-v4",
+    label: "Textbox Canvas V4",
+    icon: FlaskConical,
+  },
+  {
+    href: "/test/grid-layout-debug",
+    label: "Grid Layout Debug",
+    icon: Grid2X2,
+  },
+]
+
 const navGroups: NavItem[][] = [
   [
     { href: "/exams", label: "試験一覧", icon: Home },
@@ -51,21 +67,7 @@ const navGroups: NavItem[][] = [
     { href: "/classes", label: "学級管理", icon: School },
     { href: "/subtotal-groups", label: "小計点管理", icon: Calculator },
   ],
-  [
-    { href: "/dnd-kit-test", label: "DnD テスト", icon: TestTube2 },
-    { href: "/simple-dnd-kit-test", label: "シンプル DnD", icon: TestTube2 },
-    { href: "/table-dnd-kit-test", label: "テーブル DnD", icon: TestTube2 },
-    {
-      href: "/textbox-on-canvas-v4",
-      label: "Textbox Canvas V4",
-      icon: FlaskConical,
-    },
-    {
-      href: "/test/grid-layout-debug",
-      label: "Grid Layout Debug",
-      icon: Grid2X2,
-    },
-  ],
+  ...(process.env.NODE_ENV === "development" ? [devNavGroup] : []),
   [{ href: "/settings", label: "設定", icon: Settings }],
 ]
 


### PR DESCRIPTION
## Summary
- `Navigation.tsx` で開発用テストページ（5件）を `process.env.NODE_ENV === "development"` でゲート
- DnDテスト、Textbox Canvas V4、Grid Layout Debug がproductionビルドで非表示に
- テストページファイル自体は削除せず保持

## Test plan
- [ ] `npm run check-all` パス確認済み
- [ ] 開発モードでテストページがナビゲーションに表示されることを確認
- [ ] productionビルドでテストページが非表示になることを確認

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)