### PR TITLE
sqlite-nas-syncをv0.6.0に更新しschemaVersion対応を追加

### DIFF
--- a/electron-src/lib/sync/syncConfig.ts
+++ b/electron-src/lib/sync/syncConfig.ts
@@ -14,6 +14,23 @@ import * as path from "path"
 import { getDataDirectory } from "../dataManager"
 import { DEFAULT_SYNC_CONFIG, SyncAppConfig } from "./types"
 
+/** prisma/migrationsから最新マイグレーション名を取得し、schemaVersionとして返す */
+export function getSchemaVersion(): string {
+  try {
+    const migrationsDir = path.join(app.getAppPath(), "prisma", "migrations")
+    if (!fs.existsSync(migrationsDir)) return "unknown"
+
+    const entries = fs
+      .readdirSync(migrationsDir)
+      .filter((e) => /^\d{14}_/.test(e))
+      .sort()
+
+    return entries.length > 0 ? entries[entries.length - 1] : "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
 function getConfigPath(): string {
   return path.join(app.getPath("userData"), "sync-config.json")
 }

--- a/electron-src/lib/sync/syncService.ts
+++ b/electron-src/lib/sync/syncService.ts
@@ -21,6 +21,7 @@ import {
   getLocalDbPath,
   getNasDbPath,
   getNasSyncPath,
+  getSchemaVersion,
   loadSyncConfig,
   saveSyncConfig,
 } from "./syncConfig"
@@ -167,6 +168,7 @@ export async function startSync(config: SyncAppConfig): Promise<void> {
     tables: SYNC_TABLES,
     intervalMs: config.intervalMs,
     changelogRetentionDays: config.changelogRetentionDays,
+    schemaVersion: getSchemaVersion(),
     onAfterSync: (db: Database.Database, _result: SyncResult) => {
       enforceTombstones(db)
       updateStatus({

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "remark-math": "^6.0.0",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
-        "sqlite-nas-sync": "^0.3.1",
+        "sqlite-nas-sync": "^0.6.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "vaul": "^1.1.2",
@@ -20449,9 +20449,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/sqlite-nas-sync": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/sqlite-nas-sync/-/sqlite-nas-sync-0.3.1.tgz",
-      "integrity": "sha512-t+kTouwzHOUwylmmfN35KXSsYDYl9nwIZHPIAwLVH+dyZH3oHJ1N7PRiOQblmWwcTa7BlKgwJ70q+3Rij8AKNg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/sqlite-nas-sync/-/sqlite-nas-sync-0.6.0.tgz",
+      "integrity": "sha512-oRADcR8kwSr1+SGJTO2dcWx0edbVb3+vHqDEtB4eO5II4SNm6H9dmfeNtlb9D/y2QNYDfvwBVpLm6H8nbtIhPA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "remark-math": "^6.0.0",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
-    "sqlite-nas-sync": "^0.3.1",
+    "sqlite-nas-sync": "^0.6.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "vaul": "^1.1.2",


### PR DESCRIPTION
## Summary

- sqlite-nas-syncを0.3.1→0.6.0にアップデート
- 新機能`schemaVersion`を活用し、Prismaマイグレーション名を自動取得して同期設定に渡す
- 異なるスキーマバージョンのアプリ間での同期スキップによりデータ破損を防止

Closes #734

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] sync関連テスト全28件通過（`npx vitest run __tests__/sync/`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)