### PR TITLE
CompoundAnswer・Tag拡張のImport/Exportアーカイブ対応

### DIFF
--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -77,6 +77,13 @@ export async function collectExamData(
                     drawingAnnotations: true,
                   },
                 },
+                compoundMembership: true,
+              },
+            },
+            compoundAnswers: {
+              include: {
+                members: true,
+                scores: true,
               },
             },
           },
@@ -389,6 +396,57 @@ export async function collectExamData(
           }))
         )
       ),
+      // v1.11.0+: CompoundAnswer
+      compoundAnswers: exam.examPages.flatMap((page) =>
+        page.compoundAnswers.map((ca) => ({
+          id: ca.id,
+          examPageId: ca.examPageId,
+          label: ca.label,
+          answerFormat: ca.answerFormat,
+          correctAnswer: ca.correctAnswer,
+          points: ca.points,
+          orderIndex: ca.orderIndex,
+          alternativeAnswers: ca.alternativeAnswers,
+          requireReduced: ca.requireReduced,
+          createdAt: ca.createdAt.toISOString(),
+          updatedAt: ca.updatedAt.toISOString(),
+        }))
+      ),
+      // v1.11.0+: CompoundAnswerMember
+      compoundAnswerMembers: exam.examPages.flatMap((page) =>
+        page.compoundAnswers.flatMap((ca) =>
+          ca.members.map((m) => ({
+            id: m.id,
+            compoundAnswerId: m.compoundAnswerId,
+            cropRegionId: m.cropRegionId,
+            order: m.order,
+            roleLabel: m.roleLabel,
+            separator: m.separator,
+            createdAt: m.createdAt.toISOString(),
+            updatedAt: m.updatedAt.toISOString(),
+          }))
+        )
+      ),
+      // v1.11.0+: CompoundAnswerScore (ログインユーザーのみ)
+      compoundAnswerScores: isTemplate
+        ? []
+        : exam.examPages.flatMap((page) =>
+            page.compoundAnswers.flatMap((ca) =>
+              ca.scores
+                .filter((s) => s.userId === userId)
+                .map((s) => ({
+                  id: s.id,
+                  compoundAnswerId: s.compoundAnswerId,
+                  studentId: s.studentId,
+                  userId: s.userId,
+                  recognizedAnswer: s.recognizedAnswer,
+                  status: s.status,
+                  partialScore: s.partialScore?.toString() ?? null,
+                  createdAt: s.createdAt.toISOString(),
+                  updatedAt: s.updatedAt.toISOString(),
+                }))
+            )
+          ),
       // v1.2.0+: pageImagesは空配列（後方互換性のため維持）
       pageImages: [],
       // v1.2.0+: 新形式
@@ -566,6 +624,8 @@ export async function collectExamData(
       tags: tags.map((t) => ({
         id: t.id,
         name: t.name,
+        order: t.order,
+        color: t.color,
         createdAt: t.createdAt.toISOString(),
         updatedAt: t.updatedAt.toISOString(),
       })),

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -156,6 +156,8 @@ export async function createImportedData(
             create: {
               id: remapIdRequired(tag.id, mappings.tag),
               name: tag.name,
+              order: tag.order ?? 0,
+              color: tag.color ?? null,
             },
           })
         }
@@ -436,6 +438,71 @@ export async function createImportedData(
               normalizedY: box.normalizedY,
               normalizedW: box.normalizedW,
               normalizedH: box.normalizedH,
+            },
+          })
+        }
+      }
+
+      // 12.10. CompoundAnswerを作成 (v1.11.0+)
+      for (const ca of data.examData.compoundAnswers || []) {
+        const newExamPageId = remapId(ca.examPageId, mappings.examPage)
+        if (newExamPageId) {
+          await tx.compoundAnswer.create({
+            data: {
+              id: remapIdRequired(ca.id, mappings.compoundAnswer),
+              examPageId: newExamPageId,
+              label: ca.label,
+              answerFormat: ca.answerFormat,
+              correctAnswer: ca.correctAnswer,
+              points: ca.points,
+              orderIndex: ca.orderIndex,
+              alternativeAnswers: ca.alternativeAnswers,
+              requireReduced: ca.requireReduced,
+            },
+          })
+        }
+      }
+
+      // 12.11. CompoundAnswerMemberを作成 (v1.11.0+)
+      for (const cam of data.examData.compoundAnswerMembers || []) {
+        const newCompoundAnswerId = remapId(
+          cam.compoundAnswerId,
+          mappings.compoundAnswer
+        )
+        const newCropRegionId = remapId(cam.cropRegionId, mappings.cropRegion)
+        if (newCompoundAnswerId && newCropRegionId) {
+          await tx.compoundAnswerMember.create({
+            data: {
+              id: remapIdRequired(cam.id, mappings.compoundAnswerMember),
+              compoundAnswerId: newCompoundAnswerId,
+              cropRegionId: newCropRegionId,
+              order: cam.order,
+              roleLabel: cam.roleLabel,
+              separator: cam.separator,
+            },
+          })
+        }
+      }
+
+      // 12.12. CompoundAnswerScoreを作成 (v1.11.0+)
+      for (const cas of data.examData.compoundAnswerScores || []) {
+        const newCompoundAnswerId = remapId(
+          cas.compoundAnswerId,
+          mappings.compoundAnswer
+        )
+        const newStudentId = remapId(cas.studentId, mappings.student)
+        if (newCompoundAnswerId && newStudentId) {
+          await tx.compoundAnswerScore.create({
+            data: {
+              id: remapIdRequired(cas.id, mappings.compoundAnswerScore),
+              compoundAnswerId: newCompoundAnswerId,
+              studentId: newStudentId,
+              userId: currentUserId,
+              recognizedAnswer: cas.recognizedAnswer,
+              status: cas.status,
+              partialScore: cas.partialScore
+                ? parseFloat(cas.partialScore)
+                : null,
             },
           })
         }

--- a/electron-src/lib/import/exam-archive/idRemapper.ts
+++ b/electron-src/lib/import/exam-archive/idRemapper.ts
@@ -66,6 +66,12 @@ export interface IdMappings {
   cropRegionOmrConfig: Record<string, string>
   /** CropRegionOmrChoiceOption ID: 旧ID -> 新ID (v1.7.0+) */
   cropRegionOmrChoiceOption: Record<string, string>
+  /** CompoundAnswer ID: 旧ID -> 新ID (v1.11.0+) */
+  compoundAnswer: Record<string, string>
+  /** CompoundAnswerMember ID: 旧ID -> 新ID (v1.11.0+) */
+  compoundAnswerMember: Record<string, string>
+  /** CompoundAnswerScore ID: 旧ID -> 新ID (v1.11.0+) */
+  compoundAnswerScore: Record<string, string>
 }
 
 /**
@@ -105,6 +111,9 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     examTag: {},
     cropRegionOmrConfig: {},
     cropRegionOmrChoiceOption: {},
+    compoundAnswer: {},
+    compoundAnswerMember: {},
+    compoundAnswerScore: {},
   }
 
   // 試験
@@ -224,6 +233,21 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // v1.7.0+: CropRegionOmrChoiceOption
   for (const opt of data.examData.omrChoiceOptions || []) {
     mappings.cropRegionOmrChoiceOption[opt.id] = randomUUID()
+  }
+
+  // v1.11.0+: CompoundAnswer
+  for (const ca of data.examData.compoundAnswers || []) {
+    mappings.compoundAnswer[ca.id] = randomUUID()
+  }
+
+  // v1.11.0+: CompoundAnswerMember
+  for (const cam of data.examData.compoundAnswerMembers || []) {
+    mappings.compoundAnswerMember[cam.id] = randomUUID()
+  }
+
+  // v1.11.0+: CompoundAnswerScore
+  for (const cas of data.examData.compoundAnswerScores || []) {
+    mappings.compoundAnswerScore[cas.id] = randomUUID()
   }
 
   // v1.10.0+: Tag (旧Subject)

--- a/electron-src/lib/import/transformers/V1_10_0_to_V1_11_0.ts
+++ b/electron-src/lib/import/transformers/V1_10_0_to_V1_11_0.ts
@@ -54,12 +54,28 @@ export class V1_10_0_to_V1_11_0_Transformer implements VersionTransformer {
 
     // 新規フィールドをデフォルト空配列で追加
     examData.omrDigitBoxes = []
+    examData.compoundAnswers = []
+    examData.compoundAnswerMembers = []
+    examData.compoundAnswerScores = []
+
+    // Tag に order/color フィールドを追加（デフォルト値）
+    const tagsData = data.tagsData
+      ? {
+          ...data.tagsData,
+          tags: data.tagsData.tags.map((tag) => ({
+            ...tag,
+            order: 0,
+            color: null,
+          })),
+        }
+      : undefined
 
     return {
       data: {
         ...data,
         manifest: { ...data.manifest, version: this.toVersion },
         examData,
+        ...(tagsData ? { tagsData } : {}),
       },
       warnings,
     }

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -664,6 +664,43 @@ export interface ArchiveExamData {
     createdAt: string
     updatedAt: string
   }>
+  /** v1.11.0+ CompoundAnswer（複合回答グループ） */
+  compoundAnswers?: Array<{
+    id: string
+    examPageId: string
+    label: string
+    answerFormat: string
+    correctAnswer: string
+    points: number
+    orderIndex: number | null
+    alternativeAnswers: string | null
+    requireReduced: boolean
+    createdAt: string
+    updatedAt: string
+  }>
+  /** v1.11.0+ CompoundAnswerMember（複合回答メンバー） */
+  compoundAnswerMembers?: Array<{
+    id: string
+    compoundAnswerId: string
+    cropRegionId: string
+    order: number
+    roleLabel: string | null
+    separator: string | null
+    createdAt: string
+    updatedAt: string
+  }>
+  /** v1.11.0+ CompoundAnswerScore（複合回答スコア） */
+  compoundAnswerScores?: Array<{
+    id: string
+    compoundAnswerId: string
+    studentId: string
+    userId: string
+    recognizedAnswer: string | null
+    status: string
+    partialScore: string | null
+    createdAt: string
+    updatedAt: string
+  }>
   /** @deprecated v1.2.0以降はmasterImages/studentAnswerImagesを使用 */
   pageImages: Array<{
     id: string
@@ -921,6 +958,10 @@ export interface ArchiveTagsData {
   tags: Array<{
     id: string
     name: string
+    /** v1.11.0+ 表示順 */
+    order?: number
+    /** v1.11.0+ 表示色 */
+    color?: string | null
     createdAt: string
     updatedAt: string
   }>


### PR DESCRIPTION
## Summary

Closes #730

v1.11.0アーカイブバージョンで追加されたCompoundAnswer関連テーブルおよびTag拡張フィールドのImport/Export処理を実装。

- `examArchive.types.ts`: CompoundAnswer/Member/Score型定義、Tag.order/color追加
- `V1_10_0_to_V1_11_0`: CompoundAnswer空配列・Tag order/colorデフォルト値の初期化
- `dataCollector.ts`: CompoundAnswer/Member/Scoreデータ収集、Tag order/color出力
- `idRemapper.ts`: CompoundAnswer/Member/ScoreのIDマッピング追加
- `dataCreator.ts`: CompoundAnswer/Member/ScoreのDB挿入、Tag order/color対応

## Test plan

- [ ] 型チェック（`npm run typecheck`）通過確認済み
- [ ] Lintチェック（`npm run lint`）通過確認済み
- [ ] CompoundAnswerを含む試験のエクスポート→インポートが正常に動作すること
- [ ] v1.10.0形式のアーカイブがv1.11.0に正しく変換されること（CompoundAnswer空、Tag order=0/color=null）

🤖 Generated with [Claude Code](https://claude.com/claude-code)