### PR TITLE
feat: 採点操作モード（キーボード/マウス）の分離機能を実装

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -15,7 +15,9 @@ import type {
   CropRegionWithExamPage,
   LayoutDirection,
   MasterGridItem,
+  MouseBrushAction,
   ScoringData,
+  ScoringOperationMode,
 } from "@/components/exams/07-score-at-once/types"
 import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
 
@@ -53,6 +55,16 @@ export interface AnswerGridViewProps {
   onClickScoring?: (answerId: string, clickCount: number) => void
   /** クリック採点のデバウンス時間（ms） */
   clickScoringDebounceMs?: number
+  /** 採点操作モード */
+  scoringOperationMode?: ScoringOperationMode
+  /** マウスモード時のブラシ */
+  mouseBrush?: MouseBrushAction
+  /** マウスモード時のクリック採点コールバック */
+  onMouseScoring?: (
+    answerId: string,
+    status: MouseBrushAction,
+    isToggle: boolean
+  ) => void
   className?: string
 }
 
@@ -74,8 +86,12 @@ export default function AnswerGridView({
   pageSize,
   onClickScoring,
   clickScoringDebounceMs = 300,
+  scoringOperationMode,
+  mouseBrush,
+  onMouseScoring,
   className = "",
 }: AnswerGridViewProps) {
+  const isMouseMode = scoringOperationMode === "mouse"
   /** フィルタリングされた採点データ（模範解答 + 学生データ） */
   const masterAnswers = masterAnswerData
     ? [
@@ -162,6 +178,7 @@ export default function AnswerGridView({
 
   /** ドラッグ中のマウス移動ハンドラー */
   const handleMouseMove = (event: React.MouseEvent) => {
+    if (isMouseMode) return // マウスモードではドラッグ無効
     if (dragStart && gridRef.current) {
       const gridRect = gridRef.current.getBoundingClientRect()
       const currentX = event.clientX - gridRect.left
@@ -182,6 +199,7 @@ export default function AnswerGridView({
   }
 
   const handleMouseUp = (event: React.MouseEvent) => {
+    if (isMouseMode) return // マウスモードではドラッグ無効
     if (isDragging) {
       handleDragSelection(event, dragStart)
     }
@@ -197,19 +215,51 @@ export default function AnswerGridView({
     (event: React.MouseEvent, answerId: string) => {
       if (answerId.startsWith("master-")) return
 
+      // マウスモード: シングルクリックでブラシ適用（トグル付き）、ダブル以上はonClickScoring
+      if (isMouseMode) {
+        if (event.detail >= 2 && onClickScoring) {
+          const timers = clickTimersRef.current
+          const existing = timers.get(answerId)
+          if (existing) {
+            clearTimeout(existing.timerId)
+          }
+          const clickCount = Math.max(event.detail, existing?.clickCount ?? 0)
+          const timerId = setTimeout(() => {
+            timers.delete(answerId)
+            onClickScoring(answerId, clickCount)
+          }, clickScoringDebounceMs)
+          timers.set(answerId, { timerId, clickCount })
+          return
+        }
+
+        // シングルクリック: ブラシで採点
+        if (event.detail === 1 && onMouseScoring && mouseBrush) {
+          // デバウンスでダブルクリックを待つ
+          const timers = clickTimersRef.current
+          const existing = timers.get(answerId)
+          if (existing) {
+            clearTimeout(existing.timerId)
+          }
+          const timerId = setTimeout(() => {
+            timers.delete(answerId)
+            onMouseScoring(answerId, mouseBrush, true)
+          }, clickScoringDebounceMs)
+          timers.set(answerId, { timerId, clickCount: 1 })
+        }
+        return
+      }
+
+      // キーボードモード: 従来動作
       if (event.detail >= 2 && onClickScoring) {
-        // ダブルクリック以上: ドラッグ開始せず、クリック採点デバウンスに委譲
         const timers = clickTimersRef.current
         const existing = timers.get(answerId)
 
-        // 既存タイマーがあればクリア（有効時間を延長）
         if (existing) {
           clearTimeout(existing.timerId)
         }
 
         const clickCount = Math.max(event.detail, existing?.clickCount ?? 0)
 
-        // 新しいタイマーを設定（有効時間終了後に確定）
         const timerId = setTimeout(() => {
           timers.delete(answerId)
           onClickScoring(answerId, clickCount)
@@ -226,7 +276,15 @@ export default function AnswerGridView({
       }
       handleMouseDown(event, answerId)
     },
-    [startDrag, handleMouseDown, onClickScoring, clickScoringDebounceMs]
+    [
+      isMouseMode,
+      startDrag,
+      handleMouseDown,
+      onClickScoring,
+      clickScoringDebounceMs,
+      onMouseScoring,
+      mouseBrush,
+    ]
   )
 
   const isColumnLayout =

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -11,8 +11,10 @@ import type {
   LayoutDirection,
   MasterAnswerDisplayMode,
   MasterGridItem,
+  MouseBrushAction,
   QuestionScore,
   ScoringData,
+  ScoringOperationMode,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
 
@@ -47,6 +49,13 @@ interface ScoringContentAreaProps {
   pageSize?: string
   onClickScoring?: (answerId: string, clickCount: number) => void
   clickScoringDebounceMs?: number
+  scoringOperationMode?: ScoringOperationMode
+  mouseBrush?: MouseBrushAction
+  onMouseScoring?: (
+    answerId: string,
+    status: MouseBrushAction,
+    isToggle: boolean
+  ) => void
 }
 
 export function ScoringContentArea({
@@ -80,6 +89,9 @@ export function ScoringContentArea({
   pageSize = "A4",
   onClickScoring,
   clickScoringDebounceMs,
+  scoringOperationMode,
+  mouseBrush,
+  onMouseScoring,
 }: ScoringContentAreaProps) {
   const currentScoringDataId =
     gradingMode === "individual"
@@ -187,6 +199,9 @@ export function ScoringContentArea({
         pageSize={pageSize}
         onClickScoring={onClickScoring}
         clickScoringDebounceMs={clickScoringDebounceMs}
+        scoringOperationMode={scoringOperationMode}
+        mouseBrush={mouseBrush}
+        onMouseScoring={onMouseScoring}
         className="p-4"
       />
     )

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -19,6 +19,7 @@ import { useScoringDataLoader } from "@/components/exams/07-score-at-once/Scorin
 import { useScoringEffects } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringEffects"
 import { useScoringFilter } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter"
 import { useScoringMainState } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMainState"
+import { useScoringMode } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMode"
 import { useScoringNavigation } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringNavigation"
 import { useScoringSettings } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings"
 import { useScoringShortcuts } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts"
@@ -26,12 +27,16 @@ import { useStudentAnswerManagement } from "@/components/exams/07-score-at-once/
 import { ScoringContentArea } from "@/components/exams/07-score-at-once/ScoringMain/ScoringContentArea"
 import { ScoringHeaderControls } from "@/components/exams/07-score-at-once/ScoringMain/ScoringHeaderControls"
 import { ScoringModals } from "@/components/exams/07-score-at-once/ScoringMain/ScoringModals"
+import { ScoringModeModal } from "@/components/exams/07-score-at-once/ScoringMain/ScoringModeModal"
 import {
   ScoringErrorState,
   ScoringLoadingState,
 } from "@/components/exams/07-score-at-once/ScoringMain/ScoringStates"
 import { ScoringSidePanel } from "@/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel"
-import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
+import type {
+  MouseBrushAction,
+  ScoringStatus,
+} from "@/components/exams/07-score-at-once/types"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 import { useAuth } from "@/contexts/AuthContext"
@@ -43,6 +48,18 @@ function ScoringMainViewContent() {
   const { user: authUser } = useAuth()
   const { helpButton } = usePageHelp()
   const { keyBindings } = useShortcutContext()
+
+  /** 操作モード管理 */
+  const {
+    scoringOperationMode,
+    showModeSelectionModal,
+    selectMode,
+    setScoringOperationMode,
+    closeModeSelectionModal,
+    mouseBrush,
+    setMouseBrush,
+  } = useScoringMode()
+  const effectiveMode = scoringOperationMode ?? "keyboard"
 
   /** モーダル用のキーバインディング */
   const modalKeyBindings = useMemo(
@@ -414,6 +431,78 @@ function ScoringMainViewContent() {
     ]
   )
 
+  /** マウスモード: クリック採点（トグル付き） */
+  const handleMouseScoring = useCallback(
+    (answerId: string, status: MouseBrushAction, isToggle: boolean) => {
+      if (answerId.startsWith("master-")) return
+
+      // トグル: 同じステータスなら未採点に戻す
+      if (isToggle) {
+        const currentData = allScoringData.find((d) => d.id === answerId)
+        if (currentData?.status === status) {
+          const targetSet = new Set([answerId])
+          handleBatchScore("unscored" as ScoringStatus, null, null, targetSet)
+          setRecentlyScoredAnswers((prev) => {
+            const newSet = new Set(prev)
+            newSet.add(answerId)
+            return newSet
+          })
+          return
+        }
+      }
+
+      const targetSet = new Set([answerId])
+      handleBatchScore(status as ScoringStatus, null, null, targetSet)
+      setRecentlyScoredAnswers((prev) => {
+        const newSet = new Set(prev)
+        newSet.add(answerId)
+        return newSet
+      })
+    },
+    [allScoringData, handleBatchScore, setRecentlyScoredAnswers]
+  )
+
+  /** マウスモード: 表示中の未採点を一括採点 */
+  const handleBatchScoreVisibleUnscored = useCallback(
+    (status: MouseBrushAction) => {
+      const unscoredVisible = allScoringData.filter(
+        (d) => d.status === "unscored" && filteredScoringDataIds.includes(d.id)
+      )
+      if (unscoredVisible.length === 0) return
+      const targetSet = new Set(unscoredVisible.map((d) => d.id))
+      handleBatchScore(status as ScoringStatus, null, null, targetSet)
+      setRecentlyScoredAnswers((prev) => {
+        const newSet = new Set(prev)
+        unscoredVisible.forEach((d) => newSet.add(d.id))
+        return newSet
+      })
+    },
+    [
+      allScoringData,
+      filteredScoringDataIds,
+      handleBatchScore,
+      setRecentlyScoredAnswers,
+    ]
+  )
+
+  /** 表示中の未採点件数 */
+  const visibleUnscoredCount = useMemo(
+    () =>
+      allScoringData.filter(
+        (d) => d.status === "unscored" && filteredScoringDataIds.includes(d.id)
+      ).length,
+    [allScoringData, filteredScoringDataIds]
+  )
+
+  /** 非表示の未採点件数 */
+  const hiddenUnscoredCount = useMemo(
+    () =>
+      allScoringData.filter(
+        (d) => d.status === "unscored" && !filteredScoringDataIds.includes(d.id)
+      ).length,
+    [allScoringData, filteredScoringDataIds]
+  )
+
   /** 表示モード切り替え（グリッド⇔個別） */
   const handleToggleViewMode = useCallback(
     () => setGradingMode((prev) => (prev === "grid" ? "individual" : "grid")),
@@ -486,6 +575,7 @@ function ScoringMainViewContent() {
   useContextValue("sidePanelVisible", showSidePanel)
   useContextValue("partialScoreModalOpen", showPartialScoreModal)
   useContextValue("modalOpen", showPartialScoreModal || showScoreComparison)
+  useContextValue("scoringOperationMode", effectiveMode)
 
   /** キーボードショートカット登録 */
   useScoringShortcuts({
@@ -510,6 +600,7 @@ function ScoringMainViewContent() {
     handleSelectAll,
     handleToggleViewMode: handleToggleViewMode,
     handleToggleMasterAnswer,
+    scoringOperationMode: effectiveMode,
   })
 
   const currentStudentId = useMemo(() => {
@@ -596,6 +687,9 @@ function ScoringMainViewContent() {
             pageSize={pageSize}
             onClickScoring={handleClickScoring}
             clickScoringDebounceMs={clickScoringDebounceMs}
+            scoringOperationMode={effectiveMode}
+            mouseBrush={mouseBrush}
+            onMouseScoring={handleMouseScoring}
           />
         </div>
 
@@ -664,6 +758,13 @@ function ScoringMainViewContent() {
               onToggleMasterAnswer={handleToggleMasterAnswer}
               onMasterAnswerShow={handleMasterAnswerShow}
               onMasterAnswerHide={handleMasterAnswerHide}
+              scoringOperationMode={effectiveMode}
+              onScoringOperationModeChange={setScoringOperationMode}
+              mouseBrush={mouseBrush}
+              onMouseBrushChange={setMouseBrush}
+              visibleUnscoredCount={visibleUnscoredCount}
+              hiddenUnscoredCount={hiddenUnscoredCount}
+              onBatchScoreVisibleUnscored={handleBatchScoreVisibleUnscored}
             />
           </div>
         </div>
@@ -676,6 +777,13 @@ function ScoringMainViewContent() {
         open={showOmrModal}
         onOpenChange={setShowOmrModal}
         onScoresApplied={handleQuestionScoreCreated}
+      />
+
+      {/* モード選択モーダル */}
+      <ScoringModeModal
+        open={showModeSelectionModal}
+        onSelect={selectMode}
+        onClose={closeModeSelectionModal}
       />
 
       {/* モーダル類 */}

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringModeModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringModeModal.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { Keyboard, Mouse } from "lucide-react"
+import { useState } from "react"
+
+import type { ScoringOperationMode } from "@/components/exams/07-score-at-once/types"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ScoringModeModalProps {
+  open: boolean
+  onSelect: (mode: ScoringOperationMode, remember: boolean) => void
+  onClose: () => void
+}
+
+export function ScoringModeModal({
+  open,
+  onSelect,
+  onClose,
+}: ScoringModeModalProps) {
+  const [remember, setRemember] = useState(false)
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>採点操作モードを選択</DialogTitle>
+          <DialogDescription>
+            採点時の操作方法を選んでください。後からサイドパネルで切り替えられます。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-4 py-4">
+          {/* キーボードモード */}
+          <Button
+            variant="outline"
+            className="flex h-32 flex-col items-center justify-center gap-3 border-2 hover:border-blue-500 hover:bg-blue-50"
+            onClick={() => onSelect("keyboard", remember)}
+          >
+            <Keyboard className="h-10 w-10 text-blue-600" />
+            <div className="text-center">
+              <div className="font-medium">キーボード</div>
+              <div className="mt-1 text-[10px] text-gray-500">
+                選択してキーで採点
+              </div>
+            </div>
+          </Button>
+
+          {/* マウスモード */}
+          <Button
+            variant="outline"
+            className="flex h-32 flex-col items-center justify-center gap-3 border-2 hover:border-green-500 hover:bg-green-50"
+            onClick={() => onSelect("mouse", remember)}
+          >
+            <Mouse className="h-10 w-10 text-green-600" />
+            <div className="text-center">
+              <div className="font-medium">マウス</div>
+              <div className="mt-1 text-[10px] text-gray-500">
+                クリックで直接採点
+              </div>
+            </div>
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2 border-t pt-3">
+          <Checkbox
+            id="remember-mode"
+            checked={remember}
+            onCheckedChange={(v) => setRemember(v === true)}
+          />
+          <label
+            htmlFor="remember-mode"
+            className="cursor-pointer text-sm text-gray-600"
+          >
+            この選択を記憶する
+          </label>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
@@ -166,6 +166,7 @@ function evaluateWhenClause(
       "partialScoreModalOpen",
       "sidePanelVisible",
       "hasSelectedAnswers",
+      "scoringOperationMode",
       `return ${when}`
     )
 
@@ -176,7 +177,8 @@ function evaluateWhenClause(
       context.modalOpen,
       context.partialScoreModalOpen,
       context.sidePanelVisible,
-      context.hasSelectedAnswers
+      context.hasSelectedAnswers,
+      context.scoringOperationMode
     )
   } catch (error) {
     console.error("Failed to evaluate when clause:", when, error)
@@ -211,6 +213,7 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
     partialScoreModalOpen: false,
     sidePanelVisible: true,
     hasSelectedAnswers: false,
+    scoringOperationMode: "keyboard",
   })
 
   // コマンドレジストリ（commandId -> CommandHandler[]）

--- a/src/components/exams/07-score-at-once/ScoringMain/contexts/shortcutContextTypes.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/contexts/shortcutContextTypes.ts
@@ -28,6 +28,9 @@ export interface ScoringContextState {
 
   /** 答案が選択されている状態 */
   hasSelectedAnswers: boolean
+
+  /** 採点操作モード */
+  scoringOperationMode: "keyboard" | "mouse"
 }
 
 /**

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMode.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringMode.ts
@@ -1,0 +1,107 @@
+/**
+ * 採点操作モード管理フック
+ * キーボード/マウスモードの切替とlocalStorage永続化を提供
+ */
+
+import { useCallback, useState } from "react"
+
+import type {
+  MouseBrushAction,
+  ScoringOperationMode,
+} from "@/components/exams/07-score-at-once/types"
+
+const STORAGE_KEY_MODE = "scoring-operation-mode"
+const STORAGE_KEY_REMEMBER = "scoring-operation-mode-remember"
+
+interface UseScoringModeReturn {
+  /** 現在の操作モード */
+  scoringOperationMode: ScoringOperationMode
+  /** モード選択モーダルを表示するか */
+  showModeSelectionModal: boolean
+  /** モーダルからモードを選択 */
+  selectMode: (mode: ScoringOperationMode, remember: boolean) => void
+  /** モードを直接設定（トグル用） */
+  setScoringOperationMode: (mode: ScoringOperationMode) => void
+  /** モーダルを閉じる */
+  closeModeSelectionModal: () => void
+  /** モーダルを開く */
+  openModeSelectionModal: () => void
+  /** 現在のマウスブラシ */
+  mouseBrush: MouseBrushAction
+  /** マウスブラシを設定 */
+  setMouseBrush: (brush: MouseBrushAction) => void
+}
+
+export function useScoringMode(): UseScoringModeReturn {
+  // localStorageから記憶済みモードを取得
+  const remembered = (() => {
+    try {
+      const shouldRemember = localStorage.getItem(STORAGE_KEY_REMEMBER)
+      if (shouldRemember === "true") {
+        const mode = localStorage.getItem(STORAGE_KEY_MODE)
+        if (mode === "keyboard" || mode === "mouse") {
+          return mode
+        }
+      }
+    } catch {
+      // localStorage利用不可の場合は無視
+    }
+    return null
+  })()
+
+  const [scoringOperationMode, setModeInternal] =
+    useState<ScoringOperationMode>(remembered ?? "keyboard")
+  const [showModeSelectionModal, setShowModeSelectionModal] =
+    useState(!remembered)
+  const [mouseBrush, setMouseBrush] = useState<MouseBrushAction>("correct")
+
+  const selectMode = useCallback(
+    (mode: ScoringOperationMode, remember: boolean) => {
+      setModeInternal(mode)
+      setShowModeSelectionModal(false)
+      try {
+        if (remember) {
+          localStorage.setItem(STORAGE_KEY_MODE, mode)
+          localStorage.setItem(STORAGE_KEY_REMEMBER, "true")
+        } else {
+          localStorage.removeItem(STORAGE_KEY_MODE)
+          localStorage.removeItem(STORAGE_KEY_REMEMBER)
+        }
+      } catch {
+        // localStorage利用不可の場合は無視
+      }
+    },
+    []
+  )
+
+  const setScoringOperationMode = useCallback((mode: ScoringOperationMode) => {
+    setModeInternal(mode)
+    try {
+      const shouldRemember = localStorage.getItem(STORAGE_KEY_REMEMBER)
+      if (shouldRemember === "true") {
+        localStorage.setItem(STORAGE_KEY_MODE, mode)
+      }
+    } catch {
+      // localStorage利用不可の場合は無視
+    }
+  }, [])
+
+  const closeModeSelectionModal = useCallback(() => {
+    setShowModeSelectionModal(false)
+  }, [])
+
+  const openModeSelectionModal = useCallback(() => {
+    setShowModeSelectionModal(true)
+  }, [])
+
+  return {
+    scoringOperationMode,
+    showModeSelectionModal,
+    selectMode,
+    setScoringOperationMode,
+    closeModeSelectionModal,
+    openModeSelectionModal,
+    mouseBrush,
+    setMouseBrush,
+  }
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -6,7 +6,10 @@
  */
 
 import { useCommand } from "@/components/exams/07-score-at-once/hooks/useCommand"
-import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
+import type {
+  ScoringOperationMode,
+  ScoringStatus,
+} from "@/components/exams/07-score-at-once/types"
 
 /**
  * ショートカットハンドラーの型定義
@@ -50,6 +53,8 @@ interface ScoringShortcutHandlers {
   handleToggleViewMode: () => void
   /** 模範解答表示トグル（個別モード） */
   handleToggleMasterAnswer?: () => void
+  /** 採点操作モード（キーボード専用コマンドの制御用） */
+  scoringOperationMode?: ScoringOperationMode
 }
 
 /**
@@ -78,13 +83,17 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
     handleSelectAll,
     handleToggleViewMode,
     handleToggleMasterAnswer,
+    scoringOperationMode: _scoringOperationMode,
   } = handlers
+
+  // キーボードモード専用コマンドのwhen句サフィックス
+  const kbOnly = " && scoringOperationMode == 'keyboard'"
 
   // ========================================
   // 選択コマンド
   // ========================================
   useCommand("selection.selectAll", handleSelectAll, {
-    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    when: `!inputFocus && !modalOpen && gradingMode == 'grid'${kbOnly}`,
     metadata: {
       title: "全選択",
       category: "選択",
@@ -96,7 +105,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   // 採点コマンド（サイドパネル非表示でも有効）
   // ========================================
   useCommand("scoring.unscored", () => handleScore("unscored"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "未採点として採点",
       category: "採点",
@@ -105,7 +114,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.correct", () => handleScore("correct"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "正答として採点",
       category: "採点",
@@ -114,7 +123,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.partial", () => handleScore("partial"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "部分点として採点",
       category: "採点",
@@ -123,7 +132,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.pending", () => handleScore("pending"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "保留として採点",
       category: "採点",
@@ -132,7 +141,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.incorrect", () => handleScore("incorrect"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "誤答として採点",
       category: "採点",
@@ -141,7 +150,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.noAnswer", () => handleScore("no_answer"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "無答として採点",
       category: "採点",
@@ -150,7 +159,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("scoring.doubleMark", () => handleScore("double_mark"), {
-    when: "!inputFocus && !modalOpen && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && hasSelectedAnswers${kbOnly}`,
     metadata: {
       title: "Wマークとして採点",
       category: "採点",
@@ -297,7 +306,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("navigation.moveUp", () => handleGridNavigation("w"), {
-    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    when: `!inputFocus && !modalOpen && gradingMode == 'grid'${kbOnly}`,
     metadata: {
       title: "上に移動",
       category: "ナビゲーション",
@@ -305,7 +314,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("navigation.moveDown", () => handleGridNavigation("s"), {
-    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    when: `!inputFocus && !modalOpen && gradingMode == 'grid'${kbOnly}`,
     metadata: {
       title: "下に移動",
       category: "ナビゲーション",
@@ -313,7 +322,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("navigation.moveLeft", () => handleGridNavigation("a"), {
-    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    when: `!inputFocus && !modalOpen && gradingMode == 'grid'${kbOnly}`,
     metadata: {
       title: "左に移動",
       category: "ナビゲーション",
@@ -321,7 +330,7 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   })
 
   useCommand("navigation.moveRight", () => handleGridNavigation("d"), {
-    when: "!inputFocus && !modalOpen && gradingMode == 'grid'",
+    when: `!inputFocus && !modalOpen && gradingMode == 'grid'${kbOnly}`,
     metadata: {
       title: "右に移動",
       category: "ナビゲーション",
@@ -514,57 +523,57 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   // 部分点入力ショートカット（グリッド・個別共通）
   // ========================================
   useCommand("scoring.openPartialWith0", () => handlePartialScoreInput("0"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "0キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith1", () => handlePartialScoreInput("1"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "1キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith2", () => handlePartialScoreInput("2"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "2キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith3", () => handlePartialScoreInput("3"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "3キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith4", () => handlePartialScoreInput("4"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "4キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith5", () => handlePartialScoreInput("5"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "5キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith6", () => handlePartialScoreInput("6"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "6キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith7", () => handlePartialScoreInput("7"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "7キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith8", () => handlePartialScoreInput("8"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "8キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith9", () => handlePartialScoreInput("9"), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: "9キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWithDot", () => handlePartialScoreInput("."), {
-    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
+    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
     metadata: { title: ".キーで部分点入力", category: "採点" },
   })
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -28,6 +28,8 @@ import type {
   LayoutDirection,
   MasterAnswerDisplayMode,
   MasterAnswerKeyBehavior,
+  MouseBrushAction,
+  ScoringOperationMode,
   ScoringStatus,
   StudentAnswerImageWithExamStudents,
 } from "@/components/exams/07-score-at-once/types"
@@ -163,6 +165,14 @@ interface ScoringSidePanelProps {
   onToggleMasterAnswer?: () => void
   onMasterAnswerShow?: () => void
   onMasterAnswerHide?: () => void
+  // 操作モード関連
+  scoringOperationMode?: ScoringOperationMode
+  onScoringOperationModeChange?: (mode: ScoringOperationMode) => void
+  mouseBrush?: MouseBrushAction
+  onMouseBrushChange?: (brush: MouseBrushAction) => void
+  visibleUnscoredCount?: number
+  hiddenUnscoredCount?: number
+  onBatchScoreVisibleUnscored?: (status: MouseBrushAction) => void
 }
 
 export function ScoringSidePanel({
@@ -221,6 +231,13 @@ export function ScoringSidePanel({
   onToggleMasterAnswer,
   onMasterAnswerShow,
   onMasterAnswerHide,
+  scoringOperationMode,
+  onScoringOperationModeChange,
+  mouseBrush,
+  onMouseBrushChange,
+  visibleUnscoredCount,
+  hiddenUnscoredCount,
+  onBatchScoreVisibleUnscored,
 }: ScoringSidePanelProps) {
   const annotationBrowser = useAnnotationBrowser()
   const { keyBindings } = useKeyBindings()
@@ -422,6 +439,13 @@ export function ScoringSidePanel({
             onGridNavigation={onGridNavigation}
             isSectionOpen={isSectionOpen}
             onToggleSection={toggleSection}
+            scoringOperationMode={scoringOperationMode}
+            onScoringOperationModeChange={onScoringOperationModeChange}
+            mouseBrush={mouseBrush}
+            onMouseBrushChange={onMouseBrushChange}
+            visibleUnscoredCount={visibleUnscoredCount}
+            hiddenUnscoredCount={hiddenUnscoredCount}
+            onBatchScoreVisibleUnscored={onBatchScoreVisibleUnscored}
           />
 
           {/* 個別表示モード時：生徒選択パネル */}

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -10,7 +10,9 @@ import {
   Circle,
   Clock,
   CopyX,
+  Keyboard,
   Minus,
+  Mouse,
   Target,
   X,
 } from "lucide-react"
@@ -21,7 +23,11 @@ import type {
   ClickScoringAction,
   ClickScoringConfig,
 } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig"
-import type { ScoringStatus } from "@/components/exams/07-score-at-once/types"
+import type {
+  MouseBrushAction,
+  ScoringOperationMode,
+  ScoringStatus,
+} from "@/components/exams/07-score-at-once/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -78,6 +84,13 @@ interface ScoringToolbarProps {
   onGridNavigation?: (direction: string) => void
   isSectionOpen?: (sectionId: string) => boolean
   onToggleSection?: (sectionId: string) => void
+  scoringOperationMode?: ScoringOperationMode
+  onScoringOperationModeChange?: (mode: ScoringOperationMode) => void
+  mouseBrush?: MouseBrushAction
+  onMouseBrushChange?: (brush: MouseBrushAction) => void
+  visibleUnscoredCount?: number
+  hiddenUnscoredCount?: number
+  onBatchScoreVisibleUnscored?: (status: MouseBrushAction) => void
 }
 
 const STATUS_MAP: Record<ScoringStatus, ScoringStatusType> = {
@@ -135,6 +148,16 @@ const SCORING_BUTTONS = [
   },
 ] as const
 
+/** マウスモード用ブラシ（unscoredを除く） */
+const BRUSH_BUTTONS = SCORING_BUTTONS.filter(
+  (b) => b.status !== "unscored"
+) as Array<{
+  status: MouseBrushAction
+  label: string
+  icon: typeof CheckCircle
+  description: string
+}>
+
 const CLICK_ACTION_OPTIONS: { value: ClickScoringAction; label: string }[] = [
   { value: "none", label: "なし" },
   { value: "correct", label: "正答" },
@@ -171,6 +194,13 @@ export default function ScoringToolbar({
   onGridNavigation,
   isSectionOpen,
   onToggleSection,
+  scoringOperationMode = "keyboard",
+  onScoringOperationModeChange,
+  mouseBrush = "correct",
+  onMouseBrushChange,
+  visibleUnscoredCount = 0,
+  hiddenUnscoredCount = 0,
+  onBatchScoreVisibleUnscored,
 }: ScoringToolbarProps) {
   const { keyBindings } = useKeyBindings()
   const scoringColors = useScoringStatusColors()
@@ -201,183 +231,354 @@ export default function ScoringToolbar({
         }
       >
         <div className="space-y-3">
-          {/* 採点ボタン */}
-          <div style={GRID_4_3_STYLE}>
-            {SCORING_BUTTONS.map((button) => {
-              const Icon = button.icon
-              const commandId = `scoring.${button.status === "no_answer" ? "noAnswer" : button.status}`
-              const keyBinding = keyBindings[commandId] || "?"
-              const statusType = STATUS_MAP[button.status]
-              const colors = scoringColors[statusType]
-              return (
-                <Tooltip key={button.status}>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className={`flex h-12 flex-col gap-1 border-2 ${
-                        selectedAnswersCount === 0
-                          ? "cursor-not-allowed opacity-50"
-                          : "hover:opacity-80"
-                      }`}
-                      style={{
-                        backgroundColor: colors.bg,
-                        color: colors.text,
-                        borderColor: colors.bg,
-                      }}
-                      onClick={() => onScore(button.status)}
-                      disabled={selectedAnswersCount === 0}
-                    >
-                      <Icon className="h-4 w-4" />
-                      <div className="text-xs">{button.label}</div>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="text-center">
-                      <div className="font-medium">{button.description}</div>
-                      <KeyHint label={keyBinding.toUpperCase()} />
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )
-            })}
-          </div>
+          {/* モード切替トグル（グリッドモードのみ） */}
+          {gradingMode === "grid" && onScoringOperationModeChange && (
+            <div className="flex items-center gap-1 rounded-md border border-gray-200 p-0.5">
+              <Button
+                variant={
+                  scoringOperationMode === "keyboard" ? "default" : "ghost"
+                }
+                size="sm"
+                className="flex flex-1 items-center gap-1.5 text-xs"
+                onClick={() => onScoringOperationModeChange("keyboard")}
+              >
+                <Keyboard className="h-3.5 w-3.5" />
+                キーボード
+              </Button>
+              <Button
+                variant={scoringOperationMode === "mouse" ? "default" : "ghost"}
+                size="sm"
+                className="flex flex-1 items-center gap-1.5 text-xs"
+                onClick={() => onScoringOperationModeChange("mouse")}
+              >
+                <Mouse className="h-3.5 w-3.5" />
+                マウス
+              </Button>
+            </div>
+          )}
 
-          {/* 選択操作 */}
-          {gradingMode === "grid" && (
-            <div className="space-y-1">
-              {onSelectUnscored && (
+          {/* マウスモード用UI（グリッドモードのみ） */}
+          {scoringOperationMode === "mouse" && gradingMode === "grid" && (
+            <>
+              {/* ブラシ選択 */}
+              <div>
+                <div className="mb-1 text-xs font-medium text-gray-600">
+                  クリック時の採点ブラシ
+                </div>
+                <div style={GRID_4_3_STYLE}>
+                  {BRUSH_BUTTONS.map((button) => {
+                    const Icon = button.icon
+                    const statusType = STATUS_MAP[button.status]
+                    const colors = scoringColors[statusType]
+                    const isActive = mouseBrush === button.status
+                    return (
+                      <Tooltip key={button.status}>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className={`flex h-12 flex-col gap-1 border-2 ${
+                              isActive
+                                ? "ring-2 ring-blue-500 ring-offset-1"
+                                : "opacity-60 hover:opacity-80"
+                            }`}
+                            style={{
+                              backgroundColor: colors.bg,
+                              color: colors.text,
+                              borderColor: colors.bg,
+                            }}
+                            onClick={() => onMouseBrushChange?.(button.status)}
+                          >
+                            <Icon className="h-4 w-4" />
+                            <div className="text-xs">{button.label}</div>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <div className="text-center">
+                            <div className="font-medium">
+                              {button.description}
+                            </div>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    )
+                  })}
+                </div>
+              </div>
+
+              {/* 一括採点ボタン */}
+              {onBatchScoreVisibleUnscored && visibleUnscoredCount > 0 && (
+                <div className="space-y-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full text-xs"
+                    onClick={() => onBatchScoreVisibleUnscored(mouseBrush)}
+                  >
+                    表示中の未採点{visibleUnscoredCount}件を
+                    {BRUSH_BUTTONS.find((b) => b.status === mouseBrush)
+                      ?.label ?? mouseBrush}
+                    にする
+                  </Button>
+                  {hiddenUnscoredCount > 0 && (
+                    <div className="flex items-center gap-1 text-[10px] text-amber-600">
+                      <AlertTriangle className="h-3 w-3" />
+                      非表示の未採点が{hiddenUnscoredCount}件あります
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* フィルタ更新 */}
+              {onRefreshFilter && (
                 <Button
                   variant="outline"
                   size="sm"
                   className="w-full text-xs"
-                  onClick={onSelectUnscored}
+                  onClick={onRefreshFilter}
                 >
-                  未採点の生徒答案を全て選択
+                  表示フィルターに合わせて表示を更新
                 </Button>
               )}
-              {onSelectAll && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full text-xs"
-                      onClick={onSelectAll}
-                    >
-                      表示されている生徒答案を全て選択
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="text-center">
-                      <div className="font-medium">表示中の答案を全て選択</div>
-                      <KeyHint label={`${ctrlLabel}+A`} />
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {onRefreshFilter && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full text-xs"
-                      onClick={onRefreshFilter}
-                    >
-                      表示フィルターに合わせて表示を更新
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="text-center">
-                      <div className="font-medium">フィルターを再適用</div>
-                      <KeyHint label="R" />
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
-          )}
 
-          {/* クリックで採点 */}
-          {gradingMode === "grid" &&
-            clickScoringConfig &&
-            onClickActionChange && (
-              <div className="space-y-1.5">
-                {([2, 3, 4] as const).map((clickCount) => {
-                  const labels = {
-                    2: "ダブルクリック:",
-                    3: "トリプルクリック:",
-                    4: "クアトロクリック:",
-                  }
-                  return (
-                    <div
-                      key={clickCount}
-                      className="flex items-center justify-between text-xs"
-                    >
-                      <span className="text-gray-600">
-                        {labels[clickCount]}
-                      </span>
-                      <Select
-                        value={clickScoringConfig[clickCount]}
-                        onValueChange={(v) =>
-                          onClickActionChange(
-                            clickCount,
-                            v as ClickScoringAction
-                          )
-                        }
-                      >
-                        <SelectTrigger className="h-7 w-60 text-xs">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {CLICK_ACTION_OPTIONS.map((opt) => (
-                            <SelectItem
-                              key={opt.value}
-                              value={opt.value}
-                              className="text-xs"
-                            >
-                              {opt.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )
-                })}
-
-                {onClickScoringDebounceMsChange && (
-                  <div className="space-y-0.5">
-                    <span className="text-[10px] text-gray-500">
-                      クリックの最長間隔
-                    </span>
-                    <div className="flex items-center gap-2 text-xs text-gray-600">
-                      <span className="shrink-0 text-base" title="速い">
-                        🐇
-                      </span>
-                      <Slider
-                        className="flex-1"
-                        value={[clickScoringDebounceMs]}
-                        min={100}
-                        max={800}
-                        step={50}
-                        onValueChange={([v]) =>
-                          onClickScoringDebounceMsChange(v)
-                        }
-                      />
-                      <span className="shrink-0 text-base" title="遅い">
-                        🐢
-                      </span>
-                      <span className="w-10 shrink-0 text-right text-[10px] text-gray-400">
-                        {clickScoringDebounceMs}ms
-                      </span>
-                    </div>
+              {/* クリックで採点（ダブル以上） */}
+              {gradingMode === "grid" &&
+                clickScoringConfig &&
+                onClickActionChange && (
+                  <div className="space-y-1.5">
+                    {([2, 3, 4] as const).map((clickCount) => {
+                      const labels = {
+                        2: "ダブルクリック:",
+                        3: "トリプルクリック:",
+                        4: "クアトロクリック:",
+                      }
+                      return (
+                        <div
+                          key={clickCount}
+                          className="flex items-center justify-between text-xs"
+                        >
+                          <span className="text-gray-600">
+                            {labels[clickCount]}
+                          </span>
+                          <Select
+                            value={clickScoringConfig[clickCount]}
+                            onValueChange={(v) =>
+                              onClickActionChange(
+                                clickCount,
+                                v as ClickScoringAction
+                              )
+                            }
+                          >
+                            <SelectTrigger className="h-7 w-60 text-xs">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {CLICK_ACTION_OPTIONS.map((opt) => (
+                                <SelectItem
+                                  key={opt.value}
+                                  value={opt.value}
+                                  className="text-xs"
+                                >
+                                  {opt.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )
+                    })}
                   </div>
                 )}
-              </div>
-            )}
+            </>
+          )}
 
-          {/* 自動スクロール */}
+          {/* キーボードモード用UI（キーボードモードまたは個別表示時） */}
+          {(scoringOperationMode === "keyboard" ||
+            gradingMode === "individual") && (
+            <>
+              {/* 採点ボタン */}
+              <div style={GRID_4_3_STYLE}>
+                {SCORING_BUTTONS.map((button) => {
+                  const Icon = button.icon
+                  const commandId = `scoring.${button.status === "no_answer" ? "noAnswer" : button.status}`
+                  const keyBinding = keyBindings[commandId] || "?"
+                  const statusType = STATUS_MAP[button.status]
+                  const colors = scoringColors[statusType]
+                  return (
+                    <Tooltip key={button.status}>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className={`flex h-12 flex-col gap-1 border-2 ${
+                            selectedAnswersCount === 0
+                              ? "cursor-not-allowed opacity-50"
+                              : "hover:opacity-80"
+                          }`}
+                          style={{
+                            backgroundColor: colors.bg,
+                            color: colors.text,
+                            borderColor: colors.bg,
+                          }}
+                          onClick={() => onScore(button.status)}
+                          disabled={selectedAnswersCount === 0}
+                        >
+                          <Icon className="h-4 w-4" />
+                          <div className="text-xs">{button.label}</div>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <div className="text-center">
+                          <div className="font-medium">
+                            {button.description}
+                          </div>
+                          <KeyHint label={keyBinding.toUpperCase()} />
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  )
+                })}
+              </div>
+
+              {/* 選択操作 */}
+              {gradingMode === "grid" && (
+                <div className="space-y-1">
+                  {onSelectUnscored && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={onSelectUnscored}
+                    >
+                      未採点の生徒答案を全て選択
+                    </Button>
+                  )}
+                  {onSelectAll && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full text-xs"
+                          onClick={onSelectAll}
+                        >
+                          表示されている生徒答案を全て選択
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <div className="text-center">
+                          <div className="font-medium">
+                            表示中の答案を全て選択
+                          </div>
+                          <KeyHint label={`${ctrlLabel}+A`} />
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {onRefreshFilter && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full text-xs"
+                          onClick={onRefreshFilter}
+                        >
+                          表示フィルターに合わせて表示を更新
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <div className="text-center">
+                          <div className="font-medium">フィルターを再適用</div>
+                          <KeyHint label="R" />
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              )}
+
+              {/* クリックで採点 */}
+              {gradingMode === "grid" &&
+                clickScoringConfig &&
+                onClickActionChange && (
+                  <div className="space-y-1.5">
+                    {([2, 3, 4] as const).map((clickCount) => {
+                      const labels = {
+                        2: "ダブルクリック:",
+                        3: "トリプルクリック:",
+                        4: "クアトロクリック:",
+                      }
+                      return (
+                        <div
+                          key={clickCount}
+                          className="flex items-center justify-between text-xs"
+                        >
+                          <span className="text-gray-600">
+                            {labels[clickCount]}
+                          </span>
+                          <Select
+                            value={clickScoringConfig[clickCount]}
+                            onValueChange={(v) =>
+                              onClickActionChange(
+                                clickCount,
+                                v as ClickScoringAction
+                              )
+                            }
+                          >
+                            <SelectTrigger className="h-7 w-60 text-xs">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {CLICK_ACTION_OPTIONS.map((opt) => (
+                                <SelectItem
+                                  key={opt.value}
+                                  value={opt.value}
+                                  className="text-xs"
+                                >
+                                  {opt.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )
+                    })}
+
+                    {onClickScoringDebounceMsChange && (
+                      <div className="space-y-0.5">
+                        <span className="text-[10px] text-gray-500">
+                          クリックの最長間隔
+                        </span>
+                        <div className="flex items-center gap-2 text-xs text-gray-600">
+                          <span className="shrink-0 text-base" title="速い">
+                            🐇
+                          </span>
+                          <Slider
+                            className="flex-1"
+                            value={[clickScoringDebounceMs]}
+                            min={100}
+                            max={800}
+                            step={50}
+                            onValueChange={([v]) =>
+                              onClickScoringDebounceMsChange(v)
+                            }
+                          />
+                          <span className="shrink-0 text-base" title="遅い">
+                            🐢
+                          </span>
+                          <span className="w-10 shrink-0 text-right text-[10px] text-gray-400">
+                            {clickScoringDebounceMs}ms
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+            </>
+          )}
+
+          {/* 自動スクロール（共通） */}
           {gradingMode === "grid" && onAutoScrollChange && (
             <div className="flex items-center justify-between">
               <span className="text-xs text-gray-500">自動スクロール</span>
@@ -388,83 +589,85 @@ export default function ScoringToolbar({
             </div>
           )}
 
-          {/* WASD移動（横一列） */}
-          {gradingMode === "grid" && onGridNavigation && (
-            <div className="flex items-center justify-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-8"
-                    onClick={() => onGridNavigation("a")}
-                  >
-                    <ArrowLeft className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div className="font-medium">左に移動</div>
-                    <KeyHint label="A" />
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-8"
-                    onClick={() => onGridNavigation("w")}
-                  >
-                    <ArrowUp className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div className="font-medium">上に移動</div>
-                    <KeyHint label="W" />
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-8"
-                    onClick={() => onGridNavigation("s")}
-                  >
-                    <ArrowDown className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div className="font-medium">下に移動</div>
-                    <KeyHint label="S" />
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-8"
-                    onClick={() => onGridNavigation("d")}
-                  >
-                    <ArrowRight className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="text-center">
-                    <div className="font-medium">右に移動</div>
-                    <KeyHint label="D" />
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )}
+          {/* WASD移動（キーボードモードのみ） */}
+          {scoringOperationMode === "keyboard" &&
+            gradingMode === "grid" &&
+            onGridNavigation && (
+              <div className="flex items-center justify-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 w-8"
+                      onClick={() => onGridNavigation("a")}
+                    >
+                      <ArrowLeft className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">左に移動</div>
+                      <KeyHint label="A" />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 w-8"
+                      onClick={() => onGridNavigation("w")}
+                    >
+                      <ArrowUp className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">上に移動</div>
+                      <KeyHint label="W" />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 w-8"
+                      onClick={() => onGridNavigation("s")}
+                    >
+                      <ArrowDown className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">下に移動</div>
+                      <KeyHint label="S" />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 w-8"
+                      onClick={() => onGridNavigation("d")}
+                    >
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-center">
+                      <div className="font-medium">右に移動</div>
+                      <KeyHint label="D" />
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            )}
         </div>
       </SidePanelSection>
     </TooltipProvider>

--- a/src/components/exams/07-score-at-once/types/index.ts
+++ b/src/components/exams/07-score-at-once/types/index.ts
@@ -133,6 +133,18 @@ export interface ScoringData {
 }
 
 /**
+ * 採点操作モード
+ * - "keyboard": キーボードモード（選択→キーで採点）
+ * - "mouse": マウスモード（クリックで直接採点、選択概念なし）
+ */
+export type ScoringOperationMode = "keyboard" | "mouse"
+
+/**
+ * マウスモード時のブラシ（クリック時に適用する採点ステータス）
+ */
+export type MouseBrushAction = Exclude<ScoringStatus, "unscored">
+
+/**
  * 模範解答表示モード
  */
 export type MasterAnswerDisplayMode =


### PR DESCRIPTION
## Summary
- キーボードモード（選択→キーで一括採点）とマウスモード（クリックで直接採点）を完全分離
- 初回モード選択モーダル、採点パネル内モード切替トグル
- マウスモード: ブラシ選択式シングルクリック採点、トグル動作、一括採点ボタン（表示中のみ対象+非表示件数警告）

## Test plan
- [ ] キーボードモード選択時、従来通りの採点操作が可能であること
- [ ] マウスモード選択時、シングルクリックでブラシに応じた採点が行われること
- [ ] マウスモード時、同じ状態をクリックで未採点に戻ること（トグル動作）
- [ ] マウスモード時、ドラッグ選択が無効化されていること
- [ ] 「表示中の未採点N件を○○にする」ボタンが正しく動作すること
- [ ] 非表示の未採点がある場合に警告が表示されること
- [ ] 個別表示モード時にモード切替トグルが非表示であること
- [ ] 初回モーダルで「記憶する」選択後、次回起動時にモーダルが表示されないこと
- [ ] マウスモード時にキーボードショートカット（E/O/F/WASD/数字）が無効化されていること
- [ ] 設問移動（Shift+A/D）やフィルターキーは両モードで有効であること

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)