### PR TITLE
fix: DateTime形式混在を正規化し成績の学級追加0名バグを修正

### DIFF
--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -1,0 +1,246 @@
+/**
+ * DateTime正規化マイグレーション (normalize_datetime_to_text) のテスト
+ *
+ * 背景: Prisma v7 の driver adapter (@prisma/adapter-better-sqlite3) は DateTime を
+ * ISO 8601 text で読み書きするが、adapter移行前の既存データは integer(ms) のまま残り
+ * 混在した。SQLiteの型優先順位 (integer < text) により、driver adapter が渡す text の
+ * 基準日と integer の endDate が比較できず、成績の学級在籍フィルタが在籍者を拾えなくなる
+ * (「学級追加→生徒0名」バグ)。本テストは migration が integer を ISO text へ正規化し、
+ * 在籍フィルタが本番と同じ経路(Prismaクエリ + driver adapter)で正しく動くことを検証する。
+ */
+import { PrismaClient } from "@prisma/client"
+import * as fs from "fs"
+import * as path from "path"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
+
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_DB_DIR = path.resolve(__dirname, "../../data")
+const TEST_DB_PATH = path.join(TEST_DB_DIR, "test-normalize-datetime.db")
+const MIGRATION_SQL = path.resolve(
+  __dirname,
+  "../../prisma/migrations/20260613144726_normalize_datetime_to_text/migration.sql"
+)
+
+// integer(ms) のサンプル値
+const PAST_MS = 1743346800000 // 2025-03-30T15:00:00Z (基準日より過去 = 在籍終了)
+const FUTURE_MS = 1806418800000 // 2027-03-30T15:00:00Z (基準日より未来 = 在籍中)
+const START_MS = 1700000000000 // 2023-11 (開始日)
+const REFERENCE = "2026-06-13T00:00:00.000+00:00"
+
+let prisma: PrismaClient
+
+const createPrisma = () => createPrismaClientForPath(TEST_DB_PATH)
+const exec = (sql: string) => prisma.$executeRawUnsafe(sql)
+
+const resetDb = async () => {
+  if (prisma) await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+  fs.writeFileSync(TEST_DB_PATH, "")
+  prisma = createPrisma()
+  await prisma.$connect()
+}
+
+/**
+ * migration.sql を migrationDeployer と同じ ';' 分割ロジックで読み、
+ * 指定テーブルへの UPDATE 文のみを適用する
+ * (テストDBには全テーブルを作らないため対象を絞る)
+ */
+const applyMigrationFor = async (tables: string[]) => {
+  const sql = fs.readFileSync(MIGRATION_SQL, "utf-8")
+  const statements = sql
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => {
+      const stripped = s
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/--[^\n]*/g, "")
+        .trim()
+      return stripped.length > 0
+    })
+  for (const stmt of statements) {
+    const m = stmt.match(/UPDATE\s+"(\w+)"/)
+    if (m && tables.includes(m[1])) {
+      await prisma.$executeRawUnsafe(stmt)
+    }
+  }
+}
+
+/** typeofごとの件数を返す */
+const countByType = async (table: string, col: string) => {
+  const rows = await prisma.$queryRawUnsafe<{ t: string; c: number }[]>(
+    `SELECT typeof("${col}") AS t, COUNT(*) AS c FROM "${table}" GROUP BY typeof("${col}")`
+  )
+  return Object.fromEntries(rows.map((r) => [r.t, Number(r.c)]))
+}
+
+beforeAll(async () => {
+  if (!fs.existsSync(TEST_DB_DIR))
+    fs.mkdirSync(TEST_DB_DIR, { recursive: true })
+  prisma = createPrisma()
+})
+
+afterEach(async () => {
+  if (prisma) await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+})
+
+afterAll(async () => {
+  if (prisma) await prisma.$disconnect()
+  if (fs.existsSync(TEST_DB_PATH)) fs.unlinkSync(TEST_DB_PATH)
+})
+
+const buildSchema = async () => {
+  // FK制約はテストに不要なため省略。カラムは schema.prisma 準拠（Prismaクエリが通るよう全カラム）
+  await exec(
+    `CREATE TABLE "StudentClassMembership" ("id" TEXT NOT NULL PRIMARY KEY, "studentId" TEXT NOT NULL, "classId" TEXT NOT NULL, "startDate" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "endDate" DATETIME, "attendanceNumber" INTEGER, "notes" TEXT, "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" DATETIME NOT NULL)`
+  )
+  await exec(
+    `CREATE TABLE "Grade" ("id" TEXT NOT NULL PRIMARY KEY, "name" TEXT NOT NULL, "description" TEXT, "referenceDate" DATETIME, "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" DATETIME NOT NULL)`
+  )
+}
+
+/** integer(ms)形式の membership を3件注入（過去終了 / 未来終了 / 在籍中null） */
+const insertIntegerMemberships = async () => {
+  await exec(
+    `INSERT INTO "StudentClassMembership" ("id","studentId","classId","startDate","endDate","updatedAt") VALUES ('m_past','s1','c1',${START_MS},${PAST_MS},${START_MS})`
+  )
+  await exec(
+    `INSERT INTO "StudentClassMembership" ("id","studentId","classId","startDate","endDate","updatedAt") VALUES ('m_future','s2','c1',${START_MS},${FUTURE_MS},${START_MS})`
+  )
+  await exec(
+    `INSERT INTO "StudentClassMembership" ("id","studentId","classId","startDate","endDate","updatedAt") VALUES ('m_active','s3','c1',${START_MS},NULL,${START_MS})`
+  )
+}
+
+describe("DateTime正規化マイグレーション", () => {
+  it("バグ再現→修正: integer形式のendDateは在籍フィルタで拾えず、正規化後に拾える", async () => {
+    await resetDb()
+    await buildSchema()
+    await insertIntegerMemberships()
+
+    // 適用前は endDate が integer
+    expect(await countByType("StudentClassMembership", "endDate")).toEqual({
+      integer: 2,
+      null: 1,
+    })
+
+    // 本番と同じ経路: Prismaクエリ (driver adapter が Date を ISO text で渡す)
+    const refDate = new Date(REFERENCE)
+    const filter = {
+      OR: [{ endDate: null }, { endDate: { gte: refDate } }],
+    }
+
+    // 【バグ再現】integer(endDate) >= text(基準日) は SQLite型優先順位で常にfalse。
+    // 在籍中の未来終了(m_future)が除外され、null(m_active)の1件しか拾えない
+    const before = await prisma.studentClassMembership.count({ where: filter })
+    expect(before).toBe(1)
+
+    // 正規化マイグレーション適用
+    await applyMigrationFor(["StudentClassMembership"])
+
+    // 適用後は endDate が text に統一（integerは0件）
+    expect(await countByType("StudentClassMembership", "endDate")).toEqual({
+      text: 2,
+      null: 1,
+    })
+
+    // 【修正確認】未来終了(m_future) + 在籍中(m_active) の2件が正しく拾える。
+    // 過去終了(m_past)は基準日時点で在籍していないため除外されるのが正しい
+    const after = await prisma.studentClassMembership.count({ where: filter })
+    expect(after).toBe(2)
+  })
+
+  it("変換形式が driver adapter と同一 (YYYY-MM-DDTHH:MM:SS.mmm+00:00)", async () => {
+    await resetDb()
+    await buildSchema()
+    await insertIntegerMemberships()
+
+    await applyMigrationFor(["StudentClassMembership"])
+
+    // Prismaは DateTime列をDateオブジェクトに変換するため、CAST AS TEXTでDB格納の生値を取得
+    const rows = await prisma.$queryRawUnsafe<{ endDate: string }[]>(
+      `SELECT CAST("endDate" AS TEXT) AS endDate FROM "StudentClassMembership" WHERE "id" = 'm_past'`
+    )
+    expect(rows[0].endDate).toBe("2025-03-30T15:00:00.000+00:00")
+  })
+
+  it("冪等性: 再適用しても text 行は変化しない", async () => {
+    await resetDb()
+    await buildSchema()
+    await insertIntegerMemberships()
+
+    await applyMigrationFor(["StudentClassMembership"])
+    const first = await prisma.$queryRawUnsafe<{ endDate: string }[]>(
+      `SELECT CAST("endDate" AS TEXT) AS endDate FROM "StudentClassMembership" WHERE "id" = 'm_future'`
+    )
+
+    await applyMigrationFor(["StudentClassMembership"])
+    const second = await prisma.$queryRawUnsafe<{ endDate: string }[]>(
+      `SELECT CAST("endDate" AS TEXT) AS endDate FROM "StudentClassMembership" WHERE "id" = 'm_future'`
+    )
+
+    expect(second[0].endDate).toBe(first[0].endDate)
+    expect(
+      (await countByType("StudentClassMembership", "endDate")).integer ?? 0
+    ).toBe(0)
+  })
+
+  it("網羅性: migration.sql が schema.prisma の全 DateTime カラムをカバーする", () => {
+    const schemaPath = path.resolve(__dirname, "../../prisma/schema.prisma")
+    const schemaText = fs.readFileSync(schemaPath, "utf-8")
+    const migrationText = fs.readFileSync(MIGRATION_SQL, "utf-8")
+
+    // schema.prisma から (物理テーブル名, DateTimeカラム) を抽出
+    const expected: [string, string][] = []
+    const modelRe = /model\s+(\w+)\s*\{([\s\S]*?)\n\}/g
+    let mm: RegExpExecArray | null
+    while ((mm = modelRe.exec(schemaText))) {
+      const body = mm[2]
+      const mapMatch = body.match(/@@map\("([^"]+)"\)/)
+      const table = mapMatch ? mapMatch[1] : mm[1]
+      for (const line of body.split("\n")) {
+        const parts = line.trim().split(/\s+/)
+        if (parts.length >= 2 && parts[1].startsWith("DateTime")) {
+          expected.push([table, parts[0]])
+        }
+      }
+    }
+
+    expect(expected.length).toBeGreaterThan(0)
+
+    // 各 (table, col) に対応する UPDATE 文が migration.sql に存在すること
+    const missing = expected.filter(
+      ([table, col]) =>
+        !migrationText.includes(`UPDATE "${table}" SET "${col}"`)
+    )
+    expect(missing).toEqual([])
+  })
+
+  it("分割健全性: migrationDeployer分割で全片がUPDATE文になる(コメント内セミコロン混入防止)", () => {
+    // migrationDeployer は SQL を ';' で単純分割するため、コメント内にセミコロンがあると
+    // 未閉じコメント片が実行対象に混入し "no statements" で落ちる。それを検出する。
+    const sql = fs.readFileSync(MIGRATION_SQL, "utf-8")
+    const statements = sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter((s) => {
+        if (s.length === 0) return false
+        const stripped = s
+          .replace(/\/\*[\s\S]*?\*\//g, "")
+          .replace(/--[^\n]*/g, "")
+          .trim()
+        return stripped.length > 0
+      })
+
+    // filterを通過した全片は実行可能なUPDATE文であるべき
+    const nonExecutable = statements.filter((s) => {
+      const stripped = s
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/--[^\n]*/g, "")
+        .trim()
+      return !/^UPDATE\s+"/.test(stripped)
+    })
+    expect(nonExecutable).toEqual([])
+  })
+})

--- a/prisma/migrations/20260613144726_normalize_datetime_to_text/migration.sql
+++ b/prisma/migrations/20260613144726_normalize_datetime_to_text/migration.sql
@@ -1,0 +1,234 @@
+/*
+  Normalize legacy integer (Unix epoch millisecond) DateTime values to ISO 8601 text.
+
+  Background: Prisma v7 への driver adapter (@prisma/adapter-better-sqlite3) 移行で
+  DateTime の保存形式が integer(ms) から ISO 8601 text へ変わったが、既存データは
+  integer のまま残り混在した。SQLite の型優先順位 (integer < text) により
+  integer の値と driver adapter が渡す text の基準日が比較できず、範囲フィルタ
+  (例: 成績の学級在籍判定)・orderBy ソート・sqlite-nas-sync の LWW 競合解決が壊れていた。
+
+  本マイグレーションは全 DateTime カラムの integer 行のみを driver adapter と同一形式
+  (YYYY-MM-DDTHH:MM:SS.mmm+00:00) の text へ変換し、形式を統一する。
+  WHERE typeof(col)='integer' ガードにより冪等 (text/null 行は不変、再実行・途中失敗後の
+  再適用も安全)。注: migrationDeployer は SQL をセミコロン区切りで分割して逐次実行し各文を
+  トランザクション外で適用するため、PRAGMA / BEGIN / COMMIT は記述しない。
+  またコメント内にセミコロンを含めてはならない (分割が壊れるため)。
+*/
+
+
+-- User
+UPDATE "User" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "User" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- classes
+UPDATE "classes" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "classes" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- Student
+UPDATE "Student" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "Student" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- StudentClassMembership
+UPDATE "StudentClassMembership" SET "startDate" = strftime('%Y-%m-%dT%H:%M:%f', "startDate"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("startDate") = 'integer';
+UPDATE "StudentClassMembership" SET "endDate" = strftime('%Y-%m-%dT%H:%M:%f', "endDate"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("endDate") = 'integer';
+UPDATE "StudentClassMembership" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "StudentClassMembership" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- Exam
+UPDATE "Exam" SET "examDate" = strftime('%Y-%m-%dT%H:%M:%f', "examDate"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("examDate") = 'integer';
+UPDATE "Exam" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "Exam" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamStudent
+UPDATE "ExamStudent" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamStudent" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamPage
+UPDATE "ExamPage" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamPage" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- MasterImage
+UPDATE "MasterImage" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "MasterImage" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- StudentAnswerImage
+UPDATE "StudentAnswerImage" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "StudentAnswerImage" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropRegion
+UPDATE "CropRegion" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropRegion" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- SubtotalGroup
+UPDATE "SubtotalGroup" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "SubtotalGroup" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- Subtotal
+UPDATE "Subtotal" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "Subtotal" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropSubtotal
+UPDATE "CropSubtotal" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropSubtotal" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- UserExam
+UPDATE "UserExam" SET "invitedAt" = strftime('%Y-%m-%dT%H:%M:%f', "invitedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("invitedAt") = 'integer';
+UPDATE "UserExam" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "UserExam" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamSubtotalGroup
+UPDATE "ExamSubtotalGroup" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamSubtotalGroup" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- QuestionScore
+UPDATE "QuestionScore" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "QuestionScore" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ScoreDecision
+UPDATE "ScoreDecision" SET "decidedAt" = strftime('%Y-%m-%dT%H:%M:%f', "decidedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("decidedAt") = 'integer';
+UPDATE "ScoreDecision" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ScoreDecision" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- DrawingAnnotation
+UPDATE "DrawingAnnotation" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "DrawingAnnotation" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- DeletedRecord
+UPDATE "DeletedRecord" SET "deletedAt" = strftime('%Y-%m-%dT%H:%M:%f', "deletedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("deletedAt") = 'integer';
+
+-- ExamClass
+UPDATE "ExamClass" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamClass" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- Tag
+UPDATE "Tag" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "Tag" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- TagSubtotalGroup
+UPDATE "TagSubtotalGroup" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "TagSubtotalGroup" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamTag
+UPDATE "ExamTag" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamTag" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- UserKeyboardShortcut
+UPDATE "UserKeyboardShortcut" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "UserKeyboardShortcut" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- UserPreference
+UPDATE "UserPreference" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "UserPreference" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamMarkingFormat
+UPDATE "ExamMarkingFormat" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamMarkingFormat" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ExamExportSettings
+UPDATE "ExamExportSettings" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ExamExportSettings" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropRegionMarkingOverride
+UPDATE "CropRegionMarkingOverride" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropRegionMarkingOverride" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropRegionOmrConfig
+UPDATE "CropRegionOmrConfig" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropRegionOmrConfig" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropRegionOmrChoiceOption
+UPDATE "CropRegionOmrChoiceOption" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropRegionOmrChoiceOption" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CropRegionOmrDigitBox
+UPDATE "CropRegionOmrDigitBox" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CropRegionOmrDigitBox" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CompoundAnswer
+UPDATE "CompoundAnswer" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CompoundAnswer" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CompoundAnswerMember
+UPDATE "CompoundAnswerMember" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CompoundAnswerMember" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- CompoundAnswerScore
+UPDATE "CompoundAnswerScore" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "CompoundAnswerScore" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- Grade
+UPDATE "Grade" SET "referenceDate" = strftime('%Y-%m-%dT%H:%M:%f', "referenceDate"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("referenceDate") = 'integer';
+UPDATE "Grade" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "Grade" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeItem
+UPDATE "GradeItem" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeItem" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeClass
+UPDATE "GradeClass" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeClass" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeStudent
+UPDATE "GradeStudent" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeStudent" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeDataSource
+UPDATE "GradeDataSource" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeDataSource" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- ManualScore
+UPDATE "ManualScore" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "ManualScore" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeItemExclusion
+UPDATE "GradeItemExclusion" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeItemExclusion" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeBoundarySet
+UPDATE "GradeBoundarySet" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeBoundarySet" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeOverride
+UPDATE "GradeOverride" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeOverride" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeBoundary
+UPDATE "GradeBoundary" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeBoundary" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- GradeExportSettings
+UPDATE "GradeExportSettings" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "GradeExportSettings" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbDefinition
+UPDATE "AsbDefinition" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbDefinition" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbMajorQuestion
+UPDATE "AsbMajorQuestion" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbMajorQuestion" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbSubQuestion
+UPDATE "AsbSubQuestion" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbSubQuestion" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbBranchQuestion
+UPDATE "AsbBranchQuestion" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbBranchQuestion" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbTextElement
+UPDATE "AsbTextElement" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbTextElement" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbImageElement
+UPDATE "AsbImageElement" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbImageElement" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbOmrConfig
+UPDATE "AsbOmrConfig" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbOmrConfig" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';
+
+-- AsbOmrChoiceOption
+UPDATE "AsbOmrChoiceOption" SET "createdAt" = strftime('%Y-%m-%dT%H:%M:%f', "createdAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("createdAt") = 'integer';
+UPDATE "AsbOmrChoiceOption" SET "updatedAt" = strftime('%Y-%m-%dT%H:%M:%f', "updatedAt"/1000.0, 'unixepoch') || '+00:00' WHERE typeof("updatedAt") = 'integer';


### PR DESCRIPTION
Closes #815

## 背景

Prisma v7 への driver adapter (`@prisma/adapter-better-sqlite3`) 移行で、SQLiteの `DateTime` 保存形式が integer(Unix ms) から ISO 8601 text へ変わったが、既存データ変換マイグレーションを伴わなかったため integer/text が混在していた。SQLiteの型優先順位 (integer < text) により、driver adapter が渡す text 基準日と integer の `endDate` が比較できず、成績の学級在籍フィルタ (`membershipFilterAt`) が在籍者を拾えず「学級追加→生徒0名」が発生していた（範囲比較・orderBy ソート・sqlite-nas-sync の LWW 競合解決も同根で破綻）。

## 変更内容

- **`prisma/migrations/20260613144726_normalize_datetime_to_text/migration.sql`**（新規）
  - 全 DateTime カラム（111カラム）の `typeof='integer'` 行のみを driver adapter と同一形式 (`YYYY-MM-DDTHH:MM:SS.mmm+00:00`) の ISO text へ変換
  - `typeof=integer` ガードで冪等（text/null 行は不変、再適用・途中失敗後の再適用も安全）
  - アプリ再起動時に `migrationDeployer` が自動バックアップ付きで適用
- **`__tests__/migration/normalizeDatetime.test.ts`**（新規・5テスト）
  - バグ再現→修正（本番と同じ Prismaクエリ + driver adapter 経路）
  - 変換形式の一致 / 冪等性 / 全カラム網羅性 / 分割健全性（コメント内セミコロン混入防止）

## 検証

- 本番DBコピーに対し deployer 同一ロジックで適用 → **integer残存0件・在籍判定135件**（実在籍数と一致）
- 実機で学級追加が正しく表示されることを確認済み
- `__tests__/migration/` 全体 緑

## 注意（運用）

- 初回起動時に全 DateTime データを書き換えるため、適用時に sqlite-nas-sync の changelog が一時的に増える（収束する）
- マイグレーション追加で schemaVersion が自動 bump され、未適用クライアントは sync 時に skip+warning となる（全クライアント適用まで安全に分離）