### PR TITLE
fix: アノテーションテキストの縮尺不整合を修正し既定値を5mmに変更

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModalV4.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModalV4.tsx
@@ -69,7 +69,7 @@ export function RichTextEditorModalV4({
   canvasWidth = 800,
   canvasHeight = 600,
   backgroundImageUrl,
-  fontSize: initialFontSize = 16,
+  fontSize: initialFontSize = 5,
   onFontSizeChange,
   anchorDirection: initialAnchorDirection = "top-left",
   onAnchorDirectionChange,
@@ -202,13 +202,13 @@ export function RichTextEditorModalV4({
     insertFormatting("$$\n", "\n$$")
   }, [insertFormatting])
 
-  // フォントサイズ調整
+  // フォントサイズ調整 (mm単位)
   const handleFontSizeIncrease = useCallback(() => {
-    setFontSize(Math.min(fontSize + 2, 48))
+    setFontSize(Math.min(fontSize + 1, 20))
   }, [fontSize, setFontSize])
 
   const handleFontSizeDecrease = useCallback(() => {
-    setFontSize(Math.max(fontSize - 2, 8))
+    setFontSize(Math.max(fontSize - 1, 2))
   }, [fontSize, setFontSize])
 
   // アンカー方向の取得関数
@@ -506,7 +506,7 @@ export function RichTextEditorModalV4({
               rows={6}
               className="mt-2 resize-none"
               style={{
-                fontSize: `${fontSize}px`,
+                fontSize: "16px",
                 color: color,
               }}
             />

--- a/src/components/exams/07-score-at-once/ScoringIndividual/constants/drawingConstants.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/constants/drawingConstants.ts
@@ -15,7 +15,7 @@ export const DEFAULT_DRAWING_SETTINGS = {
   strokeColor: "#ef4444",
   strokeWidth: 0.5,
   lineStyle: "solid" as const,
-  fontSize: 4.0,
+  fontSize: 5.0,
 } as const
 
 // 描画時の許容誤差（正規化座標 0-1）

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -20,6 +20,7 @@ import type {
   MarkPosition,
   ScoringMarkConfig,
 } from "@/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes"
+import { mmToPixels } from "@/lib/paperSize"
 import { getTextPositionFromAnchor } from "@/lib/textbox-canvas/canvasUtils"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
@@ -915,9 +916,16 @@ export function useCanvasDrawing({
           // ページオフセット分だけコンテキストを平行移動して描画
           ctx.save()
           ctx.translate(0, annotPageOffsetY)
+          const fontSizePx = mmToPixels(
+            element.fontSize || 4.0,
+            pageSize,
+            canvasWidth,
+            annotPageHeight
+          )
+          const pxElement = { ...element, fontSize: fontSizePx }
           const result = await renderTextElementV4(
             ctx,
-            element,
+            pxElement,
             canvasWidth,
             annotPageHeight,
             isSelected,
@@ -962,9 +970,16 @@ export function useCanvasDrawing({
           try {
             ctx.save()
             ctx.translate(0, currentPageOffsetY)
+            const fontSizePx = mmToPixels(
+              element.fontSize || 4.0,
+              pageSize,
+              canvasWidth,
+              currentPageHeight
+            )
+            const pxElement = { ...element, fontSize: fontSizePx }
             const result = await renderTextElementV4(
               ctx,
-              element,
+              pxElement,
               canvasWidth,
               currentPageHeight,
               isSelected,
@@ -1003,6 +1018,7 @@ export function useCanvasDrawing({
     allCropRegionsWithStatus,
     textBoundsCacheRef,
     convertAnnotationToDrawingElement,
+    pageSize,
   ])
 
   // オーバーレイキャンバスの描画

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts
@@ -11,6 +11,7 @@ import { mmToPixels } from "@/lib/paperSize"
 import { getTextPositionFromAnchor } from "@/lib/textbox-canvas/canvasUtils"
 import type { DrawingAnnotationWithQuestionScore } from "@/types/drawingAnnotation.types"
 
+import { DEFAULT_DRAWING_SETTINGS } from "../../constants/drawingConstants"
 import { renderTextElementV4 } from "../../utils/canvasTextRendererV4"
 
 interface UseDrawingRendererReturn {
@@ -96,7 +97,7 @@ export function useDrawingRenderer(): UseDrawingRendererReturn {
       )
 
       const fontSizePx = mmToPixels(
-        element.fontSize || 4.0,
+        element.fontSize || DEFAULT_DRAWING_SETTINGS.fontSize,
         pageSize,
         baseImg.naturalWidth,
         baseImg.naturalHeight

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/textbox-canvas/coordinateConversion"
 import type { TextBox } from "@/lib/textbox-canvas/types"
 
+import { DEFAULT_DRAWING_SETTINGS } from "../../constants/drawingConstants"
 import type {
   AnchorDirection,
   DrawingElement,
@@ -87,7 +88,9 @@ export function useTextboxV4Integration({
   const [currentTextValue, setCurrentTextValue] = useState("")
   const [currentTextColor, setCurrentTextColor] = useState("#ef4444")
   const [currentPosition, setCurrentPosition] = useState({ x: 0.5, y: 0.5 })
-  const [currentFontSize, setCurrentFontSize] = useState(16)
+  const [currentFontSize, setCurrentFontSize] = useState<number>(
+    DEFAULT_DRAWING_SETTINGS.fontSize
+  )
   const [currentAnchorDirection, setCurrentAnchorDirection] =
     useState<AnchorDirection>("top-left")
   const [editingElementId, setEditingElementId] = useState<string | null>(null)
@@ -109,14 +112,16 @@ export function useTextboxV4Integration({
           (el) => el.id === elementId
         )
         if (existingElement && existingElement.type === "text") {
-          setCurrentFontSize(existingElement.fontSize ?? 16)
+          setCurrentFontSize(
+            existingElement.fontSize ?? DEFAULT_DRAWING_SETTINGS.fontSize
+          )
           setCurrentAnchorDirection(
             existingElement.anchorDirection ?? "top-left"
           )
         }
       } else {
         // 新規の場合はデフォルト値
-        setCurrentFontSize(16)
+        setCurrentFontSize(DEFAULT_DRAWING_SETTINGS.fontSize)
         setCurrentAnchorDirection("top-left")
       }
 
@@ -130,7 +135,7 @@ export function useTextboxV4Integration({
     setShowV4Modal(false)
     setCurrentTextValue("")
     setCurrentTextColor("#000000")
-    setCurrentFontSize(16)
+    setCurrentFontSize(DEFAULT_DRAWING_SETTINGS.fontSize)
     setCurrentAnchorDirection("top-left")
     setEditingElementId(null)
   }, [])

--- a/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -249,7 +249,7 @@ async function drawAnnotations(
     ctx.save()
     ctx.strokeStyle = anno.color
     ctx.fillStyle = anno.color
-    ctx.lineWidth = Math.max(1, anno.strokeWidth * scaleFactor)
+    ctx.lineWidth = anno.strokeWidth * scaleFactor
     ctx.lineCap = "round"
     ctx.lineJoin = "round"
 
@@ -357,7 +357,7 @@ async function drawGridTextV4(
     color: anno.color,
     strokeWidth: anno.strokeWidth,
     text: anno.text,
-    fontSize: Math.max(2, anno.fontSize * scaleFactor),
+    fontSize: anno.fontSize * scaleFactor,
     anchorDirection: anno.anchorDirection || "top-left",
   }
 
@@ -393,8 +393,8 @@ function drawGridLine(
   const dy = endY - startY
   const lineLength = Math.sqrt(dx * dx + dy * dy)
   const angle = Math.atan2(dy, dx)
-  const sw = Math.max(1, anno.strokeWidth * scaleFactor)
-  const arrowSize = Math.max(sw * 5, 8)
+  const sw = anno.strokeWidth * scaleFactor
+  const arrowSize = sw * 5
 
   ctx.lineWidth = sw
   ctx.setLineDash([])


### PR DESCRIPTION
Closes #759

## Summary

- 個別表示のテキスト描画で欠落していた mm→px 変換を追加し、一覧表示と用紙比率を一致させた
- 一覧表示 (`CroppedAnswerImage`) の最小値クランプ (`Math.max`) を撤廃し、物理サイズに完全追従
- 既定フォントサイズを 5mm に統一（`DEFAULT_DRAWING_SETTINGS.fontSize`）
- 編集モーダルの入力 textarea のみ可読性優先で 16px 固定

## 変更ファイル

- `src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts` — `drawTextCanvas` 内 2 箇所に `mmToPixels` 変換追加
- `src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx` — fontSize / strokeWidth / arrowSize のクランプ撤廃
- `src/components/exams/07-score-at-once/ScoringIndividual/constants/drawingConstants.ts` — 既定値 4.0 → 5.0 mm
- `src/components/exams/07-score-at-once/ScoringIndividual/hooks/text/useTextboxIntegration.ts` — リテラル `16` を `DEFAULT_DRAWING_SETTINGS.fontSize` に置換
- `src/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModalV4.tsx` — `initialFontSize` 5 に変更、±範囲を mm 基準へ、textarea 表示は 16px 固定
- `src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingRenderer.ts` — フォールバックを `DEFAULT_DRAWING_SETTINGS.fontSize` に統一

## Test plan

- [ ] 個別採点画面で既存テキストアノテーションが用紙比例サイズで描画されるか確認
- [ ] 採点済み答案プレビュー・一覧表示と個別表示のテキストが用紙上で同等サイズで見えるか比較
- [ ] 新規テキスト作成時の既定サイズが 5mm で登録されるか確認
- [ ] テキスト編集モーダルの ±ボタンが 2〜20mm の範囲で 1mm 刻みに動作するか確認
- [ ] 編集 textarea の入力テキスト自体は fontSize 変更に影響されず読める大きさを維持するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)