### PR TITLE
feat: 個別表示の模範解答分割表示でパネルサイズ変化時に中心を維持

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -177,6 +177,34 @@ export function ScoringContentArea({
     return () => cancelAnimationFrame(rafIdRef.current)
   }, [showSplit])
 
+  // ===== split表示の表示前後で答案ビューの中心を維持 =====
+  // 模範解答パネルの表示/非表示で答案パネルの幅（左右分割）または高さ（上下分割）が
+  // 変化する。サイズ変化に追従して、変化前にビューポート中心にあったコンテンツ点を
+  // 変化後も中心に保つ（補正量はサイズ差のみに依存し、ズームに非依存）。
+  // CSS transition の各フレームで ResizeObserver が発火するため滑らかに追従し、
+  // 非表示に戻す際は対称的な補正で元の中心へ復帰する。
+  useEffect(() => {
+    if (gradingMode !== "individual") return
+    const el = answerScrollRef.current
+    if (!el) return
+
+    let prevW = el.clientWidth
+    let prevH = el.clientHeight
+
+    const observer = new ResizeObserver(() => {
+      const newW = el.clientWidth
+      const newH = el.clientHeight
+      if (newW === prevW && newH === prevH) return
+      // 旧サイズで中心にあったコンテンツ点を、新サイズでも中心に保つ
+      el.scrollLeft += (prevW - newW) / 2
+      el.scrollTop += (prevH - newH) / 2
+      prevW = newW
+      prevH = newH
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [gradingMode])
+
   if (gradingMode !== "individual") {
     return (
       <AnswerGridView


### PR DESCRIPTION
## 概要

個別表示で模範解答の分割表示（左右／上下）を表示・非表示すると、答案パネルのサイズが `flex: 100%` ↔ `50%` で変化し、ビューポート中心にあった箇所がずれていた。サイズ変化に追従して中心を維持するよう修正する。

Closes #827

## 変更内容

`ScoringContentArea.tsx` に、答案スクロールコンテナのサイズ変化を `ResizeObserver` で監視し、変化前に中心にあったコンテンツ点を変化後も中心に保つロジックを追加。

```
scrollLeft += (旧幅 - 新幅) / 2
scrollTop  += (旧高 - 新高) / 2
```

## 設計上のポイント

- **ズーム非依存**: 補正量はビューポートのサイズ差のみで決まるため、既存の「同座標・同拡大率」同期ロジックを一切壊さない。
- **対称的に復帰**: 表示時に縮小した分を非表示時に拡大した分で逆補正するため、「非表示でまた戻る」が自動的に成立する。
- **滑らかに追従**: `transition: flex 0.2s` の各アニメーションフレームで `ResizeObserver` が発火するため、ジャンプせず中心が維持される。
- スクロール書き込みはサイズを変えないため `ResizeObserver` のループ警告は発生しない。`gradingMode` を依存に入れ、グリッド↔個別の切り替え後も再アタッチされる。

## 確認

- 型チェック: 該当ファイル型エラーなし
- lint（eslint / prettier）: 該当ファイル問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)