### PR TITLE
fix: マイグレーションデプロイヤーのSQLコメントフィルター修正

### DIFF
--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -217,6 +217,11 @@ export class DatabaseSetup {
             await import("./prisma/schema/baselineMigrations")
           await createBaseline(this.prisma)
 
+          // 初期スキーマ以降の未適用マイグレーションを適用
+          const { deployPendingMigrations } =
+            await import("./prisma/schema/migrationDeployer")
+          await deployPendingMigrations(this.prisma)
+
           await this.runSeed()
           setupPerformed = true
         }

--- a/electron-src/lib/prisma/schema/migrationDeployer.ts
+++ b/electron-src/lib/prisma/schema/migrationDeployer.ts
@@ -54,10 +54,19 @@ export const deployPendingMigrations = async (
 
     try {
       // SQLを文単位で分割して実行
+      // コメント行を除去してからSQL本体の有無を判定する
       const statements = sql
         .split(";")
         .map((s) => s.trim())
-        .filter((s) => s.length > 0 && !s.startsWith("--"))
+        .filter((s) => {
+          if (s.length === 0) return false
+          // ブロックコメント・行コメントを除去した後に実行可能なSQLが残るか判定
+          const stripped = s
+            .replace(/\/\*[\s\S]*?\*\//g, "") // ブロックコメント除去
+            .replace(/--[^\n]*/g, "") // 行コメント除去
+            .trim()
+          return stripped.length > 0
+        })
 
       for (const stmt of statements) {
         await prisma.$executeRawUnsafe(stmt)


### PR DESCRIPTION
## Summary

- `deployPendingMigrations` のSQLフィルター `startsWith("--")` がPrisma生成コメント付きSQL本体を除去するバグを修正
- 初回DB作成後にも `deployPendingMigrations()` を呼び出すよう追加

Closes #720

## 変更ファイル

- `electron-src/lib/prisma/schema/migrationDeployer.ts` — コメント除去後にSQL本体の有無で判定
- `electron-src/lib/databaseSetup.ts` — 初回起動パスに `deployPendingMigrations()` 追加

## Test plan

- [ ] dataフォルダを空にして初回起動 → 正常動作を確認
- [ ] アプリ終了後に再起動 → 正常動作を確認
- [ ] DBにデータ投入後、再起動 → データ保持・正常動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)