### PR TITLE
アノテーション一覧の生��移動機能追加とテキスト削除時の���画残留バグ修正

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -896,7 +896,8 @@ export function useCanvasDrawing({
           if (localElement) {
             element = localElement
           } else {
-            element = convertAnnotationToDrawingElement(annotation)
+            // drawingElementsに存在しない = ローカルで削除済み → 描画スキップ
+            return null
           }
         } else {
           element = convertAnnotationToDrawingElement(annotation)

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
@@ -2,6 +2,7 @@
 
 import {
   Circle,
+  Eye,
   Minus,
   Plus,
   RectangleHorizontal,
@@ -12,6 +13,12 @@ import { useCallback, useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 import {
   Select,
   SelectContent,
@@ -56,6 +63,10 @@ interface AnnotationBrowserPanelProps {
   onQuestionScoreCreated?: () => void
   /** ブラウザの+ボタンでアノテーション追加後のコールバック（キャンバスリロード用） */
   onAnnotationAddedFromBrowser?: () => void
+  /** アノテーションの生徒・設問に移動 */
+  onNavigateTo?: (studentId: string, cropRegionId: string) => void
+  /** グループ内全アノテーション参照用 */
+  allAnnotations?: AnnotationWithContext[]
 }
 
 // アノテーションタイプのアイコン
@@ -120,6 +131,8 @@ export function AnnotationBrowserPanel({
   allScoringData,
   onQuestionScoreCreated,
   onAnnotationAddedFromBrowser,
+  onNavigateTo,
+  allAnnotations = [],
 }: AnnotationBrowserPanelProps) {
   // 初回ロード
   useEffect(() => {
@@ -421,6 +434,81 @@ export function AnnotationBrowserPanel({
                     )}
                   />
                 </button>
+
+                {/* 移動ボタン（左クリック: 代表に移動, 右クリック: 生徒選択メニュー） */}
+                {onNavigateTo &&
+                  item.representative.questionScore?.studentId &&
+                  item.representative.questionScore?.cropRegionId &&
+                  (item.count > 1 ? (
+                    <ContextMenu>
+                      <ContextMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 shrink-0 px-1.5 text-gray-400 hover:text-blue-500"
+                          title="クリック: 移動 / 右クリック: 生徒選択"
+                          onClick={() =>
+                            onNavigateTo(
+                              item.representative.questionScore!.studentId!,
+                              item.representative.questionScore!.cropRegionId!
+                            )
+                          }
+                        >
+                          <Eye className="h-3.5 w-3.5" />
+                        </Button>
+                      </ContextMenuTrigger>
+                      <ContextMenuContent>
+                        {item.allIds
+                          .map((id) => allAnnotations.find((a) => a.id === id))
+                          .filter(
+                            (a): a is AnnotationWithContext =>
+                              !!a?.questionScore?.studentId &&
+                              !!a?.questionScore?.cropRegionId
+                          )
+                          .map((a) => {
+                            const s = a.questionScore!.student
+                            const label = s
+                              ? `${s.studentNumber} ${s.lastName}${s.firstName}`
+                              : a.questionScore!.studentId!.slice(0, 8)
+                            const question =
+                              a.questionScore!.cropRegion?.label ?? ""
+                            return (
+                              <ContextMenuItem
+                                key={a.id}
+                                onClick={() =>
+                                  onNavigateTo(
+                                    a.questionScore!.studentId!,
+                                    a.questionScore!.cropRegionId!
+                                  )
+                                }
+                              >
+                                {label}
+                                {question && (
+                                  <span className="ml-2 text-xs text-gray-400">
+                                    {question}
+                                  </span>
+                                )}
+                              </ContextMenuItem>
+                            )
+                          })}
+                      </ContextMenuContent>
+                    </ContextMenu>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 shrink-0 px-1.5 text-gray-400 hover:text-blue-500"
+                      title="この生徒・設問に移動"
+                      onClick={() =>
+                        onNavigateTo(
+                          item.representative.questionScore!.studentId!,
+                          item.representative.questionScore!.cropRegionId!
+                        )
+                      }
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                    </Button>
+                  ))}
 
                 {/* 追加ボタン */}
                 <Button

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -13,7 +13,7 @@ import {
   User,
   X,
 } from "lucide-react"
-import { useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 import { useKeyBindings } from "@/components/exams/07-score-at-once/hooks/useKeyBindings"
 import { QuestionProgress } from "@/components/exams/07-score-at-once/ScoringData/types/scoringDataTypes"
@@ -240,6 +240,20 @@ export function ScoringSidePanel({
     }
     prevRefreshKeyRef.current = annotationRefreshKey
   }, [annotationRefreshKey, reloadBrowserAnnotations, examId])
+
+  // アノテーションの生徒・設問に移動
+  const handleNavigateTo = useCallback(
+    (studentId: string, cropRegionId: string) => {
+      const targetCropRegion = cropRegions.find((cr) => cr.id === cropRegionId)
+      if (targetCropRegion) {
+        onCropRegionChange(targetCropRegion)
+      }
+      if (onStudentChange) {
+        onStudentChange(studentId)
+      }
+    },
+    [cropRegions, onCropRegionChange, onStudentChange]
+  )
 
   // 現在のstudentIdを取得
   const currentStudentId = (() => {
@@ -483,6 +497,8 @@ export function ScoringSidePanel({
             allScoringData={allScoringData ?? []}
             onQuestionScoreCreated={onQuestionScoreCreated}
             onAnnotationAddedFromBrowser={onAnnotationAddedFromBrowser}
+            onNavigateTo={handleNavigateTo}
+            allAnnotations={annotationBrowser.allAnnotations}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary
- アノテーションブラウザパネルにEyeアイコンの移動ボタンを追加（左クリック: 直接移動、右クリック: 生徒選択メニュー）
- テキストアノテーションをBackspaceで削除した際にtextCanvasに表示が残るバグを修正

Closes #764

## Test plan
- [ ] アノテーション一覧でEyeアイコンをクリックし、該当生徒・設問に移動することを確認
- [ ] ×2以上のグループでEyeアイコンを右クリックし、コンテキストメニューから生徒を選択できることを確認
- [ ] テキストアノテーションをBackspaceで削除し、キャンバスから即座に消えることを確認
- [ ] 直線・矩形・楕円の削除が従来通り正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)