### PR TITLE
fix: 既存DBのマイグレーションベースライン不整合を修復

### DIFF
--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -257,7 +257,12 @@ export class DatabaseSetup {
     }
 
     if (version === "MIGRATED") {
-      // 既にPrisma管理下 — 将来のマイグレーションのみ適用
+      // 既にPrisma管理下 — ベースラインが最新か確認
+      const { ensureBaselineUpToDate } =
+        await import("./prisma/schema/baselineMigrations")
+      await ensureBaselineUpToDate(this.prisma)
+
+      // 将来のマイグレーションのみ適用
       const { deployPendingMigrations } =
         await import("./prisma/schema/migrationDeployer")
       await deployPendingMigrations(this.prisma)

--- a/electron-src/lib/prisma/schema/baselineMigrations.ts
+++ b/electron-src/lib/prisma/schema/baselineMigrations.ts
@@ -48,6 +48,38 @@ export const createBaseline = async (prisma: PrismaClient): Promise<void> => {
   )
 }
 
+/**
+ * _prisma_migrationsテーブルが存在するが、現在のベースラインが未登録の場合に修復する。
+ * 旧ベースライン（20件）や不整合な状態から、現在の正しいベースラインに更新する。
+ */
+export const ensureBaselineUpToDate = async (
+  prisma: PrismaClient
+): Promise<void> => {
+  if (!(await tableExists(prisma, "_prisma_migrations"))) return
+
+  const baselineName = MIGRATION_CHECKSUMS[0].name
+  const result = await prisma.$queryRawUnsafe<{ cnt: number }[]>(
+    `SELECT COUNT(*) as cnt FROM "_prisma_migrations" WHERE "migration_name" = '${baselineName}'`
+  )
+
+  if (Number(result[0]?.cnt) > 0) return // ベースライン登録済み
+
+  // 旧エントリを削除して現在のベースラインに置換
+  console.info("Updating _prisma_migrations baseline to current version...")
+  await prisma.$executeRawUnsafe(`DELETE FROM "_prisma_migrations"`)
+
+  const now = new Date().toISOString()
+  for (const { name, checksum } of MIGRATION_CHECKSUMS) {
+    const id = generateUuid()
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "_prisma_migrations" ("id", "checksum", "finished_at", "migration_name", "started_at", "applied_steps_count")
+       VALUES ('${id}', '${checksum}', '${now}', '${name}', '${now}', 1)`
+    )
+  }
+
+  console.info("Baseline updated successfully")
+}
+
 /** UUID v4を生成する */
 const generateUuid = (): string => {
   const hex = (n: number) =>


### PR DESCRIPTION
## Summary

- 旧ベースライン(20件)が登録された既存DBで`migrationDeployer`が新initマイグレーションを再適用しようとする問題を修正
- `ensureBaselineUpToDate()`で旧エントリを現在の正しいベースラインに自動置換

Relates to #689

## Test plan

- [x] マイグレーションテスト13件全通過
- [x] TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)