### PR TITLE
OMR自動採点モーダルに閾値調整UIを追加

### DIFF
--- a/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
+++ b/src/components/exams/07-score-at-once/OMRRecognition/OMRAutoScoringModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckCircle, Loader2, ScanLine, XCircle } from "lucide-react"
+import { CheckCircle, Loader2, ScanLine, Sparkles, XCircle } from "lucide-react"
 import { useCallback } from "react"
 
 import { useOmrAutoScoring } from "@/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring"
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Progress } from "@/components/ui/progress"
+import { Slider } from "@/components/ui/slider"
 
 interface OMRAutoScoringModalProps {
   examId: string
@@ -36,8 +37,14 @@ export function OMRAutoScoringModal({
     summary,
     error,
     hasOmrConfigs,
+    areaThreshold,
+    confidenceThreshold,
+    recommendedAreaThreshold,
     runRecognition,
     applyScores,
+    updateAreaThreshold,
+    updateConfidenceThreshold,
+    applyRecommendedThreshold,
   } = useOmrAutoScoring(examId)
 
   const handleApply = useCallback(async () => {
@@ -143,6 +150,53 @@ export function OMRAutoScoringModal({
               </div>
               <div className="text-muted-foreground text-xs">
                 合計 {summary.total} 件（低信頼は保留として反映）
+              </div>
+
+              {/* 閾値調整 */}
+              <div className="space-y-3 border-t pt-3">
+                <div className="text-sm font-medium">閾値調整</div>
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-xs">
+                    <span>塗りつぶし判定閾値</span>
+                    <span className="font-medium tabular-nums">
+                      {Math.round(areaThreshold * 100)}%
+                    </span>
+                  </div>
+                  <Slider
+                    min={5}
+                    max={90}
+                    step={1}
+                    value={[Math.round(areaThreshold * 100)]}
+                    onValueChange={([v]) => updateAreaThreshold(v / 100)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between text-xs">
+                    <span>信頼度閾値（保留判定）</span>
+                    <span className="font-medium tabular-nums">
+                      {Math.round(confidenceThreshold * 100)}%
+                    </span>
+                  </div>
+                  <Slider
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={[Math.round(confidenceThreshold * 100)]}
+                    onValueChange={([v]) => updateConfidenceThreshold(v / 100)}
+                  />
+                </div>
+                {recommendedAreaThreshold != null && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={applyRecommendedThreshold}
+                  >
+                    <Sparkles className="mr-1 h-3.5 w-3.5" />
+                    推奨塗りつぶし閾値を適用（
+                    {Math.round(recommendedAreaThreshold * 100)}%）
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -9,27 +9,16 @@ import type {
   CropRegionOmrConfigWithOptions,
   OMRBatchProgress,
   OMRCellConfig,
-  OMRCellResult,
   OMRSheetResult,
 } from "@/types/omr.types"
 import type { CropRegionWithDetails } from "@/types/prismaExtensions"
 
-/** 自動採点エントリ（rendererプロセス用） */
-interface AutoScoreEntry {
-  label: string
-  cropRegionId?: string
-  questionPath: number[]
-  status:
-    | "correct"
-    | "incorrect"
-    | "partial"
-    | "no_answer"
-    | "double_mark"
-    | "pending"
-  score: number
-  maxPoints: number
-  recognizedValues: string[]
-}
+import {
+  type AutoScoreEntry,
+  recommendAreaThreshold,
+  reevaluateWithThreshold,
+  type ScoringResultSummary,
+} from "../utils/reevaluateResults"
 
 export interface OmrAutoScoringState {
   /** OMR設定リスト */
@@ -42,20 +31,22 @@ export interface OmrAutoScoringState {
   progress: OMRBatchProgress | null
   /** 認識結果（生徒ごと） */
   sheetResults: OMRSheetResult[]
+  /** 初回バッチの不変コピー（閾値再評価のソース） */
+  originalSheetResults: OMRSheetResult[]
   /** 自動採点エントリ（全生徒分） */
   scoreEntries: Map<string, AutoScoreEntry[]>
   /** 結果サマリー */
-  summary: {
-    correct: number
-    incorrect: number
-    noAnswer: number
-    doubleMark: number
-    partial: number
-    pending: number
-    total: number
-  } | null
+  summary: ScoringResultSummary | null
   /** エラー */
   error: string | null
+  /** 塗りつぶし判定閾値 */
+  areaThreshold: number
+  /** 信頼度閾値 */
+  confidenceThreshold: number
+  /** 配点マップ（cropRegionId → points） */
+  pointsMap: Record<string, number>
+  /** 推奨areaThreshold */
+  recommendedAreaThreshold: number | null
 }
 
 /**
@@ -68,9 +59,14 @@ export function useOmrAutoScoring(examId: string) {
     isApplying: false,
     progress: null,
     sheetResults: [],
+    originalSheetResults: [],
     scoreEntries: new Map(),
     summary: null,
     error: null,
+    areaThreshold: 0.4,
+    confidenceThreshold: 0.7,
+    pointsMap: {},
+    recommendedAreaThreshold: null,
   })
 
   /** OMR設定をDBから読み込み */
@@ -269,16 +265,7 @@ export function useOmrAutoScoring(examId: string) {
         pageIndex: 0,
       })
 
-      // 7. 自動採点エントリの構築
-      const allEntries = new Map<string, AutoScoreEntry[]>()
-      let correct = 0,
-        incorrect = 0,
-        noAnswer = 0,
-        doubleMark = 0,
-        partial = 0,
-        pending = 0
-
-      // CropRegionの配点マップ
+      // 7. 配点マップ構築
       const pointsMap: Record<string, number> = {}
       for (const r of page1Regions) {
         if (r.points != null) {
@@ -307,116 +294,34 @@ export function useOmrAutoScoring(examId: string) {
         )
       }
 
-      for (const sheetResult of results) {
-        if (!sheetResult.success || !sheetResult.studentId) continue
+      // 再評価ユーティリティで採点結果を構築
+      const initialAreaThreshold = recognitionParams.areaThreshold
+      const initialConfidenceThreshold =
+        recognitionParams.confidenceThreshold ?? 0.7
 
-        const entries: AutoScoreEntry[] = sheetResult.cellResults.map(
-          (cellResult: OMRCellResult) => {
-            const cropRegionId = cellResult.label
-            const maxPoints = pointsMap[cropRegionId] ?? 0
-            const cfg = configs.find((c) => c.cropRegionId === cropRegionId)
+      const { updatedSheetResults, scoreEntries, summary } =
+        reevaluateWithThreshold({
+          sheetResults: results,
+          omrConfigs: configs,
+          pointsMap,
+          areaThreshold: initialAreaThreshold,
+          confidenceThreshold: initialConfidenceThreshold,
+        })
 
-            let status: AutoScoreEntry["status"]
-            let score: number
-
-            switch (cellResult.autoScoreStatus) {
-              case "correct":
-                status = "correct"
-                score = maxPoints
-                correct++
-                break
-              case "incorrect":
-                status = "incorrect"
-                score = 0
-                incorrect++
-                break
-              case "no_answer":
-                status = "no_answer"
-                score = 0
-                noAnswer++
-                break
-              case "ambiguous":
-                status = "double_mark"
-                score = 0
-                doubleMark++
-                break
-              default:
-                status = "no_answer"
-                score = 0
-                noAnswer++
-            }
-
-            // 部分点チェック
-            if (
-              cfg?.type === "choice" &&
-              status === "incorrect" &&
-              cellResult.recognizedValues.length > 0
-            ) {
-              const correctLabels = cfg.choiceOptions
-                .filter((o) => o.isCorrect)
-                .map((o) => o.label)
-              if (correctLabels.length > 1) {
-                const correctCount = cellResult.recognizedValues.filter((v) =>
-                  correctLabels.includes(v)
-                ).length
-                if (correctCount > 0 && correctCount < correctLabels.length) {
-                  status = "partial"
-                  score = Math.floor(
-                    (maxPoints * correctCount) / correctLabels.length
-                  )
-                  incorrect--
-                  partial++
-                }
-              }
-            }
-
-            // 低信頼チェック: 閾値未満は保留にしてレビュー対象にする
-            const confidenceThreshold =
-              recognitionParams.confidenceThreshold ?? 0.7
-            if (
-              cellResult.confidence < confidenceThreshold &&
-              status !== "no_answer" &&
-              status !== "double_mark"
-            ) {
-              // カウンターを元に戻してpendingに振り替え
-              if (status === "correct") correct--
-              else if (status === "incorrect") incorrect--
-              else if (status === "partial") partial--
-              status = "pending"
-              score = 0
-              pending++
-            }
-
-            return {
-              label: cellResult.label,
-              cropRegionId,
-              questionPath: cellResult.questionPath,
-              status,
-              score,
-              maxPoints,
-              recognizedValues: cellResult.recognizedValues,
-            }
-          }
-        )
-
-        allEntries.set(sheetResult.studentId, entries)
-      }
+      // 推奨閾値を算出
+      const recommended = recommendAreaThreshold(results)
 
       setState((s) => ({
         ...s,
         isRecognizing: false,
-        sheetResults: results,
-        scoreEntries: allEntries,
-        summary: {
-          correct,
-          incorrect,
-          noAnswer,
-          doubleMark,
-          partial,
-          pending,
-          total:
-            correct + incorrect + noAnswer + doubleMark + partial + pending,
-        },
+        sheetResults: updatedSheetResults,
+        originalSheetResults: results,
+        scoreEntries,
+        summary,
+        pointsMap,
+        areaThreshold: initialAreaThreshold,
+        confidenceThreshold: initialConfidenceThreshold,
+        recommendedAreaThreshold: recommended,
       }))
     } catch (error) {
       setState((s) => ({
@@ -490,11 +395,77 @@ export function useOmrAutoScoring(examId: string) {
     [state.scoreEntries]
   )
 
+  /** areaThresholdを変更し、キャッシュ済みfillRatiosから即座に再判定 */
+  const updateAreaThreshold = useCallback(
+    (newThreshold: number) => {
+      if (state.originalSheetResults.length === 0) return
+      const { updatedSheetResults, scoreEntries, summary } =
+        reevaluateWithThreshold({
+          sheetResults: state.originalSheetResults,
+          omrConfigs: state.omrConfigs,
+          pointsMap: state.pointsMap,
+          areaThreshold: newThreshold,
+          confidenceThreshold: state.confidenceThreshold,
+        })
+      setState((s) => ({
+        ...s,
+        areaThreshold: newThreshold,
+        sheetResults: updatedSheetResults,
+        scoreEntries,
+        summary,
+      }))
+    },
+    [
+      state.originalSheetResults,
+      state.omrConfigs,
+      state.pointsMap,
+      state.confidenceThreshold,
+    ]
+  )
+
+  /** confidenceThresholdを変更し、即座に再判定 */
+  const updateConfidenceThreshold = useCallback(
+    (newThreshold: number) => {
+      if (state.originalSheetResults.length === 0) return
+      const { updatedSheetResults, scoreEntries, summary } =
+        reevaluateWithThreshold({
+          sheetResults: state.originalSheetResults,
+          omrConfigs: state.omrConfigs,
+          pointsMap: state.pointsMap,
+          areaThreshold: state.areaThreshold,
+          confidenceThreshold: newThreshold,
+        })
+      setState((s) => ({
+        ...s,
+        confidenceThreshold: newThreshold,
+        sheetResults: updatedSheetResults,
+        scoreEntries,
+        summary,
+      }))
+    },
+    [
+      state.originalSheetResults,
+      state.omrConfigs,
+      state.pointsMap,
+      state.areaThreshold,
+    ]
+  )
+
+  /** 推奨areaThresholdを適用 */
+  const applyRecommendedThreshold = useCallback(() => {
+    if (state.recommendedAreaThreshold != null) {
+      updateAreaThreshold(state.recommendedAreaThreshold)
+    }
+  }, [state.recommendedAreaThreshold, updateAreaThreshold])
+
   return {
     ...state,
     hasOmrConfigs: state.omrConfigs.length > 0,
     runRecognition,
     applyScores,
+    updateAreaThreshold,
+    updateConfidenceThreshold,
+    applyRecommendedThreshold,
   }
 }
 

--- a/src/components/exams/07-score-at-once/OMRRecognition/utils/reevaluateResults.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/utils/reevaluateResults.ts
@@ -1,0 +1,360 @@
+/**
+ * OMR認識結果の閾値再評価ユーティリティ
+ *
+ * キャッシュ済みfillRatiosに対して新しいareaThresholdを適用し、
+ * 認識結果・採点ステータス・サマリーを再計算する。
+ * IPC不要のレンダラー完結処理。
+ */
+
+import type {
+  CropRegionOmrConfigWithOptions,
+  OMRCellResult,
+  OMRSheetResult,
+} from "@/types/omr.types"
+
+/** 自動採点エントリ */
+export interface AutoScoreEntry {
+  label: string
+  cropRegionId?: string
+  questionPath: number[]
+  status:
+    | "correct"
+    | "incorrect"
+    | "partial"
+    | "no_answer"
+    | "double_mark"
+    | "pending"
+  score: number
+  maxPoints: number
+  recognizedValues: string[]
+}
+
+export interface ScoringResultSummary {
+  correct: number
+  incorrect: number
+  noAnswer: number
+  doubleMark: number
+  partial: number
+  pending: number
+  total: number
+}
+
+export interface ReevaluationInput {
+  sheetResults: OMRSheetResult[]
+  omrConfigs: CropRegionOmrConfigWithOptions[]
+  pointsMap: Record<string, number>
+  areaThreshold: number
+  confidenceThreshold: number
+}
+
+export interface ReevaluationOutput {
+  updatedSheetResults: OMRSheetResult[]
+  scoreEntries: Map<string, AutoScoreEntry[]>
+  summary: ScoringResultSummary
+}
+
+/**
+ * キャッシュ済みfillRatiosから閾値を変えて認識結果を再評価する
+ *
+ * markRecognizer.ts の recognizeChoiceCell と同一ロジックを
+ * fillRatios起点で再計算する。手書き数字型セルは元の結果をそのまま保持。
+ */
+export function reevaluateWithThreshold(
+  input: ReevaluationInput
+): ReevaluationOutput {
+  const {
+    sheetResults,
+    omrConfigs,
+    pointsMap,
+    areaThreshold,
+    confidenceThreshold,
+  } = input
+
+  const allEntries = new Map<string, AutoScoreEntry[]>()
+  const updatedSheetResults: OMRSheetResult[] = []
+
+  for (const sheet of sheetResults) {
+    if (!sheet.success || !sheet.studentId) {
+      updatedSheetResults.push(sheet)
+      continue
+    }
+
+    const updatedCellResults: OMRCellResult[] = []
+    const entries: AutoScoreEntry[] = []
+
+    for (const cellResult of sheet.cellResults) {
+      const cropRegionId = cellResult.label
+      const cfg = omrConfigs.find((c) => c.cropRegionId === cropRegionId)
+      const maxPoints = pointsMap[cropRegionId] ?? 0
+
+      // fillRatiosがない場合（手書き数字型など）は元の結果をそのまま使用
+      if (!cellResult.fillRatios || !cfg || cfg.type !== "choice") {
+        updatedCellResults.push(cellResult)
+        entries.push(
+          buildEntryFromCellResult(
+            cellResult,
+            cfg,
+            maxPoints,
+            confidenceThreshold
+          )
+        )
+        continue
+      }
+
+      // fillRatiosからareaThresholdで再判定
+      const updatedCell = reevaluateChoiceCell(cellResult, cfg, areaThreshold)
+      updatedCellResults.push(updatedCell)
+      entries.push(
+        buildEntryFromCellResult(
+          updatedCell,
+          cfg,
+          maxPoints,
+          confidenceThreshold
+        )
+      )
+    }
+
+    updatedSheetResults.push({ ...sheet, cellResults: updatedCellResults })
+    allEntries.set(sheet.studentId, entries)
+  }
+
+  // サマリーはエントリのstatusから集計
+  const summary = countSummary(allEntries)
+
+  return { updatedSheetResults, scoreEntries: allEntries, summary }
+}
+
+/**
+ * 選択式セルのfillRatiosから新しいareaThresholdで再判定する
+ * markRecognizer.ts recognizeChoiceCell のfillRatio以降ロジックと同一
+ */
+function reevaluateChoiceCell(
+  cellResult: OMRCellResult,
+  cfg: CropRegionOmrConfigWithOptions,
+  areaThreshold: number
+): OMRCellResult {
+  const fillRatios = cellResult.fillRatios!
+  const correctAnswers = cfg.choiceOptions
+    .filter((o) => o.isCorrect)
+    .map((o) => o.choiceIndex)
+  const labels = cfg.choiceOptions.map((o) => o.label)
+
+  const markedIndices: number[] = []
+  for (let i = 0; i < fillRatios.length; i++) {
+    if (fillRatios[i] >= areaThreshold) {
+      markedIndices.push(i)
+    }
+  }
+
+  const recognizedValues = markedIndices.map(
+    (idx) => labels[idx] ?? String(idx)
+  )
+
+  // 信頼度計算（markRecognizer.ts と同一）
+  let confidence: number
+  if (markedIndices.length === 0) {
+    const maxRatio = Math.max(...fillRatios)
+    confidence = 1 - maxRatio / areaThreshold
+  } else if (markedIndices.length === 1) {
+    const markedRatio = fillRatios[markedIndices[0]]
+    const otherMaxRatio = Math.max(
+      ...fillRatios.filter((_, i) => !markedIndices.includes(i)),
+      0
+    )
+    confidence = Math.min(
+      markedRatio / areaThreshold,
+      1 - otherMaxRatio / areaThreshold
+    )
+    confidence = Math.max(0, Math.min(1, confidence))
+  } else {
+    confidence = 0.3
+  }
+
+  // 自動採点ステータス
+  let autoScoreStatus: OMRCellResult["autoScoreStatus"]
+  if (markedIndices.length === 0) {
+    autoScoreStatus = "no_answer"
+  } else if (markedIndices.length > correctAnswers.length) {
+    autoScoreStatus = "ambiguous"
+  } else {
+    const isCorrect =
+      markedIndices.length === correctAnswers.length &&
+      markedIndices.every((idx) => correctAnswers.includes(idx))
+    autoScoreStatus = isCorrect ? "correct" : "incorrect"
+  }
+
+  return {
+    ...cellResult,
+    recognizedValues,
+    confidence,
+    autoScoreStatus,
+  }
+}
+
+/**
+ * OMRCellResultからAutoScoreEntryを構築（部分点・低信頼チェック含む）
+ */
+function buildEntryFromCellResult(
+  cellResult: OMRCellResult,
+  cfg: CropRegionOmrConfigWithOptions | undefined,
+  maxPoints: number,
+  confidenceThreshold: number
+): AutoScoreEntry {
+  const cropRegionId = cellResult.label
+  let status: AutoScoreEntry["status"]
+  let score: number
+
+  switch (cellResult.autoScoreStatus) {
+    case "correct":
+      status = "correct"
+      score = maxPoints
+      break
+    case "incorrect":
+      status = "incorrect"
+      score = 0
+      break
+    case "no_answer":
+      status = "no_answer"
+      score = 0
+      break
+    case "ambiguous":
+      status = "double_mark"
+      score = 0
+      break
+    default:
+      status = "no_answer"
+      score = 0
+  }
+
+  // 部分点チェック
+  if (
+    cfg?.type === "choice" &&
+    status === "incorrect" &&
+    cellResult.recognizedValues.length > 0
+  ) {
+    const correctLabels = cfg.choiceOptions
+      .filter((o) => o.isCorrect)
+      .map((o) => o.label)
+    if (correctLabels.length > 1) {
+      const correctCount = cellResult.recognizedValues.filter((v) =>
+        correctLabels.includes(v)
+      ).length
+      if (correctCount > 0 && correctCount < correctLabels.length) {
+        status = "partial"
+        score = Math.floor((maxPoints * correctCount) / correctLabels.length)
+      }
+    }
+  }
+
+  // 低信頼チェック
+  if (
+    cellResult.confidence < confidenceThreshold &&
+    status !== "no_answer" &&
+    status !== "double_mark"
+  ) {
+    status = "pending"
+    score = 0
+  }
+
+  return {
+    label: cellResult.label,
+    cropRegionId,
+    questionPath: cellResult.questionPath,
+    status,
+    score,
+    maxPoints,
+    recognizedValues: cellResult.recognizedValues,
+  }
+}
+
+/** エントリのstatusからサマリーを集計 */
+function countSummary(
+  allEntries: Map<string, AutoScoreEntry[]>
+): ScoringResultSummary {
+  let correct = 0,
+    incorrect = 0,
+    noAnswer = 0,
+    doubleMark = 0,
+    partial = 0,
+    pending = 0
+
+  for (const entries of allEntries.values()) {
+    for (const entry of entries) {
+      switch (entry.status) {
+        case "correct":
+          correct++
+          break
+        case "incorrect":
+          incorrect++
+          break
+        case "no_answer":
+          noAnswer++
+          break
+        case "double_mark":
+          doubleMark++
+          break
+        case "partial":
+          partial++
+          break
+        case "pending":
+          pending++
+          break
+      }
+    }
+  }
+
+  return {
+    correct,
+    incorrect,
+    noAnswer,
+    doubleMark,
+    partial,
+    pending,
+    total: correct + incorrect + noAnswer + doubleMark + partial + pending,
+  }
+}
+
+/**
+ * 全シートのfillRatio分布から最適なareaThresholdを推奨する
+ *
+ * 全セルのfillRatioをフラットに収集し、ソート済み配列の[0.05, 0.85]区間で
+ * 隣接値間の最大ギャップを探索、ギャップの中点を推奨閾値とする。
+ */
+export function recommendAreaThreshold(
+  sheetResults: OMRSheetResult[]
+): number | null {
+  const allRatios: number[] = []
+
+  for (const sheet of sheetResults) {
+    if (!sheet.success) continue
+    for (const cell of sheet.cellResults) {
+      if (cell.fillRatios) {
+        allRatios.push(...cell.fillRatios)
+      }
+    }
+  }
+
+  if (allRatios.length < 2) return null
+
+  const sorted = allRatios
+    .filter((r) => r >= 0.05 && r <= 0.85)
+    .sort((a, b) => a - b)
+
+  if (sorted.length < 2) return null
+
+  let maxGap = 0
+  let gapMidpoint = 0.4
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const gap = sorted[i + 1] - sorted[i]
+    if (gap > maxGap) {
+      maxGap = gap
+      gapMidpoint = (sorted[i] + sorted[i + 1]) / 2
+    }
+  }
+
+  // ギャップが小さすぎる場合は推奨不可
+  if (maxGap < 0.05) return null
+
+  return Math.round(gapMidpoint * 100) / 100
+}


### PR DESCRIPTION
## Summary
- 認識完了後にスライダーで塗りつぶし判定閾値（areaThreshold）・信頼度閾値（confidenceThreshold）をリアルタイム調整可能に
- キャッシュ済みfillRatiosをレンダラー側で即時再評価（IPC不要、ゼロレイテンシー）
- fillRatio分布の最大ギャップから推奨塗りつぶし閾値を自動算出

Closes #728

## Test plan
- [ ] OMR認識実行後にスライダーが表示されること
- [ ] areaThresholdスライダー操作でサマリー数値が即座に更新されること
- [ ] confidenceThresholdスライダー操作で保留件数が変化すること
- [ ] 「推奨塗りつぶし閾値を適用」ボタンで合理的な閾値が適用されること
- [ ] 閾値調整後に「採点結果を反映」でDB保存が正常に動作すること
- [ ] `npm run typecheck` / `npm run lint` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)