### PR TITLE
feat: 答案プレビュー段階での動的マーカー補正

### DIFF
--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../src/types/omr.types"
 import { getDataDirectory } from "../lib/dataManager"
 import {
+  correctImage,
   createTransform,
   detectCornerMarkers,
   loadImageRaw,
@@ -353,5 +354,74 @@ export function setupOMRHandlers(): void {
       }
     },
     "マスターマーカー検出に失敗しました"
+  )
+
+  // ────────────────────────────────────────
+  // 単一画像補正（クライアント側プレビュー用）
+  // ────────────────────────────────────────
+  registerSafeHandler(
+    "omr:correct-image",
+    async (
+      examId: string,
+      pageNumber: number,
+      buffer: Uint8Array,
+      colorThreshold?: number
+    ): Promise<{
+      success: boolean
+      correctedBuffer?: Uint8Array
+      status: "corrected" | "skipped"
+      error?: string
+    }> => {
+      const cacheKey = `${examId}:${pageNumber}`
+      let masterResult = masterMarkerCache.get(cacheKey)
+
+      if (!masterResult) {
+        const masterImage = await prisma.masterImage.findFirst({
+          where: { examPage: { examId, pageNumber } },
+          include: { examPage: true },
+        })
+        if (!masterImage) {
+          return {
+            success: false,
+            status: "skipped",
+            error: "マスター画像が見つかりません",
+          }
+        }
+        const dataDir = getDataDirectory()
+        const imagePath = path.join(dataDir, masterImage.imagePath)
+        masterResult = await detectCornerMarkers(imagePath, colorThreshold)
+        masterMarkerCache.set(cacheKey, masterResult)
+      }
+
+      if (!masterResult.success) {
+        return {
+          success: false,
+          status: "skipped",
+          error: "マスター画像のマーカーが検出できませんでした",
+        }
+      }
+
+      const result = await correctImage(
+        Buffer.from(buffer),
+        masterResult.markers,
+        masterResult.imageWidth,
+        masterResult.imageHeight,
+        colorThreshold ?? 128
+      )
+
+      if (result.success && result.correctedBuffer) {
+        return {
+          success: true,
+          correctedBuffer: new Uint8Array(result.correctedBuffer),
+          status: "corrected",
+        }
+      }
+      return {
+        success: false,
+        status: "skipped",
+        error: result.error,
+      }
+    },
+    "画像補正に失敗しました"
   )
 }

--- a/electron-src/preload-apis/omrApi.ts
+++ b/electron-src/preload-apis/omrApi.ts
@@ -40,6 +40,19 @@ export function createOmrApi() {
       }) => ipcRenderer.invoke("omr:batch-recognize", args),
       detectMasterMarkers: (examId: string, colorThreshold?: number) =>
         ipcRenderer.invoke("omr:detect-master-markers", examId, colorThreshold),
+      correctImage: (
+        examId: string,
+        pageNumber: number,
+        buffer: Uint8Array,
+        colorThreshold?: number
+      ) =>
+        ipcRenderer.invoke(
+          "omr:correct-image",
+          examId,
+          pageNumber,
+          buffer,
+          colorThreshold
+        ),
       onBatchProgress: (
         callback: (progress: {
           total: number

--- a/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -39,12 +39,24 @@ export function StudentAnswerUpload({
     passwordDialog,
     observerRef,
 
+    // Marker correction
+    markerCorrectionEnabled,
+    markerCorrectionAvailable,
+    markerDiagnostics,
+    markerAvailablePages,
+    setMarkerCorrectionEnabled,
+
     // Actions
     setFiles,
     setFileOrder,
     handleDrop,
     handleUpload,
-  } = useStudentAnswerUpload(examId, onUploadComplete, onCorrectionStatusUpdate)
+  } = useStudentAnswerUpload(
+    examId,
+    onUploadComplete,
+    onCorrectionStatusUpdate,
+    mode
+  )
 
   // 確認モード用の初期化処理
   useEffect(() => {
@@ -158,6 +170,11 @@ export function StudentAnswerUpload({
           mode={mode}
           onReloadData={onUploadComplete}
           existingStudentAnswers={finalExistingAnswers}
+          markerCorrectionEnabled={markerCorrectionEnabled}
+          markerCorrectionAvailable={markerCorrectionAvailable}
+          markerDiagnostics={markerDiagnostics}
+          markerAvailablePages={markerAvailablePages}
+          onMarkerCorrectionChange={setMarkerCorrectionEnabled}
         />
       </div>
 

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import type {
@@ -12,7 +12,10 @@ import { type ConvertedImage, convertPdfToImages } from "@/lib/pdfConverter"
 export function useStudentAnswerUpload(
   examId: string,
   onUploadComplete?: () => void,
-  onCorrectionStatusUpdate?: (map: Map<string, "corrected" | "skipped">) => void
+  onCorrectionStatusUpdate?: (
+    map: Map<string, "corrected" | "skipped">
+  ) => void,
+  mode: "upload" | "view" = "upload"
 ) {
   // State管理
   const [isUploading, setIsUploading] = useState(false)
@@ -20,6 +23,40 @@ export function useStudentAnswerUpload(
   const [files, setFiles] = useState<UnifiedFile[]>([])
   const [pdfProcessingProgress, setPdfProcessingProgress] = useState(0)
   const [fileOrder, setFileOrder] = useState<PlacementStrategy>("page-first")
+
+  // マーカー補正
+  const [markerCorrectionEnabled, setMarkerCorrectionEnabled] = useState(false)
+  const [markerCorrectionAvailable, setMarkerCorrectionAvailable] =
+    useState(false)
+  const [markerDiagnostics, setMarkerDiagnostics] = useState("")
+  const [markerAvailablePages, setMarkerAvailablePages] = useState<Set<number>>(
+    new Set()
+  )
+  const filesRef = useRef<UnifiedFile[]>([])
+  const prevFilesRef = useRef<UnifiedFile[]>([])
+
+  // 前回描画と比較し、削除されたファイルのblob URLを解放
+  useEffect(() => {
+    const currentIds = new Set(files.map((f) => f.id))
+    for (const prev of prevFilesRef.current) {
+      if (!currentIds.has(prev.id) && prev.preview?.startsWith("blob:")) {
+        URL.revokeObjectURL(prev.preview)
+      }
+    }
+    prevFilesRef.current = files
+    filesRef.current = files
+  }, [files])
+
+  // アンマウント時に全blob URLを解放
+  useEffect(() => {
+    return () => {
+      for (const f of prevFilesRef.current) {
+        if (f.preview?.startsWith("blob:")) {
+          URL.revokeObjectURL(f.preview)
+        }
+      }
+    }
+  }, [])
 
   // PDFパスワード処理
   const [passwordDialog, setPasswordDialog] = useState<{
@@ -187,6 +224,64 @@ export function useStudentAnswerUpload(
     [convertPdfWithRetry]
   )
 
+  // マスターマーカー検出（補正可否判定）
+  useEffect(() => {
+    if (mode !== "upload" || !examId) return
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const result = await window.electronAPI.omr.detectMasterMarkers(examId)
+        if (cancelled) return
+        // マスターマーカーを検出できたページを記録
+        const availablePages = new Set<number>()
+        if (result.pages) {
+          for (const page of result.pages) {
+            if (page.result.success) {
+              availablePages.add(page.pageNumber)
+            }
+          }
+        }
+        // 内容が同じなら既存参照を維持（effect誤発火防止）
+        setMarkerAvailablePages((prev) => {
+          if (
+            prev.size === availablePages.size &&
+            [...prev].every((p) => availablePages.has(p))
+          ) {
+            return prev
+          }
+          return availablePages
+        })
+        setMarkerCorrectionAvailable(availablePages.size > 0)
+        setMarkerCorrectionEnabled(availablePages.size > 0)
+        if (!result.success && result.pages) {
+          const lines: string[] = []
+          for (const page of result.pages) {
+            if (!page.result.success && page.result.diagnostics) {
+              lines.push(`ページ${page.pageNumber}:`)
+              for (const d of page.result.diagnostics) {
+                if (!d.detected) {
+                  lines.push(
+                    `  ${d.corner}: ${d.failReason ?? "不明"} (黒px: ${d.darkPixels}/${d.totalPixels})`
+                  )
+                }
+              }
+            }
+          }
+          setMarkerDiagnostics(lines.join("\n"))
+        }
+      } catch {
+        if (!cancelled) {
+          setMarkerCorrectionAvailable(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [examId, mode])
+
   // ファイルドロップ処理
   const handleDrop = useCallback(
     async (rawFiles: File[]) => {
@@ -224,9 +319,22 @@ export function useStudentAnswerUpload(
       setIsUploading(true)
 
       try {
+        // クライアント側補正結果からマップ構築（uploadDataの(studentId,pageNumber)=生徒×マスターページ）
         const correctionMap = new Map<string, "corrected" | "skipped">()
+        for (const d of uploadData) {
+          if (
+            d.correctionStatus &&
+            d.correctionStatus !== "not_requested" &&
+            d.studentId
+          ) {
+            const key = `${d.studentId}-${d.pageNumber}`
+            correctionMap.set(
+              key,
+              d.correctionStatus as "corrected" | "skipped"
+            )
+          }
+        }
 
-        // 全件を一括送信（バックエンドで画像補正を並列処理）
         const result = await window.electronAPI.uploadStudentAnswers(
           examId,
           uploadData
@@ -234,25 +342,6 @@ export function useStudentAnswerUpload(
 
         if (result.success && result.answerSheets) {
           const successCount = result.answerSheets.length
-
-          // correctionStatus収集
-          for (let i = 0; i < result.answerSheets.length; i++) {
-            const sheet = result.answerSheets[i] as Record<string, unknown> & {
-              correctionStatus?: string
-            }
-            if (
-              sheet?.correctionStatus &&
-              sheet.correctionStatus !== "not_requested" &&
-              i < uploadData.length
-            ) {
-              const data = uploadData[i]
-              const key = `${data.studentId}-${data.pageNumber}`
-              correctionMap.set(
-                key,
-                sheet.correctionStatus as "corrected" | "skipped"
-              )
-            }
-          }
 
           toast.success(`${successCount}件の答案をアップロードしました`)
           setFiles([])
@@ -283,6 +372,13 @@ export function useStudentAnswerUpload(
     fileOrder,
     passwordDialog,
     observerRef,
+
+    // Marker correction
+    markerCorrectionEnabled,
+    markerCorrectionAvailable,
+    markerDiagnostics,
+    markerAvailablePages,
+    setMarkerCorrectionEnabled,
 
     // Actions
     setFiles,

--- a/src/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell.tsx
@@ -6,6 +6,12 @@ import { useEffect, useRef, useState } from "react"
 
 import { loadStudentAnswerImage } from "@/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles"
 import type { FilePreviewCellProps } from "@/components/exams/06-student-answers/student-answer-table/types"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 /**
  * ファイルプレビューセルコンポーネント
@@ -28,10 +34,12 @@ export function FilePreviewCell({
   isPendingChange = false,
   hasExistingAnswer = false,
   allowOverwrite = false,
+  isCorrecting = false,
 }: FilePreviewCellProps & {
   isPendingChange?: boolean
   hasExistingAnswer?: boolean
   allowOverwrite?: boolean
+  isCorrecting?: boolean
 }) {
   const [nameRegionPreview, setNameRegionPreview] = useState<string | null>(
     null
@@ -249,13 +257,43 @@ export function FilePreviewCell({
       )}
 
       {file.correctionStatus === "corrected" && (
-        <div className="pointer-events-none absolute inset-0 z-20 border-2 border-green-500" />
+        <div
+          className={`pointer-events-none absolute z-20 border-2 border-blue-500 ${
+            hasExistingAnswer && allowOverwrite ? "inset-[3px]" : "inset-0"
+          }`}
+        />
       )}
       {file.correctionStatus === "skipped" && (
-        <div className="pointer-events-none absolute inset-0 z-20 border-2 border-red-500" />
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={`absolute z-20 border-2 border-amber-500 ${
+                  hasExistingAnswer && allowOverwrite
+                    ? "inset-[3px]"
+                    : "inset-0"
+                }`}
+              />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-sm">
+              <p className="font-medium">マーカー補正スキップ</p>
+              {file.correctionError && (
+                <p className="mt-1 text-xs text-gray-300">
+                  {file.correctionError}
+                </p>
+              )}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
 
       {renderLoadingState()}
+
+      {isCorrecting && (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-white/60">
+          <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
@@ -43,6 +43,7 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
     markerCorrectionAvailable,
     markerDiagnostics,
     setMarkerCorrectionEnabled,
+    correctingFileIds,
     previewMode,
     uploadModalState,
     handlePreviewModeChange,
@@ -118,6 +119,7 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
                 affectedCells={affectedCells}
                 imageLoadStates={imageLoadStates}
                 observerRef={observerRef}
+                correctingFileIds={correctingFileIds}
                 getEnabledFiles={getEnabledFiles}
                 getFileColor={getFileColor}
                 drawNameRegionCanvas={drawNameRegionCanvas}

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -44,6 +44,7 @@ interface TableContentProps {
   affectedCells?: Set<string>
   imageLoadStates?: Record<string, "pending" | "loading" | "loaded" | "error">
   observerRef?: React.RefObject<IntersectionObserver | null>
+  correctingFileIds?: Set<string>
   getEnabledFiles: () => UnifiedFile[]
   getFileColor: (file: UnifiedFile) => string
   drawNameRegionCanvas: (
@@ -76,6 +77,7 @@ export function TableContent({
   affectedCells,
   imageLoadStates = {},
   observerRef,
+  correctingFileIds,
   getEnabledFiles,
   getFileColor,
   drawNameRegionCanvas,
@@ -235,6 +237,7 @@ export function TableContent({
                       isPendingChange={affectedCells?.has(file.id) || false}
                       hasExistingAnswer={hasExistingAnswer}
                       allowOverwrite={allowOverwrite}
+                      isCorrecting={correctingFileIds?.has(file.id) || false}
                     />
                   </SortableTableCell>
                 )

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useState } from "react"
+
+import type { CellData } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+
+interface UseMarkerCorrectionArgs {
+  examId: string
+  files: UnifiedFile[]
+  tableData: CellData[][]
+  markerCorrectionEnabled: boolean
+  markerAvailablePages: Set<number>
+  onFilesChange: (files: UnifiedFile[]) => void
+}
+
+interface UseMarkerCorrectionResult {
+  correctingFileIds: Set<string>
+}
+
+/**
+ * 配置戦略に応じた動的マーカー補正フック
+ *
+ * 仕組み:
+ * - tableData から各ファイルのマスターページ番号を決定
+ * - file.correctedForPage と異なれば再補正（または復元）
+ * - トグルOFF、マスター無し、未配置ファイルは元に戻す
+ */
+export function useMarkerCorrection({
+  examId,
+  files,
+  tableData,
+  markerCorrectionEnabled,
+  markerAvailablePages,
+  onFilesChange,
+}: UseMarkerCorrectionArgs): UseMarkerCorrectionResult {
+  const originalBuffersRef = useRef<Map<string, ArrayBuffer>>(new Map())
+  const runIdRef = useRef(0)
+  const filesRef = useRef(files)
+  filesRef.current = files
+  const [correctingFileIds, setCorrectingFileIds] = useState<Set<string>>(
+    new Set()
+  )
+
+  // 削除されたファイルの元バッファ参照を解放（メモリリーク防止）
+  useEffect(() => {
+    const currentIds = new Set(files.map((f) => f.id))
+    for (const id of originalBuffersRef.current.keys()) {
+      if (!currentIds.has(id)) {
+        originalBuffersRef.current.delete(id)
+      }
+    }
+  }, [files])
+
+  useEffect(() => {
+    const runId = ++runIdRef.current
+
+    // ファイルID → 対応マスターページ番号 のマップを構築
+    const targetMap = new Map<string, number>()
+    if (markerCorrectionEnabled) {
+      for (const row of tableData) {
+        for (const cell of row) {
+          if (cell.file && cell.pageNumber) {
+            targetMap.set(cell.file.id, cell.pageNumber)
+          }
+        }
+      }
+    }
+
+    // 処理が必要なファイルを抽出
+    type Task = { file: UnifiedFile; target: number | undefined }
+    const tasks: Task[] = []
+    for (const file of files) {
+      // DB読み込み済みの既存答案（imagePathあり、buffer空）は対象外
+      if (file.imagePath) continue
+      const rawTarget = targetMap.get(file.id)
+      // マスターが存在しないページは対象外（undefined扱いで復元）
+      const target =
+        rawTarget !== undefined && markerAvailablePages.has(rawTarget)
+          ? rawTarget
+          : undefined
+
+      if (target === undefined) {
+        if (
+          file.correctedForPage !== undefined ||
+          file.correctionStatus !== undefined
+        ) {
+          tasks.push({ file, target: undefined })
+        }
+      } else if (file.correctedForPage !== target) {
+        tasks.push({ file, target })
+      }
+    }
+
+    if (tasks.length === 0) return
+
+    // 補正対象のIDを loading 状態として公開（補正実行のもののみ）
+    const correctingIds = new Set(
+      tasks.filter((t) => t.target !== undefined).map((t) => t.file.id)
+    )
+    if (correctingIds.size > 0) {
+      setCorrectingFileIds((prev) => {
+        const next = new Set(prev)
+        for (const id of correctingIds) next.add(id)
+        return next
+      })
+    }
+
+    const processTasks = async () => {
+      const processed = await Promise.all(
+        tasks.map(async ({ file, target }) => {
+          // 元バッファを初回のみ記憶
+          if (!originalBuffersRef.current.has(file.id)) {
+            originalBuffersRef.current.set(file.id, file.buffer)
+          }
+          const origBuffer = originalBuffersRef.current.get(file.id)!
+
+          // 復元（target未指定）
+          if (target === undefined) {
+            return restoreFromOriginal(file, origBuffer)
+          }
+
+          // 補正実行
+          try {
+            const sendBuffer = new Uint8Array(origBuffer.byteLength)
+            sendBuffer.set(new Uint8Array(origBuffer))
+            const result = await window.electronAPI.omr.correctImage(
+              examId,
+              target,
+              sendBuffer
+            )
+            if (result.success && result.correctedBuffer) {
+              const correctedAB = result.correctedBuffer.buffer.slice(
+                result.correctedBuffer.byteOffset,
+                result.correctedBuffer.byteOffset +
+                  result.correctedBuffer.byteLength
+              ) as ArrayBuffer
+              if (file.preview && file.preview.startsWith("blob:")) {
+                URL.revokeObjectURL(file.preview)
+              }
+              const blob = new Blob([correctedAB], { type: "image/png" })
+              return {
+                ...file,
+                buffer: correctedAB,
+                type: "image/png",
+                preview: URL.createObjectURL(blob),
+                correctionStatus: "corrected" as const,
+                correctedForPage: target,
+                correctionError: undefined,
+              }
+            }
+            const reason = result.error ?? "不明なエラー"
+            console.warn(
+              `補正スキップ (${file.name}, 対象p${target}): ${reason}`
+            )
+            const restored = restoreFromOriginal(file, origBuffer)
+            return {
+              ...restored,
+              correctionStatus: "skipped" as const,
+              correctedForPage: target,
+              correctionError: reason,
+            }
+          } catch (error) {
+            const reason =
+              error instanceof Error ? error.message : "画像補正IPC例外"
+            console.error("画像補正エラー:", error)
+            const restored = restoreFromOriginal(file, origBuffer)
+            return {
+              ...restored,
+              correctionStatus: "skipped" as const,
+              correctedForPage: target,
+              correctionError: reason,
+            }
+          }
+        })
+      )
+
+      if (runId !== runIdRef.current) {
+        // 新しい実行で置き換えられた — loadingフラグは最新runが管理
+        return
+      }
+
+      // 最新のfiles（他所で更新された可能性）に対してid一致で差し替え
+      const byId = new Map(processed.map((p) => [p.id, p]))
+      const merged = filesRef.current.map((f) => byId.get(f.id) ?? f)
+      onFilesChange(merged)
+
+      // loading終了
+      if (correctingIds.size > 0) {
+        setCorrectingFileIds((prev) => {
+          const next = new Set(prev)
+          for (const id of correctingIds) next.delete(id)
+          return next
+        })
+      }
+    }
+
+    processTasks()
+  }, [
+    examId,
+    files,
+    tableData,
+    markerCorrectionEnabled,
+    markerAvailablePages,
+    onFilesChange,
+  ])
+
+  return { correctingFileIds }
+}
+
+/** 元バッファから preview を作り直して復元 */
+function restoreFromOriginal(
+  file: UnifiedFile,
+  origBuffer: ArrayBuffer
+): UnifiedFile {
+  if (file.buffer === origBuffer) {
+    return {
+      ...file,
+      correctionStatus: undefined,
+      correctedForPage: undefined,
+      correctionError: undefined,
+    }
+  }
+  if (file.preview && file.preview.startsWith("blob:")) {
+    URL.revokeObjectURL(file.preview)
+  }
+  const blob = new Blob([origBuffer], { type: file.type })
+  return {
+    ...file,
+    buffer: origBuffer,
+    preview: URL.createObjectURL(blob),
+    correctionStatus: undefined,
+    correctedForPage: undefined,
+    correctionError: undefined,
+  }
+}

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 
 import { useDisabledState } from "@/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState"
 import { useDragDrop } from "@/components/exams/06-student-answers/student-answer-table/hooks/useDragDrop"
+import { useMarkerCorrection } from "@/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection"
 import { useNameRegion } from "@/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion"
 import { useTableData } from "@/components/exams/06-student-answers/student-answer-table/hooks/useTableData"
 import type { PreviewMode } from "@/components/exams/06-student-answers/student-answer-table/types"
@@ -27,6 +28,11 @@ export function useStudentAnswerTableLogic({
   onReloadData,
   onUpdatePendingChanges,
   existingStudentAnswers = [],
+  markerCorrectionEnabled: markerCorrectionEnabledProp,
+  markerCorrectionAvailable: markerCorrectionAvailableProp,
+  markerDiagnostics: markerDiagnosticsProp,
+  markerAvailablePages: markerAvailablePagesProp,
+  onMarkerCorrectionChange,
 }: StudentAnswerTableProps) {
   // ============================================================================
   // カスタムフック
@@ -91,10 +97,22 @@ export function useStudentAnswerTableLogic({
   const [uploadModalState, setUploadModalState] = useState<UploadModalState>({
     isOpen: false,
   })
-  const [markerCorrectionEnabled, setMarkerCorrectionEnabled] = useState(false)
-  const [markerCorrectionAvailable, setMarkerCorrectionAvailable] =
-    useState(false)
-  const [markerDiagnostics, setMarkerDiagnostics] = useState<string>("")
+  // マーカー補正状態は親フック（useStudentAnswerUpload）から注入される
+  const markerCorrectionEnabled = markerCorrectionEnabledProp ?? false
+  const markerCorrectionAvailable = markerCorrectionAvailableProp ?? false
+  const markerDiagnostics = markerDiagnosticsProp ?? ""
+  const markerAvailablePages = markerAvailablePagesProp ?? new Set<number>()
+  const setMarkerCorrectionEnabled = onMarkerCorrectionChange ?? (() => {})
+
+  // 配置戦略に応じた動的マーカー補正
+  const { correctingFileIds } = useMarkerCorrection({
+    examId,
+    files,
+    tableData,
+    markerCorrectionEnabled,
+    markerAvailablePages,
+    onFilesChange,
+  })
 
   // ============================================================================
   // 削除処理
@@ -139,51 +157,6 @@ export function useStudentAnswerTableLogic({
     initializeStudentsWithoutAnswers(students)
   }, [students, initializeStudentsWithoutAnswers])
 
-  // マスター画像のマーカー検出（マーカー補正の利用可否判定）
-  useEffect(() => {
-    if (mode !== "upload" || !examId) return
-
-    let cancelled = false
-    ;(async () => {
-      try {
-        const result = await window.electronAPI.omr.detectMasterMarkers(examId)
-        if (!cancelled) {
-          setMarkerCorrectionAvailable(result.success)
-          if (result.success) {
-            setMarkerCorrectionEnabled(true)
-          } else {
-            setMarkerCorrectionEnabled(false)
-            // 診断情報をUIに表示するため構築
-            if (result.pages) {
-              const lines: string[] = []
-              for (const page of result.pages) {
-                if (!page.result.success && page.result.diagnostics) {
-                  lines.push(`ページ${page.pageNumber}:`)
-                  for (const d of page.result.diagnostics) {
-                    if (!d.detected) {
-                      lines.push(
-                        `  ${d.corner}: ${d.failReason ?? "不明"} (黒px: ${d.darkPixels}/${d.totalPixels})`
-                      )
-                    }
-                  }
-                }
-              }
-              setMarkerDiagnostics(lines.join("\n"))
-            }
-          }
-        }
-      } catch {
-        if (!cancelled) {
-          setMarkerCorrectionAvailable(false)
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [examId, mode])
-
   // ============================================================================
   // イベントハンドラー
   // ============================================================================
@@ -213,7 +186,8 @@ export function useStudentAnswerTableLogic({
             studentId: cell.student.id,
             pageNumber: cell.pageNumber,
             overwrite: allowOverwrite,
-            correctWithMarkers: markerCorrectionEnabled,
+            correctWithMarkers: false, // クライアント側で補正済み
+            correctionStatus: cell.file.correctionStatus,
           })
         }
       })
@@ -282,6 +256,7 @@ export function useStudentAnswerTableLogic({
     markerCorrectionAvailable,
     markerDiagnostics,
     setMarkerCorrectionEnabled,
+    correctingFileIds,
 
     // ローカル状態
     previewMode,

--- a/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
@@ -51,6 +51,13 @@ export interface StudentAnswerTableProps {
     studentId: string | null
     pageNumber: number
   }>
+
+  // マーカー補正状態（親フックから注入）
+  markerCorrectionEnabled?: boolean
+  markerCorrectionAvailable?: boolean
+  markerDiagnostics?: string
+  markerAvailablePages?: Set<number>
+  onMarkerCorrectionChange?: (enabled: boolean) => void
 }
 
 export type DisabledReason =

--- a/src/components/exams/06-student-answers/types.ts
+++ b/src/components/exams/06-student-answers/types.ts
@@ -46,6 +46,8 @@ export interface UnifiedFile {
   position?: number // table内の位置（studentIndex * maxPages + pageNumber - 1）
   imagePath?: string | null // 既存画像ファイルのパス（遅延読み込み用）
   correctionStatus?: "corrected" | "skipped" | "not_requested" // マーカー補正結果
+  correctedForPage?: number // 補正時に対応付けたマスターページ番号
+  correctionError?: string // 補正失敗時の理由
 }
 
 // ============================================================================
@@ -97,6 +99,7 @@ export interface UploadData {
   pageNumber: number // ページ番号
   overwrite: boolean // 上書きフラグ
   correctWithMarkers?: boolean // マーカー補正フラグ
+  correctionStatus?: "corrected" | "skipped" | "not_requested" // クライアント側補正結果
 }
 
 /**

--- a/src/types/electron/omrApi.d.ts
+++ b/src/types/electron/omrApi.d.ts
@@ -45,6 +45,17 @@ export interface OmrAPI {
       }>
       error?: string
     }>
+    correctImage: (
+      examId: string,
+      pageNumber: number,
+      buffer: Uint8Array,
+      colorThreshold?: number
+    ) => Promise<{
+      success: boolean
+      correctedBuffer?: Uint8Array
+      status: "corrected" | "skipped"
+      error?: string
+    }>
     onBatchProgress: (
       callback: (progress: import("../omr.types").OMRBatchProgress) => void
     ) => () => void


### PR DESCRIPTION
Closes #757

## Summary
- 答案アップロードのプレビュー段階で、tableData から動的に対応マスターページを決定し、クライアント側で画像補正するフック `useMarkerCorrection` を新設
- 配置戦略切替・ファイル無効化・ドラッグ移動などで配置が変わるたび自動的に再補正
- 補正結果を青/amber 枠・tooltip・ローディングで可視化し、Blob URL と元バッファ参照のクリーンアップでメモリリークを防止

## Test plan
- [ ] 複数ページ PDF を新規追加タブにドロップ → 配置されたセルに青枠（補正済）が表示される
- [ ] 氏名欄プレビューモード（`name-only`）で氏名領域が正しい位置で切り出される
- [ ] 配置戦略を page-first ↔ student-first で切替 → ファイルが別マスターページに割り当てられ、自動で再補正される
- [ ] ファイルを無効化（trash）→ amber/青枠が消え、元画像に戻る
- [ ] マスター画像が存在しないページに配置 → 枠なし（補正されない）
- [ ] 補正失敗ケース（マーカー検出失敗・回転角/スケール範囲外）→ amber 枠 + tooltip で理由表示
- [ ] 補正中は該当セルにスピナーオーバーレイ
- [ ] マーカー補正トグル ON/OFF → 全ファイルが再補正/元画像復元
- [ ] アップロード完了後 → ファイル一覧クリア、配置済み答案タブに補正ステータス（青/amber 枠）反映
- [ ] DevTools で Blob URL 数がセッション中に単調増加しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)