### PR TITLE
fix: enforceTombstonesの全テーブル対応とsync設定パスのローカル化

### DIFF
--- a/__tests__/sync/syncConfig.test.ts
+++ b/__tests__/sync/syncConfig.test.ts
@@ -6,18 +6,21 @@ import * as fs from "fs"
 import * as path from "path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+// テスト用ディレクトリ
+const TEST_DATA_DIR = path.join("/tmp", `sync-test-${Date.now()}`)
+const TEST_USER_DATA_DIR = path.join("/tmp", `sync-test-userdata-${Date.now()}`)
+
 // electronのapp.getPathをモック
 vi.mock("electron", () => ({
   app: {
     getPath: (name: string) => {
-      if (name === "userData") return "/tmp/test-userdata"
+      if (name === "userData") return TEST_USER_DATA_DIR
       return "/tmp/test"
     },
   },
 }))
 
 // dataManagerをモック（テスト用データディレクトリ）
-const TEST_DATA_DIR = path.join("/tmp", `sync-test-${Date.now()}`)
 vi.mock("../../electron-src/lib/dataManager", () => ({
   getDataDirectory: () => TEST_DATA_DIR,
 }))
@@ -39,11 +42,17 @@ describe("syncConfig", () => {
     if (!fs.existsSync(TEST_DATA_DIR)) {
       fs.mkdirSync(TEST_DATA_DIR, { recursive: true })
     }
+    if (!fs.existsSync(TEST_USER_DATA_DIR)) {
+      fs.mkdirSync(TEST_USER_DATA_DIR, { recursive: true })
+    }
   })
 
   afterEach(() => {
     if (fs.existsSync(TEST_DATA_DIR)) {
       fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true })
+    }
+    if (fs.existsSync(TEST_USER_DATA_DIR)) {
+      fs.rmSync(TEST_USER_DATA_DIR, { recursive: true, force: true })
     }
   })
 
@@ -57,12 +66,14 @@ describe("syncConfig", () => {
     })
 
     it("getLocalDbDirectoryがuserData/score-at-onceを返す", () => {
-      expect(getLocalDbDirectory()).toBe("/tmp/test-userdata/score-at-once")
+      expect(getLocalDbDirectory()).toBe(
+        path.join(TEST_USER_DATA_DIR, "score-at-once")
+      )
     })
 
     it("getLocalDbPathがuserData/score-at-once/database.dbを返す", () => {
       expect(getLocalDbPath()).toBe(
-        "/tmp/test-userdata/score-at-once/database.db"
+        path.join(TEST_USER_DATA_DIR, "score-at-once", "database.db")
       )
     })
   })
@@ -87,7 +98,7 @@ describe("syncConfig", () => {
     })
 
     it("不正なJSONの場合はデフォルトを返す", () => {
-      const configPath = path.join(TEST_DATA_DIR, "sync-config.json")
+      const configPath = path.join(TEST_USER_DATA_DIR, "sync-config.json")
       fs.writeFileSync(configPath, "invalid json", "utf-8")
 
       const config = loadSyncConfig()

--- a/electron-src/lib/sync/syncConfig.ts
+++ b/electron-src/lib/sync/syncConfig.ts
@@ -2,7 +2,7 @@
  * NAS同期設定の永続化
  *
  * sync設定はマシン固有（clientId）のため、
- * 同期対象DBではなくローカルJSONファイルに保存する。
+ * 同期対象DBではなくElectronのuserDataディレクトリに保存する。
  * NAS syncパスはデータディレクトリから自動導出（{dataDir}/sync/）。
  */
 
@@ -15,7 +15,7 @@ import { getDataDirectory } from "../dataManager"
 import { DEFAULT_SYNC_CONFIG, SyncAppConfig } from "./types"
 
 function getConfigPath(): string {
-  return path.join(getDataDirectory(), "sync-config.json")
+  return path.join(app.getPath("userData"), "sync-config.json")
 }
 
 /** sqlite-nas-syncが使用するNAS上のsyncディレクトリパスを返す */

--- a/electron-src/lib/sync/syncService.ts
+++ b/electron-src/lib/sync/syncService.ts
@@ -51,8 +51,16 @@ function broadcastSyncStatus(): void {
   }
 }
 
+/** enforceTombstonesの対象テーブル名（SYNC_TABLESからDeletedRecord自身を除外） */
+const TOMBSTONE_TARGET_TABLES = new Set(
+  SYNC_TABLES.filter((t) => t.name !== "DeletedRecord").map((t) => t.name)
+)
+
 /**
  * sync後のtombstone適用
+ *
+ * DeletedRecordに記録された全テーブルの削除済みレコードを物理削除する。
+ * SQLインジェクション防止のため、SYNC_TABLESに含まれるテーブル名のみ許可。
  */
 function enforceTombstones(db: Database.Database): void {
   try {
@@ -63,11 +71,10 @@ function enforceTombstones(db: Database.Database): void {
       .all() as Array<{ recordId: string; tableName: string }>
 
     for (const { recordId, tableName } of tombstones) {
-      if (tableName === "DrawingAnnotation") {
-        db.prepare(`DELETE FROM "DrawingAnnotation" WHERE "id" = ?`).run(
-          recordId
-        )
-      }
+      if (!TOMBSTONE_TARGET_TABLES.has(tableName)) continue
+
+      // テーブル名はSYNC_TABLESのホワイトリストで検証済みのため安全
+      db.prepare(`DELETE FROM "${tableName}" WHERE "id" = ?`).run(recordId)
     }
   } catch (error) {
     console.error("Failed to enforce tombstones:", error)


### PR DESCRIPTION
## Summary
- `enforceTombstones()`をDrawingAnnotation限定から、SYNC_TABLESホワイトリストに基づく全テーブル対応に拡張
- `sync-config.json`の保存先を共有NASディレクトリからマシンローカル(`app.getPath("userData")`)に変更
- テストを修正に追随させ、動的テストディレクトリを使用するよう修正

Closes #685

## Test plan
- [x] `npx vitest run __tests__/sync/` — 全28テスト通過
- [x] `npm run lint` — エラーなし
- [x] `npm run format` — フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)