### PR TITLE
学級所属の重複防止とN+1問題修正、個別/一括追加の機能統一

### DIFF
--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -265,7 +265,7 @@ export function setupStudentHandlers(): void {
   registerSafeHandler(
     "export-classes-excel",
     async (selectedClassIds: string[]) => {
-      const { fetchClasses } = await import("../lib/prisma/student")
+      const { fetchClasses } = await import("../lib/prisma/class")
       const allClasses = await fetchClasses()
       const selectedSet = new Set(selectedClassIds)
       const classes = allClasses.filter((c) => selectedSet.has(c.id))

--- a/electron-src/lib/prisma/student.ts
+++ b/electron-src/lib/prisma/student.ts
@@ -15,19 +15,6 @@ type StudentWithMemberships = Prisma.StudentGetPayload<{
   }
 }>
 
-type ClassWithMemberships = Prisma.ClassGetPayload<{
-  include: {
-    memberships: {
-      include: {
-        student: true
-      }
-      where: {
-        endDate: null // 現在所属中の学生のみ
-      }
-    }
-  }
-}>
-
 /** 全生徒を取得する（学級メンバーシップ・クラス情報含む、現在・過去両方） */
 export const fetchStudents = async (): Promise<StudentWithMemberships[]> => {
   try {
@@ -113,105 +100,6 @@ export const deleteStudent = async (id: string): Promise<void> => {
     await prisma.student.delete({ where: { id } })
   } catch (error) {
     console.error("Failed to delete student:", error)
-    throw error
-  }
-}
-
-/** 全学級を取得する（現在所属中の生徒メンバーシップ含む） */
-export const fetchClasses = async (): Promise<ClassWithMemberships[]> => {
-  try {
-    return await prisma.class.findMany({
-      include: {
-        memberships: {
-          include: {
-            student: true,
-          },
-          where: {
-            endDate: null, // 現在所属中の学生のみ
-          },
-        },
-      },
-    })
-  } catch (error) {
-    console.error("Failed to fetch classes:", error)
-    throw error
-  }
-}
-
-/** 学級を作成する（現在所属中のメンバーシップ含む） */
-export const createClass = async (
-  classData: Prisma.ClassCreateInput
-): Promise<ClassWithMemberships> => {
-  try {
-    return await prisma.class.create({
-      data: classData,
-      include: {
-        memberships: {
-          include: {
-            student: true,
-          },
-          where: {
-            endDate: null,
-          },
-        },
-      },
-    })
-  } catch (error) {
-    console.error("Failed to create class:", error)
-    throw error
-  }
-}
-
-/** 学級情報を更新する（現在所属中のメンバーシップ含む） */
-export const updateClass = async (
-  id: string,
-  classData: Prisma.ClassUpdateInput
-): Promise<ClassWithMemberships> => {
-  try {
-    return await prisma.class.update({
-      where: { id },
-      data: classData,
-      include: {
-        memberships: {
-          include: {
-            student: true,
-          },
-          where: {
-            endDate: null,
-          },
-        },
-      },
-    })
-  } catch (error) {
-    console.error("Failed to update class:", error)
-    throw error
-  }
-}
-
-/** 学級を削除する（現在所属中の生徒がいる場合はエラー） */
-export const deleteClass = async (id: string): Promise<void> => {
-  try {
-    // Check if class has current students before deleting
-    const classWithMemberships = await prisma.class.findUnique({
-      where: { id },
-      include: {
-        memberships: {
-          where: {
-            endDate: null, // 現在所属中の学生をチェック
-          },
-        },
-      },
-    })
-
-    if (classWithMemberships && classWithMemberships.memberships.length > 0) {
-      throw new Error(
-        "この学級には現在も所属している生徒がいるため削除できません。"
-      )
-    }
-
-    await prisma.class.delete({ where: { id } })
-  } catch (error) {
-    console.error("Failed to delete class:", error)
     throw error
   }
 }
@@ -318,5 +206,4 @@ export const getStudentExamResults = async (
   }
 }
 
-// Export the updated types
-export { type ClassWithMemberships, type StudentWithMemberships }
+export { type StudentWithMemberships }

--- a/electron-src/lib/prisma/studentClassMembership.ts
+++ b/electron-src/lib/prisma/studentClassMembership.ts
@@ -156,7 +156,10 @@ export const getCurrentMembershipsByClassId = async (
   }
 }
 
-/** 生徒を学級に追加する（新規所属レコード作成、student・class含む） */
+/** 生徒を学級に追加する（新規所属レコード作成、student・class含む）
+ *  同一生徒・同一学級のアクティブな所属（endDate: null）があれば
+ *  自動的に終了してから新規作成する。
+ */
 export const addStudentToClass = async (
   studentId: string,
   classId: string,
@@ -165,6 +168,17 @@ export const addStudentToClass = async (
   notes?: string
 ): Promise<StudentClassMembershipWithDetails> => {
   try {
+    const existingActive = await prisma.studentClassMembership.findMany({
+      where: {
+        studentId,
+        classId,
+        endDate: null,
+      },
+    })
+    for (const membership of existingActive) {
+      await endStudentMembership(membership.id, startDate)
+    }
+
     const result = await createStudentClassMembership({
       student: { connect: { id: studentId } },
       class: { connect: { id: classId } },

--- a/src/app/students/[studentId]/hooks/useStudentDetail.ts
+++ b/src/app/students/[studentId]/hooks/useStudentDetail.ts
@@ -80,10 +80,20 @@ export function useStudentDetail(studentId: string) {
           membershipData
         )
       } else {
-        await window.electronAPI.addStudentToClass(
+        const membership = await window.electronAPI.addStudentToClass(
           studentId,
-          membershipData.classId
+          membershipData.classId,
+          membershipData.startDate ?? undefined,
+          membershipData.attendanceNumber ?? undefined,
+          membershipData.notes ?? undefined
         )
+        // 終了日が指定されている場合は所属を終了
+        if (membershipData.endDate) {
+          await window.electronAPI.endStudentMembership(
+            membership.id,
+            new Date(membershipData.endDate)
+          )
+        }
       }
 
       // Refresh student data

--- a/src/components/class/ClassStudentImportModal.tsx
+++ b/src/components/class/ClassStudentImportModal.tsx
@@ -13,10 +13,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import type { ClassWithMemberships } from "@/types/prismaExtensions"
-
-// ClassWithMembershipsのmemberships配列の要素型を抽出
-type ClassMembership = ClassWithMemberships["memberships"][number]
 
 interface ClassStudentImportModalProps {
   isOpen: boolean
@@ -135,82 +131,46 @@ export default function ClassStudentImportModal({
     try {
       const validRows = studentData.filter((row) => row.studentId.trim() !== "")
 
+      // 生徒一覧を一度だけ取得（N+1問題の修正）
+      const students = await window.electronAPI.fetchStudents()
+      const studentByNumber = new Map(students.map((s) => [s.studentNumber, s]))
+
       let successCount = 0
-      let notFoundStudents: string[] = []
+      const notFoundStudents: string[] = []
 
       for (const row of validRows) {
         try {
-          const studentId = row.studentId.trim()
+          const studentNumber = row.studentId.trim()
           const attendanceNumber = row.attendanceNumber.trim()
+          const student = studentByNumber.get(studentNumber)
 
-          const students = await window.electronAPI.fetchStudents()
-          const student = students.find((s) => s.studentNumber === studentId)
-
-          if (student) {
-            // 既存のメンバーシップをチェック
-            const classes = await window.electronAPI.fetchClasses()
-            const targetClass = classes.find((c) => c.id === classId)
-            const existingMembership = targetClass?.memberships.find(
-              (m: ClassMembership) => m.student.id === student.id
-            )
-
-            if (existingMembership) {
-              // 既存のメンバーシップがある場合は終了してから新規追加
-              await window.electronAPI.endStudentMembership(
-                existingMembership.id
-              )
-            }
-
-            const startDate = row.startDate.trim()
-              ? new Date(row.startDate.trim().replace(/\//g, "-"))
-              : new Date()
-            const endDateStr = row.endDate.trim()
-
-            await window.electronAPI.addStudentToClass(
-              student.id,
-              classId,
-              startDate,
-              attendanceNumber ? parseInt(attendanceNumber) : undefined
-            )
-
-            const verifyClasses = await window.electronAPI.fetchClasses()
-            const verifyClass = verifyClasses.find((c) => c.id === classId)
-            const addedMembership = verifyClass?.memberships
-              .filter((m: ClassMembership) => m.student.id === student.id)
-              .sort(
-                (a: ClassMembership, b: ClassMembership) =>
-                  new Date(b.startDate).getTime() -
-                  new Date(a.startDate).getTime()
-              )[0]
-
-            if (!addedMembership) {
-              throw new Error("データベースへの保存に失敗しました")
-            }
-
-            // 終了日が指定されている場合は、追加後に終了処理
-            if (endDateStr) {
-              const newClasses = await window.electronAPI.fetchClasses()
-              const newTargetClass = newClasses.find((c) => c.id === classId)
-              // 最新のメンバーシップを取得（開始日でソート）
-              const newMembership = newTargetClass?.memberships
-                .filter((m: ClassMembership) => m.student.id === student.id)
-                .sort(
-                  (a: ClassMembership, b: ClassMembership) =>
-                    new Date(b.startDate).getTime() -
-                    new Date(a.startDate).getTime()
-                )[0]
-              if (newMembership) {
-                await window.electronAPI.endStudentMembership(
-                  newMembership.id,
-                  new Date(endDateStr.replace(/\//g, "-"))
-                )
-              }
-            }
-            successCount++
-          } else {
-            console.warn(`学籍番号 ${studentId} の生徒が見つかりません`)
-            notFoundStudents.push(studentId)
+          if (!student) {
+            notFoundStudents.push(studentNumber)
+            continue
           }
+
+          const startDate = row.startDate.trim()
+            ? new Date(row.startDate.trim().replace(/\//g, "-"))
+            : new Date()
+          const endDateStr = row.endDate.trim()
+
+          // バックエンド側で重複チェック・既存所属終了を処理
+          const membership = await window.electronAPI.addStudentToClass(
+            student.id,
+            classId,
+            startDate,
+            attendanceNumber ? parseInt(attendanceNumber) : undefined
+          )
+
+          // 終了日が指定されている場合は所属を終了
+          if (endDateStr) {
+            await window.electronAPI.endStudentMembership(
+              membership.id,
+              new Date(endDateStr.replace(/\//g, "-"))
+            )
+          }
+
+          successCount++
         } catch (error) {
           console.error(`学籍番号 ${row.studentId} の追加に失敗:`, error)
           alert(
@@ -313,6 +273,7 @@ export default function ClassStudentImportModal({
               onDataChange={handleDataChange}
             />
           </div>
+
           <ValidationMessages validation={validation} />
         </div>
 

--- a/src/components/student/StudentClassMembershipModal.tsx
+++ b/src/components/student/StudentClassMembershipModal.tsx
@@ -23,16 +23,19 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 
-// 呼び出し元との互換性を持たせた型定義
+export interface MembershipSaveData {
+  studentId: string
+  classId: string
+  startDate?: Date
+  endDate?: Date
+  attendanceNumber?: number
+  notes?: string
+}
+
 interface StudentClassMembershipModalProps {
   isOpen: boolean
   onClose: () => void
-  onSave: (membershipData: {
-    studentId: string
-    classId: string
-    attendanceNumber?: number
-    notes?: string
-  }) => void
+  onSave: (membershipData: MembershipSaveData) => void
   studentId?: string
   classId?: string
   availableStudents: Array<{
@@ -52,6 +55,8 @@ interface StudentClassMembershipModalProps {
     id: string
     studentId: string
     classId: string
+    startDate?: Date | string | null
+    endDate?: Date | string | null
     attendanceNumber?: number | null
     notes?: string | null
   } | null
@@ -70,9 +75,20 @@ export default function StudentClassMembershipModal({
   const [studentId, setStudentId] = useState(initialStudentId || "")
   const [classId, setClassId] = useState(initialClassId || "")
   const [attendanceNumber, setAttendanceNumber] = useState<string>("")
+  const [startDate, setStartDate] = useState("")
+  const [endDate, setEndDate] = useState("")
   const [notes, setNotes] = useState("")
   const [studentSearchTerm, setStudentSearchTerm] = useState("")
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
+
+  const formatDateForInput = (
+    date: Date | string | null | undefined
+  ): string => {
+    if (!date) return ""
+    const d = typeof date === "string" ? new Date(date) : date
+    if (isNaN(d.getTime())) return ""
+    return d.toISOString().split("T")[0]
+  }
 
   useEffect(() => {
     let canceled = false
@@ -85,11 +101,15 @@ export default function StudentClassMembershipModal({
         setStudentId(membershipToEdit.studentId)
         setClassId(membershipToEdit.classId)
         setAttendanceNumber(membershipToEdit.attendanceNumber?.toString() || "")
+        setStartDate(formatDateForInput(membershipToEdit.startDate))
+        setEndDate(formatDateForInput(membershipToEdit.endDate))
         setNotes(membershipToEdit.notes || "")
       } else {
         setStudentId(initialStudentId || "")
         setClassId(initialClassId || "")
         setAttendanceNumber("")
+        setStartDate("")
+        setEndDate("")
         setNotes("")
       }
       setStudentSearchTerm("")
@@ -125,6 +145,8 @@ export default function StudentClassMembershipModal({
     onSave({
       studentId,
       classId,
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
       attendanceNumber: attendanceNumber
         ? parseInt(attendanceNumber)
         : undefined,
@@ -239,6 +261,42 @@ export default function StudentClassMembershipModal({
                 placeholder="この学級での出席番号"
                 min="1"
               />
+            </div>
+          </div>
+
+          {/* 開始日 */}
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="startDate" className="text-right">
+              開始日
+            </Label>
+            <div className="col-span-3">
+              <Input
+                id="startDate"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+              />
+              <p className="text-muted-foreground mt-1 text-xs">
+                未指定の場合は今日の日付になります
+              </p>
+            </div>
+          </div>
+
+          {/* 終了日 */}
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="endDate" className="text-right">
+              終了日
+            </Label>
+            <div className="col-span-3">
+              <Input
+                id="endDate"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+              />
+              <p className="text-muted-foreground mt-1 text-xs">
+                未指定の場合は現在所属中（終了日なし）になります
+              </p>
             </div>
           </div>
 

--- a/src/hooks/useClassManagement.ts
+++ b/src/hooks/useClassManagement.ts
@@ -107,10 +107,20 @@ export function useClassManagement(classId: string) {
         )
       } else if (membershipData.studentId) {
         // 新規所属関係を作成
-        await window.electronAPI.addStudentToClass(
+        const membership = await window.electronAPI.addStudentToClass(
           membershipData.studentId,
-          classId
+          classId,
+          membershipData.startDate ?? undefined,
+          membershipData.attendanceNumber ?? undefined,
+          membershipData.notes ?? undefined
         )
+        // 終了日が指定されている場合は所属を終了
+        if (membershipData.endDate) {
+          await window.electronAPI.endStudentMembership(
+            membership.id,
+            new Date(membershipData.endDate)
+          )
+        }
       }
 
       // Refresh class data


### PR DESCRIPTION
## Summary
- 同一学級への重複アクティブ所属（endDate: null）を防止するロジックをバックエンドに追加
- 個別追加モーダルにstartDate/endDate入力を追加し、一括追加と機能統一
- 一括追加のN+1問題を修正（ループ内fetch→事前Mapルックアップ）
- student.tsの重複学級関連関数を削除しclass.tsに一本化

Closes #692

## Test plan
- [ ] 個別追加モーダルでstartDate/endDate/出席番号が正しく保存されることを確認
- [ ] 同一学級に所属中の生徒を再追加した際、既存所属が自動終了されることを確認
- [ ] 一括追加で大量行（30行以上）を投入してもパフォーマンスが改善されていることを確認
- [ ] 学級一覧・生徒一覧の表示が正常であることを確認（fetchClasses一本化の影響）
- [ ] Excel出力（学級データ）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)