### PR TITLE
feat: マウスクリック採点機能と採点パネルUI再設計

### DIFF
--- a/src/app/settings/components/DisplaySettingsTab.tsx
+++ b/src/app/settings/components/DisplaySettingsTab.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { ColorPicker } from "@/components/ui/color-picker"
 import { Label } from "@/components/ui/label"
+import { Slider } from "@/components/ui/slider"
 import { useAuth } from "@/contexts/AuthContext"
 import {
   applyScoringColorPreset,
@@ -20,6 +21,11 @@ import {
   type ScoringStatusColors,
   type ScoringStatusType,
 } from "@/lib/scoringStatusColors"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
 import { cn } from "@/lib/utils"
 
 const DEFAULT_SELECTION_BORDER_COLOR = "#F97316"
@@ -40,6 +46,16 @@ export function DisplaySettingsTab() {
   // 選択枠色の状態
   const [selectionBorderColor, setSelectionBorderColor] = useState(
     DEFAULT_SELECTION_BORDER_COLOR
+  )
+
+  // クリック採点設定の状態
+  const [clickScoringConfig, setClickScoringConfig] = useState({
+    2: "incorrect" as string,
+    3: "partial_modal" as string,
+    4: "individual" as string,
+  })
+  const [clickScoringDebounceMs, setClickScoringDebounceMs] = useState<number>(
+    USER_PREFERENCE_SCHEMA.clickScoringDebounceMs.default
   )
 
   // 採点状態色の状態
@@ -80,6 +96,44 @@ export function DisplaySettingsTab() {
         }
       }
 
+      // クリック採点設定の読み込み
+      try {
+        const [configResult, debounceResult] = await Promise.all([
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "clickScoringConfig"
+          ),
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "clickScoringDebounceMs"
+          ),
+        ])
+        if (configResult.success) {
+          const raw = parsePreference(
+            "clickScoringConfig",
+            configResult.value ?? null
+          )
+          if (raw) {
+            try {
+              const parsed = JSON.parse(raw)
+              setClickScoringConfig((prev) => ({ ...prev, ...parsed }))
+            } catch {
+              // keep default
+            }
+          }
+        }
+        if (debounceResult.success) {
+          setClickScoringDebounceMs(
+            parsePreference(
+              "clickScoringDebounceMs",
+              debounceResult.value ?? null
+            )
+          )
+        }
+      } catch (error) {
+        console.error("クリック採点設定の読み込みに失敗しました:", error)
+      }
+
       await loadScoringStatusColors(userId)
       setScoringColors(getScoringStatusColors())
       setCurrentPresetId(getCurrentPresetId())
@@ -106,6 +160,45 @@ export function DisplaySettingsTab() {
         } catch (error) {
           console.error("選択枠色の保存に失敗しました:", error)
           toast.error("選択枠色の保存に失敗しました")
+        }
+      }
+    },
+    [userId]
+  )
+
+  // クリック採点アクション変更
+  const handleClickActionChange = useCallback(
+    async (clickCount: 2 | 3 | 4, action: string) => {
+      const next = { ...clickScoringConfig, [clickCount]: action }
+      setClickScoringConfig(next)
+      if (userId && window.electronAPI?.settings) {
+        try {
+          await window.electronAPI.settings.setUserPreference(
+            userId,
+            "clickScoringConfig",
+            serializePreference("clickScoringConfig", JSON.stringify(next))
+          )
+        } catch (error) {
+          console.error("クリック採点設定の保存に失敗しました:", error)
+        }
+      }
+    },
+    [userId, clickScoringConfig]
+  )
+
+  // クリック採点デバウンス時間変更
+  const handleDebounceMsChange = useCallback(
+    async (value: number) => {
+      setClickScoringDebounceMs(value)
+      if (userId && window.electronAPI?.settings) {
+        try {
+          await window.electronAPI.settings.setUserPreference(
+            userId,
+            "clickScoringDebounceMs",
+            serializePreference("clickScoringDebounceMs", value)
+          )
+        } catch (error) {
+          console.error("デバウンス時間の保存に失敗しました:", error)
         }
       }
     },
@@ -153,6 +246,86 @@ export function DisplaySettingsTab() {
 
   return (
     <div className="space-y-8">
+      {/* クリックで採点 */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">クリックで採点</h2>
+          <p className="text-muted-foreground text-sm">
+            一括採点でのマウスクリック操作を設定できます
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          {([2, 3, 4] as const).map((clickCount) => {
+            const labels = {
+              2: "ダブルクリック",
+              3: "トリプルクリック",
+              4: "クアトロクリック",
+            }
+            const actionOptions = [
+              { value: "none", label: "なし" },
+              { value: "correct", label: "正答" },
+              { value: "incorrect", label: "誤答" },
+              { value: "partial_modal", label: "部分点入力" },
+              { value: "partial", label: "部分点（非推奨）" },
+              { value: "pending", label: "保留（非推奨）" },
+              { value: "unscored", label: "未採点" },
+              { value: "no_answer", label: "無答" },
+              { value: "double_mark", label: "Wマーク" },
+              { value: "individual", label: "個別表示" },
+            ]
+            return (
+              <div key={clickCount} className="flex items-center gap-3">
+                <Label className="w-36 shrink-0 text-sm">
+                  {labels[clickCount]}
+                </Label>
+                <select
+                  className="border-input bg-background flex-1 rounded-md border px-3 py-1.5 text-sm"
+                  value={
+                    clickScoringConfig[
+                      clickCount as keyof typeof clickScoringConfig
+                    ]
+                  }
+                  onChange={(e) =>
+                    handleClickActionChange(clickCount, e.target.value)
+                  }
+                >
+                  {actionOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )
+          })}
+
+          {/* デバウンス時間 */}
+          <div className="space-y-1 pt-2">
+            <Label className="text-sm">クリック判定の待ち時間</Label>
+            <div className="flex items-center gap-2">
+              <span className="shrink-0 text-lg" title="速い">
+                🐇
+              </span>
+              <Slider
+                className="flex-1"
+                value={[clickScoringDebounceMs]}
+                min={100}
+                max={800}
+                step={50}
+                onValueChange={([v]) => handleDebounceMsChange(v)}
+              />
+              <span className="shrink-0 text-lg" title="遅い">
+                🐢
+              </span>
+              <span className="text-muted-foreground w-14 shrink-0 text-right text-sm">
+                {clickScoringDebounceMs}ms
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* 選択枠の色 */}
       <section className="space-y-4">
         <div>

--- a/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { DragSelectionOverlay } from "@/components/exams/07-score-at-once/ScoringGrid/DragSelectionOverlay"
 import { GridCell } from "@/components/exams/07-score-at-once/ScoringGrid/GridCell"
@@ -49,6 +49,10 @@ export interface AnswerGridViewProps {
   annotationRefreshKey?: number
   /** 用紙サイズ（mm→px変換基準） */
   pageSize?: string
+  /** クリック採点コールバック（answerId, 最終クリック回数） */
+  onClickScoring?: (answerId: string, clickCount: number) => void
+  /** クリック採点のデバウンス時間（ms） */
+  clickScoringDebounceMs?: number
   className?: string
 }
 
@@ -68,6 +72,8 @@ export default function AnswerGridView({
   currentUserId,
   annotationRefreshKey,
   pageSize,
+  onClickScoring,
+  clickScoringDebounceMs = 300,
   className = "",
 }: AnswerGridViewProps) {
   /** フィルタリングされた採点データ（模範解答 + 学生データ） */
@@ -182,14 +188,46 @@ export default function AnswerGridView({
     endDrag()
   }
 
-  const onCellMouseDown = (event: React.MouseEvent, answerId: string) => {
-    if (gridRef.current) {
-      const gridRect = gridRef.current.getBoundingClientRect()
-      startDrag(event.clientX - gridRect.left, event.clientY - gridRect.top)
-    }
+  /** 生徒答案ごとの独立デバウンスタイマー管理 */
+  const clickTimersRef = useRef<
+    Map<string, { timerId: ReturnType<typeof setTimeout>; clickCount: number }>
+  >(new Map())
 
-    handleMouseDown(event, answerId)
-  }
+  const onCellMouseDown = useCallback(
+    (event: React.MouseEvent, answerId: string) => {
+      if (answerId.startsWith("master-")) return
+
+      if (event.detail >= 2 && onClickScoring) {
+        // ダブルクリック以上: ドラッグ開始せず、クリック採点デバウンスに委譲
+        const timers = clickTimersRef.current
+        const existing = timers.get(answerId)
+
+        // 既存タイマーがあればクリア（有効時間を延長）
+        if (existing) {
+          clearTimeout(existing.timerId)
+        }
+
+        const clickCount = Math.max(event.detail, existing?.clickCount ?? 0)
+
+        // 新しいタイマーを設定（有効時間終了後に確定）
+        const timerId = setTimeout(() => {
+          timers.delete(answerId)
+          onClickScoring(answerId, clickCount)
+        }, clickScoringDebounceMs)
+
+        timers.set(answerId, { timerId, clickCount })
+        return
+      }
+
+      // シングルクリック: ドラッグ開始 + 通常の選択処理
+      if (gridRef.current) {
+        const gridRect = gridRef.current.getBoundingClientRect()
+        startDrag(event.clientX - gridRect.left, event.clientY - gridRect.top)
+      }
+      handleMouseDown(event, answerId)
+    },
+    [startDrag, handleMouseDown, onClickScoring, clickScoringDebounceMs]
+  )
 
   const isColumnLayout =
     layoutDirection === "down-right" || layoutDirection === "down-left"

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridDragSelection.ts
@@ -24,6 +24,9 @@ export function useGridDragSelection({
       return
     }
 
+    // ダブルクリック以上はAnswerGridView側で処理（採点・部分点モーダル等）
+    if (event.detail >= 2) return
+
     if (event.ctrlKey) {
       event.preventDefault()
       onAnswerSelect(answerId, !selectedAnswers.has(answerId))

--- a/src/components/exams/07-score-at-once/ScoringMain/PartialScoreModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/PartialScoreModal.tsx
@@ -38,6 +38,8 @@ interface PartialScoreModalProps {
   onChange?: (value: string) => void
   onConfirmPartial?: () => void
   onConfirmPending?: () => void
+  onDigit?: (key: string) => void
+  onBackspace?: () => void
   keyBindings?: KeyBindings
 }
 
@@ -50,6 +52,8 @@ export default function PartialScoreModal({
   onChange,
   onConfirmPartial,
   onConfirmPending,
+  onDigit,
+  onBackspace,
   keyBindings,
 }: PartialScoreModalProps) {
   // デフォルト値を設定
@@ -169,6 +173,37 @@ export default function PartialScoreModal({
               </div>
             </div>
           </div>
+
+          {/* NumPad（マウス操作用） */}
+          {onDigit && onBackspace && (
+            <div className="grid grid-cols-3 gap-2">
+              {["7", "8", "9", "4", "5", "6", "1", "2", "3", "0", "."].map(
+                (key) => (
+                  <Button
+                    key={key}
+                    variant="outline"
+                    className="h-10 font-mono text-lg"
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      onDigit(key)
+                    }}
+                  >
+                    {key}
+                  </Button>
+                )
+              )}
+              <Button
+                variant="outline"
+                className="h-10 text-lg"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  onBackspace()
+                }}
+              >
+                ⌫
+              </Button>
+            </div>
+          )}
 
           {/* 確認ボタン（マウス操作用） */}
           <div className="flex justify-end gap-2">

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -45,6 +45,8 @@ interface ScoringContentAreaProps {
   masterAnswerVisible?: boolean
   allMasterImageUrls?: string[]
   pageSize?: string
+  onClickScoring?: (answerId: string, clickCount: number) => void
+  clickScoringDebounceMs?: number
 }
 
 export function ScoringContentArea({
@@ -76,6 +78,8 @@ export function ScoringContentArea({
   masterAnswerVisible = false,
   allMasterImageUrls,
   pageSize = "A4",
+  onClickScoring,
+  clickScoringDebounceMs,
 }: ScoringContentAreaProps) {
   const currentScoringDataId =
     gradingMode === "individual"
@@ -181,6 +185,8 @@ export function ScoringContentArea({
         currentUserId={currentUserId}
         annotationRefreshKey={gridAnnotationRefreshKey}
         pageSize={pageSize}
+        onClickScoring={onClickScoring}
+        clickScoringDebounceMs={clickScoringDebounceMs}
         className="p-4"
       />
     )

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -31,6 +31,7 @@ import {
   ScoringLoadingState,
 } from "@/components/exams/07-score-at-once/ScoringMain/ScoringStates"
 import { ScoringSidePanel } from "@/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel"
+import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 import { useAuth } from "@/contexts/AuthContext"
@@ -64,6 +65,8 @@ function ScoringMainViewContent() {
     showStudentNames,
     layoutDirection,
     expandMargin,
+    clickScoringConfig,
+    clickScoringDebounceMs,
     masterAnswerDisplayMode,
     masterAnswerOpacity,
     masterAnswerKeyBehavior,
@@ -72,6 +75,8 @@ function ScoringMainViewContent() {
     setShowStudentNames,
     setLayoutDirection,
     setExpandMargin,
+    setClickAction,
+    setClickScoringDebounceMs,
     setMasterAnswerDisplayMode,
     setMasterAnswerOpacity,
     setMasterAnswerKeyBehavior,
@@ -242,24 +247,48 @@ function ScoringMainViewContent() {
     replaceSelection(filteredScoringDataIds)
   }, [replaceSelection, filteredScoringDataIds])
 
-  const {
-    handleNextQuestion,
-    handlePrevQuestion,
-    handleZoomIn,
-    handleZoomOut,
-    handleResetZoom,
-    handleGridNavigation,
-  } = useScoringNavigation({
-    answerSheetsLength: studentAnswerImages.length,
-    currentCropRegionId: currentCropRegionId,
-    setCurrentCropRegionId: setCurrentCropRegionId,
-    selectedStudentAnswerImageIds: selectedStudentAnswerImageIds,
-    setSelectedPageImageIds: setSelectedPageImageIds,
-    layoutDirection: layoutDirection,
-    getGridAnswerData,
-    effectiveColumns: itemsPerLine[0],
-    cropRegions: cropRegions,
-  })
+  /** 未採点の生徒を全て選択（フィルターで非表示なら強制表示） */
+  const handleSelectUnscored = useCallback(() => {
+    // 未採点フィルターが無効なら有効にする
+    if (!filterSettings.unscored) {
+      handleToggleFilter("unscored")
+    }
+    // 次のレンダー後に選択するためqueueMicrotaskで遅延
+    queueMicrotask(() => {
+      const unscoredIds = allScoringData
+        .filter((d) => d.status === "unscored")
+        .map((d) => d.id)
+      replaceSelection(unscoredIds)
+    })
+  }, [allScoringData, replaceSelection, filterSettings, handleToggleFilter])
+
+  const { handleNextQuestion, handlePrevQuestion, handleGridNavigation } =
+    useScoringNavigation({
+      answerSheetsLength: studentAnswerImages.length,
+      currentCropRegionId: currentCropRegionId,
+      setCurrentCropRegionId: setCurrentCropRegionId,
+      selectedStudentAnswerImageIds: selectedStudentAnswerImageIds,
+      setSelectedPageImageIds: setSelectedPageImageIds,
+      layoutDirection: layoutDirection,
+      getGridAnswerData,
+      effectiveColumns: itemsPerLine[0],
+      cropRegions: cropRegions,
+    })
+
+  /** 1行あたりの表示件数を増減（ショートカットキー =/-） */
+  const handleZoomIn = useCallback(() => {
+    const next = Math.min(itemsPerLine[0] + 1, 10)
+    setItemsPerLine([next])
+  }, [itemsPerLine, setItemsPerLine])
+
+  const handleZoomOut = useCallback(() => {
+    const next = Math.max(itemsPerLine[0] - 1, 1)
+    setItemsPerLine([next])
+  }, [itemsPerLine, setItemsPerLine])
+
+  const handleResetZoom = useCallback(() => {
+    setItemsPerLine([5])
+  }, [setItemsPerLine])
 
   /**
    * 個別モード用ナビゲーション
@@ -335,6 +364,7 @@ function ScoringMainViewContent() {
   const {
     partialScoreInput,
     showPartialScoreModal,
+    openPartialScoreModal,
     handlePartialScoreInput,
     handlePartialScoreConfirm,
     handlePartialScoreCancel,
@@ -345,6 +375,44 @@ function ScoringMainViewContent() {
     currentCropRegion,
     onBatchScore: handleBatchScoreWithProgress,
   })
+
+  /** クリック採点：デバウンス後にクリック回数に応じたアクションを実行 */
+  const handleClickScoring = useCallback(
+    (answerId: string, clickCount: number) => {
+      if (answerId.startsWith("master-")) return
+      const action = clickScoringConfig[clickCount as 2 | 3 | 4] ?? "none"
+      if (action === "none") return
+
+      if (action === "individual") {
+        replaceSelection([answerId])
+        setGradingMode("individual")
+        return
+      }
+
+      if (action === "partial_modal") {
+        replaceSelection([answerId])
+        openPartialScoreModal()
+        return
+      }
+
+      // 採点ステータスを直接適用
+      const targetSet = new Set([answerId])
+      handleBatchScore(action as ScoringStatus, null, null, targetSet)
+      setRecentlyScoredAnswers((prev) => {
+        const newSet = new Set(prev)
+        newSet.add(answerId)
+        return newSet
+      })
+    },
+    [
+      clickScoringConfig,
+      replaceSelection,
+      setGradingMode,
+      openPartialScoreModal,
+      handleBatchScore,
+      setRecentlyScoredAnswers,
+    ]
+  )
 
   /** 表示モード切り替え（グリッド⇔個別） */
   const handleToggleViewMode = useCallback(
@@ -526,6 +594,8 @@ function ScoringMainViewContent() {
             masterAnswerVisible={masterAnswerVisible}
             allMasterImageUrls={allMasterImageUrls}
             pageSize={pageSize}
+            onClickScoring={handleClickScoring}
+            clickScoringDebounceMs={clickScoringDebounceMs}
           />
         </div>
 
@@ -551,13 +621,18 @@ function ScoringMainViewContent() {
               onScore={handleBatchScoreWithProgress}
               onToggleFilter={handleToggleFilter}
               onRefreshFilter={handleRefreshFilter}
+              onSelectAll={handleSelectAll}
+              onSelectUnscored={handleSelectUnscored}
               partialScoreInput={partialScoreInput}
+              clickScoringConfig={clickScoringConfig}
+              clickScoringDebounceMs={clickScoringDebounceMs}
+              onClickActionChange={setClickAction}
+              onClickScoringDebounceMsChange={setClickScoringDebounceMs}
               layoutDirection={layoutDirection}
               visibleAnswersCount={visibleAnswers.length}
               totalAnswersCount={studentAnswerImages.length}
               onLayoutDirectionChange={setLayoutDirection}
               onGridNavigation={handleGridNavigation}
-              onRefreshView={handleRefreshFilter}
               itemsPerLine={itemsPerLine}
               onItemsPerLineChange={handleItemsPerLineChange}
               autoScroll={autoScroll}
@@ -616,6 +691,8 @@ function ScoringMainViewContent() {
         onPartialScoreConfirmPending={() =>
           handlePartialScoreConfirm("pending")
         }
+        onPartialScoreDigit={handlePartialScoreInput}
+        onPartialScoreBackspace={handlePartialScoreBackspace}
         keyBindings={modalKeyBindings}
         showScoreComparison={showScoreComparison}
         onScoreComparisonClose={() => setShowScoreComparison(false)}

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringModals.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringModals.tsx
@@ -23,6 +23,8 @@ interface ScoringModalsProps {
   onPartialScoreChange: (value: string) => void
   onPartialScoreConfirmPartial?: () => void
   onPartialScoreConfirmPending?: () => void
+  onPartialScoreDigit?: (key: string) => void
+  onPartialScoreBackspace?: () => void
   keyBindings?: ModalKeyBindings
   // Score Comparison Modal props
   showScoreComparison: boolean
@@ -38,6 +40,8 @@ export function ScoringModals({
   onPartialScoreChange,
   onPartialScoreConfirmPartial,
   onPartialScoreConfirmPending,
+  onPartialScoreDigit,
+  onPartialScoreBackspace,
   keyBindings,
   showScoreComparison,
   onScoreComparisonClose,
@@ -57,6 +61,8 @@ export function ScoringModals({
         onChange={onPartialScoreChange}
         onConfirmPartial={onPartialScoreConfirmPartial}
         onConfirmPending={onPartialScoreConfirmPending}
+        onDigit={onPartialScoreDigit}
+        onBackspace={onPartialScoreBackspace}
         keyBindings={keyBindings}
       />
 

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview クリック採点設定フック
+ * @description ダブル/トリプル/クアトロクリック時の採点動作とデバウンス時間をユーザー設定として永続化
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
+
+/** クリック採点で選択可能なアクション */
+export type ClickScoringAction =
+  | "none"
+  | "correct"
+  | "incorrect"
+  | "partial"
+  | "partial_modal"
+  | "pending"
+  | "unscored"
+  | "no_answer"
+  | "double_mark"
+  | "individual"
+
+/** クリック回数ごとのアクション設定 */
+export interface ClickScoringConfig {
+  2: ClickScoringAction
+  3: ClickScoringAction
+  4: ClickScoringAction
+}
+
+/** デフォルト設定 */
+export const DEFAULT_CLICK_SCORING_CONFIG: ClickScoringConfig = {
+  2: "incorrect",
+  3: "partial_modal",
+  4: "individual",
+}
+
+const DEFAULT_DEBOUNCE_MS =
+  USER_PREFERENCE_SCHEMA.clickScoringDebounceMs.default
+
+/** クリック採点設定（アクション割当 + デバウンス時間）をユーザー設定として永続化するフック */
+export function useClickScoringConfig() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [clickScoringConfig, setClickScoringConfigState] =
+    useState<ClickScoringConfig>(DEFAULT_CLICK_SCORING_CONFIG)
+  const [clickScoringDebounceMs, setClickScoringDebounceMsState] =
+    useState<number>(DEFAULT_DEBOUNCE_MS)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (initializedUserIdRef.current === userId) return
+    if (!userId) return
+
+    initializedUserIdRef.current = userId
+
+    const load = async () => {
+      if (!window.electronAPI?.settings) return
+
+      try {
+        const [configResult, debounceResult] = await Promise.all([
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "clickScoringConfig"
+          ),
+          window.electronAPI.settings.getUserPreference(
+            userId,
+            "clickScoringDebounceMs"
+          ),
+        ])
+
+        if (configResult.success) {
+          const raw = parsePreference(
+            "clickScoringConfig",
+            configResult.value ?? null
+          )
+          if (raw) {
+            try {
+              const parsed = JSON.parse(raw)
+              setClickScoringConfigState({
+                ...DEFAULT_CLICK_SCORING_CONFIG,
+                ...parsed,
+              })
+            } catch {
+              // keep default
+            }
+          }
+        }
+
+        if (debounceResult.success) {
+          setClickScoringDebounceMsState(
+            parsePreference(
+              "clickScoringDebounceMs",
+              debounceResult.value ?? null
+            )
+          )
+        }
+      } catch (error) {
+        console.error("クリック採点設定の読み込みに失敗しました:", error)
+      }
+    }
+
+    load()
+  }, [userId])
+
+  /** 特定クリック回数のアクションを変更 */
+  const setClickAction = useCallback(
+    (clickCount: 2 | 3 | 4, action: ClickScoringAction) => {
+      setClickScoringConfigState((prev) => {
+        const next = { ...prev, [clickCount]: action }
+        if (userId && window.electronAPI?.settings) {
+          window.electronAPI.settings
+            .setUserPreference(
+              userId,
+              "clickScoringConfig",
+              serializePreference("clickScoringConfig", JSON.stringify(next))
+            )
+            .catch((error) =>
+              console.error("クリック採点設定の保存に失敗しました:", error)
+            )
+        }
+        return next
+      })
+    },
+    [userId]
+  )
+
+  /** デバウンス時間を変更 */
+  const setClickScoringDebounceMs = useCallback(
+    (value: number) => {
+      setClickScoringDebounceMsState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "clickScoringDebounceMs",
+            serializePreference("clickScoringDebounceMs", value)
+          )
+          .catch((error) =>
+            console.error("デバウンス時間の保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return {
+    clickScoringConfig,
+    clickScoringDebounceMs,
+    setClickAction,
+    setClickScoringDebounceMs,
+  }
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -42,6 +42,16 @@ export function usePartialScore({
     }
   }, [])
 
+  /** 部分点モーダルを開く（マウストリプルクリック等から呼び出し用） */
+  const openPartialScoreModal = useCallback(() => {
+    if (selectedAnswers.size === 0 || !currentCropRegion) return
+
+    setPartialScoreInput("")
+    setShowPartialScoreModal(true)
+    setContextValue("partialScoreModalOpen", true)
+    setContextValue("modalOpen", true)
+  }, [selectedAnswers, currentCropRegion, setContextValue])
+
   // 部分点入力開始（数字キー・小数点対応）
   const handlePartialScoreInput = useCallback(
     (key: string) => {
@@ -215,6 +225,7 @@ export function usePartialScore({
   return {
     partialScoreInput,
     showPartialScoreModal,
+    openPartialScoreModal,
     handlePartialScoreInput,
     handlePartialScoreConfirm,
     handlePartialScoreCancel,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringNavigation.ts
@@ -62,19 +62,6 @@ export function useScoringNavigation({
     }
   }, [currentCropRegionId, cropRegions, setCurrentCropRegionId])
 
-  // プレースホルダー関数（Individual View内で実装される）
-  const handleZoomIn = useCallback(() => {
-    // Individual View内で実装される
-  }, [])
-
-  const handleZoomOut = useCallback(() => {
-    // Individual View内で実装される
-  }, [])
-
-  const handleResetZoom = useCallback(() => {
-    // Individual View内で実装される
-  }, [])
-
   // 模範解答をスキップして次の有効な答案を見つける関数
   const findNextValidAnswer = useCallback(
     (
@@ -272,9 +259,6 @@ export function useScoringNavigation({
   return {
     handleNextQuestion,
     handlePrevQuestion,
-    handleZoomIn,
-    handleZoomOut,
-    handleResetZoom,
     handleGridNavigation,
   }
 }

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -4,6 +4,7 @@
  */
 
 import { useAutoScroll } from "./useAutoScroll"
+import { useClickScoringConfig } from "./useClickScoringConfig"
 import { useExpandMargin } from "./useExpandMargin"
 import { useItemsPerLine } from "./useItemsPerLine"
 import { useLayoutDirection } from "./useLayoutDirection"
@@ -17,6 +18,12 @@ export function useScoringSettings() {
   const { showStudentNames, setShowStudentNames } = useShowStudentNames()
   const { layoutDirection, setLayoutDirection } = useLayoutDirection()
   const { expandMargin, setExpandMargin } = useExpandMargin()
+  const {
+    clickScoringConfig,
+    clickScoringDebounceMs,
+    setClickAction,
+    setClickScoringDebounceMs,
+  } = useClickScoringConfig()
   const {
     masterAnswerDisplayMode,
     masterAnswerOpacity,
@@ -32,6 +39,8 @@ export function useScoringSettings() {
     showStudentNames,
     layoutDirection,
     expandMargin,
+    clickScoringConfig,
+    clickScoringDebounceMs,
     masterAnswerDisplayMode,
     masterAnswerOpacity,
     masterAnswerKeyBehavior,
@@ -40,6 +49,8 @@ export function useScoringSettings() {
     setShowStudentNames,
     setLayoutDirection,
     setExpandMargin,
+    setClickAction,
+    setClickScoringDebounceMs,
     setMasterAnswerDisplayMode,
     setMasterAnswerOpacity,
     setMasterAnswerKeyBehavior,

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard.tsx
@@ -1,13 +1,11 @@
 "use client"
 
-import { AlertCircle, RefreshCw, Users } from "lucide-react"
+import { AlertCircle, RefreshCw } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 
-// 試験進捗の型定義
 interface ExamProgress {
   totalStudents: number
   totalQuestions: number
@@ -21,21 +19,20 @@ interface ExamProgress {
 interface ExamProgressCardProps {
   examId: string
   autoRefresh?: boolean
-  refreshInterval?: number // ミリ秒
+  refreshInterval?: number
   onProgressUpdate?: (progress: ExamProgress) => void
 }
 
 export default function ExamProgressCard({
   examId,
   autoRefresh = true,
-  refreshInterval = 30000, // 30秒
+  refreshInterval = 30000,
   onProgressUpdate,
 }: ExamProgressCardProps) {
   const [progress, setProgress] = useState<ExamProgress | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // 進捗データを取得する関数
   const fetchProgress = useCallback(async () => {
     try {
       setError(null)
@@ -64,77 +61,41 @@ export default function ExamProgressCard({
     }
   }, [examId, onProgressUpdate])
 
-  // 初回読み込み
   useEffect(() => {
     fetchProgress()
   }, [fetchProgress])
 
-  // 自動リフレッシュの設定
   useEffect(() => {
     if (!autoRefresh) return
-
     const interval = setInterval(fetchProgress, refreshInterval)
     return () => clearInterval(interval)
   }, [autoRefresh, refreshInterval, fetchProgress])
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="flex items-center text-sm font-medium">
-            <Users className="mr-2 h-4 w-4" />
-            試験進捗
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="animate-pulse space-y-3">
-            <div className="h-4 rounded bg-gray-200"></div>
-            <div className="h-2 rounded bg-gray-200"></div>
-            <div className="h-2 rounded bg-gray-200"></div>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="animate-pulse space-y-2">
+        <div className="h-3 rounded bg-gray-200"></div>
+        <div className="h-1.5 rounded bg-gray-200"></div>
+      </div>
     )
   }
 
   if (error) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="flex items-center text-sm font-medium">
-            <Users className="mr-2 h-4 w-4" />
-            試験進捗
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3 text-center">
-            <AlertCircle className="mx-auto h-8 w-8 text-red-500" />
-            <p className="text-sm text-red-600">{error}</p>
-            <Button size="sm" variant="outline" onClick={fetchProgress}>
-              <RefreshCw className="mr-1 h-4 w-4" />
-              再試行
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="space-y-2 text-center">
+        <AlertCircle className="mx-auto h-5 w-5 text-red-400" />
+        <p className="text-xs text-red-500">{error}</p>
+        <Button size="sm" variant="outline" onClick={fetchProgress}>
+          <RefreshCw className="mr-1 h-3 w-3" />
+          再試行
+        </Button>
+      </div>
     )
   }
 
   if (!progress) {
     return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="flex items-center text-sm font-medium">
-            <Users className="mr-2 h-4 w-4" />
-            試験進捗
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm">
-            進捗データがありません
-          </p>
-        </CardContent>
-      </Card>
+      <p className="text-muted-foreground text-xs">進捗データがありません</p>
     )
   }
 
@@ -142,84 +103,52 @@ export default function ExamProgressCard({
     progress.totalItems > 0 && progress.finalizedItems >= progress.totalItems
 
   return (
-    <Card>
-      <CardHeader className="pb-1">
-        <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center text-xs font-medium">
-            <Users className="mr-1 h-3 w-3" />
-            試験進捗
-            {isComplete && (
-              <span className="ml-1.5 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-semibold text-green-700">
-                完了
-              </span>
-            )}
-          </CardTitle>
-          <div className="flex items-center space-x-1">
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={fetchProgress}
-              className="h-4 w-4 p-0"
-              title="進捗を更新"
-            >
-              <RefreshCw className="h-2 w-2" />
-            </Button>
-          </div>
+    <div className="space-y-2">
+      {/* 基本統計 */}
+      <div className="flex items-center justify-between text-xs text-gray-600">
+        <span>
+          生徒 {progress.totalStudents} / 設問 {progress.totalQuestions} / 計{" "}
+          {progress.totalItems}項目
+        </span>
+        <div className="flex items-center gap-1">
+          {isComplete && (
+            <span className="rounded bg-green-100 px-1 py-0.5 text-[10px] font-medium text-green-700">
+              完了
+            </span>
+          )}
+          <button
+            onClick={fetchProgress}
+            className="text-gray-400 hover:text-gray-600"
+            title="進捗を更新"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {/* 基本統計 */}
-        <div className="grid grid-cols-3 gap-2 text-center">
-          <div>
-            <div className="text-sm font-semibold">
-              {progress.totalStudents}
-            </div>
-            <div className="text-muted-foreground text-xs">生徒</div>
-          </div>
-          <div>
-            <div className="text-sm font-semibold">
-              {progress.totalQuestions}
-            </div>
-            <div className="text-muted-foreground text-xs">設問</div>
-          </div>
-          <div>
-            <div className="text-sm font-semibold">{progress.totalItems}</div>
-            <div className="text-muted-foreground text-xs">採点項目</div>
-          </div>
-        </div>
+      </div>
 
-        {/* 採点進捗 */}
-        <div className="space-y-1">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium">採点進捗</span>
-            <span className="text-muted-foreground text-xs">
-              {progress.scoredItems}/{progress.totalItems}
-            </span>
-          </div>
-          <Progress value={progress.scoredPercentage} className="h-1.5" />
-          <div className="text-right">
-            <span className="text-muted-foreground text-xs">
-              {Math.round(progress.scoredPercentage)}%
-            </span>
-          </div>
+      {/* 採点進捗 */}
+      <div className="space-y-0.5">
+        <div className="flex items-center justify-between text-[10px] text-gray-500">
+          <span>採点</span>
+          <span>
+            {progress.scoredItems}/{progress.totalItems} (
+            {Math.round(progress.scoredPercentage)}%)
+          </span>
         </div>
+        <Progress value={progress.scoredPercentage} className="h-1" />
+      </div>
 
-        {/* 最終確定進捗 */}
-        <div className="space-y-1">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium">最終確定</span>
-            <span className="text-muted-foreground text-xs">
-              {progress.finalizedItems}/{progress.totalItems}
-            </span>
-          </div>
-          <Progress value={progress.finalizedPercentage} className="h-1.5" />
-          <div className="text-right">
-            <span className="text-muted-foreground text-xs">
-              {Math.round(progress.finalizedPercentage)}%
-            </span>
-          </div>
+      {/* 最終確定進捗 */}
+      <div className="space-y-0.5">
+        <div className="flex items-center justify-between text-[10px] text-gray-500">
+          <span>確定</span>
+          <span>
+            {progress.finalizedItems}/{progress.totalItems} (
+            {Math.round(progress.finalizedPercentage)}%)
+          </span>
         </div>
-      </CardContent>
-    </Card>
+        <Progress value={progress.finalizedPercentage} className="h-1" />
+      </div>
+    </div>
   )
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
@@ -1,21 +1,6 @@
 "use client"
 
-import {
-  ArrowDown,
-  ArrowLeft,
-  ArrowRight,
-  ArrowUp,
-  Eye,
-  Maximize2,
-  Navigation,
-  RotateCcw,
-  Settings,
-  Sliders,
-} from "lucide-react"
-
 import type { LayoutDirection } from "@/components/exams/07-score-at-once/types"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import {
   Select,
   SelectContent,
@@ -24,29 +9,12 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Slider } from "@/components/ui/slider"
-import { Switch } from "@/components/ui/switch"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
-
-import { SidePanelSection } from "./SidePanelSection"
 
 interface NavigationControlsProps {
   layoutDirection: LayoutDirection
-  selectedAnswersCount: number
-  visibleAnswersCount: number
-  totalAnswersCount: number
   onLayoutDirectionChange: (direction: LayoutDirection) => void
-  onGridNavigation: (direction: string) => void
-  onRefreshView: () => void
-  currentPosition?: { row: number; col: number }
   itemsPerRow?: number[]
   onItemsPerRowChange?: (value: number[]) => void
-  autoScroll?: boolean
-  onAutoScrollChange?: (enabled: boolean) => void
   gradingMode?: "grid" | "individual"
   expandMargin?: number
   onExpandMarginChange?: (value: number) => void
@@ -61,54 +29,33 @@ const LAYOUT_OPTIONS = [
 
 export default function NavigationControls({
   layoutDirection,
-  selectedAnswersCount,
-  visibleAnswersCount,
-  totalAnswersCount,
   onLayoutDirectionChange,
-  onGridNavigation,
-  onRefreshView,
-  currentPosition,
   itemsPerRow,
   onItemsPerRowChange,
-  autoScroll = true,
-  onAutoScrollChange,
   gradingMode = "grid",
   expandMargin,
   onExpandMarginChange,
 }: NavigationControlsProps) {
-  return (
-    <TooltipProvider delayDuration={300}>
-      {/* 表示状況 - 個別表示モードでは非表示 */}
-      {gradingMode !== "individual" && (
-        <SidePanelSection icon={Eye} title="表示状況">
-          <div className="flex items-center gap-3 text-xs">
-            <div className="flex items-center gap-1">
-              <Eye className="h-3 w-3 text-blue-500" />
-              <Badge variant="outline">{visibleAnswersCount}</Badge>
-            </div>
-            <div className="text-gray-400">/</div>
-            <Badge variant="secondary">{totalAnswersCount}</Badge>
-            {selectedAnswersCount > 0 && (
-              <>
-                <div className="text-gray-400">/</div>
-                <Badge className="bg-blue-500">{selectedAnswersCount}</Badge>
-              </>
-            )}
-          </div>
-        </SidePanelSection>
-      )}
+  const isColumnLayout =
+    layoutDirection === "down-right" || layoutDirection === "down-left"
 
-      {/* 1行あたりの表示件数 - 一覧表示モードでのみ表示 */}
-      {gradingMode !== "individual" && itemsPerRow && onItemsPerRowChange && (
-        <SidePanelSection
-          icon={Sliders}
-          title={
-            layoutDirection === "down-right" || layoutDirection === "down-left"
-              ? "1列あたりの表示件数"
-              : "1行あたりの表示件数"
-          }
-        >
-          <div className="flex items-center space-x-4">
+  if (gradingMode === "individual") return null
+
+  return (
+    <div className="space-y-2.5">
+      {/* 1行あたりの表示答案 */}
+      {itemsPerRow && onItemsPerRowChange && (
+        <div className="py-2">
+          <div className="flex items-center justify-between">
+            <span className="shrink-0 text-xs text-gray-500">
+              1{isColumnLayout ? "列" : "行"}あたりの表示答案
+            </span>
+            <span className="text-[10px] text-gray-400">
+              <kbd className="rounded bg-gray-100 px-1 py-0.5">=</kbd> 増 /{" "}
+              <kbd className="rounded bg-gray-100 px-1 py-0.5">-</kbd> 減
+            </span>
+          </div>
+          <div className="mt-1 flex items-center gap-2">
             <Slider
               value={itemsPerRow}
               onValueChange={onItemsPerRowChange}
@@ -117,215 +64,54 @@ export default function NavigationControls({
               step={1}
               className="flex-1"
             />
-            <span className="text-muted-foreground min-w-[30px] text-sm">
+            <span className="text-muted-foreground w-8 shrink-0 text-right text-xs">
               {itemsPerRow[0]}件
             </span>
           </div>
-        </SidePanelSection>
+        </div>
       )}
 
-      {/* 表示領域拡張 - 一覧表示モードでのみ表示 */}
-      {gradingMode !== "individual" &&
-        expandMargin !== undefined &&
-        onExpandMarginChange && (
-          <SidePanelSection icon={Maximize2} title="表示領域拡張">
-            <div className="flex items-center space-x-4">
-              <Slider
-                value={[expandMargin]}
-                onValueChange={(value) => onExpandMarginChange(value[0])}
-                max={50}
-                min={0}
-                step={5}
-                className="flex-1"
-              />
-              <span className="text-muted-foreground min-w-[40px] text-sm">
-                {expandMargin}%
-              </span>
-            </div>
-            <p className="text-xs text-gray-500">
-              枠の外側を表示（スキャンズレ対策）
-            </p>
-          </SidePanelSection>
-        )}
-
-      {/* 自動スクロール設定 - 一覧表示モードでのみ表示 */}
-      {gradingMode !== "individual" && onAutoScrollChange && (
-        <SidePanelSection
-          icon={Settings}
-          title="自動スクロール"
-          rightElement={
-            <Switch checked={autoScroll} onCheckedChange={onAutoScrollChange} />
-          }
-        >
-          <p className="text-xs text-gray-500">
-            WASD移動時に選択答案を画面中央に表示
-          </p>
-        </SidePanelSection>
-      )}
-
-      {/* レイアウト設定 - 一覧表示モードでのみ表示 */}
-      {gradingMode !== "individual" && (
-        <SidePanelSection icon={Navigation} title="レイアウト方向">
-          <Select
-            value={layoutDirection}
-            onValueChange={(value) =>
-              onLayoutDirectionChange(value as LayoutDirection)
-            }
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {LAYOUT_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </SidePanelSection>
-      )}
-
-      {/* WASD移動コントロール - 一覧表示モードでのみ表示 */}
-      {gradingMode !== "individual" && (
-        <SidePanelSection
-          icon={Navigation}
-          title="移動"
-          badge={
-            currentPosition
-              ? `${currentPosition.row + 1}:${currentPosition.col + 1}`
-              : undefined
-          }
-        >
-          {/* 移動ボタン */}
-          <div className="flex flex-col items-center gap-1">
-            {/* 上 */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-10 w-12"
-                  onClick={() => onGridNavigation("w")}
-                >
-                  <ArrowUp className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="text-center">
-                  <div>上に移動</div>
-                  <div className="mt-1 text-xs text-gray-400">
-                    キー:{" "}
-                    <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                      W
-                    </kbd>
-                  </div>
-                </div>
-              </TooltipContent>
-            </Tooltip>
-
-            {/* 中央行: 左・更新・右 */}
-            <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-12"
-                    onClick={() => onGridNavigation("a")}
-                  >
-                    <ArrowLeft className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div>左に移動</div>
-                    <div className="mt-1 text-xs text-gray-400">
-                      キー:{" "}
-                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                        A
-                      </kbd>
-                    </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-12"
-                    onClick={onRefreshView}
-                  >
-                    <RotateCcw className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div>表示を更新</div>
-                    <div className="mt-1 text-xs text-gray-400">
-                      キー:{" "}
-                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                        R
-                      </kbd>
-                    </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-12"
-                    onClick={() => onGridNavigation("d")}
-                  >
-                    <ArrowRight className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div>右に移動</div>
-                    <div className="mt-1 text-xs text-gray-400">
-                      キー:{" "}
-                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                        D
-                      </kbd>
-                    </div>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-
-            {/* 下 */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-10 w-12"
-                  onClick={() => onGridNavigation("s")}
-                >
-                  <ArrowDown className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="text-center">
-                  <div>下に移動</div>
-                  <div className="mt-1 text-xs text-gray-400">
-                    キー:{" "}
-                    <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                      S
-                    </kbd>
-                  </div>
-                </div>
-              </TooltipContent>
-            </Tooltip>
+      {/* 表示領域拡張 */}
+      {expandMargin !== undefined && onExpandMarginChange && (
+        <div className="py-2">
+          <span className="text-xs text-gray-500">表示領域の拡張</span>
+          <div className="mt-1 flex items-center gap-2">
+            <Slider
+              value={[expandMargin]}
+              onValueChange={(value) => onExpandMarginChange(value[0])}
+              max={50}
+              min={0}
+              step={5}
+              className="flex-1"
+            />
+            <span className="text-muted-foreground w-8 shrink-0 text-right text-xs">
+              {expandMargin}%
+            </span>
           </div>
-        </SidePanelSection>
+        </div>
       )}
-    </TooltipProvider>
+
+      {/* 配置方向 */}
+      <div className="flex items-center gap-2">
+        <span className="shrink-0 text-xs text-gray-500">配置方向</span>
+        <Select
+          value={layoutDirection}
+          onValueChange={(value) =>
+            onLayoutDirectionChange(value as LayoutDirection)
+          }
+        >
+          <SelectTrigger className="h-7 flex-1 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LAYOUT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
   )
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/QuestionNavigator.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/QuestionNavigator.tsx
@@ -40,6 +40,9 @@ interface QuestionNavigatorProps {
       percentage: number
     }
   }
+  collapsible?: boolean
+  isOpen?: boolean
+  onToggle?: () => void
 }
 
 export default function QuestionNavigator({
@@ -49,6 +52,9 @@ export default function QuestionNavigator({
   onPrevQuestion,
   onNextQuestion,
   questionProgress,
+  collapsible = false,
+  isOpen = true,
+  onToggle,
 }: QuestionNavigatorProps) {
   const currentIndex = currentCropRegion
     ? questionRegions.findIndex((q) => q.id === currentCropRegion.id)
@@ -75,7 +81,13 @@ export default function QuestionNavigator({
   }
   return (
     <TooltipProvider delayDuration={300}>
-      <SidePanelSection icon={FileText} title="設問">
+      <SidePanelSection
+        icon={FileText}
+        title="設問"
+        collapsible={collapsible}
+        isOpen={isOpen}
+        onToggle={onToggle}
+      >
         {/* ナビゲーション: [前] [設問プルダウン] [次] */}
         <div className="flex items-center gap-2">
           <Tooltip>

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -1,7 +1,21 @@
 "use client"
 
+import {
+  AlertTriangle,
+  BarChart3,
+  CheckCircle,
+  Circle,
+  Clock,
+  CopyX,
+  Eye,
+  Layout,
+  Minus,
+  User,
+  X,
+} from "lucide-react"
 import { useEffect, useRef } from "react"
 
+import { useKeyBindings } from "@/components/exams/07-score-at-once/hooks/useKeyBindings"
 import { QuestionProgress } from "@/components/exams/07-score-at-once/ScoringData/types/scoringDataTypes"
 import { IndividualModePanel } from "@/components/exams/07-score-at-once/ScoringIndividual/IndividualModePanel"
 import ExamProgressCard from "@/components/exams/07-score-at-once/ScoringSidePanel/ExamProgressCard"
@@ -17,11 +31,47 @@ import type {
   ScoringStatus,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
-import { Separator } from "@/components/ui/separator"
+import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
+import type { ScoringStatusType } from "@/lib/scoringStatusColors"
+
+const STATUS_MAP: Record<string, ScoringStatusType> = {
+  unscored: "unscored",
+  correct: "correct",
+  partial: "partial",
+  pending: "pending",
+  incorrect: "incorrect",
+  no_answer: "no_answer",
+  double_mark: "double_mark",
+}
+
+const FILTER_BUTTONS = [
+  { key: "unscored", label: "未採点", icon: Circle },
+  { key: "correct", label: "正答", icon: CheckCircle },
+  { key: "partial", label: "部分点", icon: AlertTriangle },
+  { key: "pending", label: "保留", icon: Clock },
+  { key: "incorrect", label: "誤答", icon: X },
+  { key: "no_answer", label: "無答", icon: Minus },
+  { key: "double_mark", label: "Wマーク", icon: CopyX },
+] as const
+
+const GRID_4_3_STYLE = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, 1fr)",
+  gap: "0.5rem",
+} as const
 
 import { AnnotationBrowserPanel } from "./AnnotationBrowserPanel"
 import { useAnnotationBrowser } from "./hooks/useAnnotationBrowser"
+import { useSidePanelCollapse } from "./hooks/useSidePanelCollapse"
+import { SidePanelSection } from "./SidePanelSection"
 
 interface ScoringSidePanelProps {
   examId: string
@@ -49,14 +99,22 @@ interface ScoringSidePanelProps {
   ) => void
   onToggleFilter: (filterId: string) => void
   onRefreshFilter: () => void
+  onSelectAll?: () => void
+  onSelectUnscored?: () => void
   partialScoreInput: string
+  clickScoringConfig?: import("@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig").ClickScoringConfig
+  clickScoringDebounceMs?: number
+  onClickActionChange?: (
+    clickCount: 2 | 3 | 4,
+    action: import("@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig").ClickScoringAction
+  ) => void
+  onClickScoringDebounceMsChange?: (value: number) => void
   // Navigation Controls props
   layoutDirection: LayoutDirection
   visibleAnswersCount: number
   totalAnswersCount: number
   onLayoutDirectionChange: (direction: LayoutDirection) => void
   onGridNavigation: (direction: string) => void
-  onRefreshView: () => void
   itemsPerLine: number[]
   onItemsPerLineChange: (value: number[]) => void
   autoScroll: boolean
@@ -120,13 +178,18 @@ export function ScoringSidePanel({
   onScore,
   onToggleFilter,
   onRefreshFilter,
+  onSelectAll,
+  onSelectUnscored,
   partialScoreInput,
+  clickScoringConfig,
+  clickScoringDebounceMs,
+  onClickActionChange,
+  onClickScoringDebounceMsChange,
   layoutDirection,
   visibleAnswersCount,
   totalAnswersCount,
   onLayoutDirectionChange,
   onGridNavigation,
-  onRefreshView,
   itemsPerLine,
   onItemsPerLineChange,
   autoScroll,
@@ -160,6 +223,9 @@ export function ScoringSidePanel({
   onMasterAnswerHide,
 }: ScoringSidePanelProps) {
   const annotationBrowser = useAnnotationBrowser()
+  const { keyBindings } = useKeyBindings()
+  const scoringColors = useScoringStatusColors()
+  const { isSectionOpen, toggleSection } = useSidePanelCollapse()
   const { loadAnnotations: reloadBrowserAnnotations } = annotationBrowser
 
   // キャンバスでアノテーション変更時にブラウザ一覧をリロード
@@ -191,7 +257,18 @@ export function ScoringSidePanel({
           <TabsTrigger value="annotations">アノテーション</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="scoring" className="flex-1 overflow-y-auto px-4">
+        <TabsContent value="scoring" className="flex-1 overflow-y-auto px-3">
+          {/* 進捗 */}
+          <SidePanelSection
+            icon={BarChart3}
+            title="進捗"
+            collapsible
+            isOpen={isSectionOpen("progress")}
+            onToggle={() => toggleSection("progress")}
+          >
+            <ExamProgressCard examId={examId} />
+          </SidePanelSection>
+
           {/* 設問ナビゲーター */}
           <QuestionNavigator
             questionRegions={cropRegions}
@@ -200,20 +277,137 @@ export function ScoringSidePanel({
             onPrevQuestion={onPrevQuestion}
             onNextQuestion={onNextQuestion}
             questionProgress={questionProgress}
+            collapsible
+            isOpen={isSectionOpen("question")}
+            onToggle={() => toggleSection("question")}
           />
 
-          <Separator />
+          {/* 表示 */}
+          <SidePanelSection
+            icon={Layout}
+            title="表示"
+            collapsible
+            isOpen={isSectionOpen("display")}
+            onToggle={() => toggleSection("display")}
+            rightElement={
+              gradingMode === "grid" ? (
+                <div className="flex items-center gap-0.5 text-[10px] text-gray-500">
+                  {selectedAnswersCount > 0 && (
+                    <>
+                      <span>選択</span>
+                      <span className="font-medium text-blue-600">
+                        {selectedAnswersCount}
+                      </span>
+                      <span className="text-gray-300">|</span>
+                    </>
+                  )}
+                  <span>表示</span>
+                  <span className="font-medium">{visibleAnswersCount}</span>
+                  <span className="text-gray-300">|</span>
+                  <span>全体</span>
+                  <span className="font-medium">{totalAnswersCount}</span>
+                </div>
+              ) : undefined
+            }
+          >
+            <div className="space-y-3">
+              {/* 表示フィルター */}
+              {gradingMode === "grid" && onToggleFilter && (
+                <TooltipProvider delayDuration={300}>
+                  <div style={GRID_4_3_STYLE}>
+                    {FILTER_BUTTONS.map((button) => {
+                      const Icon = button.icon
+                      const isActive =
+                        filterSettings[
+                          button.key as keyof typeof filterSettings
+                        ]
+                      const statusKey =
+                        button.key === "no_answer"
+                          ? "NoAnswer"
+                          : button.key.charAt(0).toUpperCase() +
+                            button.key.slice(1)
+                      const commandId = `filter.toggle${statusKey}`
+                      const keyBinding = keyBindings[commandId] || "?"
+                      const colors = scoringColors[STATUS_MAP[button.key]]
+                      return (
+                        <Tooltip key={button.key}>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="flex h-10 w-full min-w-0 items-center gap-1 border-2 px-1"
+                              style={
+                                isActive
+                                  ? {
+                                      backgroundColor: colors.bg,
+                                      color: colors.text,
+                                      borderColor: colors.icon,
+                                    }
+                                  : {
+                                      backgroundColor: "transparent",
+                                      color: colors.icon,
+                                      borderColor: colors.icon,
+                                    }
+                              }
+                              onClick={() => onToggleFilter(button.key)}
+                            >
+                              <Icon className="h-3 w-3 shrink-0" />
+                              <span className="w-10 shrink-0 text-center text-[10px]">
+                                {button.label}
+                              </span>
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="text-center">
+                              <div className="font-medium">
+                                {button.label}を{isActive ? "非表示" : "表示"}
+                              </div>
+                              <div className="mt-1 text-xs text-gray-400">
+                                キー:{" "}
+                                <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
+                                  {keyBinding.toUpperCase()}
+                                </kbd>
+                              </div>
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      )
+                    })}
+                  </div>
+                </TooltipProvider>
+              )}
+
+              {/* レイアウト・表示設定 */}
+              <NavigationControls
+                layoutDirection={layoutDirection}
+                onLayoutDirectionChange={onLayoutDirectionChange}
+                itemsPerRow={itemsPerLine}
+                onItemsPerRowChange={onItemsPerLineChange}
+                gradingMode={gradingMode}
+                expandMargin={expandMargin}
+                onExpandMarginChange={onExpandMarginChange}
+              />
+            </div>
+          </SidePanelSection>
 
           {/* 採点ツールバー */}
           <ScoringToolbar
             selectedAnswersCount={selectedAnswersCount}
-            currentCropRegion={currentCropRegion}
-            filterSettings={filterSettings}
             onScore={onScore}
-            onToggleFilter={onToggleFilter}
+            onSelectAll={onSelectAll}
+            onSelectUnscored={onSelectUnscored}
             onRefreshFilter={onRefreshFilter}
             partialScoreInput={partialScoreInput}
             gradingMode={gradingMode}
+            clickScoringConfig={clickScoringConfig}
+            clickScoringDebounceMs={clickScoringDebounceMs}
+            onClickActionChange={onClickActionChange}
+            onClickScoringDebounceMsChange={onClickScoringDebounceMsChange}
+            autoScroll={autoScroll}
+            onAutoScrollChange={onAutoScrollChange}
+            onGridNavigation={onGridNavigation}
+            isSectionOpen={isSectionOpen}
+            onToggleSection={toggleSection}
           />
 
           {/* 個別表示モード時：生徒選択パネル */}
@@ -222,8 +416,13 @@ export function ScoringSidePanel({
             onStudentChange &&
             onScoringBehaviorChange &&
             scoringBehavior && (
-              <>
-                <Separator />
+              <SidePanelSection
+                icon={User}
+                title="生徒選択"
+                collapsible
+                isOpen={isSectionOpen("individualMode")}
+                onToggle={() => toggleSection("individualMode")}
+              >
                 <IndividualModePanel
                   students={students}
                   selectedAnswers={selectedStudentAnswerImageIds}
@@ -232,15 +431,20 @@ export function ScoringSidePanel({
                   scoringBehavior={scoringBehavior}
                   onScoringBehaviorChange={onScoringBehaviorChange}
                 />
-              </>
+              </SidePanelSection>
             )}
 
           {/* 個別表示モード時：模範解答表示設定 */}
           {gradingMode === "individual" &&
             masterAnswerDisplayMode !== undefined &&
             onMasterAnswerDisplayModeChange && (
-              <>
-                <Separator />
+              <SidePanelSection
+                icon={Eye}
+                title="模範解答"
+                collapsible
+                isOpen={isSectionOpen("masterAnswer")}
+                onToggle={() => toggleSection("masterAnswer")}
+              >
                 <MasterAnswerControls
                   displayMode={masterAnswerDisplayMode}
                   opacity={masterAnswerOpacity ?? 50}
@@ -255,35 +459,8 @@ export function ScoringSidePanel({
                   onMasterAnswerShow={onMasterAnswerShow}
                   onMasterAnswerHide={onMasterAnswerHide}
                 />
-              </>
+              </SidePanelSection>
             )}
-
-          <Separator />
-
-          {/* ナビゲーション制御 */}
-          <NavigationControls
-            layoutDirection={layoutDirection}
-            selectedAnswersCount={selectedAnswersCount}
-            visibleAnswersCount={visibleAnswersCount}
-            totalAnswersCount={totalAnswersCount}
-            onLayoutDirectionChange={onLayoutDirectionChange}
-            onGridNavigation={onGridNavigation}
-            onRefreshView={onRefreshView}
-            itemsPerRow={itemsPerLine}
-            onItemsPerRowChange={onItemsPerLineChange}
-            autoScroll={autoScroll}
-            onAutoScrollChange={onAutoScrollChange}
-            gradingMode={gradingMode}
-            expandMargin={expandMargin}
-            onExpandMarginChange={onExpandMarginChange}
-          />
-
-          <Separator />
-
-          {/* 試験進捗 */}
-          <div className="py-3">
-            <ExamProgressCard examId={examId} />
-          </div>
         </TabsContent>
 
         <TabsContent value="annotations" className="flex-1 overflow-y-auto">

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -2,20 +2,37 @@
 
 import {
   AlertTriangle,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
   CheckCircle,
   Circle,
   Clock,
   CopyX,
   Minus,
-  RefreshCw,
   Target,
   X,
 } from "lucide-react"
+import { useState } from "react"
 
 import { useKeyBindings } from "@/components/exams/07-score-at-once/hooks/useKeyBindings"
+import type {
+  ClickScoringAction,
+  ClickScoringConfig,
+} from "@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig"
 import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Slider } from "@/components/ui/slider"
+import { Switch } from "@/components/ui/switch"
 import {
   Tooltip,
   TooltipContent,
@@ -23,31 +40,46 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
+import { getModifierKeyLabel } from "@/lib/platformUtils"
 import type { ScoringStatusType } from "@/lib/scoringStatusColors"
 
 import { SidePanelSection } from "./SidePanelSection"
+
+/** ショートカットキー表示用ヘルパー */
+function KeyHint({ label }: { label: string }) {
+  return (
+    <div className="mt-1 text-xs text-gray-400">
+      キー:{" "}
+      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">{label}</kbd>
+    </div>
+  )
+}
 
 interface ScoringToolbarProps {
   selectedAnswersCount: number
   currentCropRegion?: {
     points: number | null
   } | null
-  filterSettings?: {
-    unscored: boolean
-    correct: boolean
-    incorrect: boolean
-    partial: boolean
-    pending: boolean
-    no_answer: boolean
-  }
   onScore: (status: ScoringStatus) => void
-  onToggleFilter?: (key: string) => void
+  onSelectAll?: () => void
+  onSelectUnscored?: () => void
   onRefreshFilter?: () => void
   partialScoreInput: string
-  gradingMode?: "grid" | "individual" // 採点モード
+  gradingMode?: "grid" | "individual"
+  clickScoringConfig?: ClickScoringConfig
+  clickScoringDebounceMs?: number
+  onClickActionChange?: (
+    clickCount: 2 | 3 | 4,
+    action: ClickScoringAction
+  ) => void
+  onClickScoringDebounceMsChange?: (value: number) => void
+  autoScroll?: boolean
+  onAutoScrollChange?: (enabled: boolean) => void
+  onGridNavigation?: (direction: string) => void
+  isSectionOpen?: (sectionId: string) => boolean
+  onToggleSection?: (sectionId: string) => void
 }
 
-// ScoringStatus -> ScoringStatusType へのマッピング（統一済み）
 const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
   unscored: "unscored",
   correct: "correct",
@@ -58,7 +90,6 @@ const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
   double_mark: "double_mark",
 }
 
-// 採点ボタン設定（色はuseScoringStatusColorsから動的取得）
 const SCORING_BUTTONS = [
   {
     status: "unscored" as ScoringStatus,
@@ -104,47 +135,56 @@ const SCORING_BUTTONS = [
   },
 ] as const
 
-// フィルターボタン設定（色はuseScoringStatusColorsから動的取得）
-const FILTER_BUTTONS = [
-  { key: "unscored", filterKey: "unscored", label: "未採点", icon: Circle },
-  { key: "correct", filterKey: "correct", label: "正答", icon: CheckCircle },
-  {
-    key: "partial",
-    filterKey: "partial",
-    label: "部分点",
-    icon: AlertTriangle,
-  },
-  { key: "pending", filterKey: "pending", label: "保留", icon: Clock },
-  { key: "incorrect", filterKey: "incorrect", label: "誤答", icon: X },
-  { key: "no_answer", filterKey: "no_answer", label: "無答", icon: Minus },
-  {
-    key: "double_mark",
-    filterKey: "double_mark",
-    label: "Wマーク",
-    icon: CopyX,
-  },
-] as const
+const CLICK_ACTION_OPTIONS: { value: ClickScoringAction; label: string }[] = [
+  { value: "none", label: "なし" },
+  { value: "correct", label: "正答" },
+  { value: "incorrect", label: "誤答" },
+  { value: "partial_modal", label: "部分点入力" },
+  { value: "partial", label: "部分点（非推奨）" },
+  { value: "pending", label: "保留（非推奨）" },
+  { value: "unscored", label: "未採点" },
+  { value: "no_answer", label: "無答" },
+  { value: "double_mark", label: "Wマーク" },
+  { value: "individual", label: "個別表示" },
+]
+
+const GRID_4_3_STYLE = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, 1fr)",
+  gap: "0.5rem",
+} as const
 
 export default function ScoringToolbar({
   selectedAnswersCount,
-  filterSettings,
   onScore,
-  onToggleFilter,
+  onSelectAll,
+  onSelectUnscored,
   onRefreshFilter,
   partialScoreInput,
   gradingMode = "grid",
+  clickScoringConfig,
+  clickScoringDebounceMs = 300,
+  onClickActionChange,
+  onClickScoringDebounceMsChange,
+  autoScroll = true,
+  onAutoScrollChange,
+  onGridNavigation,
+  isSectionOpen,
+  onToggleSection,
 }: ScoringToolbarProps) {
-  // 新しいショートカットシステム: キーバインディング取得
   const { keyBindings } = useKeyBindings()
-  // 動的採点状態色を取得
   const scoringColors = useScoringStatusColors()
+  const [modifierKeyLabel] = useState(() => getModifierKeyLabel() || "Alt")
+  const ctrlLabel = modifierKeyLabel === "Option" ? "⌘" : "Ctrl"
 
   return (
     <TooltipProvider delayDuration={300}>
-      {/* 採点セクション */}
       <SidePanelSection
         icon={Target}
         title="採点"
+        collapsible={!!onToggleSection}
+        isOpen={isSectionOpen?.("scoring") ?? true}
+        onToggle={() => onToggleSection?.("scoring")}
         badge={
           selectedAnswersCount > 0 ? `${selectedAnswersCount}件` : undefined
         }
@@ -160,137 +200,273 @@ export default function ScoringToolbar({
           ) : undefined
         }
       >
-        <div className="grid grid-cols-3 gap-2">
-          {SCORING_BUTTONS.map((button) => {
-            const Icon = button.icon
-            // コマンドIDからキーバインディングを取得
-            const commandId = `scoring.${button.status === "no_answer" ? "noAnswer" : button.status}`
-            const keyBinding = keyBindings[commandId] || "?"
-            // 動的色を取得
-            const statusType = STATUS_MAP[button.status]
-            const colors = scoringColors[statusType]
-            return (
-              <Tooltip key={button.status}>
+        <div className="space-y-3">
+          {/* 採点ボタン */}
+          <div style={GRID_4_3_STYLE}>
+            {SCORING_BUTTONS.map((button) => {
+              const Icon = button.icon
+              const commandId = `scoring.${button.status === "no_answer" ? "noAnswer" : button.status}`
+              const keyBinding = keyBindings[commandId] || "?"
+              const statusType = STATUS_MAP[button.status]
+              const colors = scoringColors[statusType]
+              return (
+                <Tooltip key={button.status}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className={`flex h-12 flex-col gap-1 border-2 ${
+                        selectedAnswersCount === 0
+                          ? "cursor-not-allowed opacity-50"
+                          : "hover:opacity-80"
+                      }`}
+                      style={{
+                        backgroundColor: colors.bg,
+                        color: colors.text,
+                        borderColor: colors.bg,
+                      }}
+                      onClick={() => onScore(button.status)}
+                      disabled={selectedAnswersCount === 0}
+                    >
+                      <Icon className="h-4 w-4" />
+                      <div className="text-xs">{button.label}</div>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">{button.description}</div>
+                      <KeyHint label={keyBinding.toUpperCase()} />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              )
+            })}
+          </div>
+
+          {/* 選択操作 */}
+          {gradingMode === "grid" && (
+            <div className="space-y-1">
+              {onSelectUnscored && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-xs"
+                  onClick={onSelectUnscored}
+                >
+                  未採点の生徒答案を全て選択
+                </Button>
+              )}
+              {onSelectAll && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={onSelectAll}
+                    >
+                      表示されている生徒答案を全て選択
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">表示中の答案を全て選択</div>
+                      <KeyHint label={`${ctrlLabel}+A`} />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              {onRefreshFilter && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={onRefreshFilter}
+                    >
+                      表示フィルターに合わせて表示を更新
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">フィルターを再適用</div>
+                      <KeyHint label="R" />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          )}
+
+          {/* クリックで採点 */}
+          {gradingMode === "grid" &&
+            clickScoringConfig &&
+            onClickActionChange && (
+              <div className="space-y-1.5">
+                {([2, 3, 4] as const).map((clickCount) => {
+                  const labels = {
+                    2: "ダブルクリック:",
+                    3: "トリプルクリック:",
+                    4: "クアトロクリック:",
+                  }
+                  return (
+                    <div
+                      key={clickCount}
+                      className="flex items-center justify-between text-xs"
+                    >
+                      <span className="text-gray-600">
+                        {labels[clickCount]}
+                      </span>
+                      <Select
+                        value={clickScoringConfig[clickCount]}
+                        onValueChange={(v) =>
+                          onClickActionChange(
+                            clickCount,
+                            v as ClickScoringAction
+                          )
+                        }
+                      >
+                        <SelectTrigger className="h-7 w-60 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CLICK_ACTION_OPTIONS.map((opt) => (
+                            <SelectItem
+                              key={opt.value}
+                              value={opt.value}
+                              className="text-xs"
+                            >
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )
+                })}
+
+                {onClickScoringDebounceMsChange && (
+                  <div className="space-y-0.5">
+                    <span className="text-[10px] text-gray-500">
+                      クリックの最長間隔
+                    </span>
+                    <div className="flex items-center gap-2 text-xs text-gray-600">
+                      <span className="shrink-0 text-base" title="速い">
+                        🐇
+                      </span>
+                      <Slider
+                        className="flex-1"
+                        value={[clickScoringDebounceMs]}
+                        min={100}
+                        max={800}
+                        step={50}
+                        onValueChange={([v]) =>
+                          onClickScoringDebounceMsChange(v)
+                        }
+                      />
+                      <span className="shrink-0 text-base" title="遅い">
+                        🐢
+                      </span>
+                      <span className="w-10 shrink-0 text-right text-[10px] text-gray-400">
+                        {clickScoringDebounceMs}ms
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+          {/* 自動スクロール */}
+          {gradingMode === "grid" && onAutoScrollChange && (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-500">自動スクロール</span>
+              <Switch
+                checked={autoScroll}
+                onCheckedChange={onAutoScrollChange}
+              />
+            </div>
+          )}
+
+          {/* WASD移動（横一列） */}
+          {gradingMode === "grid" && onGridNavigation && (
+            <div className="flex items-center justify-center gap-1">
+              <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="outline"
                     size="sm"
-                    className={`flex h-12 flex-col gap-1 border-2 ${
-                      selectedAnswersCount === 0
-                        ? "cursor-not-allowed opacity-50"
-                        : "hover:opacity-80"
-                    }`}
-                    style={{
-                      backgroundColor: colors.bg,
-                      color: colors.text,
-                      borderColor: colors.bg,
-                    }}
-                    onClick={() => onScore(button.status)}
-                    disabled={selectedAnswersCount === 0}
+                    className="h-7 w-8"
+                    onClick={() => onGridNavigation("a")}
                   >
-                    <Icon className="h-4 w-4" />
-                    <div className="text-xs">{button.label}</div>
+                    <ArrowLeft className="h-3.5 w-3.5" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                   <div className="text-center">
-                    <div className="font-medium">{button.description}</div>
-                    <div className="mt-1 text-xs text-gray-400">
-                      キー:{" "}
-                      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                        {keyBinding.toUpperCase()}
-                      </kbd>
-                    </div>
+                    <div className="font-medium">左に移動</div>
+                    <KeyHint label="A" />
                   </div>
                 </TooltipContent>
               </Tooltip>
-            )
-          })}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-8"
+                    onClick={() => onGridNavigation("w")}
+                  >
+                    <ArrowUp className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-center">
+                    <div className="font-medium">上に移動</div>
+                    <KeyHint label="W" />
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-8"
+                    onClick={() => onGridNavigation("s")}
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-center">
+                    <div className="font-medium">下に移動</div>
+                    <KeyHint label="S" />
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-8"
+                    onClick={() => onGridNavigation("d")}
+                  >
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-center">
+                    <div className="font-medium">右に移動</div>
+                    <KeyHint label="D" />
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
       </SidePanelSection>
-
-      {/* フィルターセクション - グリッド表示時のみ */}
-      {gradingMode === "grid" &&
-        filterSettings &&
-        onToggleFilter &&
-        onRefreshFilter && (
-          <SidePanelSection
-            icon={RefreshCw}
-            title="フィルター"
-            rightElement={
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={onRefreshFilter}
-                className="h-6 px-2 text-xs"
-              >
-                <RefreshCw className="mr-1 h-3 w-3" />
-                更新
-              </Button>
-            }
-          >
-            <div className="grid grid-cols-3 gap-2">
-              {FILTER_BUTTONS.map((button) => {
-                const Icon = button.icon
-                const isActive =
-                  filterSettings[
-                    button.filterKey as keyof typeof filterSettings
-                  ]
-                // コマンドIDからキーバインディングを取得
-                const statusKey =
-                  button.key === "no_answer"
-                    ? "NoAnswer"
-                    : button.key.charAt(0).toUpperCase() + button.key.slice(1)
-                const commandId = `filter.toggle${statusKey}`
-                const keyBinding = keyBindings[commandId] || "?"
-                // 動的色を取得
-                const statusType = STATUS_MAP[button.key as ScoringStatus]
-                const colors = scoringColors[statusType]
-                return (
-                  <Tooltip key={button.key}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="flex h-10 items-center gap-2 border-2"
-                        style={
-                          isActive
-                            ? {
-                                backgroundColor: colors.bg,
-                                color: colors.text,
-                                borderColor: colors.icon,
-                              }
-                            : {
-                                backgroundColor: "transparent",
-                                color: colors.icon,
-                                borderColor: colors.icon,
-                              }
-                        }
-                        onClick={() => onToggleFilter(button.key)}
-                      >
-                        <Icon className="h-3 w-3" />
-                        <div className="text-xs">{button.label}</div>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div className="text-center">
-                        <div className="font-medium">
-                          {button.label}を{isActive ? "非表示" : "表示"}
-                        </div>
-                        <div className="mt-1 text-xs text-gray-400">
-                          キー:{" "}
-                          <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">
-                            {keyBinding.toUpperCase()}
-                          </kbd>
-                        </div>
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
-                )
-              })}
-            </div>
-          </SidePanelSection>
-        )}
     </TooltipProvider>
   )
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/SidePanelSection.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/SidePanelSection.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { LucideIcon } from "lucide-react"
+import { ChevronDown, ChevronRight, LucideIcon } from "lucide-react"
 import { ReactNode } from "react"
 
 interface SidePanelSectionProps {
-  // セクションヘッダー
   icon: LucideIcon
   title: string
   badge?: string | number
   rightElement?: ReactNode
-
-  // セクション内容
   children: ReactNode
-
-  // スタイル設定
+  collapsible?: boolean
+  isOpen?: boolean
+  onToggle?: () => void
   className?: string
 }
 
 /**
  * サイドパネル内の統一されたセクションコンポーネント
- * icon, title, contentの共通構造を提供
+ * セクション間はborder-bottomで区切り（Separator不要）
  */
 export function SidePanelSection({
   icon: Icon,
@@ -27,28 +25,45 @@ export function SidePanelSection({
   badge,
   rightElement,
   children,
+  collapsible = false,
+  isOpen = true,
+  onToggle,
   className = "",
 }: SidePanelSectionProps) {
-  return (
-    <div className={`py-3 ${className}`}>
-      {/* セクションヘッダー（統一スタイル） */}
-      <div className="mb-2 flex items-center gap-2">
-        <Icon className="h-4 w-4 text-gray-500" />
-        <span className="text-sm font-medium text-gray-700">{title}</span>
+  const open = collapsible ? isOpen : true
 
-        {/* バッジ表示 */}
+  return (
+    <div
+      className={`border-b border-gray-100 py-2 last:border-b-0 ${className}`}
+    >
+      {/* セクションヘッダー */}
+      <div
+        className={`flex items-center gap-1.5 ${open ? "mb-1.5" : ""} ${collapsible ? "cursor-pointer select-none" : ""}`}
+        onClick={collapsible ? onToggle : undefined}
+      >
+        {collapsible &&
+          (open ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-gray-400" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-gray-400" />
+          ))}
+        <Icon className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+        <span className="text-xs font-medium text-gray-600">{title}</span>
+
         {badge && (
-          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+          <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500">
             {badge}
           </span>
         )}
 
-        {/* 右端要素（ボタン等） */}
-        {rightElement && <div className="ml-auto">{rightElement}</div>}
+        {rightElement && (
+          <div className="ml-auto" onClick={(e) => e.stopPropagation()}>
+            {rightElement}
+          </div>
+        )}
       </div>
 
-      {/* セクション内容 */}
-      <div>{children}</div>
+      {open && <div>{children}</div>}
     </div>
   )
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useSidePanelCollapse.ts
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useSidePanelCollapse.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview サイドパネルセクション折りたたみ状態管理フック
+ * @description 閉じたセクションIDをUserPreferenceに永続化（既定は全展開）
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useAuth } from "@/contexts/AuthContext"
+import { parsePreference, serializePreference } from "@/lib/userPreferences"
+
+/** セクション折りたたみ状態をユーザー設定として永続化するフック */
+export function useSidePanelCollapse() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  // 閉じているセクションIDのSet（既定は空＝全展開）
+  const [collapsedSections, setCollapsedSectionsState] = useState<Set<string>>(
+    new Set()
+  )
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (initializedUserIdRef.current === userId) return
+    if (!userId) return
+
+    initializedUserIdRef.current = userId
+
+    const load = async () => {
+      if (!window.electronAPI?.settings) return
+
+      try {
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "sidePanelCollapsedSections"
+        )
+        if (result.success) {
+          const raw = parsePreference(
+            "sidePanelCollapsedSections",
+            result.value ?? null
+          )
+          if (raw) {
+            try {
+              const parsed = JSON.parse(raw)
+              if (Array.isArray(parsed)) {
+                setCollapsedSectionsState(new Set(parsed))
+              }
+            } catch {
+              // keep default
+            }
+          }
+        }
+      } catch (error) {
+        console.error("パネル折りたたみ設定の読み込みに失敗しました:", error)
+      }
+    }
+
+    load()
+  }, [userId])
+
+  /** 保存処理 */
+  const save = useCallback(
+    (next: Set<string>) => {
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "sidePanelCollapsedSections",
+            serializePreference(
+              "sidePanelCollapsedSections",
+              JSON.stringify(Array.from(next))
+            )
+          )
+          .catch((error) =>
+            console.error("パネル折りたたみ設定の保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  /** セクションの開閉をトグル */
+  const toggleSection = useCallback(
+    (sectionId: string) => {
+      setCollapsedSectionsState((prev) => {
+        const next = new Set(prev)
+        if (next.has(sectionId)) {
+          next.delete(sectionId)
+        } else {
+          next.add(sectionId)
+        }
+        save(next)
+        return next
+      })
+    },
+    [save]
+  )
+
+  /** セクションが開いているか */
+  const isSectionOpen = useCallback(
+    (sectionId: string) => !collapsedSections.has(sectionId),
+    [collapsedSections]
+  )
+
+  return { isSectionOpen, toggleSection }
+}

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -39,6 +39,15 @@ export const USER_PREFERENCE_SCHEMA = {
     default: "toggle",
     validate: (v: string) => ["toggle", "hold-to-show"].includes(v),
   },
+  clickScoringConfig: {
+    type: "string?" as const,
+    default: null as string | null,
+  },
+  clickScoringDebounceMs: { type: "number" as const, default: 300 },
+  sidePanelCollapsedSections: {
+    type: "string?" as const,
+    default: null as string | null,
+  },
 } as const
 
 /** 設定キーの型 */
@@ -57,6 +66,9 @@ export type PreferenceValueType = {
   masterAnswerDisplayMode: string
   masterAnswerOpacity: number
   masterAnswerKeyBehavior: string
+  clickScoringConfig: string | null
+  clickScoringDebounceMs: number
+  sidePanelCollapsedSections: string | null
 }
 
 /**


### PR DESCRIPTION
## Summary
- #741 の要望に基づき、マウスクリックのみで採点を完結させる機能を追加
- サイドパネルの構造を4セクション（進捗・設問・表示・採点）に統合し、視覚的に整理
- 全ボタンにTooltip+ショートカットキー表示を追加（Mac/Windows対応）

## 関連Issue
Closes #742, Closes #743, Closes #744, Closes #745

### #742 ダブルクリックで正答/誤答の採点機能
- ダブル/トリプル/クアトロクリックに全採点種別+部分点入力+個別表示を割当可能
- 生徒答案ごとに独立したデバウンスで、クリックするたびに有効時間を延長し終了後に確定
- デバウンス時間をスライダーで調整可能（🐇〜🐢）
- UserPreferenceに永続化

### #743 トリプルクリックで部分点設定モーダル展開
- クリック採点設定でトリプルクリックに「部分点入力」を割当（デフォルト）
- `usePartialScore.openPartialScoreModal()` を追加

### #744 部分点設定モーダルにNumPad実装
- PartialScoreModal内にクリック可能な数値パッド（0-9, ., ⌫）を追加
- `onMouseDown` + `preventDefault` でInputフォーカスを維持

### #745 採点パネルに全選択ボタン追加
- 「未採点の生徒答案を全て選択」「表示されている生徒答案を全て選択」「表示フィルターに合わせて表示を更新」を採点パネル内に配置

## その他の変更
- サイドパネルを7→4セクションに統合（採点+選択操作+クリック採点→採点、表示フィルター+表示設定→表示）
- 全セクション折りたたみ対応（開閉状態をUserPreferenceに永続化、既定は全展開）
- 採点/フィルターボタンを4+3等幅グリッドレイアウトに変更
- ExamProgressCardのCard除去によるフラット化
- Separator全削除、border-bottom統一による視覚的整理
- 表示件数ショートカットキー（=/-）を実装（useScoringNavigationの空実装を置換）
- hooks整理（不要props/返り値/underscore変数を削除）

## Test plan
- [ ] グリッドモードでダブルクリック→設定に応じた採点が実行される
- [ ] トリプルクリック→部分点モーダルが開く（ダブルクリック採点はキャンセル）
- [ ] クアトロクリック→個別表示モードに切り替わる
- [ ] 異なる生徒答案へのクリックが独立してデバウンスされる
- [ ] NumPadで部分点を入力・確定できる
- [ ] パネルの折りたたみ→再展開が永続化される
- [ ] = キーで表示件数増加、- キーで減少
- [ ] Mac/Windowsで修飾キー表記が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)