### PR TITLE
fix: appimgスキームにcorsEnabledを付与し採点領域の枠検出を修正

### DIFF
--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -54,6 +54,10 @@ protocol.registerSchemesAsPrivileged([
       standard: true,
       supportFetchAPI: true,
       stream: true,
+      // フレーム検出（02-template）は img.crossOrigin="anonymous" で読み込むため、
+      // スキーム自体をCORS対象にしないと応答の Access-Control-Allow-Origin が
+      // 参照されず、crossOrigin付きの読み込みが onerror で失敗する。
+      corsEnabled: true,
     },
   },
 ])


### PR DESCRIPTION
## 概要

採点領域作成画面（`/exams/[examId]/02-template`）の枠自動検出が「Failed to load image」で失敗する問題を修正する。

Closes #791

## 原因

- 枠検出（`frameDetector.ts`）は `img.crossOrigin = "anonymous"` で画像を読み込むが、`registerSchemesAsPrivileged` の `appimg` スキーム特権に `corsEnabled` が無いため、Chromium が `appimg://` を CORS 対象として扱わず、応答に付与済みの `Access-Control-Allow-Origin: *` が参照されずに `onerror` で失敗していた。
- 同じ画像でも `crossOrigin` を付けない読み込み（寸法取得・CSS背景）は成功するため、CORS が原因と切り分けられる。

## 修正内容

- `electron-src/index.ts` の `appimg` スキーム特権に `corsEnabled: true` を追加。

## テスト

- `npm run lint`：パス
- メインプロセス変更のため、動作確認には `npm run dev` の再起動（`buildMain` による `main/` 再ビルド）が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)