### PR TITLE
feat: ダブルマーク(double_mark)採点ステータスの追加

### DIFF
--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -19,7 +19,8 @@ export const calculateActualScore = (
       return maxScore
     case "incorrect":
     case "no_answer":
-      return 0 // 誤答・無答は 0/配点 と表示
+    case "double_mark":
+      return 0 // 誤答・無答・Wマークは 0/配点 と表示
     case "unscored":
       return null // 未採点は null を返して -/配点 と表示
     case "partial":
@@ -48,6 +49,7 @@ export interface CreateQuestionScoreData {
     | "no_answer"
     | "proposed"
     | "final"
+    | "double_mark"
   comment?: string
   userId: string
 }
@@ -63,6 +65,7 @@ export interface UpdateQuestionScoreData {
     | "no_answer"
     | "proposed"
     | "final"
+    | "double_mark"
   comment?: string
   version?: number
 }
@@ -491,13 +494,17 @@ export const getExamProgress = async (examId: string) => {
     }
 
     // 採点済みの項目数を取得
-    // correct/incorrect/no_answer は無条件でカウント
+    // correct/incorrect/no_answer/double_mark は無条件でカウント
     // partial/pending は partialScore が null でないもののみカウント
     const scoredItems = await prisma.questionScore.count({
       where: {
         ...cropRegionFilter,
         OR: [
-          { status: { in: ["correct", "incorrect", "no_answer"] } },
+          {
+            status: {
+              in: ["correct", "incorrect", "no_answer", "double_mark"],
+            },
+          },
           {
             status: { in: ["partial", "pending"] },
             partialScore: { not: null },
@@ -507,13 +514,17 @@ export const getExamProgress = async (examId: string) => {
     })
 
     // 最終確定の項目数を取得
-    // correct/incorrect/no_answer は無条件でカウント
+    // correct/incorrect/no_answer/double_mark は無条件でカウント
     // partial は partialScore が null でないもののみカウント（pendingは未確定なので除外）
     const finalizedItems = await prisma.questionScore.count({
       where: {
         ...cropRegionFilter,
         OR: [
-          { status: { in: ["correct", "incorrect", "no_answer"] } },
+          {
+            status: {
+              in: ["correct", "incorrect", "no_answer", "double_mark"],
+            },
+          },
           {
             status: "partial",
             partialScore: { not: null },

--- a/electron-src/lib/shared/types/exportTypes.ts
+++ b/electron-src/lib/shared/types/exportTypes.ts
@@ -53,6 +53,7 @@ export interface ScoreDetail {
     | "hold"
     | "incorrect"
     | "no_answer"
+    | "double_mark"
 }
 
 export interface ExportResult {

--- a/electron-src/lib/shared/utilities/excelUtilities.ts
+++ b/electron-src/lib/shared/utilities/excelUtilities.ts
@@ -30,6 +30,8 @@ export function getStatusSymbol(status: string, score?: number): string {
       return "×"
     case "no_answer":
       return "-"
+    case "double_mark":
+      return "W"
     default:
       return "-"
   }

--- a/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
+++ b/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
@@ -118,10 +118,10 @@ export function OMRAutoScoringModal({
                     {summary.noAnswer}
                   </span>
                 </div>
-                <div className="flex items-center justify-between rounded border p-2">
-                  <span>曖昧</span>
-                  <span className="font-bold text-yellow-600">
-                    {summary.ambiguous}
+                <div className="flex items-center justify-between rounded border border-orange-200 bg-orange-50 p-2">
+                  <span>Wマーク</span>
+                  <span className="font-bold text-orange-600">
+                    {summary.doubleMark}
                   </span>
                 </div>
                 {summary.pending > 0 && (
@@ -142,8 +142,7 @@ export function OMRAutoScoringModal({
                 )}
               </div>
               <div className="text-muted-foreground text-xs">
-                合計 {summary.total}{" "}
-                件（曖昧な結果はスキップ、低信頼は保留として反映）
+                合計 {summary.total} 件（低信頼は保留として反映）
               </div>
             </div>
           )}

--- a/src/components/exams/07-score-at-once/OMRRecognition/OMRResultsTable.tsx
+++ b/src/components/exams/07-score-at-once/OMRRecognition/OMRResultsTable.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { AlertTriangle, CheckCircle2, MinusCircle, XCircle } from "lucide-react"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CopyX,
+  MinusCircle,
+  XCircle,
+} from "lucide-react"
 
 import type { OMRCellResult, OMRSheetResult } from "@/types/omr.types"
 
@@ -20,7 +26,7 @@ function StatusIcon({ status }: { status: OMRCellResult["autoScoreStatus"] }) {
     case "incorrect":
       return <XCircle className="h-4 w-4 text-red-500" />
     case "ambiguous":
-      return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+      return <CopyX className="h-4 w-4 text-orange-500" />
     case "no_answer":
       return <MinusCircle className="text-muted-foreground h-4 w-4" />
     default:

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -24,7 +24,7 @@ interface AutoScoreEntry {
     | "incorrect"
     | "partial"
     | "no_answer"
-    | "ambiguous"
+    | "double_mark"
     | "pending"
   score: number
   maxPoints: number
@@ -49,7 +49,7 @@ export interface OmrAutoScoringState {
     correct: number
     incorrect: number
     noAnswer: number
-    ambiguous: number
+    doubleMark: number
     partial: number
     pending: number
     total: number
@@ -274,7 +274,7 @@ export function useOmrAutoScoring(examId: string) {
       let correct = 0,
         incorrect = 0,
         noAnswer = 0,
-        ambiguous = 0,
+        doubleMark = 0,
         partial = 0,
         pending = 0
 
@@ -336,9 +336,9 @@ export function useOmrAutoScoring(examId: string) {
                 noAnswer++
                 break
               case "ambiguous":
-                status = "ambiguous"
+                status = "double_mark"
                 score = 0
-                ambiguous++
+                doubleMark++
                 break
               default:
                 status = "no_answer"
@@ -376,7 +376,7 @@ export function useOmrAutoScoring(examId: string) {
             if (
               cellResult.confidence < confidenceThreshold &&
               status !== "no_answer" &&
-              status !== "ambiguous"
+              status !== "double_mark"
             ) {
               // カウンターを元に戻してpendingに振り替え
               if (status === "correct") correct--
@@ -411,10 +411,11 @@ export function useOmrAutoScoring(examId: string) {
           correct,
           incorrect,
           noAnswer,
-          ambiguous,
+          doubleMark,
           partial,
           pending,
-          total: correct + incorrect + noAnswer + ambiguous + partial + pending,
+          total:
+            correct + incorrect + noAnswer + doubleMark + partial + pending,
         },
       }))
     } catch (error) {
@@ -443,7 +444,6 @@ export function useOmrAutoScoring(examId: string) {
 
         for (const [studentId, scoreEntries] of state.scoreEntries) {
           for (const entry of scoreEntries) {
-            if (entry.status === "ambiguous") continue // 曖昧な結果はスキップ
             entries.push({
               studentId,
               cropRegionId: entry.cropRegionId!,

--- a/src/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -16,6 +16,7 @@ const VALID_STATUS_KEYS: ScoreStatusKey[] = [
   "pending",
   "incorrect",
   "no_answer",
+  "double_mark",
   "master",
 ]
 

--- a/src/components/exams/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/constants/scoreStatusConfig.ts
@@ -3,6 +3,7 @@ import {
   CheckCircle,
   Circle,
   Clock,
+  CopyX,
   Minus,
   X,
 } from "lucide-react"
@@ -64,6 +65,14 @@ export function getDynamicScoreStatusConfig(colors: ScoringStatusColors) {
       textStyle: { color: colors.no_answer.text },
       iconStyle: { color: colors.no_answer.icon },
       key: "p",
+    },
+    double_mark: {
+      icon: CopyX,
+      bgStyle: { backgroundColor: colors.double_mark.bg },
+      selectedBgStyle: { backgroundColor: colors.double_mark.bg, opacity: 0.8 },
+      textStyle: { color: colors.double_mark.text },
+      iconStyle: { color: colors.double_mark.icon },
+      key: "t",
     },
     master: {
       icon: CheckCircle,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useScoringMarks.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useScoringMarks.ts
@@ -67,6 +67,7 @@ export function getScoringMarkKey(status: string): MarkType | null {
     case "pending":
       return "hold"
     case "no_answer":
+    case "double_mark":
       return "incorrect"
     case "correct":
     case "incorrect":

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -38,6 +38,7 @@ interface FilterSettings {
   partial: boolean
   pending: boolean
   no_answer: boolean
+  double_mark: boolean
 }
 
 interface UseScoringFilterProps {
@@ -73,6 +74,7 @@ export function useScoringFilter({
     partial: false,
     pending: false,
     no_answer: false,
+    double_mark: false,
   })
 
   const [visibleAnswers, setVisibleAnswers] = useState<string[]>([])

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -149,6 +149,15 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     },
   })
 
+  useCommand("scoring.doubleMark", () => handleScore("double_mark"), {
+    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    metadata: {
+      title: "Wマークとして採点",
+      category: "採点",
+      description: "選択中の答案をダブルマークとして採点します",
+    },
+  })
+
   // ========================================
   // フィルタトグルコマンド（サイドパネル非表示でも有効、グリッドモードのみ）
   // ========================================
@@ -200,6 +209,18 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
       category: "フィルタ",
     },
   })
+
+  useCommand(
+    "filter.toggleDoubleMark",
+    () => handleToggleFilter("double_mark"),
+    {
+      when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+      metadata: {
+        title: "Wマークフィルタトグル",
+        category: "フィルタ",
+      },
+    }
+  )
 
   // ========================================
   // 表示関連ショートカット

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircle,
   Circle,
   Clock,
+  CopyX,
   Minus,
   RefreshCw,
   Target,
@@ -54,6 +55,7 @@ const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
   pending: "pending",
   incorrect: "incorrect",
   no_answer: "no_answer",
+  double_mark: "double_mark",
 }
 
 // 採点ボタン設定（色はuseScoringStatusColorsから動的取得）
@@ -94,6 +96,12 @@ const SCORING_BUTTONS = [
     icon: Minus,
     description: "無答にする",
   },
+  {
+    status: "double_mark" as ScoringStatus,
+    label: "Wマーク",
+    icon: CopyX,
+    description: "ダブルマークにする",
+  },
 ] as const
 
 // フィルターボタン設定（色はuseScoringStatusColorsから動的取得）
@@ -109,6 +117,12 @@ const FILTER_BUTTONS = [
   { key: "pending", filterKey: "pending", label: "保留", icon: Clock },
   { key: "incorrect", filterKey: "incorrect", label: "誤答", icon: X },
   { key: "no_answer", filterKey: "no_answer", label: "無答", icon: Minus },
+  {
+    key: "double_mark",
+    filterKey: "double_mark",
+    label: "Wマーク",
+    icon: CopyX,
+  },
 ] as const
 
 export default function ScoringToolbar({

--- a/src/components/exams/07-score-at-once/constants/scoringKeybindings.ts
+++ b/src/components/exams/07-score-at-once/constants/scoringKeybindings.ts
@@ -19,6 +19,7 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "scoring.pending": "j", // モーダル内でも確定キーとして機能
   "scoring.incorrect": "o",
   "scoring.noAnswer": "p",
+  "scoring.doubleMark": "t",
 
   // ============================================
   // ナビゲーション (Navigation)
@@ -56,6 +57,7 @@ export const DEFAULT_KEYBINDINGS: KeyBinding = {
   "filter.togglePending": "Alt+j",
   "filter.toggleIncorrect": "Alt+o",
   "filter.toggleNoAnswer": "Alt+p",
+  "filter.toggleDoubleMark": "Alt+t",
 
   // 更新
   "filter.refresh": "r",

--- a/src/components/exams/07-score-at-once/types/index.ts
+++ b/src/components/exams/07-score-at-once/types/index.ts
@@ -28,6 +28,7 @@ export type ScoringStatus =
   | "partial"
   | "pending"
   | "no_answer"
+  | "double_mark"
 
 /**
  * StudentAnswerImageを学生とExamStudents情報で拡張した型
@@ -93,6 +94,7 @@ export function calculateActualScore(
       return maxScore
     case "incorrect":
     case "no_answer":
+    case "double_mark":
       return 0
     case "unscored":
       return null

--- a/src/components/exams/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
@@ -50,6 +50,7 @@ export const defaultConfig: ScoringMarkConfig = {
     partial: true,
     pending: true,
     no_answer: true,
+    double_mark: true,
   },
   showScoreForStatus: {
     unscored: false,
@@ -58,6 +59,7 @@ export const defaultConfig: ScoringMarkConfig = {
     partial: true,
     pending: true,
     no_answer: true,
+    double_mark: true,
   },
   // 採点マーク設定
   markPosition: "middle-center",
@@ -108,4 +110,5 @@ export const statusLabels: Record<ScoringStatus, string> = {
   partial: "部分点",
   pending: "処理中",
   no_answer: "無答",
+  double_mark: "Wマーク",
 }

--- a/src/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
@@ -6,6 +6,7 @@ export type ScoringStatus =
   | "partial" // 部分点
   | "pending" // 処理中
   | "no_answer" // 無答
+  | "double_mark" // ダブルマーク
 
 // 位置の型定義
 export type MarkPosition =

--- a/src/components/exams/08-export/components/scoring-mark-settings/utils/scoringMarkUtils.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/utils/scoringMarkUtils.ts
@@ -19,6 +19,8 @@ export function getMarkImagePath(
       return `/score-assets/${prefix}partial.png` // 処理中は部分点マークを使用
     case "no_answer":
       return `/score-assets/${prefix}incorrect.png` // 無答も誤答マークを使用
+    case "double_mark":
+      return `/score-assets/${prefix}incorrect.png` // Wマークも誤答マークを使用
     default:
       return `/score-assets/${prefix}unscored.png`
   }

--- a/src/components/exams/08-export/hooks/useExcelPreview.ts
+++ b/src/components/exams/08-export/hooks/useExcelPreview.ts
@@ -14,6 +14,7 @@ interface ExcelPreviewScore {
     | "hold"
     | "incorrect"
     | "no_answer"
+    | "double_mark"
 }
 
 interface ExcelPreviewSubtotalScore {

--- a/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
+++ b/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
@@ -816,7 +816,8 @@ export async function renderAnswerSheetToCanvas(
       const markKey =
         scoringData.status === "pending"
           ? "hold"
-          : scoringData.status === "no_answer"
+          : scoringData.status === "no_answer" ||
+              scoringData.status === "double_mark"
             ? "incorrect"
             : scoringData.status
       const markImage = scoringMarkImages.get(markKey)
@@ -850,9 +851,10 @@ export async function renderAnswerSheetToCanvas(
         scoreToDisplay = scoringData.partialScore ?? null
       } else if (
         scoringData.status === "incorrect" ||
-        scoringData.status === "no_answer"
+        scoringData.status === "no_answer" ||
+        scoringData.status === "double_mark"
       ) {
-        // 誤答/無答: 0点を表示
+        // 誤答/無答/Wマーク: 0点を表示
         scoreToDisplay = 0
       }
 

--- a/src/lib/scoringStatusColors.ts
+++ b/src/lib/scoringStatusColors.ts
@@ -15,6 +15,7 @@ export type ScoringStatusType =
   | "pending"
   | "incorrect"
   | "no_answer"
+  | "double_mark"
 
 /** 各状態の色設定 */
 export interface StatusColorConfig {
@@ -45,6 +46,7 @@ export const SCORING_STATUS_LABELS: Record<ScoringStatusType, string> = {
   pending: "保留",
   incorrect: "誤答",
   no_answer: "無答",
+  double_mark: "Wマーク",
 }
 
 /** 状態の表示順序 */
@@ -55,6 +57,7 @@ export const SCORING_STATUS_ORDER: ScoringStatusType[] = [
   "pending",
   "incorrect",
   "no_answer",
+  "double_mark",
 ]
 
 /**
@@ -72,6 +75,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
       pending: { bg: "#DBEAFE", text: "#1E40AF", icon: "#2563EB" },
       incorrect: { bg: "#FEE2E2", text: "#991B1B", icon: "#DC2626" },
       no_answer: { bg: "#EDE9FE", text: "#5B21B6", icon: "#7C3AED" },
+      double_mark: { bg: "#FFF7ED", text: "#9A3412", icon: "#EA580C" },
     },
   },
   {
@@ -85,6 +89,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
       pending: { bg: "#93C5FD", text: "#1E3A8A", icon: "#3B82F6" },
       incorrect: { bg: "#FECACA", text: "#7F1D1D", icon: "#EF4444" },
       no_answer: { bg: "#DDD6FE", text: "#4C1D95", icon: "#8B5CF6" },
+      double_mark: { bg: "#FFEDD5", text: "#7C2D12", icon: "#F97316" },
     },
   },
   {
@@ -98,6 +103,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
       pending: { bg: "#E0F2FE", text: "#075985", icon: "#0EA5E9" },
       incorrect: { bg: "#FFE4E6", text: "#9F1239", icon: "#F43F5E" },
       no_answer: { bg: "#F3E8FF", text: "#6B21A8", icon: "#A855F7" },
+      double_mark: { bg: "#FEF3C7", text: "#78350F", icon: "#D97706" },
     },
   },
   {
@@ -111,6 +117,7 @@ export const SCORING_COLOR_PRESETS: ScoringColorPreset[] = [
       pending: { bg: "#D0EBFA", text: "#0066A0", icon: "#56B4E9" },
       incorrect: { bg: "#FADDC8", text: "#8B3A00", icon: "#D55E00" },
       no_answer: { bg: "#F5E0EC", text: "#7A3F66", icon: "#CC79A7" },
+      double_mark: { bg: "#FAE8D0", text: "#8B4513", icon: "#E69F00" },
     },
   },
 ]

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -273,6 +273,7 @@ export interface ExportAPI {
             | "hold"
             | "incorrect"
             | "no_answer"
+            | "double_mark"
         }>
         totalScore: number | null
         totalMaxScore: number

--- a/src/types/electron/scoringApi.d.ts
+++ b/src/types/electron/scoringApi.d.ts
@@ -54,6 +54,7 @@ export interface ScoringAPI {
       | "no_answer"
       | "proposed"
       | "final"
+      | "double_mark"
     userId: string // v0.4.0+: required
   }) => Promise<QuestionScoreOperationResult>
 
@@ -70,6 +71,7 @@ export interface ScoringAPI {
         | "no_answer"
         | "proposed"
         | "final"
+        | "double_mark"
       comment?: string
       version?: number
     },


### PR DESCRIPTION
## Summary
- OMRダブルマーク検出時に`double_mark`ステータスでDB保存（従来のスキップを廃止）
- 採点UI全体（グリッド・ツールバー・フィルター・ショートカット・エクスポート）にdouble_mark対応を追加
- Sharp resize操作にkernel明示指定 + 低信頼結果のpending保留（OS間一貫性対策）

Closes #722

## Test plan
- [ ] `npm run typecheck` 型エラーなし
- [ ] `npm run lint` lintエラーなし
- [ ] 採点グリッドでTキーによるdouble_markステータス設定が動作すること
- [ ] Alt+Tでdouble_markフィルタが切り替わること
- [ ] OMR自動採点でダブルマーク検出時にdouble_markとしてDB保存されること
- [ ] Excel出力でdouble_markが"W"記号で表示されること
- [ ] PDF出力でdouble_markに×マークが描画されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)