### PR TITLE
feat: タグ管理ページ・タグ機能の実装と試験一覧フィルタリング

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,18 +361,19 @@ export class V1_9_0_to_V1_10_0_Transformer implements VersionTransformer {
 - ExamSubtotalGroupテーブルによる中間テーブル管理
 - 同一設問構成の試験における集計設定の統一化
 
-**新規Subject（教科）テーブルの追加**:
+**Tag（タグ）テーブル**:
 
-- Subject (id, name) テーブルの新設
-- SubjectSubtotalGroupテーブルによるSubject-SubtotalGroup多対多関係
-- 教科別フィルタリング・分析機能の基盤
+- Tag (id, name) テーブル（教科名・試験種別など汎用タグ）
+- TagSubtotalGroupテーブルによるTag-SubtotalGroup多対多関係
+- ExamTagテーブルによるExam-Tag多対多関係
+- タグ別フィルタリング・分析機能の基盤
 
 #### 🎯 期待される機能向上
 
 **個人成績の横断分析**:
 
 - 複数Exam間でのSubtotal推移追跡
-- 教科別成績分析とフィルタリング表示
+- タグ別成績分析とフィルタリング表示
 - 長期的な学習進度の可視化
 
 **協調採点機能の完全実現**:

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -350,7 +350,7 @@ export async function seedClasses(
 }
 
 // ---------------------------------------------------------------------------
-// 小計グループ + 教科
+// 小計グループ + タグ
 // ---------------------------------------------------------------------------
 export async function seedSubtotalAndTag(): Promise<{
   subtotalGroupId: string

--- a/electron-src/ipc-handlers/tagHandlers.ts
+++ b/electron-src/ipc-handlers/tagHandlers.ts
@@ -11,8 +11,10 @@ import {
 import {
   createTag,
   deleteTag,
+  findOrCreateTag,
   getAllTags,
   getTagById,
+  reorderTags,
   updateTag,
 } from "../lib/prisma/tag"
 import {
@@ -33,16 +35,30 @@ export function setupTagHandlers(): void {
     return getTagById(id)
   })
 
-  registerHandler("tag:create", async (data: { name: string }) => {
-    return createTag(data)
-  })
+  registerHandler(
+    "tag:create",
+    async (data: { name: string; color?: string }) => {
+      return createTag(data)
+    }
+  )
 
-  registerHandler("tag:update", async (id: string, data: { name: string }) => {
-    return updateTag(id, data)
+  registerHandler(
+    "tag:update",
+    async (id: string, data: { name?: string; color?: string | null }) => {
+      return updateTag(id, data)
+    }
+  )
+
+  registerHandler("tag:reorder", async (tagIds: string[]) => {
+    return reorderTags(tagIds)
   })
 
   registerHandler("tag:delete", async (id: string) => {
     return deleteTag(id)
+  })
+
+  registerHandler("tag:findOrCreate", async (name: string) => {
+    return findOrCreateTag(name)
   })
 
   // TagSubtotalGroup CRUD

--- a/electron-src/lib/import/exam-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/exam-archive/archiveExtractor.ts
@@ -40,7 +40,7 @@ export interface ExtractedArchiveData {
   subtotalsData: ArchiveSubtotalsData
   /** 採点データ */
   scoresData: ArchiveScoresData
-  /** 教科データ (v1.4.0-v1.9.0, deprecated) */
+  /** タグデータ (v1.4.0-v1.9.0, deprecated) */
   subjectsData: ArchiveSubjectsData
   /** タグデータ (v1.10.0+) */
   tagsData: ArchiveTagsData
@@ -111,7 +111,7 @@ export async function extractArchive(archivePath: string): Promise<{
     )
     const scoresData = readJsonFile<ArchiveScoresData>(tempDir, "scores.json")
 
-    // v1.4.0-v1.9.0: 教科データ（存在しない場合はデフォルト値）
+    // v1.4.0-v1.9.0: タグデータ（存在しない場合はデフォルト値）
     const subjectsData = readJsonFile<ArchiveSubjectsData>(
       tempDir,
       "subjects.json"

--- a/electron-src/lib/import/transformers/V1_3_0_to_V1_4_0.ts
+++ b/electron-src/lib/import/transformers/V1_3_0_to_V1_4_0.ts
@@ -3,7 +3,7 @@
  *
  * 主な変更点:
  * - ExamMarkingFormat, ExamExportSettings, CropRegionMarkingOverride を試験データに追加
- * - Subject, SubjectSubtotalGroup を教科データとして追加
+ * - Subject, SubjectSubtotalGroup をタグデータとして追加
  *
  * v1.3.0形式のアーカイブにはこれらのフィールドが存在しないため、
  * デフォルト値（空配列/null）を設定する
@@ -25,7 +25,7 @@ export class V1_3_0_to_V1_4_0_Transformer implements VersionTransformer {
 
     warnings.push(
       `アーカイブはv0.5.x形式(archive v${this.fromVersion})で作成されています。` +
-        `採点マーク設定・エクスポート設定・設問別マークオーバーライド・教科データが追加されます。`
+        `採点マーク設定・エクスポート設定・設問別マークオーバーライド・タグデータが追加されます。`
     )
 
     return {

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -20,9 +20,10 @@ export const getExamsForList = async (userId: string) => {
       examTags: {
         select: {
           tag: {
-            select: { id: true, name: true },
+            select: { id: true, name: true, color: true },
           },
         },
+        orderBy: { tag: { order: "asc" } },
       },
       createdAt: true,
       updatedAt: true,
@@ -119,9 +120,10 @@ export const getExams = async (userId: string) => {
       examTags: {
         select: {
           tag: {
-            select: { id: true, name: true },
+            select: { id: true, name: true, color: true },
           },
         },
+        orderBy: { tag: { order: "asc" } },
       },
     },
     orderBy: {
@@ -193,9 +195,10 @@ export const getExamById = async (id: string) => {
       examTags: {
         select: {
           tag: {
-            select: { id: true, name: true },
+            select: { id: true, name: true, color: true },
           },
         },
+        orderBy: { tag: { order: "asc" } },
       },
     },
   })
@@ -247,9 +250,10 @@ export const createExam = async (
       examTags: {
         select: {
           tag: {
-            select: { id: true, name: true },
+            select: { id: true, name: true, color: true },
           },
         },
+        orderBy: { tag: { order: "asc" } },
       },
     },
   })

--- a/electron-src/lib/prisma/tag.ts
+++ b/electron-src/lib/prisma/tag.ts
@@ -5,11 +5,11 @@
 import prisma from "./client"
 
 /**
- * 全タグを取得
+ * 全タグを取得（order昇順、同orderはname昇順）
  */
 export async function getAllTags() {
   return prisma.tag.findMany({
-    orderBy: { name: "asc" },
+    orderBy: [{ order: "asc" }, { name: "asc" }],
   })
 }
 
@@ -41,21 +41,30 @@ export async function getTagsBySubtotalGroupIds(subtotalGroupIds: string[]) {
 }
 
 /**
- * タグを作成
+ * タグを作成（orderは自動採番）
  */
-export async function createTag(data: { name: string }) {
+export async function createTag(data: { name: string; color?: string }) {
+  const maxOrder = await prisma.tag.aggregate({ _max: { order: true } })
+  const nextOrder = (maxOrder._max.order ?? -1) + 1
   return prisma.tag.create({
-    data: { name: data.name },
+    data: {
+      name: data.name,
+      color: data.color ?? null,
+      order: nextOrder,
+    },
   })
 }
 
 /**
  * タグを更新
  */
-export async function updateTag(id: string, data: { name: string }) {
+export async function updateTag(
+  id: string,
+  data: { name?: string; color?: string | null }
+) {
   return prisma.tag.update({
     where: { id },
-    data: { name: data.name },
+    data,
   })
 }
 
@@ -77,7 +86,23 @@ export async function findOrCreateTag(name: string) {
   })
   if (existing) return existing
 
+  const maxOrder = await prisma.tag.aggregate({ _max: { order: true } })
+  const nextOrder = (maxOrder._max.order ?? -1) + 1
   return prisma.tag.create({
-    data: { name },
+    data: { name, order: nextOrder },
   })
+}
+
+/**
+ * タグの並び順を一括更新
+ */
+export async function reorderTags(tagIds: string[]) {
+  return prisma.$transaction(
+    tagIds.map((id, index) =>
+      prisma.tag.update({
+        where: { id },
+        data: { order: index },
+      })
+    )
+  )
 }

--- a/electron-src/lib/sync/syncTableConfig.ts
+++ b/electron-src/lib/sync/syncTableConfig.ts
@@ -35,7 +35,7 @@ export const SYNC_TABLES: TableConfig[] = [
   std("QuestionScore"),
   std("DrawingAnnotation"),
 
-  // 小計・教科
+  // 小計・タグ
   std("SubtotalGroup"),
   std("Subtotal"),
   std("CropSubtotal"),

--- a/electron-src/preload-apis/tagApi.ts
+++ b/electron-src/preload-apis/tagApi.ts
@@ -6,11 +6,14 @@ export function createTagApi() {
     // Tag（タグ）
     tagGetAll: () => ipcRenderer.invoke("tag:getAll"),
     tagGetById: (id: string) => ipcRenderer.invoke("tag:getById", id),
-    tagCreate: (data: { name: string }) =>
+    tagCreate: (data: { name: string; color?: string }) =>
       ipcRenderer.invoke("tag:create", data),
-    tagUpdate: (id: string, data: { name: string }) =>
+    tagUpdate: (id: string, data: { name?: string; color?: string | null }) =>
       ipcRenderer.invoke("tag:update", id, data),
     tagDelete: (id: string) => ipcRenderer.invoke("tag:delete", id),
+    tagFindOrCreate: (name: string) =>
+      ipcRenderer.invoke("tag:findOrCreate", name),
+    tagReorder: (tagIds: string[]) => ipcRenderer.invoke("tag:reorder", tagIds),
 
     // TagSubtotalGroup（タグ-小計グループ関連）
     tagSubtotalGroupGetByTagId: (tagId: string) =>

--- a/prisma/migrations/20260323010447_add_tag_order_and_color/migration.sql
+++ b/prisma/migrations/20260323010447_add_tag_order_and_color/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Tag" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "color" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Tag" ("createdAt", "id", "name", "updatedAt") SELECT "createdAt", "id", "name", "updatedAt" FROM "Tag";
+DROP TABLE "Tag";
+ALTER TABLE "new_Tag" RENAME TO "Tag";
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -322,6 +322,8 @@ model ExamClass {
 model Tag {
   id        String   @id @default(uuid())
   name      String   @unique
+  order     Int      @default(0)
+  color     String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import ProtectedRoute from "@/components/auth/ProtectedRoute"
+import PageHeader from "@/components/layout/PageHeader"
+import { TagsPageContainer } from "@/components/tag/TagsPageContainer"
+
+export default function TagsPage() {
+  return (
+    <ProtectedRoute>
+      <div className="flex h-full flex-col">
+        <PageHeader title="タグ管理" />
+        <div className="flex-1 overflow-hidden">
+          <TagsPageContainer />
+        </div>
+      </div>
+    </ProtectedRoute>
+  )
+}

--- a/src/components/exams/detail/ExamHeader.tsx
+++ b/src/components/exams/detail/ExamHeader.tsx
@@ -26,7 +26,7 @@ interface ExamData {
   examName: string
   description: string | null
   examDate: Date | null
-  examTags?: { tag: { id: string; name: string } }[]
+  examTags?: { tag: { id: string; name: string; color: string | null } }[]
   createdAt: Date
 }
 
@@ -55,7 +55,15 @@ export default function ExamHeader({
             {exam.examTags &&
               exam.examTags.length > 0 &&
               exam.examTags.map((et) => (
-                <Badge key={et.tag.id} variant="outline">
+                <Badge
+                  key={et.tag.id}
+                  variant="outline"
+                  style={
+                    et.tag.color
+                      ? { borderColor: et.tag.color, color: et.tag.color }
+                      : undefined
+                  }
+                >
                   <Tag className="mr-1 h-3 w-3" />
                   {et.tag.name}
                 </Badge>

--- a/src/components/exams/forms/CreateExamWindow.tsx
+++ b/src/components/exams/forms/CreateExamWindow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { X as XIcon } from "lucide-react"
-import React, { useState } from "react"
+import { Tag as TagIcon, X as XIcon } from "lucide-react"
+import React, { useCallback, useEffect, useState } from "react"
 
 import { useExams } from "@/components/hooks/useExams"
 import { Badge } from "@/components/ui/badge"
@@ -30,9 +30,24 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
   const [examName, setExamName] = useState("")
   const [examDate, setExamDate] = useState<Date | null>(null)
   const [description, setDescription] = useState("")
-  const [tagTexts, setTagTexts] = useState<string[]>([]) // タグの文字列配列
-  const [currentTagInput, setCurrentTagInput] = useState("") // 現在のタグ入力値
-  const { createExam } = useExams() // addExam から createExam に変更
+  const [tagTexts, setTagTexts] = useState<string[]>([])
+  const [currentTagInput, setCurrentTagInput] = useState("")
+  const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const { createExam } = useExams()
+
+  // 既存タグを取得
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        const tags = await window.electronAPI.tagGetAll()
+        setAllTags(tags)
+      } catch {
+        // ignore
+      }
+    }
+    void loadTags()
+  }, [])
 
   const handleSubmit = async () => {
     if (!examName.trim()) {
@@ -40,26 +55,40 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
       return
     }
     try {
-      // createExam の引数をPrismaの型に合わせる
-      await createExam({
+      const createdExam = await createExam({
         examName: examName.trim(),
         examDate: examDate,
         description: description.trim() || undefined,
       })
-      onExamCreated?.() // 試験作成成功時のコールバック
+
+      // タグを保存
+      if (tagTexts.length > 0 && createdExam?.id) {
+        const tagIds: string[] = []
+        for (const tagName of tagTexts) {
+          const tag = await window.electronAPI.tagFindOrCreate(tagName)
+          tagIds.push(tag.id)
+        }
+        await window.electronAPI.examTagSetExamTags(createdExam.id, tagIds)
+      }
+
+      onExamCreated?.()
       onClose()
     } catch (error) {
       console.error("Failed to create exam:", error)
-      // Handle error display to user
     }
   }
 
-  const handleAddTag = () => {
-    if (currentTagInput.trim() && !tagTexts.includes(currentTagInput.trim())) {
-      setTagTexts([...tagTexts, currentTagInput.trim()])
+  const handleAddTag = useCallback(
+    (tagName?: string) => {
+      const name = (tagName ?? currentTagInput).trim()
+      if (name && !tagTexts.includes(name)) {
+        setTagTexts([...tagTexts, name])
+      }
       setCurrentTagInput("")
-    }
-  }
+      setShowSuggestions(false)
+    },
+    [currentTagInput, tagTexts]
+  )
 
   const handleRemoveTag = (tagToRemove: string) => {
     setTagTexts(tagTexts.filter((tag) => tag !== tagToRemove))
@@ -72,20 +101,24 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
     }
   }
 
+  // サジェスト候補（入力中のテキストでフィルタ、既に追加済みは除外）
+  const suggestions = allTags.filter(
+    (t) =>
+      !tagTexts.includes(t.name) &&
+      (currentTagInput.trim() === "" ||
+        t.name.toLowerCase().includes(currentTagInput.trim().toLowerCase()))
+  )
+
   return (
     <Dialog open onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
-        {" "}
-        {/* sm:max-w-md に変更 */}
         <DialogHeader>
           <DialogTitle>新規試験作成</DialogTitle>
           <DialogDescription>
-            新しい試験試験の詳細情報を入力してください。
+            新しい試験の詳細情報を入力してください。
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-6 py-4">
-          {" "}
-          {/* gap-6 に変更 */}
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="examName" className="text-right">
               試験名
@@ -117,31 +150,61 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
             <Label htmlFor="description" className="pt-2 text-right">
               説明
             </Label>
-            <Textarea // textarea を Textarea コンポーネントに変更
+            <Textarea
               id="description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="col-span-3 min-h-20" // クラス名を調整
+              className="col-span-3 min-h-20"
               placeholder="試験の説明（任意）"
             />
           </div>
           <div className="grid grid-cols-4 items-start gap-4">
             <Label htmlFor="tagTexts" className="pt-2 text-right">
-              科目
+              タグ
             </Label>
             <div className="col-span-3">
-              <div className="mb-2 flex items-center gap-2">
+              <div className="relative mb-2 flex items-center gap-2">
                 <Input
                   id="tagTexts"
                   value={currentTagInput}
-                  onChange={(e) => setCurrentTagInput(e.target.value)}
+                  onChange={(e) => {
+                    setCurrentTagInput(e.target.value)
+                    setShowSuggestions(true)
+                  }}
+                  onFocus={() => setShowSuggestions(true)}
+                  onBlur={() => {
+                    // blurを少し遅延させてクリックイベントを拾えるようにする
+                    setTimeout(() => setShowSuggestions(false), 200)
+                  }}
                   onKeyDown={handleTagInputKeyDown}
                   className="grow"
-                  placeholder="科目を入力してEnter"
+                  placeholder="教科名や試験種別などのタグを入力"
                 />
-                <Button type="button" onClick={handleAddTag} variant="outline">
+                <Button
+                  type="button"
+                  onClick={() => handleAddTag()}
+                  variant="outline"
+                >
                   追加
                 </Button>
+                {showSuggestions && suggestions.length > 0 && (
+                  <div className="bg-popover border-border absolute top-full right-10 left-0 z-50 mt-1 max-h-32 overflow-y-auto rounded-md border shadow-md">
+                    {suggestions.map((tag) => (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        className="hover:bg-accent flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          handleAddTag(tag.name)
+                        }}
+                      >
+                        <TagIcon className="h-3 w-3 opacity-50" />
+                        {tag.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
               <div className="flex flex-wrap gap-2">
                 {tagTexts.map((tagText, index) => (

--- a/src/components/exams/forms/EditExamWindow.tsx
+++ b/src/components/exams/forms/EditExamWindow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { CheckIcon, Edit2Icon, Trash2Icon, X as XIcon } from "lucide-react"
-import React, { useState } from "react"
+import { Tag as TagIcon, X as XIcon } from "lucide-react"
+import React, { useCallback, useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -18,11 +18,6 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import type { ExamWithDetails } from "@/types/common.types"
 
-type Tag = {
-  id: string
-  text: string
-}
-
 interface EditExamWindowProps {
   examToEdit: ExamWithDetails
   setIsShowEditExamWindow: (isOpen: boolean) => void
@@ -37,7 +32,6 @@ const EditExamWindow = ({
   const [examName, setExamName] = useState(examToEdit.examName)
   const [examDate, setExamDate] = useState<Date | undefined>(() => {
     if (!examToEdit.examDate) return undefined
-    // examDateが文字列の場合はDateオブジェクトに変換
     return examToEdit.examDate instanceof Date
       ? examToEdit.examDate
       : new Date(examToEdit.examDate)
@@ -45,17 +39,46 @@ const EditExamWindow = ({
   const [description, setDescription] = useState<string | null>(
     examToEdit.description ?? null
   )
-  // タグ機能は未実装のため、空の配列で初期化
-  const [tags, setTags] = useState<Tag[]>([])
+  const [tagNames, setTagNames] = useState<string[]>([])
   const [currentTagInput, setCurrentTagInput] = useState("")
-  const [editingTagId, setEditingTagId] = useState<string | null>(null)
-  const [editingTagText, setEditingTagText] = useState<string>("")
+  const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+
+  // 既存タグと全タグ一覧を取得
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        const [examTags, tags] = await Promise.all([
+          window.electronAPI.examTagGetByExamId(examToEdit.id),
+          window.electronAPI.tagGetAll(),
+        ])
+        setTagNames(examTags.map((et) => et.tag.name))
+        setAllTags(tags)
+      } catch {
+        // ignore
+      }
+    }
+    void loadTags()
+  }, [examToEdit.id])
 
   const handleSave = async () => {
     if (!examName.trim()) {
       alert("試験名は必須です。")
       return
     }
+
+    // タグを保存
+    try {
+      const tagIds: string[] = []
+      for (const name of tagNames) {
+        const tag = await window.electronAPI.tagFindOrCreate(name)
+        tagIds.push(tag.id)
+      }
+      await window.electronAPI.examTagSetExamTags(examToEdit.id, tagIds)
+    } catch (error) {
+      console.error("Failed to save tags:", error)
+    }
+
     const updatedExamPayload: ExamWithDetails = {
       ...examToEdit,
       examName: examName.trim(),
@@ -66,71 +89,20 @@ const EditExamWindow = ({
     await onSave(updatedExamPayload)
   }
 
-  const handleAddTag = async () => {
-    if (
-      currentTagInput.trim() &&
-      !tags.find((tag) => tag.text === currentTagInput.trim())
-    ) {
-      try {
-        // Tag functionality is not implemented yet
-        const newTag = {
-          id: Date.now().toString(),
-          text: currentTagInput.trim(),
-        }
-        if (newTag) {
-          setTags([...tags, newTag])
-        }
-        setCurrentTagInput("")
-      } catch (error) {
-        console.error("Failed to create tag:", error)
-        alert("タグの作成に失敗しました。")
+  const handleAddTag = useCallback(
+    (tagName?: string) => {
+      const name = (tagName ?? currentTagInput).trim()
+      if (name && !tagNames.includes(name)) {
+        setTagNames([...tagNames, name])
       }
-    }
-  }
+      setCurrentTagInput("")
+      setShowSuggestions(false)
+    },
+    [currentTagInput, tagNames]
+  )
 
-  const handleRemoveTagFromExam = (tagIdToRemove: string) => {
-    setTags(tags.filter((tag) => tag.id !== tagIdToRemove))
-  }
-
-  const handleDeleteTagFromDb = async (_tagIdToDelete: string) => {
-    if (
-      window.confirm(
-        "このタグをデータベースから完全に削除しますか？関連する他の試験からも削除されます。"
-      )
-    ) {
-      try {
-        // Tag deletion functionality is not implemented yet
-        alert("タグ削除機能は未実装です。")
-        // await window.electronAPI.deleteTag(tagIdToDelete)
-        // setTags(tags.filter((tag) => tag.id !== tagIdToDelete))
-      } catch (error) {
-        console.error("Failed to delete tag from DB:", error)
-        alert("タグの削除に失敗しました。")
-      }
-    }
-  }
-
-  const handleEditTag = (tag: Tag) => {
-    setEditingTagId(tag.id)
-    setEditingTagText(tag.text)
-  }
-
-  const handleSaveEditedTag = async () => {
-    if (!editingTagId || !editingTagText.trim()) return
-    try {
-      // Tag update functionality is not implemented yet
-      alert("タグ更新機能は未実装です。")
-      // const updatedTag = await window.electronAPI.updateTag(
-      //   editingTagId,
-      //   editingTagText.trim(),
-      // )
-      // setTags(tags.map((tag) => (tag.id === editingTagId ? updatedTag : tag)))
-      setEditingTagId(null)
-      setEditingTagText("")
-    } catch (error) {
-      console.error("Failed to update tag:", error)
-      alert("タグの更新に失敗しました。")
-    }
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTagNames(tagNames.filter((t) => t !== tagToRemove))
   }
 
   const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -140,25 +112,17 @@ const EditExamWindow = ({
     }
   }
 
-  const handleEditingTagInputKeyDown = (
-    e: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-      e.preventDefault()
-      handleSaveEditedTag()
-    }
-    if (e.key === "Escape") {
-      e.preventDefault()
-      setEditingTagId(null)
-      setEditingTagText("")
-    }
-  }
+  // サジェスト候補
+  const suggestions = allTags.filter(
+    (t) =>
+      !tagNames.includes(t.name) &&
+      (currentTagInput.trim() === "" ||
+        t.name.toLowerCase().includes(currentTagInput.trim().toLowerCase()))
+  )
 
   return (
     <Dialog open onOpenChange={setIsShowEditExamWindow}>
       <DialogContent className="sm:max-w-md">
-        {" "}
-        {/* sm:max-w-md に変更 */}
         <DialogHeader>
           <DialogTitle>試験情報を編集</DialogTitle>
           <DialogDescription>
@@ -166,8 +130,6 @@ const EditExamWindow = ({
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-6 py-4">
-          {" "}
-          {/* gap-6 に変更 */}
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="examName" className="text-right">
               試験名
@@ -196,7 +158,6 @@ const EditExamWindow = ({
               className="col-span-3"
             />
           </div>
-          {/* Description の編集機能がなかったので追加 */}
           <div className="grid grid-cols-4 items-start gap-4">
             <Label htmlFor="edit-description" className="pt-2 text-right">
               説明
@@ -211,80 +172,63 @@ const EditExamWindow = ({
           </div>
           <div className="grid grid-cols-4 items-start gap-4">
             <Label htmlFor="tags" className="pt-2 text-right">
-              科目
+              タグ
             </Label>
             <div className="col-span-3">
-              <div className="mb-2 flex items-center gap-2">
+              <div className="relative mb-2 flex items-center gap-2">
                 <Input
                   id="tags"
                   value={currentTagInput}
-                  onChange={(e) => setCurrentTagInput(e.target.value)}
+                  onChange={(e) => {
+                    setCurrentTagInput(e.target.value)
+                    setShowSuggestions(true)
+                  }}
+                  onFocus={() => setShowSuggestions(true)}
+                  onBlur={() => {
+                    setTimeout(() => setShowSuggestions(false), 200)
+                  }}
                   onKeyDown={handleTagInputKeyDown}
                   className="grow"
-                  placeholder="科目を入力してEnter"
+                  placeholder="教科名や試験種別などのタグを入力"
                 />
-                <Button type="button" onClick={handleAddTag} variant="outline">
+                <Button
+                  type="button"
+                  onClick={() => handleAddTag()}
+                  variant="outline"
+                >
                   追加
                 </Button>
+                {showSuggestions && suggestions.length > 0 && (
+                  <div className="bg-popover border-border absolute top-full right-10 left-0 z-50 mt-1 max-h-32 overflow-y-auto rounded-md border shadow-md">
+                    {suggestions.map((tag) => (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        className="hover:bg-accent flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm"
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          handleAddTag(tag.name)
+                        }}
+                      >
+                        <TagIcon className="h-3 w-3 opacity-50" />
+                        {tag.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
               <div className="flex flex-wrap gap-2">
-                {tags.map((tag) => (
-                  <Badge
-                    key={tag.id}
-                    variant="secondary"
-                    className="group relative flex items-center pr-2" // pr-2 に変更し、items-center を追加
-                  >
-                    {editingTagId === tag.id ? (
-                      <Input
-                        type="text"
-                        value={editingTagText}
-                        onChange={(e) => setEditingTagText(e.target.value)}
-                        onKeyDown={handleEditingTagInputKeyDown}
-                        onBlur={() => {
-                          // 編集中のタグからフォーカスが外れたら保存するか、キャンセルするか検討
-                          // ここでは一旦何もしない (Enterキーでの保存を促す)
-                          // もし自動保存したい場合は handleSaveEditedTag() を呼ぶ
-                          // もしキャンセルしたい場合は setEditingTagId(null) を呼ぶ
-                        }}
-                        className="mr-1 h-6 grow px-1 text-xs"
-                        autoFocus
-                      />
-                    ) : (
-                      <span className="mr-1">{tag.text}</span> // mr-1 を追加
-                    )}
-                    <div className="flex items-center opacity-0 transition-opacity group-hover:opacity-100">
-                      {" "}
-                      {/* absolute を削除し、flex items-center を適用 */}
-                      {editingTagId === tag.id ? (
-                        <CheckIcon
-                          size={16} // サイズを少し大きく
-                          className="cursor-pointer text-green-600 hover:text-green-800"
-                          onClick={handleSaveEditedTag}
-                        />
-                      ) : (
-                        <Edit2Icon
-                          size={16} // サイズを少し大きく
-                          className="mr-1 cursor-pointer text-blue-600 hover:text-blue-800"
-                          onClick={() => handleEditTag(tag)}
-                        />
-                      )}
-                      {/* 試験からタグを外すボタン (XIcon) を追加 */}
-                      <div title="この試験から科目を削除">
-                        <XIcon
-                          size={16}
-                          className="ml-1 cursor-pointer text-gray-500 hover:text-gray-700"
-                          onClick={() => handleRemoveTagFromExam(tag.id)}
-                        />
-                      </div>
-                      {/* DBからタグ自体を削除するボタン (TrashIcon) はより危険な操作なので、アイコンを分けるか、別の場所に配置することを検討 */}
-                      <div title="データベースから科目を完全に削除">
-                        <Trash2Icon
-                          size={16}
-                          className="ml-1 cursor-pointer text-red-600 hover:text-red-800"
-                          onClick={() => handleDeleteTagFromDb(tag.id)}
-                        />
-                      </div>
-                    </div>
+                {tagNames.map((name, index) => (
+                  <Badge key={index} variant="secondary">
+                    {name}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveTag(name)}
+                      className="text-secondary-foreground hover:text-destructive ml-1.5 cursor-pointer appearance-none border-none bg-transparent p-0"
+                      aria-label={`Remove ${name}`}
+                    >
+                      <XIcon size={14} />
+                    </button>
                   </Badge>
                 ))}
               </div>

--- a/src/components/exams/list/ExamList.tsx
+++ b/src/components/exams/list/ExamList.tsx
@@ -1,27 +1,25 @@
 "use client"
 
 import {
-  ArrowDownAZ,
-  ArrowUpAZ,
   Calculator,
-  CalendarArrowDown,
-  CalendarArrowUp,
-  Check,
   Download,
   Edit,
   Eye,
   FileImage,
+  Filter,
   FolderInput,
   FolderOutput,
   PlayCircle,
   PlusCircle,
+  Search,
   Settings,
-  SortDesc,
+  Tag,
   Upload,
   Users,
+  X as XIcon,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import ExportModeModal from "@/components/exams/detail/ExportModeModal"
@@ -29,16 +27,16 @@ import CreateExamWindow from "@/components/exams/forms/CreateExamWindow"
 import { useExams } from "@/components/hooks/useExams"
 import { useFileActions } from "@/components/hooks/useFileActions"
 import { ImportWizardModal } from "@/components/import/ImportWizardModal"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { SortableTableHead } from "@/components/ui/SortableTableHead"
 import {
   Table,
   TableBody,
@@ -48,7 +46,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { useAuth } from "@/contexts/AuthContext"
-import { SortDirection, useTableSort } from "@/hooks/useTableSort"
+import { useTableSort } from "@/hooks/useTableSort"
 import type { ExamListItem } from "@/types/common.types"
 import type { ExportMode } from "@/types/examArchive.types"
 
@@ -59,33 +57,6 @@ interface ExamSortable {
   original: ExamListItem
 }
 
-const SORT_OPTIONS = [
-  {
-    key: "examDate",
-    direction: "desc",
-    label: "実施日（新しい順）",
-    icon: CalendarArrowDown,
-  },
-  {
-    key: "examDate",
-    direction: "asc",
-    label: "実施日（古い順）",
-    icon: CalendarArrowUp,
-  },
-  {
-    key: "examName",
-    direction: "asc",
-    label: "試験名（A→Z）",
-    icon: ArrowDownAZ,
-  },
-  {
-    key: "examName",
-    direction: "desc",
-    label: "試験名（Z→A）",
-    icon: ArrowUpAZ,
-  },
-] as const
-
 const File = () => {
   const { exams, loadExams } = useExams()
   const { user } = useAuth()
@@ -94,42 +65,67 @@ const File = () => {
   const [isBulkExporting, setIsBulkExporting] = useState(false)
   const [showBulkExportModal, setShowBulkExportModal] = useState(false)
 
+  const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
+  const [bulkTagInput, setBulkTagInput] = useState("")
+  const [showBulkTagPopover, setShowBulkTagPopover] = useState(false)
+  const bulkTagInputRef = useRef<HTMLInputElement>(null)
+  const [searchTerm, setSearchTerm] = useState("")
+  const [filterTagIds, setFilterTagIds] = useState<Set<string>>(new Set())
+
   const { createExamModal } = useFileActions()
   const router = useRouter()
 
+  // 既存タグ一覧を取得
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        const tags = await window.electronAPI.tagGetAll()
+        setAllTags(tags)
+      } catch {
+        // ignore
+      }
+    }
+    void loadTags()
+  }, [])
+
+  // フィルタリング
+  const filteredExams = useMemo(() => {
+    return exams.filter((exam) => {
+      // テキスト検索
+      if (searchTerm.trim()) {
+        const term = searchTerm.trim().toLowerCase()
+        const nameMatch = exam.examName.toLowerCase().includes(term)
+        const descMatch = exam.description?.toLowerCase().includes(term)
+        const tagMatch = exam.tags.some((t) =>
+          t.name.toLowerCase().includes(term)
+        )
+        if (!nameMatch && !descMatch && !tagMatch) return false
+      }
+      // タグフィルタ
+      if (filterTagIds.size > 0) {
+        const examTagIds = new Set(exam.tags.map((t) => t.id))
+        const hasMatch = [...filterTagIds].some((id) => examTagIds.has(id))
+        if (!hasMatch) return false
+      }
+      return true
+    })
+  }, [exams, searchTerm, filterTagIds])
+
   // ソート用データに変換
   const sortableData = useMemo<ExamSortable[]>(() => {
-    return exams.map((exam) => ({
+    return filteredExams.map((exam) => ({
       id: exam.id,
       examName: exam.examName,
       examDate: exam.examDate ? new Date(exam.examDate).toISOString() : null,
       original: exam,
     }))
-  }, [exams])
+  }, [filteredExams])
 
   // ソート機能（localStorage永続化、既定: 実施日降順）
-  const { sortedData, sortConfig, setSort } = useTableSort(sortableData, {
+  const { sortedData, sortConfig, requestSort } = useTableSort(sortableData, {
     defaultSort: { key: "examDate", direction: "desc" },
     storageKey: "examList-sort",
   })
-
-  // 現在のソート設定に一致するオプションを取得
-  const currentSortLabel = useMemo(() => {
-    const option = SORT_OPTIONS.find(
-      (opt) =>
-        opt.key === sortConfig.key && opt.direction === sortConfig.direction
-    )
-    return option?.label || "並び替え"
-  }, [sortConfig])
-
-  const handleSortSelect = (
-    key: keyof ExamSortable,
-    direction: SortDirection
-  ) => {
-    if (direction) {
-      setSort(key, direction)
-    }
-  }
 
   const handleStartScoring = (exam: ExamListItem) => {
     router.push(`/exams/${exam.id}`)
@@ -164,6 +160,39 @@ const File = () => {
       return new Set(sortedData.map((d) => d.id))
     })
   }, [sortedData])
+
+  const handleBulkAddTag = useCallback(
+    async (tagName: string) => {
+      if (!tagName.trim() || selectedExamIds.size === 0) return
+      try {
+        const tag = await window.electronAPI.tagFindOrCreate(tagName.trim())
+        for (const examId of selectedExamIds) {
+          try {
+            await window.electronAPI.examTagCreate({
+              examId,
+              tagId: tag.id,
+            })
+          } catch {
+            // 既に紐づいている場合はunique制約で失敗するが無視
+          }
+        }
+        toast.success("タグを追加しました", {
+          description: `${selectedExamIds.size}件の試験に「${tagName.trim()}」を追加`,
+        })
+        setBulkTagInput("")
+        setShowBulkTagPopover(false)
+        setSelectedExamIds(new Set())
+        // タグ一覧を再取得
+        const tags = await window.electronAPI.tagGetAll()
+        setAllTags(tags)
+        loadExams()
+      } catch (error) {
+        toast.error("タグの追加に失敗しました")
+        console.error(error)
+      }
+    },
+    [selectedExamIds, loadExams]
+  )
 
   const handleBulkExport = useCallback(
     async (exportMode: ExportMode) => {
@@ -258,6 +287,62 @@ const File = () => {
                 <span className="text-muted-foreground ml-2 text-sm">
                   {selectedExamIds.size}件選択中
                 </span>
+                <Popover
+                  open={showBulkTagPopover}
+                  onOpenChange={setShowBulkTagPopover}
+                >
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" className="rounded-lg">
+                      <Tag className="mr-2 h-4 w-4" />
+                      タグを一括追加
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64 p-3" align="start">
+                    <div className="space-y-2">
+                      <p className="text-muted-foreground text-xs">
+                        選択中の{selectedExamIds.size}
+                        件にタグを追加
+                      </p>
+                      <Input
+                        ref={bulkTagInputRef}
+                        value={bulkTagInput}
+                        onChange={(e) => setBulkTagInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                            e.preventDefault()
+                            void handleBulkAddTag(bulkTagInput)
+                          }
+                        }}
+                        placeholder="タグ名を入力してEnter"
+                        className="h-8 text-sm"
+                        autoFocus
+                      />
+                      {allTags.length > 0 && (
+                        <div className="max-h-28 overflow-y-auto">
+                          {allTags
+                            .filter(
+                              (t) =>
+                                !bulkTagInput.trim() ||
+                                t.name
+                                  .toLowerCase()
+                                  .includes(bulkTagInput.trim().toLowerCase())
+                            )
+                            .map((tag) => (
+                              <button
+                                key={tag.id}
+                                type="button"
+                                className="hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm"
+                                onClick={() => void handleBulkAddTag(tag.name)}
+                              >
+                                <Tag className="h-3 w-3 opacity-50" />
+                                {tag.name}
+                              </button>
+                            ))}
+                        </div>
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
                 <Button
                   onClick={() => setShowBulkExportModal(true)}
                   variant="outline"
@@ -271,38 +356,84 @@ const File = () => {
             )}
           </div>
 
-          {/* ソート選択 */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="gap-2 rounded-lg">
-                <SortDesc className="h-4 w-4" />
-                {currentSortLabel}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuLabel>並び替え</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {SORT_OPTIONS.map((option) => {
-                const Icon = option.icon
-                const isSelected =
-                  sortConfig.key === option.key &&
-                  sortConfig.direction === option.direction
-                return (
-                  <DropdownMenuItem
-                    key={`${option.key}-${option.direction}`}
-                    onClick={() =>
-                      handleSortSelect(option.key, option.direction)
+          {/* 検索・フィルタ */}
+          <div className="ml-auto flex items-center gap-2">
+            <div className="relative">
+              <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+              <Input
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="試験名・タグで検索"
+                className="h-8 w-48 pl-8 text-sm"
+              />
+            </div>
+            {allTags.length > 0 && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={
+                      filterTagIds.size > 0 ? "border-primary text-primary" : ""
                     }
-                    className="gap-2"
                   >
-                    <Icon className="h-4 w-4" />
-                    {option.label}
-                    {isSelected && <Check className="ml-auto h-4 w-4" />}
-                  </DropdownMenuItem>
-                )
-              })}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                    <Filter className="mr-1.5 h-3.5 w-3.5" />
+                    タグ
+                    {filterTagIds.size > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="ml-1.5 h-5 min-w-5 px-1 text-xs"
+                      >
+                        {filterTagIds.size}
+                      </Badge>
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-48 p-2" align="start">
+                  <div className="max-h-48 space-y-1 overflow-y-auto">
+                    {allTags.map((tag) => (
+                      <label
+                        key={tag.id}
+                        className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm"
+                      >
+                        <Checkbox
+                          checked={filterTagIds.has(tag.id)}
+                          onCheckedChange={(checked) => {
+                            setFilterTagIds((prev) => {
+                              const next = new Set(prev)
+                              if (checked) {
+                                next.add(tag.id)
+                              } else {
+                                next.delete(tag.id)
+                              }
+                              return next
+                            })
+                          }}
+                        />
+                        {tag.name}
+                      </label>
+                    ))}
+                  </div>
+                  {filterTagIds.size > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="mt-1 w-full text-xs"
+                      onClick={() => setFilterTagIds(new Set())}
+                    >
+                      <XIcon className="mr-1 h-3 w-3" />
+                      フィルタをクリア
+                    </Button>
+                  )}
+                </PopoverContent>
+              </Popover>
+            )}
+            <span className="text-muted-foreground text-xs">
+              {filteredExams.length === exams.length
+                ? `${exams.length}件`
+                : `${filteredExams.length} / ${exams.length}件`}
+            </span>
+          </div>
         </div>
 
         {/* テーブルエリア */}
@@ -321,7 +452,23 @@ const File = () => {
                       aria-label="全選択"
                     />
                   </TableHead>
-                  <TableHead>試験名</TableHead>
+                  <SortableTableHead
+                    sortKey="examName"
+                    currentSortKey={sortConfig.key}
+                    currentDirection={sortConfig.direction}
+                    onSort={requestSort}
+                  >
+                    試験名
+                  </SortableTableHead>
+                  <SortableTableHead
+                    sortKey="examDate"
+                    currentSortKey={sortConfig.key}
+                    currentDirection={sortConfig.direction}
+                    onSort={requestSort}
+                    className="w-28 text-center"
+                  >
+                    試験日
+                  </SortableTableHead>
                   <TableHead className="w-32 text-center">詳細</TableHead>
                   <TableHead className="w-40 text-center">
                     次のステップ
@@ -331,28 +478,55 @@ const File = () => {
               <TableBody>
                 {sortedData.map(({ original: exam }) => {
                   return (
-                    <TableRow key={exam.id} className="group">
+                    <TableRow
+                      key={exam.id}
+                      className="group cursor-pointer"
+                      onClick={() => handleToggleSelect(exam.id)}
+                    >
                       <TableCell className="text-center">
                         <Checkbox
                           checked={selectedExamIds.has(exam.id)}
                           onCheckedChange={() => handleToggleSelect(exam.id)}
+                          onClick={(e) => e.stopPropagation()}
                           aria-label={`${exam.examName}を選択`}
                         />
                       </TableCell>
                       <TableCell>
                         <div>
                           <div className="font-medium">{exam.examName}</div>
-                          <div className="text-muted-foreground text-sm tabular-nums">
-                            {exam.examDate
-                              ? new Date(exam.examDate).toLocaleDateString(
-                                  "ja-JP"
-                                )
-                              : "実施日未設定"}
-                          </div>
+                          {exam.tags.length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1">
+                              {exam.tags.map((tag) => (
+                                <Badge
+                                  key={tag.id}
+                                  variant="outline"
+                                  className="text-xs font-normal"
+                                  style={
+                                    tag.color
+                                      ? {
+                                          borderColor: tag.color,
+                                          color: tag.color,
+                                        }
+                                      : undefined
+                                  }
+                                >
+                                  {tag.name}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       </TableCell>
+                      <TableCell className="text-muted-foreground text-center text-sm tabular-nums">
+                        {exam.examDate
+                          ? new Date(exam.examDate).toLocaleDateString("ja-JP")
+                          : "—"}
+                      </TableCell>
 
-                      <TableCell className="text-center">
+                      <TableCell
+                        className="text-center"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <Button
                           variant="outline"
                           size="sm"
@@ -364,7 +538,10 @@ const File = () => {
                         </Button>
                       </TableCell>
 
-                      <TableCell className="text-center">
+                      <TableCell
+                        className="text-center"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <Button
                           size="sm"
                           onClick={() => handleNextStep(exam)}

--- a/src/components/help/page-specific/HelpContentSubtotalGroups.tsx
+++ b/src/components/help/page-specific/HelpContentSubtotalGroups.tsx
@@ -152,13 +152,13 @@ export function HelpContentSubtotalGroups() {
           <div className="space-y-3">
             <TipItem type="success">
               <strong>命名規則：</strong>
-              「教科名 +
+              「タグ名 +
               種別」で命名（例：数学標準、英語応用）。学年情報も含めると分かりやすいです。
             </TipItem>
 
             <TipItem type="success">
               <strong>効率的な運用：</strong>
-              教科別に標準構成を事前定義し、特別な試験用の専用構成も別途作成しましょう。
+              タグ別に標準構成を事前定義し、特別な試験用の専用構成も別途作成しましょう。
             </TipItem>
 
             <TipItem type="success">

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -12,6 +12,7 @@ import {
   LogOut,
   School,
   Settings,
+  Tag,
   User,
   Users,
 } from "lucide-react"
@@ -47,6 +48,7 @@ const navGroups: NavItem[][] = [
     { href: "/students", label: "生徒管理", icon: Users },
     { href: "/classes", label: "学級管理", icon: School },
     { href: "/subtotal-groups", label: "小計点管理", icon: Calculator },
+    { href: "/tags", label: "タグ管理", icon: Tag },
   ],
   [{ href: "/settings", label: "設定", icon: Settings }],
 ]

--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -1,0 +1,350 @@
+"use client"
+
+import type { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+import { Edit2, PlusCircle, Trash2, X as XIcon } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { DragHandle } from "@/components/common/sortable-table/DragHandle"
+import { SortableTableProvider } from "@/components/common/sortable-table/SortableTableProvider"
+import { useSortableRow } from "@/components/common/sortable-table/useSortableRow"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ColorPicker } from "@/components/ui/color-picker"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface TagItem {
+  id: string
+  name: string
+  order: number
+  color: string | null
+}
+
+const TAG_COLOR_PRESETS = [
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#06b6d4", // cyan
+  "#3b82f6", // blue
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#6b7280", // gray
+]
+
+// ---------------------------------------------------------------------------
+// Sortable Tag Row
+// ---------------------------------------------------------------------------
+
+function SortableTagRow({
+  tag,
+  onEdit,
+  onDelete,
+}: {
+  tag: TagItem
+  onEdit: (tag: TagItem) => void
+  onDelete: (tag: TagItem) => void
+}) {
+  const { setNodeRef, style, dragHandleProps } = useSortableRow(tag.id)
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border-border bg-card flex items-center gap-3 rounded-lg border px-3 py-2"
+    >
+      <DragHandle dragHandleProps={dragHandleProps} />
+      {tag.color && (
+        <div
+          className="h-4 w-4 shrink-0 rounded-full border"
+          style={{ backgroundColor: tag.color }}
+        />
+      )}
+      <span className="min-w-0 flex-1 truncate font-medium">{tag.name}</span>
+      <Badge
+        variant="outline"
+        className="text-xs font-normal"
+        style={
+          tag.color ? { borderColor: tag.color, color: tag.color } : undefined
+        }
+      >
+        プレビュー
+      </Badge>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 w-7 p-0"
+        onClick={() => onEdit(tag)}
+      >
+        <Edit2 className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-destructive hover:text-destructive h-7 w-7 p-0"
+        onClick={() => onDelete(tag)}
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tag Modal (Create / Edit)
+// ---------------------------------------------------------------------------
+
+function TagModal({
+  open,
+  tag,
+  onClose,
+  onSave,
+}: {
+  open: boolean
+  tag: TagItem | null
+  onClose: () => void
+  onSave: (name: string, color: string | null) => Promise<void>
+}) {
+  const [name, setName] = useState("")
+  const [color, setColor] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setName(tag?.name ?? "")
+      setColor(tag?.color ?? null)
+    }
+  }, [open, tag])
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error("タグ名を入力してください")
+      return
+    }
+    await onSave(name.trim(), color)
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{tag ? "タグを編集" : "新規タグ作成"}</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label className="text-right">タグ名</Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                  e.preventDefault()
+                  void handleSave()
+                }
+              }}
+              className="col-span-3"
+              placeholder="例: 数学"
+              autoFocus
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label className="text-right">色</Label>
+            <div className="col-span-3 flex items-center gap-2">
+              {color ? (
+                <>
+                  <ColorPicker
+                    value={color}
+                    onChange={setColor}
+                    presets={TAG_COLOR_PRESETS}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => setColor(null)}
+                  >
+                    <XIcon className="mr-1 h-3 w-3" />
+                    色なし
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setColor(TAG_COLOR_PRESETS[5])}
+                >
+                  色を設定
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button onClick={() => void handleSave()}>
+            {tag ? "保存" : "作成"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main Container
+// ---------------------------------------------------------------------------
+
+export function TagsPageContainer() {
+  const [tags, setTags] = useState<TagItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modalTag, setModalTag] = useState<TagItem | null>(null)
+  const [showModal, setShowModal] = useState(false)
+
+  const loadTags = useCallback(async () => {
+    try {
+      const data = await window.electronAPI.tagGetAll()
+      setTags(data)
+    } catch {
+      toast.error("タグの取得に失敗しました")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadTags()
+  }, [loadTags])
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+
+      const oldIndex = tags.findIndex((t) => t.id === active.id)
+      const newIndex = tags.findIndex((t) => t.id === over.id)
+      if (oldIndex === -1 || newIndex === -1) return
+
+      const reordered = arrayMove(tags, oldIndex, newIndex)
+      setTags(reordered)
+      void window.electronAPI.tagReorder(reordered.map((t) => t.id))
+    },
+    [tags]
+  )
+
+  const handleCreate = () => {
+    setModalTag(null)
+    setShowModal(true)
+  }
+
+  const handleEdit = (tag: TagItem) => {
+    setModalTag(tag)
+    setShowModal(true)
+  }
+
+  const handleDelete = async (tag: TagItem) => {
+    if (
+      !window.confirm(
+        `タグ「${tag.name}」を削除しますか？\n関連する全ての試験からこのタグが外れます。`
+      )
+    )
+      return
+
+    try {
+      await window.electronAPI.tagDelete(tag.id)
+      toast.success(`タグ「${tag.name}」を削除しました`)
+      await loadTags()
+    } catch {
+      toast.error("タグの削除に失敗しました")
+    }
+  }
+
+  const handleSave = async (name: string, color: string | null) => {
+    try {
+      if (modalTag) {
+        await window.electronAPI.tagUpdate(modalTag.id, { name, color })
+        toast.success(`タグ「${name}」を更新しました`)
+      } else {
+        await window.electronAPI.tagCreate({ name, color: color ?? undefined })
+        toast.success(`タグ「${name}」を作成しました`)
+      }
+      await loadTags()
+    } catch (error) {
+      const msg =
+        error instanceof Error && error.message.includes("Unique")
+          ? "同じ名前のタグが既に存在します"
+          : "タグの保存に失敗しました"
+      toast.error(msg)
+      throw error // モーダルを閉じない
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <TagModal
+        open={showModal}
+        tag={modalTag}
+        onClose={() => setShowModal(false)}
+        onSave={handleSave}
+      />
+
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={handleCreate}>
+              <PlusCircle className="mr-2 h-4 w-4" />
+              新規タグ作成
+            </Button>
+            <span className="text-muted-foreground text-sm">
+              {tags.length}件
+            </span>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4">
+          {tags.length === 0 ? (
+            <div className="flex h-32 items-center justify-center">
+              <p className="text-muted-foreground">
+                タグがまだ作成されていません。教科名や試験種別などのタグを作成しましょう。
+              </p>
+            </div>
+          ) : (
+            <div className="mx-auto max-w-xl space-y-2">
+              <SortableTableProvider
+                items={tags.map((t) => t.id)}
+                onDragEnd={handleDragEnd}
+              >
+                {tags.map((tag) => (
+                  <SortableTagRow
+                    key={tag.id}
+                    tag={tag}
+                    onEdit={handleEdit}
+                    onDelete={(t) => void handleDelete(t)}
+                  />
+                ))}
+              </SortableTableProvider>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -33,7 +33,7 @@ export type ExamWithDetails = Prisma.ExamGetPayload<{
     }
     examStudents: true
     examTags: {
-      select: { tag: { select: { id: true; name: true } } }
+      select: { tag: { select: { id: true; name: true; color: true } } }
     }
   }
 }> & {
@@ -59,7 +59,7 @@ export interface ExamListItem {
   id: string
   examName: string
   examDate: Date | null
-  tags: { id: string; name: string }[]
+  tags: { id: string; name: string; color: string | null }[]
   description: string | null
   createdAt: Date
   updatedAt: Date

--- a/src/types/electron/tagApi.d.ts
+++ b/src/types/electron/tagApi.d.ts
@@ -1,24 +1,27 @@
 /**
  * Tag（タグ）・TagSubtotalGroup・ExamTag関連API
  */
+
+interface TagRecord {
+  id: string
+  name: string
+  order: number
+  color: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
 export interface TagAPI {
-  tagGetAll: () => Promise<
-    Array<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
-  >
-  tagGetById: (id: string) => Promise<{
-    id: string
-    name: string
-    createdAt: Date
-    updatedAt: Date
-  } | null>
-  tagCreate: (data: {
-    name: string
-  }) => Promise<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
+  tagGetAll: () => Promise<TagRecord[]>
+  tagGetById: (id: string) => Promise<TagRecord | null>
+  tagCreate: (data: { name: string; color?: string }) => Promise<TagRecord>
   tagUpdate: (
     id: string,
-    data: { name: string }
-  ) => Promise<{ id: string; name: string; createdAt: Date; updatedAt: Date }>
+    data: { name?: string; color?: string | null }
+  ) => Promise<TagRecord>
   tagDelete: (id: string) => Promise<void>
+  tagFindOrCreate: (name: string) => Promise<TagRecord>
+  tagReorder: (tagIds: string[]) => Promise<TagRecord[]>
 
   tagSubtotalGroupGetByTagId: (tagId: string) => Promise<
     Array<{
@@ -46,7 +49,7 @@ export interface TagAPI {
       id: string
       examId: string
       tagId: string
-      tag: { id: string; name: string; createdAt: Date; updatedAt: Date }
+      tag: TagRecord
       createdAt: Date
       updatedAt: Date
     }>
@@ -67,7 +70,7 @@ export interface TagAPI {
       id: string
       examId: string
       tagId: string
-      tag: { id: string; name: string; createdAt: Date; updatedAt: Date }
+      tag: TagRecord
       createdAt: Date
       updatedAt: Date
     }>

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -876,7 +876,7 @@ export interface ArchiveScoresData {
 }
 
 /**
- * 教科データ (subjects.json) - v1.4.0-v1.9.0
+ * タグデータ (subjects.json) - v1.4.0-v1.9.0
  * @deprecated v1.10.0以降は ArchiveTagsData を使用
  */
 export interface ArchiveSubjectsData {


### PR DESCRIPTION
## Summary

- タグ管理ページ (/tags) を新規作成: DnD並べ替え、色選択、CRUD
- 試験作成・編集でのタグ保存機能を実装（サジェスト選択 + 自由入力）
- 試験一覧にタグバッジ表示、テキスト検索、タグフィルタリングを追加
- 試験一覧を sortable table 化し、タグ一括追加、行クリック選択に対応
- Tag モデルに order/color を追加、色付きバッジ表示対応

Closes #698

## Test plan

- [ ] タグ管理ページ (/tags) でタグの作成・編集・削除・並べ替えが動作すること
- [ ] 試験作成時にタグが保存されること
- [ ] 試験編集時に既存タグが読み込まれ、追加・削除が保存されること
- [ ] 試験一覧でタグバッジが表示されること
- [ ] 試験一覧のテキスト検索・タグフィルタが正しく動作すること
- [ ] 試験一覧の列ヘッダーソートが動作すること
- [ ] タグ一括追加が選択した試験に適用されること
- [ ] `npm run check-all` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)