### PR TITLE
feat: 受験生徒一覧に紐づき答案枚数を表示

### DIFF
--- a/electron-src/lib/prisma/examStudent.ts
+++ b/electron-src/lib/prisma/examStudent.ts
@@ -26,20 +26,31 @@ export async function getStudentsForExam(examId: string) {
                 startDate: "desc",
               },
             },
+            _count: {
+              select: {
+                studentAnswerImages: {
+                  where: { examPage: { examId } },
+                },
+              },
+            },
           },
         },
       },
     })
 
-    const studentsWithStatus = examStudents.map((examStudent) => ({
-      ...examStudent.student,
-      status: examStudent.status.toLowerCase() as
-        | "participating"
-        | "expected"
-        | "absent",
-      isInExam: true,
-      customOrder: examStudent.customOrder,
-    }))
+    const studentsWithStatus = examStudents.map((examStudent) => {
+      const { _count, ...studentRest } = examStudent.student
+      return {
+        ...studentRest,
+        status: examStudent.status.toLowerCase() as
+          | "participating"
+          | "expected"
+          | "absent",
+        isInExam: true,
+        customOrder: examStudent.customOrder,
+        answerSheetCount: _count.studentAnswerImages,
+      }
+    })
 
     return {
       success: true,

--- a/src/components/exams/05-students/components/exam-students-page/types/examStudentsTypes.ts
+++ b/src/components/exams/05-students/components/exam-students-page/types/examStudentsTypes.ts
@@ -28,6 +28,7 @@ export interface Student {
   status: StudentStatus
   isInExam: boolean
   customOrder?: number | null
+  answerSheetCount: number
 }
 
 // クラスデータの型

--- a/src/components/exams/05-students/components/sortable-student-table/components/SortableTableRow.tsx
+++ b/src/components/exams/05-students/components/sortable-student-table/components/SortableTableRow.tsx
@@ -4,6 +4,7 @@ import { UserCheck, Users, UserX } from "lucide-react"
 
 import { DragHandle, useSortableRow } from "@/components/common/sortable-table"
 import type { SortableTableRowProps } from "@/components/exams/05-students/components/sortable-student-table/types/studentTableTypes"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { TableCell, TableRow } from "@/components/ui/table"
@@ -56,6 +57,15 @@ export function SortableTableRow({
         {student.lastNameKana} {student.firstNameKana}
       </TableCell>
       <TableCell>{student.examClassInfo?.className ?? "-"}</TableCell>
+      <TableCell className="text-center">
+        {student.answerSheetCount > 0 ? (
+          <Badge variant="secondary" className="tabular-nums">
+            {student.answerSheetCount}枚
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground">-</span>
+        )}
+      </TableCell>
       <TableCell>
         <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
           <Button

--- a/src/components/exams/05-students/components/sortable-student-table/components/TableHeaderRow.tsx
+++ b/src/components/exams/05-students/components/sortable-student-table/components/TableHeaderRow.tsx
@@ -37,6 +37,7 @@ export function TableHeaderRow({
         <TableHead>氏名</TableHead>
         <TableHead>ふりがな</TableHead>
         <TableHead>学級</TableHead>
+        <TableHead className="w-24 text-center">答案枚数</TableHead>
         <TableHead>受験状態</TableHead>
       </TableRow>
     </TableHeader>

--- a/src/components/exams/05-students/components/sortable-student-table/types/studentTableTypes.ts
+++ b/src/components/exams/05-students/components/sortable-student-table/types/studentTableTypes.ts
@@ -25,6 +25,7 @@ export interface Student {
   status: StudentStatus
   isInExam: boolean
   customOrder?: number | null
+  answerSheetCount: number
 }
 
 // クラスデータの型

--- a/src/types/electron/examApi.d.ts
+++ b/src/types/electron/examApi.d.ts
@@ -38,6 +38,7 @@ export interface ExamAPI {
       status: "participating" | "expected" | "absent"
       isInExam: boolean
       customOrder: number | null
+      answerSheetCount: number
     })[]
     error?: string
   }>


### PR DESCRIPTION
## Summary

- 受験生徒一覧テーブルに「答案枚数」列を追加し、各生徒に紐づく `StudentAnswerImage` の件数をバッジで表示
- 0枚は `-`、1枚以上は `secondary` バッジで `N枚` と表示
- `getStudentsForExam` で Prisma の filtered `_count` を用い、当該試験の `ExamPage` に紐づく画像のみを集計

Closes #761

## Test plan

- [ ] `/exams/[examId]/05-students` を開いて「答案枚数」列が表示されること
- [ ] 答案未アップロードの生徒は `-` が表示されること
- [ ] 答案アップロード済みの生徒はバッジで枚数が表示されること
- [ ] 別試験の答案がカウントに含まれないこと
- [ ] 生徒追加・削除後にリフレッシュで正しい枚数が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)