### PR TITLE
協調採点の基盤整備: ScoreDecision導入・同期バージョンゲート・マイグレーション防御

### DIFF
--- a/__tests__/calculations/scoreResolution.test.ts
+++ b/__tests__/calculations/scoreResolution.test.ts
@@ -1,0 +1,290 @@
+/**
+ * 有効スコアリゾルバのテスト
+ *
+ * テスト対象:
+ * - resolveEffectiveScores: 確定（ScoreDecision）> 提案合意 > 競合 の決定的解決
+ * - calculateEffectiveScoreValue: 有効スコアの得点計算
+ * - calculateActualScore: 旧status（final）耐性
+ */
+import { describe, expect, it } from "vitest"
+
+import { calculateActualScore } from "@/electron-src/lib/prisma/questionScore"
+import {
+  calculateEffectiveScoreValue,
+  ResolvableDecision,
+  ResolvableScore,
+  resolveEffectiveScores,
+} from "@/electron-src/lib/shared/calculations/scoreResolution"
+
+// ================== ヘルパー ==================
+
+let seq = 0
+
+function score(overrides: Partial<ResolvableScore> = {}): ResolvableScore {
+  seq++
+  return {
+    id: `id-${String(seq).padStart(4, "0")}`,
+    studentId: "student-1",
+    cropRegionId: "region-1",
+    status: "correct",
+    partialScore: null,
+    updatedAt: new Date("2026-06-01T10:00:00Z"),
+    ...overrides,
+  }
+}
+
+function decision(
+  overrides: Partial<ResolvableDecision> = {}
+): ResolvableDecision {
+  return {
+    studentId: "student-1",
+    cropRegionId: "region-1",
+    verdict: "partial",
+    score: 5,
+    decidedAt: new Date("2026-06-02T10:00:00Z"),
+    sourceQuestionScoreId: null,
+    ...overrides,
+  }
+}
+
+// ================== resolveEffectiveScores: 提案のみ ==================
+
+describe("resolveEffectiveScores - 提案のみ", () => {
+  it("単一の提案はそのまま解決される", () => {
+    const s = score({ status: "correct" })
+    const { resolved, conflicts } = resolveEffectiveScores([s])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0]).toMatchObject({
+      studentId: "student-1",
+      cropRegionId: "region-1",
+      status: "correct",
+      partialScore: null,
+      questionScoreId: s.id,
+      source: "proposal",
+      isStale: false,
+    })
+    expect(conflicts).toEqual([])
+  })
+
+  it("生徒×設問ごとに独立して解決される", () => {
+    const a = score({ studentId: "s1", cropRegionId: "r1" })
+    const b = score({ studentId: "s1", cropRegionId: "r2" })
+    const c = score({ studentId: "s2", cropRegionId: "r1" })
+    const { resolved, conflicts } = resolveEffectiveScores([a, b, c])
+    expect(resolved).toHaveLength(3)
+    expect(conflicts).toEqual([])
+  })
+
+  it("unscored行は採点済み行があれば無視される", () => {
+    // scoringInitializer がデフォルトユーザー名義で量産する初期行を想定
+    const initRow = score({ status: "unscored" })
+    const scored = score({ status: "correct" })
+    const { resolved, conflicts } = resolveEffectiveScores([initRow, scored])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].questionScoreId).toBe(scored.id)
+    expect(conflicts).toEqual([])
+  })
+
+  it("全行unscoredなら1件だけ残る", () => {
+    const a = score({ status: "unscored" })
+    const b = score({ status: "unscored" })
+    const { resolved, conflicts } = resolveEffectiveScores([a, b])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].status).toBe("unscored")
+    expect(conflicts).toEqual([])
+  })
+
+  it("複数採点者の判定と点数が一致していれば合意として解決される", () => {
+    const teacherA = score({ status: "partial", partialScore: 3 })
+    const teacherB = score({ status: "partial", partialScore: 3 })
+    const { resolved, conflicts } = resolveEffectiveScores([teacherA, teacherB])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].partialScore).toBe(3)
+    expect(conflicts).toEqual([])
+  })
+
+  it("点数が一致してもstatusが異なれば競合になる", () => {
+    const teacherA = score({ status: "partial", partialScore: 3 })
+    const teacherB = score({ status: "pending", partialScore: 3 })
+    const { resolved, conflicts } = resolveEffectiveScores([teacherA, teacherB])
+    expect(resolved).toEqual([])
+    expect(conflicts).toHaveLength(1)
+  })
+
+  it("複数採点者の点数が食い違えば競合になり値を出さない", () => {
+    const teacherA = score({ status: "partial", partialScore: 3 })
+    const teacherB = score({ status: "partial", partialScore: 7 })
+    const { resolved, conflicts } = resolveEffectiveScores([teacherA, teacherB])
+    expect(resolved).toEqual([])
+    expect(conflicts).toEqual([
+      { studentId: "student-1", cropRegionId: "region-1", candidateCount: 2 },
+    ])
+  })
+
+  it("partialScoreはDecimal風オブジェクトや文字列でも数値比較される", () => {
+    const decimalLike = score({
+      status: "partial",
+      partialScore: { toString: () => "3" },
+    })
+    const numeric = score({ status: "partial", partialScore: 3 })
+    const { resolved, conflicts } = resolveEffectiveScores([
+      decimalLike,
+      numeric,
+    ])
+    expect(resolved).toHaveLength(1)
+    expect(conflicts).toEqual([])
+  })
+
+  it("updatedAtが同時刻ならidで決定的に選択される", () => {
+    const t = new Date("2026-06-01T10:00:00Z")
+    const a = score({ id: "id-aaa", status: "correct", updatedAt: t })
+    const b = score({ id: "id-zzz", status: "correct", updatedAt: t })
+    const result1 = resolveEffectiveScores([a, b])
+    const result2 = resolveEffectiveScores([b, a])
+    expect(result1.resolved[0].questionScoreId).toBe("id-zzz")
+    expect(result2.resolved[0].questionScoreId).toBe("id-zzz")
+  })
+
+  it("studentIdがnullの行は無視される", () => {
+    const orphan = score({ studentId: null })
+    const { resolved, conflicts } = resolveEffectiveScores([orphan])
+    expect(resolved).toEqual([])
+    expect(conflicts).toEqual([])
+  })
+
+  it("旧データのfinal行は提案より優先される（耐性）", () => {
+    const proposal = score({ status: "correct" })
+    const final = score({ status: "final", partialScore: 5 })
+    const { resolved, conflicts } = resolveEffectiveScores([proposal, final])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].status).toBe("final")
+    expect(resolved[0].partialScore).toBe(5)
+    expect(conflicts).toEqual([])
+  })
+})
+
+// ================== resolveEffectiveScores: 確定あり ==================
+
+describe("resolveEffectiveScores - 確定（ScoreDecision）", () => {
+  it("確定があれば提案の食い違いに関わらず確定が採用される", () => {
+    const teacherA = score({ status: "partial", partialScore: 3 })
+    const teacherB = score({ status: "partial", partialScore: 7 })
+    const d = decision({ verdict: "partial", score: 5 })
+    const { resolved, conflicts } = resolveEffectiveScores(
+      [teacherA, teacherB],
+      [d]
+    )
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0]).toMatchObject({
+      status: "partial",
+      partialScore: 5,
+      source: "decision",
+    })
+    // 確定済みセルは競合として報告しない
+    expect(conflicts).toEqual([])
+  })
+
+  it("提案が無いセルの確定も解決される", () => {
+    const d = decision()
+    const { resolved } = resolveEffectiveScores([], [d])
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].source).toBe("decision")
+    expect(resolved[0].questionScoreId).toBeNull()
+  })
+
+  it("採用元提案がある確定はquestionScoreIdに引き継がれる", () => {
+    const d = decision({ sourceQuestionScoreId: "qs-123" })
+    const { resolved } = resolveEffectiveScores([], [d])
+    expect(resolved[0].questionScoreId).toBe("qs-123")
+  })
+
+  it("確定より新しい提案があればisStaleが立つ", () => {
+    const newer = score({
+      status: "partial",
+      partialScore: 9,
+      updatedAt: new Date("2026-06-03T10:00:00Z"),
+    })
+    const d = decision({ decidedAt: new Date("2026-06-02T10:00:00Z") })
+    const { resolved } = resolveEffectiveScores([newer], [d])
+    expect(resolved[0].isStale).toBe(true)
+    // 値は確定のまま
+    expect(resolved[0].partialScore).toBe(5)
+  })
+
+  it("確定より古い提案しか無ければisStaleは立たない", () => {
+    const older = score({
+      status: "partial",
+      partialScore: 3,
+      updatedAt: new Date("2026-06-01T10:00:00Z"),
+    })
+    const d = decision({ decidedAt: new Date("2026-06-02T10:00:00Z") })
+    const { resolved } = resolveEffectiveScores([older], [d])
+    expect(resolved[0].isStale).toBe(false)
+  })
+
+  it("確定の無い他のセルは通常通り解決される", () => {
+    const decided = score({ cropRegionId: "r1", status: "correct" })
+    const undecided = score({ cropRegionId: "r2", status: "incorrect" })
+    const d = decision({ cropRegionId: "r1" })
+    const { resolved } = resolveEffectiveScores([decided, undecided], [d])
+    expect(resolved).toHaveLength(2)
+    const r2 = resolved.find((r) => r.cropRegionId === "r2")
+    expect(r2?.source).toBe("proposal")
+    expect(r2?.status).toBe("incorrect")
+  })
+})
+
+// ================== calculateEffectiveScoreValue ==================
+
+describe("calculateEffectiveScoreValue", () => {
+  it("correctは満点を返す", () => {
+    expect(
+      calculateEffectiveScoreValue(
+        { status: "correct", partialScore: null },
+        10
+      )
+    ).toBe(10)
+  })
+
+  it("incorrect/no_answer/double_markは0を返す", () => {
+    for (const status of ["incorrect", "no_answer", "double_mark"]) {
+      expect(
+        calculateEffectiveScoreValue({ status, partialScore: null }, 10)
+      ).toBe(0)
+    }
+  })
+
+  it("unscoredはnullを返す", () => {
+    expect(
+      calculateEffectiveScoreValue(
+        { status: "unscored", partialScore: null },
+        10
+      )
+    ).toBeNull()
+  })
+
+  it("partial/pendingはpartialScoreを返す", () => {
+    expect(
+      calculateEffectiveScoreValue({ status: "partial", partialScore: 3 }, 10)
+    ).toBe(3)
+    expect(
+      calculateEffectiveScoreValue({ status: "pending", partialScore: 6 }, 10)
+    ).toBe(6)
+  })
+})
+
+// ================== calculateActualScore (旧データ耐性) ==================
+
+describe("calculateActualScore - 旧status耐性", () => {
+  it("finalはpartialScoreの確定値を返す（満点固定にしない）", () => {
+    expect(calculateActualScore({ status: "final", partialScore: 3 }, 10)).toBe(
+      3
+    )
+  })
+
+  it("finalでpartialScoreがnullなら満点を返す（旧データ互換）", () => {
+    expect(
+      calculateActualScore({ status: "final", partialScore: null }, 10)
+    ).toBe(10)
+  })
+})

--- a/__tests__/import-export/unit/scoresDataV1_13Conversion.test.ts
+++ b/__tests__/import-export/unit/scoresDataV1_13Conversion.test.ts
@@ -1,0 +1,173 @@
+/**
+ * v1.12.0 → v1.13.0 採点データ変換のテスト
+ *
+ * テスト対象:
+ * - convertScoresDataToV1_13: 旧 final/proposed status の浄化と ScoreDecision の導出
+ *   （DBマイグレーション 20260611135650_add_score_decision と同一ロジック）
+ */
+import { describe, expect, it } from "vitest"
+
+import { convertScoresDataToV1_13 } from "../../../electron-src/lib/import/transformers/V1_12_0_to_V1_13_0"
+import type { ArchiveScoresData } from "../../../src/types/examArchive.types"
+
+type ArchiveQuestionScore = ArchiveScoresData["questionScores"][number]
+type ArchiveAnnotation = ArchiveScoresData["drawingAnnotations"][number]
+
+let seq = 0
+
+function qs(
+  overrides: Partial<ArchiveQuestionScore> = {}
+): ArchiveQuestionScore {
+  seq++
+  return {
+    id: `qs-${String(seq).padStart(4, "0")}`,
+    cropRegionId: "region-1",
+    studentId: "student-1",
+    partialScore: null,
+    status: "correct",
+    userId: "user-1",
+    createdAt: "2026-06-01T10:00:00Z",
+    updatedAt: "2026-06-01T10:00:00Z",
+    ...overrides,
+  }
+}
+
+function annotation(questionScoreId: string): ArchiveAnnotation {
+  seq++
+  return {
+    id: `ann-${String(seq).padStart(4, "0")}`,
+    questionScoreId,
+    type: "circle",
+    x: 0,
+    y: 0,
+    color: "#ef4444",
+    strokeWidth: 0.5,
+    width: 0,
+    height: 0,
+    endX: 0,
+    endY: 0,
+    lineStyle: "solid",
+    text: "",
+    fontSize: 4,
+    textBoxWidth: 0,
+    textBoxHeight: 0,
+    horizontalAlign: "left",
+    verticalAlign: "top",
+    anchorDirection: "top-left",
+    displayX: 0,
+    displayY: 0,
+    isFavorite: false,
+    userId: "user-1",
+    createdAt: "2026-06-01T10:00:00Z",
+    updatedAt: "2026-06-01T10:00:00Z",
+  }
+}
+
+function scoresData(
+  questionScores: ArchiveQuestionScore[],
+  drawingAnnotations: ArchiveAnnotation[] = []
+): ArchiveScoresData {
+  return { questionScores, drawingAnnotations }
+}
+
+describe("convertScoresDataToV1_13", () => {
+  it("final行からScoreDecisionが生成される（IDはfinal行を流用）", () => {
+    const final = qs({ status: "final", partialScore: "3" })
+    const { scoresData: result, warnings } = convertScoresDataToV1_13(
+      scoresData([final])
+    )
+
+    expect(result.scoreDecisions).toHaveLength(1)
+    expect(result.scoreDecisions?.[0]).toMatchObject({
+      id: final.id,
+      verdict: "partial",
+      score: "3",
+      decidedByUserId: "user-1",
+    })
+    expect(warnings).toHaveLength(1)
+  })
+
+  it("partialScoreがnullのfinal行はverdict=correctになる", () => {
+    const final = qs({ status: "final", partialScore: null })
+    const { scoresData: result } = convertScoresDataToV1_13(scoresData([final]))
+    expect(result.scoreDecisions?.[0].verdict).toBe("correct")
+  })
+
+  it("複数final行は最新（updatedAt降順→id降順）のみ確定になる", () => {
+    const older = qs({
+      status: "final",
+      partialScore: "3",
+      updatedAt: "2026-06-01T10:00:00Z",
+    })
+    const newer = qs({
+      status: "final",
+      partialScore: "8",
+      updatedAt: "2026-06-02T10:00:00Z",
+    })
+    const { scoresData: result } = convertScoresDataToV1_13(
+      scoresData([older, newer])
+    )
+    expect(result.scoreDecisions).toHaveLength(1)
+    expect(result.scoreDecisions?.[0].id).toBe(newer.id)
+    expect(result.scoreDecisions?.[0].score).toBe("8")
+  })
+
+  it("同じ採点者の提案行があるfinal行は削除され、注釈が提案行へ移動する", () => {
+    const proposal = qs({ status: "partial", partialScore: "3" })
+    const final = qs({ status: "final", partialScore: "3" })
+    const ann = annotation(final.id)
+
+    const { scoresData: result } = convertScoresDataToV1_13(
+      scoresData([proposal, final], [ann])
+    )
+
+    const ids = result.questionScores.map((s) => s.id)
+    expect(ids).toContain(proposal.id)
+    expect(ids).not.toContain(final.id)
+    expect(result.drawingAnnotations[0].questionScoreId).toBe(proposal.id)
+  })
+
+  it("提案行が無いfinal行は判定のみの提案行へ変換される", () => {
+    const final = qs({ status: "final", partialScore: "3" })
+    const { scoresData: result } = convertScoresDataToV1_13(scoresData([final]))
+    expect(result.questionScores).toHaveLength(1)
+    expect(result.questionScores[0]).toMatchObject({
+      id: final.id,
+      status: "partial",
+      partialScore: "3",
+    })
+  })
+
+  it("proposedは点数の有無でpartial/pendingへ変換される", () => {
+    const withScore = qs({ status: "proposed", partialScore: "5" })
+    const withoutScore = qs({
+      status: "proposed",
+      partialScore: null,
+      cropRegionId: "region-2",
+    })
+    const { scoresData: result } = convertScoresDataToV1_13(
+      scoresData([withScore, withoutScore])
+    )
+    const byId = new Map(result.questionScores.map((s) => [s.id, s]))
+    expect(byId.get(withScore.id)?.status).toBe("partial")
+    expect(byId.get(withoutScore.id)?.status).toBe("pending")
+  })
+
+  it("v1.13.0形式（final/proposedなし・scoreDecisionsあり）には冪等", () => {
+    const data: ArchiveScoresData = {
+      questionScores: [qs({ status: "correct" })],
+      drawingAnnotations: [],
+      scoreDecisions: [],
+    }
+    const { scoresData: result, warnings } = convertScoresDataToV1_13(data)
+    expect(result).toBe(data)
+    expect(warnings).toEqual([])
+  })
+
+  it("scoreDecisions未定義（旧アーカイブ）でも空配列で補完される", () => {
+    const { scoresData: result } = convertScoresDataToV1_13(
+      scoresData([qs({ status: "correct" })])
+    )
+    expect(result.scoreDecisions).toEqual([])
+  })
+})

--- a/__tests__/migration/migrationGuard.test.ts
+++ b/__tests__/migration/migrationGuard.test.ts
@@ -1,0 +1,152 @@
+import { PrismaClient } from "@prisma/client"
+import * as fs from "fs"
+import * as path from "path"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
+
+import { ensureBaselineUpToDate } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { listLocalMigrationNames } from "../../electron-src/lib/prisma/schema/migrationDeployer"
+import {
+  assertDatabaseNotNewerThanApp,
+  DatabaseNewerThanAppError,
+} from "../../electron-src/lib/prisma/schema/migrationGuard"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_DB_DIR = path.resolve(__dirname, "../../data")
+const TEST_DB_PATH = path.join(TEST_DB_DIR, "test-migration-guard.db")
+
+let prisma: PrismaClient
+
+const createPrisma = () => createPrismaClientForPath(TEST_DB_PATH)
+
+const resetDb = async () => {
+  await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+  fs.writeFileSync(TEST_DB_PATH, "")
+  prisma = createPrisma()
+  await prisma.$connect()
+}
+
+const createMigrationsTable = async () => {
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE "_prisma_migrations" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "checksum" TEXT NOT NULL,
+      "finished_at" DATETIME,
+      "migration_name" TEXT NOT NULL,
+      "logs" TEXT,
+      "rolled_back_at" DATETIME,
+      "started_at" DATETIME NOT NULL DEFAULT current_timestamp,
+      "applied_steps_count" INTEGER NOT NULL DEFAULT 0
+    )
+  `)
+}
+
+const insertMigration = async (name: string, rolledBack = false) => {
+  await prisma.$executeRawUnsafe(
+    `INSERT INTO "_prisma_migrations" ("id", "checksum", "finished_at", "migration_name", "started_at", "applied_steps_count", "rolled_back_at")
+     VALUES ('${name}-id', 'checksum', '2026-01-01T00:00:00Z', '${name}', '2026-01-01T00:00:00Z', 1, ${rolledBack ? "'2026-01-01T00:00:00Z'" : "NULL"})`
+  )
+}
+
+const getMigrationNames = async (): Promise<string[]> => {
+  const rows = await prisma.$queryRawUnsafe<{ migration_name: string }[]>(
+    `SELECT "migration_name" FROM "_prisma_migrations" ORDER BY "migration_name"`
+  )
+  return rows.map((r) => r.migration_name)
+}
+
+beforeAll(async () => {
+  if (!fs.existsSync(TEST_DB_DIR))
+    fs.mkdirSync(TEST_DB_DIR, { recursive: true })
+  prisma = createPrisma()
+})
+
+afterEach(async () => {
+  await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+})
+
+describe("assertDatabaseNotNewerThanApp", () => {
+  it("_prisma_migrationsテーブルが無ければ何もしない", async () => {
+    await resetDb()
+    await expect(assertDatabaseNotNewerThanApp(prisma)).resolves.not.toThrow()
+  })
+
+  it("ローカルと同じマイグレーションのみ適用済みなら通過する", async () => {
+    await resetDb()
+    await createMigrationsTable()
+    for (const name of listLocalMigrationNames()) {
+      await insertMigration(name)
+    }
+    await expect(assertDatabaseNotNewerThanApp(prisma)).resolves.not.toThrow()
+  })
+
+  it("アプリが知らない新しいマイグレーションが適用済みなら例外を投げる", async () => {
+    await resetDb()
+    await createMigrationsTable()
+    for (const name of listLocalMigrationNames()) {
+      await insertMigration(name)
+    }
+    await insertMigration("20990101000000_future_feature")
+
+    await expect(assertDatabaseNotNewerThanApp(prisma)).rejects.toThrow(
+      DatabaseNewerThanAppError
+    )
+    await expect(assertDatabaseNotNewerThanApp(prisma)).rejects.toThrow(
+      "20990101000000_future_feature"
+    )
+  })
+
+  it("旧カスタムシステム由来の古い未知エントリは対象外", async () => {
+    await resetDb()
+    await createMigrationsTable()
+    // 旧システムのエントリはタイムスタンプ接頭辞より辞書順で古い
+    await insertMigration("0001_legacy_custom_migration")
+    await expect(assertDatabaseNotNewerThanApp(prisma)).resolves.not.toThrow()
+  })
+
+  it("ロールバック済みの新しいマイグレーションは対象外", async () => {
+    await resetDb()
+    await createMigrationsTable()
+    await insertMigration("20990101000000_future_feature", true)
+    await expect(assertDatabaseNotNewerThanApp(prisma)).resolves.not.toThrow()
+  })
+})
+
+describe("ensureBaselineUpToDate", () => {
+  it("ベースライン未登録時、旧エントリのみ削除しローカル既知の記録は保持する", async () => {
+    await resetDb()
+    await createMigrationsTable()
+
+    const localNames = listLocalMigrationNames()
+    const knownLater = localNames[1] // init以外のローカル既知マイグレーション
+    await insertMigration("0001_legacy_custom_migration")
+    await insertMigration(knownLater)
+
+    await ensureBaselineUpToDate(prisma)
+
+    const names = await getMigrationNames()
+    expect(names).not.toContain("0001_legacy_custom_migration")
+    expect(names).toContain(knownLater)
+    expect(names).toContain(localNames[0]) // init が挿入されている
+  })
+
+  it("ベースライン登録済みなら何も変更しない", async () => {
+    await resetDb()
+    await createMigrationsTable()
+    const localNames = listLocalMigrationNames()
+    await insertMigration(localNames[0])
+    await insertMigration("0001_legacy_custom_migration")
+
+    await ensureBaselineUpToDate(prisma)
+
+    const names = await getMigrationNames()
+    // ベースライン（init）が既にあるため、旧エントリも残る（変更なし）
+    expect(names).toContain("0001_legacy_custom_migration")
+  })
+})

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -1,10 +1,11 @@
-import { app, net, protocol } from "electron"
+import { app, dialog, net, protocol } from "electron"
 import * as path from "path"
 import { pathToFileURL } from "url"
 
 import { initializeApp } from "./appInitializer"
 import { setupAllIPCHandlers } from "./ipc-handlers"
 import { getAbsolutePathFromData } from "./lib/dataManager"
+import { DB_NEWER_THAN_APP_MARKER } from "./lib/prisma/schema/migrationGuard"
 import { startEmbeddedNextServer } from "./nextServerEmbedded"
 import { createMainWindow, setupWindowEvents } from "./windowManager"
 
@@ -128,6 +129,13 @@ app.on("ready", async () => {
   } catch (error) {
     console.error("Critical error during application startup:", error)
     console.error("Error stack:", error instanceof Error ? error.stack : error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (message.includes(DB_NEWER_THAN_APP_MARKER)) {
+      dialog.showErrorBox(
+        "アプリの更新が必要です",
+        message.replace(`[${DB_NEWER_THAN_APP_MARKER}] `, "")
+      )
+    }
     app.quit()
   }
 })

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -16,7 +16,10 @@ import {
   finalizeStreamingSession,
   getPdfExportData,
 } from "../lib/prisma/pdfExport"
-import { validateScoringData } from "../lib/shared/utilities/validateScoringData"
+import {
+  buildConflictIdentifiers,
+  validateScoringData,
+} from "../lib/shared/utilities/validateScoringData"
 import { registerSafeHandler } from "./ipcHandlerUtils"
 
 /** Excel・PDF出力・個人成績表・ストリーミングPDF生成に関するIPCチャンネルを登録する */
@@ -35,7 +38,13 @@ export function setupExportHandlers(): void {
           error: result.error || "データ取得に失敗しました",
         }
       }
-      const validationResult = validateScoringData(result.scoringData)
+      const validationResult = validateScoringData(
+        result.scoringData,
+        buildConflictIdentifiers(
+          result.scoringData,
+          result.scoreConflicts ?? []
+        )
+      )
       return { success: true, ...validationResult }
     }
   )

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -4,7 +4,6 @@ import {
   createQuestionScore,
   CreateQuestionScoreData,
   deleteQuestionScore,
-  finalizeQuestionScore,
   getAnswerSheetProgress,
   getExamProgress,
   getQuestionScoreById,
@@ -14,6 +13,7 @@ import {
   updateQuestionScore,
   UpdateQuestionScoreData,
 } from "../lib/prisma/questionScore"
+import { upsertScoreDecision } from "../lib/prisma/scoreDecision"
 import { initializeScoringRecords } from "../lib/prisma/scoringInitializer"
 import { registerHandler } from "./ipcHandlerUtils"
 
@@ -120,7 +120,19 @@ export function setupScoringHandlers(): void {
   registerHandler(
     "get-question-score-comparison",
     async (studentId: string, cropRegionId: string) => {
-      return await getQuestionScoreComparison(studentId, cropRegionId)
+      const result = await getQuestionScoreComparison(studentId, cropRegionId)
+      if (!result.success || !("decision" in result)) return result
+      return {
+        ...result,
+        decision: result.decision
+          ? {
+              ...result.decision,
+              score: result.decision.score
+                ? Number(result.decision.score)
+                : null,
+            }
+          : null,
+      }
     }
   )
 
@@ -134,20 +146,39 @@ export function setupScoringHandlers(): void {
         partialScore?: number
         status: string
         comment?: string
+        sourceQuestionScoreId?: string
       }
     ) => {
-      const result = await finalizeQuestionScore(
-        studentId,
-        cropRegionId,
-        userId,
-        scoreData
-      )
+      // 旧API互換: status="final" は点数有無からverdictを導出する
+      const verdict =
+        scoreData.status === "final"
+          ? scoreData.partialScore === null ||
+            scoreData.partialScore === undefined
+            ? "correct"
+            : "partial"
+          : scoreData.status
 
-      if (!result.success || !("score" in result)) {
-        return result
+      const result = await upsertScoreDecision({
+        cropRegionId,
+        studentId,
+        verdict,
+        score: scoreData.partialScore ?? null,
+        comment: scoreData.comment ?? null,
+        decidedByUserId: userId,
+        sourceQuestionScoreId: scoreData.sourceQuestionScoreId ?? null,
+      })
+
+      if (!result.success || !result.decision) {
+        return { success: false, error: result.error }
       }
 
-      return { success: true, score: serializeScore(result.score) }
+      return {
+        success: true,
+        decision: {
+          ...result.decision,
+          score: result.decision.score ? Number(result.decision.score) : null,
+        },
+      }
     }
   )
 

--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -262,6 +262,11 @@ export class DatabaseSetup {
     }
 
     if (version === "MIGRATED") {
+      // DBがアプリより新しい場合は書き込み前に起動を中止する
+      const { assertDatabaseNotNewerThanApp } =
+        await import("./prisma/schema/migrationGuard")
+      await assertDatabaseNotNewerThanApp(this.prisma)
+
       // 既にPrisma管理下 — ベースラインが最新か確認
       const { ensureBaselineUpToDate } =
         await import("./prisma/schema/baselineMigrations")

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -250,6 +250,7 @@ export async function collectExamData(
     // v0.3.0以降: ログインユーザーのデータのみをエクスポート
     const questionScores: ArchiveScoresData["questionScores"] = []
     const drawingAnnotations: ArchiveScoresData["drawingAnnotations"] = []
+    const scoreDecisions: ArchiveScoresData["scoreDecisions"] = []
 
     if (!isTemplate) {
       for (const page of exam.examPages) {
@@ -307,6 +308,27 @@ export async function collectExamData(
             }
           }
         }
+      }
+
+      // 9.5. ScoreDecisionを収集 (v1.13.0+)
+      // 確定は試験ごとに1セットなので採点者によるフィルタはしない
+      const decisions = await prisma.scoreDecision.findMany({
+        where: { cropRegion: { examPage: { examId } } },
+      })
+      for (const d of decisions) {
+        scoreDecisions.push({
+          id: d.id,
+          cropRegionId: d.cropRegionId,
+          studentId: d.studentId,
+          verdict: d.verdict,
+          score: d.score?.toString() ?? null,
+          comment: d.comment,
+          decidedByUserId: d.decidedByUserId,
+          decidedAt: d.decidedAt.toISOString(),
+          sourceQuestionScoreId: d.sourceQuestionScoreId,
+          createdAt: d.createdAt.toISOString(),
+          updatedAt: d.updatedAt.toISOString(),
+        })
       }
     }
 
@@ -619,6 +641,7 @@ export async function collectExamData(
     const scoresData: ArchiveScoresData = {
       questionScores,
       drawingAnnotations,
+      scoreDecisions,
     }
 
     const tagsData: ArchiveTagsData = {

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -1,19 +1,17 @@
-import type {
-  CropRegion,
-  Exam,
-  ExamStudent,
-  QuestionScore,
-  Student,
-} from "@prisma/client"
+import type { CropRegion, Exam, ExamStudent, Student } from "@prisma/client"
 
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
 import { getExamById } from "../../prisma/exam"
 import { getStudentsForExam } from "../../prisma/examStudent"
-import {
-  calculateActualScore,
-  getQuestionScoresForExam,
-} from "../../prisma/questionScore"
+import { getQuestionScoresForExam } from "../../prisma/questionScore"
+import { getScoreDecisionsForExam } from "../../prisma/scoreDecision"
 import { getActiveSubtotalGroupsForExam } from "../../prisma/subtotalGroup"
+import {
+  calculateEffectiveScoreValue,
+  EffectiveScore,
+  resolveEffectiveScores,
+  ScoreConflict,
+} from "../../shared/calculations/scoreResolution"
 import {
   calculateSubtotalScoreBySubtotalId,
   QuestionScoreData,
@@ -53,6 +51,8 @@ export interface ExportDataResult {
   subtotalRegions?: CropRegion[]
   subtotalColumns?: SubtotalColumn[]
   scoringData?: ScoringData[]
+  /** 複数採点者の値が食い違い解決できなかった生徒×設問（出力上は未採点扱い） */
+  scoreConflicts?: ScoreConflict[]
 }
 
 /**
@@ -79,7 +79,21 @@ export async function fetchExportData(
     }
 
     const cropRegions = await getCropRegionsByExamId(examId)
-    const questionScores = await getQuestionScoresForExam(examId)
+    const questionScoresResult = await getQuestionScoresForExam(examId)
+    const decisionsResult = await getScoreDecisionsForExam(examId)
+
+    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+    const { resolved: questionScores, conflicts: scoreConflicts } =
+      resolveEffectiveScores(
+        questionScoresResult.success ? (questionScoresResult.scores ?? []) : [],
+        decisionsResult.success ? (decisionsResult.decisions ?? []) : []
+      )
+    if (scoreConflicts.length > 0) {
+      console.warn(
+        `Export: ${scoreConflicts.length}件の採点競合を検出しました（未採点として出力されます）`,
+        scoreConflicts
+      )
+    }
 
     // 選択された生徒のフィルタリングとソート
     // 空配列の場合は全生徒を取得（統計計算用）
@@ -181,6 +195,7 @@ export async function fetchExportData(
       subtotalRegions,
       subtotalColumns,
       scoringData,
+      scoreConflicts,
     }
   } catch (error) {
     console.error("Error fetching export data:", error)
@@ -211,22 +226,20 @@ async function buildScoringData(
   })[],
   questionRegions: CropRegion[],
   subtotalGroups: SubtotalGroupData[],
-  questionScores: { success: boolean; scores?: QuestionScore[] }
+  questionScores: EffectiveScore[]
 ): Promise<ScoringData[]> {
   return Promise.all(
     selectedStudents.map(async (student) => {
-      const studentScores = questionScores.success
-        ? questionScores.scores?.filter(
-            (score: QuestionScore) => score.studentId === student.id
-          ) || []
-        : []
+      const studentScores = questionScores.filter(
+        (score) => score.studentId === student.id
+      )
 
       const scores = buildScoreDetails(studentScores, questionRegions)
       const subtotalScores = await buildSubtotalScores(
         student.id,
         subtotalGroups,
         questionRegions,
-        questionScores.scores || []
+        questionScores
       )
 
       const allUnscored = scores.every((s) => s.status === "unscored")
@@ -263,25 +276,15 @@ async function buildScoringData(
  * @returns 設問別スコア詳細配列
  */
 function buildScoreDetails(
-  studentScores: QuestionScore[],
+  studentScores: EffectiveScore[],
   questionRegions: CropRegion[]
 ): ScoreDetail[] {
   return questionRegions.map((region: CropRegion) => {
     const scoreRecord = studentScores.find(
-      (score: QuestionScore) => score.cropRegionId === region.id
+      (score) => score.cropRegionId === region.id
     )
     const actualScore = scoreRecord
-      ? calculateActualScore(
-          {
-            status: scoreRecord.status,
-            partialScore:
-              scoreRecord.partialScore !== null &&
-              scoreRecord.partialScore !== undefined
-                ? Number(scoreRecord.partialScore)
-                : null,
-          },
-          region.points || 0
-        )
+      ? calculateEffectiveScoreValue(scoreRecord, region.points || 0)
       : null
 
     return {
@@ -314,17 +317,17 @@ async function buildSubtotalScores(
   studentId: string,
   subtotalGroups: SubtotalGroupData[],
   questionRegions: CropRegion[],
-  allQuestionScores: QuestionScore[]
+  allQuestionScores: EffectiveScore[]
 ): Promise<SubtotalScore[]> {
   // 設問スコアデータを変換
-  const questionScoreData: QuestionScoreData[] = allQuestionScores
-    .filter((score) => score.studentId !== null)
-    .map((score) => ({
-      studentId: score.studentId!,
+  const questionScoreData: QuestionScoreData[] = allQuestionScores.map(
+    (score) => ({
+      studentId: score.studentId,
       cropRegionId: score.cropRegionId,
       status: score.status,
-      partialScore: score.partialScore ? Number(score.partialScore) : null,
-    }))
+      partialScore: score.partialScore,
+    })
+  )
 
   const results: SubtotalScore[] = []
 

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -4,7 +4,10 @@ import {
   ExportGradingDataOptions,
   ExportResult,
 } from "../../shared/types/exportTypes"
-import { validateScoringData } from "../../shared/utilities/validateScoringData"
+import {
+  buildConflictIdentifiers,
+  validateScoringData,
+} from "../../shared/utilities/validateScoringData"
 import { fetchExportData } from "./dataFetcher"
 import { saveWorkbook } from "./fileSaver"
 import { createItemAnalysisSheet } from "./itemAnalysisSheetCreator"
@@ -39,7 +42,13 @@ export async function exportGradingDataExcel(
 
     // 採点データの検証と警告の生成（強制実行でない場合のみ）
     if (!options.forceExport) {
-      const validationResult = validateScoringData(dataResult.scoringData)
+      const validationResult = validateScoringData(
+        dataResult.scoringData,
+        buildConflictIdentifiers(
+          dataResult.scoringData,
+          dataResult.scoreConflicts ?? []
+        )
+      )
       if (validationResult.hasWarnings) {
         return {
           success: false,

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -2,12 +2,17 @@
  * 個人成績表用データ取得・統合ロジック
  */
 
-import type { CropRegion, QuestionScore } from "@prisma/client"
+import type { CropRegion } from "@prisma/client"
 
 import prisma from "../../prisma/client"
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
 import { getQuestionScoresForExam } from "../../prisma/questionScore"
+import { getScoreDecisionsForExam } from "../../prisma/scoreDecision"
 import { getActiveSubtotalGroupsForExam } from "../../prisma/subtotalGroup"
+import {
+  EffectiveScore,
+  resolveEffectiveScores,
+} from "../../shared/calculations/scoreResolution"
 import {
   calculateSubtotalScoreBySubtotalId,
   type QuestionScoreData,
@@ -84,9 +89,12 @@ export async function fetchIndividualReportData(
       (r) => r.type === "QUESTION_ANSWER"
     )
     const questionScoresResult = await getQuestionScoresForExam(examId)
-    const allQuestionScores = questionScoresResult.success
-      ? questionScoresResult.scores || []
-      : []
+    const decisionsResult = await getScoreDecisionsForExam(examId)
+    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+    const { resolved: allQuestionScores } = resolveEffectiveScores(
+      questionScoresResult.success ? (questionScoresResult.scores ?? []) : [],
+      decisionsResult.success ? (decisionsResult.decisions ?? []) : []
+    )
 
     // 全生徒の小計点を計算（Subtotal単位）
     const allScoringData = await Promise.all(
@@ -223,18 +231,18 @@ async function getSubtotalGroupsWithSubtotals(
 async function buildSubtotalScoresFromGroups(
   studentId: string,
   subtotalGroups: SubtotalGroupData[],
-  allQuestionScores: QuestionScore[],
+  allQuestionScores: EffectiveScore[],
   questionRegions: CropRegion[]
 ): Promise<SubtotalScore[]> {
   // 採点データを変換
-  const questionScoreData: QuestionScoreData[] = allQuestionScores
-    .filter((score) => score.studentId !== null)
-    .map((score) => ({
-      studentId: score.studentId!,
+  const questionScoreData: QuestionScoreData[] = allQuestionScores.map(
+    (score) => ({
+      studentId: score.studentId,
       cropRegionId: score.cropRegionId,
       status: score.status,
-      partialScore: score.partialScore ? Number(score.partialScore) : null,
-    }))
+      partialScore: score.partialScore,
+    })
+  )
 
   const results: SubtotalScore[] = []
 

--- a/electron-src/lib/import/exam-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/exam-archive/archiveExtractor.ts
@@ -21,6 +21,7 @@ import type {
   ArchiveTagsData,
   ArchiveUsersData,
 } from "../../../../src/types/examArchive.types"
+import { convertScoresDataToV1_13 } from "../transformers/V1_12_0_to_V1_13_0"
 
 /**
  * 展開されたアーカイブデータ
@@ -109,7 +110,14 @@ export async function extractArchive(archivePath: string): Promise<{
       tempDir,
       "subtotals.json"
     )
-    const scoresData = readJsonFile<ArchiveScoresData>(tempDir, "scores.json")
+    // v1.13.0+: scoreDecisions（旧形式の final/proposed 行は読み込み時に変換）
+    const rawScoresData = readJsonFile<ArchiveScoresData>(
+      tempDir,
+      "scores.json"
+    )
+    const scoresData = rawScoresData
+      ? convertScoresDataToV1_13(rawScoresData).scoresData
+      : null
 
     // v1.4.0-v1.9.0: タグデータ（存在しない場合はデフォルト値）
     const subjectsData = readJsonFile<ArchiveSubjectsData>(

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -549,6 +549,32 @@ export async function createImportedData(
         }
       }
 
+      // 14.5. ScoreDecisionを作成 (v1.13.0+)
+      // decidedByUserIdは現在のログインユーザーで上書き
+      for (const sd of data.scoresData.scoreDecisions || []) {
+        const newCropRegionId = remapId(sd.cropRegionId, mappings.cropRegion)
+        const newStudentId = remapId(sd.studentId, mappings.student)
+
+        if (newCropRegionId && newStudentId) {
+          await tx.scoreDecision.create({
+            data: {
+              id: remapIdRequired(sd.id, mappings.scoreDecision),
+              cropRegionId: newCropRegionId,
+              studentId: newStudentId,
+              verdict: sd.verdict,
+              score: sd.score ? parseFloat(sd.score) : null,
+              comment: sd.comment,
+              decidedByUserId: currentUserId,
+              decidedAt: new Date(sd.decidedAt),
+              sourceQuestionScoreId: remapId(
+                sd.sourceQuestionScoreId,
+                mappings.questionScore
+              ),
+            },
+          })
+        }
+      }
+
       // 15. DrawingAnnotationを作成
       // v0.3.0以降: userIdを現在のログインユーザーで上書き
       for (const da of data.scoresData.drawingAnnotations) {

--- a/electron-src/lib/import/exam-archive/idRemapper.ts
+++ b/electron-src/lib/import/exam-archive/idRemapper.ts
@@ -48,6 +48,8 @@ export interface IdMappings {
   cropSubtotal: Record<string, string>
   /** QuestionScore ID: 旧ID -> 新ID */
   questionScore: Record<string, string>
+  /** ScoreDecision ID: 旧ID -> 新ID (v1.13.0+) */
+  scoreDecision: Record<string, string>
   /** DrawingAnnotation ID: 旧ID -> 新ID */
   drawingAnnotation: Record<string, string>
   /** ExamMarkingFormat ID: 旧ID -> 新ID (v1.4.0+) */
@@ -102,6 +104,7 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     subtotal: {},
     cropSubtotal: {},
     questionScore: {},
+    scoreDecision: {},
     drawingAnnotation: {},
     examMarkingFormat: {},
     examExportSettings: {},
@@ -202,6 +205,11 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // QuestionScore
   for (const qs of data.scoresData.questionScores) {
     mappings.questionScore[qs.id] = randomUUID()
+  }
+
+  // v1.13.0+: ScoreDecision
+  for (const sd of data.scoresData.scoreDecisions || []) {
+    mappings.scoreDecision[sd.id] = randomUUID()
   }
 
   // DrawingAnnotation

--- a/electron-src/lib/import/transformers/V1_12_0_to_V1_13_0.ts
+++ b/electron-src/lib/import/transformers/V1_12_0_to_V1_13_0.ts
@@ -1,0 +1,176 @@
+/**
+ * v1.12.0 → v1.13.0 変換器
+ *
+ * 主な変更点:
+ * - ScoreDecision 追加（OWNERによる確定スコア。生徒×設問ごとに高々1件）
+ * - QuestionScore.status の "proposed" / "final" 廃止
+ *
+ * 変換ロジックはDBマイグレーション（20260611135650_add_score_decision）と同一:
+ * 1. 生徒×設問ごとに最新の final 行から ScoreDecision を生成
+ *    （IDは final 行のIDを流用 — 決定的変換のため）
+ * 2. final 行の描画注釈を同じ採点者の既存提案行へ移動（あれば）
+ * 3. 同じ採点者の提案行がある final 行は削除、無ければ判定のみの提案行へ変換
+ * 4. proposed は partial / pending へ変換
+ *
+ * 実際のインポートフロー（archiveExtractor）からは convertScoresDataToV1_13 を
+ * 直接利用する（フィールド単位の互換処理パターンに合わせるため）。
+ */
+
+import type { ArchiveScoresData } from "../../../../src/types/examArchive.types"
+import type {
+  ArchiveData,
+  ArchiveVersion,
+  TransformResult,
+  VersionTransformer,
+} from "./types"
+
+type ArchiveQuestionScore = ArchiveScoresData["questionScores"][number]
+
+const cellKey = (s: ArchiveQuestionScore): string =>
+  `${s.studentId} ${s.cropRegionId}`
+
+/** updatedAt 降順 → id 降順で最新の行を選ぶ（決定的） */
+const pickLatest = (rows: ArchiveQuestionScore[]): ArchiveQuestionScore =>
+  rows.reduce((latest, current) => {
+    if (current.updatedAt !== latest.updatedAt) {
+      return current.updatedAt > latest.updatedAt ? current : latest
+    }
+    return current.id > latest.id ? current : latest
+  })
+
+/**
+ * scores.json を v1.13.0 形式へ正規化する。
+ *
+ * - scoreDecisions が無ければ final 行から導出して補完
+ * - status の "final" / "proposed" を浄化
+ *
+ * v1.13.0 アーカイブ（final/proposed 行なし・scoreDecisions あり）には無変更で冪等。
+ */
+export function convertScoresDataToV1_13(scoresData: ArchiveScoresData): {
+  scoresData: ArchiveScoresData
+  warnings: string[]
+} {
+  const warnings: string[] = []
+  const questionScores = scoresData.questionScores ?? []
+  const drawingAnnotations = scoresData.drawingAnnotations ?? []
+  const existingDecisions = scoresData.scoreDecisions ?? []
+
+  const finals = questionScores.filter((s) => s.status === "final")
+  if (finals.length === 0 && scoresData.scoreDecisions) {
+    // 既にv1.13.0形式
+    const hasProposed = questionScores.some((s) => s.status === "proposed")
+    if (!hasProposed) return { scoresData, warnings }
+  }
+
+  // 1) 生徒×設問ごとに最新の final 行から確定を生成
+  const finalsByCell = new Map<string, ArchiveQuestionScore[]>()
+  for (const f of finals) {
+    const key = cellKey(f)
+    const group = finalsByCell.get(key)
+    if (group) {
+      group.push(f)
+    } else {
+      finalsByCell.set(key, [f])
+    }
+  }
+
+  const decidedCells = new Set(
+    existingDecisions.map((d) => `${d.studentId} ${d.cropRegionId}`)
+  )
+  const scoreDecisions = [...existingDecisions]
+  for (const group of finalsByCell.values()) {
+    const latest = pickLatest(group)
+    if (decidedCells.has(cellKey(latest))) continue
+    scoreDecisions.push({
+      id: latest.id,
+      cropRegionId: latest.cropRegionId,
+      studentId: latest.studentId,
+      verdict: latest.partialScore === null ? "correct" : "partial",
+      score: latest.partialScore,
+      comment: null,
+      decidedByUserId: latest.userId,
+      decidedAt: latest.updatedAt,
+      sourceQuestionScoreId: null,
+      createdAt: latest.createdAt,
+      updatedAt: latest.updatedAt,
+    })
+  }
+
+  // 2) final 行の注釈を同じ採点者の既存提案行へ移動
+  const proposalByCellUser = new Map<string, ArchiveQuestionScore>()
+  for (const s of questionScores) {
+    if (s.status === "final") continue
+    const key = `${cellKey(s)} ${s.userId}`
+    const existing = proposalByCellUser.get(key)
+    if (!existing || pickLatest([existing, s]) === s) {
+      proposalByCellUser.set(key, s)
+    }
+  }
+
+  const finalIdToProposalId = new Map<string, string>()
+  const finalIdsToDelete = new Set<string>()
+  for (const f of finals) {
+    const proposal = proposalByCellUser.get(`${cellKey(f)} ${f.userId}`)
+    if (proposal) {
+      finalIdToProposalId.set(f.id, proposal.id)
+      finalIdsToDelete.add(f.id) // 3) 提案行がある final 行は削除
+    }
+  }
+
+  const movedAnnotations = drawingAnnotations.map((a) => {
+    const newId = finalIdToProposalId.get(a.questionScoreId)
+    return newId ? { ...a, questionScoreId: newId } : a
+  })
+
+  // 3-4) final 行の削除・変換、proposed の浄化
+  const cleanedScores = questionScores
+    .filter((s) => !finalIdsToDelete.has(s.id))
+    .map((s) => {
+      if (s.status === "final") {
+        return {
+          ...s,
+          status: s.partialScore === null ? "correct" : "partial",
+        }
+      }
+      if (s.status === "proposed") {
+        return {
+          ...s,
+          status: s.partialScore === null ? "pending" : "partial",
+        }
+      }
+      return s
+    })
+
+  if (finals.length > 0) {
+    warnings.push(
+      `旧形式の final 採点 ${finals.length}件を確定（ScoreDecision）へ変換しました`
+    )
+  }
+
+  return {
+    scoresData: {
+      ...scoresData,
+      questionScores: cleanedScores,
+      drawingAnnotations: movedAnnotations,
+      scoreDecisions,
+    },
+    warnings,
+  }
+}
+
+export class V1_12_0_to_V1_13_0_Transformer implements VersionTransformer {
+  readonly fromVersion: ArchiveVersion = "1.12.0"
+  readonly toVersion: ArchiveVersion = "1.13.0"
+
+  transform(data: ArchiveData): TransformResult {
+    const { scoresData, warnings } = convertScoresDataToV1_13(data.scoresData)
+    return {
+      data: {
+        ...data,
+        manifest: { ...data.manifest, version: this.toVersion },
+        scoresData,
+      },
+      warnings: warnings.map((w) => `1.12.0→1.13.0: ${w}`),
+    }
+  }
+}

--- a/electron-src/lib/import/transformers/index.ts
+++ b/electron-src/lib/import/transformers/index.ts
@@ -26,3 +26,7 @@ export { V1_8_0_to_V1_9_0_Transformer } from "./V1_8_0_to_V1_9_0"
 export { V1_9_0_to_V1_10_0_Transformer } from "./V1_9_0_to_V1_10_0"
 export { V1_10_0_to_V1_11_0_Transformer } from "./V1_10_0_to_V1_11_0"
 export { V1_11_0_to_V1_12_0_Transformer } from "./V1_11_0_to_V1_12_0"
+export {
+  convertScoresDataToV1_13,
+  V1_12_0_to_V1_13_0_Transformer,
+} from "./V1_12_0_to_V1_13_0"

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -38,6 +38,7 @@ import type {
  * - 1.10.0: v0.9.x (Subject→Tag リネーム, ExamTag 追加, Exam.subject 削除)
  * - 1.11.0: v0.10.x (OMRバブル位置永続化, CropRegionOmrDigitBox追加, CompoundAnswer追加, cellGeometryJson削除)
  * - 1.12.0: v0.12.x (Exam.markerCorrectionEnabled 追加 — ASB由来試験のマーク補正既定ONフラグ)
+ * - 1.13.0: v0.12.x (ScoreDecision 追加 — OWNERによる確定スコア。QuestionScoreのstatus proposed/final廃止)
  */
 export type ArchiveVersion =
   | "1.0.0"
@@ -53,9 +54,10 @@ export type ArchiveVersion =
   | "1.10.0"
   | "1.11.0"
   | "1.12.0"
+  | "1.13.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.12.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.13.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -72,6 +74,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.10.0",
   "1.11.0",
   "1.12.0",
+  "1.13.0",
 ] as const
 
 // =============================================================================

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -6,12 +6,14 @@ import path from "path"
 import { PageSizes, PDFDocument } from "pdf-lib"
 
 import { getAbsolutePathFromData } from "../dataManager"
+import { resolveEffectiveScores } from "../shared/calculations/scoreResolution"
 import { calculateSubtotalScoreForStudent } from "../shared/calculations/subtotalCalculator"
 import { getCropRegionsByExamId } from "./cropRegion"
 import { getDrawingAnnotationsByQuestionScore } from "./drawingAnnotation"
 import { getExamById } from "./exam"
 import { getStudentsForExam } from "./examStudent"
 import { calculateActualScore, getQuestionScoresForExam } from "./questionScore"
+import { getScoreDecisionsForExam } from "./scoreDecision"
 import { getStudentAnswersByExamId } from "./studentAnswer"
 
 /**
@@ -150,9 +152,13 @@ export async function getPdfExportData(options: {
     // 採点領域を取得
     const cropRegions = await getCropRegionsByExamId(examId)
 
-    // 採点スコアを取得
+    // 採点スコアと確定を取得し、生徒×設問ごとに有効スコア1件へ解決
     const scoresResult = await getQuestionScoresForExam(examId)
-    const allScores = scoresResult.scores || []
+    const decisionsResult = await getScoreDecisionsForExam(examId)
+    const { resolved: allScores } = resolveEffectiveScores(
+      scoresResult.scores ?? [],
+      decisionsResult.success ? (decisionsResult.decisions ?? []) : []
+    )
 
     // 生徒情報を取得
     const studentsResult = await getStudentsForExam(examId)
@@ -233,12 +239,9 @@ export async function getPdfExportData(options: {
               (s) => s.cropRegionId === region.id && s.studentId === student.id
             )
             return {
-              questionScoreId: score?.id || "",
+              questionScoreId: score?.questionScoreId || "",
               status: score?.status || "unscored",
-              partialScore:
-                score?.partialScore !== null
-                  ? Number(score?.partialScore)
-                  : null,
+              partialScore: score?.partialScore ?? null,
               cropRegion: {
                 id: region.id,
                 x: region.x,
@@ -252,8 +255,10 @@ export async function getPdfExportData(options: {
             }
           })
           .filter(
+            // 提案行が無くても確定（decision）で採点済みのセルはマークを描画する
             (sd): sd is NonNullable<typeof sd> =>
-              sd !== null && sd.questionScoreId !== ""
+              sd !== null &&
+              (sd.questionScoreId !== "" || sd.status !== "unscored")
           )
 
         // アノテーションを取得
@@ -318,15 +323,12 @@ export async function getPdfExportData(options: {
           const subtotalResult = await calculateSubtotalScoreForStudent(
             student.id,
             subtotalRegion.id,
-            allScores
-              .filter((s) => s.studentId !== null)
-              .map((s) => ({
-                studentId: s.studentId as string,
-                cropRegionId: s.cropRegionId,
-                status: s.status,
-                partialScore:
-                  s.partialScore !== null ? Number(s.partialScore) : null,
-              })),
+            allScores.map((s) => ({
+              studentId: s.studentId,
+              cropRegionId: s.cropRegionId,
+              status: s.status,
+              partialScore: s.partialScore,
+            })),
             cropRegions as CropRegion[]
           )
 

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -15,8 +15,14 @@ export const calculateActualScore = (
 ): number | null => {
   switch (questionScore.status) {
     case "correct":
-    case "final":
       return maxScore
+    case "final":
+      // 廃止済みstatus。未変換の旧データへの耐性として残す
+      // （確定値は partialScore、満点確定時は null のことがある）
+      return questionScore.partialScore !== null &&
+        questionScore.partialScore !== undefined
+        ? Number(questionScore.partialScore)
+        : maxScore
     case "incorrect":
     case "no_answer":
     case "double_mark":
@@ -25,7 +31,7 @@ export const calculateActualScore = (
       return null // 未採点は null を返して -/配点 と表示
     case "partial":
     case "pending":
-    case "proposed":
+    case "proposed": // 廃止済みstatus（旧データ耐性）
       return questionScore.partialScore !== null &&
         questionScore.partialScore !== undefined
         ? Number(questionScore.partialScore)
@@ -36,6 +42,8 @@ export const calculateActualScore = (
 }
 
 // 採点データの型定義
+// 注: "proposed"/"final" は廃止済み。QuestionScoreは常に採点者ごとの「提案」であり、
+// 確定はScoreDecision（scoreDecision.ts）で表現する。
 export interface CreateQuestionScoreData {
   studentId: string
   cropRegionId: string
@@ -47,8 +55,6 @@ export interface CreateQuestionScoreData {
     | "partial"
     | "pending"
     | "no_answer"
-    | "proposed"
-    | "final"
     | "double_mark"
   comment?: string
   userId: string
@@ -63,8 +69,6 @@ export interface UpdateQuestionScoreData {
     | "partial"
     | "pending"
     | "no_answer"
-    | "proposed"
-    | "final"
     | "double_mark"
   comment?: string
   version?: number
@@ -325,109 +329,61 @@ export const deleteQuestionScore = async (id: string) => {
 
 /**
  * 複数教員の採点結果を比較するためのデータを取得
+ *
+ * - proposedScores: 採点者ごとの提案（unscored を除く全行）
+ * - decision: OWNER による確定（ScoreDecision）
+ * - hasConflict: 提案同士の値が食い違っている、または確定後に新しい提案がある
  */
 export const getQuestionScoreComparison = async (
   studentId: string,
   cropRegionId: string
 ) => {
   try {
-    const scores = await prisma.questionScore.findMany({
-      where: {
-        studentId: studentId,
-        cropRegionId: cropRegionId,
-      },
-      include: {
-        user: true,
-      },
-      orderBy: {
-        createdAt: "asc",
-      },
-    })
+    const [scores, decision] = await Promise.all([
+      prisma.questionScore.findMany({
+        where: {
+          studentId: studentId,
+          cropRegionId: cropRegionId,
+        },
+        include: {
+          user: true,
+        },
+        orderBy: {
+          createdAt: "asc",
+        },
+      }),
+      prisma.scoreDecision.findUnique({
+        where: {
+          cropRegionId_studentId: { cropRegionId, studentId },
+        },
+        include: {
+          decidedBy: true,
+        },
+      }),
+    ])
 
-    // finalとproposedに分類
-    const finalScore = scores.find((s) => s.status === "final")
-    const proposedScores = scores.filter((s) => s.status === "proposed")
+    const proposedScores = scores.filter((s) => s.status !== "unscored")
+
+    const first = proposedScores[0]
+    const proposalsDisagree =
+      proposedScores.length > 1 &&
+      proposedScores.some(
+        (s) =>
+          s.status !== first.status ||
+          Number(s.partialScore ?? NaN) !== Number(first.partialScore ?? NaN)
+      )
+    const decisionIsStale =
+      decision !== null &&
+      proposedScores.some((s) => s.updatedAt > decision.decidedAt)
 
     return {
       success: true,
-      finalScore,
+      decision,
       proposedScores,
-      hasConflict:
-        proposedScores.length > 1 || (finalScore && proposedScores.length > 0),
+      hasConflict: proposalsDisagree || decisionIsStale,
     }
   } catch (error) {
     console.error("Failed to get question score comparison:", error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    }
-  }
-}
-
-/**
- * 採点結果を最終決定として確定
- */
-export const finalizeQuestionScore = async (
-  studentId: string,
-  cropRegionId: string,
-  userId: string,
-  scoreData: {
-    partialScore?: number // 部分点・保留の場合のみ
-    status: string
-    comment?: string
-  }
-) => {
-  try {
-    return await prisma.$transaction(async (tx) => {
-      // 既存の最終決定レコードのIDを取得してtombstone記録
-      const existingFinals = await tx.questionScore.findMany({
-        where: {
-          studentId: studentId,
-          cropRegionId: cropRegionId,
-          status: "final",
-        },
-        select: { id: true },
-      })
-      if (existingFinals.length > 0) {
-        await recordDrawingAnnotationDeletionsForQuestionScores(
-          existingFinals.map((s) => s.id),
-          { tx }
-        )
-      }
-
-      // 既存の最終決定レコードを削除
-      await tx.questionScore.deleteMany({
-        where: {
-          studentId: studentId,
-          cropRegionId: cropRegionId,
-          status: "final",
-        },
-      })
-
-      // 新しい最終決定レコードを作成
-      const finalScore = await tx.questionScore.create({
-        data: {
-          studentId: studentId,
-          cropRegionId: cropRegionId,
-          partialScore:
-            scoreData.partialScore !== null &&
-            scoreData.partialScore !== undefined
-              ? new Decimal(scoreData.partialScore)
-              : null,
-          status: scoreData.status,
-          userId,
-        },
-        include: {
-          student: true,
-          cropRegion: true,
-          user: true,
-        },
-      })
-
-      return { success: true, score: finalScore }
-    })
-  } catch (error) {
-    console.error("Failed to finalize question score:", error)
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",

--- a/electron-src/lib/prisma/schema/baselineMigrations.ts
+++ b/electron-src/lib/prisma/schema/baselineMigrations.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "@prisma/client"
 
 import { tableExists } from "../databaseUtils"
+import { listLocalMigrationNames } from "./migrationDeployer"
 
 /** ベースラインマイグレーション（現行スキーマの完全な初期マイグレーション） */
 const MIGRATION_CHECKSUMS: ReadonlyArray<{ name: string; checksum: string }> = [
@@ -64,9 +65,21 @@ export const ensureBaselineUpToDate = async (
 
   if (Number(result[0]?.cnt) > 0) return // ベースライン登録済み
 
-  // 旧エントリを削除して現在のベースラインに置換
+  // 旧カスタムシステム由来のエントリのみ削除して現在のベースラインに置換する。
+  // アプリ同梱のマイグレーションに対応する適用記録は保持する
+  // （全削除すると適用済みマイグレーションが再実行されDBが壊れる）
+  const localNames = listLocalMigrationNames()
+  if (localNames.length === 0) {
+    console.warn(
+      "ensureBaselineUpToDate: no local migrations found, skipping baseline update"
+    )
+    return
+  }
   console.info("Updating _prisma_migrations baseline to current version...")
-  await prisma.$executeRawUnsafe(`DELETE FROM "_prisma_migrations"`)
+  const quotedNames = localNames.map((n) => `'${n}'`).join(", ")
+  await prisma.$executeRawUnsafe(
+    `DELETE FROM "_prisma_migrations" WHERE "migration_name" NOT IN (${quotedNames})`
+  )
 
   const now = new Date().toISOString()
   for (const { name, checksum } of MIGRATION_CHECKSUMS) {

--- a/electron-src/lib/prisma/schema/bridgeMigrations.ts
+++ b/electron-src/lib/prisma/schema/bridgeMigrations.ts
@@ -20,14 +20,45 @@ const executeSqlStatements = async (
   }
 }
 
-/** ブリッジマイグレーション前にDBファイルをバックアップする */
+const BACKUP_SUFFIX = ".pre-migration-backup"
+const BACKUP_KEEP_COUNT = 5
+
+/** 古いバックアップを削除し、直近のBACKUP_KEEP_COUNT世代のみ保持する */
+const pruneOldBackups = (absolutePath: string): void => {
+  try {
+    const dir = path.dirname(absolutePath)
+    const prefix = `${path.basename(absolutePath)}${BACKUP_SUFFIX}`
+    const backups = fs
+      .readdirSync(dir)
+      .filter((f) => f.startsWith(prefix))
+      .sort()
+    for (const f of backups.slice(
+      0,
+      Math.max(0, backups.length - BACKUP_KEEP_COUNT)
+    )) {
+      fs.unlinkSync(path.join(dir, f))
+    }
+  } catch (error) {
+    console.warn("Failed to prune old migration backups:", error)
+  }
+}
+
+/**
+ * マイグレーション前にDBファイルをバックアップする。
+ * NAS共有時に他クライアントのバックアップを上書きしないようタイムスタンプを付与する。
+ */
 export const createBackup = (): string | null => {
   try {
     const dbPath = getDatabasePath()
     const absolutePath = path.resolve(dbPath)
     if (!fs.existsSync(absolutePath)) return null
-    const backupPath = `${absolutePath}.pre-migration-backup`
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[-:T]/g, "")
+      .slice(0, 14)
+    const backupPath = `${absolutePath}${BACKUP_SUFFIX}-${timestamp}`
     fs.copyFileSync(absolutePath, backupPath)
+    pruneOldBackups(absolutePath)
     console.info(`Migration backup created: ${backupPath}`)
     return backupPath
   } catch (error) {

--- a/electron-src/lib/prisma/schema/migrationDeployer.ts
+++ b/electron-src/lib/prisma/schema/migrationDeployer.ts
@@ -4,10 +4,12 @@ import * as fs from "fs"
 import * as path from "path"
 
 import { tableExists } from "../databaseUtils"
+import { createBackup, restoreBackup } from "./bridgeMigrations"
 
 /**
  * prisma/migrations/ ディレクトリから未適用のマイグレーションを検出し、順番に適用する。
  * _prisma_migrationsテーブルを参照・更新して適用状態を管理する。
+ * 適用前にDBファイルをバックアップし、失敗時は復元する。
  */
 export const deployPendingMigrations = async (
   prisma: PrismaClient
@@ -31,21 +33,22 @@ export const deployPendingMigrations = async (
   )
   const appliedNames = new Set(applied.map((r) => r.migration_name))
 
-  // マイグレーションディレクトリをスキャン
-  const dirs = fs
-    .readdirSync(migrationsDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && d.name !== "migration_lock.toml")
-    .map((d) => d.name)
-    .sort()
+  // 未適用のマイグレーションを抽出
+  const pendingDirs = listLocalMigrationNames().filter((dirName) => {
+    if (appliedNames.has(dirName)) return false
+    return fs.existsSync(path.join(migrationsDir, dirName, "migration.sql"))
+  })
+
+  if (pendingDirs.length === 0) return 0
+
+  // 適用前にバックアップを作成（PRAGMAを含むSQLはトランザクション化できないため、
+  // 失敗時はファイルレベルで復元する）
+  const backupPath = createBackup()
 
   let appliedCount = 0
 
-  for (const dirName of dirs) {
-    if (appliedNames.has(dirName)) continue
-
+  for (const dirName of pendingDirs) {
     const sqlPath = path.join(migrationsDir, dirName, "migration.sql")
-    if (!fs.existsSync(sqlPath)) continue
-
     const sql = fs.readFileSync(sqlPath, "utf-8")
     const checksum = crypto.createHash("sha256").update(sql).digest("hex")
 
@@ -84,6 +87,10 @@ export const deployPendingMigrations = async (
       console.info(`Migration applied: ${dirName}`)
     } catch (error) {
       console.error(`Migration failed: ${dirName}`, error)
+      if (backupPath) {
+        console.info("Restoring database from pre-migration backup...")
+        restoreBackup(backupPath)
+      }
       throw new Error(
         `Migration ${dirName} failed: ${error instanceof Error ? error.message : error}`
       )
@@ -95,6 +102,17 @@ export const deployPendingMigrations = async (
   }
 
   return appliedCount
+}
+
+/** prisma/migrations/ に同梱されているマイグレーション名を昇順で返す */
+export const listLocalMigrationNames = (): string[] => {
+  const migrationsDir = getMigrationsDir()
+  if (!migrationsDir || !fs.existsSync(migrationsDir)) return []
+  return fs
+    .readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
 }
 
 /** prisma/migrations/ ディレクトリのパスを解決する */

--- a/electron-src/lib/prisma/schema/migrationGuard.ts
+++ b/electron-src/lib/prisma/schema/migrationGuard.ts
@@ -1,0 +1,65 @@
+import { PrismaClient } from "@prisma/client"
+
+import { tableExists } from "../databaseUtils"
+import { listLocalMigrationNames } from "./migrationDeployer"
+
+/**
+ * 「DBがアプリより新しい」エラーの識別マーカー。
+ * エラーが上位でラップされてもメッセージ文字列から判別できるようにする。
+ */
+export const DB_NEWER_THAN_APP_MARKER = "DB_NEWER_THAN_APP"
+
+export class DatabaseNewerThanAppError extends Error {
+  readonly unknownMigrations: string[]
+
+  constructor(unknownMigrations: string[]) {
+    super(
+      `[${DB_NEWER_THAN_APP_MARKER}] このデータベースは、より新しいバージョンの Score at Once で更新されています。` +
+        `データ保護のため起動を中止しました。アプリを最新バージョンに更新してから再度起動してください。` +
+        `（未知のマイグレーション: ${unknownMigrations.join(", ")}）`
+    )
+    this.name = "DatabaseNewerThanAppError"
+    this.unknownMigrations = unknownMigrations
+  }
+}
+
+/**
+ * DBに「アプリが知らない、より新しいマイグレーション」が適用済みの場合に例外を投げる。
+ *
+ * 新しいバージョンのアプリでマイグレーション済みのDB（NAS共有・同期フォルダ経由を含む）を
+ * 旧バージョンのアプリで開くと、スキーマ不整合のまま読み書きしてデータを壊す恐れがあるため、
+ * 書き込みが発生する前に起動を中止する。
+ *
+ * 旧カスタムマイグレーションシステム由来のエントリは、アプリ同梱の最新マイグレーション名より
+ * 辞書順で古いため対象外となる（prisma migrate dev のタイムスタンプ接頭辞は常に単調増加）。
+ */
+export const assertDatabaseNotNewerThanApp = async (
+  prisma: PrismaClient
+): Promise<void> => {
+  if (!(await tableExists(prisma, "_prisma_migrations"))) return
+
+  const localNames = listLocalMigrationNames()
+  if (localNames.length === 0) {
+    // マイグレーション同梱なし（開発環境の異常系等）では判定不能のためスキップ
+    console.warn(
+      "assertDatabaseNotNewerThanApp: no local migrations found, skipping check"
+    )
+    return
+  }
+
+  const latestLocal = localNames[localNames.length - 1]
+  const localSet = new Set(localNames)
+
+  const applied = await prisma.$queryRawUnsafe<{ migration_name: string }[]>(
+    `SELECT "migration_name" FROM "_prisma_migrations" WHERE "rolled_back_at" IS NULL`
+  )
+
+  const unknownNewer = applied
+    .map((r) => r.migration_name)
+    .filter((name) => !localSet.has(name) && name > latestLocal)
+    .sort()
+
+  if (unknownNewer.length > 0) {
+    throw new DatabaseNewerThanAppError(unknownNewer)
+  }
+}

--- a/electron-src/lib/prisma/scoreDecision.ts
+++ b/electron-src/lib/prisma/scoreDecision.ts
@@ -1,0 +1,156 @@
+import { Decimal } from "@prisma/client/runtime/client"
+
+import prisma from "./client"
+
+export interface UpsertScoreDecisionData {
+  cropRegionId: string
+  studentId: string
+  verdict: string
+  score?: number | null
+  comment?: string | null
+  decidedByUserId: string
+  sourceQuestionScoreId?: string | null
+}
+
+/**
+ * 確定権限のチェック。
+ *
+ * 試験に UserExam が登録されている場合は OWNER のみ確定できる。
+ * UserExam が1件も無い試験（個人利用・旧データ）は制限しない。
+ */
+export const canDecideScore = async (
+  cropRegionId: string,
+  userId: string
+): Promise<{ allowed: boolean; reason?: string }> => {
+  const cropRegion = await prisma.cropRegion.findUnique({
+    where: { id: cropRegionId },
+    select: { examPage: { select: { examId: true } } },
+  })
+  if (!cropRegion) {
+    return { allowed: false, reason: "採点領域が見つかりません" }
+  }
+
+  const members = await prisma.userExam.findMany({
+    where: { examId: cropRegion.examPage.examId },
+    select: { userId: true, role: true },
+  })
+
+  // 個人利用（メンバー管理なし）の試験は制限しない
+  if (members.length === 0) return { allowed: true }
+
+  const me = members.find((m) => m.userId === userId)
+  if (me?.role === "OWNER") return { allowed: true }
+
+  return {
+    allowed: false,
+    reason: "採点結果の確定は試験の所有者（OWNER）のみが行えます",
+  }
+}
+
+/**
+ * 確定スコアをupsertする（生徒×設問ごとに1行）。
+ *
+ * 削除・再作成はしない — LWW同期でセカンダリUNIQUEにより単一行へ収束させるため、
+ * 同一セルの確定は常に既存行のin-place更新で表現する。
+ */
+export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
+  try {
+    const permission = await canDecideScore(
+      data.cropRegionId,
+      data.decidedByUserId
+    )
+    if (!permission.allowed) {
+      return { success: false, error: permission.reason ?? "権限がありません" }
+    }
+
+    const score =
+      data.score !== null && data.score !== undefined
+        ? new Decimal(data.score)
+        : null
+
+    const decision = await prisma.scoreDecision.upsert({
+      where: {
+        cropRegionId_studentId: {
+          cropRegionId: data.cropRegionId,
+          studentId: data.studentId,
+        },
+      },
+      create: {
+        cropRegionId: data.cropRegionId,
+        studentId: data.studentId,
+        verdict: data.verdict,
+        score,
+        comment: data.comment ?? null,
+        decidedByUserId: data.decidedByUserId,
+        decidedAt: new Date(),
+        sourceQuestionScoreId: data.sourceQuestionScoreId ?? null,
+      },
+      update: {
+        verdict: data.verdict,
+        score,
+        comment: data.comment ?? null,
+        decidedByUserId: data.decidedByUserId,
+        decidedAt: new Date(),
+        sourceQuestionScoreId: data.sourceQuestionScoreId ?? null,
+      },
+      include: {
+        decidedBy: true,
+      },
+    })
+
+    return { success: true, decision }
+  } catch (error) {
+    console.error("Failed to upsert score decision:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/** 試験の全確定スコアを取得する */
+export const getScoreDecisionsForExam = async (examId: string) => {
+  try {
+    const decisions = await prisma.scoreDecision.findMany({
+      where: {
+        cropRegion: {
+          examPage: { examId },
+        },
+      },
+      include: {
+        decidedBy: true,
+      },
+    })
+    return { success: true, decisions }
+  } catch (error) {
+    console.error("Failed to get score decisions for exam:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/** 特定の生徒×設問の確定スコアを取得する */
+export const getScoreDecision = async (
+  studentId: string,
+  cropRegionId: string
+) => {
+  try {
+    const decision = await prisma.scoreDecision.findUnique({
+      where: {
+        cropRegionId_studentId: { cropRegionId, studentId },
+      },
+      include: {
+        decidedBy: true,
+      },
+    })
+    return { success: true, decision }
+  } catch (error) {
+    console.error("Failed to get score decision:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../../../src/types/grade.types"
 import prisma from "../../prisma/client"
 import { calculateActualScore } from "../../prisma/questionScore"
+import { resolveEffectiveScores } from "./scoreResolution"
 import {
   calculateSubtotalScoreBySubtotalId,
   type QuestionScoreData,
@@ -129,14 +130,27 @@ export async function calculateGrades(gradeId: string): Promise<{
     const examDataCache = new Map<string, ExamDataCache>()
 
     for (const examId of examIds) {
-      const [questionScores, examPages] = await Promise.all([
+      const [questionScores, scoreDecisions, examPages] = await Promise.all([
         prisma.questionScore.findMany({
           where: { cropRegion: { examPage: { examId: examId } } },
           select: {
+            id: true,
             studentId: true,
             cropRegionId: true,
             status: true,
             partialScore: true,
+            updatedAt: true,
+          },
+        }),
+        prisma.scoreDecision.findMany({
+          where: { cropRegion: { examPage: { examId: examId } } },
+          select: {
+            studentId: true,
+            cropRegionId: true,
+            verdict: true,
+            score: true,
+            decidedAt: true,
+            sourceQuestionScoreId: true,
           },
         }),
         prisma.examPage.findMany({
@@ -145,12 +159,17 @@ export async function calculateGrades(gradeId: string): Promise<{
         }),
       ])
       const cropRegions = examPages.flatMap((pp) => pp.cropRegions)
+      // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+      const { resolved: resolvedScores } = resolveEffectiveScores(
+        questionScores,
+        scoreDecisions
+      )
       examDataCache.set(examId, {
-        questionScores: questionScores.map((qs) => ({
+        questionScores: resolvedScores.map((qs) => ({
           studentId: qs.studentId,
           cropRegionId: qs.cropRegionId,
           status: qs.status,
-          partialScore: qs.partialScore ? Number(qs.partialScore) : null,
+          partialScore: qs.partialScore,
         })),
         cropRegions: cropRegions.map((cr) => ({
           id: cr.id,

--- a/electron-src/lib/shared/calculations/scoreResolution.ts
+++ b/electron-src/lib/shared/calculations/scoreResolution.ts
@@ -1,0 +1,211 @@
+/**
+ * 有効スコアの解決（リゾルバ）
+ *
+ * 採点データは2層で保持される:
+ * - QuestionScore: 採点者ごとの「提案」（生徒×設問×採点者）
+ * - ScoreDecision: 試験OWNERによる「確定」（生徒×設問ごとに高々1行）
+ *
+ * 集計・出力系（Excel出力・個人レポート・PDF出力・小計・成績連携）は
+ * 必ずこのモジュールで生徒×設問ごとに1つの有効スコアへ解決してから処理する。
+ *
+ * 解決ルール（決定的）:
+ * 1. ScoreDecision があればそれを採用（確定後に新しい提案があれば isStale を立てる）
+ * 2. 提案のうち unscored 以外が1つならそれを採用
+ * 3. unscored 以外の提案が複数でも、判定と点数が全行一致していれば合意として採用
+ *    （参加採点者が1人の試験では常にここで解決される = 個人利用と同一挙動）
+ * 4. 一致しなければ競合 — 値を出さず conflicts に記録する
+ *
+ * unscored 行は他の行が存在する場合は無視する（scoringInitializer が
+ * デフォルトユーザー名義で初期行を量産するため、採点の提案としては扱わない）。
+ * status="final" は廃止済みだが、未変換の旧データへの耐性として提案より優先する。
+ */
+
+export interface ResolvableScore {
+  studentId: string | null
+  cropRegionId: string
+  status: string
+  partialScore: number | string | { toString(): string } | null
+  id?: string
+  updatedAt?: Date | string
+}
+
+export interface ResolvableDecision {
+  studentId: string
+  cropRegionId: string
+  verdict: string
+  score: number | string | { toString(): string } | null
+  decidedAt?: Date | string
+  sourceQuestionScoreId?: string | null
+}
+
+/** 生徒×設問ごとに解決された有効スコア */
+export interface EffectiveScore {
+  studentId: string
+  cropRegionId: string
+  /** 採点判定（correct | incorrect | partial | pending | no_answer | double_mark | unscored） */
+  status: string
+  partialScore: number | null
+  /**
+   * 採点マーク・描画注釈の参照に使う QuestionScore 行の id。
+   * 確定（decision）で採用元提案が無い場合は null。
+   */
+  questionScoreId: string | null
+  /** 由来: OWNER の確定か、提案（単独/合意）か */
+  source: "decision" | "proposal"
+  /** 確定より新しい提案が存在する（OWNER の再確認を推奨） */
+  isStale: boolean
+}
+
+export interface ScoreConflict {
+  studentId: string
+  cropRegionId: string
+  /** 競合した採点行の数（unscored を除く） */
+  candidateCount: number
+}
+
+export interface ResolveResult {
+  /** 生徒×設問ごとに高々1件へ解決済みの有効スコア配列 */
+  resolved: EffectiveScore[]
+  /** 確定が無く、提案の値も食い違って解決できなかった生徒×設問の一覧 */
+  conflicts: ScoreConflict[]
+}
+
+const normalizeScore = (
+  value: ResolvableScore["partialScore"]
+): number | null => {
+  if (value === null || value === undefined) return null
+  const n = Number(value)
+  return Number.isNaN(n) ? null : n
+}
+
+const toTime = (value: Date | string | undefined): number =>
+  value ? new Date(value).getTime() : 0
+
+/** updatedAt 降順 → id 降順の決定的な「最新」選択 */
+const pickLatest = <T extends ResolvableScore>(group: T[]): T =>
+  group.reduce((latest, current) => {
+    const tLatest = toTime(latest.updatedAt)
+    const tCurrent = toTime(current.updatedAt)
+    if (tCurrent !== tLatest) return tCurrent > tLatest ? current : latest
+    return (current.id ?? "") > (latest.id ?? "") ? current : latest
+  })
+
+const cellKey = (studentId: string, cropRegionId: string): string =>
+  `${studentId} ${cropRegionId}`
+
+const proposalToEffective = (
+  proposal: ResolvableScore,
+  isStale = false
+): EffectiveScore => ({
+  studentId: proposal.studentId as string,
+  cropRegionId: proposal.cropRegionId,
+  status: proposal.status,
+  partialScore: normalizeScore(proposal.partialScore),
+  questionScoreId: proposal.id ?? null,
+  source: "proposal",
+  isStale,
+})
+
+export function resolveEffectiveScores(
+  scores: ResolvableScore[],
+  decisions: ResolvableDecision[] = []
+): ResolveResult {
+  const groups = new Map<string, ResolvableScore[]>()
+  for (const score of scores) {
+    if (!score.studentId) continue
+    const key = cellKey(score.studentId, score.cropRegionId)
+    const group = groups.get(key)
+    if (group) {
+      group.push(score)
+    } else {
+      groups.set(key, [score])
+    }
+  }
+
+  const resolved: EffectiveScore[] = []
+  const conflicts: ScoreConflict[] = []
+  const decidedCells = new Set<string>()
+
+  // 1) 明示的な確定（ScoreDecision）が最優先
+  for (const decision of decisions) {
+    const key = cellKey(decision.studentId, decision.cropRegionId)
+    if (decidedCells.has(key)) continue // 不正データ耐性（uniqueにより通常は発生しない）
+    decidedCells.add(key)
+
+    const proposals = groups.get(key) ?? []
+    const decidedAt = toTime(decision.decidedAt)
+    const isStale = proposals.some(
+      (p) => p.status !== "unscored" && toTime(p.updatedAt) > decidedAt
+    )
+
+    resolved.push({
+      studentId: decision.studentId,
+      cropRegionId: decision.cropRegionId,
+      status: decision.verdict,
+      partialScore: normalizeScore(decision.score),
+      questionScoreId: decision.sourceQuestionScoreId ?? null,
+      source: "decision",
+      isStale,
+    })
+  }
+
+  // 2) 確定が無いセルは提案から導出
+  for (const [key, group] of groups) {
+    if (decidedCells.has(key)) continue
+
+    // 旧データ耐性: 未変換の final 行があれば提案より優先する
+    const finals = group.filter((s) => s.status === "final")
+    const candidates =
+      finals.length > 0 ? finals : group.filter((s) => s.status !== "unscored")
+
+    if (candidates.length === 0) {
+      // 全行 unscored — 表示用に1件残す
+      resolved.push(proposalToEffective(pickLatest(group)))
+      continue
+    }
+
+    const first = candidates[0]
+    const allAgree = candidates.every(
+      (s) =>
+        s.status === first.status &&
+        normalizeScore(s.partialScore) === normalizeScore(first.partialScore)
+    )
+
+    if (allAgree) {
+      resolved.push(proposalToEffective(pickLatest(candidates)))
+    } else {
+      conflicts.push({
+        studentId: first.studentId as string,
+        cropRegionId: first.cropRegionId,
+        candidateCount: candidates.length,
+      })
+    }
+  }
+
+  return { resolved, conflicts }
+}
+
+/**
+ * 有効スコアの実際の得点を計算する。
+ * （prisma/questionScore.ts の calculateActualScore と同等のルール）
+ */
+export const calculateEffectiveScoreValue = (
+  effective: Pick<EffectiveScore, "status" | "partialScore">,
+  maxScore: number
+): number | null => {
+  switch (effective.status) {
+    case "correct":
+      return maxScore
+    case "incorrect":
+    case "no_answer":
+    case "double_mark":
+      return 0
+    case "unscored":
+      return null
+    case "partial":
+    case "pending":
+      return effective.partialScore
+    default:
+      return 0
+  }
+}

--- a/electron-src/lib/shared/utilities/validateScoringData.ts
+++ b/electron-src/lib/shared/utilities/validateScoringData.ts
@@ -1,6 +1,22 @@
 import type { ScoringData } from "../types/exportTypes"
 
 /**
+ * リゾルバの競合一覧を「生徒名 - 設問ラベル」の識別子に変換する
+ */
+export function buildConflictIdentifiers(
+  scoringData: ScoringData[],
+  scoreConflicts: Array<{ studentId: string; cropRegionId: string }>
+): string[] {
+  return scoreConflicts.map((c) => {
+    const student = scoringData.find((s) => s.studentId === c.studentId)
+    const question = student?.scores.find(
+      (q) => q.questionId === c.cropRegionId
+    )
+    return `${student?.studentName ?? c.studentId} - ${question?.questionLabel ?? c.cropRegionId}`
+  })
+}
+
+/**
  * 採点データの検証結果
  */
 export interface ValidationResult {
@@ -9,6 +25,8 @@ export interface ValidationResult {
     noScoringData: string[]
     ungraded: string[]
     missingPartialScore: string[]
+    /** 複数採点者の値が食い違い、確定もされていない（出力上は未採点扱い） */
+    conflicted: string[]
   }
 }
 
@@ -18,14 +36,17 @@ export interface ValidationResult {
  * - 🔴 noScoringData: 採点データが存在しない（status=unscored, score=null）
  * - 🟠 ungraded: 未採点（status=unscored, score≠null）
  * - 🟡 missingPartialScore: 部分点・保留で値が未入力（status=partial|hold, score=null）
+ * - 🟣 conflicted: 採点の競合（呼び出し元がリゾルバの競合一覧から識別子を渡す）
  */
 export function validateScoringData(
-  scoringData: ScoringData[]
+  scoringData: ScoringData[],
+  conflictIdentifiers: string[] = []
 ): ValidationResult {
   const warnings = {
     noScoringData: [] as string[],
     ungraded: [] as string[],
     missingPartialScore: [] as string[],
+    conflicted: conflictIdentifiers,
   }
 
   for (const studentData of scoringData) {
@@ -58,7 +79,8 @@ export function validateScoringData(
     hasWarnings:
       warnings.noScoringData.length > 0 ||
       warnings.ungraded.length > 0 ||
-      warnings.missingPartialScore.length > 0,
+      warnings.missingPartialScore.length > 0 ||
+      warnings.conflicted.length > 0,
     warnings,
   }
 }

--- a/electron-src/lib/sync/syncConfig.ts
+++ b/electron-src/lib/sync/syncConfig.ts
@@ -12,19 +12,17 @@ import * as fs from "fs"
 import * as path from "path"
 
 import { getDataDirectory } from "../dataManager"
+import { listLocalMigrationNames } from "../prisma/schema/migrationDeployer"
 import { DEFAULT_SYNC_CONFIG, SyncAppConfig } from "./types"
 
-/** prisma/migrationsから最新マイグレーション名を取得し、schemaVersionとして返す */
+/**
+ * prisma/migrationsから最新マイグレーション名を取得し、schemaVersionとして返す。
+ * マイグレーションガード（migrationGuard）と同じ解決ロジックを使い、
+ * 起動時チェックと同期ゲートが必ず同じバージョン文字列を参照するようにする。
+ */
 export function getSchemaVersion(): string {
   try {
-    const migrationsDir = path.join(app.getAppPath(), "prisma", "migrations")
-    if (!fs.existsSync(migrationsDir)) return "unknown"
-
-    const entries = fs
-      .readdirSync(migrationsDir)
-      .filter((e) => /^\d{14}_/.test(e))
-      .sort()
-
+    const entries = listLocalMigrationNames().filter((e) => /^\d{14}_/.test(e))
     return entries.length > 0 ? entries[entries.length - 1] : "unknown"
   } catch {
     return "unknown"

--- a/electron-src/lib/sync/syncService.ts
+++ b/electron-src/lib/sync/syncService.ts
@@ -26,7 +26,33 @@ import {
   saveSyncConfig,
 } from "./syncConfig"
 import { SYNC_EXCLUDE_TABLES, SYNC_TABLE_OPTIONS } from "./syncTableConfig"
-import type { SyncAppConfig, SyncAppStatus } from "./types"
+import type {
+  SyncAppConfig,
+  SyncAppStatus,
+  VersionMismatchRemote,
+} from "./types"
+
+/**
+ * sqlite-nas-sync@0.10.0 で追加された SyncResult.skippedRemotes の型。
+ * 依存を ^0.10.0 に更新したらライブラリの SkippedRemote 型に置き換えてキャストを除去する。
+ */
+interface SkippedRemoteInfo {
+  clientId: string
+  remoteVersion: string | null
+  localVersion: string
+}
+
+/** SyncResultからバージョン不一致リモートの一覧を抽出する */
+function extractVersionMismatches(result: SyncResult): VersionMismatchRemote[] {
+  const skippedRemotes =
+    (result as SyncResult & { skippedRemotes?: SkippedRemoteInfo[] })
+      .skippedRemotes ?? []
+  return skippedRemotes.map((s) => ({
+    clientId: s.clientId,
+    remoteVersion: s.remoteVersion,
+    remoteIsNewer: s.remoteVersion !== null && s.remoteVersion > s.localVersion,
+  }))
+}
 
 let syncInstance: SyncInstance | null = null
 
@@ -35,6 +61,7 @@ let currentStatus: SyncAppStatus = {
   lastSyncTime: null,
   lastError: null,
   syncCount: 0,
+  versionMismatches: [],
 }
 
 function updateStatus(partial: Partial<SyncAppStatus>): void {
@@ -173,13 +200,14 @@ export async function startSync(config: SyncAppConfig): Promise<void> {
     intervalMs: config.intervalMs,
     changelogRetentionDays: config.changelogRetentionDays,
     schemaVersion: getSchemaVersion(),
-    onAfterSync: (db: Database.Database, _result: SyncResult) => {
+    onAfterSync: (db: Database.Database, result: SyncResult) => {
       enforceTombstones(db)
       updateStatus({
         state: "idle",
         lastSyncTime: new Date().toISOString(),
         lastError: null,
         syncCount: currentStatus.syncCount + 1,
+        versionMismatches: extractVersionMismatches(result),
       })
     },
   })

--- a/electron-src/lib/sync/syncService.ts
+++ b/electron-src/lib/sync/syncService.ts
@@ -32,22 +32,9 @@ import type {
   VersionMismatchRemote,
 } from "./types"
 
-/**
- * sqlite-nas-sync@0.10.0 で追加された SyncResult.skippedRemotes の型。
- * 依存を ^0.10.0 に更新したらライブラリの SkippedRemote 型に置き換えてキャストを除去する。
- */
-interface SkippedRemoteInfo {
-  clientId: string
-  remoteVersion: string | null
-  localVersion: string
-}
-
 /** SyncResultからバージョン不一致リモートの一覧を抽出する */
 function extractVersionMismatches(result: SyncResult): VersionMismatchRemote[] {
-  const skippedRemotes =
-    (result as SyncResult & { skippedRemotes?: SkippedRemoteInfo[] })
-      .skippedRemotes ?? []
-  return skippedRemotes.map((s) => ({
+  return result.skippedRemotes.map((s) => ({
     clientId: s.clientId,
     remoteVersion: s.remoteVersion,
     remoteIsNewer: s.remoteVersion !== null && s.remoteVersion > s.localVersion,

--- a/electron-src/lib/sync/types.ts
+++ b/electron-src/lib/sync/types.ts
@@ -10,12 +10,25 @@ export interface SyncAppConfig {
   changelogRetentionDays: number
 }
 
+/** スキーマバージョン不一致でスキップされたリモートクライアント */
+export interface VersionMismatchRemote {
+  clientId: string
+  remoteVersion: string | null
+  /**
+   * リモートの方が新しいかどうか（= このPCのアプリ更新が必要）。
+   * マイグレーション名はタイムスタンプ接頭辞のため辞書順比較で判定できる。
+   */
+  remoteIsNewer: boolean
+}
+
 /** syncステータス（ランタイム状態） */
 export interface SyncAppStatus {
   state: "idle" | "syncing" | "error" | "disabled"
   lastSyncTime: string | null
   lastError: string | null
   syncCount: number
+  /** 直近のsyncでスキーマバージョン不一致によりスキップされたリモート */
+  versionMismatches: VersionMismatchRemote[]
 }
 
 /** デフォルトsync設定 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "remark-math": "^6.0.0",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
-        "sqlite-nas-sync": "^0.9.0",
+        "sqlite-nas-sync": "^0.11.0",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.0",
         "vaul": "^1.1.2",
@@ -20227,9 +20227,9 @@
       "optional": true
     },
     "node_modules/sqlite-nas-sync": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/sqlite-nas-sync/-/sqlite-nas-sync-0.9.0.tgz",
-      "integrity": "sha512-XEsreHLfjh57SSu3YflxOSq/43wzhDL9Et0FmUeW+oUfSw3CjPfIabLpG2I3H2DsI8m9TBjSJjAa4elQ+O7o+g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/sqlite-nas-sync/-/sqlite-nas-sync-0.11.0.tgz",
+      "integrity": "sha512-sImV5Ev0a7E8SJu/PyOjbMDFp22nfGc2P3vxxNggWTeXgv+6jbSV+G9YWDjyxy+o+IEYWnLui4wRVxXcuq+ZNQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "remark-math": "^6.0.0",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
-    "sqlite-nas-sync": "^0.9.0",
+    "sqlite-nas-sync": "^0.11.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",
     "vaul": "^1.1.2",

--- a/prisma/migrations/20260611135650_add_score_decision/migration.sql
+++ b/prisma/migrations/20260611135650_add_score_decision/migration.sql
@@ -1,0 +1,86 @@
+-- CreateTable
+CREATE TABLE "ScoreDecision" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "cropRegionId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "verdict" TEXT NOT NULL,
+    "score" DECIMAL,
+    "comment" TEXT,
+    "decidedByUserId" TEXT NOT NULL,
+    "decidedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sourceQuestionScoreId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ScoreDecision_cropRegionId_fkey" FOREIGN KEY ("cropRegionId") REFERENCES "CropRegion" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ScoreDecision_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ScoreDecision_decidedByUserId_fkey" FOREIGN KEY ("decidedByUserId") REFERENCES "User" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE INDEX "ScoreDecision_studentId_idx" ON "ScoreDecision"("studentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScoreDecision_cropRegionId_studentId_key" ON "ScoreDecision"("cropRegionId", "studentId");
+
+-- ============================================================
+-- データ変換: 旧 status="final"/"proposed" の廃止
+-- 各クライアントのローカルDBで同一の決定的変換が行われるよう、
+-- ScoreDecision.id には final 行の id を流用する（final 行は同期済みのため
+-- 全クライアントで同一 id となり、同期後も単一行に収束する）。
+-- ============================================================
+
+-- 1) 生徒×設問ごとに最新の final 行から確定（ScoreDecision）を生成
+INSERT INTO "ScoreDecision" ("id", "cropRegionId", "studentId", "verdict", "score", "decidedByUserId", "decidedAt", "createdAt", "updatedAt")
+SELECT qs."id", qs."cropRegionId", qs."studentId",
+       CASE WHEN qs."partialScore" IS NULL THEN 'correct' ELSE 'partial' END,
+       qs."partialScore", qs."userId", qs."updatedAt", qs."createdAt", qs."updatedAt"
+FROM "QuestionScore" qs
+WHERE qs."status" = 'final'
+  AND qs."id" = (
+    SELECT q2."id" FROM "QuestionScore" q2
+    WHERE q2."cropRegionId" = qs."cropRegionId"
+      AND q2."studentId" = qs."studentId"
+      AND q2."status" = 'final'
+    ORDER BY q2."updatedAt" DESC, q2."id" DESC
+    LIMIT 1
+  );
+
+-- 2) final 行の描画注釈を、同じ採点者の既存提案行へ移す（提案行がある場合のみ）
+UPDATE "DrawingAnnotation"
+SET "questionScoreId" = COALESCE(
+  (
+    SELECT p."id" FROM "QuestionScore" p, "QuestionScore" f
+    WHERE f."id" = "DrawingAnnotation"."questionScoreId"
+      AND p."cropRegionId" = f."cropRegionId"
+      AND p."studentId" = f."studentId"
+      AND p."userId" = f."userId"
+      AND p."status" != 'final'
+      AND p."id" != f."id"
+    ORDER BY p."updatedAt" DESC, p."id" DESC
+    LIMIT 1
+  ),
+  "questionScoreId"
+)
+WHERE "questionScoreId" IN (SELECT "id" FROM "QuestionScore" WHERE "status" = 'final');
+
+-- 3) 同じ採点者の提案行が既にある final 行は削除（注釈は手順2で移動済み）
+DELETE FROM "QuestionScore"
+WHERE "status" = 'final'
+  AND EXISTS (
+    SELECT 1 FROM "QuestionScore" p
+    WHERE p."cropRegionId" = "QuestionScore"."cropRegionId"
+      AND p."studentId" = "QuestionScore"."studentId"
+      AND p."userId" = "QuestionScore"."userId"
+      AND p."status" != 'final'
+      AND p."id" != "QuestionScore"."id"
+  );
+
+-- 4) 残りの final 行を採点判定のみの提案行へ変換（status 浄化）
+UPDATE "QuestionScore"
+SET "status" = CASE WHEN "partialScore" IS NULL THEN 'correct' ELSE 'partial' END
+WHERE "status" = 'final';
+
+-- 5) proposed の浄化（点数ありは partial、点数なしは pending へ）
+UPDATE "QuestionScore"
+SET "status" = CASE WHEN "partialScore" IS NULL THEN 'pending' ELSE 'partial' END
+WHERE "status" = 'proposed';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   preferences         UserPreference[]
   answerSheetDefinitions AsbDefinition[]
   compoundAnswerScores   CompoundAnswerScore[]
+  scoreDecisions         ScoreDecision[]
 }
 
 model Class {
@@ -61,6 +62,7 @@ model Student {
   gradeOverrides      GradeOverride[]
   gradeItemExclusions  GradeItemExclusion[]
   compoundAnswerScores CompoundAnswerScore[]
+  scoreDecisions       ScoreDecision[]
 }
 
 model StudentClassMembership {
@@ -179,6 +181,7 @@ model CropRegion {
   gradeDataSources GradeDataSource[]
   omrConfig            CropRegionOmrConfig?
   compoundMembership   CompoundAnswerMember?
+  scoreDecisions       ScoreDecision[]
 }
 
 model SubtotalGroup {
@@ -256,6 +259,32 @@ model QuestionScore {
   cropRegion         CropRegion          @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   student            Student             @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   user               User                @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+/// 生徒×設問ごとの確定スコア（試験OWNERによる裁定）。
+/// QuestionScore（採点者ごとの提案）とは別に1セル1行で保持し、upsertのみで運用する
+/// （削除・再作成しない — LWW同期でセカンダリUNIQUEにより単一行へ収束させるため）。
+model ScoreDecision {
+  id                    String     @id @default(uuid())
+  cropRegionId          String
+  studentId             String
+  /// 確定した採点判定（correct | incorrect | partial | pending | no_answer | double_mark）
+  verdict               String
+  /// 確定点。correct等のverdict自体が点数を決める場合はnull可
+  score                 Decimal?
+  comment               String?
+  decidedByUserId       String
+  decidedAt             DateTime   @default(now())
+  /// 採用元の提案（QuestionScore）のID。手入力で確定した場合はnull
+  sourceQuestionScoreId String?
+  createdAt             DateTime   @default(now())
+  updatedAt             DateTime   @default(now()) @updatedAt
+  cropRegion            CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student               Student    @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  decidedBy             User       @relation(fields: [decidedByUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([cropRegionId, studentId])
+  @@index([studentId])
 }
 
 model DrawingAnnotation {

--- a/src/app/settings/components/SyncSettingsTab.tsx
+++ b/src/app/settings/components/SyncSettingsTab.tsx
@@ -150,6 +150,30 @@ export function SyncSettingsTab() {
         <StateIndicator state={status.state} />
       </div>
 
+      {/* スキーマバージョン不一致の通知 */}
+      {(status.versionMismatches ?? []).length > 0 && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <div className="space-y-1 text-sm text-amber-800">
+              {status.versionMismatches.some((m) => m.remoteIsNewer) ? (
+                <p className="font-medium">
+                  他のPCがより新しいバージョンのアプリを使用しています。このPCのアプリを更新するまで、そのPCとの同期は保留されます。
+                </p>
+              ) : (
+                <p className="font-medium">
+                  他のPCが古いバージョンのアプリを使用しています。そのPCのアプリが更新されるまで、そのPCとの同期は保留されます。
+                </p>
+              )}
+              <p className="text-xs text-amber-700">
+                保留中: {status.versionMismatches.length}台
+                （このPC以外のデータが失われることはありません）
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* ステータス */}
       <div className="rounded-lg border p-4">
         <h3 className="mb-3 text-sm font-medium">同期ステータス</h3>

--- a/src/app/settings/hooks/useSyncSettings.ts
+++ b/src/app/settings/hooks/useSyncSettings.ts
@@ -9,6 +9,7 @@ const DEFAULT_STATUS: SyncAppStatus = {
   lastSyncTime: null,
   lastError: null,
   syncCount: 0,
+  versionMismatches: [],
 }
 
 export function useSyncSettings() {

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreComparisonModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreComparisonModal.tsx
@@ -10,6 +10,7 @@ import {
   X,
 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
+import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -60,6 +61,8 @@ export default function ScoreComparisonModal({
   const [finalizing, setFinalizing] = useState(false)
   const [finalScore, setFinalScore] = useState(0)
   const [finalComment, setFinalComment] = useState("")
+  // 「この結果を採用」で選んだ提案のID（手入力で変更したらリセット）
+  const [sourceScoreId, setSourceScoreId] = useState<string | null>(null)
 
   // 採点比較データを取得
   const fetchComparison = useCallback(async () => {
@@ -116,6 +119,7 @@ export default function ScoreComparisonModal({
         partialScore: finalScore,
         status: "final",
         comments: finalComment,
+        sourceQuestionScoreId: sourceScoreId ?? undefined,
       }
       const result = await window.electronAPI.finalizeQuestionScore(
         studentId,
@@ -125,13 +129,16 @@ export default function ScoreComparisonModal({
       )
 
       if (result.success && result.decision) {
+        toast.success("採点結果を確定しました")
         onScoreFinalized?.()
         onClose()
       } else {
-        console.error("Failed to finalize score:", result.error)
+        // OWNER以外による確定の拒否など、理由をユーザーに通知する
+        toast.error(result.error ?? "採点結果の確定に失敗しました")
       }
     } catch (error) {
       console.error("Failed to finalize score:", error)
+      toast.error("採点結果の確定に失敗しました")
     } finally {
       setFinalizing(false)
     }
@@ -267,6 +274,7 @@ export default function ScoreComparisonModal({
                               onClick={() => {
                                 setFinalScore(Number(score.partialScore) || 0)
                                 setFinalComment("")
+                                setSourceScoreId(score.id)
                               }}
                             >
                               この結果を採用
@@ -284,12 +292,30 @@ export default function ScoreComparisonModal({
               <div className="flex items-center rounded-lg border border-yellow-200 bg-yellow-50 p-4">
                 <AlertTriangle className="mr-3 h-5 w-5 text-yellow-600" />
                 <div>
-                  <div className="font-medium text-yellow-800">
-                    採点結果に相違があります
-                  </div>
-                  <div className="text-sm text-yellow-700">
-                    複数の教員が異なる採点結果を提案しています。最終結果を決定してください。
-                  </div>
+                  {comparison.decision &&
+                  comparison.proposedScores?.some(
+                    (s) =>
+                      new Date(s.updatedAt) >
+                      new Date(comparison.decision!.decidedAt)
+                  ) ? (
+                    <>
+                      <div className="font-medium text-yellow-800">
+                        確定後に新しい採点が追加されています
+                      </div>
+                      <div className="text-sm text-yellow-700">
+                        内容を確認し、必要であれば再確定してください。
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="font-medium text-yellow-800">
+                        採点結果に相違があります
+                      </div>
+                      <div className="text-sm text-yellow-700">
+                        複数の教員が異なる採点結果を提案しています。最終結果を決定してください。
+                      </div>
+                    </>
+                  )}
                 </div>
               </div>
             )}
@@ -312,9 +338,11 @@ export default function ScoreComparisonModal({
                       min="0"
                       max={maxScore}
                       value={finalScore}
-                      onChange={(e) =>
+                      onChange={(e) => {
                         setFinalScore(parseInt(e.target.value) || 0)
-                      }
+                        // 手入力に切り替わったら採用元の紐付けを解除
+                        setSourceScoreId(null)
+                      }}
                     />
                   </div>
                   <div>

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreComparisonModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreComparisonModal.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/contexts/AuthContext"
 import type { QuestionScoreComparisonResult } from "@/types/electron/scoringApi"
 import type { QuestionScoreWithUser } from "@/types/prismaExtensions"
 
@@ -52,6 +53,7 @@ export default function ScoreComparisonModal({
   studentName,
   onScoreFinalized,
 }: ScoreComparisonModalProps) {
+  const { user } = useAuth()
   const [comparison, setComparison] =
     useState<QuestionScoreComparisonResult | null>(null)
   const [loading, setLoading] = useState(false)
@@ -74,10 +76,10 @@ export default function ScoreComparisonModal({
       if (result.success) {
         setComparison(result)
 
-        // 既存の最終結果がある場合はフォームに設定
-        if (result.finalScore) {
-          setFinalScore(Number(result.finalScore.partialScore) || 0)
-          setFinalComment("")
+        // 既存の確定がある場合はフォームに設定
+        if (result.decision) {
+          setFinalScore(result.decision.score ?? 0)
+          setFinalComment(result.decision.comment ?? "")
         } else if (result.proposedScores?.length === 1) {
           // 採点結果が1つだけの場合は自動で設定
           setFinalScore(Number(result.proposedScores[0].partialScore) || 0)
@@ -103,6 +105,10 @@ export default function ScoreComparisonModal({
   // 採点結果を最終決定
   const handleFinalize = async () => {
     if (!studentId || !cropRegionId) return
+    if (!user) {
+      console.error("Cannot finalize score: no authenticated user")
+      return
+    }
 
     setFinalizing(true)
     try {
@@ -114,11 +120,11 @@ export default function ScoreComparisonModal({
       const result = await window.electronAPI.finalizeQuestionScore(
         studentId,
         cropRegionId,
-        "current-user", // TODO: 認証システムと連携
+        user.id,
         finalizeData
       )
 
-      if (result.success && result.score) {
+      if (result.success && result.decision) {
         onScoreFinalized?.()
         onClose()
       } else {
@@ -192,35 +198,32 @@ export default function ScoreComparisonModal({
           </div>
         ) : (
           <div className="space-y-6">
-            {/* 最終結果が既にある場合 */}
-            {comparison?.finalScore && (
+            {/* 確定済みの場合 */}
+            {comparison?.decision && (
               <Card className="border-purple-200 bg-purple-50">
                 <CardHeader className="pb-3">
                   <CardTitle className="flex items-center text-sm">
                     <CheckCircle className="mr-2 h-4 w-4 text-purple-600" />
-                    最終決定済み
+                    確定済み
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="flex items-center justify-between">
                     <div>
                       <div className="text-lg font-semibold">
-                        {Number(comparison.finalScore.partialScore) || 0} /{" "}
-                        {maxScore} 点
+                        {comparison.decision.score ?? maxScore} / {maxScore} 点
                       </div>
-                      {comparison.finalScore.user && (
-                        <div className="text-muted-foreground text-sm">
-                          決定者: {comparison.finalScore.user.name}
-                        </div>
-                      )}
                       <div className="text-muted-foreground text-sm">
-                        決定日時:{" "}
+                        確定者: {comparison.decision.decidedBy.name}
+                      </div>
+                      <div className="text-muted-foreground text-sm">
+                        確定日時:{" "}
                         {new Date(
-                          comparison.finalScore.updatedAt
+                          comparison.decision.decidedAt
                         ).toLocaleString()}
                       </div>
                     </div>
-                    {getStatusBadge(comparison.finalScore.status)}
+                    {getStatusBadge(comparison.decision.verdict)}
                   </div>
                 </CardContent>
               </Card>

--- a/src/components/exams/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/hooks/ScoringData/hooks/useBatchScoring.ts
@@ -194,23 +194,13 @@ export function useBatchScoring({
             }
           }
 
-          // TODO: Check for auto-finalization in collaborative mode
-          // Temporarily disabled during QuestionScore array migration
-          // if (scoringStatus === "pending" && pageImage.studentId) {
-          //   await checkForAutoFinalization(
-          //     pageImage.studentId,
-          //     currentCropRegion.id,
-          //     currentUserId,
-          //     setQuestionScores,
-          //   )
-          // }
+          // 注: 自動確定処理は不要。有効スコアは読み取り時に
+          // resolveEffectiveScores（確定 > 提案全員一致 > 競合）で導出されるため、
+          // 提案が一致していれば確定操作なしで集計に反映される。
+          // 食い違いはOWNERがScoreComparisonModalで裁定（ScoreDecision）する。
 
-          // TODO: Add subtotal score recalculation here
-          // After individual question scoring, we should:
-          // 1. Identify all subtotal regions that depend on this question
-          // 2. Recalculate those subtotal scores
-          // 3. Save the updated subtotal scores to database
-          // 4. Update the local scoring data state
+          // 注: 小計の再計算・保存も不要。小計はDBに保存せず、
+          // 出力・集計時に有効スコアから毎回計算する（subtotalCalculator）。
         } catch (error) {
           console.error("Error in batch scoring:", error)
           toast.error(

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -35,6 +35,7 @@ export default function ExportMainView() {
     noScoringData: [] as string[],
     unscored: [] as string[],
     missingPartialScore: [] as string[],
+    conflicted: [] as string[],
   })
   const [pendingExportType, setPendingExportType] = useState<
     "scored-answers" | "grading-data" | "individual-reports" | null
@@ -251,6 +252,7 @@ export default function ExportMainView() {
         noScoringData: result.warnings.noScoringData,
         unscored: result.warnings.ungraded,
         missingPartialScore: result.warnings.missingPartialScore,
+        conflicted: result.warnings.conflicted ?? [],
       })
       setPendingExportType(exportType)
       setShowWarningModal(true)

--- a/src/components/exams/08-export/components/ExportWarningModal.tsx
+++ b/src/components/exams/08-export/components/ExportWarningModal.tsx
@@ -19,6 +19,7 @@ interface ExportWarningModalProps {
     noScoringData: string[]
     unscored: string[]
     missingPartialScore: string[]
+    conflicted?: string[]
   }
 }
 
@@ -31,7 +32,8 @@ export default function ExportWarningModal({
   const hasWarnings =
     (warnings?.noScoringData?.length ?? 0) > 0 ||
     (warnings?.unscored?.length ?? 0) > 0 ||
-    (warnings?.missingPartialScore?.length ?? 0) > 0
+    (warnings?.missingPartialScore?.length ?? 0) > 0 ||
+    (warnings?.conflicted?.length ?? 0) > 0
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -71,6 +73,28 @@ export default function ExportWarningModal({
                 <div className="mb-2 font-medium">次の設問答案が未採点です</div>
                 <div className="space-y-1 text-sm">
                   {(warnings?.unscored ?? []).map((item, index) => (
+                    <div key={index} className="pl-2">
+                      • {item}
+                    </div>
+                  ))}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* 採点の競合（複数採点者の値が食い違い、未確定） */}
+          {(warnings?.conflicted?.length ?? 0) > 0 && (
+            <Alert className="border-purple-200 bg-purple-50">
+              <AlertTriangle className="h-4 w-4 text-purple-600" />
+              <AlertDescription className="text-purple-800">
+                <div className="mb-2 font-medium">
+                  次の設問答案は採点者間で結果が食い違っています（未採点として出力されます）
+                </div>
+                <div className="mb-2 text-sm">
+                  採点画面の比較モーダルから、試験の所有者が結果を確定してください。
+                </div>
+                <div className="space-y-1 text-sm">
+                  {(warnings?.conflicted ?? []).map((item, index) => (
                     <div key={index} className="pl-2">
                       • {item}
                     </div>

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -22,6 +22,7 @@ export interface ExportAPI {
         noScoringData: string[]
         ungraded: string[]
         missingPartialScore: string[]
+        conflicted: string[]
       }
     }>
 
@@ -313,6 +314,7 @@ export interface ExportAPI {
       noScoringData: string[]
       unscored: string[]
       missingPartialScore: string[]
+      conflicted?: string[]
     }
     validationResult?: {
       hasWarnings: boolean
@@ -320,6 +322,7 @@ export interface ExportAPI {
         noScoringData: string[]
         unscored: string[]
         missingPartialScore: string[]
+        conflicted?: string[]
       }
     }
   }>

--- a/src/types/electron/scoringApi.d.ts
+++ b/src/types/electron/scoringApi.d.ts
@@ -5,10 +5,26 @@ import type {
   QuestionScoreWithUser,
 } from "../prismaExtensions"
 
+// OWNERによる確定スコア（IPC経由でscoreはnumberに変換済み）
+export interface ScoreDecisionForComparison {
+  id: string
+  cropRegionId: string
+  studentId: string
+  verdict: string
+  score: number | null
+  comment: string | null
+  decidedByUserId: string
+  decidedAt: Date | string
+  sourceQuestionScoreId: string | null
+  decidedBy: { id: string; name: string; username: string }
+}
+
 // QuestionScore comparison result type
 export interface QuestionScoreComparisonResult {
   success: boolean
-  finalScore?: QuestionScoreWithUser
+  /** OWNERによる確定。未確定の場合はnull */
+  decision?: ScoreDecisionForComparison | null
+  /** 採点者ごとの提案（unscoredを除く） */
   proposedScores?: QuestionScoreWithUser[]
   hasConflict?: boolean
   error?: string
@@ -52,8 +68,6 @@ export interface ScoringAPI {
       | "partial"
       | "pending"
       | "no_answer"
-      | "proposed"
-      | "final"
       | "double_mark"
     userId: string // v0.4.0+: required
   }) => Promise<QuestionScoreOperationResult>
@@ -69,8 +83,6 @@ export interface ScoringAPI {
         | "partial"
         | "pending"
         | "no_answer"
-        | "proposed"
-        | "final"
         | "double_mark"
       comment?: string
       version?: number
@@ -90,8 +102,13 @@ export interface ScoringAPI {
       partialScore?: number
       status: string
       comments?: string
+      sourceQuestionScoreId?: string
     }
-  ) => Promise<QuestionScoreOperationResult>
+  ) => Promise<{
+    success: boolean
+    decision?: ScoreDecisionForComparison
+    error?: string
+  }>
 
   getAnswerSheetProgress: (answerSheetId: string) => Promise<{
     totalQuestions: number

--- a/src/types/electron/syncApi.d.ts
+++ b/src/types/electron/syncApi.d.ts
@@ -9,11 +9,21 @@ export interface SyncAppConfig {
   changelogRetentionDays: number
 }
 
+/** スキーマバージョン不一致でスキップされたリモートクライアント */
+export interface VersionMismatchRemote {
+  clientId: string
+  remoteVersion: string | null
+  /** リモートの方が新しいかどうか（= このPCのアプリ更新が必要） */
+  remoteIsNewer: boolean
+}
+
 export interface SyncAppStatus {
   state: "idle" | "syncing" | "error" | "disabled"
   lastSyncTime: string | null
   lastError: string | null
   syncCount: number
+  /** 直近のsyncでスキーマバージョン不一致によりスキップされたリモート */
+  versionMismatches: VersionMismatchRemote[]
 }
 
 export interface SyncAPI {

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -930,6 +930,20 @@ export interface ArchiveScoresData {
     createdAt: string
     updatedAt: string
   }>
+  /** v1.13.0+ OWNERによる確定スコア（生徒×設問ごとに高々1件）。旧バージョンのアーカイブには存在しない */
+  scoreDecisions?: Array<{
+    id: string
+    cropRegionId: string
+    studentId: string
+    verdict: string
+    score: string | null // Decimal as string
+    comment: string | null
+    decidedByUserId: string
+    decidedAt: string
+    sourceQuestionScoreId: string | null
+    createdAt: string
+    updatedAt: string
+  }>
 }
 
 /**


### PR DESCRIPTION
Closes #808

## 概要

複数教員によるNAS経由の協調採点の基盤整備。背景と解決する問題の詳細は #808 を参照。

## 変更内容

- **fix: マイグレーション防御の強化** — DBがアプリより新しい場合の起動中止+更新案内、適用前バックアップ(タイムスタンプ付き5世代)と失敗時復元、_prisma_migrations 全削除の廃止
- **feat: 同期スキーマバージョン不一致の検出と通知** — 不一致リモートのスキップ状況を設定画面にバナー表示(どちらが更新すべきかを判別)
- **feat: ScoreDecision導入と有効スコアリゾルバの一本化** — 確定の独立テーブル化(1セル1行・upsertのみでLWW収束)、「確定 > 提案全員一致 > 競合」の決定的導出、Excel出力の非決定性とfinal満点バグの修正、確定権限のOWNER制限
- **feat: 試験アーカイブ形式 v1.13.0** — scoreDecisions対応、旧形式の読み込み時自動変換
- **feat: OWNER裁定UXと採点競合の出力時警告** — 比較モーダルのトースト通知・採用元記録・stale検出、出力前警告への競合カテゴリ追加
- **chore: sqlite-nas-sync を ^0.11.0 へ更新** — セカンダリUNIQUE違反のLWW競合解決(確定の同期収束の前提条件)

## テスト

- 型チェック・Lint クリーン
- テスト 667/672 成功(失敗5件は本変更前からの既存問題: bulkExportExams の archiver interop、grade/integration のパスエイリアス)
- 新規テスト39件(リゾルバ23・マイグレーションガード7・アーカイブ変換8、sqlite-nas-sync側にも収束統合テスト追加済み)

## 注意

- DBマイグレーション 20260611135650_add_score_decision を含む(既存 final 行を ScoreDecision へ変換。各クライアントで決定的)
- 配布前提条件の sqlite-nas-sync@0.11.0 は npm 公開済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)