### PR TITLE
feat: 成績出力のExcelプレビュー追加と個人通知書の調整

### DIFF
--- a/electron-src/lib/export/gradeExcel/gradeSheetCreator.ts
+++ b/electron-src/lib/export/gradeExcel/gradeSheetCreator.ts
@@ -152,6 +152,16 @@ export function createDetailSheet(
     }
   })
 
+  // 番号・氏名以外のヘッダー（データソース名・各観点の合計・総合）はすべて縦書きに
+  // （名前が長く横幅を取るため）
+  for (let i = 3; i <= headers.length; i++) {
+    headerRow.getCell(i).alignment = {
+      textRotation: "vertical",
+      vertical: "middle",
+      horizontal: "center",
+    }
+  }
+
   for (const student of result.students) {
     const row: (string | number | null)[] = [
       student.attendanceNumber,

--- a/src/components/grades/07-export/ExportContainer.tsx
+++ b/src/components/grades/07-export/ExportContainer.tsx
@@ -28,6 +28,7 @@ import { useGradeResults } from "@/hooks/grades/useGradeResults"
 
 import { ExcelExportTab } from "./ExcelExportTab"
 import { generateGradeReportBatchHtml } from "./generateGradeReportHtml"
+import { GradeExcelPreview } from "./GradeExcelPreview"
 import { IndividualReportTab } from "./IndividualReportTab"
 import { PreviewPane } from "./PreviewPane"
 import {
@@ -370,12 +371,21 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
                 value="preview"
                 className="mt-0 flex min-h-0 flex-1 flex-col"
               >
-                {exportTab !== "individual-report" ? (
-                  <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border bg-gray-100">
-                    <p className="text-muted-foreground text-sm">
-                      個人成績通知書タブでプレビューを確認できます
-                    </p>
-                  </div>
+                {exportTab === "excel" ? (
+                  selectedStudentIds.length === 0 ? (
+                    <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border bg-gray-100">
+                      <p className="text-muted-foreground text-sm">
+                        生徒を選択してください
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="min-h-0 flex-1 overflow-auto rounded-md border p-2">
+                      <GradeExcelPreview
+                        result={result}
+                        selectedStudentIds={selectedStudentIds}
+                      />
+                    </div>
+                  )
                 ) : selectedStudentIds.length === 0 ? (
                   <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border bg-gray-100">
                     <p className="text-muted-foreground text-sm">

--- a/src/components/grades/07-export/GradeExcelPreview.tsx
+++ b/src/components/grades/07-export/GradeExcelPreview.tsx
@@ -1,0 +1,340 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type {
+  GradeCalculationResult,
+  StudentGradeResult,
+} from "@/types/grade.types"
+
+interface GradeExcelPreviewProps {
+  result: GradeCalculationResult
+  selectedStudentIds: string[]
+}
+
+/** gradeSheetCreator と同じ丸め（成績一覧: 小数1桁） */
+function round1(value: number | null): number | null {
+  return value !== null ? Math.round(value * 10) / 10 : null
+}
+
+/** gradeSheetCreator と同じ丸め（詳細: 小数2桁） */
+function round2(value: number | null): number | null {
+  return value !== null ? Math.round(value * 100) / 100 : null
+}
+
+/**
+ * 成績算出Excel出力のプレビュー
+ *
+ * gradeSheetCreator.ts が生成する2シート（成績一覧 / 詳細）を、
+ * 試験のExcelプレビューと同じスタイルでReactのテーブルとして描画する。
+ */
+export function GradeExcelPreview({
+  result,
+  selectedStudentIds,
+}: GradeExcelPreviewProps) {
+  const [sheetTab, setSheetTab] = useState<"result" | "detail">("result")
+
+  const selectedSet = useMemo(
+    () => new Set(selectedStudentIds),
+    [selectedStudentIds]
+  )
+  const students = useMemo(
+    () => result.students.filter((s) => selectedSet.has(s.studentId)),
+    [result.students, selectedSet]
+  )
+
+  // 詳細シートの列構成（GradeItemごとのデータソース名）。
+  // 除外などで空にならないよう、各GradeItemで非除外の結果を持つ生徒から導出する。
+  const detailColumns = useMemo(
+    () =>
+      result.gradeItems.map((gradeItem) => {
+        let sourceNames: string[] = []
+        for (const student of result.students) {
+          const gir = student.gradeItemResults.find(
+            (r) => r.gradeItemId === gradeItem.id
+          )
+          if (gir && !gir.isExcluded && gir.sourceScores.length > 0) {
+            sourceNames = gir.sourceScores.map((ss) => ss.dataSourceName)
+            break
+          }
+        }
+        return { gradeItem, sourceNames }
+      }),
+    [result.gradeItems, result.students]
+  )
+
+  const studentName = (s: StudentGradeResult) => `${s.lastName} ${s.firstName}`
+
+  return (
+    <div className="flex h-full flex-col">
+      <Tabs
+        value={sheetTab}
+        onValueChange={(v) => setSheetTab(v as "result" | "detail")}
+        className="flex flex-1 flex-col"
+      >
+        <TabsList className="mb-1 grid w-full grid-cols-2">
+          <TabsTrigger value="result" className="text-xs">
+            成績一覧
+          </TabsTrigger>
+          <TabsTrigger value="detail" className="text-xs">
+            詳細
+          </TabsTrigger>
+        </TabsList>
+
+        {/* ── 成績一覧シート ── */}
+        <TabsContent value="result" className="mt-0 flex-1 overflow-auto">
+          <table className="w-full border-collapse text-[10px]">
+            <thead className="bg-muted sticky top-0">
+              <tr>
+                <th className="border px-1 py-0.5 text-left">番号</th>
+                <th className="border px-1 py-0.5 text-left">氏名</th>
+                {result.gradeItems.map((gi) => (
+                  <th
+                    key={gi.id}
+                    colSpan={2}
+                    className="border px-1 py-0.5 text-center"
+                  >
+                    {gi.name}
+                  </th>
+                ))}
+                <th colSpan={2} className="border px-1 py-0.5 text-center">
+                  総合
+                </th>
+              </tr>
+              <tr>
+                <th className="border px-1 py-0.5" />
+                <th className="border px-1 py-0.5" />
+                {result.gradeItems.map((gi) => (
+                  <ResultSubHeader key={gi.id} />
+                ))}
+                <ResultSubHeader />
+              </tr>
+            </thead>
+            <tbody>
+              {students.map((student) => (
+                <tr key={student.studentId} className="hover:bg-muted/50">
+                  <td className="border px-1 py-0.5 text-center">
+                    {student.attendanceNumber ?? "-"}
+                  </td>
+                  <td className="border px-1 py-0.5 whitespace-nowrap">
+                    {studentName(student)}
+                  </td>
+                  {result.gradeItems.map((gi) => {
+                    const gir = student.gradeItemResults.find(
+                      (r) => r.gradeItemId === gi.id
+                    )
+                    if (gir?.isExcluded) {
+                      return <ExcludedCells key={gi.id} count={2} />
+                    }
+                    const pct = round1(gir?.percentage ?? null)
+                    const allMissing = gir?.isAllMissing ?? false
+                    const cls = allMissing ? "text-red-500" : ""
+                    return (
+                      <ResultCells
+                        key={gi.id}
+                        percentage={pct}
+                        label={gir?.gradeLabel ?? null}
+                        className={cls}
+                      />
+                    )
+                  })}
+                  <ResultCells
+                    percentage={round1(student.overallPercentage)}
+                    label={student.overallGradeLabel}
+                    className="font-medium"
+                  />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TabsContent>
+
+        {/* ── 詳細シート ── */}
+        <TabsContent value="detail" className="mt-0 flex-1 overflow-auto">
+          <table className="w-full border-collapse text-[10px]">
+            <thead className="bg-muted sticky top-0">
+              <tr>
+                <th className="border px-1 py-0.5 text-left">番号</th>
+                <th className="border px-1 py-0.5 text-left">氏名</th>
+                {detailColumns.map(({ gradeItem, sourceNames }) => (
+                  <th
+                    key={gradeItem.id}
+                    colSpan={sourceNames.length + 1}
+                    className="border px-1 py-0.5 text-center"
+                  >
+                    {gradeItem.name}
+                  </th>
+                ))}
+                <th className="border px-1 py-0.5 text-center">総合</th>
+              </tr>
+              <tr>
+                <th className="border px-1 py-0.5" />
+                <th className="border px-1 py-0.5" />
+                {detailColumns.map(({ gradeItem, sourceNames }) => (
+                  <DetailSubHeaders
+                    key={gradeItem.id}
+                    sourceNames={sourceNames}
+                  />
+                ))}
+                <VerticalHeader>合計</VerticalHeader>
+              </tr>
+            </thead>
+            <tbody>
+              {students.map((student) => (
+                <tr key={student.studentId} className="hover:bg-muted/50">
+                  <td className="border px-1 py-0.5 text-center">
+                    {student.attendanceNumber ?? "-"}
+                  </td>
+                  <td className="border px-1 py-0.5 whitespace-nowrap">
+                    {studentName(student)}
+                  </td>
+                  {detailColumns.map(({ gradeItem, sourceNames }) => {
+                    const gir = student.gradeItemResults.find(
+                      (r) => r.gradeItemId === gradeItem.id
+                    )
+                    if (gir?.isExcluded) {
+                      return (
+                        <ExcludedCells
+                          key={gradeItem.id}
+                          count={sourceNames.length + 1}
+                        />
+                      )
+                    }
+                    return (
+                      <DetailCells
+                        key={gradeItem.id}
+                        gir={gir}
+                        sourceCount={sourceNames.length}
+                      />
+                    )
+                  })}
+                  <td className="border px-1 py-0.5 text-right font-medium">
+                    {round2(student.overallScore) ?? "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function ResultSubHeader() {
+  return (
+    <>
+      <th className="border px-1 py-0.5 text-right font-normal">%</th>
+      <th className="border px-1 py-0.5 text-right font-normal">成績</th>
+    </>
+  )
+}
+
+function ResultCells({
+  percentage,
+  label,
+  className = "",
+}: {
+  percentage: number | null
+  label: string | null
+  className?: string
+}) {
+  return (
+    <>
+      <td className={`border px-1 py-0.5 text-right ${className}`}>
+        {percentage ?? "-"}
+      </td>
+      <td className={`border px-1 py-0.5 text-right ${className}`}>
+        {label ?? "-"}
+      </td>
+    </>
+  )
+}
+
+function DetailSubHeaders({ sourceNames }: { sourceNames: string[] }) {
+  return (
+    <>
+      {sourceNames.map((name, i) => (
+        <VerticalHeader key={i} normal>
+          {name}
+        </VerticalHeader>
+      ))}
+      <VerticalHeader>合計</VerticalHeader>
+    </>
+  )
+}
+
+/**
+ * 縦書きのヘッダーセル（番号・氏名以外の詳細シート2段目用）。
+ * 名前が長く横幅を取るため writing-mode: vertical-rl で縦書きにする。
+ */
+function VerticalHeader({
+  children,
+  normal = false,
+}: {
+  children: React.ReactNode
+  normal?: boolean
+}) {
+  return (
+    <th
+      className={`border px-1 py-0.5 text-center align-middle ${
+        normal ? "font-normal" : ""
+      }`}
+    >
+      <span className="inline-block whitespace-nowrap [writing-mode:vertical-rl]">
+        {children}
+      </span>
+    </th>
+  )
+}
+
+function DetailCells({
+  gir,
+  sourceCount,
+}: {
+  gir:
+    | GradeCalculationResult["students"][number]["gradeItemResults"][number]
+    | undefined
+  sourceCount: number
+}) {
+  // 表示する列数を sourceCount に合わせる（生徒間で列数を揃える）
+  const cells: React.ReactNode[] = []
+  for (let i = 0; i < sourceCount; i++) {
+    const ss = gir?.sourceScores[i]
+    const value = ss ? (round2(ss.weightedScore) ?? "-") : "-"
+    const estimated = ss?.isEstimated ?? false
+    cells.push(
+      <td
+        key={i}
+        className={`border px-1 py-0.5 text-right ${
+          estimated ? "text-amber-600 italic" : ""
+        }`}
+        title={estimated ? "欠測推定値" : undefined}
+      >
+        {value}
+      </td>
+    )
+  }
+  cells.push(
+    <td key="total" className="border px-1 py-0.5 text-right font-medium">
+      {round2(gir?.weightedScore ?? null) ?? "-"}
+    </td>
+  )
+  return <>{cells}</>
+}
+
+function ExcludedCells({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <td
+          key={i}
+          className="text-muted-foreground bg-muted/50 border px-1 py-0.5 text-right italic"
+        >
+          除外
+        </td>
+      ))}
+    </>
+  )
+}

--- a/src/components/grades/07-export/IndividualReportTab.tsx
+++ b/src/components/grades/07-export/IndividualReportTab.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import type { GradeCalculationResult } from "@/types/grade.types"
 
 import { generateGradeReportBatchHtml } from "./generateGradeReportHtml"
@@ -187,7 +188,7 @@ export function IndividualReportTab({
                     variant="sub"
                   />
                   <OptionCard
-                    label="換算満点"
+                    label="換算得点"
                     checked={options.sourceBreakdownColumns.weight}
                     onChange={(v) =>
                       updateOption("sourceBreakdownColumns", {
@@ -258,9 +259,9 @@ export function IndividualReportTab({
       {/* フッター */}
       <Section title="フッター">
         <div className="flex flex-col gap-2">
-          <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="w-6 shrink-0 text-xs">左</Label>
-            <Input
+          <div className="bg-muted/50 flex items-start gap-2 rounded-lg border p-2">
+            <Label className="w-6 shrink-0 pt-1 text-xs">左</Label>
+            <Textarea
               value={options.footer.left}
               onChange={(e) =>
                 updateOption("footer", {
@@ -268,12 +269,13 @@ export function IndividualReportTab({
                   left: e.target.value,
                 })
               }
-              className="h-6 flex-1 text-xs"
+              rows={2}
+              className="min-h-0 flex-1 resize-y text-xs"
             />
           </div>
-          <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="w-6 shrink-0 text-xs">中</Label>
-            <Input
+          <div className="bg-muted/50 flex items-start gap-2 rounded-lg border p-2">
+            <Label className="w-6 shrink-0 pt-1 text-xs">中</Label>
+            <Textarea
               value={options.footer.center}
               onChange={(e) =>
                 updateOption("footer", {
@@ -281,12 +283,13 @@ export function IndividualReportTab({
                   center: e.target.value,
                 })
               }
-              className="h-6 flex-1 text-xs"
+              rows={2}
+              className="min-h-0 flex-1 resize-y text-xs"
             />
           </div>
-          <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">
-            <Label className="w-6 shrink-0 text-xs">右</Label>
-            <Input
+          <div className="bg-muted/50 flex items-start gap-2 rounded-lg border p-2">
+            <Label className="w-6 shrink-0 pt-1 text-xs">右</Label>
+            <Textarea
               value={options.footer.right}
               onChange={(e) =>
                 updateOption("footer", {
@@ -294,7 +297,8 @@ export function IndividualReportTab({
                   right: e.target.value,
                 })
               }
-              className="h-6 flex-1 text-xs"
+              rows={2}
+              className="min-h-0 flex-1 resize-y text-xs"
             />
           </div>
         </div>

--- a/src/components/grades/07-export/generateGradeReportHtml.ts
+++ b/src/components/grades/07-export/generateGradeReportHtml.ts
@@ -201,9 +201,9 @@ function renderStudentReport(
   const hasFooter = footer.left || footer.center || footer.right
   const footerHtml = hasFooter
     ? `<div class="report-footer">
-        <div class="report-footer-left">${escapeHtml(footer.left)}</div>
-        <div class="report-footer-center">${escapeHtml(footer.center)}</div>
-        <div class="report-footer-right">${escapeHtml(footer.right)}</div>
+        <div class="report-footer-left">${escapeHtmlMultiline(footer.left)}</div>
+        <div class="report-footer-center">${escapeHtmlMultiline(footer.center)}</div>
+        <div class="report-footer-right">${escapeHtmlMultiline(footer.right)}</div>
       </div>`
     : ""
 
@@ -293,6 +293,7 @@ function renderSourceBreakdownSection(
     rawScore: number | null
     maxScore: number
     isEstimated: boolean
+    weightedScore: number | null
     weight: number
   }
 
@@ -309,6 +310,7 @@ function renderSourceBreakdownSection(
         rawScore: source.rawScore,
         maxScore: source.maxScore,
         isEstimated: source.isEstimated,
+        weightedScore: source.weightedScore,
         weight: source.weight,
       })
     }
@@ -319,7 +321,7 @@ function renderSourceBreakdownSection(
   const buildHeaderRow = (): string => {
     const headerCols = [`<th>項目</th>`, `<th>${escapeHtml(label)}</th>`]
     if (srcCols.score) headerCols.push("<th>得点</th>")
-    if (srcCols.weight) headerCols.push("<th>換算満点</th>")
+    if (srcCols.weight) headerCols.push("<th>換算得点</th>")
     return `<tr>${headerCols.join("")}</tr>`
   }
 
@@ -340,7 +342,9 @@ function renderSourceBreakdownSection(
       cells.push(`<td>${score}${estimated} / ${row.maxScore.toFixed(1)}</td>`)
     }
     if (srcCols.weight) {
-      cells.push(`<td>${row.weight.toFixed(2)}</td>`)
+      const weighted =
+        row.weightedScore !== null ? row.weightedScore.toFixed(2) : "-"
+      cells.push(`<td>${weighted} / ${row.weight.toFixed(2)}</td>`)
     }
     return `<tr>${cells.join("")}</tr>`
   }
@@ -400,4 +404,9 @@ function escapeHtml(str: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
+}
+
+/** HTMLエスケープし、改行を <br> に変換する（フッター等の複数行テキスト用） */
+function escapeHtmlMultiline(str: string): string {
+  return escapeHtml(str).replace(/\r?\n/g, "<br>")
 }


### PR DESCRIPTION
## 概要

成績算出の出力機能に、Excelプレビューの追加と個人成績通知書の表示改善を行います。

Closes #821

## 変更内容

### Excel出力プレビュー（新規）
- 試験と同様のタブ式テーブルプレビュー `GradeExcelPreview` を追加。成績一覧・詳細の2シートを `GradeCalculationResult` から再現し、丸め・除外・全欠測・推定値のスタイルを実Excelと一致。
- `ExportContainer` のプレビュータブで、Excel出力タブ選択時にプレビューを表示。

### 詳細シートのヘッダー縦書き
- 番号・氏名以外のヘッダー（データソース名・各観点の合計・総合）を縦書き（上下中央）に。プレビュー（`writing-mode: vertical-rl`）と実Excel（`textRotation: "vertical"`）の両方へ適用。

### 個人成績通知書
- 内訳の「換算満点」→「換算得点」。値も「換算得点 / 換算満点」形式に変更。
- フッターを input → textarea にして改行対応（`escapeHtmlMultiline`）。

## 検証
- prettier 整形済み・eslint パス・型チェック（Next/Electron）パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
