### PR TITLE
fix: PNG出力がWindowsで画面サイズにクランプされ横長になる問題を修正 (#661)

### DIFF
--- a/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
+++ b/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
@@ -1,31 +1,37 @@
 /**
  * htmlToPngBuffer テスト
  *
- * BrowserWindowに正しいオプション（enableLargerThanScreen等）が
- * 渡されることを検証する。
+ * BrowserWindowに正しいオプション（enableLargerThanScreen等）が渡されること、
+ * およびウィンドウサイズが画面にクランプされた環境（Windows/Linux）での
+ * 縮小キャプチャ→拡大フォールバックを検証する。
  * ref: https://github.com/KeppyNaushika/score-at-once-electron/issues/664
+ * ref: https://github.com/KeppyNaushika/score-at-once-electron/issues/661
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import sharp from "sharp"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 // --- Electron モック ---
 
 const mockDestroy = vi.fn()
 const mockLoadFile = vi.fn().mockResolvedValue(undefined)
-const mockCapturePage = vi.fn().mockResolvedValue({
-  toPNG: () => Buffer.from("fake-png"),
-})
+const mockCapturePage = vi.fn()
+const mockInsertCSS = vi.fn().mockResolvedValue(undefined)
+const mockSetContentSize = vi.fn()
+const mockGetContentSize = vi.fn()
 const mockBrowserWindowConstructor = vi.fn()
 
 vi.mock("electron", () => ({
   app: { isPackaged: false },
   BrowserWindow: class MockBrowserWindow {
-    webContents = { capturePage: mockCapturePage }
+    webContents = { capturePage: mockCapturePage, insertCSS: mockInsertCSS }
     constructor(opts: Record<string, unknown>) {
       mockBrowserWindowConstructor(opts)
     }
     loadFile = mockLoadFile
     destroy = mockDestroy
+    setContentSize = mockSetContentSize
+    getContentSize = mockGetContentSize
   },
 }))
 
@@ -46,32 +52,86 @@ vi.mock("fs", async () => {
   }
 })
 
-import { htmlToPngBuffer } from "../../../electron-src/lib/printUtils"
+import {
+  computeCapturePlan,
+  htmlToPngBuffer,
+} from "../../../electron-src/lib/printUtils"
+
+const A4_WIDTH_PX = Math.round((210 / 25.4) * 300) // 2480
+const A4_HEIGHT_PX = Math.round((297 / 25.4) * 300) // 3508
+
+/** 指定サイズの白色PNGバッファを作成 */
+function createPng(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: { width, height, channels: 3, background: "#ffffff" },
+  })
+    .png()
+    .toBuffer()
+}
+
+describe("computeCapturePlan", () => {
+  it("コンテンツサイズが目標以上ならクランプなし・目標サイズでキャプチャする", () => {
+    const plan = computeCapturePlan(2480, 3508, 2480, 3508)
+    expect(plan).toEqual({
+      clamped: false,
+      captureWidth: 2480,
+      captureHeight: 3508,
+    })
+  })
+
+  it("画面にクランプされた場合はアスペクト比を維持した縮小矩形を返す", () => {
+    // Issue #661 のユーザー環境: 1920x1128 にクランプ
+    const plan = computeCapturePlan(2480, 3508, 1920, 1128)
+    expect(plan.clamped).toBe(true)
+    // fit = min(1920/2480, 1128/3508) = 1128/3508
+    expect(plan.captureHeight).toBe(1128)
+    expect(plan.captureWidth).toBe(Math.floor(2480 * (1128 / 3508)))
+    // アスペクト比が目標と一致する（丸め誤差1px以内）
+    const targetAspect = 2480 / 3508
+    const planAspect = plan.captureWidth / plan.captureHeight
+    expect(Math.abs(planAspect - targetAspect)).toBeLessThan(0.01)
+  })
+
+  it("横方向のみクランプされた場合もアスペクト比を維持する", () => {
+    const plan = computeCapturePlan(2480, 3508, 1920, 4000)
+    expect(plan.clamped).toBe(true)
+    expect(plan.captureWidth).toBe(1920)
+    expect(plan.captureHeight).toBe(Math.floor(3508 * (1920 / 2480)))
+  })
+
+  it("極端に小さいコンテンツでも1px以上を保証する", () => {
+    const plan = computeCapturePlan(2480, 3508, 1, 1)
+    expect(plan.captureWidth).toBeGreaterThanOrEqual(1)
+    expect(plan.captureHeight).toBeGreaterThanOrEqual(1)
+  })
+})
 
 describe("htmlToPngBuffer", () => {
+  let fullSizePng: Buffer
+
+  beforeAll(async () => {
+    fullSizePng = await createPng(A4_WIDTH_PX, A4_HEIGHT_PX)
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
+    // デフォルト: クランプなし（要求どおりのサイズが確保できた）
+    mockGetContentSize.mockReturnValue([A4_WIDTH_PX, A4_HEIGHT_PX])
+    mockCapturePage.mockResolvedValue({ toPNG: () => fullSizePng })
   })
 
   it("A4縦 300DPI で正しいピクセルサイズのBrowserWindowを作成する", async () => {
-    const pageWidthMm = 210
-    const pageHeightMm = 297
-    const dpi = 300
-
     await htmlToPngBuffer(
       "<html><head></head><body></body></html>",
-      pageWidthMm,
-      pageHeightMm,
-      dpi
+      210,
+      297,
+      300
     )
-
-    const expectedWidth = Math.round((210 / 25.4) * 300) // 2480
-    const expectedHeight = Math.round((297 / 25.4) * 300) // 3508
 
     expect(mockBrowserWindowConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
-        width: expectedWidth,
-        height: expectedHeight,
+        width: A4_WIDTH_PX,
+        height: A4_HEIGHT_PX,
       })
     )
   })
@@ -106,27 +166,32 @@ describe("htmlToPngBuffer", () => {
     )
   })
 
-  it("capturePageに正しいサイズの矩形が渡される", async () => {
-    const pageWidthMm = 210
-    const pageHeightMm = 297
-    const dpi = 300
-
+  it("作成後にsetContentSizeでサイズを再設定する（Windowsの作成時クランプ対策）", async () => {
     await htmlToPngBuffer(
       "<html><head></head><body></body></html>",
-      pageWidthMm,
-      pageHeightMm,
-      dpi
+      210,
+      297,
+      300
     )
 
-    const expectedWidth = Math.round((210 / 25.4) * 300)
-    const expectedHeight = Math.round((297 / 25.4) * 300)
+    expect(mockSetContentSize).toHaveBeenCalledWith(A4_WIDTH_PX, A4_HEIGHT_PX)
+  })
+
+  it("クランプされていない場合、capturePageに目標サイズの矩形が渡される", async () => {
+    await htmlToPngBuffer(
+      "<html><head></head><body></body></html>",
+      210,
+      297,
+      300
+    )
 
     expect(mockCapturePage).toHaveBeenCalledWith({
       x: 0,
       y: 0,
-      width: expectedWidth,
-      height: expectedHeight,
+      width: A4_WIDTH_PX,
+      height: A4_HEIGHT_PX,
     })
+    expect(mockInsertCSS).not.toHaveBeenCalled()
   })
 
   it(".page を 100vw/100vh に拡張するCSSが注入される", async () => {
@@ -157,6 +222,12 @@ describe("htmlToPngBuffer", () => {
 
   it("カスタムDPIで正しいピクセルサイズが計算される", async () => {
     const dpi = 150
+    const expectedWidth = Math.round((210 / 25.4) * dpi) // 1240
+    const expectedHeight = Math.round((297 / 25.4) * dpi) // 1754
+    mockGetContentSize.mockReturnValue([expectedWidth, expectedHeight])
+    mockCapturePage.mockResolvedValue({
+      toPNG: () => fullSizePng,
+    })
 
     await htmlToPngBuffer(
       "<html><head></head><body></body></html>",
@@ -165,14 +236,78 @@ describe("htmlToPngBuffer", () => {
       dpi
     )
 
-    const expectedWidth = Math.round((210 / 25.4) * 150) // 1240
-    const expectedHeight = Math.round((297 / 25.4) * 150) // 1754
-
     expect(mockBrowserWindowConstructor).toHaveBeenCalledWith(
       expect.objectContaining({
         width: expectedWidth,
         height: expectedHeight,
       })
     )
+  })
+
+  it("クランプ時はアスペクト比維持のCSSを注入し、縮小矩形でキャプチャする", async () => {
+    // Issue #661: ウィンドウが 1920x1128 にクランプされるWindows環境を再現
+    mockGetContentSize.mockReturnValue([1920, 1128])
+    const expectedPlan = computeCapturePlan(
+      A4_WIDTH_PX,
+      A4_HEIGHT_PX,
+      1920,
+      1128
+    )
+    const clampedPng = await createPng(
+      expectedPlan.captureWidth,
+      expectedPlan.captureHeight
+    )
+    mockCapturePage.mockResolvedValue({ toPNG: () => clampedPng })
+
+    await htmlToPngBuffer(
+      "<html><head></head><body><div class='page'></div></body></html>",
+      210,
+      297,
+      300
+    )
+
+    expect(mockInsertCSS).toHaveBeenCalledWith(
+      expect.stringContaining(`width: ${expectedPlan.captureWidth}px`)
+    )
+    expect(mockCapturePage).toHaveBeenCalledWith({
+      x: 0,
+      y: 0,
+      width: expectedPlan.captureWidth,
+      height: expectedPlan.captureHeight,
+    })
+  })
+
+  it("クランプ時の出力は目標ピクセルサイズに拡大される", async () => {
+    mockGetContentSize.mockReturnValue([1920, 1128])
+    const plan = computeCapturePlan(A4_WIDTH_PX, A4_HEIGHT_PX, 1920, 1128)
+    const clampedPng = await createPng(plan.captureWidth, plan.captureHeight)
+    mockCapturePage.mockResolvedValue({ toPNG: () => clampedPng })
+
+    const result = await htmlToPngBuffer(
+      "<html><head></head><body></body></html>",
+      210,
+      297,
+      300
+    )
+
+    const metadata = await sharp(result).metadata()
+    expect(metadata.width).toBe(A4_WIDTH_PX)
+    expect(metadata.height).toBe(A4_HEIGHT_PX)
+  })
+
+  it("Retina環境（capturePageが2倍解像度を返す）でも目標サイズに正規化される", async () => {
+    const retinaPng = await createPng(A4_WIDTH_PX * 2, A4_HEIGHT_PX * 2)
+    mockCapturePage.mockResolvedValue({ toPNG: () => retinaPng })
+
+    const result = await htmlToPngBuffer(
+      "<html><head></head><body></body></html>",
+      210,
+      297,
+      300
+    )
+
+    const metadata = await sharp(result).metadata()
+    expect(metadata.width).toBe(A4_WIDTH_PX)
+    expect(metadata.height).toBe(A4_HEIGHT_PX)
   })
 })

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -3,6 +3,7 @@
  */
 
 import { BrowserWindow, ipcMain } from "electron"
+import fs from "fs"
 import path from "path"
 
 import type { ComputedCell } from "../../src/types/answerSheetLayout.types"
@@ -24,8 +25,38 @@ import {
 import prisma from "../lib/prisma/client"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
-/** マスターマーカー検出キャッシュ (キー: "examId:pageNumber") */
-const masterMarkerCache = new Map<string, MarkerDetectionResult>()
+/**
+ * マスターマーカー検出キャッシュ (キー: "examId:pageNumber:colorThreshold")
+ *
+ * 画像ファイルのmtimeを保持し、ファイルが差し替えられた場合は
+ * キャッシュを無効とみなして再検出する（アプリ外でのファイル差し替えにも追従）。
+ */
+const masterMarkerCache = new Map<
+  string,
+  { mtimeMs: number; result: MarkerDetectionResult }
+>()
+
+/** 画像のmtimeを取得（取得できない場合はnull＝キャッシュ不使用） */
+function getMtimeMs(imagePath: string): number | null {
+  try {
+    return fs.statSync(imagePath).mtimeMs
+  } catch {
+    return null
+  }
+}
+
+/** キャッシュが現在のファイル状態に対して有効なら検出結果を返す */
+function getCachedMarkerResult(
+  cacheKey: string,
+  mtimeMs: number | null
+): MarkerDetectionResult | null {
+  if (mtimeMs === null) return null
+  const cached = masterMarkerCache.get(cacheKey)
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.result
+  }
+  return null
+}
 
 /** キャッシュ無効化（マスター画像変更時に呼び出す） */
 export function invalidateMasterMarkerCache(examId: string): void {
@@ -324,21 +355,22 @@ export function setupOMRHandlers(): void {
 
       for (const mi of masterImages) {
         const pageNumber = mi.examPage.pageNumber
-        const cacheKey = `${examId}:${pageNumber}`
+        const cacheKey = `${examId}:${pageNumber}:${colorThreshold ?? 128}`
+        const imagePath = path.join(dataDir, mi.imagePath)
+        const mtimeMs = getMtimeMs(imagePath)
 
-        // キャッシュチェック
-        const cached = masterMarkerCache.get(cacheKey)
+        // キャッシュチェック（ファイル差し替えを検知したら再検出）
+        const cached = getCachedMarkerResult(cacheKey, mtimeMs)
         if (cached) {
           pages.push({ pageNumber, result: cached })
           continue
         }
 
-        // 画像パスを解決してマーカー検出
-        const imagePath = path.join(dataDir, mi.imagePath)
         const result = await detectCornerMarkers(imagePath, colorThreshold)
 
-        // キャッシュに保存
-        masterMarkerCache.set(cacheKey, result)
+        if (mtimeMs !== null) {
+          masterMarkerCache.set(cacheKey, { mtimeMs, result })
+        }
         pages.push({ pageNumber, result })
       }
 
@@ -372,25 +404,28 @@ export function setupOMRHandlers(): void {
       status: "corrected" | "skipped"
       error?: string
     }> => {
-      const cacheKey = `${examId}:${pageNumber}`
-      let masterResult = masterMarkerCache.get(cacheKey)
-
-      if (!masterResult) {
-        const masterImage = await prisma.masterImage.findFirst({
-          where: { examPage: { examId, pageNumber } },
-          include: { examPage: true },
-        })
-        if (!masterImage) {
-          return {
-            success: false,
-            status: "skipped",
-            error: "マスター画像が見つかりません",
-          }
+      const cacheKey = `${examId}:${pageNumber}:${colorThreshold ?? 128}`
+      const masterImage = await prisma.masterImage.findFirst({
+        where: { examPage: { examId, pageNumber } },
+        include: { examPage: true },
+      })
+      if (!masterImage) {
+        return {
+          success: false,
+          status: "skipped",
+          error: "マスター画像が見つかりません",
         }
-        const dataDir = getDataDirectory()
-        const imagePath = path.join(dataDir, masterImage.imagePath)
+      }
+      const dataDir = getDataDirectory()
+      const imagePath = path.join(dataDir, masterImage.imagePath)
+      const mtimeMs = getMtimeMs(imagePath)
+
+      let masterResult = getCachedMarkerResult(cacheKey, mtimeMs)
+      if (!masterResult) {
         masterResult = await detectCornerMarkers(imagePath, colorThreshold)
-        masterMarkerCache.set(cacheKey, masterResult)
+        if (mtimeMs !== null) {
+          masterMarkerCache.set(cacheKey, { mtimeMs, result: masterResult })
+        }
       }
 
       if (!masterResult.success) {

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -9,6 +9,7 @@ import { app, BrowserWindow } from "electron"
 import fs from "fs"
 import os from "os"
 import path from "path"
+import sharp from "sharp"
 
 let mathjaxCache: string | null = null
 
@@ -41,6 +42,43 @@ export function resolveMathJaxSrc(html: string): string {
   }
 }
 
+/** キャプチャ計画: ウィンドウが目標サイズを確保できたかと、実際にキャプチャする矩形 */
+export interface CapturePlan {
+  /** ウィンドウサイズが画面にクランプされ、縮小キャプチャ→拡大が必要か */
+  clamped: boolean
+  captureWidth: number
+  captureHeight: number
+}
+
+/**
+ * 実際のウィンドウコンテンツサイズから、アスペクト比を維持したキャプチャ矩形を計算する。
+ *
+ * WindowsやLinuxではBrowserWindowの作成サイズが画面の作業領域にクランプされる
+ * （enableLargerThanScreenはmacOS専用。ref: electron/electron#20351, #30154）。
+ * クランプされた場合は、目標アスペクト比を維持できる最大の矩形でキャプチャし、
+ * 後段でsharpにより目標ピクセルサイズへ拡大する。
+ */
+export function computeCapturePlan(
+  targetWidth: number,
+  targetHeight: number,
+  contentWidth: number,
+  contentHeight: number
+): CapturePlan {
+  if (contentWidth >= targetWidth && contentHeight >= targetHeight) {
+    return {
+      clamped: false,
+      captureWidth: targetWidth,
+      captureHeight: targetHeight,
+    }
+  }
+  const fit = Math.min(contentWidth / targetWidth, contentHeight / targetHeight)
+  return {
+    clamped: true,
+    captureWidth: Math.max(1, Math.floor(targetWidth * fit)),
+    captureHeight: Math.max(1, Math.floor(targetHeight * fit)),
+  }
+}
+
 /**
  * HTML文字列をオフスクリーンBrowserWindowでロードし、capturePageでPNGバッファに変換。
  * 解答用紙のPNG出力・試験変換の模範解答画像生成で共通使用。
@@ -48,6 +86,10 @@ export function resolveMathJaxSrc(html: string): string {
  * HTMLはCSSの mm 単位で .page をレイアウトしているが、BrowserWindowは目的の
  * 出力ピクセルサイズに設定し、.page をビューポート全体に引き伸ばす CSS を注入する。
  * SVGの viewBox により自然にスケールされ、目的の解像度でラスタライズされる。
+ *
+ * ウィンドウサイズが画面にクランプされた環境（Windows/Linux）では、
+ * アスペクト比を維持した縮小キャプチャ→拡大にフォールバックし、
+ * どの環境でも必ず目標ピクセルサイズ・正しいアスペクト比のPNGを返す。
  */
 export async function htmlToPngBuffer(
   html: string,
@@ -80,7 +122,30 @@ export async function htmlToPngBuffer(
       enableLargerThanScreen: true,
       webPreferences: { offscreen: true },
     })
+    // Windows/Linuxでは作成時サイズが画面にクランプされるため、作成後に再設定する
+    win.setContentSize(widthPx, heightPx)
     await win.loadFile(tempHtmlPath)
+
+    const [contentWidth, contentHeight] = win.getContentSize()
+    const plan = computeCapturePlan(
+      widthPx,
+      heightPx,
+      contentWidth,
+      contentHeight
+    )
+
+    if (plan.clamped) {
+      console.warn(
+        `[htmlToPngBuffer] ウィンドウが ${contentWidth}x${contentHeight} にクランプされたため、` +
+          `${plan.captureWidth}x${plan.captureHeight} でキャプチャして ${widthPx}x${heightPx} へ拡大します`
+      )
+      // 100vw/100vh の引き伸ばしはアスペクト比が崩れるため、
+      // アスペクト比を維持した固定pxサイズで左上に配置し直す
+      await win.webContents.insertCSS(
+        `.page { width: ${plan.captureWidth}px !important; height: ${plan.captureHeight}px !important; ` +
+          `position: fixed !important; top: 0 !important; left: 0 !important; }`
+      )
+    }
 
     // レンダリング完了を待つ
     await new Promise((resolve) => setTimeout(resolve, 500))
@@ -88,11 +153,21 @@ export async function htmlToPngBuffer(
     const image = await win.webContents.capturePage({
       x: 0,
       y: 0,
-      width: widthPx,
-      height: heightPx,
+      width: plan.captureWidth,
+      height: plan.captureHeight,
     })
+    const buffer = image.toPNG()
 
-    return image.toPNG()
+    // 出力を必ず目標ピクセルサイズに正規化する
+    // （クランプ時の拡大と、Retina環境でcapturePageが2倍解像度を返すケースの両方を吸収）
+    const metadata = await sharp(buffer).metadata()
+    if (metadata.width === widthPx && metadata.height === heightPx) {
+      return buffer
+    }
+    return sharp(buffer)
+      .resize(widthPx, heightPx, { fit: "fill", kernel: sharp.kernel.lanczos3 })
+      .png()
+      .toBuffer()
   } finally {
     win?.destroy()
     if (tempHtmlPath) {


### PR DESCRIPTION
## 概要

PNG出力（解答用紙ビルダーのPNG出力・試験変換時の模範解答画像生成）が、Windows環境で「横長＋右側に大きな白余白」の画像になる問題（#661 / #664）の根本修正です。あわせて #665 の調査で見つけたOMRマスターマーカーキャッシュの陳腐化バグも修正します。

## 原因

- BrowserWindowの作成時サイズは、Windows/LinuxではChromiumにより**画面の作業領域へクランプ**される（electron/electron#20351, electron/electron#30154）
- #664 で追加した `enableLargerThanScreen: true` は **macOS専用オプション**のため、Windowsでは効果がない（報告者の再テストで実証）
- クランプされたビューポート（例: 1920×1128）に対し `.page { width:100vw; height:100vh }` を注入していたため、A4縦指定でも横長画像が生成されていた

## 修正内容

### `electron-src/lib/printUtils.ts`（htmlToPngBuffer）

1. ウィンドウ作成後に `setContentSize()` でサイズを再設定（作成時クランプの既知の回避策）
2. `getContentSize()` で実サイズを検証し、なおクランプされる環境では**アスペクト比を維持した縮小矩形**でキャプチャするCSSを再注入（引き伸ばしによる比率崩れを排除）
3. 出力PNGを常に要求ピクセルサイズへ正規化（クランプ時のsharp拡大と、Retinaでの2倍解像度の両方を吸収）

これにより**どの環境でも必ず正しいアスペクト比・目標解像度のPNG**が返ります。

### `electron-src/ipc-handlers/omrHandlers.ts`

`masterMarkerCache` が画像ファイルの差し替え・`colorThreshold` 変更を検知せず、アプリ再起動まで古い検出結果を返し続ける問題を修正。mtimeと閾値をキャッシュ検証に組み込みました（#661 の報告者は実際にdataフォルダ内の画像を手動差し替えしており、この経路で古い結果が返っていた可能性があります）。

## テスト

- `computeCapturePlan` を純粋関数として切り出し、報告環境（1920×1128へのクランプ）を含むユニットテストを追加
- `__tests__/answer-sheet-builder/` 115件すべて通過、`npm run typecheck`・eslint・prettier 通過

Closes #661
Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)