### PR TITLE
OMRマーク認識の色判定をグレースケール輝度に修正

### DIFF
--- a/electron-src/lib/omr/imageProcessor.ts
+++ b/electron-src/lib/omr/imageProcessor.ts
@@ -139,7 +139,11 @@ export function computeCircularFillRatio(
       if (dx * dx + dy * dy <= r2) {
         totalPixels++
         const idx = (py * width + px) * channels
-        if (data[idx] < threshold) {
+        const luminance =
+          channels >= 3
+            ? 0.299 * data[idx] + 0.587 * data[idx + 1] + 0.114 * data[idx + 2]
+            : data[idx]
+        if (luminance < threshold) {
           darkCount++
         }
       }
@@ -180,7 +184,12 @@ export function computeEllipticalFillRatio(
       if (dx * dx + dy * dy <= 1) {
         totalPixels++
         const idx = (py * width + px) * channels
-        if (data[idx] < threshold) {
+        // グレースケール輝度で判定（RGB加重平均）
+        const luminance =
+          channels >= 3
+            ? 0.299 * data[idx] + 0.587 * data[idx + 1] + 0.114 * data[idx + 2]
+            : data[idx]
+        if (luminance < threshold) {
           darkCount++
         }
       }

--- a/electron-src/lib/omr/markRecognizer.ts
+++ b/electron-src/lib/omr/markRecognizer.ts
@@ -79,13 +79,6 @@ function recognizeChoiceCell(
     )
     fillRatios.push(ratio)
 
-    // 診断ログ（最初の数セルのみ）
-    if (cell.label && bubble.choiceIndex === 0) {
-      console.log(
-        `OMR diag [${cell.label}]: center=(${center.x.toFixed(0)},${center.y.toFixed(0)}) size=(${(halfWidthPx * 2).toFixed(1)}x${(halfHeightPx * 2).toFixed(1)}px) fillRatios=[${fillRatios.map((r) => r.toFixed(3)).join(",")}] threshold=${params.areaThreshold} imgSize=${rawImage.width}x${rawImage.height}`
-      )
-    }
-
     if (ratio >= params.areaThreshold) {
       markedIndices.push(bubble.choiceIndex)
     }

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
@@ -56,7 +56,7 @@ interface UseOMRRecognitionReturn extends OMRRecognitionState {
 }
 
 const DEFAULT_PARAMS: OMRRecognitionParams = {
-  colorThreshold: 25,
+  colorThreshold: 128,
   areaThreshold: 0.4,
 }
 

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -173,7 +173,7 @@ export function useOmrAutoScoring(examId: string) {
         }
       }
       const recognitionParams = {
-        colorThreshold: configs[0].colorThreshold ?? 25,
+        colorThreshold: configs[0].colorThreshold ?? 128,
         areaThreshold: configs[0].areaThreshold ?? 0.4,
         confidenceThreshold: 0.7,
       }


### PR DESCRIPTION
## Summary

- `computeEllipticalFillRatio` / `computeFillRatio`: R値単独 → グレースケール輝度判定に修正
- `colorThreshold` デフォルト: 25 → 128
- markRecognizerの一時診断ログを除去

Closes #724

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] シミュレーションでマーク済みバブル fillRatio 0.71-0.84（閾値超過）を確認
- [x] 未マークバブル fillRatio 0.19-0.26（閾値以下）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)