### PR TITLE
feat: タグ一覧の色アイコンにtooltipとクリック編集を追加

### DIFF
--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -21,6 +21,12 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 interface TagItem {
   id: string
@@ -64,10 +70,19 @@ function SortableTagRow({
     >
       <DragHandle dragHandleProps={dragHandleProps} />
       {tag.color && (
-        <div
-          className="h-4 w-4 shrink-0 rounded-full border"
-          style={{ backgroundColor: tag.color }}
-        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="h-4 w-4 shrink-0 cursor-pointer rounded-full border transition-transform hover:scale-125"
+              style={{ backgroundColor: tag.color }}
+              onClick={() => onEdit(tag)}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={5}>
+            クリックして色を変更
+          </TooltipContent>
+        </Tooltip>
       )}
       <span className="min-w-0 flex-1 truncate font-medium">{tag.name}</span>
       <Badge
@@ -327,21 +342,23 @@ export function TagsPageContainer() {
               </p>
             </div>
           ) : (
-            <div className="mx-auto max-w-xl space-y-2">
-              <SortableTableProvider
-                items={tags.map((t) => t.id)}
-                onDragEnd={handleDragEnd}
-              >
-                {tags.map((tag) => (
-                  <SortableTagRow
-                    key={tag.id}
-                    tag={tag}
-                    onEdit={handleEdit}
-                    onDelete={(t) => void handleDelete(t)}
-                  />
-                ))}
-              </SortableTableProvider>
-            </div>
+            <TooltipProvider delayDuration={300}>
+              <div className="mx-auto max-w-xl space-y-2">
+                <SortableTableProvider
+                  items={tags.map((t) => t.id)}
+                  onDragEnd={handleDragEnd}
+                >
+                  {tags.map((tag) => (
+                    <SortableTagRow
+                      key={tag.id}
+                      tag={tag}
+                      onEdit={handleEdit}
+                      onDelete={(t) => void handleDelete(t)}
+                    />
+                  ))}
+                </SortableTableProvider>
+              </div>
+            </TooltipProvider>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 色の丸をクリック可能な`button`に変更し、編集モーダルを直接開けるように
- ホバー時に「クリックして色を変更」のtooltipを表示
- `TooltipProvider`でタグ一覧をラップ

Closes #704

## Test plan
- [ ] 色付きタグの丸アイコンにホバーするとtooltipが表示される
- [ ] 色の丸をクリックすると編集モーダルが開く
- [ ] 色なしタグでは丸アイコンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)