### PR TITLE
feat: 一括採点のクリック操作の拡張と部分点入力モーダルの改善

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -217,6 +217,14 @@ export default function AnswerGridView({
 
       // マウスモード: シングルクリックでブラシ適用（トグル付き）、ダブル以上はonClickScoring
       if (isMouseMode) {
+        // 「選択」ブラシ: 採点せず即時に選択トグル
+        if (mouseBrush === "select") {
+          if (event.detail === 1) {
+            onScoringDataSelect(answerId, !selectedScoringDataIds.has(answerId))
+          }
+          return
+        }
+
         if (event.detail >= 2 && onClickScoring) {
           const timers = clickTimersRef.current
           const existing = timers.get(answerId)
@@ -284,6 +292,8 @@ export default function AnswerGridView({
       clickScoringDebounceMs,
       onMouseScoring,
       mouseBrush,
+      onScoringDataSelect,
+      selectedScoringDataIds,
     ]
   )
 

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useKeyboard.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useKeyboard.ts
@@ -60,9 +60,20 @@ export function useKeyboard({
         setIsCtrlPressed(true)
       }
 
+      // 入力欄（テキスト編集モーダルのtextarea等）にフォーカスがある場合は
+      // 削除ショートカットを抑制する（モーダルでテキスト編集中のBackspaceで
+      // アノテーションごと削除されるのを防ぐ）
+      const target = e.target as HTMLElement | null
+      const isEditableTarget =
+        !!target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+
       // Delete/Backspaceで選択要素を削除（複数選択対応）
       if (
         (e.key === "Delete" || e.key === "Backspace") &&
+        !isEditableTarget &&
         selectedElementIds.length > 0
       ) {
         e.preventDefault()

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -408,7 +408,7 @@ function ScoringMainViewContent() {
 
       if (action === "partial_modal") {
         replaceSelection([answerId])
-        openPartialScoreModal()
+        openPartialScoreModal(new Set([answerId]))
         return
       }
 
@@ -436,6 +436,14 @@ function ScoringMainViewContent() {
     (answerId: string, status: MouseBrushAction, isToggle: boolean) => {
       if (answerId.startsWith("master-")) return
 
+      // 「部分点入力」ブラシ: クリックした答案の部分点入力モーダルを開く
+      // （ダブルクリックの「部分点入力」動作と同じ）
+      if (status === "partial_modal") {
+        replaceSelection([answerId])
+        openPartialScoreModal(new Set([answerId]))
+        return
+      }
+
       // トグル: 同じステータスなら未採点に戻す
       if (isToggle) {
         const currentData = allScoringData.find((d) => d.id === answerId)
@@ -459,7 +467,13 @@ function ScoringMainViewContent() {
         return newSet
       })
     },
-    [allScoringData, handleBatchScore, setRecentlyScoredAnswers]
+    [
+      allScoringData,
+      handleBatchScore,
+      setRecentlyScoredAnswers,
+      replaceSelection,
+      openPartialScoreModal,
+    ]
   )
 
   /** マウスモード: 表示中の未採点を一括採点 */
@@ -717,6 +731,7 @@ function ScoringMainViewContent() {
               onRefreshFilter={handleRefreshFilter}
               onSelectAll={handleSelectAll}
               onSelectUnscored={handleSelectUnscored}
+              onOpenPartialScoreModal={openPartialScoreModal}
               partialScoreInput={partialScoreInput}
               clickScoringConfig={clickScoringConfig}
               clickScoringDebounceMs={clickScoringDebounceMs}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -42,15 +42,25 @@ export function usePartialScore({
     }
   }, [])
 
-  /** 部分点モーダルを開く（マウストリプルクリック等から呼び出し用） */
-  const openPartialScoreModal = useCallback(() => {
-    if (selectedAnswers.size === 0 || !currentCropRegion) return
+  /**
+   * 部分点モーダルを開く（マウスクリック等から呼び出し用）
+   *
+   * @param targetAnswers - 対象答案を明示指定する場合に渡す。
+   *   replaceSelection直後など、selectedAnswersの反映がまだの場合に使用する。
+   *   省略時は現在の選択（selectedAnswers）を対象とする。
+   */
+  const openPartialScoreModal = useCallback(
+    (targetAnswers?: Set<string>) => {
+      const answers = targetAnswers ?? selectedAnswers
+      if (answers.size === 0 || !currentCropRegion) return
 
-    setPartialScoreInput("")
-    setShowPartialScoreModal(true)
-    setContextValue("partialScoreModalOpen", true)
-    setContextValue("modalOpen", true)
-  }, [selectedAnswers, currentCropRegion, setContextValue])
+      setPartialScoreInput("")
+      setShowPartialScoreModal(true)
+      setContextValue("partialScoreModalOpen", true)
+      setContextValue("modalOpen", true)
+    },
+    [selectedAnswers, currentCropRegion, setContextValue]
+  )
 
   // 部分点入力開始（数字キー・小数点対応）
   const handlePartialScoreInput = useCallback(

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringShortcuts.ts
@@ -523,57 +523,57 @@ export function useScoringShortcuts(handlers: ScoringShortcutHandlers): void {
   // 部分点入力ショートカット（グリッド・個別共通）
   // ========================================
   useCommand("scoring.openPartialWith0", () => handlePartialScoreInput("0"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "0キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith1", () => handlePartialScoreInput("1"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "1キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith2", () => handlePartialScoreInput("2"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "2キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith3", () => handlePartialScoreInput("3"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "3キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith4", () => handlePartialScoreInput("4"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "4キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith5", () => handlePartialScoreInput("5"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "5キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith6", () => handlePartialScoreInput("6"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "6キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith7", () => handlePartialScoreInput("7"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "7キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith8", () => handlePartialScoreInput("8"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "8キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWith9", () => handlePartialScoreInput("9"), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: "9キーで部分点入力", category: "採点" },
   })
 
   useCommand("scoring.openPartialWithDot", () => handlePartialScoreInput("."), {
-    when: `!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers${kbOnly}`,
+    when: "!inputFocus && !modalOpen && !textEditorActive && hasSelectedAnswers",
     metadata: { title: ".キーで部分点入力", category: "採点" },
   })
 }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -103,6 +103,7 @@ interface ScoringSidePanelProps {
   onRefreshFilter: () => void
   onSelectAll?: () => void
   onSelectUnscored?: () => void
+  onOpenPartialScoreModal?: () => void
   partialScoreInput: string
   clickScoringConfig?: import("@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig").ClickScoringConfig
   clickScoringDebounceMs?: number
@@ -190,6 +191,7 @@ export function ScoringSidePanel({
   onRefreshFilter,
   onSelectAll,
   onSelectUnscored,
+  onOpenPartialScoreModal,
   partialScoreInput,
   clickScoringConfig,
   clickScoringDebounceMs,
@@ -427,6 +429,7 @@ export function ScoringSidePanel({
             onScore={onScore}
             onSelectAll={onSelectAll}
             onSelectUnscored={onSelectUnscored}
+            onOpenPartialScoreModal={onOpenPartialScoreModal}
             onRefreshFilter={onRefreshFilter}
             partialScoreInput={partialScoreInput}
             gradingMode={gradingMode}

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   ArrowRight,
   ArrowUp,
+  Calculator,
   CheckCircle,
   Circle,
   Clock,
@@ -13,6 +14,7 @@ import {
   Keyboard,
   Minus,
   Mouse,
+  MousePointerClick,
   Target,
   X,
 } from "lucide-react"
@@ -69,6 +71,7 @@ interface ScoringToolbarProps {
   onScore: (status: ScoringStatus) => void
   onSelectAll?: () => void
   onSelectUnscored?: () => void
+  onOpenPartialScoreModal?: () => void
   onRefreshFilter?: () => void
   partialScoreInput: string
   gradingMode?: "grid" | "individual"
@@ -158,6 +161,27 @@ const BRUSH_BUTTONS = SCORING_BUTTONS.filter(
   description: string
 }>
 
+/** マウスモード用の特殊ブラシ（採点せず選択／モーダル展開） */
+const SPECIAL_BRUSH_BUTTONS: Array<{
+  status: MouseBrushAction
+  label: string
+  icon: typeof CheckCircle
+  description: string
+}> = [
+  {
+    status: "select",
+    label: "選択",
+    icon: MousePointerClick,
+    description: "クリックで選択（複数選択可）",
+  },
+  {
+    status: "partial_modal",
+    label: "部分点入力",
+    icon: Calculator,
+    description: "クリックで部分点入力モーダルを開く",
+  },
+]
+
 const CLICK_ACTION_OPTIONS: { value: ClickScoringAction; label: string }[] = [
   { value: "none", label: "なし" },
   { value: "correct", label: "正答" },
@@ -182,6 +206,7 @@ export default function ScoringToolbar({
   onScore,
   onSelectAll,
   onSelectUnscored,
+  onOpenPartialScoreModal,
   onRefreshFilter,
   partialScoreInput,
   gradingMode = "grid",
@@ -257,6 +282,34 @@ export default function ScoringToolbar({
             </div>
           )}
 
+          {/* 部分点入力モーダルを開くボタン（キーボード・マウス共通） */}
+          {onOpenPartialScoreModal && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={`w-full text-xs ${
+                    selectedAnswersCount === 0
+                      ? "cursor-not-allowed opacity-50"
+                      : ""
+                  }`}
+                  onClick={onOpenPartialScoreModal}
+                  disabled={selectedAnswersCount === 0}
+                >
+                  <Calculator className="mr-1 h-3.5 w-3.5" />
+                  部分点入力
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <div className="text-center">
+                  <div className="font-medium">選択中の答案に部分点を入力</div>
+                  <KeyHint label="0〜9" />
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )}
+
           {/* マウスモード用UI（グリッドモードのみ） */}
           {scoringOperationMode === "mouse" && gradingMode === "grid" && (
             <>
@@ -266,68 +319,81 @@ export default function ScoringToolbar({
                   クリック時の採点ブラシ
                 </div>
                 <div style={GRID_4_3_STYLE}>
-                  {BRUSH_BUTTONS.map((button) => {
-                    const Icon = button.icon
-                    const statusType = STATUS_MAP[button.status]
-                    const colors = scoringColors[statusType]
-                    const isActive = mouseBrush === button.status
-                    return (
-                      <Tooltip key={button.status}>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className={`flex h-12 flex-col gap-1 border-2 ${
-                              isActive
-                                ? "ring-2 ring-blue-500 ring-offset-1"
-                                : "opacity-60 hover:opacity-80"
-                            }`}
-                            style={{
-                              backgroundColor: colors.bg,
-                              color: colors.text,
-                              borderColor: colors.bg,
-                            }}
-                            onClick={() => onMouseBrushChange?.(button.status)}
-                          >
-                            <Icon className="h-4 w-4" />
-                            <div className="text-xs">{button.label}</div>
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <div className="text-center">
-                            <div className="font-medium">
-                              {button.description}
+                  {[...SPECIAL_BRUSH_BUTTONS, ...BRUSH_BUTTONS].map(
+                    (button) => {
+                      const Icon = button.icon
+                      const colors =
+                        button.status === "select"
+                          ? { bg: "#e5e7eb", text: "#374151" }
+                          : button.status === "partial_modal"
+                            ? scoringColors[STATUS_MAP.partial]
+                            : scoringColors[
+                                STATUS_MAP[button.status as ScoringStatus]
+                              ]
+                      const isActive = mouseBrush === button.status
+                      return (
+                        <Tooltip key={button.status}>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className={`flex h-12 flex-col gap-1 border-2 ${
+                                isActive
+                                  ? "ring-2 ring-blue-500 ring-offset-1"
+                                  : "opacity-60 hover:opacity-80"
+                              }`}
+                              style={{
+                                backgroundColor: colors.bg,
+                                color: colors.text,
+                                borderColor: colors.bg,
+                              }}
+                              onClick={() =>
+                                onMouseBrushChange?.(button.status)
+                              }
+                            >
+                              <Icon className="h-4 w-4" />
+                              <div className="text-xs">{button.label}</div>
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <div className="text-center">
+                              <div className="font-medium">
+                                {button.description}
+                              </div>
                             </div>
-                          </div>
-                        </TooltipContent>
-                      </Tooltip>
-                    )
-                  })}
+                          </TooltipContent>
+                        </Tooltip>
+                      )
+                    }
+                  )}
                 </div>
               </div>
 
-              {/* 一括採点ボタン */}
-              {onBatchScoreVisibleUnscored && visibleUnscoredCount > 0 && (
-                <div className="space-y-1">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full text-xs"
-                    onClick={() => onBatchScoreVisibleUnscored(mouseBrush)}
-                  >
-                    表示中の未採点{visibleUnscoredCount}件を
-                    {BRUSH_BUTTONS.find((b) => b.status === mouseBrush)
-                      ?.label ?? mouseBrush}
-                    にする
-                  </Button>
-                  {hiddenUnscoredCount > 0 && (
-                    <div className="flex items-center gap-1 text-[10px] text-amber-600">
-                      <AlertTriangle className="h-3 w-3" />
-                      非表示の未採点が{hiddenUnscoredCount}件あります
-                    </div>
-                  )}
-                </div>
-              )}
+              {/* 一括採点ボタン（採点ブラシ選択時のみ） */}
+              {onBatchScoreVisibleUnscored &&
+                visibleUnscoredCount > 0 &&
+                mouseBrush !== "select" &&
+                mouseBrush !== "partial_modal" && (
+                  <div className="space-y-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={() => onBatchScoreVisibleUnscored(mouseBrush)}
+                    >
+                      表示中の未採点{visibleUnscoredCount}件を
+                      {BRUSH_BUTTONS.find((b) => b.status === mouseBrush)
+                        ?.label ?? mouseBrush}
+                      にする
+                    </Button>
+                    {hiddenUnscoredCount > 0 && (
+                      <div className="flex items-center gap-1 text-[10px] text-amber-600">
+                        <AlertTriangle className="h-3 w-3" />
+                        非表示の未採点が{hiddenUnscoredCount}件あります
+                      </div>
+                    )}
+                  </div>
+                )}
 
               {/* フィルタ更新 */}
               {onRefreshFilter && (

--- a/src/components/exams/07-score-at-once/types/index.ts
+++ b/src/components/exams/07-score-at-once/types/index.ts
@@ -140,9 +140,15 @@ export interface ScoringData {
 export type ScoringOperationMode = "keyboard" | "mouse"
 
 /**
- * マウスモード時のブラシ（クリック時に適用する採点ステータス）
+ * マウスモード時のブラシ（シングルクリック時の動作）
+ * - 採点ステータス: クリックで該当ステータスを適用
+ * - "select": クリックで選択トグル（採点しない）
+ * - "partial_modal": クリックで部分点入力モーダルを開く
  */
-export type MouseBrushAction = Exclude<ScoringStatus, "unscored">
+export type MouseBrushAction =
+  | Exclude<ScoringStatus, "unscored">
+  | "select"
+  | "partial_modal"
 
 /**
  * 模範解答表示モード


### PR DESCRIPTION
## 概要

一括採点画面（07-score-at-once）のテキストアノテーション編集時の不具合を修正し、マウス・キーボード両モードでの採点操作を拡張する。

Closes #789

## 変更内容

### 1. テキスト編集モーダル中のアノテーション誤削除を修正
- `useKeyboard.ts` の Delete/Backspace 削除処理に、入力欄（`input`/`textarea`/`contenteditable`）にフォーカスがある場合は抑制するガードを追加。
- テキスト編集モーダルで編集中の Backspace がアノテーション削除へ伝播しなくなる。

### 2. マウスモードでも数字ショートカットを有効化
- `useScoringShortcuts.ts` の部分点入力コマンド（`scoring.openPartialWith0-9` / `Dot`）からキーボードモード限定制約を解除。
- 選択中の答案があれば、マウスモードでも数字キーで部分点入力モーダルが開く。

### 3. シングルクリックの「選択」と「部分点入力」
- `MouseBrushAction` 型に `"select"` / `"partial_modal"` を追加。
- マウスモードのブラシに以下を追加:
  - **選択**: シングルクリックで選択トグル（複数選択可・即時・採点しない）
  - **部分点入力**: クリックした答案の部分点入力モーダルを展開（ダブルクリックの「部分点入力」と同じ動作・同じモーダル）
- 採点パネルにキーボード・マウス共通の **「部分点入力」ボタン** を追加（選択中の答案に対しモーダルを開く／未選択時は無効化）。
- `openPartialScoreModal` に明示ターゲット引数を追加し、`replaceSelection` 直後でも確実にモーダルが開くよう改善。

## 確認事項
- `npx tsc --noEmit`: パス
- `npm run lint`（eslint + prettier --check）: パス
- 実機での動作確認は未実施。

## テスト観点
- テキスト編集モーダルで Backspace してもアノテーションが消えないこと
- マウスモードで「選択」ブラシ→複数選択→数字キー/「部分点入力」ボタンでモーダルが開くこと
- 「部分点入力」ブラシでシングルクリックした答案のモーダルが開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)