### PR TITLE
test: useKeyboardテストのMock型をVitest 4対応に修正

### DIFF
--- a/__tests__/renderer/hooks/scoring/useKeyboard.test.ts
+++ b/__tests__/renderer/hooks/scoring/useKeyboard.test.ts
@@ -8,14 +8,14 @@
  */
 
 import { renderHook } from "@testing-library/react"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest"
 
 import { useKeyboard } from "@/components/exams/07-score-at-once/ScoringIndividual/hooks/interaction/useKeyboard"
 
 interface Handlers {
-  setIsShiftPressed: ReturnType<typeof vi.fn>
-  setIsCtrlPressed: ReturnType<typeof vi.fn>
-  removeDrawingElement: ReturnType<typeof vi.fn>
+  setIsShiftPressed: Mock<(pressed: boolean) => void>
+  setIsCtrlPressed: Mock<(pressed: boolean) => void>
+  removeDrawingElement: Mock<(id: string) => void>
 }
 
 function mountKeyboard(opts: {
@@ -23,9 +23,9 @@ function mountKeyboard(opts: {
   isTextEditing: boolean
 }): Handlers {
   const handlers: Handlers = {
-    setIsShiftPressed: vi.fn(),
-    setIsCtrlPressed: vi.fn(),
-    removeDrawingElement: vi.fn(),
+    setIsShiftPressed: vi.fn<(pressed: boolean) => void>(),
+    setIsCtrlPressed: vi.fn<(pressed: boolean) => void>(),
+    removeDrawingElement: vi.fn<(id: string) => void>(),
   }
   renderHook(() =>
     useKeyboard({


### PR DESCRIPTION
## 概要

Vitest 4 で発生していた `useKeyboard.test.ts` の型エラー（TS2322）を修正します。

Closes #806

## 変更内容

- `vitest` から `Mock` 型を直接 import
- ハンドラ型を `ReturnType<typeof vi.fn<...>>` から `Mock<(pressed: boolean) => void>` / `Mock<(id: string) => void>` に変更

## 原因

Vitest 4 では `ReturnType<typeof vi.fn<...>>` の instantiation expression がジェネリック引数を適用できず、デフォルトの `Mock<Procedure | Constructable>` に解決されていた。

## 確認

- `npx tsc --noEmit`: 該当エラー解消
- `npx vitest run __tests__/renderer/hooks/scoring/useKeyboard.test.ts`: 5件パス
- `npm run lint`: クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)