### PR TITLE
feat: 点数印字設定を3種別常時表示に変更し合計点を緑に

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -384,16 +384,15 @@ export function useCanvasDrawing({
 
         if (shouldShowScore && actualScore !== null) {
           ctx.save()
-          // 印字設定からスコア表示設定を取得
-          const scoreConfig = scoringMarkConfig?.useSeparateScoreSettings
-            ? scoringMarkConfig.partialScore
-            : {
-                position: scoringMarkConfig?.scorePosition ?? "bottom-right",
-                offsetX: scoringMarkConfig?.scoreOffsetX ?? 0,
-                offsetY: scoringMarkConfig?.scoreOffsetY ?? 0,
-                size: scoringMarkConfig?.scoreSize ?? 14,
-                alignment: scoringMarkConfig?.scoreAlignment ?? "center",
-              }
+          // 印字設定からスコア表示設定を取得（設問ごとの点数は部分点設定を使用、
+          // 旧データで未設定の場合はレガシーフィールドへフォールバック）
+          const scoreConfig = scoringMarkConfig?.partialScore ?? {
+            position: scoringMarkConfig?.scorePosition ?? "bottom-right",
+            offsetX: scoringMarkConfig?.scoreOffsetX ?? 0,
+            offsetY: scoringMarkConfig?.scoreOffsetY ?? 0,
+            size: scoringMarkConfig?.scoreSize ?? 14,
+            alignment: scoringMarkConfig?.scoreAlignment ?? "center",
+          }
 
           const fontSize = scoreConfig.size
           ctx.font = `bold ${fontSize}px sans-serif`

--- a/src/components/exams/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
+++ b/src/components/exams/08-export/components/scoring-mark-settings/components/ScoringMarkSettingsContainer.tsx
@@ -31,8 +31,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
-import { Switch } from "@/components/ui/switch"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 interface ScoringMarkSettingsContainerProps {
   config: ScoringMarkConfig
@@ -58,7 +56,6 @@ export function ScoringMarkSettingsContainer({
   }
   const markColor = config.markColor ?? DEFAULT_MARK_COLOR
   const markOpacity = config.markOpacity ?? 100
-  const useSeparateSettings = config.useSeparateScoreSettings ?? false
 
   const updateConfig = (updates: Partial<ScoringMarkConfig>) => {
     const newConfig = { ...config, ...updates }
@@ -77,15 +74,6 @@ export function ScoringMarkSettingsContainer({
     updateConfig({ totalScore: { ...totalScore, ...updates } })
   }
 
-  const updateAllScores = (updates: Partial<ScoreTextConfig>) => {
-    updateConfig({
-      partialScore: { ...partialScore, ...updates },
-      summaryScore: { ...partialScore, ...updates },
-      subtotalScore: { ...subtotalScore, ...updates },
-      totalScore: { ...totalScore, ...updates },
-    })
-  }
-
   const updateMarkStatusDisplay = (status: ScoringStatus, show: boolean) => {
     updateConfig({
       showMarkForStatus: { ...config.showMarkForStatus, [status]: show },
@@ -101,6 +89,41 @@ export function ScoringMarkSettingsContainer({
   const resetToDefaults = () => {
     onChange(defaultConfig)
   }
+
+  // 見出し右側に並べる色・不透明度
+  const renderColorOpacity = (
+    scoreConfig: ScoreTextConfig,
+    onUpdate: (updates: Partial<ScoreTextConfig>) => void
+  ) => (
+    <div className="flex flex-wrap items-end justify-end gap-3">
+      <div className="space-y-1">
+        <Label className="text-muted-foreground text-xs">色</Label>
+        <InlineColorPicker
+          value={scoreConfig.color}
+          onChange={(color) => onUpdate({ color })}
+          presets={[...SCORE_COLOR_PRESETS]}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label className="text-muted-foreground text-xs">不透明度(%)</Label>
+        <Input
+          type="number"
+          value={scoreConfig.opacity}
+          onChange={(e) =>
+            onUpdate({
+              opacity: Math.min(
+                100,
+                Math.max(0, parseInt(e.target.value) || 0)
+              ),
+            })
+          }
+          min={0}
+          max={100}
+          className="h-9 w-24"
+        />
+      </div>
+    </div>
+  )
 
   const renderScoreSettings = (
     scoreConfig: ScoreTextConfig,
@@ -180,34 +203,6 @@ export function ScoringMarkSettingsContainer({
           </Select>
         </div>
       </div>
-      <div className="flex flex-wrap items-end gap-4">
-        <div className="space-y-1">
-          <Label className="text-muted-foreground text-xs">色</Label>
-          <InlineColorPicker
-            value={scoreConfig.color}
-            onChange={(color) => onUpdate({ color })}
-            presets={[...SCORE_COLOR_PRESETS]}
-          />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-muted-foreground text-xs">不透明度(%)</Label>
-          <Input
-            type="number"
-            value={scoreConfig.opacity}
-            onChange={(e) =>
-              onUpdate({
-                opacity: Math.min(
-                  100,
-                  Math.max(0, parseInt(e.target.value) || 0)
-                ),
-              })
-            }
-            min={0}
-            max={100}
-            className="h-9 w-24"
-          />
-        </div>
-      </div>
     </div>
   )
 
@@ -229,7 +224,39 @@ export function ScoringMarkSettingsContainer({
 
       {/* 採点マーク設定 */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">採点マーク</Label>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <Label className="text-sm font-medium">採点マーク</Label>
+          <div className="flex flex-wrap items-end justify-end gap-3">
+            <div className="space-y-1">
+              <Label className="text-muted-foreground text-xs">色</Label>
+              <InlineColorPicker
+                value={markColor}
+                onChange={(color) => updateConfig({ markColor: color })}
+                presets={[...SCORE_COLOR_PRESETS]}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-muted-foreground text-xs">
+                不透明度(%)
+              </Label>
+              <Input
+                type="number"
+                value={markOpacity}
+                onChange={(e) =>
+                  updateConfig({
+                    markOpacity: Math.min(
+                      100,
+                      Math.max(0, parseInt(e.target.value) || 0)
+                    ),
+                  })
+                }
+                min={0}
+                max={100}
+                className="h-9 w-24"
+              />
+            </div>
+          </div>
+        </div>
         <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
           <div className="space-y-1">
             <Label className="text-muted-foreground text-xs">位置</Label>
@@ -291,97 +318,39 @@ export function ScoringMarkSettingsContainer({
             />
           </div>
         </div>
-        <div className="flex flex-wrap items-end gap-4">
-          <div className="space-y-1">
-            <Label className="text-muted-foreground text-xs">色</Label>
-            <InlineColorPicker
-              value={markColor}
-              onChange={(color) => updateConfig({ markColor: color })}
-              presets={[...SCORE_COLOR_PRESETS]}
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-muted-foreground text-xs">不透明度(%)</Label>
-            <Input
-              type="number"
-              value={markOpacity}
-              onChange={(e) =>
-                updateConfig({
-                  markOpacity: Math.min(
-                    100,
-                    Math.max(0, parseInt(e.target.value) || 0)
-                  ),
-                })
-              }
-              min={0}
-              max={100}
-              className="h-9 w-24"
-            />
-          </div>
-        </div>
       </div>
 
       <Separator />
 
-      {/* 点数表示設定 */}
+      {/* 設問部分点数設定 */}
       <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">点数表示</Label>
-          <div className="flex items-center gap-2">
-            <Label
-              htmlFor="separate-settings"
-              className="text-muted-foreground text-xs"
-            >
-              別々に設定
-            </Label>
-            <Switch
-              id="separate-settings"
-              checked={useSeparateSettings}
-              onCheckedChange={(checked) =>
-                updateConfig({ useSeparateScoreSettings: checked })
-              }
-            />
-          </div>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <Label className="text-sm font-medium">設問部分点数</Label>
+          {renderColorOpacity(partialScore, updatePartialScore)}
         </div>
+        {renderScoreSettings(partialScore, updatePartialScore)}
+      </div>
 
-        {useSeparateSettings ? (
-          <Tabs defaultValue="partial" className="w-full">
-            <TabsList className="grid h-8 w-full grid-cols-3">
-              <TabsTrigger
-                value="partial"
-                className="text-xs"
-                style={{ color: partialScore.color }}
-              >
-                設問部分点
-              </TabsTrigger>
-              <TabsTrigger
-                value="subtotal"
-                className="text-xs"
-                style={{ color: subtotalScore.color }}
-              >
-                小計点
-              </TabsTrigger>
-              <TabsTrigger
-                value="total"
-                className="text-xs"
-                style={{ color: totalScore.color }}
-              >
-                合計点
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="partial" className="mt-2">
-              {renderScoreSettings(partialScore, updatePartialScore)}
-            </TabsContent>
-            <TabsContent value="subtotal" className="mt-2">
-              {renderScoreSettings(subtotalScore, updateSubtotalScore)}
-            </TabsContent>
-            <TabsContent value="total" className="mt-2">
-              {renderScoreSettings(totalScore, updateTotalScore)}
-            </TabsContent>
-          </Tabs>
-        ) : (
-          renderScoreSettings(partialScore, updateAllScores)
-        )}
+      <Separator />
+
+      {/* 小計点数設定 */}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <Label className="text-sm font-medium">小計点数</Label>
+          {renderColorOpacity(subtotalScore, updateSubtotalScore)}
+        </div>
+        {renderScoreSettings(subtotalScore, updateSubtotalScore)}
+      </div>
+
+      <Separator />
+
+      {/* 合計点数設定 */}
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <Label className="text-sm font-medium">合計点数</Label>
+          {renderColorOpacity(totalScore, updateTotalScore)}
+        </div>
+        {renderScoreSettings(totalScore, updateTotalScore)}
       </div>
 
       <Separator />

--- a/src/components/exams/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/constants/scoringMarkConstants.ts
@@ -7,7 +7,8 @@ import type {
 
 // 既定色（点数印字・採点記号マーク）
 export const DEFAULT_PARTIAL_SCORE_COLOR = "#ef4444" // 部分点・配点（赤）
-export const DEFAULT_SUMMARY_SCORE_COLOR = "#2563eb" // 小計・合計（青）
+export const DEFAULT_SUMMARY_SCORE_COLOR = "#2563eb" // 小計（青）
+export const DEFAULT_TOTAL_SCORE_COLOR = "#16a34a" // 合計（緑）
 export const DEFAULT_MARK_COLOR = "#ef4444" // 採点記号マーク（赤）
 
 // カラーパレット（一括採点アノテーションと同じ基本色）+ 任意のRGBを追加で選択可能
@@ -62,7 +63,7 @@ export const defaultTotalScoreConfig: ScoreTextConfig = {
   offsetY: 0,
   size: 18,
   alignment: "center",
-  color: DEFAULT_SUMMARY_SCORE_COLOR,
+  color: DEFAULT_TOTAL_SCORE_COLOR,
   opacity: 100,
 }
 
@@ -99,8 +100,6 @@ export const defaultConfig: ScoringMarkConfig = {
   scoreOffsetY: 0,
   scoreSize: 14,
   scoreAlignment: "center",
-  // 部分点と小計・合計点を別々に設定するかどうか
-  useSeparateScoreSettings: false,
   // 部分点設定
   partialScore: { ...defaultPartialScoreConfig },
   // 小計・合計点設定（後方互換性のため維持）

--- a/src/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
+++ b/src/components/exams/08-export/components/scoring-mark-settings/types/scoringMarkTypes.ts
@@ -59,9 +59,6 @@ export interface ScoringMarkConfig {
   scoreSize: number // 点数サイズ（8 to 48）
   scoreAlignment: TextAlignment
 
-  // 部分点と小計・合計点を別々に設定するかどうか
-  useSeparateScoreSettings: boolean
-
   // 部分点（設問ごとの点数）用設定
   partialScore: ScoreTextConfig
 


### PR DESCRIPTION
## 概要

点数印字設定のUI・挙動を改善し、設問部分点数・小計点数・合計点数を常に個別設定できるようにした。

Closes #804

## 変更内容

- 「別々に設定」トグル（Tabs切り替え）を廃止し、3種別を常時個別設定するUIに変更
- 各見出しの右側に色・不透明度を右揃え・上揃えで配置（`flex-wrap`でレスポンシブ対応）
- 採点マークセクションも同じレイアウトに統一
- 合計点の既定色を緑(#16a34a)に変更
- `useSeparateScoreSettings` フィールドを型(`scoringMarkTypes.ts`)・定数(`scoringMarkConstants.ts`)・採点画面描画(`useCanvasDrawing.ts`)から削除

## 影響範囲

- `src/components/exams/08-export/components/scoring-mark-settings/` 配下
- `src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts`

## 互換性

- 設定はJSON(`settingsJson`)保存のため**DBスキーマ変更不要**
- 旧データの余分なフィールドは読み込み時に無視され、破損しない

## 確認事項

- [x] `npm run typecheck`（変更箇所にエラーなし）
- [x] `npx eslint`（対象ファイルエラーなし）
- [x] prettier整形済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)