### PR TITLE
OMR認識のOS間一貫性対策（kernel明示＋低信頼→保留）

### DIFF
--- a/electron-src/lib/omr/digitRecognizer.ts
+++ b/electron-src/lib/omr/digitRecognizer.ts
@@ -122,7 +122,11 @@ async function prepareDigitInput(
     },
   })
     .greyscale()
-    .resize(28, 28, { fit: "contain", background: { r: 255, g: 255, b: 255 } })
+    .resize(28, 28, {
+      fit: "contain",
+      kernel: sharp.kernel.lanczos3,
+      background: { r: 255, g: 255, b: 255 },
+    })
     .raw()
     .toBuffer()
 

--- a/electron-src/lib/omr/imageCorrector.ts
+++ b/electron-src/lib/omr/imageCorrector.ts
@@ -317,7 +317,7 @@ export async function correctImage(
       const scaledH = Math.round(H * scale)
 
       const scaled = await sharp(translated)
-        .resize(scaledW, scaledH)
+        .resize(scaledW, scaledH, { kernel: sharp.kernel.lanczos3 })
         .png()
         .toBuffer()
 

--- a/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
+++ b/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
@@ -124,6 +124,14 @@ export function OMRAutoScoringModal({
                     {summary.ambiguous}
                   </span>
                 </div>
+                {summary.pending > 0 && (
+                  <div className="flex items-center justify-between rounded border border-orange-200 bg-orange-50 p-2">
+                    <span>保留（低信頼）</span>
+                    <span className="font-bold text-orange-600">
+                      {summary.pending}
+                    </span>
+                  </div>
+                )}
                 {summary.partial > 0 && (
                   <div className="col-span-2 flex items-center justify-between rounded border p-2">
                     <span>部分正解</span>
@@ -134,7 +142,8 @@ export function OMRAutoScoringModal({
                 )}
               </div>
               <div className="text-muted-foreground text-xs">
-                合計 {summary.total} 件（曖昧な結果は反映されません）
+                合計 {summary.total}{" "}
+                件（曖昧な結果はスキップ、低信頼は保留として反映）
               </div>
             </div>
           )}

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -19,7 +19,13 @@ interface AutoScoreEntry {
   label: string
   cropRegionId?: string
   questionPath: number[]
-  status: "correct" | "incorrect" | "partial" | "no_answer" | "ambiguous"
+  status:
+    | "correct"
+    | "incorrect"
+    | "partial"
+    | "no_answer"
+    | "ambiguous"
+    | "pending"
   score: number
   maxPoints: number
   recognizedValues: string[]
@@ -45,6 +51,7 @@ export interface OmrAutoScoringState {
     noAnswer: number
     ambiguous: number
     partial: number
+    pending: number
     total: number
   } | null
   /** エラー */
@@ -168,6 +175,7 @@ export function useOmrAutoScoring(examId: string) {
       const recognitionParams = {
         colorThreshold: configs[0].colorThreshold ?? 25,
         areaThreshold: configs[0].areaThreshold ?? 0.4,
+        confidenceThreshold: 0.7,
       }
 
       // 4. 答案画像を取得（全生徒分）
@@ -267,7 +275,8 @@ export function useOmrAutoScoring(examId: string) {
         incorrect = 0,
         noAnswer = 0,
         ambiguous = 0,
-        partial = 0
+        partial = 0,
+        pending = 0
 
       // CropRegionの配点マップ
       const pointsMap: Record<string, number> = {}
@@ -361,6 +370,23 @@ export function useOmrAutoScoring(examId: string) {
               }
             }
 
+            // 低信頼チェック: 閾値未満は保留にしてレビュー対象にする
+            const confidenceThreshold =
+              recognitionParams.confidenceThreshold ?? 0.7
+            if (
+              cellResult.confidence < confidenceThreshold &&
+              status !== "no_answer" &&
+              status !== "ambiguous"
+            ) {
+              // カウンターを元に戻してpendingに振り替え
+              if (status === "correct") correct--
+              else if (status === "incorrect") incorrect--
+              else if (status === "partial") partial--
+              status = "pending"
+              score = 0
+              pending++
+            }
+
             return {
               label: cellResult.label,
               cropRegionId,
@@ -387,7 +413,8 @@ export function useOmrAutoScoring(examId: string) {
           noAnswer,
           ambiguous,
           partial,
-          total: correct + incorrect + noAnswer + ambiguous + partial,
+          pending,
+          total: correct + incorrect + noAnswer + ambiguous + partial + pending,
         },
       }))
     } catch (error) {

--- a/src/types/omr.types.ts
+++ b/src/types/omr.types.ts
@@ -102,6 +102,8 @@ export interface OMRRecognitionParams {
   colorThreshold: number
   /** 塗りつぶし面積閾値（0-1、デフォルト0.4） */
   areaThreshold: number
+  /** 信頼度閾値（この値未満は low_confidence としてフラグ、デフォルト0.7） */
+  confidenceThreshold?: number
 }
 
 export const DEFAULT_OMR_RECOGNITION_PARAMS: OMRRecognitionParams = {


### PR DESCRIPTION
## Summary
- Sharp resize操作に `kernel: lanczos3` を明示指定し、OS間の補間差異を排除
- 信頼度閾値（0.7）未満の認識結果を `pending` でDB保存、教員の手動レビューを促進
- モーダルサマリーに「保留（低信頼）」件数表示を追加

Closes #718

## Test plan
- [ ] `npm run typecheck` で型エラーなしを確認
- [ ] `npm run lint` でlintエラーなしを確認
- [ ] OMR設定済み試験でOMR自動採点を実行し、低信頼結果が「保留」として表示されることを確認
- [ ] 「採点結果を反映」後、保留結果が採点グリッドでpendingアイコンで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)