### PR TITLE
feat: 小計グループの手動紐づけ・空選択デフォルト・一括設定を追加

### DIFF
--- a/electron-src/lib/import/merge/matchers/subtotalGroupMatcher.ts
+++ b/electron-src/lib/import/merge/matchers/subtotalGroupMatcher.ts
@@ -153,10 +153,18 @@ export async function preMatchSubtotalGroups(
     })
   }
 
+  // 全既存グループ情報を返す（手動紐づけ用）
+  const allExistingItems = existingGroups.map((g) => ({
+    id: g.id,
+    name: g.name,
+    subtotals: existingSubtotalsByGroup.get(g.id),
+  }))
+
   return {
     byId,
     byName,
     noMatch,
+    allExistingItems,
   }
 }
 

--- a/src/components/import/steps/IdIntegrationStep.tsx
+++ b/src/components/import/steps/IdIntegrationStep.tsx
@@ -43,6 +43,18 @@ export function IdIntegrationStep({ wizard }: IdIntegrationStepProps) {
     state.fileOverviewData.subtotalGroup.byId.length <
       (state.manifest?.counts.subtotalGroups ?? 0)
 
+  // 小計グループnoMatchに未決定のアイテムがあるか
+  const hasUndecidedSubtotalGroupNoMatch = (() => {
+    if (!state.fileOverviewData) return false
+    const noMatch = state.fileOverviewData.subtotalGroup.noMatch
+    if (noMatch.length === 0) return false
+    const strategy = state.idIntegrationConfig.subtotalGroup.strategy
+    if (strategy === "all_new") return false // all_newなら決定不要
+    const decisions = state.idIntegrationConfig.subtotalGroup.decisions
+    const decidedIds = new Set(decisions.map((d) => d.importId))
+    return noMatch.some((item) => !decidedIds.has(item.importId))
+  })()
+
   // 何も判断が必要ない場合はスキップ可能
   const canSkip =
     !hasStudentDecisions && !hasClassDecisions && !hasSubtotalGroupDecisions
@@ -159,10 +171,15 @@ export function IdIntegrationStep({ wizard }: IdIntegrationStepProps) {
       </Tabs>
 
       {/* 次へボタン */}
-      <div className="mt-6 flex justify-center">
+      <div className="mt-6 flex flex-col items-center gap-2">
+        {hasUndecidedSubtotalGroupNoMatch && (
+          <p className="text-sm text-amber-600 dark:text-amber-400">
+            小計グループタブに未決定の項目があります
+          </p>
+        )}
         <Button
           onClick={goToNextStep}
-          disabled={state.isProcessing}
+          disabled={state.isProcessing || hasUndecidedSubtotalGroupNoMatch}
           size="lg"
           className="px-8"
         >

--- a/src/components/import/steps/id-integration/DetailPanel.tsx
+++ b/src/components/import/steps/id-integration/DetailPanel.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useMemo } from "react"
+
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
@@ -24,8 +26,44 @@ export function DetailPanel({
   noMatch,
   showIndividualMessage,
   onBatchIdChoice,
+  allExistingItems,
+  onBatchNoMatchDecision,
 }: DetailPanelProps) {
   const { updateIdIntegrationDecision } = wizard
+
+  // 既にマッチ済みの既存IDを収集（重複紐づけ防止）
+  const alreadyMatchedExistingIds = useMemo(() => {
+    if (entityType !== "subtotalGroup") return undefined
+    const ids = new Set<string>()
+    // byId items（自動マッチ、常にリンク済み）
+    const overview = wizard.state.fileOverviewData?.subtotalGroup
+    if (overview?.byId) {
+      for (const item of overview.byId) ids.add(item.existingId)
+    }
+    const config = wizard.state.idIntegrationConfig.subtotalGroup
+    const decisionByImportId = new Map(
+      config.decisions.map((d) => [d.importId, d])
+    )
+    // byName items: 決定未設定（デフォルトsame_person）またはsame_personの場合のみ
+    for (const item of byName) {
+      const d = decisionByImportId.get(item.importId)
+      if (!d || d.decisionType === "same_person") {
+        ids.add(item.existingId)
+      }
+    }
+    // 全same_person決定（noMatchの手動紐づけ含む）
+    for (const d of config.decisions) {
+      if (d.decisionType === "same_person" && d.existingId) {
+        ids.add(d.existingId)
+      }
+    }
+    return ids
+  }, [
+    entityType,
+    wizard.state.fileOverviewData,
+    wizard.state.idIntegrationConfig,
+    byName,
+  ])
 
   if (byName.length === 0 && noMatch.length === 0) {
     return null
@@ -92,15 +130,42 @@ export function DetailPanel({
             )
           })}
 
+          {/* noMatchアイテムの一括設定ボタン */}
+          {noMatch.length > 0 && onBatchNoMatchDecision && (
+            <div className="bg-muted/30 mb-1 flex items-center gap-2 rounded-lg border p-3">
+              <span className="text-sm font-medium">未照合の一括設定:</span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onBatchNoMatchDecision("create_new")}
+              >
+                すべて新規作成
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onBatchNoMatchDecision("skip")}
+              >
+                すべて取り込まない
+              </Button>
+            </div>
+          )}
+
           {/* マッチしなかったアイテム */}
           {noMatch.map((item) => (
             <NoMatchItemRow
               key={item.importId}
               item={item}
-              onDecisionChange={(decision) =>
+              entityType={entityType}
+              allExistingItems={allExistingItems}
+              wizard={entityType === "subtotalGroup" ? wizard : undefined}
+              alreadyMatchedExistingIds={alreadyMatchedExistingIds}
+              onDecisionChange={(decision, existingId, idChoice) =>
                 updateIdIntegrationDecision(entityType, item.importId, {
                   importId: item.importId,
                   decisionType: decision,
+                  existingId,
+                  idChoice,
                 })
               }
             />

--- a/src/components/import/steps/id-integration/NoMatchItemRow.tsx
+++ b/src/components/import/steps/id-integration/NoMatchItemRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ChevronDown, ChevronRight } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import {
   Select,
@@ -10,10 +10,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import type { SubtotalInfo } from "@/types/examArchive.types"
+import { cn } from "@/lib/utils"
+import type { IdChoice, SubtotalInfo } from "@/types/examArchive.types"
 
+import { SubtotalMappingEditor } from "./SubtotalMappingEditor"
 import { SubtotalPreview } from "./SubtotalPreview"
-import type { NoMatchDecisionType, NoMatchItemRowProps } from "./types"
+import type {
+  DecisionType,
+  NoMatchDecisionType,
+  NoMatchItemRowProps,
+} from "./types"
 
 /**
  * マッチしなかったアイテムの行（共通コンポーネント）
@@ -21,20 +27,94 @@ import type { NoMatchDecisionType, NoMatchItemRowProps } from "./types"
 export function NoMatchItemRow({
   item,
   onDecisionChange,
+  entityType,
+  allExistingItems,
+  wizard,
+  alreadyMatchedExistingIds,
 }: NoMatchItemRowProps) {
-  const [decision, setDecision] = useState<NoMatchDecisionType>("create_new")
+  const isSubtotalGroup = entityType === "subtotalGroup"
+
+  // subtotalGroupは空選択（強制選択）、それ以外はcreate_newデフォルト
+  const [decision, setDecision] = useState<
+    NoMatchDecisionType | DecisionType | ""
+  >(isSubtotalGroup ? "" : "create_new")
+  const [selectedExistingId, setSelectedExistingId] = useState<string>("")
+  const [idChoice, setIdChoice] = useState<IdChoice>("use_existing_id")
   const [showPreview, setShowPreview] = useState(false)
 
-  const handleDecisionChange = (value: string) => {
-    const newDecision = value as NoMatchDecisionType
-    setDecision(newDecision)
-    onDecisionChange(newDecision)
-  }
+  const canManualLink =
+    isSubtotalGroup && allExistingItems && allExistingItems.length > 0
 
   const importSubtotals = (
     item as { additionalInfo?: { importSubtotals?: SubtotalInfo[] } }
   ).additionalInfo?.importSubtotals
   const hasSubtotalPreview = !!importSubtotals?.length
+
+  // 選択中の既存グループの小計項目
+  const selectedExistingSubtotals = useMemo(() => {
+    if (!selectedExistingId || !allExistingItems) return undefined
+    return allExistingItems.find((g) => g.id === selectedExistingId)?.subtotals
+  }, [selectedExistingId, allExistingItems])
+
+  // 小計項目マッピングエディタの表示条件
+  const showMappingEditor =
+    isSubtotalGroup &&
+    decision === "same_person" &&
+    selectedExistingId &&
+    wizard &&
+    importSubtotals?.length &&
+    selectedExistingSubtotals?.length
+
+  // currentDecisionの復元（wizardのstateから）
+  useEffect(() => {
+    if (!wizard || !isSubtotalGroup) return
+    const config = wizard.state.idIntegrationConfig.subtotalGroup
+    const existing = config.decisions.find((d) => d.importId === item.importId)
+    if (existing) {
+      setDecision(existing.decisionType as DecisionType)
+      if (existing.existingId) setSelectedExistingId(existing.existingId)
+      if (existing.idChoice) setIdChoice(existing.idChoice)
+    } else if (isSubtotalGroup) {
+      // stateにない場合は空選択に戻す（一括設定のクリア等に対応）
+      setDecision("")
+      setSelectedExistingId("")
+    }
+  }, [
+    wizard,
+    isSubtotalGroup,
+    item.importId,
+    wizard?.state.idIntegrationConfig,
+  ])
+
+  const handleDecisionChange = (value: string) => {
+    const newDecision = value as NoMatchDecisionType | DecisionType
+    setDecision(newDecision)
+    if (newDecision === "same_person") {
+      if (selectedExistingId) {
+        onDecisionChange(newDecision, selectedExistingId, idChoice)
+      }
+    } else {
+      setSelectedExistingId("")
+      onDecisionChange(newDecision)
+    }
+  }
+
+  const handleExistingGroupChange = (existingId: string) => {
+    setSelectedExistingId(existingId)
+    onDecisionChange("same_person", existingId, idChoice)
+    // 既存グループが変わったら小計マッピングをクリア
+    if (wizard && importSubtotals) {
+      wizard.clearSubtotalMappings(importSubtotals.map((s) => s.id))
+    }
+  }
+
+  const handleIdChoiceChange = (value: string) => {
+    const newIdChoice = value as IdChoice
+    setIdChoice(newIdChoice)
+    if (selectedExistingId) {
+      onDecisionChange("same_person", selectedExistingId, newIdChoice)
+    }
+  }
 
   return (
     <div className="rounded-lg border p-3">
@@ -63,18 +143,104 @@ export function NoMatchItemRow({
 
       {/* 小計項目プレビュー */}
       {hasSubtotalPreview && showPreview && (
-        <SubtotalPreview importSubtotals={importSubtotals} />
+        <SubtotalPreview
+          importSubtotals={importSubtotals}
+          existingSubtotals={
+            decision === "same_person" ? selectedExistingSubtotals : undefined
+          }
+        />
       )}
 
-      <Select value={decision} onValueChange={handleDecisionChange}>
-        <SelectTrigger className="w-full">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="create_new">新しく登録する</SelectItem>
-          <SelectItem value="skip">取り込まない</SelectItem>
-        </SelectContent>
-      </Select>
+      <div className="flex flex-col gap-2">
+        <Select
+          value={decision || undefined}
+          onValueChange={handleDecisionChange}
+        >
+          <SelectTrigger
+            className={cn(
+              "w-full",
+              isSubtotalGroup &&
+                !decision &&
+                "border-amber-400 dark:border-amber-600"
+            )}
+          >
+            <SelectValue placeholder="選択してください..." />
+          </SelectTrigger>
+          <SelectContent>
+            {canManualLink && (
+              <SelectItem value="same_person">
+                既存のグループに紐づける
+              </SelectItem>
+            )}
+            <SelectItem value="create_new">新しく登録する</SelectItem>
+            <SelectItem value="skip">取り込まない</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* 既存グループ選択（手動紐づけ時） */}
+        {decision === "same_person" && canManualLink && (
+          <div className="mt-1 ml-4 space-y-2">
+            <p className="text-muted-foreground text-xs">
+              紐づけ先のグループを選択してください
+            </p>
+            <Select
+              value={selectedExistingId}
+              onValueChange={handleExistingGroupChange}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="既存グループを選択..." />
+              </SelectTrigger>
+              <SelectContent>
+                {allExistingItems.map((existing) => {
+                  const isAlreadyMatched =
+                    alreadyMatchedExistingIds?.has(existing.id) ?? false
+                  return (
+                    <SelectItem
+                      key={existing.id}
+                      value={existing.id}
+                      disabled={isAlreadyMatched}
+                    >
+                      {existing.name}
+                      {isAlreadyMatched && " (他で紐づけ済み)"}
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+
+            {/* ID選択 */}
+            {selectedExistingId && (
+              <>
+                <p className="text-muted-foreground text-xs">
+                  どちらに合わせる？
+                </p>
+                <Select value={idChoice} onValueChange={handleIdChoiceChange}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="use_existing_id">
+                      このPCのIDを使う
+                    </SelectItem>
+                    <SelectItem value="use_import_id">
+                      ファイルのIDを使う
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* 小計項目マッピングエディタ */}
+        {showMappingEditor && (
+          <SubtotalMappingEditor
+            wizard={wizard}
+            importSubtotals={importSubtotals!}
+            existingSubtotals={selectedExistingSubtotals!}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/import/steps/id-integration/SubtotalGroupIntegrationPanel.tsx
+++ b/src/components/import/steps/id-integration/SubtotalGroupIntegrationPanel.tsx
@@ -103,6 +103,7 @@ export function SubtotalGroupIntegrationPanel({
           byName={overview.byName ?? []}
           noMatch={overview.noMatch}
           showIndividualMessage={strategy === "individual"}
+          allExistingItems={overview.allExistingItems}
           onBatchIdChoice={(idChoice) => {
             const items = (overview.byName ?? []).map((item) => ({
               importId: item.importId,
@@ -114,6 +115,18 @@ export function SubtotalGroupIntegrationPanel({
               "same_person",
               idChoice
             )
+          }}
+          onBatchNoMatchDecision={(decision) => {
+            for (const item of overview.noMatch) {
+              wizard.updateIdIntegrationDecision(
+                "subtotalGroup",
+                item.importId,
+                {
+                  importId: item.importId,
+                  decisionType: decision,
+                }
+              )
+            }
           }}
         />
       )}

--- a/src/components/import/steps/id-integration/types.ts
+++ b/src/components/import/steps/id-integration/types.ts
@@ -5,6 +5,7 @@
 import type { UseImportWizardReturn } from "@/hooks/import/useImportWizard"
 import type {
   ClassMatchingStrategy,
+  ExistingItemInfo,
   IdChoice,
   MatchedItem,
   StudentMatchingStrategy,
@@ -81,6 +82,10 @@ export interface DetailPanelProps {
   noMatch: Array<{ importId: string; displayLabel: string }>
   showIndividualMessage: boolean
   onBatchIdChoice?: (idChoice: IdChoice) => void
+  /** 全既存アイテム一覧（手動紐づけ用、小計グループで使用） */
+  allExistingItems?: ExistingItemInfo[]
+  /** noMatchアイテムの一括決定コールバック */
+  onBatchNoMatchDecision?: (decision: NoMatchDecisionType) => void
 }
 
 /** マッチしたアイテム行のProps */
@@ -97,7 +102,19 @@ export interface MatchedItemRowProps {
 /** マッチしなかったアイテム行のProps */
 export interface NoMatchItemRowProps {
   item: { importId: string; displayLabel: string }
-  onDecisionChange: (decision: NoMatchDecisionType) => void
+  onDecisionChange: (
+    decision: NoMatchDecisionType | DecisionType,
+    existingId?: string,
+    idChoice?: IdChoice
+  ) => void
+  /** エンティティ種別（subtotalGroupの場合、手動紐づけを許可） */
+  entityType?: EntityType
+  /** 全既存アイテム一覧（手動紐づけ用） */
+  allExistingItems?: ExistingItemInfo[]
+  /** wizardインスタンス（subtotalGroupの小計項目マッピング用） */
+  wizard?: UseImportWizardReturn
+  /** 既にマッチ済みの既存ID一覧（重複防止） */
+  alreadyMatchedExistingIds?: Set<string>
 }
 
 /** 方針選択オプションProps */

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -106,6 +106,17 @@ export interface PreMatchingResult {
   byName?: MatchedItem[]
   /** どれにも一致しない */
   noMatch: ImportItem[]
+  /** 全既存アイテム一覧（手動紐づけ用、小計グループで使用） */
+  allExistingItems?: ExistingItemInfo[]
+}
+
+/**
+ * 既存アイテムの概要情報（手動紐づけ用）
+ */
+export interface ExistingItemInfo {
+  id: string
+  name: string
+  subtotals?: SubtotalInfo[]
 }
 
 /**


### PR DESCRIPTION
## Summary
- noMatchの小計グループに既存グループへの手動紐づけ機能を追加（小計項目レベルのマッピングも対応）
- subtotalGroupのnoMatchデフォルトを空選択（強制選択）に変更し、未決定時は次へ進めないバリデーションを実装
- noMatchアイテム用の一括設定ボタン（すべて新規作成 / すべて取り込まない）を追加

Closes #687

## Test plan
- [ ] noMatchの小計グループで「既存のグループに紐づける」を選択し、既存グループを選べることを確認
- [ ] 紐づけ後にSubtotalMappingEditorが表示され、小計項目の個別マッピングが可能なことを確認
- [ ] 小計グループタブでnoMatch未決定のまま「次へ」を押すと無効化されていることを確認
- [ ] 一括設定ボタンで全noMatchアイテムが一括変更されることを確認
- [ ] 既にマッチ済みのグループがドロップダウンでdisabled表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)