### PR TITLE
feat: 国語向け縦組み解答用紙と原稿用紙の罫線・文字数ガイド対応

### DIFF
--- a/__tests__/answer-sheet-builder/manuscriptVertical.test.ts
+++ b/__tests__/answer-sheet-builder/manuscriptVertical.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import { manuscriptCharPosition } from "@/components/answer-sheet-builder/hooks/layout/layoutUtils"
+
+describe("manuscriptCharPosition", () => {
+  describe("横書き (vertical=false)", () => {
+    const columns = 4
+    const rows = 3
+
+    it("0文字目は左上 (col=0, row=0)", () => {
+      expect(manuscriptCharPosition(0, columns, rows, false)).toEqual({
+        col: 0,
+        row: 0,
+      })
+    })
+
+    it("1行を埋めると次の文字は2行目の先頭へ折り返す", () => {
+      expect(manuscriptCharPosition(columns, columns, rows, false)).toEqual({
+        col: 0,
+        row: 1,
+      })
+    })
+
+    it("行内は左→右に進む", () => {
+      expect(manuscriptCharPosition(2, columns, rows, false)).toEqual({
+        col: 2,
+        row: 0,
+      })
+    })
+
+    it("マス数を超えると null", () => {
+      expect(
+        manuscriptCharPosition(columns * rows, columns, rows, false)
+      ).toBeNull()
+    })
+  })
+
+  describe("縦書き (vertical=true)", () => {
+    const columns = 4
+    const rows = 3
+
+    it("0文字目は右上 (col=columns-1, row=0)", () => {
+      expect(manuscriptCharPosition(0, columns, rows, true)).toEqual({
+        col: columns - 1,
+        row: 0,
+      })
+    })
+
+    it("1列を埋めると次の文字は左隣の列の先頭へ", () => {
+      expect(manuscriptCharPosition(rows, columns, rows, true)).toEqual({
+        col: columns - 2,
+        row: 0,
+      })
+    })
+
+    it("列内は上→下に進む", () => {
+      expect(manuscriptCharPosition(1, columns, rows, true)).toEqual({
+        col: columns - 1,
+        row: 1,
+      })
+    })
+
+    it("最後のマスは左下 (col=0, row=rows-1)", () => {
+      expect(
+        manuscriptCharPosition(columns * rows - 1, columns, rows, true)
+      ).toEqual({ col: 0, row: rows - 1 })
+    })
+
+    it("マス数を超えると null", () => {
+      expect(
+        manuscriptCharPosition(columns * rows, columns, rows, true)
+      ).toBeNull()
+    })
+  })
+
+  it("横書きと縦書きでマス総数は一致する（全インデックスが非nullの範囲）", () => {
+    const columns = 5
+    const rows = 4
+    const total = columns * rows
+    for (let i = 0; i < total; i++) {
+      expect(manuscriptCharPosition(i, columns, rows, false)).not.toBeNull()
+      expect(manuscriptCharPosition(i, columns, rows, true)).not.toBeNull()
+    }
+    expect(manuscriptCharPosition(total, columns, rows, false)).toBeNull()
+    expect(manuscriptCharPosition(total, columns, rows, true)).toBeNull()
+  })
+})

--- a/__tests__/answer-sheet-builder/verticalGlyph.test.ts
+++ b/__tests__/answer-sheet-builder/verticalGlyph.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { verticalGlyphAdjust } from "@/components/answer-sheet-builder/components/preview/verticalGlyph"
+
+describe("verticalGlyphAdjust", () => {
+  it("通常の漢字・仮名は補正なし", () => {
+    for (const ch of "あ亜A1") {
+      expect(verticalGlyphAdjust(ch)).toEqual({
+        rotate: 0,
+        dxRatio: 0,
+        dyRatio: 0,
+      })
+    }
+  })
+
+  it("カギ括弧・各種括弧は90°回転", () => {
+    for (const ch of "「」『』（）〔〕【】") {
+      expect(verticalGlyphAdjust(ch).rotate).toBe(90)
+    }
+  })
+
+  it("長音符・ダッシュ類は90°回転", () => {
+    for (const ch of "ー〜…—") {
+      expect(verticalGlyphAdjust(ch).rotate).toBe(90)
+    }
+  })
+
+  it("拗促音（小書き仮名）は右上寄せ（回転なし）", () => {
+    for (const ch of "ゃゅょっぁゥ") {
+      const adj = verticalGlyphAdjust(ch)
+      expect(adj.rotate).toBe(0)
+      expect(adj.dxRatio).toBeGreaterThan(0) // 右へ
+      expect(adj.dyRatio).toBeLessThan(0) // 上へ
+    }
+  })
+
+  it("句読点は右上寄せ（回転なし）", () => {
+    for (const ch of "、。") {
+      const adj = verticalGlyphAdjust(ch)
+      expect(adj.rotate).toBe(0)
+      expect(adj.dxRatio).toBeGreaterThan(0)
+      expect(adj.dyRatio).toBeLessThan(0)
+    }
+  })
+})

--- a/__tests__/answer-sheet-builder/verticalTransform.test.ts
+++ b/__tests__/answer-sheet-builder/verticalTransform.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest"
+
+import { DEFAULT_SETTINGS } from "@/components/answer-sheet-builder/constants"
+import { computeLayoutFromDefinition } from "@/components/answer-sheet-builder/hooks/layout/computeLayout"
+import {
+  transformLayoutToVertical,
+  transposePoint,
+  transposeRect,
+} from "@/components/answer-sheet-builder/hooks/layout/verticalTransform"
+import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
+import type {
+  ComputedCell,
+  ComputedLayout,
+} from "@/types/answerSheetLayout.types"
+
+// A4縦: 実寸 W=210, H=297（縦組みでも物理用紙は不変）
+const W = 210
+const H = 297
+
+describe("transposePoint", () => {
+  it("論理原点(0,0)は実座標の右上(W,0)へ", () => {
+    expect(transposePoint(0, 0, W)).toEqual({ x: W, y: 0 })
+  })
+
+  it("x'=W-y, y'=x", () => {
+    expect(transposePoint(30, 50, W)).toEqual({ x: W - 50, y: 30 })
+  })
+})
+
+describe("transposeRect", () => {
+  it("矩形は幅高さが入れ替わり、原点は右→左へミラー", () => {
+    expect(transposeRect(10, 20, 30, 40, W)).toEqual({
+      x: W - (20 + 40),
+      y: 10,
+      w: 40,
+      h: 30,
+    })
+  })
+
+  it("面積は保存される", () => {
+    const r = transposeRect(5, 7, 11, 13, W)
+    expect(r.w * r.h).toBe(11 * 13)
+  })
+
+  it("論理ページ右下端の矩形が実座標内に収まる", () => {
+    // 論理ページは幅高さ入れ替え (LW=H, LH=W)。論理の右下隅 (LW, LH)=(297,210)
+    const r = transposeRect(H - 10, W - 10, 10, 10, W)
+    expect(r.x).toBeGreaterThanOrEqual(0)
+    expect(r.y).toBeGreaterThanOrEqual(0)
+    expect(r.x + r.w).toBeLessThanOrEqual(W + 1e-9)
+    expect(r.y + r.h).toBeLessThanOrEqual(H + 1e-9)
+  })
+})
+
+function makeCell(overrides: Partial<ComputedCell> = {}): ComputedCell {
+  return {
+    questionPath: [0, 0],
+    x: 10,
+    y: 20,
+    width: 30,
+    height: 40,
+    normalizedX: 10 / H, // 論理座標は LW=H で正規化されている
+    normalizedY: 20 / W,
+    normalizedW: 30 / H,
+    normalizedH: 40 / W,
+    label: "1-(1)",
+    points: 5,
+    textElements: [],
+    cellType: "answer",
+    pageIndex: 0,
+    ...overrides,
+  }
+}
+
+function makeLayout(cells: ComputedCell[]): ComputedLayout {
+  return {
+    pageWidthMm: H, // 論理ページ幅 = 実高さ
+    pageHeightMm: W,
+    cells,
+    lines: [],
+    numberLabels: [],
+    omrMarkerPositions: [],
+    headerFields: [],
+    overflow: false,
+    contentHeightMm: 100,
+  }
+}
+
+describe("transformLayoutToVertical", () => {
+  it("ページ寸法は実寸 (W,H) に設定される", () => {
+    const out = transformLayoutToVertical(makeLayout([makeCell()]), W, H)
+    expect(out.pageWidthMm).toBe(W)
+    expect(out.pageHeightMm).toBe(H)
+  })
+
+  it("セルの normalized は変換後の実座標で再計算され [0,1] に収まる", () => {
+    const out = transformLayoutToVertical(makeLayout([makeCell()]), W, H)
+    const c = out.cells[0]
+    expect(c.normalizedX).toBeCloseTo(c.x / W)
+    expect(c.normalizedY).toBeCloseTo(c.y / H)
+    expect(c.normalizedW).toBeCloseTo(c.width / W)
+    expect(c.normalizedH).toBeCloseTo(c.height / H)
+    for (const v of [
+      c.normalizedX,
+      c.normalizedY,
+      c.normalizedW,
+      c.normalizedH,
+    ]) {
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it("原稿用紙グリッドは columns↔rows が入れ替わり vertical=true になる", () => {
+    const cell = makeCell({
+      manuscriptGrid: {
+        columns: 20,
+        rows: 5,
+        cellSizeMm: 8,
+        gridX: 10,
+        gridY: 20,
+        gridWidth: 160,
+        gridHeight: 40,
+        vertical: false,
+        charDividerStyle: "dashed",
+        charDividerWidth: 0.2,
+        lineDividerStyle: "solid",
+        lineDividerWidth: 0.2,
+        charGuides: [{ atChar: 80, label: "80" }],
+        guideFontSize: 2.2,
+        guidePosition: "bottom-left",
+      },
+    })
+    const out = transformLayoutToVertical(makeLayout([cell]), W, H)
+    const g = out.cells[0].manuscriptGrid!
+    expect(g.columns).toBe(5)
+    expect(g.rows).toBe(20)
+    expect(g.vertical).toBe(true)
+    expect(g.cellSizeMm).toBe(8)
+    // 矩形の幅高さも入れ替わる
+    expect(g.gridWidth).toBe(40)
+    expect(g.gridHeight).toBe(160)
+    // 罫線スタイル・ガイドは方向セマンティック/atChar基準のため転置不変で素通り
+    expect(g.charDividerStyle).toBe("dashed")
+    expect(g.lineDividerStyle).toBe("solid")
+    expect(g.charGuides).toEqual([{ atChar: 80, label: "80" }])
+    expect(g.guidePosition).toBe("bottom-left")
+  })
+
+  it("OMRマーカーは矩形変換で四隅アンカーが保たれ用紙内に収まる", () => {
+    // 論理ページ右下隅のマーカー（LW=H, LH=W）。size=5, offset=3
+    const size = 5
+    const offset = 3
+    const layout = makeLayout([])
+    layout.omrMarkerPositions = [
+      // 論理: 左上 / 右上 / 左下 / 右下
+      { x: offset, y: offset, size },
+      { x: H - offset - size, y: offset, size },
+      { x: offset, y: W - offset - size, size },
+      { x: H - offset - size, y: W - offset - size, size },
+    ]
+    const out = transformLayoutToVertical(layout, W, H)
+    for (const m of out.omrMarkerPositions) {
+      expect(m.size).toBe(size)
+      expect(m.x).toBeGreaterThanOrEqual(0)
+      expect(m.y).toBeGreaterThanOrEqual(0)
+      expect(m.x + m.size).toBeLessThanOrEqual(W + 1e-9)
+      expect(m.y + m.size).toBeLessThanOrEqual(H + 1e-9)
+    }
+    // 全マーカーが実用紙の四隅（offset余白）に1つずつ配置される
+    const corners = out.omrMarkerPositions
+      .map((m) => `${Math.round(m.x)},${Math.round(m.y)}`)
+      .sort()
+    expect(corners).toEqual(
+      [
+        `${offset},${offset}`,
+        `${offset},${H - offset - size}`,
+        `${W - offset - size},${offset}`,
+        `${W - offset - size},${H - offset - size}`,
+      ].sort()
+    )
+  })
+
+  it("OMRバブルの正規化中心と幅高さが縦組み変換される", () => {
+    const cell = makeCell({
+      omrBubbles: [
+        {
+          normalizedCx: 0.25,
+          normalizedCy: 0.1,
+          normalizedWidth: 0.02,
+          normalizedHeight: 0.032,
+          choiceIndex: 0,
+          label: "ア",
+        },
+      ],
+    })
+    const out = transformLayoutToVertical(makeLayout([cell]), W, H)
+    const b = out.cells[0].omrBubbles![0]
+    expect(b.normalizedCx).toBeCloseTo(1 - 0.1)
+    expect(b.normalizedCy).toBeCloseTo(0.25)
+    expect(b.normalizedWidth).toBeCloseTo(0.032)
+    expect(b.normalizedHeight).toBeCloseTo(0.02)
+  })
+})
+
+describe("computeLayoutFromDefinition の vertical フラグ伝播", () => {
+  function makeDef(
+    vertical: boolean,
+    multiColumn: boolean
+  ): AnswerSheetDefinition {
+    return {
+      id: "d1",
+      name: "t",
+      renderMode: "answer-sheet",
+      settings: {
+        ...DEFAULT_SETTINGS,
+        verticalLayout: vertical,
+        multiColumn: {
+          ...DEFAULT_SETTINGS.multiColumn,
+          enabled: multiColumn,
+          columnCount: 2,
+        },
+      },
+      majorQuestions: [
+        {
+          id: "m1",
+          label: "一",
+          subQuestions: [
+            {
+              id: "s1",
+              label: "(1)",
+              branchQuestions: [],
+              heightMultiplier: 2,
+              points: 5,
+              textElements: [
+                {
+                  id: "t1",
+                  text: "あいう",
+                  fontSize: 6,
+                  horizontalAlign: "center",
+                  verticalAlign: "middle",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  it("縦書き・段組みなしで layout.vertical=true", () => {
+    expect(computeLayoutFromDefinition(makeDef(true, false)).vertical).toBe(
+      true
+    )
+  })
+
+  it("縦書き・段組みありでも layout.vertical=true（委譲経路でも伝播）", () => {
+    expect(computeLayoutFromDefinition(makeDef(true, true)).vertical).toBe(true)
+  })
+
+  it("横書きでは layout.vertical は未設定（falsy）", () => {
+    expect(
+      computeLayoutFromDefinition(makeDef(false, false)).vertical
+    ).toBeFalsy()
+  })
+})

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -263,6 +263,11 @@ export async function saveAsbDefinition(
             manuscriptColumns: sq.manuscriptPaper?.columns ?? 20,
             manuscriptRows: sq.manuscriptPaper?.rows ?? 10,
             manuscriptCellSizeMm: 0, // 廃止: cellHeight / rows から逆算
+            manuscriptCharGuides: sq.manuscriptPaper?.charGuides
+              ? JSON.stringify(sq.manuscriptPaper.charGuides)
+              : null,
+            manuscriptGuideFontSize: sq.manuscriptPaper?.guideFontSize ?? null,
+            manuscriptGuidePosition: sq.manuscriptPaper?.guidePosition ?? null,
             borderStyleTop: sq.borderStyles?.top ?? null,
             borderStyleBottom: sq.borderStyles?.bottom ?? null,
             borderStyleLeft: sq.borderStyles?.left ?? null,

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -25,6 +25,8 @@ import type {
   LineStyle,
   LinkedRegionType,
   MajorQuestion,
+  ManuscriptCharGuide,
+  ManuscriptGuidePosition,
   SubQuestion,
 } from "../../../src/types/answerSheetDefinition.types"
 import type {
@@ -40,6 +42,7 @@ import type { DbDefinitionFull } from "./asbDefinition"
 export type FlatGlobalSettings = {
   paperSize: string
   orientation: string
+  verticalLayout: boolean
   baseRowHeight: number
   numberDisplayMode: string
   marginTop: number
@@ -65,6 +68,10 @@ export type FlatGlobalSettings = {
   borderMajorNumberDividerWidth: number | null
   borderSubNumberDividerWidth: number | null
   borderBranchNumberDividerWidth: number | null
+  borderManuscriptCharDivider: string
+  borderManuscriptLineDivider: string
+  borderManuscriptCharDividerWidth: number | null
+  borderManuscriptLineDividerWidth: number | null
   omrMarkersEnabled: boolean
   omrMarkersSizeMm: number
   omrMarkersOffsetMm: number
@@ -85,6 +92,7 @@ export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
   return {
     paperSize: s.paperSize,
     orientation: s.orientation,
+    verticalLayout: s.verticalLayout ?? false,
     baseRowHeight: s.baseRowHeight,
     numberDisplayMode: s.numberDisplayMode,
     marginTop: s.margins.top,
@@ -112,6 +120,14 @@ export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
     borderSubNumberDividerWidth: s.borderConfig.subNumberDividerWidth ?? null,
     borderBranchNumberDividerWidth:
       s.borderConfig.branchNumberDividerWidth ?? null,
+    borderManuscriptCharDivider:
+      s.borderConfig.manuscriptCharDivider ?? "dashed",
+    borderManuscriptLineDivider:
+      s.borderConfig.manuscriptLineDivider ?? "solid",
+    borderManuscriptCharDividerWidth:
+      s.borderConfig.manuscriptCharDividerWidth ?? null,
+    borderManuscriptLineDividerWidth:
+      s.borderConfig.manuscriptLineDividerWidth ?? null,
     omrMarkersEnabled: s.omrMarkers.enabled,
     omrMarkersSizeMm: s.omrMarkers.sizeMm,
     omrMarkersOffsetMm: s.omrMarkers.offsetMm,
@@ -128,11 +144,35 @@ export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
   }
 }
 
+/** DB の JSON文字列から文字数ガイド配列を復元する（壊れていれば空配列） */
+function parseCharGuides(
+  json: string | null
+): ManuscriptCharGuide[] | undefined {
+  if (!json) return undefined
+  try {
+    const parsed: unknown = JSON.parse(json)
+    if (!Array.isArray(parsed)) return undefined
+    const guides = parsed
+      .filter(
+        (g): g is ManuscriptCharGuide =>
+          typeof g === "object" &&
+          g !== null &&
+          typeof (g as ManuscriptCharGuide).atChar === "number" &&
+          typeof (g as ManuscriptCharGuide).label === "string"
+      )
+      .map((g) => ({ atChar: g.atChar, label: g.label }))
+    return guides.length > 0 ? guides : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** DBフラットカラムから GlobalSettings に復元する */
 function unflattenGlobalSettings(row: AsbDefinition): GlobalSettings {
   return {
     paperSize: row.paperSize as GlobalSettings["paperSize"],
     orientation: row.orientation as GlobalSettings["orientation"],
+    verticalLayout: row.verticalLayout,
     baseRowHeight: row.baseRowHeight,
     numberDisplayMode:
       row.numberDisplayMode as GlobalSettings["numberDisplayMode"],
@@ -166,6 +206,16 @@ function unflattenGlobalSettings(row: AsbDefinition): GlobalSettings {
       majorNumberDividerWidth: row.borderMajorNumberDividerWidth ?? undefined,
       subNumberDividerWidth: row.borderSubNumberDividerWidth ?? undefined,
       branchNumberDividerWidth: row.borderBranchNumberDividerWidth ?? undefined,
+      manuscriptCharDivider:
+        (row.borderManuscriptCharDivider as BorderConfig["manuscriptCharDivider"]) ??
+        undefined,
+      manuscriptLineDivider:
+        (row.borderManuscriptLineDivider as BorderConfig["manuscriptLineDivider"]) ??
+        undefined,
+      manuscriptCharDividerWidth:
+        row.borderManuscriptCharDividerWidth ?? undefined,
+      manuscriptLineDividerWidth:
+        row.borderManuscriptLineDividerWidth ?? undefined,
     } as BorderConfig,
     omrMarkers: {
       enabled: row.omrMarkersEnabled,
@@ -279,6 +329,11 @@ export function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
             enabled: true as const,
             columns: sq.manuscriptColumns,
             rows: sq.manuscriptRows,
+            charGuides: parseCharGuides(sq.manuscriptCharGuides),
+            guideFontSize: sq.manuscriptGuideFontSize ?? undefined,
+            guidePosition:
+              (sq.manuscriptGuidePosition as ManuscriptGuidePosition | null) ??
+              undefined,
           }
         : undefined
       const borderStyles =

--- a/prisma/migrations/20260613124323_asb_manuscript_grid_lines_and_char_guides/migration.sql
+++ b/prisma/migrations/20260613124323_asb_manuscript_grid_lines_and_char_guides/migration.sql
@@ -1,0 +1,71 @@
+-- AlterTable
+ALTER TABLE "AsbSubQuestion" ADD COLUMN "manuscriptCharGuides" TEXT;
+ALTER TABLE "AsbSubQuestion" ADD COLUMN "manuscriptGuideFontSize" REAL;
+ALTER TABLE "AsbSubQuestion" ADD COLUMN "manuscriptGuidePosition" TEXT;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AsbDefinition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL DEFAULT '新しい解答用紙',
+    "renderMode" TEXT NOT NULL DEFAULT 'answer-sheet',
+    "labelPresetMajor" TEXT,
+    "labelPresetSub" TEXT,
+    "labelPresetBranch" TEXT,
+    "paperSize" TEXT NOT NULL DEFAULT 'A4',
+    "orientation" TEXT NOT NULL DEFAULT 'portrait',
+    "verticalLayout" BOOLEAN NOT NULL DEFAULT false,
+    "baseRowHeight" REAL NOT NULL DEFAULT 12,
+    "numberDisplayMode" TEXT NOT NULL DEFAULT 'multirow',
+    "marginTop" REAL NOT NULL DEFAULT 15,
+    "marginBottom" REAL NOT NULL DEFAULT 15,
+    "marginLeft" REAL NOT NULL DEFAULT 10,
+    "marginRight" REAL NOT NULL DEFAULT 10,
+    "colWidthMajorNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthSubNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthBranchNumber" REAL NOT NULL DEFAULT 10,
+    "majorQuestionSpacing" REAL NOT NULL DEFAULT 5,
+    "headerHeight" REAL NOT NULL DEFAULT 0,
+    "borderOuterBorder" TEXT NOT NULL DEFAULT 'solid',
+    "borderMajorDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderMajorNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderOuterBorderWidth" REAL DEFAULT 0.7,
+    "borderMajorDividerWidth" REAL DEFAULT 0.5,
+    "borderSubDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchDividerWidth" REAL DEFAULT 0.3,
+    "borderMajorNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderSubNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchNumberDividerWidth" REAL DEFAULT 0.3,
+    "borderManuscriptCharDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderManuscriptLineDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderManuscriptCharDividerWidth" REAL DEFAULT 0.2,
+    "borderManuscriptLineDividerWidth" REAL DEFAULT 0.2,
+    "omrMarkersEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "omrMarkersSizeMm" REAL NOT NULL DEFAULT 5,
+    "omrMarkersOffsetMm" REAL NOT NULL DEFAULT 3,
+    "fontFamily" TEXT NOT NULL DEFAULT 'Noto Sans JP',
+    "fontDefaultSize" REAL NOT NULL DEFAULT 6,
+    "fontMajorNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontSubNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontBranchNumberSize" REAL NOT NULL DEFAULT 5,
+    "multiColumnEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "multiColumnCount" INTEGER NOT NULL DEFAULT 2,
+    "multiColumnGapMm" REAL NOT NULL DEFAULT 5,
+    "multiColumnDividerLine" TEXT,
+    "multiColumnDividerLineWidth" REAL NOT NULL DEFAULT 0.3,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "AsbDefinition_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_AsbDefinition" ("baseRowHeight", "borderBranchDivider", "borderBranchDividerWidth", "borderBranchNumberDivider", "borderBranchNumberDividerWidth", "borderMajorDivider", "borderMajorDividerWidth", "borderMajorNumberDivider", "borderMajorNumberDividerWidth", "borderOuterBorder", "borderOuterBorderWidth", "borderSubDivider", "borderSubDividerWidth", "borderSubNumberDivider", "borderSubNumberDividerWidth", "colWidthBranchNumber", "colWidthMajorNumber", "colWidthSubNumber", "createdAt", "fontBranchNumberSize", "fontDefaultSize", "fontFamily", "fontMajorNumberSize", "fontSubNumberSize", "headerHeight", "id", "labelPresetBranch", "labelPresetMajor", "labelPresetSub", "majorQuestionSpacing", "marginBottom", "marginLeft", "marginRight", "marginTop", "multiColumnCount", "multiColumnDividerLine", "multiColumnDividerLineWidth", "multiColumnEnabled", "multiColumnGapMm", "name", "numberDisplayMode", "omrMarkersEnabled", "omrMarkersOffsetMm", "omrMarkersSizeMm", "orientation", "paperSize", "renderMode", "updatedAt", "userId", "verticalLayout") SELECT "baseRowHeight", "borderBranchDivider", "borderBranchDividerWidth", "borderBranchNumberDivider", "borderBranchNumberDividerWidth", "borderMajorDivider", "borderMajorDividerWidth", "borderMajorNumberDivider", "borderMajorNumberDividerWidth", "borderOuterBorder", "borderOuterBorderWidth", "borderSubDivider", "borderSubDividerWidth", "borderSubNumberDivider", "borderSubNumberDividerWidth", "colWidthBranchNumber", "colWidthMajorNumber", "colWidthSubNumber", "createdAt", "fontBranchNumberSize", "fontDefaultSize", "fontFamily", "fontMajorNumberSize", "fontSubNumberSize", "headerHeight", "id", "labelPresetBranch", "labelPresetMajor", "labelPresetSub", "majorQuestionSpacing", "marginBottom", "marginLeft", "marginRight", "marginTop", "multiColumnCount", "multiColumnDividerLine", "multiColumnDividerLineWidth", "multiColumnEnabled", "multiColumnGapMm", "name", "numberDisplayMode", "omrMarkersEnabled", "omrMarkersOffsetMm", "omrMarkersSizeMm", "orientation", "paperSize", "renderMode", "updatedAt", "userId", "verticalLayout" FROM "AsbDefinition";
+DROP TABLE "AsbDefinition";
+ALTER TABLE "new_AsbDefinition" RENAME TO "AsbDefinition";
+CREATE INDEX "AsbDefinition_userId_idx" ON "AsbDefinition"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260613160451_asb_definition_vertical_layout/migration.sql
+++ b/prisma/migrations/20260613160451_asb_definition_vertical_layout/migration.sql
@@ -1,0 +1,63 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AsbDefinition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL DEFAULT '新しい解答用紙',
+    "renderMode" TEXT NOT NULL DEFAULT 'answer-sheet',
+    "labelPresetMajor" TEXT,
+    "labelPresetSub" TEXT,
+    "labelPresetBranch" TEXT,
+    "paperSize" TEXT NOT NULL DEFAULT 'A4',
+    "orientation" TEXT NOT NULL DEFAULT 'portrait',
+    "verticalLayout" BOOLEAN NOT NULL DEFAULT false,
+    "baseRowHeight" REAL NOT NULL DEFAULT 12,
+    "numberDisplayMode" TEXT NOT NULL DEFAULT 'multirow',
+    "marginTop" REAL NOT NULL DEFAULT 15,
+    "marginBottom" REAL NOT NULL DEFAULT 15,
+    "marginLeft" REAL NOT NULL DEFAULT 10,
+    "marginRight" REAL NOT NULL DEFAULT 10,
+    "colWidthMajorNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthSubNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthBranchNumber" REAL NOT NULL DEFAULT 10,
+    "majorQuestionSpacing" REAL NOT NULL DEFAULT 5,
+    "headerHeight" REAL NOT NULL DEFAULT 0,
+    "borderOuterBorder" TEXT NOT NULL DEFAULT 'solid',
+    "borderMajorDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderMajorNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderOuterBorderWidth" REAL DEFAULT 0.7,
+    "borderMajorDividerWidth" REAL DEFAULT 0.5,
+    "borderSubDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchDividerWidth" REAL DEFAULT 0.3,
+    "borderMajorNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderSubNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchNumberDividerWidth" REAL DEFAULT 0.3,
+    "omrMarkersEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "omrMarkersSizeMm" REAL NOT NULL DEFAULT 5,
+    "omrMarkersOffsetMm" REAL NOT NULL DEFAULT 3,
+    "fontFamily" TEXT NOT NULL DEFAULT 'Noto Sans JP',
+    "fontDefaultSize" REAL NOT NULL DEFAULT 6,
+    "fontMajorNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontSubNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontBranchNumberSize" REAL NOT NULL DEFAULT 5,
+    "multiColumnEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "multiColumnCount" INTEGER NOT NULL DEFAULT 2,
+    "multiColumnGapMm" REAL NOT NULL DEFAULT 5,
+    "multiColumnDividerLine" TEXT,
+    "multiColumnDividerLineWidth" REAL NOT NULL DEFAULT 0.3,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    CONSTRAINT "AsbDefinition_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_AsbDefinition" ("baseRowHeight", "borderBranchDivider", "borderBranchDividerWidth", "borderBranchNumberDivider", "borderBranchNumberDividerWidth", "borderMajorDivider", "borderMajorDividerWidth", "borderMajorNumberDivider", "borderMajorNumberDividerWidth", "borderOuterBorder", "borderOuterBorderWidth", "borderSubDivider", "borderSubDividerWidth", "borderSubNumberDivider", "borderSubNumberDividerWidth", "colWidthBranchNumber", "colWidthMajorNumber", "colWidthSubNumber", "createdAt", "fontBranchNumberSize", "fontDefaultSize", "fontFamily", "fontMajorNumberSize", "fontSubNumberSize", "headerHeight", "id", "labelPresetBranch", "labelPresetMajor", "labelPresetSub", "majorQuestionSpacing", "marginBottom", "marginLeft", "marginRight", "marginTop", "multiColumnCount", "multiColumnDividerLine", "multiColumnDividerLineWidth", "multiColumnEnabled", "multiColumnGapMm", "name", "numberDisplayMode", "omrMarkersEnabled", "omrMarkersOffsetMm", "omrMarkersSizeMm", "orientation", "paperSize", "renderMode", "updatedAt", "userId") SELECT "baseRowHeight", "borderBranchDivider", "borderBranchDividerWidth", "borderBranchNumberDivider", "borderBranchNumberDividerWidth", "borderMajorDivider", "borderMajorDividerWidth", "borderMajorNumberDivider", "borderMajorNumberDividerWidth", "borderOuterBorder", "borderOuterBorderWidth", "borderSubDivider", "borderSubDividerWidth", "borderSubNumberDivider", "borderSubNumberDividerWidth", "colWidthBranchNumber", "colWidthMajorNumber", "colWidthSubNumber", "createdAt", "fontBranchNumberSize", "fontDefaultSize", "fontFamily", "fontMajorNumberSize", "fontSubNumberSize", "headerHeight", "id", "labelPresetBranch", "labelPresetMajor", "labelPresetSub", "majorQuestionSpacing", "marginBottom", "marginLeft", "marginRight", "marginTop", "multiColumnCount", "multiColumnDividerLine", "multiColumnDividerLineWidth", "multiColumnEnabled", "multiColumnGapMm", "name", "numberDisplayMode", "omrMarkersEnabled", "omrMarkersOffsetMm", "omrMarkersSizeMm", "orientation", "paperSize", "renderMode", "updatedAt", "userId" FROM "AsbDefinition";
+DROP TABLE "AsbDefinition";
+ALTER TABLE "new_AsbDefinition" RENAME TO "AsbDefinition";
+CREATE INDEX "AsbDefinition_userId_idx" ON "AsbDefinition"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -809,6 +809,7 @@ model AsbDefinition {
   // GlobalSettings (フラット化)
   paperSize            String  @default("A4")
   orientation          String  @default("portrait")
+  verticalLayout       Boolean @default(false)
   baseRowHeight        Float   @default(12)
   numberDisplayMode    String  @default("multirow")
   marginTop            Float   @default(15)
@@ -835,6 +836,11 @@ model AsbDefinition {
   borderMajorNumberDividerWidth  Float? @default(0.4)
   borderSubNumberDividerWidth    Float? @default(0.4)
   borderBranchNumberDividerWidth Float? @default(0.3)
+  // 原稿用紙マス目罫線（字間=行方向は破線、行間は実線が既定。色は常に黒）
+  borderManuscriptCharDivider      String  @default("dashed")
+  borderManuscriptLineDivider      String  @default("solid")
+  borderManuscriptCharDividerWidth Float?  @default(0.2)
+  borderManuscriptLineDividerWidth Float?  @default(0.2)
   // OMRMarkers
   omrMarkersEnabled Boolean @default(false)
   omrMarkersSizeMm  Float   @default(5)
@@ -916,6 +922,10 @@ model AsbSubQuestion {
   manuscriptColumns  Int     @default(20)
   manuscriptRows     Int     @default(10)
   manuscriptCellSizeMm Float @default(8)
+  // 文字数ガイド: JSON配列 [{atChar,label}]、表示位置・文字サイズ
+  manuscriptCharGuides    String?
+  manuscriptGuideFontSize Float?
+  manuscriptGuidePosition String?
   // BorderStyles (per-side)
   borderStyleTop    String?
   borderStyleBottom String?

--- a/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -242,6 +242,7 @@ export function AnswerSheetBuilderMainView({
                   majorQuestions={definition.majorQuestions}
                   labelPresets={definition.labelPresets}
                   definitionId={definition.id}
+                  vertical={definition.settings.verticalLayout ?? false}
                   onSetLabelPreset={setLabelPreset}
                   onAddMajor={addMajorQuestion}
                   onUpdateMajor={updateMajorQuestion}
@@ -271,6 +272,7 @@ export function AnswerSheetBuilderMainView({
                 <MultiColumnSettings
                   settings={definition.settings}
                   onUpdate={updateSettings}
+                  vertical={definition.settings.verticalLayout ?? false}
                 />
               </div>
             </ScrollArea>
@@ -285,6 +287,7 @@ export function AnswerSheetBuilderMainView({
                   onUpdate={updateHeaderField}
                   onDelete={deleteHeaderField}
                   onReorder={reorderHeaderFields}
+                  vertical={definition.settings.verticalLayout ?? false}
                 />
               </div>
             </ScrollArea>

--- a/src/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/BranchQuestionForm.tsx
@@ -21,6 +21,8 @@ interface BranchQuestionFormProps {
   onDelete: () => void
   onMoveUp?: () => void
   onMoveDown?: () => void
+  /** 縦書きレイアウトか（高さ/幅ラベルの表示を入れ替える） */
+  vertical?: boolean
 }
 
 export function BranchQuestionForm({
@@ -32,7 +34,11 @@ export function BranchQuestionForm({
   onDelete,
   onMoveUp,
   onMoveDown,
+  vertical = false,
 }: BranchQuestionFormProps) {
+  // 縦書きでは見た目の高さ/幅が入れ替わるためラベルだけ入れ替える（内部値は不変）
+  const heightLabel = vertical ? "幅" : "高さ"
+  const widthLabel = vertical ? "高さ" : "幅"
   const [detailOpen, setDetailOpen] = useState(false)
 
   const hasDetailContent =
@@ -80,9 +86,10 @@ export function BranchQuestionForm({
             </div>
           )}
           <div className="flex items-center gap-0.5 px-1.5">
-            <span className="text-muted-foreground">高さ</span>
+            <span className="text-muted-foreground">{heightLabel}</span>
             <input
               type="number"
+              aria-label={heightLabel}
               className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               value={branch.heightMultiplier}
               min={1}
@@ -98,8 +105,9 @@ export function BranchQuestionForm({
           </div>
           {/* 幅 (layoutWidth) */}
           <div className="flex items-center gap-0.5 px-1.5">
-            <span className="text-muted-foreground">幅</span>
+            <span className="text-muted-foreground">{widthLabel}</span>
             <input
+              aria-label={widthLabel}
               className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
               value={branch.layoutWidth ?? ""}
               onChange={(e) => {
@@ -254,6 +262,7 @@ export function BranchQuestionForm({
           <TextElementEditor
             textElements={branch.textElements}
             onUpdate={(elements) => onUpdate({ textElements: elements })}
+            vertical={vertical}
           />
           <ImageElementEditor
             imageElements={branch.imageElements ?? []}

--- a/src/components/answer-sheet-builder/components/form/GlobalSettingsForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/GlobalSettingsForm.tsx
@@ -35,15 +35,15 @@ export function GlobalSettingsForm({
     <div className="space-y-4">
       <h3 className="text-muted-foreground text-sm font-semibold">用紙設定</h3>
 
-      {/* 用紙サイズ・向き・大問番号表示 */}
-      <div className="grid grid-cols-3 gap-3">
+      {/* 用紙サイズ・向き・大問番号・組み方向（2×2で等幅に統一） */}
+      <div className="grid grid-cols-2 gap-3">
         <div>
           <Label className="text-xs">用紙サイズ</Label>
           <Select
             value={settings.paperSize}
             onValueChange={(v) => onUpdate({ paperSize: v as PaperSize })}
           >
-            <SelectTrigger className="h-8 text-xs">
+            <SelectTrigger className="h-8 w-full text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -61,7 +61,7 @@ export function GlobalSettingsForm({
             value={settings.orientation}
             onValueChange={(v) => onUpdate({ orientation: v as Orientation })}
           >
-            <SelectTrigger className="h-8 text-xs">
+            <SelectTrigger className="h-8 w-full text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -78,7 +78,7 @@ export function GlobalSettingsForm({
               onUpdate({ numberDisplayMode: v as MajorNumberDisplayMode })
             }
           >
-            <SelectTrigger className="h-8 text-xs">
+            <SelectTrigger className="h-8 w-full text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -87,7 +87,32 @@ export function GlobalSettingsForm({
             </SelectContent>
           </Select>
         </div>
+        <div>
+          <Label className="text-xs">書字方向</Label>
+          <Select
+            value={settings.verticalLayout ? "vertical" : "horizontal"}
+            onValueChange={(v) =>
+              onUpdate({ verticalLayout: v === "vertical" })
+            }
+          >
+            <SelectTrigger className="h-8 w-full text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="horizontal">横書き</SelectItem>
+              <SelectItem value="vertical">縦書き（国語向け）</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
+
+      {/* 縦書き時の補足：段組みは上下方向になる */}
+      {settings.verticalLayout && settings.multiColumn.enabled && (
+        <p className="text-muted-foreground text-[10px]">
+          縦書きでは段組みが上下方向（上下{settings.multiColumn.columnCount}
+          段）になります。
+        </p>
+      )}
 
       {/* マージン */}
       <div className="space-y-2">

--- a/src/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
+++ b/src/components/answer-sheet-builder/components/form/HeaderFieldEditor.tsx
@@ -34,6 +34,8 @@ interface HeaderFieldEditorProps {
   onUpdate: (fieldId: string, data: Partial<HeaderFieldDefinition>) => void
   onDelete: (fieldId: string) => void
   onReorder: (fromIndex: number, toIndex: number) => void
+  /** 縦書きレイアウトか（幅/高さラベルの表示を入れ替える） */
+  vertical?: boolean
 }
 
 const TYPE_LABELS: Record<HeaderFieldType, string> = {
@@ -56,7 +58,11 @@ export function HeaderFieldEditor({
   onUpdate,
   onDelete,
   onReorder,
+  vertical = false,
 }: HeaderFieldEditorProps) {
+  // 縦書きでは見た目の幅/高さが入れ替わるためラベルだけ入れ替える（内部値は不変）
+  const widthLabel = vertical ? "高さ" : "幅"
+  const heightLabel = vertical ? "幅" : "高さ"
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -174,19 +180,21 @@ export function HeaderFieldEditor({
               )}
             </div>
 
-            {/* field / label: 幅・高さ */}
+            {/* field / label: 幅・高さ（縦書き時はラベルのみ入れ替え） */}
             {fieldType !== "hfill" && (
               <div className="grid grid-cols-2 gap-2">
                 <SliderWithInput
-                  label="幅"
+                  label={widthLabel}
                   value={field.widthMm}
                   min={10}
-                  max={100}
+                  max={200}
                   step={1}
+                  inputMin={-10000}
+                  inputMax={10000}
                   onChange={(v) => onUpdate(field.id, { widthMm: v })}
                 />
                 <SliderWithInput
-                  label="高さ"
+                  label={heightLabel}
                   value={field.heightMm}
                   min={4}
                   max={20}

--- a/src/components/answer-sheet-builder/components/form/LineStylePicker.tsx
+++ b/src/components/answer-sheet-builder/components/form/LineStylePicker.tsx
@@ -25,6 +25,8 @@ interface BorderField {
   widthKey: keyof BorderConfig
   label: string
   defaultWidth: number
+  /** 値未設定時に選択表示する線種（任意フィールド用） */
+  defaultStyle?: LineStyle
 }
 
 const DIVIDER_FIELDS: BorderField[] = [
@@ -51,6 +53,23 @@ const DIVIDER_FIELDS: BorderField[] = [
     widthKey: "branchDividerWidth",
     label: "枝問",
     defaultWidth: 0.3,
+  },
+]
+
+const MANUSCRIPT_FIELDS: BorderField[] = [
+  {
+    styleKey: "manuscriptCharDivider",
+    widthKey: "manuscriptCharDividerWidth",
+    label: "字間",
+    defaultWidth: 0.2,
+    defaultStyle: "dashed",
+  },
+  {
+    styleKey: "manuscriptLineDivider",
+    widthKey: "manuscriptLineDividerWidth",
+    label: "行間",
+    defaultWidth: 0.2,
+    defaultStyle: "solid",
   },
 ]
 
@@ -192,6 +211,9 @@ function BorderFieldRow({
 }) {
   const width =
     (borderConfig[field.widthKey] as number | undefined) ?? field.defaultWidth
+  const activeStyle =
+    (borderConfig[field.styleKey] as LineStyle | undefined) ??
+    field.defaultStyle
   return (
     <div className="flex min-h-6 items-center gap-2">
       <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
@@ -205,7 +227,7 @@ function BorderFieldRow({
             title={ls.title}
             className={cn(
               "hover:bg-accent flex h-6 w-7 items-center justify-center transition-colors first:rounded-l-md last:rounded-r-md",
-              borderConfig[field.styleKey] === ls.value
+              activeStyle === ls.value
                 ? "bg-accent text-accent-foreground"
                 : "text-muted-foreground"
             )}
@@ -256,6 +278,19 @@ export function LineStylePicker({
       <div className="space-y-1.5">
         <span className="text-muted-foreground text-[10px]">番号列</span>
         {NUMBER_FIELDS.map((field) => (
+          <BorderFieldRow
+            key={field.styleKey}
+            field={field}
+            borderConfig={borderConfig}
+            onUpdate={onUpdate}
+          />
+        ))}
+      </div>
+      <div className="space-y-1.5">
+        <span className="text-muted-foreground text-[10px]">
+          原稿用紙マス目
+        </span>
+        {MANUSCRIPT_FIELDS.map((field) => (
           <BorderFieldRow
             key={field.styleKey}
             field={field}

--- a/src/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/MajorQuestionForm.tsx
@@ -86,6 +86,8 @@ interface MajorQuestionFormProps {
     fromIndex: number,
     toIndex: number
   ) => void
+  /** 縦書きレイアウトか（高さ/幅ラベルの表示を入れ替える） */
+  vertical?: boolean
 }
 
 export function MajorQuestionForm({
@@ -104,6 +106,7 @@ export function MajorQuestionForm({
   onUpdateBranch,
   onDeleteBranch,
   onReorderBranch,
+  vertical = false,
 }: MajorQuestionFormProps) {
   const [isOpen, setIsOpen] = useState(true)
 
@@ -209,6 +212,7 @@ export function MajorQuestionForm({
                   onUpdateBranch={(bi, data) => onUpdateBranch(si, bi, data)}
                   onDeleteBranch={(bi) => onDeleteBranch(si, bi)}
                   onReorderBranch={(from, to) => onReorderBranch(si, from, to)}
+                  vertical={vertical}
                 />
               ))}
             </div>

--- a/src/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
+++ b/src/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
@@ -1,9 +1,29 @@
 "use client"
 
+import { Plus, Trash2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import type { ManuscriptPaperConfig } from "@/types/answerSheetDefinition.types"
+import type {
+  ManuscriptCharGuide,
+  ManuscriptGuidePosition,
+  ManuscriptPaperConfig,
+} from "@/types/answerSheetDefinition.types"
+
+import {
+  DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+  DEFAULT_MANUSCRIPT_GUIDE_POSITION,
+} from "../../constants"
+import { SliderWithInput } from "./SliderWithInput"
 
 interface ManuscriptPaperSettingsProps {
   config: ManuscriptPaperConfig | undefined
@@ -14,6 +34,13 @@ const DEFAULT_CONFIG: ManuscriptPaperConfig = {
   enabled: false,
   columns: 20,
   rows: 10,
+}
+
+const GUIDE_POSITION_LABELS: Record<ManuscriptGuidePosition, string> = {
+  "bottom-left": "左下",
+  "bottom-right": "右下",
+  "top-left": "左上",
+  "top-right": "右上",
 }
 
 export function ManuscriptPaperSettings({
@@ -28,6 +55,39 @@ export function ManuscriptPaperSettings({
 
   const handleChange = (data: Partial<ManuscriptPaperConfig>) => {
     onUpdate({ ...current, ...data })
+  }
+
+  /** 入力値を [min, max] の整数に丸める。空欄・非数値は fallback（0設定によるエラーを防ぐ） */
+  const clampInt = (
+    raw: string,
+    min: number,
+    max: number,
+    fallback: number
+  ): number => {
+    const n = Math.floor(Number(raw))
+    if (!Number.isFinite(n)) return fallback
+    return Math.min(max, Math.max(min, n))
+  }
+
+  const capacity = current.columns * current.rows
+  const guides = current.charGuides ?? []
+
+  const updateGuide = (index: number, data: Partial<ManuscriptCharGuide>) => {
+    handleChange({
+      charGuides: guides.map((g, i) => (i === index ? { ...g, ...data } : g)),
+    })
+  }
+
+  const addGuide = () => {
+    // 既定は用紙容量（末尾マス）を指す。ラベルは数値を初期表示。
+    const atChar = Math.min(capacity, 100)
+    handleChange({
+      charGuides: [...guides, { atChar, label: String(atChar) }],
+    })
+  }
+
+  const removeGuide = (index: number) => {
+    handleChange({ charGuides: guides.filter((_, i) => i !== index) })
   }
 
   return (
@@ -52,11 +112,10 @@ export function ManuscriptPaperSettings({
               min={1}
               max={40}
               onChange={(e) =>
-                handleChange({ columns: Number(e.target.value) })
+                handleChange({
+                  columns: clampInt(e.target.value, 1, 40, current.columns),
+                })
               }
-              onBlur={(e) => {
-                e.target.value = String(Number(e.target.value))
-              }}
             />
           </div>
           <div>
@@ -67,12 +126,117 @@ export function ManuscriptPaperSettings({
               value={current.rows}
               min={1}
               max={20}
-              onChange={(e) => handleChange({ rows: Number(e.target.value) })}
-              onBlur={(e) => {
-                e.target.value = String(Number(e.target.value))
-              }}
+              onChange={(e) =>
+                handleChange({
+                  rows: clampInt(e.target.value, 1, 20, current.rows),
+                })
+              }
             />
           </div>
+        </div>
+      )}
+
+      {current.enabled && (
+        <div className="space-y-2 rounded border p-2">
+          <div className="flex items-center justify-between">
+            <Label className="text-muted-foreground text-[10px]">
+              文字数ガイド
+            </Label>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 text-[10px]"
+              onClick={addGuide}
+            >
+              <Plus className="mr-1 h-3 w-3" />
+              追加
+            </Button>
+          </div>
+
+          {guides.length > 0 && (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label className="text-muted-foreground text-[10px]">
+                  表示位置
+                </Label>
+                <Select
+                  value={
+                    current.guidePosition ?? DEFAULT_MANUSCRIPT_GUIDE_POSITION
+                  }
+                  onValueChange={(v) =>
+                    handleChange({
+                      guidePosition: v as ManuscriptGuidePosition,
+                    })
+                  }
+                >
+                  <SelectTrigger className="h-7 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(GUIDE_POSITION_LABELS).map(
+                      ([value, label]) => (
+                        <SelectItem key={value} value={value}>
+                          {label}
+                        </SelectItem>
+                      )
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-end">
+                <SliderWithInput
+                  label="文字サイズ"
+                  value={
+                    current.guideFontSize ?? DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE
+                  }
+                  min={1}
+                  max={6}
+                  step={0.1}
+                  onChange={(v) => handleChange({ guideFontSize: v })}
+                />
+              </div>
+            </div>
+          )}
+
+          {guides.map((guide, index) => (
+            <div key={index} className="flex items-center gap-1">
+              <Input
+                type="number"
+                className="h-7 w-16 text-xs"
+                value={guide.atChar}
+                min={1}
+                max={capacity}
+                title="先頭からの文字数"
+                onChange={(e) =>
+                  updateGuide(index, {
+                    atChar: clampInt(e.target.value, 1, capacity, guide.atChar),
+                  })
+                }
+              />
+              <span className="text-muted-foreground text-[10px]">字目</span>
+              <Input
+                className="h-7 flex-1 text-xs"
+                value={guide.label}
+                placeholder="表示文字"
+                onChange={(e) => updateGuide(index, { label: e.target.value })}
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-destructive h-6 w-6"
+                onClick={() => removeGuide(index)}
+              >
+                <Trash2 className="h-3 w-3" />
+              </Button>
+            </div>
+          ))}
+
+          {guides.length === 0 && (
+            <p className="text-muted-foreground text-[10px]">
+              「追加」で先頭からの文字数の目印（例: 80,
+              100）をマスに表示できます。
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/src/components/answer-sheet-builder/components/form/MultiColumnSettings.tsx
+++ b/src/components/answer-sheet-builder/components/form/MultiColumnSettings.tsx
@@ -20,11 +20,14 @@ import { SliderWithInput } from "./SliderWithInput"
 interface MultiColumnSettingsProps {
   settings: GlobalSettings
   onUpdate: (settings: Partial<GlobalSettings>) => void
+  /** 縦組みレイアウトか（段が上下方向に分割される旨を案内する） */
+  vertical?: boolean
 }
 
 export function MultiColumnSettings({
   settings,
   onUpdate,
+  vertical = false,
 }: MultiColumnSettingsProps) {
   const mc = settings.multiColumn
 
@@ -44,6 +47,11 @@ export function MultiColumnSettings({
 
       {mc.enabled && (
         <div className="space-y-2 pl-1">
+          {vertical && (
+            <p className="text-muted-foreground text-[10px] leading-snug">
+              縦組みでは段が上下方向に分割されます（例: 2段＝上下2段）。
+            </p>
+          )}
           <div>
             <Label className="text-xs">段数</Label>
             <Select

--- a/src/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
+++ b/src/components/answer-sheet-builder/components/form/QuestionListEditor.tsx
@@ -70,12 +70,15 @@ interface QuestionListEditorProps {
     fromIndex: number,
     toIndex: number
   ) => void
+  /** 縦書きレイアウトか（高さ/幅ラベルの表示を入れ替える） */
+  vertical?: boolean
 }
 
 export function QuestionListEditor({
   majorQuestions,
   labelPresets,
   definitionId,
+  vertical = false,
   onSetLabelPreset,
   onAddMajor,
   onUpdateMajor,
@@ -178,6 +181,7 @@ export function QuestionListEditor({
             majorIndex={mi}
             totalMajorCount={majorQuestions.length}
             definitionId={definitionId}
+            vertical={vertical}
             onUpdate={(data) => onUpdateMajor(mi, data)}
             onDelete={() => onDeleteMajor(mi)}
             onMoveUp={mi > 0 ? () => onReorderMajor(mi, mi - 1) : undefined}

--- a/src/components/answer-sheet-builder/components/form/SliderWithInput.tsx
+++ b/src/components/answer-sheet-builder/components/form/SliderWithInput.tsx
@@ -12,6 +12,10 @@ interface SliderWithInputProps {
   step: number
   /** 表示小数桁数 (デフォルト: step < 1 なら1、それ以外は0) */
   decimals?: number
+  /** 数値入力欄の下限（スライダーとは別。未指定 = min）。負値・-Infinity 可 */
+  inputMin?: number
+  /** 数値入力欄の上限（スライダーとは別。未指定 = max）。Infinity 可 */
+  inputMax?: number
   onChange: (value: number) => void
 }
 
@@ -22,8 +26,13 @@ export function SliderWithInput({
   max,
   step,
   decimals,
+  inputMin,
+  inputMax,
   onChange,
 }: SliderWithInputProps) {
+  // 入力欄の許容範囲はスライダーと独立に設定できる（既定はスライダーと同じ）
+  const lo = inputMin ?? min
+  const hi = inputMax ?? max
   const displayDecimals = decimals ?? (step < 1 ? 1 : 0)
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState("")
@@ -40,11 +49,11 @@ export function SliderWithInput({
     (raw: string) => {
       setEditValue(raw)
       const parsed = parseFloat(raw)
-      if (!isNaN(parsed) && parsed >= min && parsed <= max) {
+      if (!isNaN(parsed) && parsed >= lo && parsed <= hi) {
         onChange(parsed)
       }
     },
-    [min, max, onChange]
+    [lo, hi, onChange]
   )
 
   const startEdit = useCallback(() => {
@@ -72,8 +81,8 @@ export function SliderWithInput({
           aria-label={label}
           className="border-input bg-background box-border h-5 w-10 shrink-0 rounded border text-center text-[10px] outline-none"
           value={editValue}
-          min={min}
-          max={max}
+          min={Number.isFinite(lo) ? lo : undefined}
+          max={Number.isFinite(hi) ? hi : undefined}
           step={step}
           onChange={(e) => handleChange(e.target.value)}
           onBlur={() => setEditing(false)}

--- a/src/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/SubQuestionForm.tsx
@@ -79,6 +79,8 @@ interface SubQuestionFormProps {
   onUpdateBranch: (branchIndex: number, data: Partial<BranchQuestion>) => void
   onDeleteBranch: (branchIndex: number) => void
   onReorderBranch: (fromIndex: number, toIndex: number) => void
+  /** 縦書きレイアウトか（高さ/幅ラベルの表示を入れ替える） */
+  vertical?: boolean
 }
 
 export function SubQuestionForm({
@@ -93,9 +95,13 @@ export function SubQuestionForm({
   onUpdateBranch,
   onDeleteBranch,
   onReorderBranch,
+  vertical = false,
 }: SubQuestionFormProps) {
   const hasBranches = sub.branchQuestions.length > 0
   const [detailOpen, setDetailOpen] = useState(false)
+  // 縦書きでは見た目の高さ/幅が入れ替わるためラベルだけ入れ替える（内部値は不変）
+  const heightLabel = vertical ? "幅" : "高さ"
+  const widthLabel = vertical ? "高さ" : "幅"
 
   const hasDetailContent =
     sub.textElements.length > 0 ||
@@ -151,13 +157,13 @@ export function SubQuestionForm({
               />
             </div>
           )}
-          {/* 高さ: 枝問なしの時のみ */}
+          {/* 高さ: 枝問なしの時のみ（縦書き時はラベルを「幅」に） */}
           {!hasBranches && (
             <div className="flex items-center gap-0.5 px-1.5">
-              <span className="text-muted-foreground">高さ</span>
+              <span className="text-muted-foreground">{heightLabel}</span>
               <input
                 type="number"
-                aria-label="高さ"
+                aria-label={heightLabel}
                 className="focus:bg-accent/50 w-9 [appearance:textfield] bg-transparent px-0.5 text-center outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                 value={sub.heightMultiplier}
                 min={1}
@@ -172,11 +178,12 @@ export function SubQuestionForm({
               />
             </div>
           )}
-          {/* 幅 (layoutWidth) - 原稿用紙有効時は列数から自動計算のため非表示 */}
+          {/* 幅 (layoutWidth) - 原稿用紙有効時は列数から自動計算のため非表示。縦書き時はラベルを「高さ」に */}
           {!isManuscriptPaper && (
             <div className="flex items-center gap-0.5 px-1.5">
-              <span className="text-muted-foreground">幅</span>
+              <span className="text-muted-foreground">{widthLabel}</span>
               <input
+                aria-label={widthLabel}
                 className="focus:bg-accent/50 w-10 bg-transparent px-0.5 text-center outline-none"
                 value={sub.layoutWidth ?? ""}
                 onChange={(e) => {
@@ -192,7 +199,6 @@ export function SubQuestionForm({
                   }
                 }}
                 placeholder="—"
-                aria-label="幅"
               />
             </div>
           )}
@@ -360,6 +366,7 @@ export function SubQuestionForm({
           <TextElementEditor
             textElements={sub.textElements}
             onUpdate={(elements) => onUpdate({ textElements: elements })}
+            vertical={vertical}
           />
           <ImageElementEditor
             imageElements={sub.imageElements ?? []}
@@ -404,6 +411,7 @@ export function SubQuestionForm({
                   ? () => onReorderBranch(bi, bi + 1)
                   : undefined
               }
+              vertical={vertical}
             />
           ))}
         </div>

--- a/src/components/answer-sheet-builder/components/form/TextElementEditor.tsx
+++ b/src/components/answer-sheet-builder/components/form/TextElementEditor.tsx
@@ -47,9 +47,23 @@ const V_ALIGN_TITLE: Record<VerticalAlign, string> = {
   bottom: "下揃え",
 }
 
+// 縦書き時のタイトル（軸が入れ替わるため表示文言も入れ替える。内部の編集対象プロパティは不変）
+const H_ALIGN_TITLE_VERTICAL: Record<HorizontalAlign, string> = {
+  left: "上揃え",
+  center: "中央",
+  right: "下揃え",
+}
+const V_ALIGN_TITLE_VERTICAL: Record<VerticalAlign, string> = {
+  top: "右揃え",
+  middle: "中央",
+  bottom: "左揃え",
+}
+
 interface TextElementEditorProps {
   textElements: CellTextElement[]
   onUpdate: (elements: CellTextElement[]) => void
+  /** 縦書きレイアウトか（揃えコントロールの左右↔上下を入れ替え、アイコンを90°回転） */
+  vertical?: boolean
 }
 
 function createDefaultTextElement(): CellTextElement {
@@ -69,6 +83,7 @@ function createDefaultTextElement(): CellTextElement {
 export function TextElementEditor({
   textElements,
   onUpdate,
+  vertical = false,
 }: TextElementEditorProps) {
   const handleAdd = () => {
     onUpdate([...textElements, createDefaultTextElement()])
@@ -143,7 +158,8 @@ export function TextElementEditor({
               values={H_ALIGNS}
               current={el.horizontalAlign}
               icons={H_ALIGN_ICON}
-              titles={H_ALIGN_TITLE}
+              titles={vertical ? H_ALIGN_TITLE_VERTICAL : H_ALIGN_TITLE}
+              rotate={vertical}
               onChange={(v) => handleChange(i, { horizontalAlign: v })}
             />
 
@@ -151,7 +167,8 @@ export function TextElementEditor({
               values={V_ALIGNS}
               current={el.verticalAlign}
               icons={V_ALIGN_ICON}
-              titles={V_ALIGN_TITLE}
+              titles={vertical ? V_ALIGN_TITLE_VERTICAL : V_ALIGN_TITLE}
+              rotate={vertical}
               onChange={(v) => handleChange(i, { verticalAlign: v })}
             />
           </div>
@@ -173,12 +190,15 @@ function CycleButton<T extends string>({
   current,
   icons,
   titles,
+  rotate = false,
   onChange,
 }: {
   values: T[]
   current: T
   icons: Record<T, LucideIcon>
   titles: Record<T, string>
+  /** 縦書き時にアイコンを90°回転する */
+  rotate?: boolean
   onChange: (v: T) => void
 }) {
   const idx = values.indexOf(current)
@@ -197,7 +217,7 @@ function CycleButton<T extends string>({
       onClick={handleClick}
       title={titles[current]}
     >
-      <Icon className="h-3.5 w-3.5" />
+      <Icon className={rotate ? "h-3.5 w-3.5 rotate-90" : "h-3.5 w-3.5"} />
     </Button>
   )
 }

--- a/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -9,6 +9,7 @@ import type {
   DragInfo,
 } from "@/types/answerSheetLayout.types"
 
+import { manuscriptCharPosition } from "../../hooks/layout/layoutUtils"
 import {
   getDashProps,
   isDragInfoEqual,
@@ -16,6 +17,7 @@ import {
   renderSegmentsHtmlForPrint,
   renderSegmentsTspan,
 } from "./svgRenderUtils"
+import { verticalGlyphAdjust } from "./verticalGlyph"
 
 interface AnswerSheetSVGRendererProps {
   layout: ComputedLayout
@@ -51,6 +53,8 @@ export function AnswerSheetSVGRenderer({
   const omrMarkerPositions =
     pageLayout?.omrMarkerPositions ?? layout.omrMarkerPositions
   const headerFields = pageLayout?.headerFields ?? layout.headerFields
+  // 縦書きレイアウトか（テキストの描画方向に使う）
+  const vertical = (pageLayout ?? layout).vertical ?? false
 
   return (
     <>
@@ -76,12 +80,42 @@ export function AnswerSheetSVGRenderer({
 
         // label タイプ: ボックスなしのテキスト表示
         if (field.type === "label") {
+          const fLabelSize = field.fontSize ?? 5
+          // 縦書き: foreignObject + writing-mode（番号ラベルと同方式）
+          if (vertical) {
+            return (
+              <foreignObject
+                key={`hf-${field.fieldId}`}
+                x={field.x}
+                y={field.y}
+                width={field.width}
+                height={field.height}
+              >
+                <div
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    writingMode: "vertical-rl",
+                    fontSize: `${fLabelSize}px`,
+                    fontFamily: "'Noto Sans JP', sans-serif",
+                    color: "#333",
+                    lineHeight: 1,
+                  }}
+                >
+                  {field.label}
+                </div>
+              </foreignObject>
+            )
+          }
           return (
             <text
               key={`hf-${field.fieldId}`}
               x={field.x + field.width / 2}
               y={field.y + field.height / 2}
-              fontSize={field.fontSize ?? 5}
+              fontSize={fLabelSize}
               fontFamily="'Noto Sans JP', sans-serif"
               textAnchor="middle"
               dominantBaseline="central"
@@ -186,7 +220,7 @@ export function AnswerSheetSVGRenderer({
         )
       })}
 
-      {/* 番号ラベル */}
+      {/* 番号ラベル（横書き） */}
       {numberLabels.map((label, i) => (
         <text
           key={`label-${i}`}
@@ -223,16 +257,32 @@ export function AnswerSheetSVGRenderer({
             }
             return chars
               .map(({ char, seg }, ci) => {
-                const col = ci % g.columns
-                const row = Math.floor(ci / g.columns)
-                if (row >= g.rows) return null
-                const cx = g.gridX + col * g.cellSizeMm + g.cellSizeMm / 2
-                const cy = g.gridY + row * g.cellSizeMm + g.cellSizeMm / 2
+                const pos = manuscriptCharPosition(
+                  ci,
+                  g.columns,
+                  g.rows,
+                  g.vertical
+                )
+                if (!pos) return null
+                const { col, row } = pos
+                const cellCx = g.gridX + col * g.cellSizeMm + g.cellSizeMm / 2
+                const cellCy = g.gridY + row * g.cellSizeMm + g.cellSizeMm / 2
+                // 縦書きのみ約物の回転・右上寄せを適用
+                const adj = g.vertical
+                  ? verticalGlyphAdjust(char)
+                  : { rotate: 0, dxRatio: 0, dyRatio: 0 }
+                const cx = cellCx + adj.dxRatio * g.cellSizeMm
+                const cy = cellCy + adj.dyRatio * g.cellSizeMm
                 return (
                   <text
                     key={`mc-${cellIdx}-${cell.label}-${ci}`}
                     x={cx}
                     y={cy}
+                    transform={
+                      adj.rotate
+                        ? `rotate(${adj.rotate} ${cx} ${cy})`
+                        : undefined
+                    }
                     fontSize={fontSize}
                     fontFamily="'Noto Sans JP', sans-serif"
                     textAnchor="middle"
@@ -268,6 +318,41 @@ export function AnswerSheetSVGRenderer({
             const segments = parseInlineMarkup(te.text)
             const hasMath = segments.some((s) => s.math)
             const hasNewline = te.text.includes("\n")
+
+            // 縦書き: foreignObject + writing-mode:vertical-rl 方式（デバッグで縦書き実証済み）。
+            // インラインマークアップ（太字/斜体/模範解答色）も renderSegmentsHtml で保持する。
+            // 括弧回転・拗促音/句読点はブラウザの縦書きエンジンが処理する。
+            if (vertical) {
+              return (
+                <foreignObject
+                  key={`te-${cellIdx}-${cell.label}-${ti}`}
+                  x={cell.x + 1}
+                  y={cell.y + 1}
+                  width={cell.width - 2}
+                  height={cell.height - 2}
+                >
+                  <div
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      writingMode: "vertical-rl",
+                      fontSize: `${te.fontSize}px`,
+                      fontFamily: "'Noto Sans JP', sans-serif",
+                      color: "#000",
+                      lineHeight: 1,
+                      whiteSpace: "pre-wrap",
+                    }}
+                  >
+                    {forPrint
+                      ? renderSegmentsHtmlForPrint(segments, renderMode)
+                      : renderSegmentsHtml(segments, renderMode, te.fontSize)}
+                  </div>
+                </foreignObject>
+              )
+            }
 
             // foreignObject: 数式 or 改行テキスト
             if (hasMath || hasNewline) {
@@ -468,6 +553,12 @@ export function AnswerSheetSVGRenderer({
         .filter((c) => c.cellType === "answer" && c.manuscriptGrid)
         .map((cell, cellIdx) => {
           const g = cell.manuscriptGrid!
+          // 縦線(col)/横線(row)への線種割当は書字方向で決まる。
+          // 行方向（字間）= 縦書きなら横線・横書きなら縦線。輪転印刷でかすれぬよう黒。
+          const colStyle = g.vertical ? g.lineDividerStyle : g.charDividerStyle
+          const colWidth = g.vertical ? g.lineDividerWidth : g.charDividerWidth
+          const rowStyle = g.vertical ? g.charDividerStyle : g.lineDividerStyle
+          const rowWidth = g.vertical ? g.charDividerWidth : g.lineDividerWidth
           const gridLines: React.ReactNode[] = []
           for (let col = 1; col < g.columns; col++) {
             const x = g.gridX + col * g.cellSizeMm
@@ -478,8 +569,9 @@ export function AnswerSheetSVGRenderer({
                 y1={g.gridY}
                 x2={x}
                 y2={g.gridY + g.gridHeight}
-                stroke="#ccc"
-                strokeWidth={0.2}
+                stroke="#000"
+                strokeWidth={colWidth}
+                {...getDashProps(colStyle, colWidth, g.gridHeight)}
               />
             )
           }
@@ -492,12 +584,51 @@ export function AnswerSheetSVGRenderer({
                 y1={y}
                 x2={g.gridX + g.gridWidth}
                 y2={y}
-                stroke="#ccc"
-                strokeWidth={0.2}
+                stroke="#000"
+                strokeWidth={rowWidth}
+                {...getDashProps(rowStyle, rowWidth, g.gridWidth)}
               />
             )
           }
-          return <g key={`mg-${cellIdx}-${cell.label}`}>{gridLines}</g>
+          // 文字数ガイド: 先頭からN文字目のマスの隅に小さく番号を表示
+          const guides: React.ReactNode[] = []
+          const pad = g.cellSizeMm * 0.12
+          for (let gi = 0; gi < g.charGuides.length; gi++) {
+            const guide = g.charGuides[gi]
+            const pos = manuscriptCharPosition(
+              guide.atChar - 1,
+              g.columns,
+              g.rows,
+              g.vertical
+            )
+            if (!pos) continue
+            const cellX0 = g.gridX + pos.col * g.cellSizeMm
+            const cellY0 = g.gridY + pos.row * g.cellSizeMm
+            const left = g.guidePosition.endsWith("left")
+            const top = g.guidePosition.startsWith("top")
+            const gx = left ? cellX0 + pad : cellX0 + g.cellSizeMm - pad
+            const gy = top ? cellY0 + pad : cellY0 + g.cellSizeMm - pad
+            guides.push(
+              <text
+                key={`mguide-${cellIdx}-${cell.label}-${gi}`}
+                x={gx}
+                y={gy}
+                fontSize={g.guideFontSize}
+                fontFamily="'Noto Sans JP', sans-serif"
+                textAnchor={left ? "start" : "end"}
+                dominantBaseline={top ? "hanging" : "alphabetic"}
+                fill="#000"
+              >
+                {guide.label}
+              </text>
+            )
+          }
+          return (
+            <g key={`mg-${cellIdx}-${cell.label}`}>
+              {gridLines}
+              {guides}
+            </g>
+          )
         })}
 
       {/* 溢れ警告（単一ページモード時のみ表示） */}

--- a/src/components/answer-sheet-builder/components/preview/verticalGlyph.ts
+++ b/src/components/answer-sheet-builder/components/preview/verticalGlyph.ts
@@ -1,0 +1,49 @@
+/**
+ * 縦書き原稿用紙のマス内字形調整
+ *
+ * 縦書きでは約物の見た目が横書きと異なるため、文字ごとに回転・位置を補正する。
+ * 原稿用紙は「1文字=1マス中心配置」なので、マス中心 (cx,cy) に対する
+ * 回転角度とオフセット比（セルサイズに対する割合）を返す純関数で表現する。
+ *
+ * - 90°回転: 長音符・各種括弧・ダッシュ類（横長グリフを縦向きにする）
+ * - 右上寄せ: 拗促音（小書き仮名）と句読点（縦書きではマス右上に置く）
+ */
+
+export interface VerticalGlyphAdjust {
+  /** 回転角度（度・時計回り）。0なら回転なし */
+  rotate: number
+  /** マス中心からのXオフセット（cellSizeMm に対する比） */
+  dxRatio: number
+  /** マス中心からのYオフセット（cellSizeMm に対する比） */
+  dyRatio: number
+}
+
+const NO_ADJUST: VerticalGlyphAdjust = { rotate: 0, dxRatio: 0, dyRatio: 0 }
+
+/** 縦書きで90°回転させる文字（長音符・括弧・ダッシュ類） */
+const ROTATE_CHARS = new Set([
+  ..."ー〜～…‥—―‐ｰ",
+  ..."（）「」『』〔〕［］｛｝〈〉《》【】｜",
+  ..."()[]{}<>",
+])
+
+/** 縦書きでマス右上に寄せる句読点 */
+const TOP_RIGHT_PUNCT = new Set([..."、。，．"])
+
+/** 縦書きでマス右上に寄せる小書き仮名（拗促音） */
+const SMALL_KANA = new Set([
+  ..."ぁぃぅぇぉっゃゅょゎゕゖ",
+  ..."ァィゥェォッャュョヮヵヶ",
+])
+
+/**
+ * 縦書きでの字形補正を返す。横書き時は常に NO_ADJUST を使うこと（呼び出し側で分岐）。
+ */
+export function verticalGlyphAdjust(char: string): VerticalGlyphAdjust {
+  if (ROTATE_CHARS.has(char)) return { rotate: 90, dxRatio: 0, dyRatio: 0 }
+  // 句読点は日本語縦書きのためマス右上へ（中国語のような中央下ではない）
+  if (TOP_RIGHT_PUNCT.has(char))
+    return { rotate: 0, dxRatio: 0.4, dyRatio: -0.4 }
+  if (SMALL_KANA.has(char)) return { rotate: 0, dxRatio: 0.18, dyRatio: -0.18 }
+  return NO_ADJUST
+}

--- a/src/components/answer-sheet-builder/constants.ts
+++ b/src/components/answer-sheet-builder/constants.ts
@@ -3,10 +3,28 @@ import type {
   BranchQuestion,
   GlobalSettings,
   HeaderFieldDefinition,
+  LineStyle,
   MajorQuestion,
+  ManuscriptGuidePosition,
   PaperSize,
   SubQuestion,
 } from "@/types/answerSheetDefinition.types"
+
+// =====================
+// 原稿用紙の既定値
+// =====================
+
+/** 行方向（字間）の罫線は破線が一般的 */
+export const DEFAULT_MANUSCRIPT_CHAR_DIVIDER: LineStyle = "dashed"
+/** 行間（行の区切り）の罫線は実線 */
+export const DEFAULT_MANUSCRIPT_LINE_DIVIDER: LineStyle = "solid"
+/** 原稿用紙マス罫線の太さ（mm）。輪転印刷でかすれないよう黒・実用太さ */
+export const DEFAULT_MANUSCRIPT_DIVIDER_WIDTH = 0.2
+/** 文字数ガイドの既定文字サイズ（mm） */
+export const DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE = 2.2
+/** 文字数ガイドの既定表示位置（左下が一般的） */
+export const DEFAULT_MANUSCRIPT_GUIDE_POSITION: ManuscriptGuidePosition =
+  "bottom-left"
 
 // =====================
 // 用紙サイズ定数（mm）
@@ -30,6 +48,7 @@ export const MM_TO_PT = 2.835
 export const DEFAULT_SETTINGS: GlobalSettings = {
   paperSize: "A4",
   orientation: "portrait",
+  verticalLayout: false,
   margins: { top: 15, bottom: 15, left: 10, right: 10 },
   baseRowHeight: 12,
   columnWidths: { majorNumber: 10, subNumber: 10, branchNumber: 10 },
@@ -49,6 +68,10 @@ export const DEFAULT_SETTINGS: GlobalSettings = {
     majorNumberDividerWidth: 0.4,
     subNumberDividerWidth: 0.4,
     branchNumberDividerWidth: 0.3,
+    manuscriptCharDivider: DEFAULT_MANUSCRIPT_CHAR_DIVIDER,
+    manuscriptLineDivider: DEFAULT_MANUSCRIPT_LINE_DIVIDER,
+    manuscriptCharDividerWidth: DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
+    manuscriptLineDividerWidth: DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
   },
   omrMarkers: { enabled: false, sizeMm: 5, offsetMm: 6 },
   fonts: {

--- a/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
@@ -4,7 +4,10 @@
  * ComputedCell の生成・原稿用紙グリッド計算・OMRバブル/数字欄の座標計算を行う。
  */
 
-import type { SubQuestion } from "@/types/answerSheetDefinition.types"
+import type {
+  BorderConfig,
+  SubQuestion,
+} from "@/types/answerSheetDefinition.types"
 import type {
   ComputedCell,
   ManuscriptGrid,
@@ -15,6 +18,13 @@ import type {
   OMRCellConfig,
 } from "@/types/omr.types"
 
+import {
+  DEFAULT_MANUSCRIPT_CHAR_DIVIDER,
+  DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
+  DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+  DEFAULT_MANUSCRIPT_GUIDE_POSITION,
+  DEFAULT_MANUSCRIPT_LINE_DIVIDER,
+} from "../../constants"
 import {
   buildBranchGridLayout,
   buildSubGridLayout,
@@ -198,10 +208,13 @@ export function computeManuscriptGrid(
   cellX: number,
   cellY: number,
   cellWidth: number,
-  cellHeight: number
+  cellHeight: number,
+  borderConfig?: BorderConfig
 ): ManuscriptGrid | undefined {
   if (!sub.manuscriptPaper?.enabled) return undefined
   const { columns, rows } = sub.manuscriptPaper
+  // 0以下はゼロ除算・剰余0でNaNになるため描画しない（防御）
+  if (columns < 1 || rows < 1) return undefined
   const cellSizeMm = cellHeight / rows
   const gridWidth = columns * cellSizeMm
   const gridHeight = rows * cellSizeMm
@@ -213,6 +226,25 @@ export function computeManuscriptGrid(
     gridY: cellY,
     gridWidth,
     gridHeight,
+    // 論理（横組み）座標で計算。縦組みは verticalTransform で後段変換する。
+    vertical: false,
+    // 罫線スタイルはグローバル設定（罫線タブ）から解決。行方向（字間）は破線が既定。
+    charDividerStyle:
+      borderConfig?.manuscriptCharDivider ?? DEFAULT_MANUSCRIPT_CHAR_DIVIDER,
+    charDividerWidth:
+      borderConfig?.manuscriptCharDividerWidth ??
+      DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
+    lineDividerStyle:
+      borderConfig?.manuscriptLineDivider ?? DEFAULT_MANUSCRIPT_LINE_DIVIDER,
+    lineDividerWidth:
+      borderConfig?.manuscriptLineDividerWidth ??
+      DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
+    // 文字数ガイドは小問ごとの設定。
+    charGuides: sub.manuscriptPaper.charGuides ?? [],
+    guideFontSize:
+      sub.manuscriptPaper.guideFontSize ?? DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+    guidePosition:
+      sub.manuscriptPaper.guidePosition ?? DEFAULT_MANUSCRIPT_GUIDE_POSITION,
   }
 }
 

--- a/src/components/answer-sheet-builder/hooks/layout/computeLayout.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/computeLayout.ts
@@ -43,16 +43,18 @@ import {
   renderGridCompletionLines,
   renderGridDividerLines,
 } from "./lineRenderer"
+import { transformLayoutToVertical } from "./verticalTransform"
 
 /** AnswerSheetDefinition から単一ページの ComputedLayout を計算する */
 export function computeLayoutFromDefinition(
   definition: AnswerSheetDefinition
 ): ComputedLayout {
+  const vertical = definition.settings.verticalLayout ?? false
+  const settings = definition.settings
+
   // 段組みが有効な場合はマルチページレイアウトに委譲
-  if (
-    definition.settings.multiColumn.enabled &&
-    definition.settings.multiColumn.columnCount > 1
-  ) {
+  // （縦書きでは論理の左右段が transpose により上下段になる）
+  if (settings.multiColumn.enabled && settings.multiColumn.columnCount > 1) {
     const multiPage = computeMultiPageLayoutFromDefinition(definition)
     const page = multiPage.pages[0]
     if (!page) {
@@ -66,6 +68,7 @@ export function computeLayoutFromDefinition(
         headerFields: [],
         overflow: false,
         contentHeightMm: 0,
+        vertical,
       }
     }
     return {
@@ -78,11 +81,16 @@ export function computeLayoutFromDefinition(
       headerFields: page.headerFields,
       overflow: multiPage.totalPages > 1,
       contentHeightMm: page.contentHeightMm,
+      vertical: page.vertical,
     }
   }
 
-  const { settings, majorQuestions } = definition
-  const paper = getPaperDimensions(settings)
+  const { majorQuestions } = definition
+  // 縦組みは「幅高さを入れ替えた論理ページ」で計算し、最終段で transpose して実寸へ写す
+  const realPaper = getPaperDimensions(settings)
+  const paper = vertical
+    ? { width: realPaper.height, height: realPaper.width }
+    : realPaper
   const { margins, baseRowHeight, columnWidths, spacing } = settings
 
   const contentLeft = margins.left
@@ -249,7 +257,14 @@ export function computeLayoutFromDefinition(
               sub.textElements,
               "answer",
               0,
-              computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
+              computeManuscriptGrid(
+                sub,
+                ansX,
+                cellY,
+                ansW,
+                cellHeight,
+                settings.borderConfig
+              ),
               sub.omrConfig,
               sub.imageElements
             )
@@ -485,7 +500,8 @@ export function computeLayoutFromDefinition(
                 effAnswerX,
                 subStartY,
                 ansW,
-                subHeight
+                subHeight,
+                settings.borderConfig
               ),
               sub.omrConfig,
               sub.imageElements
@@ -828,7 +844,7 @@ export function computeLayoutFromDefinition(
   // OMRマーカー
   const omrMarkerPositions = computeOMRMarkers(settings, paper)
 
-  return {
+  const layout: ComputedLayout = {
     pageWidthMm: paper.width,
     pageHeightMm: paper.height,
     cells,
@@ -839,4 +855,8 @@ export function computeLayoutFromDefinition(
     overflow: contentBottom > paper.height - margins.bottom,
     contentHeightMm: contentBottom - margins.top,
   }
+
+  return vertical
+    ? transformLayoutToVertical(layout, realPaper.width, realPaper.height)
+    : layout
 }

--- a/src/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -46,6 +46,7 @@ import {
   renderGridCompletionLines,
   renderGridDividerLines,
 } from "./lineRenderer"
+import { transformPageToVertical } from "./verticalTransform"
 
 /** 段組みの各段の座標範囲 */
 interface ColBounds {
@@ -60,8 +61,14 @@ interface ColBounds {
 export function computeMultiPageLayoutFromDefinition(
   definition: AnswerSheetDefinition
 ): ComputedMultiPageLayout {
+  // 縦書きでは論理（横組み）の左右段が、最終段の transpose により上下段になる
+  const vertical = definition.settings.verticalLayout ?? false
   const { settings, majorQuestions } = definition
-  const paper = getPaperDimensions(settings)
+  // 縦組みは「幅高さを入れ替えた論理ページ」で計算し、最終段で transpose して実寸へ写す
+  const realPaper = getPaperDimensions(settings)
+  const paper = vertical
+    ? { width: realPaper.height, height: realPaper.width }
+    : realPaper
   const { margins, baseRowHeight, columnWidths, spacing } = settings
 
   const contentLeft = margins.left
@@ -293,7 +300,14 @@ export function computeMultiPageLayoutFromDefinition(
               sub.textElements,
               "answer",
               pageIdx,
-              computeManuscriptGrid(sub, ansX, cellY, ansW, cellHeight),
+              computeManuscriptGrid(
+                sub,
+                ansX,
+                cellY,
+                ansW,
+                cellHeight,
+                settings.borderConfig
+              ),
               sub.omrConfig,
               sub.imageElements
             )
@@ -565,7 +579,8 @@ export function computeMultiPageLayoutFromDefinition(
                 effAnswerX,
                 subStartY,
                 ansW,
-                subHeight
+                subHeight,
+                settings.borderConfig
               ),
               sub.omrConfig,
               sub.imageElements
@@ -937,6 +952,17 @@ export function computeMultiPageLayoutFromDefinition(
       contentHeightMm: pageContentBottom - margins.top,
     }
   })
+
+  if (vertical) {
+    return {
+      pages: pages.map((p) =>
+        transformPageToVertical(p, realPaper.width, realPaper.height)
+      ),
+      totalPages: pages.length,
+      pageWidthMm: realPaper.width,
+      pageHeightMm: realPaper.height,
+    }
+  }
 
   return {
     pages,

--- a/src/components/answer-sheet-builder/hooks/layout/layoutUtils.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/layoutUtils.ts
@@ -67,6 +67,34 @@ export function clipRangeToMajorLayouts(
   return result.length > 0 ? result : [range]
 }
 
+/**
+ * 原稿用紙でN文字目（0-indexed）が入るマス位置 (col, row) を返す。
+ * グリッド外（マス数を超える）の場合は null。
+ *
+ * - 横書き: 左→右、行は上→下。 col = i % columns, row = floor(i / columns)
+ * - 縦書き: 上→下、列は右→左。 row = i % rows, col = (columns-1) - floor(i / rows)
+ *
+ * col/row はいずれも 0-indexed。cx/cy 中心座標の計算式は方向に依らず共通
+ * （gridX + col*cellSize + cellSize/2 等）。
+ */
+export function manuscriptCharPosition(
+  index: number,
+  columns: number,
+  rows: number,
+  vertical: boolean
+): { col: number; row: number } | null {
+  if (vertical) {
+    const row = index % rows
+    const colFromRight = Math.floor(index / rows)
+    if (colFromRight >= columns) return null
+    return { col: columns - 1 - colFromRight, row }
+  }
+  const col = index % columns
+  const row = Math.floor(index / columns)
+  if (row >= rows) return null
+  return { col, row }
+}
+
 /** 分数文字列 (e.g. "1/4", "3/4") を 0〜1 の数値に変換 */
 export function parseFraction(s: string): number {
   const m = s.match(/^(\d+)\/(\d+)$/)

--- a/src/components/answer-sheet-builder/hooks/layout/verticalTransform.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/verticalTransform.ts
@@ -1,0 +1,243 @@
+/**
+ * 縦組み（右→左）座標変換
+ *
+ * レイアウト計算は常に「論理（横組み）座標」で行い、用紙全体を縦組みにする場合は
+ * その出力（ComputedLayout / ComputedPageLayout）を本モジュールで一括変換する。
+ *
+ * 変換の定義（論理座標 → 実座標、実用紙幅 W・高さ H）:
+ *   - 横組みの Y軸（上→下）→ 縦組みの X軸（右→左にミラー）
+ *   - 横組みの X軸（左→右）→ 縦組みの Y軸（上→下）
+ *
+ * 点:  x' = W - y,           y' = x
+ * 矩形: x' = W - (y + h),     y' = x,   w' = h,   h' = w
+ *
+ * 注: 論理座標は「幅と高さを入れ替えた仮想ページ (LW=H, LH=W)」で計算される前提
+ * （呼び出し側で getPaperDimensions の戻りを入れ替えてから compute する）。
+ * これにより論理 x∈[0,LW=H]→実 y∈[0,H]、論理 y∈[0,LH=W]→実 x∈[0,W] に正しく収まる。
+ */
+
+import type {
+  ComputedCell,
+  ComputedHeaderField,
+  ComputedLayout,
+  ComputedLine,
+  ComputedNumberLabel,
+  ComputedOMRMarker,
+  ComputedPageLayout,
+  ManuscriptGrid,
+} from "@/types/answerSheetLayout.types"
+import type { ComputedOMRBubble, ComputedOMRDigitBox } from "@/types/omr.types"
+
+/** 点 (x, y) を縦組み実座標へ変換する */
+export function transposePoint(
+  x: number,
+  y: number,
+  realWidth: number
+): { x: number; y: number } {
+  return { x: realWidth - y, y: x }
+}
+
+/** 矩形 (x, y, w, h) を縦組み実座標へ変換する（幅高さも入れ替わる） */
+export function transposeRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  realWidth: number
+): { x: number; y: number; w: number; h: number } {
+  return { x: realWidth - (y + h), y: x, w: h, h: w }
+}
+
+/**
+ * 原稿用紙グリッドを縦組みへ変換する。
+ *
+ * 矩形（原点・幅高さ）を transpose した上で columns↔rows を入れ替え vertical=true にする。
+ * これによりレンダラの縦書き写像（manuscriptCharPosition）とグリッド線描画が、
+ * 「論理（横組み）レイアウトの transpose」と完全に一致する（数式検証済み）。
+ */
+function transposeManuscriptGrid(
+  g: ManuscriptGrid,
+  realWidth: number
+): ManuscriptGrid {
+  const r = transposeRect(
+    g.gridX,
+    g.gridY,
+    g.gridWidth,
+    g.gridHeight,
+    realWidth
+  )
+  // 罫線スタイルは方向セマンティック（字間／行間）でレンダラが vertical を見て
+  // 行/列ループに割り当てるため転置不要。ガイドは atChar 基準で方向非依存。
+  return {
+    ...g,
+    columns: g.rows,
+    rows: g.columns,
+    gridX: r.x,
+    gridY: r.y,
+    gridWidth: r.w,
+    gridHeight: r.h,
+    vertical: true,
+  }
+}
+
+/** OMRバブル（正規化座標）を縦組みへ変換する。中心は点変換、幅高さは入れ替え */
+function transposeBubble(b: ComputedOMRBubble): ComputedOMRBubble {
+  return {
+    ...b,
+    normalizedCx: 1 - b.normalizedCy,
+    normalizedCy: b.normalizedCx,
+    normalizedWidth: b.normalizedHeight,
+    normalizedHeight: b.normalizedWidth,
+  }
+}
+
+/** OMR数字欄（正規化矩形）を縦組みへ変換する */
+function transposeDigitBox(d: ComputedOMRDigitBox): ComputedOMRDigitBox {
+  return {
+    ...d,
+    normalizedX: 1 - (d.normalizedY + d.normalizedH),
+    normalizedY: d.normalizedX,
+    normalizedW: d.normalizedH,
+    normalizedH: d.normalizedW,
+  }
+}
+
+function transposeCell(
+  cell: ComputedCell,
+  realWidth: number,
+  realHeight: number
+): ComputedCell {
+  const r = transposeRect(cell.x, cell.y, cell.width, cell.height, realWidth)
+  return {
+    ...cell,
+    x: r.x,
+    y: r.y,
+    width: r.w,
+    height: r.h,
+    normalizedX: r.x / realWidth,
+    normalizedY: r.y / realHeight,
+    normalizedW: r.w / realWidth,
+    normalizedH: r.h / realHeight,
+    ...(cell.manuscriptGrid
+      ? {
+          manuscriptGrid: transposeManuscriptGrid(
+            cell.manuscriptGrid,
+            realWidth
+          ),
+        }
+      : {}),
+    ...(cell.omrBubbles
+      ? { omrBubbles: cell.omrBubbles.map(transposeBubble) }
+      : {}),
+    ...(cell.omrDigitBoxes
+      ? { omrDigitBoxes: cell.omrDigitBoxes.map(transposeDigitBox) }
+      : {}),
+  }
+}
+
+function transposeLine(line: ComputedLine, realWidth: number): ComputedLine {
+  const p1 = transposePoint(line.x1, line.y1, realWidth)
+  const p2 = transposePoint(line.x2, line.y2, realWidth)
+  // dragInfo は軸の意味が変わるため縦組みでは破棄（MVPはドラッグ無効）
+  return {
+    x1: p1.x,
+    y1: p1.y,
+    x2: p2.x,
+    y2: p2.y,
+    style: line.style,
+    strokeWidth: line.strokeWidth,
+    lineType: line.lineType,
+  }
+}
+
+function transposeNumberLabel(
+  label: ComputedNumberLabel,
+  realWidth: number
+): ComputedNumberLabel {
+  const r = transposeRect(
+    label.x,
+    label.y,
+    label.width,
+    label.height,
+    realWidth
+  )
+  return { ...label, x: r.x, y: r.y, width: r.w, height: r.h }
+}
+
+function transposeHeaderField(
+  field: ComputedHeaderField,
+  realWidth: number
+): ComputedHeaderField {
+  const r = transposeRect(
+    field.x,
+    field.y,
+    field.width,
+    field.height,
+    realWidth
+  )
+  return { ...field, x: r.x, y: r.y, width: r.w, height: r.h }
+}
+
+function transposeMarker(
+  marker: ComputedOMRMarker,
+  realWidth: number
+): ComputedOMRMarker {
+  // マーカーは size を持つ正方形。点変換だと Y軸ミラーで size 分ずれて
+  // 用紙外や反対側へ飛ぶため、矩形として変換し四隅アンカーを保つ。
+  const r = transposeRect(
+    marker.x,
+    marker.y,
+    marker.size,
+    marker.size,
+    realWidth
+  )
+  return { ...marker, x: r.x, y: r.y }
+}
+
+/** ページ単位の全要素を縦組み実座標へ変換する */
+export function transformPageToVertical(
+  page: ComputedPageLayout,
+  realWidth: number,
+  realHeight: number
+): ComputedPageLayout {
+  return {
+    ...page,
+    vertical: true,
+    cells: page.cells.map((c) => transposeCell(c, realWidth, realHeight)),
+    lines: page.lines.map((l) => transposeLine(l, realWidth)),
+    numberLabels: page.numberLabels.map((n) =>
+      transposeNumberLabel(n, realWidth)
+    ),
+    omrMarkerPositions: page.omrMarkerPositions.map((m) =>
+      transposeMarker(m, realWidth)
+    ),
+    headerFields: page.headerFields.map((h) =>
+      transposeHeaderField(h, realWidth)
+    ),
+  }
+}
+
+/** 単一ページレイアウトの全要素を縦組み実座標へ変換する */
+export function transformLayoutToVertical(
+  layout: ComputedLayout,
+  realWidth: number,
+  realHeight: number
+): ComputedLayout {
+  return {
+    ...layout,
+    vertical: true,
+    pageWidthMm: realWidth,
+    pageHeightMm: realHeight,
+    cells: layout.cells.map((c) => transposeCell(c, realWidth, realHeight)),
+    lines: layout.lines.map((l) => transposeLine(l, realWidth)),
+    numberLabels: layout.numberLabels.map((n) =>
+      transposeNumberLabel(n, realWidth)
+    ),
+    omrMarkerPositions: layout.omrMarkerPositions.map((m) =>
+      transposeMarker(m, realWidth)
+    ),
+    headerFields: layout.headerFields.map((h) =>
+      transposeHeaderField(h, realWidth)
+    ),
+  }
+}

--- a/src/types/answerSheetDefinition.types.ts
+++ b/src/types/answerSheetDefinition.types.ts
@@ -65,10 +65,31 @@ export interface BorderStyles {
 // 原稿用紙設定
 // =====================
 
+/** 文字数ガイドを表示するマスの隅 */
+export type ManuscriptGuidePosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+
+/** 原稿用紙の文字数ガイド（先頭からN文字目のマスに小さく表示する目印） */
+export interface ManuscriptCharGuide {
+  /** 先頭からの文字数（1始まり）。このマスにガイドを表示する */
+  atChar: number
+  /** 表示テキスト（既定は atChar の数値） */
+  label: string
+}
+
 export interface ManuscriptPaperConfig {
   enabled: boolean
   columns: number
   rows: number
+  /** 文字数ガイド（任意マスに先頭からの文字数を小さく表示） */
+  charGuides?: ManuscriptCharGuide[]
+  /** ガイド文字サイズ（mm）。未指定 = 既定 */
+  guideFontSize?: number
+  /** ガイド表示位置（マスの隅）。未指定 = "bottom-left" */
+  guidePosition?: ManuscriptGuidePosition
 }
 
 // =====================
@@ -172,6 +193,12 @@ export interface BorderConfig {
   majorNumberDividerWidth?: number
   subNumberDividerWidth?: number
   branchNumberDividerWidth?: number
+  /** 原稿用紙: 文字を区切る罫線（行方向＝字間）。既定 dashed */
+  manuscriptCharDivider?: LineStyle
+  /** 原稿用紙: 行を区切る罫線（行間）。既定 solid */
+  manuscriptLineDivider?: LineStyle
+  manuscriptCharDividerWidth?: number
+  manuscriptLineDividerWidth?: number
 }
 
 // =====================
@@ -243,6 +270,8 @@ export interface HeaderFieldDefinition {
 export interface GlobalSettings {
   paperSize: PaperSize
   orientation: Orientation
+  /** 用紙全体を縦組み（右→左）にする。未指定 = false（横組み・左→右） */
+  verticalLayout?: boolean
   margins: Margins
   baseRowHeight: number
   columnWidths: ColumnWidths

--- a/src/types/answerSheetLayout.types.ts
+++ b/src/types/answerSheetLayout.types.ts
@@ -11,6 +11,8 @@ import type {
   CellTextElement,
   LineStyle,
   MajorNumberDisplayMode,
+  ManuscriptCharGuide,
+  ManuscriptGuidePosition,
   SubQuestion,
 } from "./answerSheetDefinition.types"
 import type { ComputedOMRBubble, ComputedOMRDigitBox } from "./omr.types"
@@ -47,6 +49,22 @@ export interface ManuscriptGrid {
   gridWidth: number
   /** = rows * cellSizeMm */
   gridHeight: number
+  /** 縦書き（縦組み・右→左）か。false = 横書き */
+  vertical: boolean
+  /** 文字を区切る罫線（行方向＝字間）の線種 */
+  charDividerStyle: LineStyle
+  /** 文字を区切る罫線の太さ（mm） */
+  charDividerWidth: number
+  /** 行を区切る罫線（行間）の線種 */
+  lineDividerStyle: LineStyle
+  /** 行を区切る罫線の太さ（mm） */
+  lineDividerWidth: number
+  /** 文字数ガイド（先頭からN文字目のマスに表示） */
+  charGuides: ManuscriptCharGuide[]
+  /** ガイド文字サイズ（mm） */
+  guideFontSize: number
+  /** ガイド表示位置（マスの隅） */
+  guidePosition: ManuscriptGuidePosition
 }
 
 // =====================
@@ -172,6 +190,8 @@ export interface ComputedLayout {
   overflow: boolean
   /** 使用した高さ（mm） */
   contentHeightMm: number
+  /** 縦書き（縦組み・右→左）レイアウトか。レンダラのテキスト描画方向に使う */
+  vertical?: boolean
 }
 
 // =====================
@@ -186,6 +206,8 @@ export interface ComputedPageLayout {
   omrMarkerPositions: ComputedOMRMarker[]
   headerFields: ComputedHeaderField[]
   contentHeightMm: number
+  /** 縦書き（縦組み・右→左）レイアウトか */
+  vertical?: boolean
 }
 
 export interface ComputedMultiPageLayout {


### PR DESCRIPTION
## 概要
解答用紙ビルダーに国語向け機能を追加。原稿用紙の罫線改善・文字数ガイド・縦組み時のOMRマーカー修正を行う。

Closes #825

## 変更点
### 縦組み（用紙全体・右→左）
- `GlobalSettings.verticalLayout` で用紙全体を縦組み化（transpose+mirror で最終段に一括座標変換、採点用 normalized 座標も再計算）。
- ヘッダー・番号ラベル・テキスト要素・原稿用紙マス目の縦書き描画。
- **OMRマーカーを矩形変換に修正**し、縦組み時の位置ずれ・サイズ変更時の四隅アンカー崩れを解消。
- 段組みは縦組み時に上下段として機能する旨の注記を追加。

### 原稿用紙の罫線（罫線タブで設定可能）
- マス目罫線を**黒色化**（輪転印刷でのかすれ防止）。
- **字間（行方向）=破線・行間=実線**を既定に、線種/太さを設定可能。

### 文字数ガイド
- 先頭からの文字数で任意マスに目印表示（自由ラベル）。表示位置（四隅）・文字サイズ設定可、既定は左下。縦組みでも正しいマスに配置。

## DB / 互換性
- `AsbDefinition`・`AsbSubQuestion` にカラム追加。マイグレーション2件、デフォルト/nullable で**既存データ保持**（適用済み・8定義保持を確認）。
- ASBアーカイブは定義 JSON 丸ごと保存のため後方互換。

## テスト
- 型チェック・eslint・prettier 通過。
- vitest（answer-sheet-builder 143件）緑。OMR矩形変換・ガイド/罫線の転置素通りを回帰テストで固定。

## 補足
- 本PRは当該機能（answer-sheet-builder）のファイルのみを対象。並行作業中の `help/*` 等は含めていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)