### PR TITLE
fix: 成績データソースの換算満点(weight)が0に固定されるバグを修正

### DIFF
--- a/src/components/grades/03-data-sources/AddDataSourceInline.tsx
+++ b/src/components/grades/03-data-sources/AddDataSourceInline.tsx
@@ -129,7 +129,11 @@ export function AddDataSourceInline({
         await window.electronAPI.grade.calculateSourceMaxScore(data)
       if (result.success && result.maxScore !== undefined) {
         setMaxScore(String(result.maxScore))
-        if (!weight) setWeight(String(result.maxScore))
+        // 満点が未確定（0）の段階では weight を埋めない。
+        // subtotal/crop_region 選択前に maxScore=0 が返ると weight が "0" に
+        // 固定され、その後 maxScore が確定しても !weight が false になり
+        // 換算満点が 0 のまま（→ 換算点が常に0）になるのを防ぐ。
+        if (!weight && result.maxScore > 0) setWeight(String(result.maxScore))
       }
     }
   }, [type, selectedExamId, selectedSubtotalId, selectedCropRegionId, weight])


### PR DESCRIPTION
## 概要

小計(subtotal)種別の成績データソース追加時、換算満点(weight)が0に固定され、成績結果が常に0になるバグを修正します。

Closes #819

## 原因

`AddDataSourceInline.tsx` の `autoCalcMaxScore` で、小計選択前に満点計算が `0` を返すと `if (!weight) setWeight("0")` により weight が文字列 `"0"` に固定される。その後満点が確定しても `!weight` が false のため weight は 0 のまま保存され、換算点が常に 0 になっていた。

## 変更内容

- 満点が確定（`> 0`）した段階でのみ weight を自動入力するよう修正

## 検証

- 実データで `maxScore=60 / weight=0` を確認し、サンプル生徒の素点60点が小計計算で正しく再現されることを確認済み（weight=0のみが原因）。
- prettier 整形済み・eslint パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
