### PR TITLE
docs: 全エクスポート関数にJSDocコメントを追加

### DIFF
--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -36,6 +36,7 @@ import {
 } from "../lib/prisma/asbDefinition"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 解答用紙作成機能のIPCチャンネル（定義CRUD・画像管理・PDF/PNG出力・印刷・インポート/エクスポート）を登録する */
 export function setupAnswerSheetBuilderHandlers(): void {
   // 定義一覧取得
   registerSafeHandler(

--- a/electron-src/ipc-handlers/authHandlers.ts
+++ b/electron-src/ipc-handlers/authHandlers.ts
@@ -1,6 +1,7 @@
 import { AuthStoreManager } from "../lib/authStore"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 認証トークンの保存・取得・削除に関するIPCチャンネルを登録する */
 export function setupAuthHandlers(): void {
   // 認証トークンを保存
   registerSafeHandler(

--- a/electron-src/ipc-handlers/cropRegionHandlers.ts
+++ b/electron-src/ipc-handlers/cropRegionHandlers.ts
@@ -78,6 +78,7 @@ import {
 } from "../lib/prisma/subtotal"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 採点領域（CropRegion）・小計点（Subtotal）・領域小計点紐付け（CropSubtotal）のCRUD用IPCチャンネルを登録する */
 export function setupCropRegionHandlers(): void {
   // --- CropRegion Handlers ---
   registerHandler(

--- a/electron-src/ipc-handlers/examClassHandlers.ts
+++ b/electron-src/ipc-handlers/examClassHandlers.ts
@@ -17,6 +17,7 @@ import {
 } from "../lib/prisma/examClass"
 import { registerHandler } from "./ipcHandlerUtils"
 
+/** 試験と学級の関連付け（ExamClass）に関するIPCチャンネルを登録する */
 export function setupExamClassHandlers(): void {
   // Get all classes for a exam
   registerHandler("exam-class:get-all", async (examId: string) => {

--- a/electron-src/ipc-handlers/examHandlers.ts
+++ b/electron-src/ipc-handlers/examHandlers.ts
@@ -176,6 +176,7 @@ function computeExamStatus(exam: ExamForListPayload) {
   }
 }
 
+/** 試験（Exam）のCRUD・一覧取得・ステータス計算に関するIPCチャンネルを登録する */
 export function setupExamHandlers(): void {
   // 試験一覧用の軽量エンドポイント（ステータスをサーバーサイドで計算）
   registerHandler("fetch-exams-summary", async (userId: string) => {

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -19,6 +19,7 @@ import {
 import { validateScoringData } from "../lib/shared/utilities/validateScoringData"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
+/** Excel・PDF出力・個人成績表・ストリーミングPDF生成に関するIPCチャンネルを登録する */
 export function setupExportHandlers(): void {
   // 採点データバリデーション（全エクスポート共通）
   registerSafeHandler(

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -67,6 +67,7 @@ import {
 import { calculateGrades } from "../lib/shared/calculations/gradeCalculator"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 成績（Grade）のCRUD・生徒管理・データソース・成績算出・Excel出力・アーカイブに関するIPCチャンネルを登録する */
 export function setupGradeHandlers(): void {
   // =====================================================================
   // Grade CRUD

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -20,6 +20,7 @@ import { setupSubjectHandlers } from "./subjectHandlers"
 import { setupSubtotalGroupHandlers } from "./subtotalGroupHandlers"
 import { setupUserExamHandlers } from "./userExamHandlers"
 
+/** 全IPCハンドラーを一括登録する */
 export function setupAllIPCHandlers(): void {
   setupExamHandlers()
   setupStudentHandlers()

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -36,6 +36,7 @@ import {
 import { fetchUsers, getCurrentUser } from "../lib/prisma/user"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** ユーザー・認証・答案・学級・模範画像・ファイル操作など汎用的なIPCチャンネルを登録する */
 export function setupMiscHandlers(): void {
   // User handlers
   registerHandler("fetch-users", async () => {

--- a/electron-src/ipc-handlers/omrConfigHandlers.ts
+++ b/electron-src/ipc-handlers/omrConfigHandlers.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/prisma/cropRegionOmrConfig"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
+/** OMR設定（CropRegionOmrConfig）のCRUD用IPCチャンネルを登録する */
 export function setupOmrConfigHandlers(): void {
   registerSafeHandler(
     "omr-config:upsert",

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -35,6 +35,7 @@ export function invalidateMasterMarkerCache(examId: string): void {
   }
 }
 
+/** OMR（光学マーク認識）のマーカー検出・シート認識・バッチ処理に関するIPCチャンネルを登録する */
 export function setupOMRHandlers(): void {
   // ────────────────────────────────────────
   // 単一画像のコーナーマーカー検出

--- a/electron-src/ipc-handlers/pdfToolsHandlers.ts
+++ b/electron-src/ipc-handlers/pdfToolsHandlers.ts
@@ -22,6 +22,7 @@ import { splitPdf } from "../lib/pdf-tools/pdfSplitter"
 import { exportPagesToPng } from "../lib/pdf-tools/pdfToPng"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** PDFツール（結合・分割・回転・2-in-1・PNG書き出し）に関するIPCチャンネルを登録する */
 export function setupPdfToolsHandlers(): void {
   // PDF結合
   registerHandler(

--- a/electron-src/ipc-handlers/questionGroupHandlers.ts
+++ b/electron-src/ipc-handlers/questionGroupHandlers.ts
@@ -32,6 +32,7 @@ import {
 } from "../lib/prisma/subtotalDefinition"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 設問グループ・設問項目・小計点割当・小計点定義のCRUD用IPCチャンネルを登録する */
 export function setupQuestionGroupHandlers(): void {
   // 既存のハンドラーをクリア（重複登録を防ぐ）
   ipcMain.removeHandler("create-question-group")

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -42,6 +42,7 @@ function serializeScore(score: {
   }
 }
 
+/** 採点（QuestionScore）のCRUD・進捗取得・一括更新・採点レコード初期化に関するIPCチャンネルを登録する */
 export function setupScoringHandlers(): void {
   // QuestionScore 関連のハンドラー
   registerHandler(

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -31,6 +31,7 @@ import { registerSafeHandler } from "./ipcHandlerUtils"
 // プロジェクターモード用のpowerSaveBlocker ID
 let projectorModeBlockerId: number | null = null
 
+/** 設定（キーボードショートカット・採点マーク書式・表示設定・プロジェクターモード等）に関するIPCチャンネルを登録する */
 export function registerSettingsHandlers() {
   // =========================================================================
   // プロジェクターモード（スクリーンセーバー無効化）

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -36,6 +36,7 @@ import {
 } from "../lib/shared/utilities/excelUtilities"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 生徒CRUD・学級所属・試験生徒関連・Excelエクスポートに関するIPCチャンネルを登録する */
 export function setupStudentHandlers(): void {
   registerHandler("fetch-students", async () => {
     return await fetchStudents()

--- a/electron-src/ipc-handlers/subjectHandlers.ts
+++ b/electron-src/ipc-handlers/subjectHandlers.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/prisma/subjectSubtotalGroup"
 import { registerHandler } from "./ipcHandlerUtils"
 
+/** 教科（Subject）と教科小計点グループ紐付け（SubjectSubtotalGroup）のCRUD用IPCチャンネルを登録する */
 export function setupSubjectHandlers(): void {
   // Subject CRUD
   registerHandler("subject:getAll", async () => {

--- a/electron-src/ipc-handlers/subtotalGroupHandlers.ts
+++ b/electron-src/ipc-handlers/subtotalGroupHandlers.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/prisma/subtotalGroup"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
+/** 小計点グループのCRUD・試験への紐付け管理に関するIPCチャンネルを登録する */
 export function setupSubtotalGroupHandlers(): void {
   // 小計点グループ一覧取得
   registerSafeHandler("get-subtotal-groups", async () => {

--- a/electron-src/ipc-handlers/userExamHandlers.ts
+++ b/electron-src/ipc-handlers/userExamHandlers.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/prisma/userExam"
 import { registerHandler } from "./ipcHandlerUtils"
 
+/** ユーザーと試験の関連（UserExam）に関するメンバー管理・権限・招待のIPCチャンネルを登録する */
 export function setupUserExamHandlers(): void {
   // Get all members of a exam
   registerHandler("user-exam:get-members", async (examId: string) => {

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -38,8 +38,7 @@ const getAppRootPath = (): string => {
   }
 }
 
-// データディレクトリのパス
-// 環境変数 SCORE_AT_ONCE_DATA_DIR が設定されている場合はそちらを優先
+/** データディレクトリのパスを取得する（環境変数 SCORE_AT_ONCE_DATA_DIR が優先） */
 export const getDataDirectory = (): string => {
   if (process.env.SCORE_AT_ONCE_DATA_DIR) {
     return path.resolve(process.env.SCORE_AT_ONCE_DATA_DIR)
@@ -48,22 +47,22 @@ export const getDataDirectory = (): string => {
   return dataPath
 }
 
-// 試験ディレクトリのパス
+/** 指定した試験IDのディレクトリパスを取得する */
 export const getExamDirectory = (examId: string): string => {
   return path.join(getDataDirectory(), "exams", examId)
 }
 
-// 答案保存ディレクトリのパス
+/** 指定した試験の答案画像保存ディレクトリのパスを取得する */
 export const getAnswerSheetsDirectory = (examId: string): string => {
   return path.join(getExamDirectory(examId), "answer-sheets")
 }
 
-// マスター解答保存ディレクトリのパス
+/** 指定した試験の模範解答画像保存ディレクトリのパスを取得する */
 export const getMasterAnswersDirectory = (examId: string): string => {
   return path.join(getExamDirectory(examId), "master-answers")
 }
 
-// ASB画像保存ディレクトリのパス
+/** 答案用紙ビルダー（ASB）の画像保存ディレクトリのパスを取得する */
 export const getAsbImagesDirectory = (definitionId: string): string => {
   return path.join(
     getDataDirectory(),
@@ -73,12 +72,12 @@ export const getAsbImagesDirectory = (definitionId: string): string => {
   )
 }
 
-// 出力ディレクトリのパス
+/** Excel・PDF等の出力ファイル保存ディレクトリのパスを取得する */
 export const getExportsDirectory = (): string => {
   return path.join(getDataDirectory(), "exports")
 }
 
-// データディレクトリの初期化
+/** データディレクトリとサブディレクトリ（exams, exports）を作成・初期化する */
 export const initializeDataDirectory = async (): Promise<void> => {
   const dataDir = getDataDirectory()
 
@@ -108,7 +107,7 @@ export const initializeDataDirectory = async (): Promise<void> => {
   }
 }
 
-// data/projects/ → data/exams/ マイグレーション（v0.6.x リネーム対応）
+/** data/projects/ を data/exams/ にマイグレーションする（v0.6.xリネーム対応、旧ディレクトリは削除される） */
 export const migrateProjectsToExams = async (): Promise<boolean> => {
   const dataDir = getDataDirectory()
   const oldProjectsDir = path.join(dataDir, "projects")
@@ -173,7 +172,7 @@ const copyDirectory = async (src: string, dest: string): Promise<void> => {
   }
 }
 
-// データディレクトリのサイズ計算
+/** データディレクトリ全体のサイズをバイト単位で再帰的に計算する */
 export const calculateDataSize = async (): Promise<number> => {
   const dataDir = getDataDirectory()
   return await getDirectorySize(dataDir)
@@ -204,13 +203,13 @@ const getDirectorySize = async (dirPath: string): Promise<number> => {
   return totalSize
 }
 
-// 絶対パスから相対パス（data/基準）への変換
+/** 絶対パスをデータディレクトリ基準の相対パスに変換する */
 export const getRelativePathFromData = (absolutePath: string): string => {
   const dataDir = getDataDirectory()
   return path.relative(dataDir, absolutePath).replace(/\\/g, "/")
 }
 
-// 相対パス（data/基準）から絶対パスへの変換
+/** データディレクトリ基準の相対パスを絶対パスに変換する */
 export const getAbsolutePathFromData = (relativePath: string): string => {
   const dataDir = getDataDirectory()
   return path.join(dataDir, relativePath)

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -24,6 +24,7 @@ export interface CollectedGradeData {
   }
 }
 
+/** 指定した成績算出IDに関連する全データ（成績項目・手動スコア・境界値・生徒情報）をDBから収集する */
 export async function collectGradeArchiveData(
   gradeId: string
 ): Promise<CollectedGradeData> {

--- a/electron-src/lib/export/gradeExcel/gradeDataFetcher.ts
+++ b/electron-src/lib/export/gradeExcel/gradeDataFetcher.ts
@@ -12,6 +12,7 @@ export interface GradeExportData {
   classNames: string[]
 }
 
+/** 成績算出の計算結果と関連情報を取得し、Excel出力用データとして返す */
 export async function fetchGradeExportData(
   gradeId: string
 ): Promise<{ success: boolean; data?: GradeExportData; error?: string }> {

--- a/electron-src/lib/import/asb-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/asb-archive/archiveExtractor.ts
@@ -133,6 +133,7 @@ function isImageFile(filename: string): boolean {
   return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"].includes(ext)
 }
 
+/** ASBアーカイブ展開時に作成された一時ディレクトリを削除する */
 export function cleanupAsbTempDir(tempDir: string): void {
   try {
     if (fs.existsSync(tempDir)) {

--- a/electron-src/lib/import/asb-transformers/index.ts
+++ b/electron-src/lib/import/asb-transformers/index.ts
@@ -37,6 +37,7 @@ function compareVersions(v1: string, v2: string): number {
   return 0
 }
 
+/** マニフェストのバージョン文字列からサポート対象のASBバージョンを判定する */
 export function detectAsbVersion(
   manifest: AsbArchiveManifest
 ): AsbArchiveVersion | "unknown" {
@@ -94,6 +95,7 @@ function buildAsbTransformChain(
   return chain
 }
 
+/** ASBアーカイブデータを変換チェーンを通じて最新バージョンに変換する */
 export function transformAsbToLatest(
   data: AsbArchiveData,
   targetVersion: AsbArchiveVersion = ASB_CURRENT_VERSION

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -29,6 +29,7 @@ async function extractZip(
   return files
 }
 
+/** 成績算出アーカイブ（.grade）を展開し、マニフェスト・成績データ・手動スコア・境界値を解析する */
 export async function extractGradeArchive(
   archivePath: string
 ): Promise<{ success: boolean; data?: GradeArchiveData; error?: string }> {

--- a/electron-src/lib/prisma/auth.ts
+++ b/electron-src/lib/prisma/auth.ts
@@ -29,7 +29,7 @@ function verifyToken(token: string): AuthTokenPayload | null {
   }
 }
 
-// Login user
+/** ユーザー名とパスコードで認証し、JWTトークンを発行する */
 export async function loginUser(username: string, password: string) {
   try {
     const user = await prisma.user.findUnique({
@@ -72,7 +72,7 @@ export async function loginUser(username: string, password: string) {
   }
 }
 
-// Create new user
+/** 新規ユーザーを作成し、JWTトークンを発行する（ユーザー名の重複チェック付き） */
 export async function createUser(userData: {
   username: string
   password: string
@@ -124,7 +124,7 @@ export async function createUser(userData: {
   }
 }
 
-// Get user by token
+/** JWTトークンを検証し、対応するユーザー情報を取得する */
 export async function getUserByToken(token: string) {
   try {
     const payload = verifyToken(token)
@@ -157,7 +157,7 @@ export async function getUserByToken(token: string) {
   }
 }
 
-// Update user password
+/** ユーザーのパスコードを更新する */
 export async function updateUserPassword(userId: string, newPassword: string) {
   try {
     await prisma.user.update({

--- a/electron-src/lib/prisma/class.ts
+++ b/electron-src/lib/prisma/class.ts
@@ -12,6 +12,7 @@ type ClassWithMemberships = Prisma.ClassGetPayload<{
   }
 }>
 
+/** 全学級を取得する（memberships.student リレーション含む、出席番号順） */
 export const fetchClasses = async (): Promise<ClassWithMemberships[]> => {
   try {
     return await prisma.class.findMany({
@@ -34,6 +35,7 @@ export const fetchClasses = async (): Promise<ClassWithMemberships[]> => {
   }
 }
 
+/** 学級を新規作成する（memberships.student リレーション含む） */
 export const createClass = async (
   classData: Prisma.ClassCreateInput
 ): Promise<ClassWithMemberships> => {
@@ -59,6 +61,7 @@ export const createClass = async (
   }
 }
 
+/** 学級情報を更新する（memberships.student リレーション含む） */
 export const updateClass = async (
   classData: Prisma.ClassUpdateInput & { id: string }
 ): Promise<ClassWithMemberships> => {
@@ -86,6 +89,7 @@ export const updateClass = async (
   }
 }
 
+/** 学級を削除する（現在所属中の生徒がいる場合はエラー） */
 export const deleteClass = async (classId: string): Promise<Class | void> => {
   try {
     // Check for current memberships instead of students directly

--- a/electron-src/lib/prisma/client.ts
+++ b/electron-src/lib/prisma/client.ts
@@ -3,6 +3,7 @@ import { createSharedPrismaClient } from "./databaseInitializer"
 // 共有ドライブ対応のPrismaクライアント（毎回新しいインスタンスを作成）
 export default createSharedPrismaClient()
 
+/** 共有ドライブ対応のPrismaクライアントを新規作成して返す */
 export function getPrismaClient() {
   return createSharedPrismaClient()
 }

--- a/electron-src/lib/prisma/cropRegion.ts
+++ b/electron-src/lib/prisma/cropRegion.ts
@@ -2,7 +2,7 @@ import type { CropRegion, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 
-// CropRegion を作成
+/** 設問領域を作成する（orderIndex未指定時は自動採番、examPage・cropSubtotals リレーション含む） */
 export const createCropRegion = async (
   data: Prisma.CropRegionUncheckedCreateInput
 ) => {
@@ -53,7 +53,7 @@ export const createCropRegion = async (
   })
 }
 
-// 複数の CropRegion を作成
+/** 複数の設問領域を一括作成する */
 export const createManyCropRegions = async (
   data: Prisma.CropRegionCreateManyInput[]
 ) => {
@@ -62,7 +62,7 @@ export const createManyCropRegions = async (
   })
 }
 
-// CropRegion を更新
+/** 設問領域を更新する（examPage・cropSubtotals リレーション含む） */
 export const updateCropRegion = async (
   id: string,
   data: Prisma.CropRegionUpdateInput
@@ -81,14 +81,14 @@ export const updateCropRegion = async (
   })
 }
 
-// CropRegion を削除
+/** 設問領域を削除する */
 export const deleteCropRegion = async (id: string) => {
   return prisma.cropRegion.delete({
     where: { id },
   })
 }
 
-// 試験IDで CropRegion を取得
+/** 試験IDで全設問領域を取得する（orderIndexがnullの場合は自動設定、examPage・cropSubtotals・questionScores リレーション含む） */
 export const getCropRegionsByExamId = async (examId: string) => {
   const regions = await prisma.cropRegion.findMany({
     where: {
@@ -207,7 +207,7 @@ export const getQuestionAnswerRegionsByExamId = async (examId: string) => {
   return regions
 }
 
-// IDで CropRegion を取得
+/** IDで設問領域を取得する（examPage・cropSubtotals・questionScores リレーション含む） */
 export const getCropRegionById = async (id: string) => {
   return prisma.cropRegion.findUnique({
     where: { id },
@@ -223,7 +223,7 @@ export const getCropRegionById = async (id: string) => {
   })
 }
 
-// 複数の CropRegion の順序を一括更新
+/** 複数の設問領域のorderIndexを一括更新する */
 export const updateCropRegionOrders = async (
   updates: Array<{ id: string; orderIndex: number }>
 ) => {

--- a/electron-src/lib/prisma/cropSubtotal.ts
+++ b/electron-src/lib/prisma/cropSubtotal.ts
@@ -2,7 +2,7 @@ import type { CropSubtotal, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 
-// CropSubtotal を作成
+/** 設問-小計紐付けを作成する（設問領域・小計項目の存在と試験での有効化を検証、cropRegion・subtotal リレーション含む） */
 export const createCropSubtotal = async (
   data: Prisma.CropSubtotalUncheckedCreateInput
 ) => {
@@ -58,7 +58,7 @@ export const createCropSubtotal = async (
   })
 }
 
-// 複数の CropSubtotal を作成
+/** 複数の設問-小計紐付けを一括作成する（各項目のデータ整合性を検証） */
 export const createManyCropSubtotals = async (
   data: Prisma.CropSubtotalUncheckedCreateInput[]
 ) => {
@@ -114,7 +114,7 @@ export const createManyCropSubtotals = async (
   })
 }
 
-// CropSubtotal を更新
+/** 設問-小計紐付けを更新する（cropRegion・subtotal リレーション含む） */
 export const updateCropSubtotal = async (
   id: string,
   data: Prisma.CropSubtotalUpdateInput
@@ -129,14 +129,14 @@ export const updateCropSubtotal = async (
   })
 }
 
-// CropSubtotal を削除
+/** 設問-小計紐付けを削除する */
 export const deleteCropSubtotal = async (id: string) => {
   return prisma.cropSubtotal.delete({
     where: { id },
   })
 }
 
-// CropRegion ID で CropSubtotal をすべて削除
+/** 指定した設問領域に紐づく全ての設問-小計紐付けを削除する */
 export const deleteCropSubtotalsByCropRegionId = async (
   cropRegionId: string
 ) => {
@@ -145,7 +145,7 @@ export const deleteCropSubtotalsByCropRegionId = async (
   })
 }
 
-// CropRegion ID で CropSubtotal を取得
+/** 設問領域IDで設問-小計紐付けを取得する（subtotal.subtotalGroup リレーション含む） */
 export const getCropSubtotalsByCropRegionId = async (cropRegionId: string) => {
   return prisma.cropSubtotal.findMany({
     where: { cropRegionId },
@@ -159,7 +159,7 @@ export const getCropSubtotalsByCropRegionId = async (cropRegionId: string) => {
   })
 }
 
-// Subtotal ID で CropSubtotal を取得
+/** 小計項目IDで設問-小計紐付けを取得する（cropRegion.examPage リレーション含む） */
 export const getCropSubtotalsBySubtotalId = async (subtotalId: string) => {
   return prisma.cropSubtotal.findMany({
     where: { subtotalId },
@@ -173,7 +173,7 @@ export const getCropSubtotalsBySubtotalId = async (subtotalId: string) => {
   })
 }
 
-// CropRegion ID とassignmentTypeで CropSubtotal を取得（旧SubtotalDefinition互換）
+/** 設問領域IDでSUBTOTAL_DEFINITION型の紐付けを取得する（旧SubtotalDefinition互換） */
 export const getSubtotalDefinitionsByCropRegionId = async (
   cropRegionId: string
 ) => {
@@ -192,7 +192,7 @@ export const getSubtotalDefinitionsByCropRegionId = async (
   })
 }
 
-// CropRegion ID とassignmentTypeで CropSubtotal を取得（旧QuestionSubtotalAssignment互換）
+/** 設問領域IDでQUESTION_ASSIGNMENT型の紐付けを取得する（旧QuestionSubtotalAssignment互換） */
 export const getQuestionSubtotalAssignmentsByCropRegionId = async (
   cropRegionId: string
 ) => {
@@ -211,7 +211,7 @@ export const getQuestionSubtotalAssignmentsByCropRegionId = async (
   })
 }
 
-// IDで CropSubtotal を取得
+/** IDで設問-小計紐付けを取得する（cropRegion.examPage・subtotal.subtotalGroup リレーション含む） */
 export const getCropSubtotalById = async (id: string) => {
   return prisma.cropSubtotal.findUnique({
     where: { id },

--- a/electron-src/lib/prisma/databaseHealth.ts
+++ b/electron-src/lib/prisma/databaseHealth.ts
@@ -1,6 +1,6 @@
 import { createSharedPrismaClient } from "./databaseInitializer"
 
-// データベースの健全性チェック
+/** SELECT 1クエリでデータベース接続の健全性を確認する */
 export const checkDatabaseHealth = async (): Promise<boolean> => {
   const prisma = createSharedPrismaClient()
 
@@ -16,7 +16,7 @@ export const checkDatabaseHealth = async (): Promise<boolean> => {
   }
 }
 
-// 共有ドライブ用のSQLite最適化設定
+/** 共有ドライブ向けにWALモード・busy_timeout・キャッシュサイズ等のSQLite PRAGMAを設定する */
 export const optimizeDatabaseForSharedDrive = async (): Promise<void> => {
   const prisma = createSharedPrismaClient()
 

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -6,12 +6,12 @@ import { getDataDirectory } from "../dataManager"
 import { checkDatabaseExists } from "./databaseUtils"
 import { INDEX_SQL, MIGRATION_SQL } from "./schema/migrationSql"
 
-// データベースファイルのパス
+/** データベースファイル（database.db）の絶対パスを返す */
 export const getDatabasePath = (): string => {
   return path.join(getDataDirectory(), "database.db")
 }
 
-// 共有ドライブ用のPrismaクライアントを作成
+/** 共有ドライブ対応のPrismaクライアントを生成し、DATABASE_URL環境変数を上書きする */
 export const createSharedPrismaClient = (): PrismaClient => {
   const databasePath = getDatabasePath()
   // パッケージ化されたアプリでは絶対パスを使用
@@ -36,7 +36,7 @@ export const createSharedPrismaClient = (): PrismaClient => {
   })
 }
 
-// データベースの初期化（初回起動時）
+/** 初回起動時にDBファイルを作成しスキーマを適用する。既にDBが存在する場合はfalseを返す */
 export const initializeDatabase = async (): Promise<boolean> => {
   try {
     // データベースファイルの存在確認

--- a/electron-src/lib/prisma/databaseUtils.ts
+++ b/electron-src/lib/prisma/databaseUtils.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises"
 
 import { getDatabasePath } from "./databaseInitializer"
 
-// テーブルのカラム情報を取得するヘルパー
+/** 指定テーブルのカラム名一覧をPRAGMA table_infoで取得する */
 export const getTableColumns = async (
   prisma: PrismaClient,
   tableName: string
@@ -18,7 +18,7 @@ export const getTableColumns = async (
   }
 }
 
-// テーブルが存在するか確認するヘルパー
+/** SQLiteのsqlite_masterを参照し、指定テーブルが存在するか確認する */
 export const tableExists = async (
   prisma: PrismaClient,
   tableName: string
@@ -29,7 +29,7 @@ export const tableExists = async (
   return result.length > 0
 }
 
-// データベースファイルの存在確認
+/** データベースファイル（database.db）がディスク上に存在するか確認する */
 export const checkDatabaseExists = async (): Promise<boolean> => {
   const databasePath = getDatabasePath()
 

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -2,7 +2,7 @@ import type { Prisma as PrismaTypes } from "@prisma/client"
 
 import prisma from "./client"
 
-// Exam一覧用の軽量クエリ（ステップ判定に必要な最小限のデータのみ取得）
+/** 試験一覧用の軽量クエリ（ステップ判定に必要な最小限のデータのみ取得、ユーザーでフィルタリング） */
 export const getExamsForList = async (userId: string) => {
   return prisma.exam.findMany({
     where: {
@@ -58,7 +58,7 @@ export type ExamForListPayload = Awaited<
   ReturnType<typeof getExamsForList>
 >[number]
 
-// Exam一覧を取得 (ユーザーでフィルタリング) - 詳細ページ用
+/** 試験一覧を全リレーション付きで取得する（詳細ページ用、userExams・examPages・examSubtotalGroups・examStudents含む） */
 export const getExams = async (userId: string) => {
   return prisma.exam.findMany({
     where: {
@@ -120,7 +120,7 @@ export const getExams = async (userId: string) => {
 // getExams の戻り値の型
 export type ExamPayload = PrismaTypes.PromiseReturnType<typeof getExams>[number]
 
-// IDで単一のExamを取得 (詳細情報も含む)
+/** IDで試験を取得する（全リレーション含む: userExams・examPages・examSubtotalGroups・examStudents） */
 export const getExamById = async (id: string) => {
   return prisma.exam.findUnique({
     where: { id },
@@ -186,7 +186,7 @@ export type ExamWithDetailsPayload = PrismaTypes.PromiseReturnType<
   typeof getExamById
 >
 
-// Exam作成
+/** 試験を作成し、指定ユーザーをOWNERとしてUserExamに登録する */
 export const createExam = async (
   data: Omit<PrismaTypes.ExamCreateInput, "userExams">,
   userId: string
@@ -227,7 +227,7 @@ export const createExam = async (
   })
 }
 
-// Exam更新
+/** 試験情報を更新する */
 export const updateExam = async (
   id: string,
   data: PrismaTypes.ExamUpdateInput
@@ -238,7 +238,7 @@ export const updateExam = async (
   })
 }
 
-// Exam削除
+/** 試験を削除する */
 export const deleteExam = async (id: string) => {
   return prisma.exam.delete({
     where: { id },

--- a/electron-src/lib/prisma/examPage.ts
+++ b/electron-src/lib/prisma/examPage.ts
@@ -2,7 +2,7 @@ import type { ExamPage, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 
-// ExamPage を作成
+/** 試験ページを作成する（masterImages・studentAnswerImages・cropRegions リレーション含む） */
 export const createExamPage = async (
   data: Prisma.ExamPageUncheckedCreateInput
 ) => {
@@ -16,7 +16,7 @@ export const createExamPage = async (
   })
 }
 
-// 複数の ExamPage を作成
+/** 複数の試験ページを一括作成する */
 export const createManyExamPages = async (
   data: Prisma.ExamPageCreateManyInput[]
 ) => {
@@ -25,7 +25,7 @@ export const createManyExamPages = async (
   })
 }
 
-// ExamPage を更新
+/** 試験ページを更新する（masterImages・studentAnswerImages・cropRegions リレーション含む） */
 export const updateExamPage = async (
   id: string,
   data: Prisma.ExamPageUpdateInput
@@ -41,7 +41,7 @@ export const updateExamPage = async (
   })
 }
 
-// ExamPage を削除
+/** 試験ページを削除する（関連するMasterImage・StudentAnswerImage・CropRegionもCascade削除） */
 export const deleteExamPage = async (id: string) => {
   // 関連する MasterImage, StudentAnswerImage, CropRegion も削除される（onDelete: Cascade 設定済み）
   return prisma.examPage.delete({
@@ -49,7 +49,7 @@ export const deleteExamPage = async (id: string) => {
   })
 }
 
-// 試験IDで ExamPage を取得
+/** 試験IDで全ページを取得する（masterImages・studentAnswerImages.student・cropRegions リレーション含む、ページ番号順） */
 export const getExamPagesByExamId = async (examId: string) => {
   return prisma.examPage.findMany({
     where: { examId },
@@ -66,7 +66,7 @@ export const getExamPagesByExamId = async (examId: string) => {
   })
 }
 
-// IDで ExamPage を取得
+/** IDで試験ページを取得する（masterImages・studentAnswerImages.student・cropRegions リレーション含む） */
 export const getExamPageById = async (id: string) => {
   return prisma.examPage.findUnique({
     where: { id },

--- a/electron-src/lib/prisma/examSettings.ts
+++ b/electron-src/lib/prisma/examSettings.ts
@@ -16,12 +16,14 @@ export interface MarkingFormatData {
   strokeWidth?: number | null
 }
 
+/** 試験の全採点マーク設定を取得する */
 export async function getExamMarkingFormats(examId: string) {
   return prisma.examMarkingFormat.findMany({
     where: { examId },
   })
 }
 
+/** 試験の特定マーク種別の採点マーク設定を取得する */
 export async function getExamMarkingFormat(examId: string, markType: string) {
   return prisma.examMarkingFormat.findUnique({
     where: {
@@ -30,6 +32,7 @@ export async function getExamMarkingFormat(examId: string, markType: string) {
   })
 }
 
+/** 採点マーク設定を作成または更新する（examId+markTypeで一意） */
 export async function upsertExamMarkingFormat(
   examId: string,
   data: MarkingFormatData
@@ -51,6 +54,7 @@ export async function upsertExamMarkingFormat(
   })
 }
 
+/** 複数の採点マーク設定を一括で作成または更新する（トランザクション内で実行） */
 export async function bulkUpsertExamMarkingFormats(
   examId: string,
   formats: MarkingFormatData[]
@@ -75,6 +79,7 @@ export async function bulkUpsertExamMarkingFormats(
   return prisma.$transaction(operations)
 }
 
+/** 指定マーク種別の採点マーク設定を削除する */
 export async function deleteExamMarkingFormat(
   examId: string,
   markType: string
@@ -88,6 +93,7 @@ export async function deleteExamMarkingFormat(
 // ExamExportSettings（エクスポート設定）
 // =============================================================================
 
+/** 試験のエクスポート設定をJSONパースして取得する（未設定またはパース失敗時はnull） */
 export async function getExamExportSettings(examId: string) {
   const settings = await prisma.examExportSettings.findUnique({
     where: { examId },
@@ -100,6 +106,7 @@ export async function getExamExportSettings(examId: string) {
   }
 }
 
+/** エクスポート設定をJSON文字列として作成または更新する */
 export async function upsertExamExportSettings(
   examId: string,
   settings: Record<string, unknown>
@@ -112,6 +119,7 @@ export async function upsertExamExportSettings(
   })
 }
 
+/** 試験のエクスポート設定を削除する */
 export async function deleteExamExportSettings(examId: string) {
   return prisma.examExportSettings.deleteMany({
     where: { examId },

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -231,6 +231,7 @@ export async function deleteGrade(id: string) {
 // GradeExportSettings（エクスポート設定）
 // =============================================================================
 
+/** 成績算出試験のエクスポート設定をJSON形式で取得する */
 export async function getGradeExportSettings(gradeId: string) {
   const settings = await prisma.gradeExportSettings.findUnique({
     where: { gradeId },
@@ -243,6 +244,7 @@ export async function getGradeExportSettings(gradeId: string) {
   }
 }
 
+/** 成績算出試験のエクスポート設定を作成または更新する（JSON文字列として保存） */
 export async function upsertGradeExportSettings(
   gradeId: string,
   settings: Record<string, unknown>

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -9,6 +9,7 @@ import {
 } from "../dataManager"
 import prisma from "./client"
 
+/** 模範解答画像をアップロードし、ExamPageとMasterImageを作成する（examPage含む） */
 export const uploadMasterAnswers = async (
   examId: string,
   filesData: {
@@ -104,6 +105,7 @@ export interface DeleteMasterAnswerResult {
   examPages: ExamPageWithMasterImages[]
 }
 
+/** 模範解答画像を削除し、空のExamPageも削除する。ページ番号の再連番も行う */
 export const deleteMasterAnswer = async (
   answerId: string
 ): Promise<DeleteMasterAnswerResult> => {
@@ -203,6 +205,7 @@ export const deleteMasterAnswer = async (
   }
 }
 
+/** 模範解答のページ順序を一括更新する（一時番号経由でユニーク制約を回避） */
 export const updateMasterAnswersOrder = async (
   answerOrders: { id: string; pageNumber: number }[]
 ): Promise<Prisma.BatchPayload> => {
@@ -275,6 +278,7 @@ export const updateMasterAnswersOrder = async (
   }
 }
 
+/** 試験IDで模範解答一覧を取得する（masterImages含む、ページ番号順） */
 export const getMasterAnswersByExamId = async (examId: string) => {
   const examPages = await prisma.examPage.findMany({
     where: { examId },
@@ -301,6 +305,7 @@ export const getMasterAnswersByExamId = async (examId: string) => {
   return masterAnswers
 }
 
+/** ExamPageと模範解答画像を1件作成する */
 export const createMasterAnswer = async (data: {
   examId: string
   path: string
@@ -323,6 +328,7 @@ export const createMasterAnswer = async (data: {
   })
 }
 
+/** 複数の模範解答画像を一括作成する */
 export const createManyMasterAnswers = async (
   data: {
     examId: string
@@ -340,6 +346,7 @@ export const createManyMasterAnswers = async (
   return { count: createdAnswers.length }
 }
 
+/** 模範解答の画像パスまたはページ番号を更新する */
 export const updateMasterAnswer = async (
   id: string,
   data: { path?: string; pageNumber?: number }
@@ -376,6 +383,7 @@ export const updateMasterAnswer = async (
   })
 }
 
+/** 試験に属する全模範解答画像を削除し、空のExamPageも削除する */
 export const deleteMasterAnswersByExamId = async (examId: string) => {
   // Delete all master images for the exam
   const deletedAnswers = await prisma.masterImage.deleteMany({
@@ -404,6 +412,7 @@ export const deleteMasterAnswersByExamId = async (examId: string) => {
   return deletedAnswers
 }
 
+/** 試験IDとページ番号で模範解答画像を1件取得する */
 export const getMasterAnswerByPage = async (
   examId: string,
   pageNumber: number
@@ -429,6 +438,7 @@ export const getMasterAnswerByPage = async (
   return null
 }
 
+/** 模範解答画像のページサイズ情報を更新する（examPage含む） */
 export const updateMasterImagePageSize = async (
   id: string,
   pageSize: string

--- a/electron-src/lib/prisma/questionGroup.ts
+++ b/electron-src/lib/prisma/questionGroup.ts
@@ -2,7 +2,7 @@ import type { Prisma, SubtotalGroup } from "@prisma/client"
 
 import prisma from "./client"
 
-// QuestionGroup を作成 (SubtotalGroup として実装)
+/** 設問グループ（SubtotalGroup）を作成する（subtotals含む） */
 export const createQuestionGroup = async (
   data: Prisma.SubtotalGroupUncheckedCreateInput
 ) => {
@@ -14,7 +14,7 @@ export const createQuestionGroup = async (
   })
 }
 
-// QuestionGroup を更新
+/** 設問グループ（SubtotalGroup）を更新する（subtotals含む） */
 export const updateQuestionGroup = async (
   id: string,
   data: Prisma.SubtotalGroupUpdateInput
@@ -28,7 +28,7 @@ export const updateQuestionGroup = async (
   })
 }
 
-// QuestionGroup を削除
+/** 設問グループ（SubtotalGroup）を削除する（関連Subtotalはカスケード削除） */
 export const deleteQuestionGroup = async (id: string) => {
   // 関連する Subtotal, CropSubtotal も削除されるか確認
   // (onDelete: Cascade が設定されていれば自動)
@@ -37,7 +37,7 @@ export const deleteQuestionGroup = async (id: string) => {
   })
 }
 
-// 試験IDで QuestionGroup を取得
+/** 試験IDで設問グループ一覧を取得する（ExamSubtotalGroup経由、subtotals含む） */
 export const getQuestionGroupsByExamId = async (examId: string) => {
   // ExamSubtotalGroup経由でSubtotalGroupを取得
   const examSubtotalGroups = await prisma.examSubtotalGroup.findMany({
@@ -66,7 +66,7 @@ export const getQuestionGroupsByExamId = async (examId: string) => {
   }))
 }
 
-// IDで QuestionGroup を取得
+/** IDで設問グループを取得する（subtotals・examSubtotalGroups含む） */
 export const getQuestionGroupById = async (id: string) => {
   const subtotalGroup = await prisma.subtotalGroup.findUnique({
     where: { id },

--- a/electron-src/lib/prisma/questionGroupItem.ts
+++ b/electron-src/lib/prisma/questionGroupItem.ts
@@ -2,7 +2,7 @@ import type { Prisma, Subtotal } from "@prisma/client"
 
 import prisma from "./client"
 
-// QuestionGroupItem を作成 (Subtotal として実装)
+/** 設問グループ項目（Subtotal）を1件作成する */
 export const createQuestionGroupItem = async (
   data: Prisma.SubtotalUncheckedCreateInput // subtotalGroupId を直接含める
 ) => {
@@ -11,7 +11,7 @@ export const createQuestionGroupItem = async (
   })
 }
 
-// 複数の QuestionGroupItem を作成 (特定の QuestionGroup に対して)
+/** 複数の設問グループ項目（Subtotal）を一括作成する */
 export const createManyQuestionGroupItems = async (
   items: Prisma.SubtotalUncheckedCreateInput[]
 ) => {
@@ -20,7 +20,7 @@ export const createManyQuestionGroupItems = async (
   })
 }
 
-// QuestionGroupItem を更新
+/** 設問グループ項目（Subtotal）を更新する */
 export const updateQuestionGroupItem = async (
   id: string,
   data: Prisma.SubtotalUpdateInput
@@ -31,7 +31,7 @@ export const updateQuestionGroupItem = async (
   })
 }
 
-// QuestionGroupItem を削除
+/** 設問グループ項目（Subtotal）を削除する（関連CropSubtotalもカスケード削除） */
 export const deleteQuestionGroupItem = async (id: string) => {
   // 関連する CropSubtotal も削除されるか確認
   return prisma.subtotal.delete({
@@ -39,7 +39,7 @@ export const deleteQuestionGroupItem = async (id: string) => {
   })
 }
 
-// QuestionGroup ID で QuestionGroupItem を取得
+/** 設問グループIDで項目一覧を取得する（order昇順） */
 export const getQuestionGroupItemsByGroupId = async (
   questionGroupId: string // 実際はsubtotalGroupId
 ) => {
@@ -51,7 +51,7 @@ export const getQuestionGroupItemsByGroupId = async (
   })
 }
 
-// IDで QuestionGroupItem を取得
+/** IDで設問グループ項目を取得する（subtotalGroup・cropSubtotals含む） */
 export const getQuestionGroupItemById = async (id: string) => {
   return prisma.subtotal.findUnique({
     where: { id },
@@ -69,7 +69,7 @@ export type SubtotalWithDetails = Prisma.SubtotalGetPayload<{
   }
 }>
 
-// QuestionGroupItem の順序を一括更新
+/** 設問グループ項目の表示順序をトランザクション内で一括更新する */
 export const updateQuestionGroupItemOrders = async (
   orders: { id: string; order: number }[]
 ) => {

--- a/electron-src/lib/prisma/questionSubtotalAssignment.ts
+++ b/electron-src/lib/prisma/questionSubtotalAssignment.ts
@@ -2,7 +2,7 @@ import type { CropSubtotal, Prisma } from "@prisma/client"
 
 import prisma from "./client"
 
-// CropSubtotal を作成 (QuestionSubtotalAssignment の新版)
+/** 採点領域と小計項目の関連付け（CropSubtotal）を作成する（cropRegion・subtotal含む） */
 export const createQuestionSubtotalAssignment = async (
   data: Prisma.CropSubtotalUncheckedCreateInput // cropRegionId と subtotalId を直接含める
 ) => {
@@ -15,7 +15,7 @@ export const createQuestionSubtotalAssignment = async (
   })
 }
 
-// 複数の CropSubtotal を作成
+/** 採点領域と小計項目の関連付けを一括作成する */
 export const createManyQuestionSubtotalAssignments = async (
   assignments: Prisma.CropSubtotalUncheckedCreateInput[]
 ) => {
@@ -24,14 +24,14 @@ export const createManyQuestionSubtotalAssignments = async (
   })
 }
 
-// CropSubtotal を削除 (IDで)
+/** IDで採点領域と小計項目の関連付けを削除する */
 export const deleteQuestionSubtotalAssignment = async (id: string) => {
   return prisma.cropSubtotal.delete({
     where: { id },
   })
 }
 
-// CropRegion ID で CropSubtotal を削除
+/** 採点領域IDに紐づく全ての小計関連付けを削除する */
 export const deleteAssignmentsByQuestionLayoutRegionId = async (
   cropRegionId: string
 ) => {
@@ -40,7 +40,7 @@ export const deleteAssignmentsByQuestionLayoutRegionId = async (
   })
 }
 
-// Subtotal ID で CropSubtotal を削除
+/** 小計項目IDに紐づく全ての採点領域関連付けを削除する */
 export const deleteAssignmentsByQuestionGroupItemId = async (
   subtotalId: string
 ) => {
@@ -49,7 +49,7 @@ export const deleteAssignmentsByQuestionGroupItemId = async (
   })
 }
 
-// CropRegion ID で CropSubtotal を取得
+/** 採点領域IDで小計関連付け一覧を取得する（subtotal含む） */
 export const getAssignmentsByQuestionLayoutRegionId = async (
   cropRegionId: string
 ) => {
@@ -61,7 +61,7 @@ export const getAssignmentsByQuestionLayoutRegionId = async (
   })
 }
 
-// Subtotal ID で CropSubtotal を取得
+/** 小計項目IDで採点領域関連付け一覧を取得する（cropRegion含む） */
 export const getAssignmentsByQuestionGroupItemId = async (
   subtotalId: string
 ) => {

--- a/electron-src/lib/prisma/schema/migrationRunner.ts
+++ b/electron-src/lib/prisma/schema/migrationRunner.ts
@@ -1,7 +1,7 @@
 import { createSharedPrismaClient } from "../databaseInitializer"
 import { getTableColumns, tableExists } from "../databaseUtils"
 
-// 既存データベースのスキーママイグレーション
+/** 既存データベースに対して未適用のスキーマ変更（カラム追加・テーブル作成等）を順次適用する */
 export const migrateExistingDatabase = async (): Promise<void> => {
   const prisma = createSharedPrismaClient()
 

--- a/electron-src/lib/prisma/student.ts
+++ b/electron-src/lib/prisma/student.ts
@@ -28,6 +28,7 @@ type ClassWithMemberships = Prisma.ClassGetPayload<{
   }
 }>
 
+/** 全生徒を取得する（学級メンバーシップ・クラス情報含む、現在・過去両方） */
 export const fetchStudents = async (): Promise<StudentWithMemberships[]> => {
   try {
     const students = await prisma.student.findMany({
@@ -50,6 +51,7 @@ export const fetchStudents = async (): Promise<StudentWithMemberships[]> => {
   }
 }
 
+/** 生徒を作成する（現在有効なメンバーシップ含む） */
 export const createStudent = async (
   studentData: Prisma.StudentCreateInput
 ): Promise<StudentWithMemberships> => {
@@ -76,6 +78,7 @@ export const createStudent = async (
   }
 }
 
+/** 生徒情報を更新する（現在有効なメンバーシップ含む） */
 export const updateStudent = async (
   id: string,
   studentData: Prisma.StudentUpdateInput
@@ -104,6 +107,7 @@ export const updateStudent = async (
   }
 }
 
+/** 生徒を削除する */
 export const deleteStudent = async (id: string): Promise<void> => {
   try {
     await prisma.student.delete({ where: { id } })
@@ -113,6 +117,7 @@ export const deleteStudent = async (id: string): Promise<void> => {
   }
 }
 
+/** 全学級を取得する（現在所属中の生徒メンバーシップ含む） */
 export const fetchClasses = async (): Promise<ClassWithMemberships[]> => {
   try {
     return await prisma.class.findMany({
@@ -133,6 +138,7 @@ export const fetchClasses = async (): Promise<ClassWithMemberships[]> => {
   }
 }
 
+/** 学級を作成する（現在所属中のメンバーシップ含む） */
 export const createClass = async (
   classData: Prisma.ClassCreateInput
 ): Promise<ClassWithMemberships> => {
@@ -156,6 +162,7 @@ export const createClass = async (
   }
 }
 
+/** 学級情報を更新する（現在所属中のメンバーシップ含む） */
 export const updateClass = async (
   id: string,
   classData: Prisma.ClassUpdateInput
@@ -181,6 +188,7 @@ export const updateClass = async (
   }
 }
 
+/** 学級を削除する（現在所属中の生徒がいる場合はエラー） */
 export const deleteClass = async (id: string): Promise<void> => {
   try {
     // Check if class has current students before deleting
@@ -208,7 +216,6 @@ export const deleteClass = async (id: string): Promise<void> => {
   }
 }
 
-// 生徒の試験成績を取得
 export interface StudentExamResult {
   examId: string
   examName: string
@@ -221,6 +228,7 @@ export interface StudentExamResult {
   status: "complete" | "partial" | "unscored"
 }
 
+/** 生徒の全試験成績を取得する（得点・配点・採点状況を集計、試験日降順） */
 export const getStudentExamResults = async (
   studentId: string
 ): Promise<StudentExamResult[]> => {

--- a/electron-src/lib/prisma/studentClassMembership.ts
+++ b/electron-src/lib/prisma/studentClassMembership.ts
@@ -36,6 +36,7 @@ type ClassWithMemberships = Prisma.ClassGetPayload<{
   }
 }>
 
+/** 生徒の学級所属レコードを作成する（student・class含む） */
 export const createStudentClassMembership = async (
   membershipData: Prisma.StudentClassMembershipCreateInput
 ): Promise<StudentClassMembershipWithDetails> => {
@@ -53,6 +54,7 @@ export const createStudentClassMembership = async (
   }
 }
 
+/** 生徒の学級所属レコードを更新する（student・class含む） */
 export const updateStudentClassMembership = async (
   id: string,
   membershipData: Prisma.StudentClassMembershipUpdateInput
@@ -72,6 +74,7 @@ export const updateStudentClassMembership = async (
   }
 }
 
+/** 生徒の学級所属レコードを削除する */
 export const deleteStudentClassMembership = async (
   id: string
 ): Promise<void> => {
@@ -83,7 +86,7 @@ export const deleteStudentClassMembership = async (
   }
 }
 
-// 学生の現在の所属クラス一覧を取得
+/** 生徒の現在所属中の学級一覧を取得する（endDateがnullのもの、student・class含む） */
 export const getCurrentMembershipsByStudentId = async (
   studentId: string
 ): Promise<StudentClassMembershipWithDetails[]> => {
@@ -107,7 +110,7 @@ export const getCurrentMembershipsByStudentId = async (
   }
 }
 
-// 学生の全所属履歴を取得
+/** 生徒の全所属履歴を取得する（過去分含む、student・class含む） */
 export const getAllMembershipsByStudentId = async (
   studentId: string
 ): Promise<StudentClassMembershipWithDetails[]> => {
@@ -128,7 +131,7 @@ export const getAllMembershipsByStudentId = async (
   }
 }
 
-// クラスの現在の所属学生一覧を取得（出席番号順）
+/** 学級の現在所属中の生徒一覧を取得する（出席番号順、student・class含む） */
 export const getCurrentMembershipsByClassId = async (
   classId: string
 ): Promise<StudentClassMembershipWithDetails[]> => {
@@ -153,7 +156,7 @@ export const getCurrentMembershipsByClassId = async (
   }
 }
 
-// 学生をクラスに追加（新規所属）
+/** 生徒を学級に追加する（新規所属レコード作成、student・class含む） */
 export const addStudentToClass = async (
   studentId: string,
   classId: string,
@@ -177,7 +180,7 @@ export const addStudentToClass = async (
   }
 }
 
-// 学生のクラス所属を終了
+/** 生徒の学級所属を終了する（endDateを設定） */
 export const endStudentMembership = async (
   membershipId: string,
   endDate: Date = new Date()
@@ -192,7 +195,7 @@ export const endStudentMembership = async (
   }
 }
 
-// 特定期間の所属情報を取得
+/** 指定期間に有効な所属情報を取得する（期間内開始・期間をまたぐもの含む、student・class含む） */
 export const getMembershipsByDateRange = async (
   startDate: Date,
   endDate?: Date

--- a/electron-src/lib/prisma/subtotal.ts
+++ b/electron-src/lib/prisma/subtotal.ts
@@ -2,7 +2,7 @@ import type { Prisma, Subtotal } from "@prisma/client"
 
 import prisma from "./client"
 
-// Subtotal を作成
+/** 小計項目（Subtotal）を1件作成する */
 export const createSubtotal = async (
   data: Prisma.SubtotalUncheckedCreateInput // subtotalGroupId を直接含める
 ) => {
@@ -11,7 +11,7 @@ export const createSubtotal = async (
   })
 }
 
-// 複数の Subtotal を作成 (特定の SubtotalGroup に対して)
+/** 複数の小計項目（Subtotal）を一括作成する */
 export const createManySubtotals = async (
   items: Prisma.SubtotalUncheckedCreateInput[]
 ) => {
@@ -20,7 +20,7 @@ export const createManySubtotals = async (
   })
 }
 
-// Subtotal を更新
+/** 小計項目（Subtotal）を更新する */
 export const updateSubtotal = async (
   id: string,
   data: Prisma.SubtotalUpdateInput
@@ -31,7 +31,7 @@ export const updateSubtotal = async (
   })
 }
 
-// Subtotal を削除
+/** 小計項目（Subtotal）を削除する（関連CropSubtotalもカスケード削除） */
 export const deleteSubtotal = async (id: string) => {
   // 関連する CropSubtotal も削除される（onDelete: Cascade が設定済み）
   return prisma.subtotal.delete({
@@ -39,7 +39,7 @@ export const deleteSubtotal = async (id: string) => {
   })
 }
 
-// SubtotalGroup ID で Subtotal を取得
+/** SubtotalGroup IDで小計項目一覧を取得する（order昇順） */
 export const getSubtotalsByGroupId = async (subtotalGroupId: string) => {
   return prisma.subtotal.findMany({
     where: { subtotalGroupId },
@@ -49,7 +49,7 @@ export const getSubtotalsByGroupId = async (subtotalGroupId: string) => {
   })
 }
 
-// IDで Subtotal を取得
+/** IDで小計項目を取得する（subtotalGroup・cropSubtotals含む） */
 export const getSubtotalById = async (id: string) => {
   return prisma.subtotal.findUnique({
     where: { id },
@@ -67,7 +67,7 @@ export type SubtotalWithDetails = Prisma.SubtotalGetPayload<{
   }
 }>
 
-// Subtotal の順序を一括更新
+/** 小計項目の表示順序をトランザクション内で一括更新する */
 export const updateSubtotalOrders = async (
   orders: { id: string; order: number }[]
 ) => {

--- a/electron-src/lib/prisma/subtotalDefinition.ts
+++ b/electron-src/lib/prisma/subtotalDefinition.ts
@@ -2,7 +2,7 @@ import type { Prisma, Subtotal } from "@prisma/client"
 
 import prisma from "./client"
 
-// Subtotal を作成
+/** 小計定義（Subtotal）を作成する（subtotalGroup・cropSubtotals含む） */
 export const createSubtotalDefinition = async (
   data: Prisma.SubtotalUncheckedCreateInput // cropRegionId と subtotalId を直接含める
 ) => {
@@ -15,7 +15,7 @@ export const createSubtotalDefinition = async (
   })
 }
 
-// 複数の Subtotal を作成 (特定の LayoutRegion に対して)
+/** 複数の小計定義（Subtotal）を一括作成する */
 export const createManySubtotalDefinitions = async (
   definitions: Prisma.SubtotalUncheckedCreateInput[]
 ) => {
@@ -24,15 +24,14 @@ export const createManySubtotalDefinitions = async (
   })
 }
 
-// Subtotal を削除 (IDで)
+/** IDで小計定義（Subtotal）を削除する */
 export const deleteSubtotalDefinition = async (id: string) => {
   return prisma.subtotal.delete({
     where: { id },
   })
 }
 
-// CropRegion ID で Subtotal を削除 (特定の採点領域の定義をすべて削除)
-// TODO: This function needs to be rewritten for new schema
+/** 採点領域IDに紐づく小計定義を全て削除する（未実装：新スキーマ対応待ち） */
 export const deleteSubtotalDefinitionsByCropRegionId = async (
   _cropRegionId: string
 ) => {
@@ -42,8 +41,7 @@ export const deleteSubtotalDefinitionsByCropRegionId = async (
   return { count: 0 }
 }
 
-// QuestionGroupItem ID で Subtotal を取得 (特定のグループ項目を参照する集計定義を取得)
-// TODO: This function needs to be rewritten for new schema
+/** 設問グループ項目IDで小計定義一覧を取得する（未実装：新スキーマ対応待ち） */
 export const getSubtotalDefinitionsByQuestionGroupItemId = async (
   _questionGroupItemId: string
 ) => {
@@ -53,8 +51,7 @@ export const getSubtotalDefinitionsByQuestionGroupItemId = async (
   return []
 }
 
-// CropRegion ID で Subtotal を取得 (特定の採点領域が持つ集計定義を取得)
-// TODO: This function needs to be rewritten for new schema
+/** 採点領域IDで小計定義一覧を取得する（未実装：新スキーマ対応待ち） */
 export const getSubtotalDefinitionsByCropRegionId = async (
   _cropRegionId: string
 ) => {

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -402,7 +402,7 @@ export async function removeSubtotalGroupFromExam(
   }
 }
 
-// 既存の関数は互換性のために残す
+/** 試験IDで有効な小計点グループ一覧を取得する（互換性レイヤー、examIdを付与して返す） */
 export const getSubtotalGroupsByExamId = async (examId: string) => {
   const result = await getActiveSubtotalGroupsForExam(examId)
   if (result.success && result.examSubtotalGroups) {
@@ -414,6 +414,7 @@ export const getSubtotalGroupsByExamId = async (examId: string) => {
   return []
 }
 
+/** IDで小計点グループを取得する（subtotals・examSubtotalGroups含む） */
 export const getSubtotalGroupById = async (id: string) => {
   return prisma.subtotalGroup.findUnique({
     where: { id },

--- a/electron-src/nextServerEmbedded.ts
+++ b/electron-src/nextServerEmbedded.ts
@@ -47,6 +47,7 @@ const ensurePackagedNodePath = (basePath: string) => {
   }
 }
 
+/** パッケージ化環境でNext.jsサーバーをlocalhost:3000で起動する（開発時はスキップ） */
 export async function startEmbeddedNextServer(): Promise<void> {
   if (isDev) return // 開発時は外部サーバーを使用
 

--- a/electron-src/preload-apis/answerSheetApi.ts
+++ b/electron-src/preload-apis/answerSheetApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 答案用紙のIPC API（アップロード・生徒紐付け・配置管理・一括更新） */
 export function createAnswerSheetApi() {
   return {
     // Student answer related

--- a/electron-src/preload-apis/answerSheetBuilderApi.ts
+++ b/electron-src/preload-apis/answerSheetBuilderApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 解答用紙ビルダーのIPC API（定義CRUD・PDF/PNG出力・印刷・インポート/エクスポート） */
 export function createAnswerSheetBuilderApi() {
   return {
     answerSheetBuilder: {

--- a/electron-src/preload-apis/archiveApi.ts
+++ b/electron-src/preload-apis/archiveApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 試験・生徒アーカイブのIPC API（エクスポート・インポート・競合検出・ID統合） */
 export function createArchiveApi() {
   return {
     // Exam Archive (Export/Import) related

--- a/electron-src/preload-apis/authApi.ts
+++ b/electron-src/preload-apis/authApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 認証・ユーザー管理のIPC API（ログイン・ユーザーCRUD・トークン永続化・パスコード） */
 export function createAuthApi() {
   return {
     // User related

--- a/electron-src/preload-apis/cropRegionApi.ts
+++ b/electron-src/preload-apis/cropRegionApi.ts
@@ -6,6 +6,7 @@ import {
   CropRegionUpdateData,
 } from "../../src/types/common.types"
 
+/** 採点領域（CropRegion）のIPC API（CRUD・一括作成・並び順更新） */
 export function createCropRegionApi() {
   return {
     // CropRegion functions (renamed from LayoutRegion)

--- a/electron-src/preload-apis/drawingApi.ts
+++ b/electron-src/preload-apis/drawingApi.ts
@@ -1,6 +1,7 @@
 import type { DrawingAnnotation } from "@prisma/client"
 import { ipcRenderer } from "electron"
 
+/** 描画アノテーションのIPC API（CRUD・一括操作・お気に入り・統計取得） */
 export function createDrawingApi() {
   return {
     // Drawing Annotation related

--- a/electron-src/preload-apis/examApi.ts
+++ b/electron-src/preload-apis/examApi.ts
@@ -3,6 +3,7 @@ import { ipcRenderer } from "electron"
 
 import { CreateExamArgs } from "../../src/types/electron/examApi"
 
+/** 試験管理のIPC API（CRUD・模範解答・受験生徒管理・学級連携） */
 export function createExamApi() {
   return {
     fetchExams: (userId: string) => ipcRenderer.invoke("fetch-exams", userId),

--- a/electron-src/preload-apis/examClassApi.ts
+++ b/electron-src/preload-apis/examClassApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 試験-学級関連のIPC API（実施・統計学級の管理・生徒一括追加・並び替え） */
 export function createExamClassApi() {
   return {
     // ExamClass

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 出力機能のIPC API（PDF/Excel出力・ストリーミング生成・個人成績表・印刷） */
 export function createExportApi() {
   return {
     // Canvas描画エンジン用PDF出力API

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 成績算出のIPC API（成績CRUD・データソース・評定境界・手動点数・Excel出力） */
 export function createGradeApi() {
   return {
     // Grade（成績算出）

--- a/electron-src/preload-apis/legacyCompatApi.ts
+++ b/electron-src/preload-apis/legacyCompatApi.ts
@@ -6,6 +6,7 @@ import {
   CropRegionUpdateData,
 } from "../../src/types/common.types"
 
+/** 旧名称互換のIPC API（LayoutRegion・QuestionGroup等の旧名を新APIへ転送） */
 export function createLegacyCompatApi() {
   return {
     // 互換性関数（段階的移行のため古い名前も残す）

--- a/electron-src/preload-apis/miscApi.ts
+++ b/electron-src/preload-apis/miscApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 汎用ユーティリティのIPC API（画像取得・ファイル操作・データディレクトリ管理） */
 export function createMiscApi() {
   return {
     // File/image related

--- a/electron-src/preload-apis/omrApi.ts
+++ b/electron-src/preload-apis/omrApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** OMR（光学マーク認識）のIPC API（マーカー検出・シート認識・一括認識・OMR設定） */
 export function createOmrApi() {
   return {
     // OMR（光学マーク認識）

--- a/electron-src/preload-apis/pdfToolsApi.ts
+++ b/electron-src/preload-apis/pdfToolsApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer, webUtils } from "electron"
 
+/** PDFツールのIPC API（結合・分割・回転・N-up・PNG出力・ファイル選択） */
 export function createPdfToolsApi() {
   return {
     // PDF Tools related

--- a/electron-src/preload-apis/scoringApi.ts
+++ b/electron-src/preload-apis/scoringApi.ts
@@ -5,6 +5,7 @@ import {
   QuestionScoreUpdateData,
 } from "../../src/types/common.types"
 
+/** 採点スコアのIPC API（設問スコアCRUD・一括更新・進捗取得・採点初期化） */
 export function createScoringApi() {
   return {
     // QuestionScore related functions

--- a/electron-src/preload-apis/settingsApi.ts
+++ b/electron-src/preload-apis/settingsApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 設定管理のIPC API（表示設定・キーボードショートカット・採点マーク書式・出力設定） */
 export function createSettingsApi() {
   return {
     // Settings

--- a/electron-src/preload-apis/studentApi.ts
+++ b/electron-src/preload-apis/studentApi.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client"
 import { ipcRenderer } from "electron"
 
+/** 生徒・学級・所属管理のIPC API（生徒CRUD・学級CRUD・クラス所属・Excel出力） */
 export function createStudentApi() {
   return {
     // Student related

--- a/electron-src/preload-apis/subjectApi.ts
+++ b/electron-src/preload-apis/subjectApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** 教科・教科-小計グループ関連のIPC API（教科CRUD・小計グループとの紐付け管理） */
 export function createSubjectApi() {
   return {
     // Subject（教科）

--- a/electron-src/preload-apis/subtotalApi.ts
+++ b/electron-src/preload-apis/subtotalApi.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client"
 import { ipcRenderer } from "electron"
 
+/** 小計グループ・小計・採点領域-小計紐付けのIPC API（CRUD・試験への割り当て管理） */
 export function createSubtotalApi() {
   return {
     // SubtotalGroup related (new management API with correct parameter format)

--- a/electron-src/preload-apis/userExamApi.ts
+++ b/electron-src/preload-apis/userExamApi.ts
@@ -1,5 +1,6 @@
 import { ipcRenderer } from "electron"
 
+/** ユーザー-試験関連のIPC API（メンバー管理・権限確認・招待・オーナー移譲） */
 export function createUserExamApi() {
   return {
     // UserExam

--- a/electron-src/windowManager.ts
+++ b/electron-src/windowManager.ts
@@ -13,6 +13,7 @@ import menu from "./menu"
 // Electron公式推奨の環境判定方法
 const isDev = !app.isPackaged
 
+/** メインウィンドウを作成し、Next.jsサーバーの準備完了後にURLを読み込んで表示する */
 export function createMainWindow(): BrowserWindow {
   // アイコンのパスを設定（プラットフォーム別）
   const getIconPath = () => {
@@ -148,6 +149,7 @@ export function createMainWindow(): BrowserWindow {
   return mainWindow
 }
 
+/** ウィンドウのフォーカス・ブラー時のイベントハンドラを設定する（ブラー時にforce-saveを送信） */
 export function setupWindowEvents(mainWindow: BrowserWindow): void {
   // アプリケーションフォーカス監視でバックグラウンド処理対策
   app.on("browser-window-focus", () => {

--- a/src/components/answer-sheet-builder/hooks/useAnswerSheetDefinition.ts
+++ b/src/components/answer-sheet-builder/hooks/useAnswerSheetDefinition.ts
@@ -339,6 +339,7 @@ function reducer(
   }
 }
 
+/** 解答用紙定義のCRUD操作とUndo/Redo対応の状態管理を提供するフック */
 export function useAnswerSheetDefinition(initial?: AnswerSheetDefinition) {
   const {
     state: definition,

--- a/src/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
+++ b/src/components/answer-sheet-builder/hooks/useAnswerSheetExport.ts
@@ -16,6 +16,7 @@ import {
 } from "../utils/generatePrintHtml"
 import { computeMultiPageLayoutFromDefinition } from "./layout/computeMultiPageLayout"
 
+/** 解答用紙のPDF/PNG出力・印刷機能を提供するフック */
 export function useAnswerSheetExport() {
   const [isExporting, setIsExporting] = useState(false)
 

--- a/src/components/answer-sheet-builder/hooks/useExamIntegration.ts
+++ b/src/components/answer-sheet-builder/hooks/useExamIntegration.ts
@@ -14,6 +14,7 @@ import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 import { generateAnswerSheetPageHtmls } from "../utils/generatePrintHtml"
 import { computeMultiPageLayoutFromDefinition } from "./layout/computeMultiPageLayout"
 
+/** 解答用紙定義を試験データに変換して登録するフック */
 export function useExamIntegration() {
   const [isConverting, setIsConverting] = useState(false)
   const router = useRouter()

--- a/src/components/answer-sheet-builder/hooks/usePreviewDragInteraction.ts
+++ b/src/components/answer-sheet-builder/hooks/usePreviewDragInteraction.ts
@@ -31,6 +31,7 @@ export interface PreviewDragResult {
   cursor: string
 }
 
+/** SVGプレビュー上の罫線ドラッグによる行高さ・列幅の微調整を管理するフック */
 export function usePreviewDragInteraction(
   layout: ComputedLayout,
   interactive: boolean,

--- a/src/components/answer-sheet-builder/hooks/useUndoRedoShortcuts.ts
+++ b/src/components/answer-sheet-builder/hooks/useUndoRedoShortcuts.ts
@@ -15,6 +15,7 @@ interface UseUndoRedoShortcutsOptions {
   canRedo: boolean
 }
 
+/** Ctrl+Z/Ctrl+Shift+ZによるUndo/Redoキーボードショートカットを登録するフック */
 export function useUndoRedoShortcuts({
   undo,
   redo,

--- a/src/components/answer-sheet-builder/hooks/useUndoableReducer.ts
+++ b/src/components/answer-sheet-builder/hooks/useUndoableReducer.ts
@@ -33,6 +33,7 @@ export interface UndoableResult<S, A> {
   redo: () => void
 }
 
+/** useReducerにUndo/Redo履歴管理とデバウンスを追加する汎用フック */
 export function useUndoableReducer<S, A extends { type: string }>(
   innerReducer: (state: S, action: A) => S,
   initialState: S

--- a/src/components/answer-sheet-builder/utils/generatePrintHtml.ts
+++ b/src/components/answer-sheet-builder/utils/generatePrintHtml.ts
@@ -117,10 +117,7 @@ function generatePageCss(pageWidthMm: number, pageHeightMm: number): string {
   foreignObject svg[role="img"] { overflow: visible !important; display: inline !important; }`
 }
 
-/**
- * 解答用紙の印刷用HTMLを生成する。
- * プレビューと同じ AnswerSheetSVGRenderer を renderToStaticMarkup で使用。
- */
+/** 解答用紙の全ページを含む印刷用HTML文書を生成する */
 export async function generateAnswerSheetPrintHtml(
   definition: AnswerSheetDefinition,
   multiLayout: ComputedMultiPageLayout
@@ -155,11 +152,7 @@ ${pagesHtml}
 </html>`
 }
 
-/**
- * 解答用紙のページごとの独立HTMLを生成する。
- * BrowserWindow + capturePage でPNG化するために使用。
- * 各HTMLは1ページ分のSVGを含む完全なHTML文書。
- */
+/** 解答用紙の各ページを個別のHTML文書として生成する（PNG出力用） */
 export async function generateAnswerSheetPageHtmls(
   definition: AnswerSheetDefinition,
   multiLayout: ComputedMultiPageLayout,

--- a/src/components/answer-sheet-builder/utils/renderSvgStrings.ts
+++ b/src/components/answer-sheet-builder/utils/renderSvgStrings.ts
@@ -7,10 +7,7 @@
 
 import type { ComputedCell } from "@/types/answerSheetLayout.types"
 
-/**
- * セル群から画像要素のパスを収集し、appimg:// → base64 data URI に変換する。
- * エクスポート時（PDF/PNG/印刷）に使用。
- */
+/** セル内の画像パスをbase64 data URIに一括変換する（エクスポート時に使用） */
 export async function resolveImageDataUris(
   cells: ComputedCell[]
 ): Promise<Map<string, string>> {

--- a/src/components/exams/02-template/hooks/useImageCanvasInteraction.ts
+++ b/src/components/exams/02-template/hooks/useImageCanvasInteraction.ts
@@ -25,6 +25,7 @@ import {
 import { useCanvasCoordinates } from "./useCanvasCoordinates"
 import { useMouseHandlers } from "./useMouseHandlers"
 
+/** 採点領域の作成・リサイズ・移動などキャンバス上のマウス操作を管理するフック */
 export function useImageCanvasInteraction({
   disabled,
   backgroundImageUrl,

--- a/src/components/exams/02-template/hooks/useKeyboardShortcuts.ts
+++ b/src/components/exams/02-template/hooks/useKeyboardShortcuts.ts
@@ -12,6 +12,7 @@
 
 import { useEffect } from "react"
 
+/** 採点領域キャンバスのキーボードショートカット（Delete/Backspaceによる領域削除）を管理するフック */
 export function useKeyboardShortcuts(
   selectedAreaIndex: number | null,
   onDeleteArea: (index: number) => void

--- a/src/components/exams/02-template/hooks/useZoomControls.ts
+++ b/src/components/exams/02-template/hooks/useZoomControls.ts
@@ -12,6 +12,7 @@
 
 import { useEffect, useRef, useState } from "react"
 
+/** キーボード・マウスホイールによるズーム操作を管理するフック */
 export function useZoomControls() {
   const imageContainerRef = useRef<HTMLDivElement>(null)
   const [zoom, setZoom] = useState(1)

--- a/src/components/exams/02-template/utils/frameDetector.ts
+++ b/src/components/exams/02-template/utils/frameDetector.ts
@@ -48,6 +48,7 @@ const MIN_LINE_LENGTH_RATIO = 0.02
 /**
  * 感度レベル（1-5）に応じたパラメータ
  */
+/** 感度レベル（1〜5）に応じた二値化・線検出パラメータを返す */
 function getSensitivityParams(sensitivity: number) {
   // sensitivity: 1(低感度) ～ 5(高感度)
   const s = Math.max(1, Math.min(5, sensitivity))
@@ -632,4 +633,5 @@ export class FrameDetector {
 /**
  * シングルトンインスタンス
  */
+/** FrameDetectorのシングルトンインスタンス */
 export const frameDetector = new FrameDetector()

--- a/src/components/exams/03-region-info/hooks/useDragAndDrop.ts
+++ b/src/components/exams/03-region-info/hooks/useDragAndDrop.ts
@@ -14,6 +14,7 @@ type UseDragAndDropProps = {
   setSelectedRowIndex: React.Dispatch<React.SetStateAction<number | null>>
 }
 
+/** 領域情報テーブルの行ドラッグ&ドロップによる並び替えを管理するフック */
 export const useDragAndDrop = ({
   regions,
   setRegions,

--- a/src/components/exams/03-region-info/hooks/useKeyboardNavigation.ts
+++ b/src/components/exams/03-region-info/hooks/useKeyboardNavigation.ts
@@ -6,6 +6,7 @@ type UseKeyboardNavigationProps = {
   filteredRegions: CropRegionWithDetails[]
 }
 
+/** 領域情報テーブルのEnter/Tabキーによるセル間移動を管理するフック */
 export const useKeyboardNavigation = ({
   filteredRegions,
 }: UseKeyboardNavigationProps) => {

--- a/src/components/exams/05-students/components/exam-student-add-modal/hooks/useExamStudentAddModal.ts
+++ b/src/components/exams/05-students/components/exam-student-add-modal/hooks/useExamStudentAddModal.ts
@@ -14,6 +14,7 @@ interface UseExamStudentAddModalProps {
   onClose: () => void
 }
 
+/** 試験への生徒追加モーダルの状態管理（学級一括追加・個別追加・フィルタ）を行うフック */
 export function useExamStudentAddModal({
   isOpen,
   examId,

--- a/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
+++ b/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
@@ -15,6 +15,7 @@ interface UseExamStudentsDataProps {
   examId: string
 }
 
+/** 試験の受験生徒一覧の取得・フィルタ・ステータス更新・並び替え・削除を管理するフック */
 export function useExamStudentsData({ examId }: UseExamStudentsDataProps) {
   const [loading, setLoading] = useState(true)
   const [students, setStudents] = useState<Student[]>([]) // 順序付き生徒リスト

--- a/src/components/exams/05-students/components/sortable-student-table/hooks/useSortableStudentTable.ts
+++ b/src/components/exams/05-students/components/sortable-student-table/hooks/useSortableStudentTable.ts
@@ -25,6 +25,7 @@ interface UseSortableStudentTableProps {
   examId: string
 }
 
+/** 生徒テーブルのドラッグ並び替え・Shift範囲選択・順序リセットを管理するフック */
 export function useSortableStudentTable({
   filteredStudents,
   selectedStudents,

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useFileProcessing.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useFileProcessing.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 import { ConvertedFile } from "@/components/exams/06-student-answers/student-answer-management/hooks/types"
 import { convertPdfToImages } from "@/lib/pdfConverter"
 
+/** PDF・画像ファイルの変換処理とパスワード保護PDF対応を管理するフック */
 export function useFileProcessing() {
   const [files, setFiles] = useState<ConvertedFile[]>([])
   const [isConverting, setIsConverting] = useState(false)

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/components/exams/06-student-answers/student-answer-management/types"
 import { type ConvertedImage, convertPdfToImages } from "@/lib/pdfConverter"
 
+/** 答案ファイルのドロップ・変換・アップロード処理を統合するフック */
 export function useStudentAnswerUpload(
   examId: string,
   onUploadComplete?: () => void,

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUploadMain.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUploadMain.ts
@@ -14,6 +14,7 @@ import { useFileProcessing } from "@/components/exams/06-student-answers/student
 import { useStudentManagement } from "@/components/exams/06-student-answers/student-answer-management/hooks/useStudentManagement"
 import type { UploadStudentAnswerFileData } from "@/types/electron/studentAnswerApi"
 
+/** 答案アップロード画面のメインフック（ファイル処理・生徒管理・アップロード実行を統合） */
 export function useStudentAnswerUploadMain({
   examId,
   students,

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentManagement.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentManagement.ts
@@ -18,6 +18,7 @@ interface UseStudentManagementProps {
   }>
 }
 
+/** 答案アップロード時の生徒選択状態・上書き設定を管理するフック */
 export function useStudentManagement({ students }: UseStudentManagementProps) {
   const [studentsWithAnswers, setStudentsWithAnswers] = useState<
     StudentWithAnswers[]

--- a/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
@@ -22,11 +22,7 @@ type AnswerSheetInput =
       }
     }
 
-/**
- * データベースから取得した答案データを、テーブル表示用のUnifiedFile形式に変換する
- * @param answerSheets データベースから取得した答案データ
- * @returns UnifiedFile配列
- */
+/** DB取得済みの答案データをテーブル表示用のUnifiedFile配列に変換する */
 export function convertAnswerSheetsToFiles(
   answerSheets: AnswerSheetInput[]
 ): UnifiedFile[] {
@@ -66,11 +62,7 @@ export function convertAnswerSheetsToFiles(
   })
 }
 
-/**
- * 生徒答案画像の遅延読み込み用関数
- * @param file UnifiedFileオブジェクト
- * @returns Base64エンコードされた画像データURL
- */
+/** UnifiedFileから答案画像をBase64データURLとして読み込む（遅延読み込み対応） */
 export async function loadStudentAnswerImage(
   file: UnifiedFile
 ): Promise<string> {

--- a/src/components/exams/06-student-answers/student-answer-management/utils/reorderFilesByStrategy.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/utils/reorderFilesByStrategy.ts
@@ -7,9 +7,7 @@ import type {
 import type { ProcessedStudentAnswer } from "../types"
 import { convertAnswerSheetsToFiles } from "./convertStudentAnswersToFiles"
 
-/**
- * 現在のファイル配列を新しい配置戦略に基づいて再配置する
- */
+/** 配置戦略（ページ順/生徒順）に基づいてファイル配列を再配置する */
 export function reorderFilesByStrategy(
   currentFiles: UnifiedFile[],
   students: UnifiedStudent[],
@@ -81,9 +79,7 @@ export function reorderFilesByStrategy(
   return reorderedFiles
 }
 
-/**
- * 既存の答案データから配置戦略に基づく統一ファイル配列を構築
- */
+/** 既存の答案データを配置戦略に基づく統一ファイル配列に変換する */
 export function buildOrderedFileArrayFromStudentAnswers(
   studentAnswers: ProcessedStudentAnswer[],
   students: UnifiedStudent[],

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react"
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
 import type { UnifiedStudent } from "@/components/exams/06-student-answers/types"
 
+/** 答案テーブルの行・列・セル単位の無効化状態と上書きモードを管理するフック */
 export function useDisabledState() {
   const [disabledState, setDisabledState] = useState<ExtendedDisabledState>({
     rows: new Set(),

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react"
 
 import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
 
+/** 答案画像から氏名欄領域をクリッピングして表示するためのフック */
 export function useNameRegion(examId: string) {
   const [nameRegionAvailable, setNameRegionAvailable] = useState<
     Record<number, boolean>

--- a/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
@@ -5,9 +5,7 @@ import type {
   UnifiedStudent,
 } from "@/components/exams/06-student-answers/types"
 
-/**
- * 3つ組からDnD配列を構築する関数（戦略ベース順序）
- */
+/** FileState配列と配置戦略からDnD用の順序付きファイル配列を構築する */
 export function buildDnDArrayFromFileStates(
   fileStates: FileState[],
   strategy: PlacementStrategy,
@@ -77,9 +75,7 @@ export function buildDnDArrayFromFileStates(
   return orderedFiles
 }
 
-/**
- * DnD配列から3つ組を更新する関数（ファイル実データを直接使用）
- */
+/** DnD後のファイル配列からFileState（ファイルID・生徒ID・ページ番号の組）を再生成する */
 export function updateFileStatesFromDnDArray(
   dndArray: UnifiedFile[]
 ): FileState[] {
@@ -91,9 +87,7 @@ export function updateFileStatesFromDnDArray(
   }))
 }
 
-/**
- * ファイル状態を比較して変更されたファイルを検知する関数
- */
+/** 初期状態と現在状態を比較し、生徒IDまたはページ番号が変更されたファイルを返す */
 export function compareFileStates(
   initialStates: FileState[],
   currentStates: FileState[]

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -4,9 +4,7 @@ import type {
   UnifiedStudent,
 } from "@/components/exams/06-student-answers/types"
 
-/**
- * 生徒をcustomOrder順にソートする
- */
+/** 生徒をcustomOrder昇順にソートした新しい配列を返す */
 export function sortStudentsByCustomOrder(
   students: UnifiedStudent[]
 ): UnifiedStudent[] {
@@ -17,9 +15,7 @@ export function sortStudentsByCustomOrder(
   })
 }
 
-/**
- * 動的無効化計算：答案がない位置を無効化（確認モードのみ）
- */
+/** 確認モードで答案が存在しないテーブル位置を無効化するSetを返す */
 export function calculateDynamicDisabledPositions(
   files: UnifiedFile[],
   sortedStudents: UnifiedStudent[],
@@ -71,9 +67,7 @@ export function calculateDynamicDisabledPositions(
   return dynamicDisabled
 }
 
-/**
- * 既存答案がある位置の計算（警告オーバーレイ用）
- */
+/** 既存の答案が割り当てられているテーブル位置のSetを返す（警告オーバーレイ用） */
 export function calculatePositionsWithExistingAnswers(
   files: UnifiedFile[],
   sortedStudents: UnifiedStudent[],
@@ -128,9 +122,7 @@ export function calculatePositionsWithExistingAnswers(
   return positions
 }
 
-/**
- * 有効ファイルのフィルタリング
- */
+/** 無効化されていないファイルのみをフィルタリングして返す */
 export function getEnabledFiles(
   files: UnifiedFile[],
   disabledState: ExtendedDisabledState
@@ -138,9 +130,7 @@ export function getEnabledFiles(
   return files.filter((file) => !disabledState.files.has(file.id))
 }
 
-/**
- * 無効ファイルのフィルタリング
- */
+/** 無効化されたファイルのみをフィルタリングして返す */
 export function getDisabledFiles(
   files: UnifiedFile[],
   disabledState: ExtendedDisabledState
@@ -148,9 +138,7 @@ export function getDisabledFiles(
   return files.filter((file) => disabledState.files.has(file.id))
 }
 
-/**
- * ファイルの色を計算する
- */
+/** ファイルIDのハッシュからTailwind背景色クラスを決定する */
 export function getFileColor(file: UnifiedFile): string {
   const colors = [
     "bg-red-200",

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
@@ -60,6 +60,7 @@ const DEFAULT_PARAMS: OMRRecognitionParams = {
   areaThreshold: 0.4,
 }
 
+/** OMRマークシート認識の実行・バッチ処理・進捗管理・結果保持を行うフック */
 export function useOMRRecognition(
   options: UseOMRRecognitionOptions
 ): UseOMRRecognitionReturn {

--- a/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -20,6 +20,7 @@ interface UseBatchScoringProps {
   setQuestionScores: React.Dispatch<React.SetStateAction<QuestionScore[]>>
 }
 
+/** 選択された答案に対する一括採点（楽観的UI更新+DB保存）を実行するフック */
 export function useBatchScoring({
   studentAnswerImages,
   cropRegions,

--- a/src/components/exams/07-score-at-once/ScoringData/utils/progressCalculator.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/utils/progressCalculator.ts
@@ -8,9 +8,7 @@ import {
   type QuestionScore,
 } from "@/components/exams/07-score-at-once/types"
 
-/**
- * 設問別進捗を計算する関数
- */
+/** 各設問の採点進捗（採点済み件数・割合）を計算する */
 export function calculateQuestionProgress(
   cropRegions: CropRegionWithExamPage[],
   pageImages: StudentAnswerImageWithExamStudents[],

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useAutoScroll.ts
@@ -6,6 +6,7 @@ interface UseAutoScrollProps {
   containerRef: RefObject<HTMLDivElement | null>
 }
 
+/** 選択された答案カードをグリッドコンテナ内で自動的に画面中央にスクロールするフック */
 export function useAutoScroll({
   selectedAnswers,
   autoScroll,

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
@@ -10,6 +10,7 @@ interface UseGridDragSelectionProps {
   sortedAnswers: () => GridAnswerItem[]
 }
 
+/** マウスドラッグ・Shift/Ctrl+クリックによるグリッド上の複数答案選択を処理するフック */
 export function useGridDragSelection({
   gridRef,
   onAnswerSelect,

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridLayout.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridLayout.ts
@@ -9,6 +9,7 @@ interface UseGridLayoutProps {
   itemsPerRow: number[]
 }
 
+/** レイアウト方向に応じたグリッドサイズ計算と答案の並び替えを行うフック */
 export function useGridLayout({
   answers,
   layoutDirection,

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridNavigation.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridNavigation.ts
@@ -8,6 +8,7 @@ interface UseGridNavigationProps {
   externalItemsPerRow?: number[]
 }
 
+/** グリッドの1行あたり表示件数の管理とAlt+[-/+]キーによる増減操作を提供するフック */
 export function useGridNavigation({
   externalItemsPerRow,
 }: UseGridNavigationProps) {

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridSelection.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridSelection.ts
@@ -6,6 +6,7 @@ export interface DragState {
   dragCurrent: { x: number; y: number } | null
 }
 
+/** グリッド上のドラッグ選択状態（開始位置・現在位置・ドラッグ中フラグ）を管理するフック */
 export function useGridSelection() {
   const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(
     null

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder.ts
@@ -10,6 +10,7 @@ import { parsePreference } from "@/lib/userPreferences"
 
 const DEFAULT_SELECTION_BORDER_COLOR = "#F97316" // orange-500
 
+/** 選択枠のボーダー色をユーザー設定から読み込み、設定変更イベントを監視するフック */
 export function useSelectionBorder(): string {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useElementMovement.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useElementMovement.ts
@@ -33,6 +33,7 @@ interface UseElementMovementProps {
   ) => string | null
 }
 
+/** 描画要素の移動・リサイズ操作を管理するフック */
 export function useElementMovement({
   currentTool,
   drawingElements,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useElementSelection.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useElementSelection.ts
@@ -35,6 +35,7 @@ interface UseElementSelectionProps {
   onTextElementReClick?: (element: DrawingElement) => void
 }
 
+/** 描画要素のクリック選択・複数選択・ダブルクリック検出を管理するフック */
 export function useElementSelection({
   currentTool,
   drawingElements,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useRectangleSelection.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useRectangleSelection.ts
@@ -30,6 +30,7 @@ interface UseRectangleSelectionProps {
   setRectangleEditMode: (mode: RectangleEditMode) => void
 }
 
+/** 矩形ドラッグによる範囲選択の開始・更新・完了を管理するフック */
 export function useRectangleSelection({
   currentTool,
   drawingElements,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
@@ -73,6 +73,7 @@ interface UseTextboxV4IntegrationReturn {
   convertToDrawingElement: (textBox: TextBox) => DrawingElement
 }
 
+/** 個別採点画面でテキストボックスの追加・編集・座標変換を統合するフック */
 export function useTextboxV4Integration({
   canvasWidth,
   canvasHeight,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
@@ -117,6 +117,7 @@ interface UseAnswerDisplayEventsProps {
   imageAspectRatio?: number
 }
 
+/** 個別採点キャンバスのポインタイベントを各ツール（選択・描画・ハンド）に振り分けるフック */
 export function useAnswerIndividualEvents(props: UseAnswerDisplayEventsProps) {
   const { canvasRef, containerRef, imageRef, zoom, onZoomChange, imageLoaded } =
     props

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useEditMode.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useEditMode.ts
@@ -7,6 +7,7 @@ import type {
   RectangleEditMode,
 } from "@/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes"
 
+/** 線・矩形要素の編集モード（移動・端点・リサイズ）を座標から判定するユーティリティフック */
 export function useEditModeUtils() {
   // 線の編集モード判定（開始点、終了点、移動）- PowerPointスタイル
   const getLineEditMode = useCallback(

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useHitTest.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useHitTest.ts
@@ -83,6 +83,7 @@ interface UseHitTestUtilsProps {
   >
 }
 
+/** 描画要素（線・矩形・楕円・テキスト）に対するズーム対応の当たり判定ユーティリティフック */
 export function useHitTestUtils({
   zoom = 1,
   textBoundsCache,

--- a/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
@@ -192,6 +192,7 @@ interface ShortcutProviderProps {
   children: ReactNode
 }
 
+/** 一括採点画面のキーボードショートカット管理（コマンド登録・キーバインド・when句評価）を提供するプロバイダー */
 export function ShortcutProvider({ children }: ShortcutProviderProps) {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useAutoScroll.ts
@@ -14,6 +14,7 @@ import {
 
 const DEFAULT = USER_PREFERENCE_SCHEMA.autoScroll.default
 
+/** 採点時の自動スクロールON/OFFをユーザー設定として永続化するフック */
 export function useAutoScroll() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress.ts
@@ -29,6 +29,7 @@ interface UseBatchScoringWithProgressParams {
   handleNextQuestion: () => void
 }
 
+/** 一括採点実行後に次の答案・設問への自動進行を行うラッパーフック */
 export function useBatchScoringWithProgress({
   selectedAnswers,
   gradingMode,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useExpandMargin.ts
@@ -14,6 +14,7 @@ import {
 
 const DEFAULT = USER_PREFERENCE_SCHEMA.expandMargin.default
 
+/** 採点グリッドの表示領域拡張マージンをユーザー設定として永続化するフック */
 export function useExpandMargin() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useItemsPerLine.ts
@@ -14,6 +14,7 @@ import {
 
 const DEFAULT = USER_PREFERENCE_SCHEMA.itemsPerLine.default
 
+/** 採点グリッドの1行あたりの表示件数をユーザー設定として永続化するフック */
 export function useItemsPerLine() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useLayoutDirection.ts
@@ -16,6 +16,7 @@ import {
 const DEFAULT = USER_PREFERENCE_SCHEMA.layoutDirection
   .default as LayoutDirection
 
+/** 採点グリッドのレイアウト方向（右下・左下・下右・下左）をユーザー設定として永続化するフック */
 export function useLayoutDirection() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useMasterAnswerSettings.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useMasterAnswerSettings.ts
@@ -16,6 +16,7 @@ import {
   USER_PREFERENCE_SCHEMA,
 } from "@/lib/userPreferences"
 
+/** 模範解答の表示モード・透明度・キー動作設定をユーザー設定として永続化するフック */
 export function useMasterAnswerSettings() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -19,6 +19,7 @@ interface UsePartialScoreProps {
   ) => void
 }
 
+/** 部分点入力モーダルの状態管理と数値入力・確定・キャンセル処理を提供するフック */
 export function usePartialScore({
   selectedAnswers,
   currentCropRegion,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringData.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringData.ts
@@ -17,6 +17,7 @@ interface UseScoringDataProps {
   cropRegions: CropRegionWithExamPage[]
 }
 
+/** 採点データの取得・一括採点・進捗計算を統合的に管理するフック */
 export function useScoringData({
   currentUserId,
   setCurrentUserId,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringDataLoader.ts
@@ -13,6 +13,7 @@ interface ScoringDataLoaderResult {
   currentUserId: string | null
 }
 
+/** 試験・答案・設問領域・ユーザー情報を一括ロードして採点画面の初期データを準備するフック */
 export function useScoringDataLoader(
   examId: string,
   authUserId: string | null

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -53,6 +53,7 @@ interface UseScoringFilterProps {
   manualSelectionVersion: number
 }
 
+/** 採点ステータスによるフィルタリングと表示対象の答案リスト管理を行うフック */
 export function useScoringFilter({
   studentAnswerImages,
   cropRegions,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMainState.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/components/exams/07-score-at-once/types"
 import { getModifierKeyLabel } from "@/lib/platformUtils"
 
+/** 採点メイン画面のUI状態（モード・選択・パネル表示等）を一括管理するフック */
 export function useScoringMainState() {
   /** 採点モード状態 */
   const [gradingMode, setGradingMode] = useState<GradingMode>("grid")

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
@@ -21,6 +21,7 @@ interface UseScoringNavigationProps {
   cropRegions?: CropRegionWithExamPage[]
 }
 
+/** 設問間の前後移動とWASDキーによるグリッド内ナビゲーションを提供するフック */
 export function useScoringNavigation({
   answerSheetsLength,
   currentCropRegionId,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -10,6 +10,7 @@ import { useLayoutDirection } from "./useLayoutDirection"
 import { useMasterAnswerSettings } from "./useMasterAnswerSettings"
 import { useShowStudentNames } from "./useShowStudentNames"
 
+/** 各種採点設定フックを統合し、採点画面全体の設定を一括提供するフック */
 export function useScoringSettings() {
   const { itemsPerLine, setItemsPerLine } = useItemsPerLine()
   const { autoScroll, setAutoScroll } = useAutoScroll()

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useShowStudentNames.ts
@@ -14,6 +14,7 @@ import {
 
 const DEFAULT = USER_PREFERENCE_SCHEMA.showStudentNames.default
 
+/** 採点画面での生徒名表示ON/OFFをユーザー設定として永続化するフック */
 export function useShowStudentNames() {
   const { user } = useAuth()
   const userId = user?.id

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
@@ -109,6 +109,7 @@ export interface UseAnnotationBrowserReturn {
   addToTargets: (params: AddToTargetsParams) => Promise<AddToTargetsResult>
 }
 
+/** アノテーション一覧の取得・フィルタリング・重複省略・お気に入り・一括追加を管理するフック */
 export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
   const [allAnnotations, setAllAnnotations] = useState<AnnotationWithContext[]>(
     []

--- a/src/components/exams/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
@@ -19,6 +19,7 @@ interface UseBatchScoringProps {
   setQuestionScores: React.Dispatch<React.SetStateAction<QuestionScore[]>>
 }
 
+/** 選択された答案に対する一括採点（DB保存・状態更新）を実行するフック */
 export function useBatchScoring({
   pageImages,
   cropRegions,

--- a/src/components/exams/08-export/components/scoring-mark-settings/utils/scoringMarkUtils.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/utils/scoringMarkUtils.ts
@@ -1,6 +1,6 @@
 import type { ScoringStatus } from "@/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes"
 
-// マーク画像パスを取得
+/** 採点状態と透過設定から対応するマーク画像のパスを返す */
 export function getMarkImagePath(
   status: ScoringStatus,
   useTransparent: boolean

--- a/src/components/exams/08-export/hooks/useExcelPreview.ts
+++ b/src/components/exams/08-export/hooks/useExcelPreview.ts
@@ -54,6 +54,7 @@ interface UseExcelPreviewProps {
   enabled: boolean
 }
 
+/** Excel出力用のプレビューデータ（設問別得点・小計・合計）をデバウンス付きで取得するフック */
 export function useExcelPreview({
   examId,
   selectedStudentIds,

--- a/src/components/exams/08-export/hooks/useExportPage.ts
+++ b/src/components/exams/08-export/hooks/useExportPage.ts
@@ -14,6 +14,7 @@ import {
   ScoringMarkConfig,
 } from "@/components/exams/08-export/components/ScoringMarkSettings"
 
+/** 結果出力ページの状態（生徒選択・出力設定・採点マーク設定・プログレス）を統合管理するフック */
 export function useExportPage() {
   const params = useParams()
   const examId = params.examId as string

--- a/src/components/exams/08-export/hooks/useItemAnalysis.ts
+++ b/src/components/exams/08-export/hooks/useItemAnalysis.ts
@@ -42,6 +42,7 @@ function getLevel(r: number | null): DiscriminationLevel {
   return "good"
 }
 
+/** 設問ごとの正答率・得点率・識別係数を算出する項目分析フック */
 export function useItemAnalysis(
   data: ExcelPreviewData | null
 ): ItemAnalysisData[] | null {

--- a/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
@@ -21,6 +21,7 @@ interface UseScoredAnswerPreviewProps {
   enabled: boolean
 }
 
+/** 採点済み答案のCanvas描画プレビューを生成するフック */
 export function useScoredAnswerPreview({
   examId,
   selectedStudentIds,

--- a/src/components/exams/08-export/utils/learningAdviceCalculator.ts
+++ b/src/components/exams/08-export/utils/learningAdviceCalculator.ts
@@ -72,9 +72,7 @@ function findReviewQuestions(
   return candidates
 }
 
-/**
- * 学習アドバイスデータを生成
- */
+/** 生徒の採点結果と正答率から復習すべき問題を抽出し学習アドバイスを生成する */
 export function calculateLearningAdvice(
   scores: ScoreDetail[],
   questionCorrectRates: Record<string, number>,

--- a/src/components/help/usePageHelp.tsx
+++ b/src/components/help/usePageHelp.tsx
@@ -41,6 +41,7 @@ const pageHelpComponents: {
   students: StudentsHelpContent,
 }
 
+/** 現在のページに対応するヘルプコンテンツをDrawer表示するフック */
 export function usePageHelp() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)

--- a/src/components/hooks/useExams.ts
+++ b/src/components/hooks/useExams.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react"
 import { useAuth } from "@/contexts/AuthContext"
 import type { ExamListItem } from "@/types/common.types"
 
+/** 試験一覧の取得・新規作成を行うフック */
 export const useExams = () => {
   const { user } = useAuth()
   const [exams, setExams] = useState<ExamListItem[]>([])

--- a/src/components/hooks/useFileActions.ts
+++ b/src/components/hooks/useFileActions.ts
@@ -8,6 +8,7 @@ type CreateExamModal = {
   close: () => void
 }
 
+/** 試験作成モーダルの開閉状態を管理するフック */
 export const useFileActions = () => {
   const [isCreateExamModalOpen, setIsCreateExamModalOpen] = useState(false)
 

--- a/src/components/hooks/useSaveStatus.ts
+++ b/src/components/hooks/useSaveStatus.ts
@@ -14,6 +14,7 @@ interface UseSaveStatusOptions {
   displayDuration?: number // ms
 }
 
+/** 保存中・保存完了のステータス表示を一定時間後に自動リセットするフック */
 export const useSaveStatus = (options?: UseSaveStatusOptions) => {
   const {
     initialMessage = SAVE_STATUS_MESSAGES[0],

--- a/src/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
+++ b/src/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/pdfConverter"
 import type { ImportedFile } from "@/types/pdfTools.types"
 
+/** PDFファイルの読み込み・ページ情報取得・サムネイル生成を行うフック */
 export function useImportedFiles() {
   // Fileオブジェクトから処理（ドラッグ&ドロップ用）
   const processFiles = useCallback(

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -28,6 +28,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
+/** 認証状態（ログイン・ログアウト・セッション確認）をアプリ全体に提供するプロバイダー */
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -121,6 +122,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   )
 }
 
+/** 認証コンテキストからユーザー情報・認証操作を取得するフック */
 export function useAuth() {
   const context = useContext(AuthContext)
   if (context === undefined) {

--- a/src/contexts/NavigationGuardContext.tsx
+++ b/src/contexts/NavigationGuardContext.tsx
@@ -42,10 +42,12 @@ const NavigationGuardContext = createContext<NavigationGuardContextType>({
   requestNavigation: () => true,
 })
 
+/** ナビゲーションガードコンテキストから未保存確認・遷移制御の機能を取得するフック */
 export function useNavigationGuardContext() {
   return useContext(NavigationGuardContext)
 }
 
+/** 未保存データがある場合の離脱確認ダイアログを管理するプロバイダー */
 export function NavigationGuardProvider({
   children,
 }: {

--- a/src/hooks/grades/useBoundaries.ts
+++ b/src/hooks/grades/useBoundaries.ts
@@ -5,6 +5,7 @@ import type {
   GradeWithDetails,
 } from "@/types/grade.types"
 
+/** 成績評定の境界値セットの取得・保存を管理するフック */
 export function useBoundaries(gradeId: string) {
   const [exam, setExam] = useState<GradeWithDetails | null>(null)
   const [boundarySets, setBoundarySets] = useState<

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 
 import type { GradeWithDetails } from "@/types/grade.types"
 
+/** 成績評定項目とデータソースのCRUD操作を管理するフック */
 export function useDataSources(gradeId: string) {
   const [exam, setExam] = useState<GradeWithDetails | null>(null)
   const [loading, setLoading] = useState(true)

--- a/src/hooks/grades/useGradeItemExclusions.ts
+++ b/src/hooks/grades/useGradeItemExclusions.ts
@@ -9,6 +9,7 @@ interface ExclusionRecord {
   gradeItemId: string
 }
 
+/** 生徒ごとの成績評定項目除外設定の取得・トグル操作を管理するフック */
 export function useGradeItemExclusions(gradeId: string) {
   const [exclusionSet, setExclusionSet] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)

--- a/src/hooks/grades/useGradeResults.ts
+++ b/src/hooks/grades/useGradeResults.ts
@@ -10,6 +10,7 @@ interface SetGradeOverrideParams {
   overrideLabel: string | null
 }
 
+/** 成績評定の計算結果取得および評定上書き（オーバーライド）を管理するフック */
 export function useGradeResults(gradeId: string) {
   const [result, setResult] = useState<GradeCalculationResult | null>(null)
   const [loading, setLoading] = useState(true)

--- a/src/hooks/useClassManagement.ts
+++ b/src/hooks/useClassManagement.ts
@@ -25,6 +25,7 @@ interface Membership {
   }
 }
 
+/** 学級の詳細表示・編集・所属関係の管理を提供するカスタムフック */
 export function useClassManagement(classId: string) {
   const [loading, setLoading] = useState(true)
   const [classData, setClassData] = useState<ClassWithMemberships | null>(null)

--- a/src/hooks/useExam.ts
+++ b/src/hooks/useExam.ts
@@ -27,6 +27,7 @@ export interface ExamStatus {
   progress: number
 }
 
+/** 試験データの取得・更新・削除およびステータス管理を提供するカスタムフック */
 export function useExam(examId?: string) {
   const [exam, setExam] = useState<ExamWithDetails | null>(null)
   const [isLoading, setIsLoading] = useState(false)

--- a/src/hooks/useExamDetail.ts
+++ b/src/hooks/useExamDetail.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner"
 
 import type { ExamWithDetails } from "@/types/common.types"
 
+/** 試験詳細ページ用のデータ取得・更新フック（生徒数・設問領域数・答案数等の集計を含む） */
 export function useExamDetail(examId: string) {
   const [exam, setExam] = useState<ExamWithDetails | null>(null)
   const [isLoading, setIsLoading] = useState(true)

--- a/src/hooks/useMasterAnswers.ts
+++ b/src/hooks/useMasterAnswers.ts
@@ -27,6 +27,7 @@ export interface MasterAnswersState {
   }
 }
 
+/** 模範解答画像のアップロード・削除・並べ替えおよびパスワード付きPDF処理を管理するフック */
 export function useMasterAnswers(
   examId: string,
   initialAnswers: MasterAnswer[],

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -5,6 +5,7 @@ import {
   useNavigationGuardContext,
 } from "@/contexts/NavigationGuardContext"
 
+/** 未保存データがある場合にページ離脱を防止するナビゲーションガードフック */
 export function useNavigationGuard(isDirty: boolean, details: DirtyDetail[]) {
   const { setNavigationGuard, clearNavigationGuard, guardedNavigate } =
     useNavigationGuardContext()

--- a/src/hooks/useStudentImport.ts
+++ b/src/hooks/useStudentImport.ts
@@ -18,6 +18,7 @@ interface ValidationResult {
   warnings: string[]
 }
 
+/** 生徒データの手動入力・バリデーション・一括インポートを管理するフック */
 export function useStudentImport() {
   const [studentData, setStudentData] = useState<StudentImportRow[]>([
     {

--- a/src/lib/answer-sheet-builder/inlineMarkupParser.ts
+++ b/src/lib/answer-sheet-builder/inlineMarkupParser.ts
@@ -45,6 +45,7 @@ const DELIMITERS = [
 
 type StyleKey = (typeof DELIMITERS)[number]["style"]
 
+/** マークアップ文字列をパースしてスタイル付きセグメント配列に変換する */
 export function parseInlineMarkup(input: string): InlineSegment[] {
   if (!input) return []
 

--- a/src/lib/pdfConverter.ts
+++ b/src/lib/pdfConverter.ts
@@ -49,6 +49,7 @@ export interface PdfConversionError {
   message: string
 }
 
+/** PDFファイルの総ページ数を取得する */
 export async function getPdfPageCount(
   file: File,
   password?: string
@@ -76,6 +77,7 @@ export async function getPdfPageCount(
   }
 }
 
+/** PDFファイルを各ページのPNG画像に変換する */
 export async function convertPdfToImages(
   file: File,
   password?: string,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/** クラス名を結合する（clsx + tailwind-merge） */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }

--- a/src/types/drawingAnnotation.types.ts
+++ b/src/types/drawingAnnotation.types.ts
@@ -126,15 +126,17 @@ export interface DrawingUpdateData {
   isFavorite?: boolean
 }
 
-// 型ガード関数
+/** アノテーションがテキスト型かどうかを判定する型ガード */
 export function isTextAnnotation(annotation: DrawingAnnotation): boolean {
   return annotation.type === "text"
 }
 
+/** アノテーションが直線型かどうかを判定する型ガード */
 export function isLineAnnotation(annotation: DrawingAnnotation): boolean {
   return annotation.type === "line"
 }
 
+/** アノテーションが図形型（長方形または楕円）かどうかを判定する型ガード */
 export function isShapeAnnotation(annotation: DrawingAnnotation): boolean {
   return annotation.type === "rectangle" || annotation.type === "ellipse"
 }


### PR DESCRIPTION
## Summary

Closes #679

- Prisma DB操作、IPCハンドラー、preload API、共有hooks、ユーティリティ関数等の約260個のエクスポート関数に日本語JSDocコメントを追加
- 関数本体の変更なし（コメントのみ）
- 型チェック・Lint・フォーマット全てパス

## Test plan

- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm run format` でフォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)