### PR TITLE
feat: 成績の学級追加に在籍期間スイッチを追加

### DIFF
--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -135,14 +135,17 @@ export function setupGradeHandlers(): void {
     return getGradeClasses(gradeId)
   })
 
-  registerHandler("grade:getAvailableClasses", async (gradeId: string) => {
-    return getAvailableClassesForGrade(gradeId)
-  })
+  registerHandler(
+    "grade:getAvailableClasses",
+    async (gradeId: string, activeOnly = true) => {
+      return getAvailableClassesForGrade(gradeId, activeOnly)
+    }
+  )
 
   registerHandler(
     "grade:addStudentsFromClass",
-    async (gradeId: string, classId: string) => {
-      return addStudentsFromClassToGrade(gradeId, classId)
+    async (gradeId: string, classId: string, activeOnly = true) => {
+      return addStudentsFromClassToGrade(gradeId, classId, activeOnly)
     }
   )
 

--- a/electron-src/lib/prisma/gradeStudent.ts
+++ b/electron-src/lib/prisma/gradeStudent.ts
@@ -90,8 +90,15 @@ export async function getGradeClasses(gradeId: string) {
 
 /**
  * まだ登録されていない学級一覧を取得
+ *
+ * @param activeOnly trueなら基準日時点で在籍中の生徒のみを数える（既定）。
+ *   falseなら在籍期間に関わらず学級に在籍歴のある全生徒を数える。
+ *   いずれの場合も、対象生徒が0名の学級は候補から除外する。
  */
-export async function getAvailableClassesForGrade(gradeId: string) {
+export async function getAvailableClassesForGrade(
+  gradeId: string,
+  activeOnly = true
+) {
   try {
     const referenceDate = await getExamReferenceDate(gradeId)
     const existing = await prisma.gradeClass.findMany({
@@ -106,8 +113,8 @@ export async function getAvailableClassesForGrade(gradeId: string) {
       },
       include: {
         memberships: {
-          where: membershipFilterAt(referenceDate),
-          select: { id: true },
+          where: activeOnly ? membershipFilterAt(referenceDate) : undefined,
+          select: { studentId: true },
         },
       },
       orderBy: [{ grade: "asc" }, { name: "asc" }],
@@ -115,11 +122,15 @@ export async function getAvailableClassesForGrade(gradeId: string) {
 
     return {
       success: true,
-      classes: classes.map((c) => ({
-        id: c.id,
-        name: c.name,
-        studentCount: c.memberships.length,
-      })),
+      classes: classes
+        .map((c) => ({
+          id: c.id,
+          name: c.name,
+          // 同一生徒の複数在籍歴を重複カウントしないようdistinct
+          studentCount: new Set(c.memberships.map((m) => m.studentId)).size,
+        }))
+        // 対象生徒が0名の学級は非表示（activeOnlyスイッチの状態に連動）
+        .filter((c) => c.studentCount > 0),
     }
   } catch (error) {
     console.error("Error getting available classes:", error)
@@ -132,10 +143,14 @@ export async function getAvailableClassesForGrade(gradeId: string) {
 
 /**
  * 学級から生徒を一括追加
+ *
+ * @param activeOnly trueなら基準日時点で在籍中の生徒のみ追加する（既定）。
+ *   falseなら在籍期間に関わらず学級に在籍歴のある全生徒を追加する。
  */
 export async function addStudentsFromClassToGrade(
   gradeId: string,
-  classId: string
+  classId: string,
+  activeOnly = true
 ) {
   try {
     const referenceDate = await getExamReferenceDate(gradeId)
@@ -156,9 +171,12 @@ export async function addStudentsFromClassToGrade(
       update: {},
     })
 
-    // 3. 基準日時点で有効な生徒を出席番号順で取得
+    // 3. 対象生徒を出席番号順で取得（activeOnlyなら基準日時点で在籍中のみ）
     const memberships = await prisma.studentClassMembership.findMany({
-      where: { classId, ...membershipFilterAt(referenceDate) },
+      where: {
+        classId,
+        ...(activeOnly ? membershipFilterAt(referenceDate) : {}),
+      },
       orderBy: [
         { attendanceNumber: "asc" },
         { student: { studentNumber: "asc" } },

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -26,10 +26,19 @@ export function createGradeApi() {
         ipcRenderer.invoke("grade:getStudents", gradeId),
       getClasses: (gradeId: string) =>
         ipcRenderer.invoke("grade:getClasses", gradeId),
-      getAvailableClasses: (gradeId: string) =>
-        ipcRenderer.invoke("grade:getAvailableClasses", gradeId),
-      addStudentsFromClass: (gradeId: string, classId: string) =>
-        ipcRenderer.invoke("grade:addStudentsFromClass", gradeId, classId),
+      getAvailableClasses: (gradeId: string, activeOnly?: boolean) =>
+        ipcRenderer.invoke("grade:getAvailableClasses", gradeId, activeOnly),
+      addStudentsFromClass: (
+        gradeId: string,
+        classId: string,
+        activeOnly?: boolean
+      ) =>
+        ipcRenderer.invoke(
+          "grade:addStudentsFromClass",
+          gradeId,
+          classId,
+          activeOnly
+        ),
       removeClass: (gradeId: string, classId: string) =>
         ipcRenderer.invoke("grade:removeClass", gradeId, classId),
       updateStudentOrders: (

--- a/src/components/grades/02-students/StudentsContainer.tsx
+++ b/src/components/grades/02-students/StudentsContainer.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 
 interface GradeClass {
   id: string
@@ -105,13 +106,15 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
   const [loading, setLoading] = useState(true)
   const [adding, setAdding] = useState(false)
   const [activeId, setActiveId] = useState<string | null>(null)
+  // true: 基準日時点で在籍中の生徒のみ対象（既定） / false: 在籍期間外の生徒も対象
+  const [activeOnly, setActiveOnly] = useState(true)
 
   const loadData = useCallback(async () => {
     try {
       const [classResult, studentResult, availableResult] = await Promise.all([
         window.electronAPI.grade.getClasses(gradeId),
         window.electronAPI.grade.getStudents(gradeId),
-        window.electronAPI.grade.getAvailableClasses(gradeId),
+        window.electronAPI.grade.getAvailableClasses(gradeId, activeOnly),
       ])
       if (classResult.success && classResult.classes) {
         setClasses(classResult.classes)
@@ -127,7 +130,7 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
     } finally {
       setLoading(false)
     }
-  }, [gradeId])
+  }, [gradeId, activeOnly])
 
   useEffect(() => {
     loadData()
@@ -139,7 +142,8 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
     try {
       const result = await window.electronAPI.grade.addStudentsFromClass(
         gradeId,
-        selectedClassId
+        selectedClassId,
+        activeOnly
       )
       if (result.success) {
         setSelectedClassId("")
@@ -253,6 +257,19 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
       {/* 学級追加 */}
       <div className="mb-6 rounded-lg border p-4">
         <h3 className="mb-3 text-sm font-medium">学級を追加</h3>
+        <label className="mb-3 flex w-fit cursor-pointer items-center gap-2 text-sm">
+          <Switch
+            checked={activeOnly}
+            onCheckedChange={(checked) => {
+              setActiveOnly(checked)
+              setSelectedClassId("")
+            }}
+          />
+          <span>在籍期間内の生徒のみ追加</span>
+          <span className="text-muted-foreground text-xs">
+            （オフにすると在籍期間外の生徒も対象になります）
+          </span>
+        </label>
         <div className="flex items-center gap-3">
           <Select value={selectedClassId} onValueChange={setSelectedClassId}>
             <SelectTrigger className="w-64">

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -68,7 +68,10 @@ export interface GradeAPI {
       }>
       error?: string
     }>
-    getAvailableClasses: (gradeId: string) => Promise<{
+    getAvailableClasses: (
+      gradeId: string,
+      activeOnly?: boolean
+    ) => Promise<{
       success: boolean
       classes?: Array<{
         id: string
@@ -79,7 +82,8 @@ export interface GradeAPI {
     }>
     addStudentsFromClass: (
       gradeId: string,
-      classId: string
+      classId: string,
+      activeOnly?: boolean
     ) => Promise<{
       success: boolean
       added?: number


### PR DESCRIPTION
Closes #817

## 概要

成績の「学級を追加」で、基準日時点で在籍中の生徒のみ追加するか、在籍期間外の生徒も追加するかをスイッチで切り替えられるようにした（既定は在籍期間内）。在籍期間内の対象生徒が0名の学級は候補から非表示にし、スイッチの状態に応じて表示/非表示・人数表示を切り替える。

## 変更内容

| 層 | ファイル | 変更 |
|---|---|---|
| prisma | `gradeStudent.ts` | `getAvailableClassesForGrade`/`addStudentsFromClassToGrade` に `activeOnly`(既定true) 追加。distinct生徒数で0名学級を除外 |
| IPC | `gradeHandlers.ts` | 両ハンドラに `activeOnly` 引数 |
| preload | `gradeApi.ts` | 両メソッドに `activeOnly` |
| 型 | `gradeApi.d.ts` | シグネチャ更新 |
| UI | `StudentsContainer.tsx` | 「在籍期間内の生徒のみ追加」スイッチ(既定ON)。切替で候補を再取得 |

## 検証

- 型チェック(src/electron-src)・eslint クリーン
- 本番DBコピーで動作確認: スイッチONで在籍0名の旧学級が候補から消え、OFFで過去在籍生徒(例: 30名)が候補に現れることを確認

## 補足

登録済み学級バッジの人数表示は在籍期間内のまま(本対応は追加候補側の表示制御が目的)。なお試験(exam)と成績(grade)の生徒管理は今後共通化して抜本改善する予定。