### PR TITLE
fix: better-sqlite3のABI不一致を恒久対策（ensure-sqlite-abi.js）

### DIFF
--- a/__tests__/globalSetup.ts
+++ b/__tests__/globalSetup.ts
@@ -11,6 +11,14 @@ import * as path from "path"
 const TEST_DB_PATH = path.resolve(__dirname, "../data/test-database.db")
 
 export async function setup() {
+  // better-sqlite3 を素のNode（テスト実行ランタイム）のABIに合わせる。
+  // npm run dev 後は Electron向けにビルドされているため、ここで Node向けに戻す。
+  // 必要なときだけリビルドする冪等スクリプト。
+  execSync("node scripts/ensure-sqlite-abi.js node", {
+    cwd: path.resolve(__dirname, ".."),
+    stdio: "inherit",
+  })
+
   // テスト用DBが既に存在する場合は削除
   for (const suffix of ["", "-journal", "-wal", "-shm"]) {
     const p = TEST_DB_PATH + suffix

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "productName": "一括採点",
   "version": "0.11.2-alpha.0",
   "scripts": {
+    "predev": "node scripts/ensure-sqlite-abi.js electron",
     "dev": "node scripts/dev.js",
     "build": "prisma generate && next build && node scripts/buildMain.js && node scripts/buildPreload.js",
     "dist": "npm run build && electron-forge package --platform=darwin",
@@ -45,7 +46,7 @@
     "github:prerelease:alpha": "node scripts/github-release.js patch alpha",
     "github:prerelease:beta": "node scripts/github-release.js patch beta",
     "github:prerelease:rc": "node scripts/github-release.js patch rc",
-    "postinstall": "prisma generate && electron-rebuild --only better-sqlite3 && node scripts/setup-mathjax-fonts.js",
+    "postinstall": "prisma generate && node scripts/ensure-sqlite-abi.js electron && node scripts/setup-mathjax-fonts.js",
     "setup-assets": "node scripts/setup-mathjax-fonts.js",
     "screenshot:setup": "npx tsx __tests__/screenshots/setup-data.ts",
     "screenshot:test": "npx playwright test --config=__tests__/playwright.screenshot.config.ts",

--- a/scripts/ensure-sqlite-abi.js
+++ b/scripts/ensure-sqlite-abi.js
@@ -1,0 +1,102 @@
+/**
+ * better-sqlite3 のネイティブバイナリを、実行ランタイムのABIに合わせて
+ * 必要なときだけリビルドする冪等スクリプト。
+ *
+ * 背景:
+ *   - Electronアプリ (npm run dev / make) は Electron同梱Node のABIを要求する
+ *   - vitestテスト / scripts は素のNode のABIを要求する
+ *   この2つはABIが異なるため、単一の .node バイナリでは両立できない。
+ *   ターゲットを切り替えるたびに該当ABIへ作り直す必要がある。
+ *
+ * 落とし穴メモ（このスクリプトが対処していること）:
+ *   1. require("better-sqlite3") はネイティブ部を遅延ロードするため、ABI不一致は
+ *      require では分からない。実際に new Database() で開いて初めて判明する。
+ *   2. 素の `electron-rebuild` は Node用プリビルド(誤ABI)をダウンロードしてしまう。
+ *      `--build-from-source` で Electronヘッダからコンパイルさせる必要がある。
+ *   3. electron-rebuild / npm rebuild は build/Release に既存バイナリがあると
+ *      キャッシュ復元で済ませ上書きしない。リビルド前に削除して強制再生成する。
+ *
+ * 使い方:
+ *   node scripts/ensure-sqlite-abi.js electron   # Electronアプリ起動前
+ *   node scripts/ensure-sqlite-abi.js node       # vitestテスト前
+ */
+
+const { execSync } = require("child_process")
+const fs = require("fs")
+const path = require("path")
+
+const target = process.argv[2]
+if (target !== "electron" && target !== "node") {
+  console.error(
+    `[ensure-sqlite-abi] 使い方: node scripts/ensure-sqlite-abi.js <electron|node>`
+  )
+  process.exit(1)
+}
+
+const BUILD_RELEASE = path.resolve(
+  __dirname,
+  "../node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+)
+
+/**
+ * 現在 build/Release に置かれているバイナリのターゲットを判定する。
+ *
+ * 必ず子プロセスで判定する: ネイティブ部は一度 new Database() で開くとプロセス内に
+ * キャッシュ＆メモリマップされ、その後ファイルを差し替えても同一プロセスからは
+ * 古いバイナリが見え続ける。リビルド前後で同じプロセスから判定すると誤検知するため。
+ *
+ * require() はネイティブ部を遅延ロードするので、実際に DB を開いて dlopen を強制する。
+ * @returns {"node"|"electron"|"none"}
+ *   - "node":     素のNodeで開けた = Node向けビルド
+ *   - "electron": ABI不一致で開けない = Electron向けビルド
+ *   - "none":     バイナリ欠落など判定不能 = 要リビルド
+ */
+function detectCurrentTarget() {
+  const probe =
+    "try{const D=require('better-sqlite3');new D(':memory:').close();" +
+    "process.stdout.write('node')}" +
+    "catch(e){process.stdout.write(String(e&&e.message).includes('NODE_MODULE_VERSION')?'electron':'none')}"
+  try {
+    const out = execSync(`node -e "${probe}"`, {
+      cwd: path.resolve(__dirname, ".."),
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    return out.toString().trim() || "none"
+  } catch {
+    return "none"
+  }
+}
+
+const current = detectCurrentTarget()
+
+if (current === target) {
+  console.log(
+    `[ensure-sqlite-abi] better-sqlite3 は既に ${target} 向けです。リビルド不要。`
+  )
+  process.exit(0)
+}
+
+console.log(
+  `[ensure-sqlite-abi] better-sqlite3 を ${target} 向けにリビルドします（現在: ${current}）...`
+)
+
+// 既存バイナリを消してキャッシュ復元による上書きスキップを防ぐ。
+if (fs.existsSync(BUILD_RELEASE)) fs.rmSync(BUILD_RELEASE)
+
+const cmd =
+  target === "electron"
+    ? "npx electron-rebuild --only better-sqlite3 --build-from-source --force"
+    : "npm rebuild better-sqlite3"
+
+execSync(cmd, { stdio: "inherit" })
+
+// 生成結果を検証（取り違え再発の早期検知）。
+const after = detectCurrentTarget()
+if (after !== target) {
+  console.error(
+    `[ensure-sqlite-abi] リビルド後も ${target} 向けになっていません（実測: ${after}）。`
+  )
+  process.exit(1)
+}
+
+console.log(`[ensure-sqlite-abi] 完了（${target} 向け）。`)


### PR DESCRIPTION
## 概要

`better-sqlite3` を Electronアプリ（ABI 145）と vitestテスト・scripts（素のNode ABI 137）で共用するための **ABI自動切替** を導入し、`NODE_MODULE_VERSION` 不一致エラーを恒久的に解消する。

Closes #802

## 真因（調査結果）

1. 素の `electron-rebuild` は **Node用プリビルド（誤ABI）をダウンロード**しており、`--build-from-source` を付けないと Electron向けにならず起動時に落ちていた。
2. `build/Release` に既存バイナリがあるとリビルドが **上書きスキップ**する。
3. ABI判定は `new Database()` が必要で、かつ **子プロセス**で行う必要がある（遅延ロード＋プロセス内キャッシュのため）。

## 変更内容

- **`scripts/ensure-sqlite-abi.js`（新規）**: ミスマッチ時のみ「削除→正しいABIで再ビルド→自己検証」する冪等スクリプト。
- **`package.json`**: `predev` 追加・`postinstall` 変更で Electron向けを保証。
- **`__tests__/globalSetup.ts`**: テスト前に Node向けへ自己修復。

steady state はバイナリが Electron既定。テスト実行時に globalSetup が自動で Node向けへ自己修復し、次の `npm run dev` で predev が Electron へ戻す。`npm update` でバイナリが差し替わっても自己修復する。

## 動作確認

- ABI双方向切替（electron↔node）＋no-op を全て確認。各リビルド後の自己検証も通過。
- 実テスト 181/186 通過（DB依存テストが通過＝globalSetup の ABI修復が機能）。残る5件は `bulkExportExams.test.ts` の出力先ENOENTで本変更とは無関係の既存問題。
- 自分の変更ファイルのみを対象に整形・lint確認済み。