### PR TITLE
feat: 解答用紙の罫線種別ごと破線設定／原稿用紙の区切り罫線・余白／ヘルプ更新

### DIFF
--- a/__tests__/answer-sheet-builder/verticalTransform.test.ts
+++ b/__tests__/answer-sheet-builder/verticalTransform.test.ts
@@ -126,9 +126,13 @@ describe("transformLayoutToVertical", () => {
         charDividerWidth: 0.2,
         lineDividerStyle: "solid",
         lineDividerWidth: 0.2,
-        charGuides: [{ atChar: 80, label: "80" }],
+        charGuides: [
+          { atChar: 80, label: "80" },
+          { atChar: 100, label: "", boundary: "solid" },
+        ],
         guideFontSize: 2.2,
         guidePosition: "bottom-left",
+        guidePadding: 0.8,
       },
     })
     const out = transformLayoutToVertical(makeLayout([cell]), W, H)
@@ -143,7 +147,10 @@ describe("transformLayoutToVertical", () => {
     // 罫線スタイル・ガイドは方向セマンティック/atChar基準のため転置不変で素通り
     expect(g.charDividerStyle).toBe("dashed")
     expect(g.lineDividerStyle).toBe("solid")
-    expect(g.charGuides).toEqual([{ atChar: 80, label: "80" }])
+    expect(g.charGuides).toEqual([
+      { atChar: 80, label: "80" },
+      { atChar: 100, label: "", boundary: "solid" },
+    ])
     expect(g.guidePosition).toBe("bottom-left")
   })
 

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -268,6 +268,7 @@ export async function saveAsbDefinition(
               : null,
             manuscriptGuideFontSize: sq.manuscriptPaper?.guideFontSize ?? null,
             manuscriptGuidePosition: sq.manuscriptPaper?.guidePosition ?? null,
+            manuscriptGuidePadding: sq.manuscriptPaper?.guidePadding ?? null,
             borderStyleTop: sq.borderStyles?.top ?? null,
             borderStyleBottom: sq.borderStyles?.bottom ?? null,
             borderStyleLeft: sq.borderStyles?.left ?? null,

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -72,6 +72,24 @@ export type FlatGlobalSettings = {
   borderManuscriptLineDivider: string
   borderManuscriptCharDividerWidth: number | null
   borderManuscriptLineDividerWidth: number | null
+  borderOuterBorderDashRatio: number | null
+  borderOuterBorderGapRatio: number | null
+  borderMajorDividerDashRatio: number | null
+  borderMajorDividerGapRatio: number | null
+  borderSubDividerDashRatio: number | null
+  borderSubDividerGapRatio: number | null
+  borderBranchDividerDashRatio: number | null
+  borderBranchDividerGapRatio: number | null
+  borderMajorNumberDividerDashRatio: number | null
+  borderMajorNumberDividerGapRatio: number | null
+  borderSubNumberDividerDashRatio: number | null
+  borderSubNumberDividerGapRatio: number | null
+  borderBranchNumberDividerDashRatio: number | null
+  borderBranchNumberDividerGapRatio: number | null
+  borderManuscriptCharDividerDashRatio: number | null
+  borderManuscriptCharDividerGapRatio: number | null
+  borderManuscriptLineDividerDashRatio: number | null
+  borderManuscriptLineDividerGapRatio: number | null
   omrMarkersEnabled: boolean
   omrMarkersSizeMm: number
   omrMarkersOffsetMm: number
@@ -128,6 +146,34 @@ export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
       s.borderConfig.manuscriptCharDividerWidth ?? null,
     borderManuscriptLineDividerWidth:
       s.borderConfig.manuscriptLineDividerWidth ?? null,
+    borderOuterBorderDashRatio: s.borderConfig.outerBorderDashRatio ?? null,
+    borderOuterBorderGapRatio: s.borderConfig.outerBorderGapRatio ?? null,
+    borderMajorDividerDashRatio: s.borderConfig.majorDividerDashRatio ?? null,
+    borderMajorDividerGapRatio: s.borderConfig.majorDividerGapRatio ?? null,
+    borderSubDividerDashRatio: s.borderConfig.subDividerDashRatio ?? null,
+    borderSubDividerGapRatio: s.borderConfig.subDividerGapRatio ?? null,
+    borderBranchDividerDashRatio: s.borderConfig.branchDividerDashRatio ?? null,
+    borderBranchDividerGapRatio: s.borderConfig.branchDividerGapRatio ?? null,
+    borderMajorNumberDividerDashRatio:
+      s.borderConfig.majorNumberDividerDashRatio ?? null,
+    borderMajorNumberDividerGapRatio:
+      s.borderConfig.majorNumberDividerGapRatio ?? null,
+    borderSubNumberDividerDashRatio:
+      s.borderConfig.subNumberDividerDashRatio ?? null,
+    borderSubNumberDividerGapRatio:
+      s.borderConfig.subNumberDividerGapRatio ?? null,
+    borderBranchNumberDividerDashRatio:
+      s.borderConfig.branchNumberDividerDashRatio ?? null,
+    borderBranchNumberDividerGapRatio:
+      s.borderConfig.branchNumberDividerGapRatio ?? null,
+    borderManuscriptCharDividerDashRatio:
+      s.borderConfig.manuscriptCharDividerDashRatio ?? null,
+    borderManuscriptCharDividerGapRatio:
+      s.borderConfig.manuscriptCharDividerGapRatio ?? null,
+    borderManuscriptLineDividerDashRatio:
+      s.borderConfig.manuscriptLineDividerDashRatio ?? null,
+    borderManuscriptLineDividerGapRatio:
+      s.borderConfig.manuscriptLineDividerGapRatio ?? null,
     omrMarkersEnabled: s.omrMarkers.enabled,
     omrMarkersSizeMm: s.omrMarkers.sizeMm,
     omrMarkersOffsetMm: s.omrMarkers.offsetMm,
@@ -144,11 +190,15 @@ export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
   }
 }
 
-/** DB の JSON文字列から文字数ガイド配列を復元する（壊れていれば空配列） */
+/**
+ * DB の JSON文字列から文字位置マーカー配列（数字ガイド＋区切り罫線の統合）を復元する。
+ * 旧形式 {atChar,label} も互換で読める（boundary 等は欠落＝未設定）。
+ */
 function parseCharGuides(
   json: string | null
 ): ManuscriptCharGuide[] | undefined {
   if (!json) return undefined
+  const VALID_STYLES = new Set<LineStyle>(["solid", "dashed", "dotted"])
   try {
     const parsed: unknown = JSON.parse(json)
     if (!Array.isArray(parsed)) return undefined
@@ -160,7 +210,28 @@ function parseCharGuides(
           typeof (g as ManuscriptCharGuide).atChar === "number" &&
           typeof (g as ManuscriptCharGuide).label === "string"
       )
-      .map((g) => ({ atChar: g.atChar, label: g.label }))
+      .map((g): ManuscriptCharGuide => {
+        const boundary =
+          typeof g.boundary === "string" &&
+          VALID_STYLES.has(g.boundary as LineStyle)
+            ? (g.boundary as LineStyle)
+            : undefined
+        return {
+          atChar: g.atChar,
+          label: g.label,
+          boundary,
+          boundaryWidth:
+            typeof g.boundaryWidth === "number" ? g.boundaryWidth : undefined,
+          boundaryDashRatio:
+            typeof g.boundaryDashRatio === "number"
+              ? g.boundaryDashRatio
+              : undefined,
+          boundaryGapRatio:
+            typeof g.boundaryGapRatio === "number"
+              ? g.boundaryGapRatio
+              : undefined,
+        }
+      })
     return guides.length > 0 ? guides : undefined
   } catch {
     return undefined
@@ -216,6 +287,33 @@ function unflattenGlobalSettings(row: AsbDefinition): GlobalSettings {
         row.borderManuscriptCharDividerWidth ?? undefined,
       manuscriptLineDividerWidth:
         row.borderManuscriptLineDividerWidth ?? undefined,
+      outerBorderDashRatio: row.borderOuterBorderDashRatio ?? undefined,
+      outerBorderGapRatio: row.borderOuterBorderGapRatio ?? undefined,
+      majorDividerDashRatio: row.borderMajorDividerDashRatio ?? undefined,
+      majorDividerGapRatio: row.borderMajorDividerGapRatio ?? undefined,
+      subDividerDashRatio: row.borderSubDividerDashRatio ?? undefined,
+      subDividerGapRatio: row.borderSubDividerGapRatio ?? undefined,
+      branchDividerDashRatio: row.borderBranchDividerDashRatio ?? undefined,
+      branchDividerGapRatio: row.borderBranchDividerGapRatio ?? undefined,
+      majorNumberDividerDashRatio:
+        row.borderMajorNumberDividerDashRatio ?? undefined,
+      majorNumberDividerGapRatio:
+        row.borderMajorNumberDividerGapRatio ?? undefined,
+      subNumberDividerDashRatio:
+        row.borderSubNumberDividerDashRatio ?? undefined,
+      subNumberDividerGapRatio: row.borderSubNumberDividerGapRatio ?? undefined,
+      branchNumberDividerDashRatio:
+        row.borderBranchNumberDividerDashRatio ?? undefined,
+      branchNumberDividerGapRatio:
+        row.borderBranchNumberDividerGapRatio ?? undefined,
+      manuscriptCharDividerDashRatio:
+        row.borderManuscriptCharDividerDashRatio ?? undefined,
+      manuscriptCharDividerGapRatio:
+        row.borderManuscriptCharDividerGapRatio ?? undefined,
+      manuscriptLineDividerDashRatio:
+        row.borderManuscriptLineDividerDashRatio ?? undefined,
+      manuscriptLineDividerGapRatio:
+        row.borderManuscriptLineDividerGapRatio ?? undefined,
     } as BorderConfig,
     omrMarkers: {
       enabled: row.omrMarkersEnabled,
@@ -334,6 +432,7 @@ export function dbToDefinition(row: DbDefinitionFull): AnswerSheetDefinition {
             guidePosition:
               (sq.manuscriptGuidePosition as ManuscriptGuidePosition | null) ??
               undefined,
+            guidePadding: sq.manuscriptGuidePadding ?? undefined,
           }
         : undefined
       const borderStyles =

--- a/prisma/migrations/20260613170000_asb_manuscript_guide_padding/migration.sql
+++ b/prisma/migrations/20260613170000_asb_manuscript_guide_padding/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AsbSubQuestion" ADD COLUMN "manuscriptGuidePadding" REAL;

--- a/prisma/migrations/20260613180000_asb_border_dash_ratios/migration.sql
+++ b/prisma/migrations/20260613180000_asb_border_dash_ratios/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable: 罫線種別ごとの破線/点線ダッシュ長・間隔（線幅に対する倍率）。
+-- いずれも任意（NULL=既定 dash3倍/gap2倍）。
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderOuterBorderDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderOuterBorderGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderMajorDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderMajorDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderSubDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderSubDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderBranchDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderBranchDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderMajorNumberDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderMajorNumberDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderSubNumberDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderSubNumberDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderBranchNumberDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderBranchNumberDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderManuscriptCharDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderManuscriptCharDividerGapRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderManuscriptLineDividerDashRatio" REAL;
+ALTER TABLE "AsbDefinition" ADD COLUMN "borderManuscriptLineDividerGapRatio" REAL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -841,6 +841,25 @@ model AsbDefinition {
   borderManuscriptLineDivider      String  @default("solid")
   borderManuscriptCharDividerWidth Float?  @default(0.2)
   borderManuscriptLineDividerWidth Float?  @default(0.2)
+  // 破線/点線のダッシュ長・間隔（線幅に対する倍率。未指定=既定 dash3/gap2）
+  borderOuterBorderDashRatio          Float?
+  borderOuterBorderGapRatio           Float?
+  borderMajorDividerDashRatio         Float?
+  borderMajorDividerGapRatio          Float?
+  borderSubDividerDashRatio           Float?
+  borderSubDividerGapRatio            Float?
+  borderBranchDividerDashRatio        Float?
+  borderBranchDividerGapRatio         Float?
+  borderMajorNumberDividerDashRatio   Float?
+  borderMajorNumberDividerGapRatio    Float?
+  borderSubNumberDividerDashRatio     Float?
+  borderSubNumberDividerGapRatio      Float?
+  borderBranchNumberDividerDashRatio  Float?
+  borderBranchNumberDividerGapRatio   Float?
+  borderManuscriptCharDividerDashRatio Float?
+  borderManuscriptCharDividerGapRatio  Float?
+  borderManuscriptLineDividerDashRatio Float?
+  borderManuscriptLineDividerGapRatio  Float?
   // OMRMarkers
   omrMarkersEnabled Boolean @default(false)
   omrMarkersSizeMm  Float   @default(5)
@@ -922,10 +941,12 @@ model AsbSubQuestion {
   manuscriptColumns  Int     @default(20)
   manuscriptRows     Int     @default(10)
   manuscriptCellSizeMm Float @default(8)
-  // 文字数ガイド: JSON配列 [{atChar,label}]、表示位置・文字サイズ
+  // 文字位置マーカー: JSON配列 [{atChar,label,boundary?,boundaryWidth?,overrideRowEnd?}]
+  // （数字ガイド＋区切り罫線の統合）、表示位置・文字サイズ・余白（マス比）
   manuscriptCharGuides    String?
   manuscriptGuideFontSize Float?
   manuscriptGuidePosition String?
+  manuscriptGuidePadding  Float?
   // BorderStyles (per-side)
   borderStyleTop    String?
   borderStyleBottom String?

--- a/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -351,6 +351,7 @@ export function AnswerSheetBuilderMainView({
           onRenderModeChange={handleRenderModeChange}
           dispatch={dispatch}
           baseRowHeight={definition.settings.baseRowHeight}
+          borderConfig={definition.settings.borderConfig}
         />
       </div>
 

--- a/src/components/answer-sheet-builder/components/form/LineStylePicker.tsx
+++ b/src/components/answer-sheet-builder/components/form/LineStylePicker.tsx
@@ -9,6 +9,8 @@ import type {
   LineStyle,
 } from "@/types/answerSheetDefinition.types"
 
+import { DEFAULT_DASH_RATIO, DEFAULT_GAP_RATIO } from "../../constants"
+
 interface LineStylePickerProps {
   borderConfig: BorderConfig
   onUpdate: (config: Partial<BorderConfig>) => void
@@ -23,6 +25,10 @@ const LINE_STYLES: { value: LineStyle; title: string }[] = [
 interface BorderField {
   styleKey: keyof BorderConfig
   widthKey: keyof BorderConfig
+  /** 破線ダッシュ長の倍率キー（線幅に対する倍率） */
+  dashRatioKey: keyof BorderConfig
+  /** 破線/点線の間隔の倍率キー（線幅に対する倍率） */
+  gapRatioKey: keyof BorderConfig
   label: string
   defaultWidth: number
   /** 値未設定時に選択表示する線種（任意フィールド用） */
@@ -33,24 +39,32 @@ const DIVIDER_FIELDS: BorderField[] = [
   {
     styleKey: "outerBorder",
     widthKey: "outerBorderWidth",
+    dashRatioKey: "outerBorderDashRatio",
+    gapRatioKey: "outerBorderGapRatio",
     label: "外枠",
     defaultWidth: 0.7,
   },
   {
     styleKey: "majorDivider",
     widthKey: "majorDividerWidth",
+    dashRatioKey: "majorDividerDashRatio",
+    gapRatioKey: "majorDividerGapRatio",
     label: "大問",
     defaultWidth: 0.5,
   },
   {
     styleKey: "subDivider",
     widthKey: "subDividerWidth",
+    dashRatioKey: "subDividerDashRatio",
+    gapRatioKey: "subDividerGapRatio",
     label: "小問",
     defaultWidth: 0.4,
   },
   {
     styleKey: "branchDivider",
     widthKey: "branchDividerWidth",
+    dashRatioKey: "branchDividerDashRatio",
+    gapRatioKey: "branchDividerGapRatio",
     label: "枝問",
     defaultWidth: 0.3,
   },
@@ -60,6 +74,8 @@ const MANUSCRIPT_FIELDS: BorderField[] = [
   {
     styleKey: "manuscriptCharDivider",
     widthKey: "manuscriptCharDividerWidth",
+    dashRatioKey: "manuscriptCharDividerDashRatio",
+    gapRatioKey: "manuscriptCharDividerGapRatio",
     label: "字間",
     defaultWidth: 0.2,
     defaultStyle: "dashed",
@@ -67,6 +83,8 @@ const MANUSCRIPT_FIELDS: BorderField[] = [
   {
     styleKey: "manuscriptLineDivider",
     widthKey: "manuscriptLineDividerWidth",
+    dashRatioKey: "manuscriptLineDividerDashRatio",
+    gapRatioKey: "manuscriptLineDividerGapRatio",
     label: "行間",
     defaultWidth: 0.2,
     defaultStyle: "solid",
@@ -77,18 +95,24 @@ const NUMBER_FIELDS: BorderField[] = [
   {
     styleKey: "majorNumberDivider",
     widthKey: "majorNumberDividerWidth",
+    dashRatioKey: "majorNumberDividerDashRatio",
+    gapRatioKey: "majorNumberDividerGapRatio",
     label: "大問",
     defaultWidth: 0.4,
   },
   {
     styleKey: "subNumberDivider",
     widthKey: "subNumberDividerWidth",
+    dashRatioKey: "subNumberDividerDashRatio",
+    gapRatioKey: "subNumberDividerGapRatio",
     label: "小問",
     defaultWidth: 0.4,
   },
   {
     styleKey: "branchNumberDivider",
     widthKey: "branchNumberDividerWidth",
+    dashRatioKey: "branchNumberDividerDashRatio",
+    gapRatioKey: "branchNumberDividerGapRatio",
     label: "枝問",
     defaultWidth: 0.3,
   },
@@ -214,46 +238,108 @@ function BorderFieldRow({
   const activeStyle =
     (borderConfig[field.styleKey] as LineStyle | undefined) ??
     field.defaultStyle
+  const dashRatio =
+    (borderConfig[field.dashRatioKey] as number | undefined) ??
+    DEFAULT_DASH_RATIO
+  const gapRatio =
+    (borderConfig[field.gapRatioKey] as number | undefined) ?? DEFAULT_GAP_RATIO
+  // 破線はダッシュ長・間隔の両方、点線は間隔のみ調整できる
+  const showDash = activeStyle === "dashed"
+  const showGap = activeStyle === "dashed" || activeStyle === "dotted"
   return (
-    <div className="flex min-h-6 items-center gap-2">
-      <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
-        {field.label}
-      </span>
-      <div className="border-input flex shrink-0 rounded-md border">
-        {LINE_STYLES.map((ls) => (
-          <button
-            key={ls.value}
-            type="button"
-            title={ls.title}
-            className={cn(
-              "hover:bg-accent flex h-6 w-7 items-center justify-center transition-colors first:rounded-l-md last:rounded-r-md",
-              activeStyle === ls.value
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground"
-            )}
-            onClick={() =>
-              onUpdate({ [field.styleKey]: ls.value as LineStyle })
-            }
-          >
-            <LineIcon style={ls.value} />
-          </button>
-        ))}
+    <div className="space-y-1">
+      <div className="flex min-h-6 items-center gap-2">
+        <span className="text-muted-foreground w-8 shrink-0 text-[10px]">
+          {field.label}
+        </span>
+        <div className="border-input flex shrink-0 rounded-md border">
+          {LINE_STYLES.map((ls) => (
+            <button
+              key={ls.value}
+              type="button"
+              title={ls.title}
+              className={cn(
+                "hover:bg-accent flex h-6 w-7 items-center justify-center transition-colors first:rounded-l-md last:rounded-r-md",
+                activeStyle === ls.value
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground"
+              )}
+              onClick={() =>
+                onUpdate({ [field.styleKey]: ls.value as LineStyle })
+              }
+            >
+              <LineIcon style={ls.value} />
+            </button>
+          ))}
+        </div>
+        <Slider
+          className="min-w-12 flex-1"
+          value={[width]}
+          min={0.1}
+          max={1.5}
+          step={0.1}
+          onValueChange={([v]) => onUpdate({ [field.widthKey]: v })}
+        />
+        <EditableValue
+          value={width}
+          min={0.1}
+          max={1.5}
+          step={0.1}
+          onChange={(v) => onUpdate({ [field.widthKey]: v })}
+        />
       </div>
-      <Slider
-        className="min-w-12 flex-1"
-        value={[width]}
-        min={0.1}
-        max={1.5}
-        step={0.1}
-        onValueChange={([v]) => onUpdate({ [field.widthKey]: v })}
-      />
-      <EditableValue
-        value={width}
-        min={0.1}
-        max={1.5}
-        step={0.1}
-        onChange={(v) => onUpdate({ [field.widthKey]: v })}
-      />
+      {showGap && (
+        <div className="flex items-center gap-2 pl-10">
+          {showDash && (
+            <div className="flex flex-1 items-center gap-1.5">
+              <span
+                className="text-muted-foreground w-7 shrink-0 text-[9px]"
+                title="ダッシュ長（線幅に対する倍率）"
+              >
+                破線
+              </span>
+              <Slider
+                className="min-w-10 flex-1"
+                value={[dashRatio]}
+                min={0.5}
+                max={10}
+                step={0.5}
+                onValueChange={([v]) => onUpdate({ [field.dashRatioKey]: v })}
+              />
+              <EditableValue
+                value={dashRatio}
+                min={0.5}
+                max={10}
+                step={0.5}
+                onChange={(v) => onUpdate({ [field.dashRatioKey]: v })}
+              />
+            </div>
+          )}
+          <div className="flex flex-1 items-center gap-1.5">
+            <span
+              className="text-muted-foreground w-7 shrink-0 text-[9px]"
+              title="間隔（線幅に対する倍率）"
+            >
+              間隔
+            </span>
+            <Slider
+              className="min-w-10 flex-1"
+              value={[gapRatio]}
+              min={0.5}
+              max={10}
+              step={0.5}
+              onValueChange={([v]) => onUpdate({ [field.gapRatioKey]: v })}
+            />
+            <EditableValue
+              value={gapRatio}
+              min={0.5}
+              max={10}
+              step={0.5}
+              onChange={(v) => onUpdate({ [field.gapRatioKey]: v })}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
+++ b/src/components/answer-sheet-builder/components/form/ManuscriptPaperSettings.tsx
@@ -14,13 +14,18 @@ import {
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import type {
+  LineStyle,
   ManuscriptCharGuide,
   ManuscriptGuidePosition,
   ManuscriptPaperConfig,
 } from "@/types/answerSheetDefinition.types"
 
 import {
-  DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+  DEFAULT_DASH_RATIO,
+  DEFAULT_GAP_RATIO,
+  DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH,
+  DEFAULT_MANUSCRIPT_GUIDE_FONT_RATIO,
+  DEFAULT_MANUSCRIPT_GUIDE_PADDING_RATIO,
   DEFAULT_MANUSCRIPT_GUIDE_POSITION,
 } from "../../constants"
 import { SliderWithInput } from "./SliderWithInput"
@@ -42,6 +47,15 @@ const GUIDE_POSITION_LABELS: Record<ManuscriptGuidePosition, string> = {
   "top-left": "左上",
   "top-right": "右上",
 }
+
+/** 区切り罫線の選択肢（先頭は「なし」＝罫線なし） */
+const BOUNDARY_NONE = "none"
+const BOUNDARY_OPTIONS: { value: string; label: string }[] = [
+  { value: BOUNDARY_NONE, label: "なし" },
+  { value: "solid", label: "実線" },
+  { value: "dashed", label: "破線" },
+  { value: "dotted", label: "点線" },
+]
 
 export function ManuscriptPaperSettings({
   config,
@@ -140,7 +154,7 @@ export function ManuscriptPaperSettings({
         <div className="space-y-2 rounded border p-2">
           <div className="flex items-center justify-between">
             <Label className="text-muted-foreground text-[10px]">
-              文字数ガイド
+              文字位置マーカー（数字ガイド・区切り罫線）
             </Label>
             <Button
               variant="outline"
@@ -157,7 +171,7 @@ export function ManuscriptPaperSettings({
             <div className="grid grid-cols-2 gap-2">
               <div>
                 <Label className="text-muted-foreground text-[10px]">
-                  表示位置
+                  数字の表示位置
                 </Label>
                 <Select
                   value={
@@ -185,56 +199,153 @@ export function ManuscriptPaperSettings({
               </div>
               <div className="flex items-end">
                 <SliderWithInput
-                  label="文字サイズ"
+                  label="文字サイズ(マス比)"
                   value={
-                    current.guideFontSize ?? DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE
+                    current.guideFontSize ?? DEFAULT_MANUSCRIPT_GUIDE_FONT_RATIO
                   }
-                  min={1}
-                  max={6}
-                  step={0.1}
+                  min={0.05}
+                  max={1}
+                  step={0.05}
                   onChange={(v) => handleChange({ guideFontSize: v })}
+                />
+              </div>
+              <div className="col-span-2">
+                <SliderWithInput
+                  label="余白(マス比)"
+                  value={
+                    current.guidePadding ??
+                    DEFAULT_MANUSCRIPT_GUIDE_PADDING_RATIO
+                  }
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  onChange={(v) => handleChange({ guidePadding: v })}
                 />
               </div>
             </div>
           )}
 
           {guides.map((guide, index) => (
-            <div key={index} className="flex items-center gap-1">
-              <Input
-                type="number"
-                className="h-7 w-16 text-xs"
-                value={guide.atChar}
-                min={1}
-                max={capacity}
-                title="先頭からの文字数"
-                onChange={(e) =>
-                  updateGuide(index, {
-                    atChar: clampInt(e.target.value, 1, capacity, guide.atChar),
-                  })
-                }
-              />
-              <span className="text-muted-foreground text-[10px]">字目</span>
-              <Input
-                className="h-7 flex-1 text-xs"
-                value={guide.label}
-                placeholder="表示文字"
-                onChange={(e) => updateGuide(index, { label: e.target.value })}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-destructive h-6 w-6"
-                onClick={() => removeGuide(index)}
-              >
-                <Trash2 className="h-3 w-3" />
-              </Button>
+            <div key={index} className="space-y-1 rounded border p-1.5">
+              <div className="flex items-center gap-1">
+                <Input
+                  type="number"
+                  className="h-7 w-16 text-xs"
+                  value={guide.atChar}
+                  min={1}
+                  max={capacity}
+                  title="先頭からの文字数"
+                  onChange={(e) =>
+                    updateGuide(index, {
+                      atChar: clampInt(
+                        e.target.value,
+                        1,
+                        capacity,
+                        guide.atChar
+                      ),
+                    })
+                  }
+                />
+                <span className="text-muted-foreground text-[10px]">字目</span>
+                <Input
+                  className="h-7 flex-1 text-xs"
+                  value={guide.label}
+                  placeholder="数字(空欄=罫線のみ)"
+                  onChange={(e) =>
+                    updateGuide(index, { label: e.target.value })
+                  }
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive h-6 w-6"
+                  onClick={() => removeGuide(index)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground shrink-0 text-[10px]">
+                  次の罫線
+                </span>
+                <Select
+                  value={guide.boundary ?? BOUNDARY_NONE}
+                  onValueChange={(v) =>
+                    updateGuide(
+                      index,
+                      v === BOUNDARY_NONE
+                        ? { boundary: undefined }
+                        : { boundary: v as LineStyle }
+                    )
+                  }
+                >
+                  <SelectTrigger className="h-7 w-20 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BOUNDARY_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {guide.boundary && (
+                  <div className="flex-1">
+                    <SliderWithInput
+                      label="太さ(mm)"
+                      value={
+                        guide.boundaryWidth ?? DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH
+                      }
+                      min={0.1}
+                      max={1.5}
+                      step={0.1}
+                      onChange={(v) => updateGuide(index, { boundaryWidth: v })}
+                    />
+                  </div>
+                )}
+              </div>
+              {(guide.boundary === "dashed" || guide.boundary === "dotted") && (
+                <div className="flex items-center gap-2 pl-2">
+                  {guide.boundary === "dashed" && (
+                    <div className="flex-1">
+                      <SliderWithInput
+                        label="破線長"
+                        value={guide.boundaryDashRatio ?? DEFAULT_DASH_RATIO}
+                        min={0.5}
+                        max={10}
+                        step={0.5}
+                        onChange={(v) =>
+                          updateGuide(index, { boundaryDashRatio: v })
+                        }
+                      />
+                    </div>
+                  )}
+                  <div className="flex-1">
+                    <SliderWithInput
+                      label="間隔"
+                      value={guide.boundaryGapRatio ?? DEFAULT_GAP_RATIO}
+                      min={0.5}
+                      max={10}
+                      step={0.5}
+                      onChange={(v) =>
+                        updateGuide(index, { boundaryGapRatio: v })
+                      }
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           ))}
 
-          {guides.length === 0 && (
+          {guides.length === 0 ? (
             <p className="text-muted-foreground text-[10px]">
-              「追加」で先頭からの文字数の目印（例: 80,
-              100）をマスに表示できます。
+              「追加」で先頭からの文字数の目印を作成。数字（例:
+              80）と区切り罫線（○字以内/以上）を組み合わせられます。罫線のみ使うときは数字を空欄に。
+            </p>
+          ) : (
+            <p className="text-muted-foreground text-[10px]">
+              区切り罫線は、行末にある小計・大問罫線を置き換えません。
             </p>
           )}
         </div>

--- a/src/components/answer-sheet-builder/components/preview/AnswerSheetPreview.tsx
+++ b/src/components/answer-sheet-builder/components/preview/AnswerSheetPreview.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react"
 
 import type {
   AnswerSheetAction,
+  BorderConfig,
   RenderMode,
 } from "@/types/answerSheetDefinition.types"
 import type {
@@ -22,6 +23,8 @@ interface AnswerSheetPreviewProps {
   onRenderModeChange: (mode: RenderMode) => void
   dispatch: (action: AnswerSheetAction) => void
   baseRowHeight: number
+  /** 罫線種別ごとの破線ダッシュ長/間隔の解決に使う */
+  borderConfig: BorderConfig
 }
 
 /**
@@ -35,6 +38,7 @@ export function AnswerSheetPreview({
   onRenderModeChange,
   dispatch,
   baseRowHeight,
+  borderConfig,
 }: AnswerSheetPreviewProps) {
   const [zoom, setZoom] = useState(100)
   const [interactive, setInteractive] = useState(false)
@@ -105,6 +109,7 @@ export function AnswerSheetPreview({
               renderMode={renderMode}
               interactive={interactive}
               hoveredDragInfo={hoveredDragInfo}
+              borderConfig={borderConfig}
             />
           </svg>
         </div>

--- a/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -2,14 +2,26 @@
 
 import type { InlineSegment } from "@/lib/answer-sheet-builder/inlineMarkupParser"
 import { parseInlineMarkup } from "@/lib/answer-sheet-builder/inlineMarkupParser"
-import type { RenderMode } from "@/types/answerSheetDefinition.types"
+import type {
+  BorderConfig,
+  LineStyle,
+  RenderMode,
+} from "@/types/answerSheetDefinition.types"
 import type {
   ComputedLayout,
   ComputedPageLayout,
   DragInfo,
 } from "@/types/answerSheetLayout.types"
 
-import { manuscriptCharPosition } from "../../hooks/layout/layoutUtils"
+import {
+  DEFAULT_DASH_RATIO,
+  DEFAULT_GAP_RATIO,
+  DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH,
+} from "../../constants"
+import {
+  getLineDashRatio,
+  manuscriptCharPosition,
+} from "../../hooks/layout/layoutUtils"
 import {
   getDashProps,
   isDragInfoEqual,
@@ -30,6 +42,8 @@ interface AnswerSheetSVGRendererProps {
   forPrint?: boolean
   /** 印刷用: 画像パス → data URI のマップ */
   imageDataUris?: Map<string, string>
+  /** 罫線種別ごとの破線ダッシュ長/間隔の解決に使う。未指定時は既定倍率 */
+  borderConfig?: BorderConfig
 }
 
 /**
@@ -44,6 +58,7 @@ export function AnswerSheetSVGRenderer({
   hoveredDragInfo,
   forPrint,
   imageDataUris,
+  borderConfig,
 }: AnswerSheetSVGRendererProps) {
   const { pageWidthMm, pageHeightMm } = layout
   // pageLayoutが指定されている場合はそちらのデータを使用
@@ -177,7 +192,10 @@ export function AnswerSheetSVGRenderer({
           interactive && isDragInfoEqual(line.dragInfo, hoveredDragInfo)
         const sw = line.strokeWidth ?? (line.lineType === "outer" ? 0.7 : 0.4)
         const len = Math.hypot(line.x2 - line.x1, line.y2 - line.y1)
-        const dashProps = getDashProps(line.style, sw, len)
+        const { dashRatio, gapRatio } = borderConfig
+          ? getLineDashRatio(line.lineType, borderConfig)
+          : { dashRatio: DEFAULT_DASH_RATIO, gapRatio: DEFAULT_GAP_RATIO }
+        const dashProps = getDashProps(line.style, sw, len, dashRatio, gapRatio)
         return (
           <g key={`line-${i}`}>
             <line
@@ -249,7 +267,9 @@ export function AnswerSheetSVGRenderer({
             for (const te of cell.textElements) {
               const segments = parseInlineMarkup(te.text)
               for (const seg of segments) {
-                if (seg.modelAnswer && renderMode !== "model-answer") continue
+                // 模範解答セグメントもマス位置は確保する（空送り）。
+                // 非表示時は下の fill="transparent" で見えなくするだけにし、
+                // スキップして後続文字を詰めない。
                 for (const ch of seg.text) {
                   chars.push({ char: ch, seg })
                 }
@@ -559,42 +579,36 @@ export function AnswerSheetSVGRenderer({
           const colWidth = g.vertical ? g.lineDividerWidth : g.charDividerWidth
           const rowStyle = g.vertical ? g.charDividerStyle : g.lineDividerStyle
           const rowWidth = g.vertical ? g.charDividerWidth : g.lineDividerWidth
-          const gridLines: React.ReactNode[] = []
-          for (let col = 1; col < g.columns; col++) {
-            const x = g.gridX + col * g.cellSizeMm
-            gridLines.push(
-              <line
-                key={`mg-v-${cellIdx}-${cell.label}-${col}`}
-                x1={x}
-                y1={g.gridY}
-                x2={x}
-                y2={g.gridY + g.gridHeight}
-                stroke="#000"
-                strokeWidth={colWidth}
-                {...getDashProps(colStyle, colWidth, g.gridHeight)}
-              />
-            )
+          // 字間（char）/行間（line）罫線の破線倍率。縦書きは縦線=行間・横線=字間。
+          const charDash = {
+            dashRatio:
+              borderConfig?.manuscriptCharDividerDashRatio ??
+              DEFAULT_DASH_RATIO,
+            gapRatio:
+              borderConfig?.manuscriptCharDividerGapRatio ?? DEFAULT_GAP_RATIO,
           }
-          for (let row = 1; row < g.rows; row++) {
-            const y = g.gridY + row * g.cellSizeMm
-            gridLines.push(
-              <line
-                key={`mg-h-${cellIdx}-${cell.label}-${row}`}
-                x1={g.gridX}
-                y1={y}
-                x2={g.gridX + g.gridWidth}
-                y2={y}
-                stroke="#000"
-                strokeWidth={rowWidth}
-                {...getDashProps(rowStyle, rowWidth, g.gridWidth)}
-              />
-            )
+          const lineDash = {
+            dashRatio:
+              borderConfig?.manuscriptLineDividerDashRatio ??
+              DEFAULT_DASH_RATIO,
+            gapRatio:
+              borderConfig?.manuscriptLineDividerGapRatio ?? DEFAULT_GAP_RATIO,
           }
-          // 文字数ガイド: 先頭からN文字目のマスの隅に小さく番号を表示
-          const guides: React.ReactNode[] = []
-          const pad = g.cellSizeMm * 0.12
-          for (let gi = 0; gi < g.charGuides.length; gi++) {
-            const guide = g.charGuides[gi]
+          const colDash = g.vertical ? lineDash : charDash
+          const rowDash = g.vertical ? charDash : lineDash
+          const cs = g.cellSizeMm
+          // 区切り罫線を「置き換え」るため、どの内部罫線セグメントを差し替えるか先に収集。
+          // 縦線セグメント: key `${ci}:${row}` / 横線セグメント: key `${ri}:${col}`
+          type BoundarySpec = {
+            style: LineStyle
+            width: number
+            dashRatio: number
+            gapRatio: number
+          }
+          const vOverride = new Map<string, BoundarySpec>()
+          const hOverride = new Map<string, BoundarySpec>()
+          for (const guide of g.charGuides) {
+            if (!guide.boundary) continue
             const pos = manuscriptCharPosition(
               guide.atChar - 1,
               g.columns,
@@ -602,21 +616,160 @@ export function AnswerSheetSVGRenderer({
               g.vertical
             )
             if (!pos) continue
-            const cellX0 = g.gridX + pos.col * g.cellSizeMm
-            const cellY0 = g.gridY + pos.row * g.cellSizeMm
+            const bw = guide.boundaryWidth ?? DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH
+            const spec: BoundarySpec = {
+              style: guide.boundary,
+              width: bw,
+              dashRatio: guide.boundaryDashRatio ?? DEFAULT_DASH_RATIO,
+              gapRatio: guide.boundaryGapRatio ?? DEFAULT_GAP_RATIO,
+            }
+            // 行末（折り返し位置）は内部罫線が無く、置き換え対象は構造罫線
+            // （小計/大問罫線）になるため、ここでは描画しない。
+            if (g.vertical) {
+              // 縦書き: 文字は上→下。トレーリング側＝マス下辺（横罫線 ri=row+1）
+              if (pos.row < g.rows - 1) {
+                hOverride.set(`${pos.row + 1}:${pos.col}`, spec)
+              }
+            } else {
+              // 横書き: 文字は左→右。トレーリング側＝マス右辺（縦罫線 ci=col+1）
+              if (pos.col < g.columns - 1) {
+                vOverride.set(`${pos.col + 1}:${pos.row}`, spec)
+              }
+            }
+          }
+          const gridLines: React.ReactNode[] = []
+          // 縦罫線（内部）: 置き換え区間を除いて連続ランで描き、区間は境界線で差し替え
+          for (let ci = 1; ci < g.columns; ci++) {
+            const x = g.gridX + ci * cs
+            const flushRun = (r0: number, r1: number) => {
+              if (r1 <= r0) return
+              gridLines.push(
+                <line
+                  key={`mg-v-${cellIdx}-${cell.label}-${ci}-${r0}`}
+                  x1={x}
+                  y1={g.gridY + r0 * cs}
+                  x2={x}
+                  y2={g.gridY + r1 * cs}
+                  stroke="#000"
+                  strokeWidth={colWidth}
+                  {...getDashProps(
+                    colStyle,
+                    colWidth,
+                    (r1 - r0) * cs,
+                    colDash.dashRatio,
+                    colDash.gapRatio
+                  )}
+                />
+              )
+            }
+            let runStart = 0
+            for (let row = 0; row < g.rows; row++) {
+              const ov = vOverride.get(`${ci}:${row}`)
+              if (!ov) continue
+              flushRun(runStart, row)
+              gridLines.push(
+                <line
+                  key={`mg-vb-${cellIdx}-${cell.label}-${ci}-${row}`}
+                  x1={x}
+                  y1={g.gridY + row * cs}
+                  x2={x}
+                  y2={g.gridY + (row + 1) * cs}
+                  stroke="#000"
+                  strokeWidth={ov.width}
+                  {...getDashProps(
+                    ov.style,
+                    ov.width,
+                    cs,
+                    ov.dashRatio,
+                    ov.gapRatio
+                  )}
+                />
+              )
+              runStart = row + 1
+            }
+            flushRun(runStart, g.rows)
+          }
+          // 横罫線（内部）: 同様に置き換え区間を差し替え
+          for (let ri = 1; ri < g.rows; ri++) {
+            const y = g.gridY + ri * cs
+            const flushRun = (c0: number, c1: number) => {
+              if (c1 <= c0) return
+              gridLines.push(
+                <line
+                  key={`mg-h-${cellIdx}-${cell.label}-${ri}-${c0}`}
+                  x1={g.gridX + c0 * cs}
+                  y1={y}
+                  x2={g.gridX + c1 * cs}
+                  y2={y}
+                  stroke="#000"
+                  strokeWidth={rowWidth}
+                  {...getDashProps(
+                    rowStyle,
+                    rowWidth,
+                    (c1 - c0) * cs,
+                    rowDash.dashRatio,
+                    rowDash.gapRatio
+                  )}
+                />
+              )
+            }
+            let runStart = 0
+            for (let col = 0; col < g.columns; col++) {
+              const ov = hOverride.get(`${ri}:${col}`)
+              if (!ov) continue
+              flushRun(runStart, col)
+              gridLines.push(
+                <line
+                  key={`mg-hb-${cellIdx}-${cell.label}-${ri}-${col}`}
+                  x1={g.gridX + col * cs}
+                  y1={y}
+                  x2={g.gridX + (col + 1) * cs}
+                  y2={y}
+                  stroke="#000"
+                  strokeWidth={ov.width}
+                  {...getDashProps(
+                    ov.style,
+                    ov.width,
+                    cs,
+                    ov.dashRatio,
+                    ov.gapRatio
+                  )}
+                />
+              )
+              runStart = col + 1
+            }
+            flushRun(runStart, g.columns)
+          }
+          // 数字ガイド: 先頭からN文字目のマスの隅に小さく表示（空ラベルは描かない）
+          const guides: React.ReactNode[] = []
+          for (let gi = 0; gi < g.charGuides.length; gi++) {
+            const guide = g.charGuides[gi]
+            if (!guide.label) continue
+            const pos = manuscriptCharPosition(
+              guide.atChar - 1,
+              g.columns,
+              g.rows,
+              g.vertical
+            )
+            if (!pos) continue
+            const fs = g.guideFontSize
+            const cellX0 = g.gridX + pos.col * cs
+            const cellY0 = g.gridY + pos.row * cs
             const left = g.guidePosition.endsWith("left")
             const top = g.guidePosition.startsWith("top")
-            const gx = left ? cellX0 + pad : cellX0 + g.cellSizeMm - pad
-            const gy = top ? cellY0 + pad : cellY0 + g.cellSizeMm - pad
+            // アンカー点 = マスの該当隅から余白分だけ内側へ
+            const gpad = g.guidePadding
+            const px = left ? cellX0 + gpad : cellX0 + cs - gpad
+            const py = top ? cellY0 + gpad : cellY0 + cs - gpad
             guides.push(
               <text
                 key={`mguide-${cellIdx}-${cell.label}-${gi}`}
-                x={gx}
-                y={gy}
-                fontSize={g.guideFontSize}
+                x={px}
+                y={py}
+                fontSize={fs}
                 fontFamily="'Noto Sans JP', sans-serif"
                 textAnchor={left ? "start" : "end"}
-                dominantBaseline={top ? "hanging" : "alphabetic"}
+                dominantBaseline={top ? "text-before-edge" : "text-after-edge"}
                 fill="#000"
               >
                 {guide.label}

--- a/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
+++ b/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
@@ -11,11 +11,21 @@ import type { InlineSegment } from "@/lib/answer-sheet-builder/inlineMarkupParse
 import type { LineStyle, RenderMode } from "@/types/answerSheetDefinition.types"
 import type { DragInfo } from "@/types/answerSheetLayout.types"
 
-/** LineStyle に応じた SVG strokeDasharray / offset / linecap を返す */
+import { DEFAULT_DASH_RATIO, DEFAULT_GAP_RATIO } from "../../constants"
+
+/**
+ * LineStyle に応じた SVG strokeDasharray / offset / linecap を返す。
+ *
+ * dashRatio / gapRatio は線幅に対する倍率。罫線種別ごとに任意の
+ * ダッシュ長・間隔を指定できる（未指定時は既定 dash=3倍 / gap=2倍）。
+ * 点線（dotted）のダッシュ長は固定（ほぼ点）で、gapRatio のみ反映する。
+ */
 export function getDashProps(
   style: LineStyle,
   strokeWidth: number,
-  lineLength: number
+  lineLength: number,
+  dashRatio: number = DEFAULT_DASH_RATIO,
+  gapRatio: number = DEFAULT_GAP_RATIO
 ): {
   strokeDasharray?: string
   strokeDashoffset?: number
@@ -24,12 +34,12 @@ export function getDashProps(
   let dash: number, gap: number
   switch (style) {
     case "dashed":
-      dash = strokeWidth * 3
-      gap = strokeWidth * 2
+      dash = strokeWidth * dashRatio
+      gap = strokeWidth * gapRatio
       break
     case "dotted":
       dash = 0.01
-      gap = strokeWidth * 2
+      gap = strokeWidth * gapRatio
       break
     default:
       return {}

--- a/src/components/answer-sheet-builder/constants.ts
+++ b/src/components/answer-sheet-builder/constants.ts
@@ -20,11 +20,24 @@ export const DEFAULT_MANUSCRIPT_CHAR_DIVIDER: LineStyle = "dashed"
 export const DEFAULT_MANUSCRIPT_LINE_DIVIDER: LineStyle = "solid"
 /** 原稿用紙マス罫線の太さ（mm）。輪転印刷でかすれないよう黒・実用太さ */
 export const DEFAULT_MANUSCRIPT_DIVIDER_WIDTH = 0.2
-/** 文字数ガイドの既定文字サイズ（mm） */
-export const DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE = 2.2
+/** 文字数ガイドの既定文字サイズ（1マス＝1とした相対値。マス比） */
+export const DEFAULT_MANUSCRIPT_GUIDE_FONT_RATIO = 0.3
+/** 文字数ガイドの隅からの既定余白（1マス＝1とした相対値。マス比） */
+export const DEFAULT_MANUSCRIPT_GUIDE_PADDING_RATIO = 0.05
+/** 区切り罫線（○字以内/以上の目印）の既定太さ（mm） */
+export const DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH = 0.5
 /** 文字数ガイドの既定表示位置（左下が一般的） */
 export const DEFAULT_MANUSCRIPT_GUIDE_POSITION: ManuscriptGuidePosition =
   "bottom-left"
+
+// =====================
+// 破線/点線パターンの既定値
+// =====================
+
+/** 破線のダッシュ長の既定倍率（線幅に対する倍率） */
+export const DEFAULT_DASH_RATIO = 3
+/** 破線/点線の間隔の既定倍率（線幅に対する倍率） */
+export const DEFAULT_GAP_RATIO = 2
 
 // =====================
 // 用紙サイズ定数（mm）

--- a/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
@@ -21,7 +21,8 @@ import type {
 import {
   DEFAULT_MANUSCRIPT_CHAR_DIVIDER,
   DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
-  DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+  DEFAULT_MANUSCRIPT_GUIDE_FONT_RATIO,
+  DEFAULT_MANUSCRIPT_GUIDE_PADDING_RATIO,
   DEFAULT_MANUSCRIPT_GUIDE_POSITION,
   DEFAULT_MANUSCRIPT_LINE_DIVIDER,
 } from "../../constants"
@@ -241,10 +242,15 @@ export function computeManuscriptGrid(
       DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
     // 文字数ガイドは小問ごとの設定。
     charGuides: sub.manuscriptPaper.charGuides ?? [],
+    // guideFontSize/guidePadding はマス比（1マス=1）で保存。cellSizeMm 倍して絶対mmへ。
     guideFontSize:
-      sub.manuscriptPaper.guideFontSize ?? DEFAULT_MANUSCRIPT_GUIDE_FONT_SIZE,
+      (sub.manuscriptPaper.guideFontSize ??
+        DEFAULT_MANUSCRIPT_GUIDE_FONT_RATIO) * cellSizeMm,
     guidePosition:
       sub.manuscriptPaper.guidePosition ?? DEFAULT_MANUSCRIPT_GUIDE_POSITION,
+    guidePadding:
+      (sub.manuscriptPaper.guidePadding ??
+        DEFAULT_MANUSCRIPT_GUIDE_PADDING_RATIO) * cellSizeMm,
   }
 }
 

--- a/src/components/answer-sheet-builder/hooks/layout/layoutUtils.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/layoutUtils.ts
@@ -10,7 +10,11 @@ import type {
   GlobalSettings,
 } from "@/types/answerSheetDefinition.types"
 
-import { PAPER_SIZES } from "../../constants"
+import {
+  DEFAULT_DASH_RATIO,
+  DEFAULT_GAP_RATIO,
+  PAPER_SIZES,
+} from "../../constants"
 
 /** lineType から BorderConfig の線幅を取得するヘルパー */
 export function getLineWidth(
@@ -35,6 +39,63 @@ export function getLineWidth(
       return borderConfig.branchNumberDividerWidth ?? 0.3
     default:
       return 0.4
+  }
+}
+
+/**
+ * lineType から破線/点線のダッシュ長・間隔倍率（線幅に対する倍率）を取得する。
+ * 罫線種別ごとに BorderConfig で個別設定でき、未指定時は既定値を返す。
+ */
+export function getLineDashRatio(
+  lineType: string,
+  borderConfig: BorderConfig
+): { dashRatio: number; gapRatio: number } {
+  const pick = (
+    dash: number | undefined,
+    gap: number | undefined
+  ): { dashRatio: number; gapRatio: number } => ({
+    dashRatio: dash ?? DEFAULT_DASH_RATIO,
+    gapRatio: gap ?? DEFAULT_GAP_RATIO,
+  })
+  switch (lineType) {
+    case "outer":
+      return pick(
+        borderConfig.outerBorderDashRatio,
+        borderConfig.outerBorderGapRatio
+      )
+    case "major":
+      return pick(
+        borderConfig.majorDividerDashRatio,
+        borderConfig.majorDividerGapRatio
+      )
+    case "sub":
+    case "subHorizontalDivider":
+      return pick(
+        borderConfig.subDividerDashRatio,
+        borderConfig.subDividerGapRatio
+      )
+    case "branch":
+      return pick(
+        borderConfig.branchDividerDashRatio,
+        borderConfig.branchDividerGapRatio
+      )
+    case "majorNumberColumn":
+      return pick(
+        borderConfig.majorNumberDividerDashRatio,
+        borderConfig.majorNumberDividerGapRatio
+      )
+    case "subNumberColumn":
+      return pick(
+        borderConfig.subNumberDividerDashRatio,
+        borderConfig.subNumberDividerGapRatio
+      )
+    case "branchNumberColumn":
+      return pick(
+        borderConfig.branchNumberDividerDashRatio,
+        borderConfig.branchNumberDividerGapRatio
+      )
+    default:
+      return pick(undefined, undefined)
   }
 }
 

--- a/src/components/answer-sheet-builder/utils/generatePrintHtml.ts
+++ b/src/components/answer-sheet-builder/utils/generatePrintHtml.ts
@@ -63,6 +63,7 @@ async function renderPageSvgHtmls(
           renderMode: effectiveRenderMode,
           forPrint: true,
           imageDataUris,
+          borderConfig: definition.settings.borderConfig,
         })
       )
     )

--- a/src/components/help/common/DocComponents.tsx
+++ b/src/components/help/common/DocComponents.tsx
@@ -1,0 +1,296 @@
+"use client"
+
+import React, { useState } from "react"
+
+/**
+ * 初心者向けヘルプ（使い方ガイド）のドキュメント風プリミティブ。
+ * 一般的なWebヘルプページのように、読みやすい1カラムで構成する。
+ */
+
+/** 記事ヘッダー：ステップ番号チップ＋大見出し＋リード文 */
+export function HelpHero({
+  eyebrow,
+  title,
+  lead,
+}: {
+  eyebrow?: string
+  title: string
+  lead: string
+}) {
+  return (
+    <header className="mb-10">
+      {eyebrow && (
+        <span className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+          {eyebrow}
+        </span>
+      )}
+      <h1 className="text-3xl leading-tight font-bold text-gray-900 md:text-4xl">
+        {title}
+      </h1>
+      <p className="mt-4 text-base leading-relaxed text-gray-600 md:text-lg">
+        {lead}
+      </p>
+    </header>
+  )
+}
+
+/** 節：h2＋下線。中身は読みやすい本文サイズに統一 */
+export function HelpSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="first:mt-0">
+      <h2 className="mb-5 border-b border-gray-200 pb-3 text-2xl font-bold text-gray-900 md:text-3xl">
+        {title}
+      </h2>
+      <div className="space-y-4 text-[15px] leading-relaxed text-gray-700">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+/** 図版コンテナ：CSS図解を中央に置き、下にキャプションを添える */
+export function Figure({
+  caption,
+  children,
+}: {
+  caption?: string
+  children: React.ReactNode
+}) {
+  return (
+    <figure className="my-6">
+      <div className="flex flex-col items-center gap-5 rounded-xl border border-gray-200 bg-gradient-to-b from-gray-50 to-white px-6 py-8">
+        {children}
+      </div>
+      {caption && (
+        <figcaption className="mt-2 text-center text-sm text-gray-500">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  )
+}
+
+type CalloutType = "tip" | "note" | "warning" | "success"
+
+const calloutStyles: Record<
+  CalloutType,
+  { box: string; title: string; body: string; label: string }
+> = {
+  tip: {
+    box: "border-blue-500 bg-blue-50",
+    title: "text-blue-800",
+    body: "text-blue-900/80",
+    label: "ポイント",
+  },
+  success: {
+    box: "border-emerald-500 bg-emerald-50",
+    title: "text-emerald-800",
+    body: "text-emerald-900/80",
+    label: "できること",
+  },
+  warning: {
+    box: "border-amber-500 bg-amber-50",
+    title: "text-amber-800",
+    body: "text-amber-900/80",
+    label: "注意",
+  },
+  note: {
+    box: "border-gray-300 bg-gray-50",
+    title: "text-gray-800",
+    body: "text-gray-600",
+    label: "メモ",
+  },
+}
+
+/** 左ボーダー付きの注記ボックス（ポイント／注意／できること など） */
+export function Callout({
+  type = "note",
+  title,
+  children,
+}: {
+  type?: CalloutType
+  title?: string
+  children: React.ReactNode
+}) {
+  const s = calloutStyles[type]
+  return (
+    <div className={`rounded-r-lg border-l-4 p-4 ${s.box}`}>
+      <div className={`mb-1 text-sm font-bold ${s.title}`}>
+        {title ?? s.label}
+      </div>
+      <div className={`text-sm leading-relaxed ${s.body}`}>{children}</div>
+    </div>
+  )
+}
+
+/** 手順リスト（番号付き） */
+export function Steps({ children }: { children: React.ReactNode }) {
+  return <ol className="space-y-5">{children}</ol>
+}
+
+export function Step({
+  n,
+  title,
+  children,
+}: {
+  n: number
+  title: string
+  children?: React.ReactNode
+}) {
+  return (
+    <li className="flex gap-4">
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white">
+        {n}
+      </span>
+      <div className="flex-1 pt-0.5">
+        <p className="font-semibold text-gray-900">{title}</p>
+        {children && (
+          <p className="mt-1 text-sm leading-relaxed text-gray-600">
+            {children}
+          </p>
+        )}
+      </div>
+    </li>
+  )
+}
+
+/**
+ * 「どちらか一方だけ知りたい」選択肢を切り替えるタブ。
+ * 選択肢が一目で分かるよう、大きめのセグメント表示にする。
+ */
+export function HelpTabs({
+  tabs,
+}: {
+  tabs: {
+    id: string
+    label: string
+    icon?: React.ReactNode
+    content: React.ReactNode
+  }[]
+}) {
+  const [active, setActive] = useState(tabs[0]?.id)
+  const current = tabs.find((t) => t.id === active) ?? tabs[0]
+  return (
+    <div>
+      <div
+        role="tablist"
+        className="inline-flex w-full gap-1 rounded-xl border border-gray-200 bg-gray-100 p-1 sm:w-auto"
+      >
+        {tabs.map((t) => {
+          const isActive = active === t.id
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActive(t.id)}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold transition-colors sm:flex-none ${
+                isActive
+                  ? "bg-white text-blue-700 shadow-sm"
+                  : "text-gray-500 hover:text-gray-800"
+              }`}
+            >
+              {t.icon}
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+      <div className="mt-6 space-y-4">{current?.content}</div>
+    </div>
+  )
+}
+
+type KeyTone = "slate" | "green" | "red" | "amber" | "blue" | "violet"
+
+const keyTones: Record<KeyTone, string> = {
+  slate: "border-gray-300 from-gray-50 to-gray-100 text-gray-700",
+  green: "border-emerald-300 from-emerald-50 to-emerald-100 text-emerald-700",
+  red: "border-rose-300 from-rose-50 to-rose-100 text-rose-700",
+  amber: "border-amber-300 from-amber-50 to-amber-100 text-amber-700",
+  blue: "border-blue-300 from-blue-50 to-blue-100 text-blue-700",
+  violet: "border-violet-300 from-violet-50 to-violet-100 text-violet-700",
+}
+
+/** 物理キー風の見た目（インライン） */
+export function Kbd({
+  children,
+  tone = "slate",
+}: {
+  children: React.ReactNode
+  tone?: KeyTone
+}) {
+  return (
+    <kbd
+      className={`inline-flex h-7 min-w-7 items-center justify-center rounded-md border border-b-2 bg-gradient-to-b px-2 font-mono text-sm font-bold ${keyTones[tone]}`}
+    >
+      {children}
+    </kbd>
+  )
+}
+
+/** キー図解用のタイル：大きなキー＋意味ラベル */
+export function KeyTile({
+  keyLabel,
+  meaning,
+  tone = "slate",
+}: {
+  keyLabel: string
+  meaning: string
+  tone?: KeyTone
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <kbd
+        className={`flex h-12 w-12 items-center justify-center rounded-lg border border-b-2 bg-gradient-to-b text-lg font-bold shadow-sm ${keyTones[tone]}`}
+      >
+        {keyLabel}
+      </kbd>
+      <span className="text-xs font-medium text-gray-600">{meaning}</span>
+    </div>
+  )
+}
+
+/** キー＋説明の一覧（補助的なショートカット用） */
+export function KeyList({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200">
+      {children}
+    </div>
+  )
+}
+
+export function KeyRow({
+  keys,
+  tone = "slate",
+  children,
+}: {
+  keys: string
+  tone?: KeyTone
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center gap-4 px-4 py-2.5">
+      <span className="w-32 shrink-0">
+        <Kbd tone={tone}>{keys}</Kbd>
+      </span>
+      <span className="text-sm text-gray-700">{children}</span>
+    </div>
+  )
+}
+
+/** ラベルのバッジ（種類の例などの一覧表示） */
+export function Pill({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700">
+      {children}
+    </span>
+  )
+}

--- a/src/components/help/page-specific/HelpContent01Upload.tsx
+++ b/src/components/help/page-specific/HelpContent01Upload.tsx
@@ -15,7 +15,7 @@ export function HelpContent01Upload() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <FileImage className="h-6 w-6 text-blue-600" />
-          模範解答画像の管理 - 使い方
+          模範解答画像の管理
         </h2>
         <p className="text-muted-foreground">
           試験問題の模範解答をアップロードして、採点の準備をしましょう。
@@ -45,7 +45,7 @@ export function HelpContent01Upload() {
           <StepItem
             number={4}
             title="順番を整える"
-            description="ページをドラッグして正しい順番に並び替える"
+            description="各ページの左右にある矢印ボタンで正しい順番に並び替える"
             isImportant
           />
         </div>
@@ -113,13 +113,13 @@ export function HelpContent01Upload() {
           <div className="space-y-3">
             <TipItem type="success">
               <strong>順番を間違えた：</strong>
-              ページをマウスでドラッグすれば順番を変えられます。
-              不要なページは右上の「×」ボタンで削除できます。
+              各ページの左右にある矢印ボタンで順番を変えられます。
+              不要なページはゴミ箱アイコンで削除できます。
             </TipItem>
 
             <TipItem type="success">
               アップロードが終わったら、「次へ:
-              採点領域作成」ボタンが表示されます。
+              答案の採点領域作成」ボタンが表示されます。
               全てのページが正しい順番になっていることを確認してから次に進みましょう。
             </TipItem>
           </div>

--- a/src/components/help/page-specific/HelpContent02Template.tsx
+++ b/src/components/help/page-specific/HelpContent02Template.tsx
@@ -15,7 +15,7 @@ export function HelpContent02Template() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Target className="h-6 w-6 text-blue-600" />
-          答案の採点領域作成 - 使い方
+          答案の採点領域作成
         </h2>
         <p className="text-muted-foreground">
           模範解答の上に採点したい範囲を四角で囲んで、採点の準備をしましょう。
@@ -45,7 +45,7 @@ export function HelpContent02Template() {
           <StepItem
             number={4}
             title="自動で保存"
-            description="設定は自動的に保存されます"
+            description="範囲を作成・移動・削除すると自動的に保存されます"
             isImportant
           />
         </div>
@@ -85,7 +85,7 @@ export function HelpContent02Template() {
             <ul className="space-y-1 text-sm text-blue-800">
               <li>• 解答が書かれる範囲より少し大きめに囲みましょう</li>
               <li>• 問題文は囲まず、解答部分だけを囲みます</li>
-              <li>• Deleteキーで選んだ範囲を削除できます</li>
+              <li>• Delete または Backspace キーで選んだ範囲を削除できます</li>
             </ul>
           </div>
         </HelpSection>
@@ -101,7 +101,8 @@ export function HelpContent02Template() {
           <div className="space-y-3">
             <TipItem type="info">
               <strong>範囲を間違えた：</strong>
-              間違えた範囲をクリックして選んでから、Deleteキーを押すと削除できます。
+              間違えた範囲をクリックして選んでから、Delete または Backspace
+              キーを押すと削除できます。
               もう一度正しい範囲をドラッグして囲み直してください。
             </TipItem>
 
@@ -125,9 +126,9 @@ export function HelpContent02Template() {
             </TipItem>
 
             <TipItem type="success">
-              すべてのページで採点範囲を囲み終わると、 「次へ:
+              表示中のページに採点範囲を1つ以上作ると、「次へ:
               採点領域の詳細情報設定」ボタンが表示されます。
-              全部終わってから次に進みましょう。
+              複数ページがある場合は、すべてのページで囲んでから次に進みましょう。
             </TipItem>
           </div>
         </HelpSection>

--- a/src/components/help/page-specific/HelpContent03RegionInfo.tsx
+++ b/src/components/help/page-specific/HelpContent03RegionInfo.tsx
@@ -23,7 +23,7 @@ export function HelpContent03RegionInfo() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Settings className="h-6 w-6 text-blue-600" />
-          採点領域の詳細情報設定 - 使い方
+          採点領域の詳細情報設定
         </h2>
         <p className="text-muted-foreground">
           採点する場所に設問番号や配点などの詳しい情報を設定しましょう。
@@ -82,9 +82,17 @@ export function HelpContent03RegionInfo() {
             </div>
             <div>
               <h4 className="mb-2 font-medium">点数の表示場所</h4>
-              <div className="flex flex-wrap gap-2">
+              <div className="mb-3 flex flex-wrap gap-2">
                 <Badge variant="secondary">🏆 合計点</Badge>
                 <Badge variant="secondary">🔢 小計</Badge>
+              </div>
+            </div>
+            <div>
+              <h4 className="mb-2 font-medium">その他</h4>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="secondary">✏️ マーク</Badge>
+                <Badge variant="secondary">💬 コメント</Badge>
+                <Badge variant="secondary">⋯ その他</Badge>
               </div>
             </div>
           </div>
@@ -142,9 +150,14 @@ export function HelpContent03RegionInfo() {
             </TipItem>
 
             <TipItem type="success">
-              すべての設定が終わったら、「次へ:
-              小計点の設定」ボタンが表示されます。
-              配点に間違いがないか確認してから次に進みましょう。
+              <strong>マークシート採点：</strong>
+              「設問解答」の行にある「OMR」ボタンから、
+              マークシートを自動で読み取る設定ができます。
+            </TipItem>
+
+            <TipItem type="success">
+              設定が終わったら、「次へ: 小計点の設定」ボタンから次に進めます。
+              配点に間違いがないか確認してから進みましょう。
             </TipItem>
           </div>
         </HelpSection>

--- a/src/components/help/page-specific/HelpContent04QuestionGroup.tsx
+++ b/src/components/help/page-specific/HelpContent04QuestionGroup.tsx
@@ -23,7 +23,7 @@ export function HelpContent04QuestionGroup() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Calculator className="h-6 w-6 text-blue-600" />
-          小計点の設定 - 使い方
+          小計点の設定
         </h2>
         <p className="text-muted-foreground">
           設問の点数を項目別に分けて集計できるよう、関連付けを設定しましょう。
@@ -42,8 +42,8 @@ export function HelpContent04QuestionGroup() {
           />
           <StepItem
             number={2}
-            title="設問と項目を関連付け"
-            description="チェックボックスで、各設問がどの項目に含まれるかを設定します"
+            title="設問と小計項目を関連付け"
+            description="チェックボックスで、各設問がどの小計項目に含まれるかを設定します"
           />
           <StepItem
             number={3}
@@ -81,8 +81,8 @@ export function HelpContent04QuestionGroup() {
             <div>
               <h4 className="mb-2 font-medium">計算のしくみ</h4>
               <p className="text-muted-foreground text-sm">
-                同じグループ内の項目は「どれか」、
-                異なるグループ間は「すべて」の条件で計算されます
+                同じグループ内の項目は「どれか1つに該当（OR）」、
+                別々のグループは「すべてに該当（AND）」した設問の点数を合計します
               </p>
             </div>
           </div>
@@ -101,7 +101,10 @@ export function HelpContent04QuestionGroup() {
               keys="ドラッグ"
               description="まとめてチェック/解除する"
             />
-            <ShortcutItem keys="リセット" description="変更を元に戻す" />
+            <ShortcutItem
+              keys="リセット"
+              description="今回の編集を取り消して直前の状態に戻す"
+            />
           </div>
           <div className="mt-3 rounded-lg bg-blue-50 p-3">
             <p className="text-sm text-blue-800">
@@ -133,8 +136,8 @@ export function HelpContent04QuestionGroup() {
 
             <TipItem type="warning">
               <strong>グループが見つからない：</strong>
-              必要な項目グループがない場合は、
-              「新規作成」で別ページを開いて作成してください。
+              「グループを追加」を押すと選択画面が開きます。
+              必要なグループがなければ、その中の「新規作成」から作成できます。
             </TipItem>
           </div>
         </HelpSection>
@@ -146,8 +149,8 @@ export function HelpContent04QuestionGroup() {
           <div className="space-y-3">
             <TipItem type="success">
               <strong>グループ作成：</strong>
-              新しい項目グループが必要な場合は、
-              「新規作成」ボタンで別ページで作成できます。
+              新しいグループは「小計点グループ管理」ページで作成・編集でき、
+              複数の試験で使い回せます。
             </TipItem>
 
             <TipItem type="success">

--- a/src/components/help/page-specific/HelpContent05Students.tsx
+++ b/src/components/help/page-specific/HelpContent05Students.tsx
@@ -15,7 +15,7 @@ export function HelpContent05Students() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Users className="h-6 w-6 text-blue-600" />
-          受験生徒の管理 - 使い方
+          受験生徒の管理
         </h2>
         <p className="text-muted-foreground">
           採点する生徒を登録して、受験状態を設定しましょう。
@@ -118,7 +118,7 @@ export function HelpContent05Students() {
             <TipItem type="warning">
               <strong>欠席者がいる：</strong>
               欠席が分かっている生徒は先に「欠席」に設定しておくと、
-              答案アップロード時にエラーが出ません。
+              答案アップロードの表で自動的に無効化され、誤って答案を割り当てるのを防げます。
             </TipItem>
           </div>
         </HelpSection>

--- a/src/components/help/page-specific/HelpContent06StudentAnswers.tsx
+++ b/src/components/help/page-specific/HelpContent06StudentAnswers.tsx
@@ -15,7 +15,7 @@ export function HelpContent06StudentAnswers() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Upload className="h-6 w-6 text-blue-600" />
-          生徒答案の追加と関連付け - 使い方
+          生徒答案の追加と関連付け
         </h2>
         <p className="text-muted-foreground">
           生徒の答案画像をアップロードして、それぞれの生徒に正しく関連付けましょう。
@@ -35,7 +35,7 @@ export function HelpContent06StudentAnswers() {
           <StepItem
             number={2}
             title="並べ方を決める"
-            description="「ページごと」か「生徒ごと」かを選んでください"
+            description="配置戦略で「ページ順」か「生徒順」かを選びます"
             isImportant
           />
           <StepItem
@@ -81,17 +81,13 @@ export function HelpContent06StudentAnswers() {
         >
           <div className="space-y-3">
             <div className="border-l-4 border-green-500 pl-3">
-              <h4 className="text-sm font-medium text-green-700">
-                ページごと並べる
-              </h4>
+              <h4 className="text-sm font-medium text-green-700">ページ順</h4>
               <p className="text-xs text-green-600">
                 1ページ目をまとめて、次に2ページ目をまとめてスキャンした場合
               </p>
             </div>
             <div className="border-l-4 border-blue-500 pl-3">
-              <h4 className="text-sm font-medium text-blue-700">
-                生徒ごと並べる
-              </h4>
+              <h4 className="text-sm font-medium text-blue-700">生徒順</h4>
               <p className="text-xs text-blue-600">
                 生徒Aの全ページ、次に生徒Bの全ページという順でスキャンした場合
               </p>
@@ -136,6 +132,12 @@ export function HelpContent06StudentAnswers() {
             <TipItem type="success">
               答案を移動するときは、採点情報も一緒に移動することをお勧めします。
               答案と採点結果がずれてしまうのを防げます。
+            </TipItem>
+
+            <TipItem type="info">
+              <strong>便利な切り替え：</strong>
+              プレビューを「氏名欄のみ」にすると名前の確認がしやすくなります。
+              すでにある答案を差し替えたいときは「既存答案上書き」をオンにしてください。
             </TipItem>
           </div>
         </HelpSection>

--- a/src/components/help/page-specific/HelpContent07Scoring.tsx
+++ b/src/components/help/page-specific/HelpContent07Scoring.tsx
@@ -1,147 +1,2128 @@
 "use client"
 
+import { ArrowRight, Eye, RotateCcw } from "lucide-react"
 import {
-  BarChart3,
-  CheckCircle,
-  Keyboard,
-  Lightbulb,
-  Settings,
-} from "lucide-react"
+  createContext,
+  type CSSProperties,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
+import { getDynamicScoreStatusConfig } from "@/components/exams/07-score-at-once/ScoringGrid/constants/scoreStatusConfig"
+import { useSelectionBorder } from "@/components/exams/07-score-at-once/ScoringGrid/hooks/useSelectionBorder"
+import { useShortcutContext } from "@/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider"
+import PartialScoreModal from "@/components/exams/07-score-at-once/ScoringMain/PartialScoreModal"
+import { Callout, HelpHero, Kbd } from "@/components/help/common/DocComponents"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
-  HelpSection,
-  ShortcutItem,
-  StepItem,
-  TipItem,
-} from "@/components/help/common/HelpComponents"
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useScoringStatusColors } from "@/hooks/07-score-at-once/useScoringStatusColors"
+import { getModifierKeyLabel } from "@/lib/platformUtils"
+import { SCORING_STATUS_LABELS } from "@/lib/scoringStatusColors"
 
-export function HelpContent07Scoring() {
+/** キー文字列を表示用に整形（"e"→"E", "Shift+d"→"Shift+D"） */
+function formatKey(key?: string): string {
+  if (!key) return ""
+  return key
+    .split("+")
+    .map((part) => (part.length === 1 ? part.toUpperCase() : part))
+    .join("+")
+}
+
+/** 修飾キーを実行環境のラベルに合わせて整形（"Alt+e"→ Mac: "Option+E"） */
+function formatModKey(key?: string): string {
+  return formatKey(key).replace(/Alt/gi, getModifierKeyLabel())
+}
+
+/** スクロール可能な最寄りの祖先を返す（IntersectionObserver の root 用） */
+function getScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let p = el?.parentElement ?? null
+  while (p) {
+    const oy = getComputedStyle(p).overflowY
+    if (oy === "auto" || oy === "scroll") return p
+    p = p.parentElement
+  }
+  return null
+}
+
+const MAX_SCORE = 10
+
+type DemoStatus =
+  | "unscored"
+  | "correct"
+  | "incorrect"
+  | "partial"
+  | "no_answer"
+  | "pending"
+
+interface GuideKeys {
+  correct: string
+  incorrect: string
+  partial: string
+  pending: string
+  nextQuestion: string
+  prevQuestion: string
+  filterCorrect: string
+  filterIncorrect: string
+  toggleView: string
+  toggleMaster: string
+}
+
+// ============================================================================
+// 見出しフォーカス（スクロール位置で現在地を示す）
+// ============================================================================
+
+/** 現在スクロール位置にある（フォーカス中の）見出しタイトルを配る */
+const HeadingFocusContext = createContext<string | null>(null)
+
+/** この見出しがフォーカス中かどうか（タイトルで識別） */
+function useHeadingActive(title: string): boolean {
+  return useContext(HeadingFocusContext) === title
+}
+
+/**
+ * フォーカス中のセクション背景。本文の流れには載せず、後ろに敷く全幅レイヤー。
+ * left:calc(50%-50vw)+w-screen でセクション中央を基準にモーダル全幅へ広げ、
+ * スクロール領域の overflow-x-hidden で左右がモーダル幅に切り取られる。
+ * 角丸なしの自然なバンドになり、本文位置はずれない。
+ */
+function FocusBackground({ active }: { active: boolean }) {
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
-          <BarChart3 className="h-6 w-6 text-blue-600" />
-          一括採点 - 使い方
-        </h2>
-        <p className="text-muted-foreground">
-          キーボードを使って素早く採点しましょう。複数の先生で一緒に採点することもできます。
-        </p>
-      </div>
+    <span
+      aria-hidden
+      className={`pointer-events-none absolute inset-y-0 left-[calc(50%-50vw)] -z-10 w-screen transition-colors duration-500 ${
+        active ? "bg-blue-100/40" : "bg-transparent"
+      }`}
+    />
+  )
+}
 
-      <HelpSection
-        icon={<Keyboard className="h-5 w-5 text-green-600" />}
-        title="基本の使い方"
-      >
-        <div className="space-y-3">
-          <StepItem
-            number={1}
-            title="答案を見る"
-            description="画面に表示された生徒の答案を確認してください"
+/** フォーカス中に左から右へ青く伸びる下線（見出しの border-b に重ねる） */
+function FocusUnderline({ active }: { active: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="absolute -bottom-px left-0 h-0.5 w-full origin-left bg-blue-500 transition-transform duration-500 ease-out"
+      style={{ transform: active ? "scaleX(1)" : "scaleX(0)" }}
+    />
+  )
+}
+
+/**
+ * ドキュメント風の節。DocComponents の HelpSection と同じ見た目だが、
+ * スクロール位置に応じて下線が青く伸びてフォーカスを示す。
+ */
+function FocusSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  const active = useHeadingActive(title)
+  return (
+    <section data-help-heading={title} className="relative isolate py-8">
+      <FocusBackground active={active} />
+      <h2 className="relative mb-5 border-b border-gray-200 pb-3 text-2xl font-bold text-gray-900 md:text-3xl">
+        {title}
+        <FocusUnderline active={active} />
+      </h2>
+      <div className="space-y-4 text-[15px] leading-relaxed text-gray-700">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+// ============================================================================
+// 採点スタイルの説明アニメーション（CSS / SVG）
+// ============================================================================
+
+const HELP07_KEYFRAMES = `
+@keyframes help07Sel {
+  0%, 100% { border-color: #e5e7eb; }
+  6% { border-color: var(--help07-sel, #F97316); }
+  18% { border-color: #e5e7eb; }
+}
+@keyframes help07Mark {
+  0%, 10% { opacity: 0; transform: scale(0.4); }
+  20% { opacity: 1; transform: scale(1); }
+  90% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1); }
+}
+@keyframes help07Pen {
+  0% { stroke-dashoffset: var(--help07-len); opacity: 1; }
+  45%, 80% { stroke-dashoffset: 0; opacity: 1; }
+  95% { stroke-dashoffset: 0; opacity: 0; }
+  100% { stroke-dashoffset: var(--help07-len); opacity: 0; }
+}
+@keyframes help07March { to { stroke-dashoffset: -14; } }
+@keyframes help07Pan {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(7px); }
+}
+`
+
+/** 一覧表示の説明アニメ：答案が並び、順に印がついていく */
+function GridStyleAnimation() {
+  const colors = useScoringStatusColors()
+  const sel = useSelectionBorder()
+  const marks = [true, false, true, true, false, true]
+  return (
+    <div
+      className="grid grid-cols-3 gap-1.5"
+      style={{ "--help07-sel": sel } as CSSProperties}
+    >
+      {marks.map((ok, i) => (
+        <div
+          key={i}
+          className="flex h-9 items-center justify-center rounded-sm border-2 bg-white"
+          style={{ animation: `help07Sel 6s ${i * 0.7}s infinite` }}
+        >
+          <span
+            className="text-lg font-bold"
+            style={{
+              color: ok ? colors.correct.icon : colors.incorrect.icon,
+              opacity: 0,
+              animation: `help07Mark 6s ${i * 0.7}s infinite`,
+            }}
+          >
+            {ok ? "○" : "×"}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** 個別表示の説明アニメ：1枚の答案に赤ペンで丸をつける */
+function IndividualStyleAnimation() {
+  const colors = useScoringStatusColors()
+  const red = colors.incorrect.icon
+  const len = 2 * Math.PI * 15
+  return (
+    <svg viewBox="0 0 140 84" className="h-20 w-full">
+      <rect
+        x="6"
+        y="6"
+        width="128"
+        height="72"
+        rx="5"
+        fill="white"
+        stroke="#e5e7eb"
+        strokeWidth="2"
+      />
+      <line
+        x1="18"
+        y1="28"
+        x2="74"
+        y2="28"
+        stroke="#d1d5db"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <line
+        x1="18"
+        y1="44"
+        x2="90"
+        y2="44"
+        stroke="#d1d5db"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <line
+        x1="18"
+        y1="60"
+        x2="62"
+        y2="60"
+        stroke="#d1d5db"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="104"
+        cy="44"
+        r="15"
+        fill="none"
+        stroke={red}
+        strokeWidth="3"
+        strokeLinecap="round"
+        style={
+          {
+            strokeDasharray: len,
+            "--help07-len": len,
+            animation: "help07Pen 4s infinite",
+          } as CSSProperties
+        }
+      />
+    </svg>
+  )
+}
+
+function StyleCard({
+  title,
+  desc,
+  animation,
+  active,
+  onClick,
+}: {
+  title: string
+  desc: string
+  animation: React.ReactNode
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`group flex flex-col gap-3 rounded-xl border p-5 text-left transition-colors ${
+        active
+          ? "border-blue-500 bg-blue-50/60 ring-1 ring-blue-200"
+          : "border-gray-200 bg-white hover:border-blue-400 hover:bg-blue-50/40"
+      }`}
+    >
+      <div className="flex h-24 items-center justify-center rounded-lg bg-gray-50 p-3">
+        {animation}
+      </div>
+      <div>
+        <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+        <p className="mt-1 text-sm leading-relaxed text-gray-600">{desc}</p>
+      </div>
+      <span className="mt-auto inline-flex items-center gap-1 text-sm font-medium text-blue-600">
+        {active ? "選択中（下に手順があります）" : "この表示で進む"}
+        {!active && (
+          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        )}
+      </span>
+    </button>
+  )
+}
+
+function StyleChooser({
+  selected,
+  onSelect,
+}: {
+  selected: "grid" | "individual" | null
+  onSelect: (style: "grid" | "individual") => void
+}) {
+  return (
+    <Scene>
+      <FocusSection title="① 採点スタイルを選ぶ">
+        <p>
+          採点画面には2つの表示があります。選ぶと、下に詳しい手順が表示されます。
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <StyleCard
+            title="一覧表示"
+            desc="同じ設問の答案を全員ぶん並べて、次々と印をつけます。同じ問題をまとめて見られます。"
+            animation={<GridStyleAnimation />}
+            active={selected === "grid"}
+            onClick={() => onSelect("grid")}
           />
-          <StepItem
-            number={2}
-            title="キーボードで採点"
-            description="Q(未採点)、E(正答)、F(部分点)、O(誤答)、P(無答)のキーを押します"
-            isImportant
-          />
-          <StepItem
-            number={3}
-            title="次の答案へ"
-            description="自動的に次の答案が表示されます"
-          />
-          <StepItem
-            number={4}
-            title="設問を変える"
-            description="Shift+A で前の設問、Shift+D で次の設問に移動できます"
+          <StyleCard
+            title="個別表示"
+            desc="1人ずつ答案を大きく表示して、じっくり採点します。答案に直接、記号やコメントを書き込めます。"
+            animation={<IndividualStyleAnimation />}
+            active={selected === "individual"}
+            onClick={() => onSelect("individual")}
           />
         </div>
-      </HelpSection>
+      </FocusSection>
+    </Scene>
+  )
+}
 
-      <div className="my-4 border-t border-gray-200" />
+// ============================================================================
+// 一覧表示の体験デモ（段階的）
+// ============================================================================
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <HelpSection
-          icon={<Keyboard className="h-5 w-5 text-blue-600" />}
-          title="採点キー"
+interface DemoCell {
+  name: string
+  answer: string
+  status: DemoStatus
+  score?: number
+}
+
+/** ②選択の練習用（全員未採点・選択のみ） */
+const SELECT_CELLS: DemoCell[] = [
+  { name: "佐藤", answer: "12", status: "unscored" },
+  { name: "鈴木", answer: "13", status: "unscored" },
+  { name: "高橋", answer: "12", status: "unscored" },
+  { name: "田中", answer: "12", status: "unscored" },
+  { name: "伊藤", answer: "13", status: "unscored" },
+  { name: "渡辺", answer: "12", status: "unscored" },
+]
+
+/** ③採点（正答・誤答だけ） */
+const STAGE1_CELLS: DemoCell[] = [
+  { name: "佐藤", answer: "12", status: "unscored" },
+  { name: "鈴木", answer: "13", status: "unscored" },
+  { name: "高橋", answer: "12", status: "unscored" },
+  { name: "田中", answer: "13", status: "unscored" },
+]
+
+/** ステップ2：1人だけ未採点（部分点の対象）、ほかは採点済み。
+    設問「1辺3cmの正方形の面積」。田中は単位を書き忘れて部分点。 */
+const STAGE2_CELLS: DemoCell[] = [
+  { name: "佐藤", answer: "9cm²", status: "correct" },
+  { name: "鈴木", answer: "6cm²", status: "incorrect" },
+  { name: "高橋", answer: "（空欄）", status: "no_answer" },
+  { name: "田中", answer: "9", status: "unscored" },
+  { name: "伊藤", answer: "9cm²", status: "correct" },
+]
+
+function scoreText(cell: DemoCell): string | null {
+  switch (cell.status) {
+    case "correct":
+      return `${MAX_SCORE}/${MAX_SCORE}`
+    case "incorrect":
+    case "no_answer":
+      return `0/${MAX_SCORE}`
+    case "partial":
+      return `${cell.score ?? 0}/${MAX_SCORE}`
+    case "pending":
+      return `-/${MAX_SCORE}`
+    default:
+      return null
+  }
+}
+
+interface PartialInput {
+  active: boolean
+  value: string
+}
+
+/**
+ * 採点グリッドの体験デモ。本体の色設定・枠色・ステータス設定・UIコンポーネントを
+ * 再利用し、本番と同じ見た目で、クリックまたはキーボードで採点を試せる。
+ *
+ * キーボードは、このデモが表示されている間（＝ヘルプを開いている間）つねに
+ * window のキャプチャ段階で横取りし、stopImmediatePropagation で本体のショート
+ * カット（document のキャプチャリスナ）に届かせない。ヘルプを閉じるとアンマウント
+ * されてリスナも外れるため、本番のキー操作には影響しない。
+ */
+interface NavKeys {
+  up: string
+  left: string
+  down: string
+  right: string
+}
+
+/** デモ各セルの幅（模範解答・生徒答案で共通） */
+const DEMO_CELL_W = "w-36"
+
+/** ショートカットキー表示（本番 ScoringToolbar の KeyHint と同一） */
+function KeyHint({ label }: { label: string }) {
+  return (
+    <div className="mt-1 text-xs text-gray-400">
+      キー:{" "}
+      <kbd className="rounded bg-gray-200 px-1 py-0.5 text-xs">{label}</kbd>
+    </div>
+  )
+}
+
+/**
+ * 採点ボタン列。本番 ScoringToolbar と完全に同一（ツールチップ含む。下表示）。
+ * 一覧表示・個別表示どちらのデモでも使う。
+ */
+function ScoringButtonRow({
+  markOrder,
+  rawKeys,
+  onScore,
+}: {
+  markOrder: DemoStatus[]
+  rawKeys: Record<DemoStatus, string>
+  onScore: (status: DemoStatus) => void
+}) {
+  const colors = useScoringStatusColors()
+  const cfg = getDynamicScoreStatusConfig(colors)
+  if (markOrder.length === 0) return null
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {markOrder.map((status) => {
+          const sc = colors[status]
+          const Icon = cfg[status].icon
+          const keyLabel = (rawKeys[status] || "?").toUpperCase()
+          return (
+            <Tooltip key={status}>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onScore(status)}
+                  className="flex h-12 w-16 flex-col gap-1 border-2 hover:opacity-80"
+                  style={{
+                    backgroundColor: sc.bg,
+                    color: sc.text,
+                    borderColor: sc.bg,
+                  }}
+                >
+                  <Icon className="h-4 w-4" />
+                  <div className="text-xs">{SCORING_STATUS_LABELS[status]}</div>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <div className="text-center">
+                  <div className="font-medium">
+                    {SCORING_STATUS_LABELS[status]}にする
+                  </div>
+                  <KeyHint label={keyLabel} />
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function ScoringGridDemo({
+  initialCells,
+  markOrder,
+  allowPartial,
+  rawKeys,
+  navKeys,
+  questionExample,
+  masterAnswer,
+  isActive,
+  completion,
+  onAllScored,
+}: {
+  initialCells: DemoCell[]
+  markOrder: DemoStatus[]
+  allowPartial: boolean
+  rawKeys: Record<DemoStatus, string>
+  navKeys: NavKeys
+  questionExample: string
+  masterAnswer: string
+  isActive: boolean
+  completion?: React.ReactNode
+  onAllScored?: () => void
+}) {
+  const colors = useScoringStatusColors()
+  const selectionColor = useSelectionBorder()
+  const cfg = getDynamicScoreStatusConfig(colors)
+  const firstUnscored = Math.max(
+    0,
+    initialCells.findIndex((c) => c.status === "unscored")
+  )
+  const [cells, setCells] = useState<DemoCell[]>(initialCells)
+  const [selected, setSelected] = useState(firstUnscored)
+  const [partial, setPartial] = useState<PartialInput>({
+    active: false,
+    value: "",
+  })
+
+  const cellsRef = useRef(initialCells)
+  const selectedRef = useRef(firstUnscored)
+  const partialRef = useRef(partial)
+  const notifiedRef = useRef(false)
+  const isActiveRef = useRef(isActive)
+  // 模範解答＋生徒答案を inline で並べる折り返しグリッド（列数の実測に使う）
+  const gridRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    isActiveRef.current = isActive
+  }, [isActive])
+
+  const setCellsSynced = (next: DemoCell[]) => {
+    cellsRef.current = next
+    setCells(next)
+  }
+  const setSelectedSynced = (n: number) => {
+    selectedRef.current = n
+    setSelected(n)
+  }
+  const setPartialSynced = (p: PartialInput) => {
+    partialRef.current = p
+    setPartial(p)
+  }
+
+  const applyStatus = useCallback((status: DemoStatus, score?: number) => {
+    const sel = selectedRef.current
+    const updated = cellsRef.current.map((c, i) =>
+      i === sel ? { ...c, status, score } : c
+    )
+    setCellsSynced(updated)
+    const after = updated.findIndex(
+      (c, i) => i > sel && c.status === "unscored"
+    )
+    const wrap =
+      after === -1 ? updated.findIndex((c) => c.status === "unscored") : after
+    if (wrap !== -1) setSelectedSynced(wrap)
+  }, [])
+
+  /** 折り返しグリッドの先頭行に並ぶセル数（模範解答含む）を DOM から実測 */
+  const measureColumns = useCallback(() => {
+    const grid = gridRef.current
+    if (!grid) return 1
+    const items = Array.from(grid.children) as HTMLElement[]
+    if (items.length === 0) return 1
+    const top0 = items[0].offsetTop
+    let cols = 0
+    for (const it of items) {
+      if (it.offsetTop === top0) cols++
+      else break
+    }
+    return Math.max(1, cols)
+  }, [])
+
+  /**
+   * 本番（right-down レイアウト）と同じ移動仕様。
+   * 模範解答を index 0 に含む結合配列で考え、W/S は ∓cols（行をまたぐ）、
+   * 端では ∓1 にフォールバック、A/D は ±1。模範解答（0）には止まらない。
+   */
+  const moveSelection = useCallback(
+    (dir: "up" | "down" | "left" | "right") => {
+      const n = cellsRef.current.length
+      const total = n + 1 // 模範解答 + 生徒答案
+      const cols = measureColumns()
+      const cur = selectedRef.current + 1 // 結合配列での現在位置
+      let next = cur
+      if (dir === "left") next = cur - 1
+      else if (dir === "right") next = cur + 1
+      else if (dir === "up") {
+        next = cur - cols
+        if (next < 0) next = Math.max(0, cur - 1)
+      } else if (dir === "down") {
+        next = cur + cols
+        if (next >= total) next = Math.min(total - 1, cur + 1)
+      }
+      next = Math.max(0, Math.min(total - 1, next))
+      // 模範解答（結合 index 0）には選択を止めない
+      if (next === 0) return
+      setSelectedSynced(next - 1)
+    },
+    [measureColumns]
+  )
+
+  const openPartial = useCallback((initial: string) => {
+    setPartialSynced({ active: true, value: initial })
+  }, [])
+
+  const editPartial = useCallback((char: string) => {
+    const cur = partialRef.current.value
+    if (char === "⌫") {
+      setPartialSynced({ active: true, value: cur.slice(0, -1) })
+      return
+    }
+    if (char === "." && cur.includes(".")) return
+    const next = cur + char
+    if (Number(next) > MAX_SCORE) return
+    if (next.replace(".", "").length > 3) return
+    setPartialSynced({ active: true, value: next })
+  }, [])
+
+  const setPartialValue = useCallback((v: string) => {
+    if (!/^\d*\.?\d*$/.test(v)) return
+    if (Number(v) > MAX_SCORE) return
+    if (v.replace(".", "").length > 3) return
+    setPartialSynced({ active: true, value: v })
+  }, [])
+
+  const confirmPartial = useCallback(() => {
+    const v = partialRef.current.value
+    if (v === "" || v === ".") {
+      setPartialSynced({ active: false, value: "" })
+      return
+    }
+    const num = Math.min(MAX_SCORE, Math.max(0, Number(v)))
+    setPartialSynced({ active: false, value: "" })
+    applyStatus("partial", num)
+  }, [applyStatus])
+
+  const confirmPending = useCallback(() => {
+    setPartialSynced({ active: false, value: "" })
+    applyStatus("pending")
+  }, [applyStatus])
+
+  const cancelPartial = useCallback(() => {
+    setPartialSynced({ active: false, value: "" })
+  }, [])
+
+  const keyToStatus = useMemo(() => {
+    const map: Record<string, DemoStatus> = {}
+    markOrder.forEach((status) => {
+      const k = rawKeys[status]
+      if (k) map[k.toLowerCase()] = status
+    })
+    return map
+  }, [markOrder, rawKeys])
+
+  useEffect(() => {
+    const partialKey = (rawKeys.partial || "").toLowerCase()
+    const pendingKey = (rawKeys.pending || "").toLowerCase()
+    const handler = (e: KeyboardEvent) => {
+      // 入力対象のステップ、または部分点モーダル表示中だけ働く
+      if (!isActiveRef.current && !partialRef.current.active) return
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      const key = e.key.length === 1 ? e.key.toLowerCase() : e.key
+
+      const block = () => {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+      }
+
+      if (partialRef.current.active) {
+        if (/^[0-9.]$/.test(key)) {
+          block()
+          editPartial(key)
+        } else if (key === "Backspace") {
+          block()
+          editPartial("⌫")
+        } else if (key === partialKey || key === "Enter") {
+          block()
+          confirmPartial()
+        } else if (key === pendingKey) {
+          block()
+          confirmPending()
+        } else if (key === "Escape") {
+          block()
+          cancelPartial()
+        } else if (keyToStatus[key]) {
+          // 採点キーは本番に漏らさない（モーダル中は無視）
+          block()
+        }
+        return
+      }
+
+      // WASD で選択を移動
+      if (key === navKeys.left) {
+        block()
+        moveSelection("left")
+        return
+      }
+      if (key === navKeys.right) {
+        block()
+        moveSelection("right")
+        return
+      }
+      if (key === navKeys.up) {
+        block()
+        moveSelection("up")
+        return
+      }
+      if (key === navKeys.down) {
+        block()
+        moveSelection("down")
+        return
+      }
+
+      if (allowPartial && /^[0-9]$/.test(key)) {
+        block()
+        openPartial(key)
+        return
+      }
+      if (allowPartial && key === partialKey) {
+        block()
+        openPartial("")
+        return
+      }
+
+      const status = keyToStatus[key]
+      if (status && status !== "partial") {
+        block()
+        applyStatus(status)
+      }
+    }
+    window.addEventListener("keydown", handler, true)
+    return () => window.removeEventListener("keydown", handler, true)
+  }, [
+    keyToStatus,
+    allowPartial,
+    rawKeys.partial,
+    rawKeys.pending,
+    navKeys,
+    moveSelection,
+    applyStatus,
+    openPartial,
+    editPartial,
+    confirmPartial,
+    confirmPending,
+    cancelPartial,
+  ])
+
+  const allScored = cells.every((c) => c.status !== "unscored")
+
+  useEffect(() => {
+    if (allScored && !notifiedRef.current) {
+      notifiedRef.current = true
+      onAllScored?.()
+    }
+  }, [allScored, onAllScored])
+
+  const reset = () => {
+    notifiedRef.current = false
+    setCellsSynced(initialCells)
+    setSelectedSynced(firstUnscored)
+    setPartialSynced({ active: false, value: "" })
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-xs text-gray-500">設問例「{questionExample}」</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={reset}
+          className="h-7 gap-1 text-xs"
         >
-          <div className="space-y-2">
-            <ShortcutItem keys="Q" description="未採点（まだ採点していない）" />
-            <ShortcutItem keys="E" description="正答（正解）" />
-            <ShortcutItem keys="F" description="部分点（一部正解）" />
-            <ShortcutItem keys="J" description="保留（後で確認する）" />
-            <ShortcutItem keys="O" description="誤答（間違い）" />
-            <ShortcutItem keys="P" description="無答（何も書いてない）" />
-          </div>
-          <TipItem type="success">
-            5つのキーでマウス不要の高速採点が可能です。
-          </TipItem>
-        </HelpSection>
-
-        <HelpSection
-          icon={<Settings className="h-5 w-5 text-green-600" />}
-          title="移動と操作"
-        >
-          <div className="space-y-2">
-            <ShortcutItem keys="Shift+A" description="前の設問に移る" />
-            <ShortcutItem keys="Shift+D" description="次の設問に移る" />
-            <ShortcutItem
-              keys="W・A・S・D"
-              description="答案を上下左右に移動"
-            />
-            <ShortcutItem keys="R" description="表示を更新" />
-            <ShortcutItem keys="N" description="生徒名の表示・非表示" />
-            <ShortcutItem keys="0-9" description="部分点を数字で入力" />
-          </div>
-          <TipItem type="info">部分点は小数点も使えます（例：2.5点）。</TipItem>
-        </HelpSection>
+          <RotateCcw className="h-3 w-3" />
+          やり直す
+        </Button>
       </div>
 
-      <div className="my-4 border-t border-gray-200" />
-
-      <div className="grid gap-6 xl:grid-cols-2">
-        <HelpSection
-          icon={<Lightbulb className="h-5 w-5 text-yellow-600" />}
-          title="困ったときは"
+      {/* 採点グリッド（本番と同じセル表示）。模範解答＋生徒答案を inline で並べ、
+          幅に応じて折り返す。模範解答は先頭セル（結合 index 0）。 */}
+      <div ref={gridRef} className="flex flex-wrap gap-2">
+        <div
+          className={`${DEMO_CELL_W} flex shrink-0 flex-col gap-1 border-2 border-black bg-white p-2`}
         >
-          <div className="space-y-3">
-            <TipItem type="info">
-              <strong>キーボードが効かない：</strong>
-              画面をクリックしてからキーを押し直してください。
-            </TipItem>
-
-            <TipItem type="info">
-              <strong>間違えて採点した：</strong>
-              正しいキーを押し直せば点数が変更されます。
-            </TipItem>
-
-            <TipItem type="warning">
-              <strong>保留機能を活用：</strong>
-              迷ったときはJキーで保留にして後でまとめて確認できます。
-            </TipItem>
+          <div className="flex h-14 items-center justify-center bg-white">
+            <span
+              className={`font-semibold text-gray-800 ${
+                masterAnswer.length > 4 ? "text-lg" : "text-3xl"
+              }`}
+            >
+              {masterAnswer}
+            </span>
           </div>
-        </HelpSection>
+          <div className="flex items-center justify-between gap-1">
+            <span className="truncate text-xs font-bold text-black">
+              模範解答
+            </span>
+            <Badge
+              variant="outline"
+              className="h-4 border-black bg-white px-1 text-xs text-black"
+            >
+              {MAX_SCORE}点満点
+            </Badge>
+          </div>
+        </div>
 
-        <HelpSection
-          icon={<CheckCircle className="h-5 w-5 text-green-600" />}
-          title="操作のコツ"
+        {cells.map((cell, i) => {
+          const isSelected = i === selected
+          const c = cfg[cell.status]
+          const Icon = c.icon
+          const bg = isSelected ? c.selectedBgStyle : c.bgStyle
+          const sd = scoreText(cell)
+          return (
+            <button
+              type="button"
+              key={cell.name}
+              onClick={() => setSelectedSynced(i)}
+              className={`${DEMO_CELL_W} flex shrink-0 flex-col gap-1 border-2 p-2 text-left outline-none focus:outline-none focus-visible:outline-none`}
+              style={{
+                ...bg,
+                borderColor: isSelected ? selectionColor : "transparent",
+              }}
+            >
+              <div className="flex h-14 items-center justify-center bg-white">
+                <span
+                  className={
+                    cell.answer === "（空欄）"
+                      ? "text-sm text-gray-400"
+                      : `text-blue-900/80 ${
+                          cell.answer.length > 4 ? "text-base" : "text-3xl"
+                        }`
+                  }
+                  style={
+                    cell.answer === "（空欄）"
+                      ? undefined
+                      : { fontFamily: "cursive" }
+                  }
+                >
+                  {cell.answer}
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-1">
+                <span
+                  className="truncate text-xs font-medium"
+                  style={c.textStyle}
+                >
+                  {cell.name}
+                </span>
+                <div className="flex shrink-0 items-center gap-1">
+                  {sd && (
+                    <Badge variant="outline" className="h-4 px-1 text-xs">
+                      {sd}
+                    </Badge>
+                  )}
+                  <Icon className="h-3 w-3" style={c.iconStyle} />
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* 印（採点ボタン）。本番 ScoringToolbar と完全に同一（ツールチップ含む） */}
+      <ScoringButtonRow
+        markOrder={markOrder}
+        rawKeys={rawKeys}
+        onScore={(status) =>
+          status === "partial" ? openPartial("") : applyStatus(status)
+        }
+      />
+
+      {/* 部分点の入力は本番のモーダルをそのまま再利用 */}
+      <PartialScoreModal
+        isOpen={partial.active}
+        value={partial.value}
+        maxPoints={MAX_SCORE}
+        questionLabel="1"
+        onClose={cancelPartial}
+        onChange={setPartialValue}
+        onConfirmPartial={confirmPartial}
+        onConfirmPending={confirmPending}
+        onDigit={(k) => editPartial(k)}
+        onBackspace={() => editPartial("⌫")}
+        keyBindings={{
+          partialKey: rawKeys.partial,
+          pendingKey: rawKeys.pending,
+          cancelKey: "Escape",
+        }}
+      />
+
+      {allScored && !partial.active && completion}
+    </div>
+  )
+}
+
+/**
+ * 各セクションのブロック。一般的なヘルプページのように、上から下へ
+ * 自然にスクロールして読み進められるよう、適度な余白だけを与える。
+ */
+function Scene({
+  children,
+  sceneRef,
+}: {
+  children: React.ReactNode
+  sceneRef?: React.Ref<HTMLDivElement>
+}) {
+  return (
+    <section ref={sceneRef} className="scroll-mt-8 pb-20 last:pb-4 sm:pb-28">
+      {children}
+    </section>
+  )
+}
+
+/** デモの見出し＋説明。スクロール位置で下線が青く伸びてフォーカスを示す */
+function DemoSection({
+  title,
+  instruction,
+  children,
+}: {
+  title: string
+  instruction: React.ReactNode
+  children: React.ReactNode
+}) {
+  const active = useHeadingActive(title)
+  return (
+    <section data-help-heading={title} className="relative isolate py-8">
+      <FocusBackground active={active} />
+      <h2 className="relative mb-4 border-b border-gray-200 pb-3 text-2xl font-bold text-gray-900 md:text-3xl">
+        {title}
+        <FocusUnderline active={active} />
+      </h2>
+      <p className="mb-4 text-[15px] leading-relaxed text-gray-700">
+        {instruction}
+      </p>
+      {children}
+    </section>
+  )
+}
+
+/**
+ * 採点の体験デモ。②選択 → ③採点 → ④部分点 の3シーンを上下に並べ、
+ * スクロール位置（覆っている最前面のシーン）で「入力対象」を判定し、
+ * キーボードの行き先を自動で切り替える。
+ */
+const DEMO_TITLE_SELECT = "② 一覧表示で答案を表示する"
+const DEMO_TITLE_SCORE = "③ 採点する"
+const DEMO_TITLE_PARTIAL = "④ 部分点をつける"
+
+function ScoringDemos({
+  rawKeys,
+  navKeys,
+  keys,
+}: {
+  rawKeys: Record<DemoStatus, string>
+  navKeys: NavKeys
+  keys: GuideKeys
+}) {
+  // 入力対象（キーボードの行き先）は、フォーカス中の見出しと一致するデモ
+  const activeSelect = useHeadingActive(DEMO_TITLE_SELECT)
+  const activeScore = useHeadingActive(DEMO_TITLE_SCORE)
+  const activePartial = useHeadingActive(DEMO_TITLE_PARTIAL)
+  const sec3Ref = useRef<HTMLDivElement>(null)
+
+  // 「採点できました。」を一瞬見せてから次へ。急に動くと驚くので 1 秒待つ。
+  const goPartial = useCallback(() => {
+    setTimeout(() => {
+      sec3Ref.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }, 1000)
+  }, [])
+
+  return (
+    <>
+      <Scene>
+        <DemoSection
+          title={DEMO_TITLE_SELECT}
+          instruction={
+            <>
+              左上に黒い枠で囲まれているのが模範解答です。それ以外が生徒の答案です。
+              クリック、または{" "}
+              <span className="inline-flex items-center gap-1">
+                <Kbd>{formatKey(navKeys.up)}</Kbd>
+                <Kbd>{formatKey(navKeys.left)}</Kbd>
+                <Kbd>{formatKey(navKeys.down)}</Kbd>
+                <Kbd>{formatKey(navKeys.right)}</Kbd>
+              </span>{" "}
+              で選択を変えられます。
+            </>
+          }
         >
-          <div className="space-y-3">
-            <TipItem type="success">
-              <strong>基本5キーをマスター：</strong>
-              Q・E・F・O・Pで採点速度が大幅向上します。
-            </TipItem>
+          <ScoringGridDemo
+            initialCells={SELECT_CELLS}
+            markOrder={[]}
+            allowPartial={false}
+            rawKeys={rawKeys}
+            navKeys={navKeys}
+            questionExample="7 + 5 = ?"
+            masterAnswer="12"
+            isActive={activeSelect}
+          />
+        </DemoSection>
+      </Scene>
 
-            <TipItem type="success">
-              <strong>部分点を活用：</strong>
-              Fキー後に数字で細かい点数を入力（2.5点など）。
-            </TipItem>
+      <Scene>
+        <DemoSection
+          title={DEMO_TITLE_SCORE}
+          instruction={
+            <>
+              選択した答案が正しければ 正答（<Kbd>{keys.correct}</Kbd>
+              ）、誤っていれば 誤答（<Kbd>{keys.incorrect}</Kbd>）を押します。
+              採点すると自動的に次の答案が選択されます。ボタン・キーのどちらでも。
+            </>
+          }
+        >
+          <ScoringGridDemo
+            initialCells={STAGE1_CELLS}
+            markOrder={["correct", "incorrect"]}
+            allowPartial={false}
+            rawKeys={rawKeys}
+            navKeys={navKeys}
+            questionExample="7 + 5 = ?"
+            masterAnswer="12"
+            isActive={activeScore}
+            onAllScored={goPartial}
+            completion={
+              <p className="mt-3 text-sm font-medium text-gray-600">
+                採点できました。下の「部分点をつける」に進みましょう。
+              </p>
+            }
+          />
+        </DemoSection>
+      </Scene>
 
-            <TipItem type="info">
-              採点データは自動保存されるため作業中断も安心です。
-            </TipItem>
-          </div>
-        </HelpSection>
+      <Scene sceneRef={sec3Ref}>
+        <DemoSection
+          title={DEMO_TITLE_PARTIAL}
+          instruction={
+            <>
+              部分点をつけたいときは数字キーを押します。たとえば <Kbd>5</Kbd>{" "}
+              を押すと部分点の入力画面が開き、点数を調整できます。
+              部分点を確定（
+              <Kbd>{keys.partial}</Kbd>）で確定します。
+            </>
+          }
+        >
+          <ScoringGridDemo
+            initialCells={STAGE2_CELLS}
+            markOrder={[
+              "correct",
+              "incorrect",
+              "partial",
+              "no_answer",
+              "pending",
+            ]}
+            allowPartial
+            rawKeys={rawKeys}
+            navKeys={navKeys}
+            questionExample="1辺3cmの正方形の面積は？"
+            masterAnswer="9cm²"
+            isActive={activePartial}
+            completion={
+              <p className="mt-3 text-sm font-medium text-gray-600">
+                ひととおり採点できました。
+              </p>
+            }
+          />
+        </DemoSection>
+      </Scene>
+    </>
+  )
+}
+
+// ============================================================================
+// 困ったとき（共通）
+// ============================================================================
+
+function Troubleshoot({ pending }: { pending: string }) {
+  return (
+    <Scene>
+      <FocusSection title="困ったときは">
+        <Callout type="success" title="間違えた・迷ったとき">
+          <span className="inline-flex flex-wrap items-center gap-1">
+            印はつけ直すだけで直せます。迷ったら「保留」（<Kbd>{pending}</Kbd>）
+          </span>
+          にして後で見直せます。採点内容は自動で保存されます。
+        </Callout>
+      </FocusSection>
+    </Scene>
+  )
+}
+
+// ============================================================================
+// 一覧表示の案内
+// ============================================================================
+
+function GridGuide({
+  rawKeys,
+  navKeys,
+  keys,
+}: {
+  rawKeys: Record<DemoStatus, string>
+  navKeys: NavKeys
+  keys: GuideKeys
+}) {
+  return (
+    <>
+      <ScoringDemos rawKeys={rawKeys} navKeys={navKeys} keys={keys} />
+
+      <Scene>
+        <FocusSection title="⑤ 正しく採点できたか確認する">
+          <p>
+            採点が終わった後、正答にした答案や誤答にした答案だけを表示して、
+            正しく採点できたかを確認できます。
+          </p>
+          <p>
+            画面右の「表示」パネルで
+            <span className="inline-flex flex-wrap items-center gap-1">
+              ［正答］を押すか <Kbd>{keys.filterCorrect}</Kbd>
+            </span>
+            を押すと、正答にした答案だけが表示されます。誤答なら
+            <span className="inline-flex flex-wrap items-center gap-1">
+              ［誤答］または <Kbd>{keys.filterIncorrect}</Kbd>
+            </span>
+            です。もう一度押すと元に戻ります。
+          </p>
+        </FocusSection>
+      </Scene>
+
+      <Scene>
+        <FocusSection title="⑥ 次の設問に進む">
+          <p>
+            1つの設問について、全ての生徒の採点が終わったら、次の設問の採点に進みましょう。
+            <span className="inline-flex flex-wrap items-center gap-1">
+              <Kbd>{keys.nextQuestion}</Kbd> で次の設問、
+              <Kbd>{keys.prevQuestion}</Kbd> で前の設問へ移動できます。
+            </span>
+            画面のボタンでも移動できます。
+          </p>
+        </FocusSection>
+      </Scene>
+
+      <Troubleshoot pending={keys.pending} />
+    </>
+  )
+}
+
+// ============================================================================
+// 個別表示の案内
+// ============================================================================
+
+interface ToolKeys {
+  line: string
+  rectangle: string
+  ellipse: string
+  text: string
+  select: string
+  hand: string
+}
+
+const INDIV_DEMO_TITLE = "③ 答案と模範解答を見くらべて採点する"
+
+/** 個別表示の体験用：3人の答案を1人ずつ大きく表示して採点する */
+const INDIV_CELLS: DemoCell[] = [
+  { name: "佐藤", answer: "希望", status: "unscored" },
+  { name: "鈴木", answer: "希棒", status: "unscored" },
+  { name: "高橋", answer: "希望", status: "unscored" },
+]
+
+/** 採点の基準となる模範解答（答え合わせ用に常に並べて表示する） */
+const INDIV_MASTER = "希望"
+
+const INDIV_MARK_ORDER: DemoStatus[] = [
+  "correct",
+  "incorrect",
+  "partial",
+  "no_answer",
+  "pending",
+]
+
+/** 個別表示で「現在採点する領域」を囲む緑の枠色（本番 #22c55e と同一） */
+const REGION_GREEN = "#22c55e"
+
+/** 答案に重ねる採点マーク（採点状態ごと） */
+const SHEET_MARKS: Record<DemoStatus, string> = {
+  unscored: "",
+  correct: "◯",
+  incorrect: "✕",
+  partial: "△",
+  no_answer: "／",
+  pending: "?",
+}
+
+/** 答案用紙のダミー行（手書きを模した薄いプレースホルダ） */
+function SheetLine({ label, widths }: { label: string; widths: string[] }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="mt-0.5 w-3 shrink-0 text-[10px] text-gray-400">
+        {label}
+      </span>
+      <div className="flex flex-1 flex-col gap-1.5 py-0.5">
+        {widths.map((w, i) => (
+          <span
+            key={i}
+            className="block h-2 rounded-sm bg-gray-200"
+            style={{ width: w }}
+          />
+        ))}
       </div>
     </div>
+  )
+}
+
+/**
+ * 個別表示の採点体験デモ。1人の答案を大きく表示し、採点（キー/ボタン）すると
+ * 次の未採点の生徒へ。前後の生徒へは W/S（設定キー）で移動。部分点は数字キー。
+ * キーボードの横取りは ScoringGridDemo と同じく window キャプチャ＋停止で、
+ * このセクションが入力対象のときだけ働き、本番には影響しない。
+ */
+function IndividualScoringDemo({
+  rawKeys,
+  navKeys,
+  isActive,
+}: {
+  rawKeys: Record<DemoStatus, string>
+  navKeys: NavKeys
+  isActive: boolean
+}) {
+  const colors = useScoringStatusColors()
+  const [cells, setCells] = useState<DemoCell[]>(INDIV_CELLS)
+  const [selected, setSelected] = useState(0)
+  const [partial, setPartial] = useState<PartialInput>({
+    active: false,
+    value: "",
+  })
+
+  const cellsRef = useRef(INDIV_CELLS)
+  const selectedRef = useRef(0)
+  const partialRef = useRef(partial)
+  const isActiveRef = useRef(isActive)
+  useEffect(() => {
+    isActiveRef.current = isActive
+  }, [isActive])
+
+  const setCellsSynced = (next: DemoCell[]) => {
+    cellsRef.current = next
+    setCells(next)
+  }
+  const setSelectedSynced = (n: number) => {
+    selectedRef.current = n
+    setSelected(n)
+  }
+  const setPartialSynced = (p: PartialInput) => {
+    partialRef.current = p
+    setPartial(p)
+  }
+
+  const applyStatus = useCallback((status: DemoStatus, score?: number) => {
+    const sel = selectedRef.current
+    const updated = cellsRef.current.map((c, i) =>
+      i === sel ? { ...c, status, score } : c
+    )
+    setCellsSynced(updated)
+    // 採点したら次の未採点の生徒へ自動で進む
+    const after = updated.findIndex(
+      (c, i) => i > sel && c.status === "unscored"
+    )
+    const wrap =
+      after === -1 ? updated.findIndex((c) => c.status === "unscored") : after
+    if (wrap !== -1) setSelectedSynced(wrap)
+  }, [])
+
+  const moveStudent = useCallback((dir: "prev" | "next") => {
+    const n = cellsRef.current.length
+    const i =
+      dir === "next"
+        ? Math.min(n - 1, selectedRef.current + 1)
+        : Math.max(0, selectedRef.current - 1)
+    setSelectedSynced(i)
+  }, [])
+
+  const openPartial = useCallback((initial: string) => {
+    setPartialSynced({ active: true, value: initial })
+  }, [])
+
+  const editPartial = useCallback((char: string) => {
+    const cur = partialRef.current.value
+    if (char === "⌫") {
+      setPartialSynced({ active: true, value: cur.slice(0, -1) })
+      return
+    }
+    if (char === "." && cur.includes(".")) return
+    const next = cur + char
+    if (Number(next) > MAX_SCORE) return
+    if (next.replace(".", "").length > 3) return
+    setPartialSynced({ active: true, value: next })
+  }, [])
+
+  const setPartialValue = useCallback((v: string) => {
+    if (!/^\d*\.?\d*$/.test(v)) return
+    if (Number(v) > MAX_SCORE) return
+    if (v.replace(".", "").length > 3) return
+    setPartialSynced({ active: true, value: v })
+  }, [])
+
+  const confirmPartial = useCallback(() => {
+    const v = partialRef.current.value
+    if (v === "" || v === ".") {
+      setPartialSynced({ active: false, value: "" })
+      return
+    }
+    const num = Math.min(MAX_SCORE, Math.max(0, Number(v)))
+    setPartialSynced({ active: false, value: "" })
+    applyStatus("partial", num)
+  }, [applyStatus])
+
+  const confirmPending = useCallback(() => {
+    setPartialSynced({ active: false, value: "" })
+    applyStatus("pending")
+  }, [applyStatus])
+
+  const cancelPartial = useCallback(() => {
+    setPartialSynced({ active: false, value: "" })
+  }, [])
+
+  const keyToStatus = useMemo(() => {
+    const map: Record<string, DemoStatus> = {}
+    INDIV_MARK_ORDER.forEach((status) => {
+      const k = rawKeys[status]
+      if (k) map[k.toLowerCase()] = status
+    })
+    return map
+  }, [rawKeys])
+
+  useEffect(() => {
+    const partialKey = (rawKeys.partial || "").toLowerCase()
+    const pendingKey = (rawKeys.pending || "").toLowerCase()
+    const handler = (e: KeyboardEvent) => {
+      if (!isActiveRef.current && !partialRef.current.active) return
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      const key = e.key.length === 1 ? e.key.toLowerCase() : e.key
+      const block = () => {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+      }
+
+      if (partialRef.current.active) {
+        if (/^[0-9.]$/.test(key)) {
+          block()
+          editPartial(key)
+        } else if (key === "Backspace") {
+          block()
+          editPartial("⌫")
+        } else if (key === partialKey || key === "Enter") {
+          block()
+          confirmPartial()
+        } else if (key === pendingKey) {
+          block()
+          confirmPending()
+        } else if (key === "Escape") {
+          block()
+          cancelPartial()
+        } else if (keyToStatus[key]) {
+          block()
+        }
+        return
+      }
+
+      // 前後の生徒へ移動（W/A=前、S/D=次）
+      if (key === navKeys.up || key === navKeys.left) {
+        block()
+        moveStudent("prev")
+        return
+      }
+      if (key === navKeys.down || key === navKeys.right) {
+        block()
+        moveStudent("next")
+        return
+      }
+
+      // 部分点（数字キー or 部分点キー）
+      if (/^[0-9]$/.test(key)) {
+        block()
+        openPartial(key)
+        return
+      }
+      if (key === partialKey) {
+        block()
+        openPartial("")
+        return
+      }
+
+      const status = keyToStatus[key]
+      if (status && status !== "partial") {
+        block()
+        applyStatus(status)
+      }
+    }
+    window.addEventListener("keydown", handler, true)
+    return () => window.removeEventListener("keydown", handler, true)
+  }, [
+    keyToStatus,
+    rawKeys.partial,
+    rawKeys.pending,
+    navKeys,
+    moveStudent,
+    applyStatus,
+    openPartial,
+    editPartial,
+    confirmPartial,
+    confirmPending,
+    cancelPartial,
+  ])
+
+  const reset = () => {
+    setCellsSynced(INDIV_CELLS)
+    setSelectedSynced(0)
+    setPartialSynced({ active: false, value: "" })
+  }
+
+  const cell = cells[selected]
+  const sd = scoreText(cell)
+  const mark = SHEET_MARKS[cell.status]
+  const scoredCount = cells.filter((x) => x.status !== "unscored").length
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="text-xs text-gray-500">設問例「『きぼう』を漢字で」</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={reset}
+          className="h-7 gap-1 text-xs"
+        >
+          <RotateCcw className="h-3 w-3" />
+          やり直す
+        </Button>
+      </div>
+
+      {/* 答案用紙の全体（左）と模範解答（右）を並べて、見くらべて採点する。 */}
+      <div className="flex flex-wrap items-start justify-center gap-3">
+        <div className="relative w-64 rounded-sm border border-gray-300 bg-white px-4 py-3 shadow-sm">
+          {/* 用紙ヘッダー */}
+          <div className="mb-3 flex items-center justify-between border-b border-gray-200 pb-1.5">
+            <span className="text-[11px] font-medium text-gray-600">
+              {"国語　答案用紙"}
+            </span>
+            <span className="text-[11px] text-gray-500">
+              {"氏名　"}
+              {cell.name}
+            </span>
+          </div>
+
+          <div className="space-y-3">
+            <SheetLine label="一" widths={["90%", "70%"]} />
+            <SheetLine label="二" widths={["80%"]} />
+
+            {/* いま採点する領域＝緑の枠。本番と同じく枠の上に緑のラベル。 */}
+            <div>
+              <span
+                className="ml-1 text-[10px] font-bold"
+                style={{ color: REGION_GREEN }}
+              >
+                {"三　「きぼう」を漢字で"}
+              </span>
+              <div
+                className="relative rounded-sm border-2 bg-white px-2 py-1.5"
+                style={{ borderColor: REGION_GREEN }}
+              >
+                <div
+                  className="flex h-10 items-center text-3xl text-blue-900/80"
+                  style={{ fontFamily: "cursive" }}
+                >
+                  {cell.answer}
+                </div>
+                {mark && (
+                  <span
+                    className="pointer-events-none absolute top-1 right-2 text-5xl leading-none"
+                    style={{
+                      color: colors[cell.status].icon,
+                      transform: "rotate(-8deg)",
+                    }}
+                  >
+                    {mark}
+                  </span>
+                )}
+                {sd && (
+                  <span
+                    className="absolute right-2 bottom-1 text-xs font-bold"
+                    style={{ color: colors[cell.status].icon }}
+                  >
+                    {sd}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <SheetLine label="四" widths={["85%", "60%"]} />
+          </div>
+        </div>
+
+        {/* 模範解答（答え合わせの基準）を横に並べて表示 */}
+        <div className="flex w-24 flex-col items-center gap-1.5 rounded-sm border-2 border-rose-300 bg-rose-50 px-2 py-3">
+          <span className="text-[10px] font-bold text-rose-600">模範解答</span>
+          <span
+            className="text-3xl text-rose-700"
+            style={{ fontFamily: "cursive" }}
+          >
+            {INDIV_MASTER}
+          </span>
+        </div>
+      </div>
+
+      <ScoringButtonRow
+        markOrder={INDIV_MARK_ORDER}
+        rawKeys={rawKeys}
+        onScore={(status) =>
+          status === "partial" ? openPartial("") : applyStatus(status)
+        }
+      />
+
+      <p className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+        <span className="inline-flex items-center gap-1">
+          前後の生徒へ <Kbd>{formatKey(navKeys.up)}</Kbd>
+          <Kbd>{formatKey(navKeys.down)}</Kbd>
+        </span>
+        <span>
+          {scoredCount}/{cells.length}人 採点済み
+          {scoredCount === cells.length && " — 全員採点できました。"}
+        </span>
+      </p>
+
+      <PartialScoreModal
+        isOpen={partial.active}
+        value={partial.value}
+        maxPoints={MAX_SCORE}
+        questionLabel="1"
+        onClose={cancelPartial}
+        onChange={setPartialValue}
+        onConfirmPartial={confirmPartial}
+        onConfirmPending={confirmPending}
+        onDigit={(k) => editPartial(k)}
+        onBackspace={() => editPartial("⌫")}
+        keyBindings={{
+          partialKey: rawKeys.partial,
+          pendingKey: rawKeys.pending,
+          cancelKey: "Escape",
+        }}
+      />
+    </div>
+  )
+}
+
+type DrawToolKind =
+  | "line"
+  | "rectangle"
+  | "ellipse"
+  | "text"
+  | "select"
+  | "hand"
+
+/** ツール説明アニメの答案下地（薄いプレースホルダ行） */
+function ToolBackdrop() {
+  return (
+    <>
+      <rect
+        x="4"
+        y="6"
+        width="112"
+        height="52"
+        rx="4"
+        fill="white"
+        stroke="#e5e7eb"
+        strokeWidth="1.5"
+      />
+      <line
+        x1="14"
+        y1="22"
+        x2="74"
+        y2="22"
+        stroke="#e5e7eb"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <line
+        x1="14"
+        y1="36"
+        x2="90"
+        y2="36"
+        stroke="#e5e7eb"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <line
+        x1="14"
+        y1="50"
+        x2="64"
+        y2="50"
+        stroke="#e5e7eb"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </>
+  )
+}
+
+/** ③のツール説明アニメ（CSS）。記号を描く／コメント／選択／手のひら。 */
+function DrawToolAnimation({ tool }: { tool: DrawToolKind }) {
+  const colors = useScoringStatusColors()
+  const red = colors.incorrect.icon
+  const blue = "#3b82f6"
+  const lineLen = 74
+  const rectLen = 2 * (44 + 24)
+  const circleLen = 2 * Math.PI * 15
+
+  return (
+    <svg viewBox="0 0 120 64" className="h-16 w-full">
+      {tool === "hand" ? (
+        <g style={{ animation: "help07Pan 3.2s ease-in-out infinite" }}>
+          <ToolBackdrop />
+          <text x="82" y="44" fontSize="22">
+            ✋
+          </text>
+        </g>
+      ) : (
+        <ToolBackdrop />
+      )}
+
+      {tool === "line" && (
+        <line
+          x1="14"
+          y1="30"
+          x2="88"
+          y2="30"
+          stroke={red}
+          strokeWidth="3"
+          strokeLinecap="round"
+          style={
+            {
+              strokeDasharray: lineLen,
+              "--help07-len": lineLen,
+              animation: "help07Pen 3.6s infinite",
+            } as CSSProperties
+          }
+        />
+      )}
+      {tool === "rectangle" && (
+        <rect
+          x="56"
+          y="14"
+          width="44"
+          height="24"
+          rx="2"
+          fill="none"
+          stroke={red}
+          strokeWidth="3"
+          style={
+            {
+              strokeDasharray: rectLen,
+              "--help07-len": rectLen,
+              animation: "help07Pen 3.6s infinite",
+            } as CSSProperties
+          }
+        />
+      )}
+      {tool === "ellipse" && (
+        <circle
+          cx="80"
+          cy="32"
+          r="15"
+          fill="none"
+          stroke={red}
+          strokeWidth="3"
+          style={
+            {
+              strokeDasharray: circleLen,
+              "--help07-len": circleLen,
+              animation: "help07Pen 3.6s infinite",
+            } as CSSProperties
+          }
+        />
+      )}
+      {tool === "text" && (
+        <text
+          x="56"
+          y="38"
+          fill={red}
+          fontSize="16"
+          fontWeight="bold"
+          style={
+            {
+              fontFamily: "cursive",
+              transformOrigin: "56px 38px",
+              animation: "help07Mark 3.6s infinite",
+            } as CSSProperties
+          }
+        >
+          よし!
+        </text>
+      )}
+      {tool === "select" && (
+        <>
+          <circle
+            cx="46"
+            cy="32"
+            r="12"
+            fill="none"
+            stroke={red}
+            strokeWidth="2.5"
+          />
+          <rect
+            x="30"
+            y="16"
+            width="32"
+            height="32"
+            fill="none"
+            stroke={blue}
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+            style={{ animation: "help07March 0.6s linear infinite" }}
+          />
+        </>
+      )}
+    </svg>
+  )
+}
+
+/** ③のツールカード：上にアニメ、下に名前・キー・説明 */
+function DrawToolCard({
+  tool,
+  name,
+  desc,
+  keyLabel,
+}: {
+  tool: DrawToolKind
+  name: string
+  desc: string
+  keyLabel: string
+}) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <div className="flex h-16 w-full items-center justify-center">
+        <DrawToolAnimation tool={tool} />
+      </div>
+      <div className="text-center">
+        <div className="flex items-center justify-center gap-1.5">
+          <span className="text-sm font-semibold text-gray-800">{name}</span>
+          <kbd className="rounded border border-gray-300 bg-white px-1 font-mono text-[10px] text-gray-600">
+            {keyLabel}
+          </kbd>
+        </div>
+        <div className="mt-0.5 text-xs leading-snug text-gray-500">{desc}</div>
+      </div>
+    </div>
+  )
+}
+
+/** 模範解答の表示モードの小さな図（答=生徒答案・模=模範解答） */
+function DisplayModeMini({
+  mode,
+}: {
+  mode: "overlay" | "split-h" | "split-v"
+}) {
+  if (mode === "overlay") {
+    return (
+      <div className="relative flex h-12 w-12 items-center justify-center rounded border border-gray-300 bg-white">
+        <span className="text-[11px] font-bold text-blue-900/70">答</span>
+        <span className="absolute text-[11px] font-bold text-rose-500/50">
+          模
+        </span>
+      </div>
+    )
+  }
+  if (mode === "split-h") {
+    return (
+      <div className="flex h-12 w-12 overflow-hidden rounded border border-gray-300">
+        <div className="flex flex-1 items-center justify-center border-r border-gray-300 bg-white text-[11px] font-bold text-blue-900/70">
+          答
+        </div>
+        <div className="flex flex-1 items-center justify-center bg-rose-50 text-[11px] font-bold text-rose-500/70">
+          模
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="flex h-12 w-12 flex-col overflow-hidden rounded border border-gray-300">
+      <div className="flex flex-1 items-center justify-center border-b border-gray-300 bg-white text-[11px] font-bold text-blue-900/70">
+        答
+      </div>
+      <div className="flex flex-1 items-center justify-center bg-rose-50 text-[11px] font-bold text-rose-500/70">
+        模
+      </div>
+    </div>
+  )
+}
+
+function IndividualGuide({
+  toolKeys,
+  keys,
+  rawKeys,
+  navKeys,
+}: {
+  toolKeys: ToolKeys
+  keys: GuideKeys
+  rawKeys: Record<DemoStatus, string>
+  navKeys: NavKeys
+}) {
+  const activeScore = useHeadingActive(INDIV_DEMO_TITLE)
+  return (
+    <>
+      <Scene>
+        <FocusSection title="② 答案の見方と模範解答の表示">
+          <p>
+            解答用紙の<strong>全体</strong>が表示され、
+            <span className="font-semibold" style={{ color: REGION_GREEN }}>
+              緑色の長方形
+            </span>
+            で囲まれた部分が、いま採点する領域です。
+          </p>
+          <p>
+            模範解答の表示方法は、「表示モード」で オーバーレイ / 左右分割 /
+            上下分割 の3つから選択できます。
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <div className="flex flex-col items-center gap-1.5">
+              <DisplayModeMini mode="overlay" />
+              <span className="text-xs font-medium text-gray-700">
+                オーバーレイ
+              </span>
+              <span className="text-[11px] text-gray-500">答案に重ねる</span>
+            </div>
+            <div className="flex flex-col items-center gap-1.5">
+              <DisplayModeMini mode="split-h" />
+              <span className="text-xs font-medium text-gray-700">
+                左右分割
+              </span>
+              <span className="text-[11px] text-gray-500">横に並べる</span>
+            </div>
+            <div className="flex flex-col items-center gap-1.5">
+              <DisplayModeMini mode="split-v" />
+              <span className="text-xs font-medium text-gray-700">
+                上下分割
+              </span>
+              <span className="text-[11px] text-gray-500">縦に並べる</span>
+            </div>
+          </div>
+          <p>
+            <span className="inline-flex h-5 items-center rounded border border-gray-300 bg-white px-1.5 align-text-bottom">
+              <Eye className="h-3.5 w-3.5 text-gray-700" />
+            </span>{" "}
+            または <Kbd>{keys.toggleMaster}</Kbd>{" "}
+            を押して、模範解答を表示するか切り替えることができます。 ［
+            <strong>押し続けて表示</strong>］をオンにすると、{" "}
+            <Kbd>{keys.toggleMaster}</Kbd>{" "}
+            を押している時だけ模範解答を表示することもできます。
+          </p>
+          <p>オーバーレイのときは「不透明度」で濃さを調整できます。</p>
+        </FocusSection>
+      </Scene>
+
+      <Scene>
+        <FocusSection title={INDIV_DEMO_TITLE}>
+          <p>
+            緑の領域の答案と、並べて表示した模範解答を見くらべて採点します。
+            正しければ 正答（<Kbd>{keys.correct}</Kbd>）、誤っていれば 誤答（
+            <Kbd>{keys.incorrect}</Kbd>
+            ）。部分点は数字キーで入力できます。採点ボタン・キーボードのどちらでも。
+          </p>
+          <IndividualScoringDemo
+            rawKeys={rawKeys}
+            navKeys={navKeys}
+            isActive={activeScore}
+          />
+        </FocusSection>
+      </Scene>
+
+      <Scene>
+        <FocusSection title="④ 生徒を切り替える・採点の進み方">
+          <p>
+            上部の「生徒答案」で、
+            <span className="inline-flex flex-wrap items-center gap-1">
+              ［←］［→］のボタン、または <Kbd>{formatKey(navKeys.up)}</Kbd>
+              <Kbd>{formatKey(navKeys.down)}</Kbd>
+            </span>
+            で生徒を切り替えられます。名前のドロップダウンから直接選ぶこともできます。「1
+            / 9」は、いま何人目を見ているかの表示です。
+          </p>
+          <p>「採点時の動作」で、1人採点した後にどこへ進むかを選べます。</p>
+          <Callout type="tip" title="次の生徒の同じ設問">
+            同じ設問のまま、次の生徒へ進みます。1つの問題を全員ぶん続けて採点したいときに向いています。
+          </Callout>
+          <Callout type="tip" title="同じ生徒の次の設問">
+            同じ生徒のまま、次の設問へ進みます。1人の答案を最後まで仕上げてから次の人へ移りたいときに向いています。
+          </Callout>
+        </FocusSection>
+      </Scene>
+
+      <Scene>
+        <FocusSection title="⑤ 答案に記号やコメントを書き込む">
+          <p>個別表示では、答案の上に直接、丸や線、コメントを書き込めます。</p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <DrawToolCard
+              tool="line"
+              name="直線"
+              desc="まっすぐ線を引く"
+              keyLabel={toolKeys.line}
+            />
+            <DrawToolCard
+              tool="rectangle"
+              name="四角"
+              desc="四角で囲む"
+              keyLabel={toolKeys.rectangle}
+            />
+            <DrawToolCard
+              tool="ellipse"
+              name="丸"
+              desc="丸で囲む"
+              keyLabel={toolKeys.ellipse}
+            />
+            <DrawToolCard
+              tool="text"
+              name="文字"
+              desc="コメントを書く"
+              keyLabel={toolKeys.text}
+            />
+            <DrawToolCard
+              tool="select"
+              name="選択"
+              desc="選んで動かす・消す（Delete）"
+              keyLabel={toolKeys.select}
+            />
+            <DrawToolCard
+              tool="hand"
+              name="手のひら"
+              desc="答案を持って動かす"
+              keyLabel={toolKeys.hand}
+            />
+          </div>
+          <Callout type="tip" title="色と太さ">
+            線や文字の色（8色）と太さは、ツールを選んだときに変えられます。
+          </Callout>
+          <Callout type="success" title="書き込みは自動で残ります">
+            書いた内容は自動で保存され、一覧表示に戻っても残ります。
+            「結果出力（08）」で採点済み答案PDFを作ると、書き込みもそのまま印刷されます。
+          </Callout>
+        </FocusSection>
+      </Scene>
+
+      <Scene>
+        <FocusSection title="⑥ 正しく採点できたか確認する">
+          <p>
+            正答にした答案や誤答にした答案だけを表示して確認したいときは、
+            <span className="inline-flex flex-wrap items-center gap-1">
+              <Kbd>{keys.toggleView}</Kbd> で一覧表示に切り替えます。
+            </span>
+            （個別表示には状態でしぼり込む機能はありません。）
+          </p>
+          <p>
+            一覧表示にしたら、「表示」パネルで
+            <span className="inline-flex flex-wrap items-center gap-1">
+              ［正答］を押すか <Kbd>{keys.filterCorrect}</Kbd>
+            </span>
+            を押すと、正答にした答案だけが表示されます。誤答なら
+            <span className="inline-flex flex-wrap items-center gap-1">
+              ［誤答］または <Kbd>{keys.filterIncorrect}</Kbd>
+            </span>
+            です。確認できたら、もう一度
+            <Kbd>{keys.toggleView}</Kbd> で個別表示に戻れます。
+          </p>
+        </FocusSection>
+      </Scene>
+
+      <Troubleshoot pending={keys.pending} />
+    </>
+  )
+}
+
+// ============================================================================
+// 本体
+// ============================================================================
+
+export function HelpContent07Scoring() {
+  // ユーザーが設定したショートカット（既定＋上書きの解決済み）を反映する
+  const { keyBindings } = useShortcutContext()
+  const [style, setStyle] = useState<"grid" | "individual" | null>(null)
+
+  const keys: GuideKeys = {
+    correct: formatKey(keyBindings["scoring.correct"]),
+    incorrect: formatKey(keyBindings["scoring.incorrect"]),
+    partial: formatKey(keyBindings["scoring.partial"]),
+    pending: formatKey(keyBindings["scoring.pending"]),
+    nextQuestion: formatKey(keyBindings["navigation.nextQuestion"]),
+    prevQuestion: formatKey(keyBindings["navigation.prevQuestion"]),
+    filterCorrect: formatModKey(keyBindings["filter.toggleCorrect"]),
+    filterIncorrect: formatModKey(keyBindings["filter.toggleIncorrect"]),
+    toggleView: formatKey(keyBindings["view.toggleViewMode"]),
+    toggleMaster: formatKey(keyBindings["view.toggleMasterAnswer"]),
+  }
+
+  const toolKeys: ToolKeys = {
+    line: formatKey(keyBindings["tool.line"]),
+    rectangle: formatKey(keyBindings["tool.rectangle"]),
+    ellipse: formatKey(keyBindings["tool.ellipse"]),
+    text: formatKey(keyBindings["tool.text"]),
+    select: formatKey(keyBindings["tool.select"]),
+    hand: formatKey(keyBindings["tool.hand"]),
+  }
+
+  // デモ用に生のキー（設定値そのまま）を渡す。識別子の同一性を保つためメモ化。
+  const rawCorrect = keyBindings["scoring.correct"]
+  const rawIncorrect = keyBindings["scoring.incorrect"]
+  const rawPartial = keyBindings["scoring.partial"]
+  const rawPending = keyBindings["scoring.pending"]
+  const rawNoAnswer = keyBindings["scoring.noAnswer"]
+  const rawKeys = useMemo<Record<DemoStatus, string>>(
+    () => ({
+      unscored: "",
+      correct: rawCorrect,
+      incorrect: rawIncorrect,
+      partial: rawPartial,
+      no_answer: rawNoAnswer,
+      pending: rawPending,
+    }),
+    [rawCorrect, rawIncorrect, rawPartial, rawNoAnswer, rawPending]
+  )
+
+  const navUp = keyBindings["navigation.moveUp"] || "w"
+  const navLeft = keyBindings["navigation.moveLeft"] || "a"
+  const navDown = keyBindings["navigation.moveDown"] || "s"
+  const navRight = keyBindings["navigation.moveRight"] || "d"
+  const navKeys = useMemo<NavKeys>(
+    () => ({
+      up: navUp.toLowerCase(),
+      left: navLeft.toLowerCase(),
+      down: navDown.toLowerCase(),
+      right: navRight.toLowerCase(),
+    }),
+    [navUp, navLeft, navDown, navRight]
+  )
+
+  const guideRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (style) {
+      guideRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+  }, [style])
+
+  // スクロール位置で「いまどの見出しを読んでいるか」を判定し、
+  // その見出しの下線を青く伸ばしてフォーカスを示す（全見出し共通）。
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [activeTitle, setActiveTitle] = useState<string | null>(null)
+  useEffect(() => {
+    const host = rootRef.current
+    const root = getScrollParent(host)
+    if (!host || !root) return
+    let raf = 0
+    const update = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        const headings = Array.from(
+          host.querySelectorAll<HTMLElement>("[data-help-heading]")
+        )
+        if (headings.length === 0) {
+          setActiveTitle(null)
+          return
+        }
+        const rootTop = root.getBoundingClientRect().top
+        const line = root.clientHeight * 0.35
+        let current = headings[0].dataset.helpHeading ?? null
+        for (const el of headings) {
+          const top = el.getBoundingClientRect().top - rootTop
+          if (top - 8 <= line) current = el.dataset.helpHeading ?? current
+          else break
+        }
+        setActiveTitle(current)
+      })
+    }
+    root.addEventListener("scroll", update, { passive: true })
+    update()
+    return () => {
+      root.removeEventListener("scroll", update)
+      cancelAnimationFrame(raf)
+    }
+  }, [style])
+
+  return (
+    <HeadingFocusContext.Provider value={activeTitle}>
+      <style>{HELP07_KEYFRAMES}</style>
+      <div ref={rootRef}>
+        <Scene>
+          <HelpHero
+            eyebrow="ステップ 7 / 採点"
+            title="答案を採点する"
+            lead="やることは、赤ペンの○×と同じ。答案に「印」をつけていくだけです。まず、採点のスタイルを選んでください。"
+          />
+        </Scene>
+
+        <StyleChooser selected={style} onSelect={setStyle} />
+
+        {style && (
+          <div ref={guideRef}>
+            {style === "grid" ? (
+              <GridGuide rawKeys={rawKeys} navKeys={navKeys} keys={keys} />
+            ) : (
+              <IndividualGuide
+                toolKeys={toolKeys}
+                keys={keys}
+                rawKeys={rawKeys}
+                navKeys={navKeys}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </HeadingFocusContext.Provider>
   )
 }

--- a/src/components/help/page-specific/HelpContent08Export.tsx
+++ b/src/components/help/page-specific/HelpContent08Export.tsx
@@ -2,6 +2,7 @@
 
 import {
   CheckCircle,
+  ClipboardList,
   Download,
   FileSpreadsheet,
   FileText,
@@ -21,7 +22,7 @@ export function HelpContent08Export() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Download className="h-6 w-6 text-blue-600" />
-          採点結果のファイル出力 - 使い方
+          採点結果のファイル出力
         </h2>
         <p className="text-muted-foreground">
           採点が完了したら、PDFファイルやExcelファイルで結果を保存しましょう。
@@ -41,7 +42,7 @@ export function HelpContent08Export() {
           <StepItem
             number={2}
             title="出力形式を選ぶ"
-            description="右側のタブで「採点済み答案PDF」「採点データExcel」から選択"
+            description="右側のタブで「採点済み答案PDF」「採点データExcel」「個人成績表PDF」から選択"
             isImportant
           />
           <StepItem
@@ -52,7 +53,7 @@ export function HelpContent08Export() {
           <StepItem
             number={4}
             title="ダウンロード"
-            description="「ダウンロード」ボタンを押して保存場所を選択"
+            description="選んだ形式の「○○をダウンロード」ボタンを押して保存場所を選択"
           />
         </div>
       </HelpSection>
@@ -82,7 +83,8 @@ export function HelpContent08Export() {
               <div className="space-y-1 text-sm">
                 <p>• 用紙の向き（A4縦・A4横）</p>
                 <p>• 採点マークの位置・大きさ</p>
-                <p>• 透明マークか通常マークか</p>
+                <p>• マークや点数の色・不透明度（濃さ）</p>
+                <p>• 採点状態ごとの表示・非表示</p>
               </div>
             </div>
           </div>
@@ -116,6 +118,23 @@ export function HelpContent08Export() {
           </div>
         </HelpSection>
       </div>
+
+      <div className="my-4 border-t border-gray-200" />
+
+      <HelpSection
+        icon={<ClipboardList className="h-5 w-5 text-indigo-600" />}
+        title="個人成績表PDF"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">🧑 生徒ごとに1枚</Badge>
+          <Badge variant="outline">📊 得点と講評</Badge>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          生徒一人ひとりの成績をまとめた個人向けのPDFです。
+          設問ごとの得点や合計点を1枚にまとめて、生徒や保護者への配付に使えます。
+          設定パネルで表示する項目を調整できます。
+        </p>
+      </HelpSection>
 
       <div className="my-4 border-t border-gray-200" />
 
@@ -158,7 +177,7 @@ export function HelpContent08Export() {
             </TipItem>
 
             <TipItem type="success">
-              透明マークは答案が見やすく、通常マークは採点結果が明確です。用途に合わせて選択してください。
+              採点マークの不透明度を下げると答案が見やすく、上げると採点結果がはっきりします。用途に合わせて調整してください。
             </TipItem>
           </div>
         </HelpSection>

--- a/src/components/help/page-specific/HelpContentClasses.tsx
+++ b/src/components/help/page-specific/HelpContentClasses.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Calendar, CheckCircle, Lightbulb, School, Users } from "lucide-react"
+import { CheckCircle, Eye, Lightbulb, School, Users } from "lucide-react"
 
 import {
   Badge,
@@ -15,7 +15,7 @@ export function HelpContentClasses() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <School className="h-6 w-6 text-blue-600" />
-          学級管理 - 使い方
+          学級管理
         </h2>
         <p className="text-muted-foreground">
           ホームルーム、習熟度別、部活動など様々な学級を作成・管理しましょう。
@@ -30,23 +30,23 @@ export function HelpContentClasses() {
           <StepItem
             number={1}
             title="学級を作成"
-            description="「新規作成」ボタンで学級名と種別を設定します"
+            description="「学級追加」ボタンで学級名を入力します（学級名は必須）"
           />
           <StepItem
             number={2}
             title="学級情報を入力"
-            description="学級コード、説明文、在籍期間を設定します"
+            description="クラスコード・学年・説明を入力します（すべて任意）"
             isImportant
           />
           <StepItem
             number={3}
             title="生徒を追加"
-            description="「生徒を追加」で学級に所属する生徒を登録します"
+            description="学級を開いて「生徒を追加」から所属する生徒を登録します"
           />
           <StepItem
             number={4}
-            title="情報を更新"
-            description="在籍人数や期間は自動更新されます"
+            title="在籍人数を確認"
+            description="所属する生徒の人数は一覧に自動で表示されます"
           />
         </div>
       </HelpSection>
@@ -56,11 +56,11 @@ export function HelpContentClasses() {
       <div className="grid gap-6 lg:grid-cols-2">
         <HelpSection
           icon={<Users className="h-5 w-5 text-blue-600" />}
-          title="学級の種類"
+          title="いろいろな学級に使えます"
         >
           <div className="space-y-3">
             <div>
-              <h4 className="mb-2 font-medium">主な学級タイプ</h4>
+              <h4 className="mb-2 font-medium">学級名の例</h4>
               <div className="mb-3 flex flex-wrap gap-2">
                 <Badge variant="outline">ホームルーム</Badge>
                 <Badge variant="outline">習熟度別</Badge>
@@ -70,28 +70,28 @@ export function HelpContentClasses() {
             </div>
             <div className="rounded-lg bg-blue-50 p-4">
               <p className="text-sm text-blue-800">
-                それぞれの学級で異なる生徒管理と 試験運用が可能です。
+                学級名は自由に付けられます。ホームルーム以外にも、
+                習熟度別や部活動などの単位でまとめて作成できます。
               </p>
             </div>
           </div>
         </HelpSection>
 
         <HelpSection
-          icon={<Calendar className="h-5 w-5 text-purple-600" />}
-          title="期間管理"
+          icon={<Eye className="h-5 w-5 text-purple-600" />}
+          title="表示設定"
         >
           <div className="space-y-3">
             <div>
-              <h4 className="mb-2 font-medium">在籍期間の設定</h4>
+              <h4 className="mb-2 font-medium">表示・非表示の切り替え</h4>
               <div className="space-y-1 text-sm">
-                <p>• 開始日：学級の開始時期</p>
-                <p>• 終了日：学級の終了時期</p>
-                <p>• 現在の在籍状況を自動判定</p>
+                <p>• 使わない学級は「非表示」にできます</p>
+                <p>• 非表示の学級は一覧から隠せます</p>
               </div>
             </div>
             <div className="rounded-lg bg-purple-50 p-3">
               <p className="text-sm text-purple-800">
-                期間外の学級は一覧で区別表示されます。
+                非表示にした学級は、生徒一覧やインポートの選択肢に出てこなくなります。
               </p>
             </div>
           </div>
@@ -108,17 +108,17 @@ export function HelpContentClasses() {
           <div className="space-y-3">
             <TipItem type="info">
               <strong>学級を削除したい：</strong>
-              所属生徒がいる学級は削除不可です。先に生徒を他学級に移動してください。
+              所属している生徒がいる学級は削除できません。先に生徒の所属を外してから削除してください。
             </TipItem>
 
             <TipItem type="warning">
-              <strong>期間が過ぎた学級：</strong>
-              終了日を過ぎた学級は「期間外」と表示されます。必要に応じて期間を延長してください。
+              <strong>学級名が重複している：</strong>
+              同じ学級名は使えません。学級名はそれぞれ別の名前にしてください。
             </TipItem>
 
             <TipItem type="info">
-              <strong>学級コードの重複：</strong>
-              同じ学級コードは使用不可です。一意の識別コードを設定してください。
+              <strong>使わない学級を隠したい：</strong>
+              削除しなくても、表示設定で「非表示」にすれば一覧から隠せます。
             </TipItem>
           </div>
         </HelpSection>
@@ -129,13 +129,13 @@ export function HelpContentClasses() {
         >
           <div className="space-y-3">
             <TipItem type="success">
-              <strong>学級コードの付け方：</strong>
-              「3A」「数学習熟上位」「サッカー部」など分かりやすい略称を使いましょう。
+              <strong>クラスコードの付け方：</strong>
+              「3A」「M2」のような短い略称にすると、生徒の所属表示で見やすくなります。
             </TipItem>
 
             <TipItem type="success">
               <strong>効率的な管理：</strong>
-              年度初めにまとめて学級を作成し、期間設定で適切に管理しましょう。
+              年度初めにまとめて学級を作成しておくと、生徒の登録や試験の準備がスムーズです。
             </TipItem>
 
             <TipItem type="success">

--- a/src/components/help/page-specific/HelpContentStudents.tsx
+++ b/src/components/help/page-specific/HelpContentStudents.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import {
+  CheckCircle,
+  Filter,
+  Lightbulb,
+  Trash2,
+  UploadCloud,
+  Users,
+} from "lucide-react"
+
+import {
+  Badge,
+  HelpSection,
+  StepItem,
+  TipItem,
+} from "@/components/help/common/HelpComponents"
+
+export function HelpContentStudents() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
+          <Users className="h-6 w-6 text-blue-600" />
+          生徒管理
+        </h2>
+        <p className="text-muted-foreground">
+          学校全体の生徒を登録・管理します。ここで登録した生徒は、学級や試験で呼び出して使えます。
+        </p>
+      </div>
+
+      <HelpSection
+        icon={<Users className="h-5 w-5 text-green-600" />}
+        title="基本の使い方"
+      >
+        <div className="space-y-3">
+          <StepItem
+            number={1}
+            title="生徒を追加"
+            description="「生徒追加」ボタンで1人ずつ登録します"
+          />
+          <StepItem
+            number={2}
+            title="まとめて追加"
+            description="「Excel 貼付一括追加」で、表計算ソフトからコピーして一度に登録できます"
+            isImportant
+          />
+          <StepItem
+            number={3}
+            title="学級に所属させる"
+            description="生徒を学級に所属させると、試験で学級ごとにまとめて追加できます"
+          />
+          <StepItem
+            number={4}
+            title="探す・絞り込む"
+            description="名前や学籍番号で検索したり、学級・所属状況で絞り込めます"
+          />
+        </div>
+      </HelpSection>
+
+      <div className="my-4 border-t border-gray-200" />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <HelpSection
+          icon={<UploadCloud className="h-5 w-5 text-purple-600" />}
+          title="追加・読み込みの方法"
+        >
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="outline">生徒追加</Badge>
+              <Badge variant="outline">Excel 貼付一括追加</Badge>
+              <Badge variant="outline">.students 読み込み</Badge>
+            </div>
+            <div className="rounded-lg bg-purple-50 p-4">
+              <p className="text-sm text-purple-800">
+                大人数を登録するときは「Excel 貼付一括追加」が便利です。
+                別の端末で作った生徒データは「.students
+                読み込み」で取り込めます。
+              </p>
+            </div>
+          </div>
+        </HelpSection>
+
+        <HelpSection
+          icon={<Filter className="h-5 w-5 text-blue-600" />}
+          title="絞り込みと検索"
+        >
+          <div className="space-y-3">
+            <div>
+              <h4 className="mb-2 font-medium">所属状況で絞り込む</h4>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="secondary">現在所属中</Badge>
+                <Badge variant="secondary">過去の所属</Badge>
+                <Badge variant="secondary">未所属</Badge>
+              </div>
+            </div>
+            <div className="rounded-lg bg-blue-50 p-4">
+              <p className="text-sm text-blue-800">
+                学級フィルタや、生徒名・学籍番号での検索と組み合わせて、
+                目的の生徒をすばやく見つけられます。
+              </p>
+            </div>
+          </div>
+        </HelpSection>
+      </div>
+
+      <div className="my-4 border-t border-gray-200" />
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <HelpSection
+          icon={<Lightbulb className="h-5 w-5 text-yellow-600" />}
+          title="困ったときは"
+        >
+          <div className="space-y-3">
+            <TipItem type="info">
+              <strong>学級に追加されない：</strong>
+              この画面は学校全体の生徒台帳です。学級への所属は、
+              各学級の画面で「生徒を追加」から設定します。
+            </TipItem>
+
+            <TipItem type="warning">
+              <strong>生徒を削除したい：</strong>
+              <span className="inline-flex items-center gap-1">
+                各行の
+                <Trash2 className="inline h-3 w-3" />
+                アイコン
+              </span>
+              で削除できます。試験の採点データがある生徒は、削除すると関連データにも影響するため注意してください。
+            </TipItem>
+          </div>
+        </HelpSection>
+
+        <HelpSection
+          icon={<CheckCircle className="h-5 w-5 text-green-600" />}
+          title="操作のコツ"
+        >
+          <div className="space-y-3">
+            <TipItem type="success">
+              <strong>書き出して共有：</strong>
+              生徒を選んでから「Excel出力」や「.students 書き出し」で、
+              一覧や生徒データを外部に保存できます。
+            </TipItem>
+
+            <TipItem type="success">
+              年度初めに生徒をまとめて登録し、学級へ所属させておくと、
+              試験ごとの受験生徒の追加がスムーズになります。
+            </TipItem>
+          </div>
+        </HelpSection>
+      </div>
+    </div>
+  )
+}

--- a/src/components/help/page-specific/HelpContentSubtotalGroups.tsx
+++ b/src/components/help/page-specific/HelpContentSubtotalGroups.tsx
@@ -14,7 +14,7 @@ export function HelpContentSubtotalGroups() {
       <div>
         <h2 className="mb-2 flex items-center gap-2 text-xl font-bold">
           <Settings className="h-6 w-6 text-blue-600" />
-          小計点グループ管理 - 使い方
+          小計点グループ管理
         </h2>
         <p className="text-muted-foreground">
           複数の試験で再利用できる小計項目グループを作成・管理しましょう。
@@ -45,7 +45,7 @@ export function HelpContentSubtotalGroups() {
           <StepItem
             number={4}
             title="保存・利用"
-            description="保存後、試験の04-question-groupページで利用可能"
+            description="保存後、試験の「小計点の設定」ページで使えます"
           />
         </div>
         <TipItem type="info">
@@ -64,7 +64,7 @@ export function HelpContentSubtotalGroups() {
             <StepItem
               number={1}
               title="試験ページに移動"
-              description="各試験の「04-question-group」ページに移動"
+              description="各試験の「小計点の設定」ページに移動"
             />
             <StepItem
               number={2}
@@ -130,7 +130,7 @@ export function HelpContentSubtotalGroups() {
           <div className="space-y-3">
             <TipItem type="warning">
               <strong>削除できない：</strong>
-              設問と関連付け中のグループは削除不可です。04-question-groupページで関連付けを解除してください。
+              設問と関連付け中のグループは削除不可です。試験の「小計点の設定」ページで関連付けを解除してください。
             </TipItem>
 
             <TipItem type="info">

--- a/src/components/help/usePageHelp.tsx
+++ b/src/components/help/usePageHelp.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Info } from "lucide-react"
+import { BookOpen } from "lucide-react"
 import { usePathname } from "next/navigation"
 import React, { useState } from "react"
 
@@ -13,16 +13,17 @@ import { HelpContent06StudentAnswers as StudentAnswersHelpContent } from "@/comp
 import { HelpContent07Scoring as ScoringHelpContent } from "@/components/help/page-specific/HelpContent07Scoring"
 import { HelpContent08Export as ExportHelpContent } from "@/components/help/page-specific/HelpContent08Export"
 import { HelpContentClasses as ClassesHelpContent } from "@/components/help/page-specific/HelpContentClasses"
+import { HelpContentStudents as StudentsMasterHelpContent } from "@/components/help/page-specific/HelpContentStudents"
 import { HelpContentSubtotalGroups as SubtotalGroupsHelpContent } from "@/components/help/page-specific/HelpContentSubtotalGroups"
 import { Button } from "@/components/ui/button"
 import {
-  Drawer,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 
 // ページごとのヘルプコンポーネント
 const pageHelpComponents: {
@@ -38,10 +39,10 @@ const pageHelpComponents: {
   "08-export": ExportHelpContent,
   "subtotal-groups": SubtotalGroupsHelpContent,
   classes: ClassesHelpContent,
-  students: StudentsHelpContent,
+  students: StudentsMasterHelpContent,
 }
 
-/** 現在のページに対応するヘルプコンテンツをDrawer表示するフック */
+/** 現在のページに対応するヘルプコンテンツを全画面モーダルで表示するフック */
 export function usePageHelp() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
@@ -90,32 +91,40 @@ export function usePageHelp() {
       "07-score-at-once": "一括採点",
       "08-export": "結果出力",
       "subtotal-groups": "小計点グループ管理",
+      classes: "学級管理",
+      students: "生徒管理",
     }
-    return currentPageId ? titles[currentPageId] : "ヘルプ"
+    return (currentPageId && titles[currentPageId]) || "ヘルプ"
   }
 
   const createHelpButton = () => {
     if (!CurrentHelpComponent) return null
 
     return (
-      <Drawer open={isOpen} onOpenChange={setIsOpen}>
-        <DrawerTrigger asChild>
-          <Button variant="ghost" size="sm" className="relative">
-            <Info className="h-4 w-4" />
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-1.5 text-gray-600">
+            <BookOpen className="h-4 w-4" />
+            使い方
           </Button>
-        </DrawerTrigger>
-        <DrawerContent className="h-[80vh]">
-          <DrawerHeader>
-            <DrawerTitle>{getPageTitle()}の使い方</DrawerTitle>
-            <DrawerDescription>
-              このページの操作方法とヒントを確認できます
-            </DrawerDescription>
-          </DrawerHeader>
-          <div className="flex-1 overflow-y-auto px-4 pb-4">
-            <CurrentHelpComponent />
+        </DialogTrigger>
+        <DialogContent className="flex h-[92vh] w-[95vw] max-w-[1400px] flex-col gap-0 overflow-hidden border-gray-200 bg-white p-0 sm:max-w-[1400px]">
+          <DialogHeader className="shrink-0 border-b border-gray-100 px-6 py-4 text-left lg:px-10">
+            <DialogTitle className="flex items-center gap-2 text-base font-semibold text-gray-900">
+              <BookOpen className="h-4 w-4 text-blue-600" />
+              使い方ガイド
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {getPageTitle()}の操作方法とヒントを確認できます
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex-1 overflow-x-hidden overflow-y-auto bg-white">
+            <article className="mx-auto w-full max-w-4xl px-6 py-10 sm:px-10 lg:px-14">
+              <CurrentHelpComponent />
+            </article>
           </div>
-        </DrawerContent>
-      </Drawer>
+        </DialogContent>
+      </Dialog>
     )
   }
 

--- a/src/types/answerSheetDefinition.types.ts
+++ b/src/types/answerSheetDefinition.types.ts
@@ -72,24 +72,39 @@ export type ManuscriptGuidePosition =
   | "bottom-left"
   | "bottom-right"
 
-/** 原稿用紙の文字数ガイド（先頭からN文字目のマスに小さく表示する目印） */
+/**
+ * 原稿用紙の文字位置マーカー（先頭からN文字目に紐づく目印）。
+ * 数字ガイド（label）と区切り罫線（boundary）を1エントリに統合する。
+ * - label が空文字列なら数字は表示しない（区切り罫線のみ使う場合）。
+ * - boundary が未指定なら区切り罫線は引かない（数字ガイドのみ使う場合）。
+ */
 export interface ManuscriptCharGuide {
-  /** 先頭からの文字数（1始まり）。このマスにガイドを表示する */
+  /** 先頭からの文字数（1始まり） */
   atChar: number
-  /** 表示テキスト（既定は atChar の数値） */
+  /** 表示テキスト（空文字列 = 数字非表示） */
   label: string
+  /** 区切り罫線の線種。未指定 = 罫線なし。N文字目の「次」の境界を置き換える */
+  boundary?: LineStyle
+  /** 区切り罫線の太さ（mm）。未指定 = 既定 */
+  boundaryWidth?: number
+  /** 破線のダッシュ長（線幅に対する倍率）。未指定 = 既定 */
+  boundaryDashRatio?: number
+  /** 破線/点線の間隔（線幅に対する倍率）。未指定 = 既定 */
+  boundaryGapRatio?: number
 }
 
 export interface ManuscriptPaperConfig {
   enabled: boolean
   columns: number
   rows: number
-  /** 文字数ガイド（任意マスに先頭からの文字数を小さく表示） */
+  /** 文字位置マーカー（数字ガイド＋区切り罫線の統合リスト） */
   charGuides?: ManuscriptCharGuide[]
-  /** ガイド文字サイズ（mm）。未指定 = 既定 */
+  /** ガイド文字サイズ（1マス＝1とした相対値。マス比）。未指定 = 既定 */
   guideFontSize?: number
   /** ガイド表示位置（マスの隅）。未指定 = "bottom-left" */
   guidePosition?: ManuscriptGuidePosition
+  /** ガイドの隅からの余白（1マス＝1とした相対値。マス比）。未指定 = 既定 */
+  guidePadding?: number
 }
 
 // =====================
@@ -199,6 +214,26 @@ export interface BorderConfig {
   manuscriptLineDivider?: LineStyle
   manuscriptCharDividerWidth?: number
   manuscriptLineDividerWidth?: number
+  // 破線/点線のダッシュ長・間隔（いずれも線幅に対する倍率）。
+  // 未指定時は既定（dash=3倍, gap=2倍）。罫線種別ごとに個別設定できる。
+  outerBorderDashRatio?: number
+  outerBorderGapRatio?: number
+  majorDividerDashRatio?: number
+  majorDividerGapRatio?: number
+  subDividerDashRatio?: number
+  subDividerGapRatio?: number
+  branchDividerDashRatio?: number
+  branchDividerGapRatio?: number
+  majorNumberDividerDashRatio?: number
+  majorNumberDividerGapRatio?: number
+  subNumberDividerDashRatio?: number
+  subNumberDividerGapRatio?: number
+  branchNumberDividerDashRatio?: number
+  branchNumberDividerGapRatio?: number
+  manuscriptCharDividerDashRatio?: number
+  manuscriptCharDividerGapRatio?: number
+  manuscriptLineDividerDashRatio?: number
+  manuscriptLineDividerGapRatio?: number
 }
 
 // =====================

--- a/src/types/answerSheetLayout.types.ts
+++ b/src/types/answerSheetLayout.types.ts
@@ -65,6 +65,8 @@ export interface ManuscriptGrid {
   guideFontSize: number
   /** ガイド表示位置（マスの隅） */
   guidePosition: ManuscriptGuidePosition
+  /** ガイドの隅からの余白（mm） */
+  guidePadding: number
 }
 
 // =====================


### PR DESCRIPTION
## 概要
解答用紙ビルダーの罫線関連2機能（A・B）とヘルプ更新（C）をまとめて反映。A・Bは共有ファイルで行が絡むため同一コミット、Cは別コミット。

Closes #829

## 変更点
### A) 罫線種別ごとの破線ダッシュ長・間隔（線幅倍率）
- 外枠/大問/小問/枝問・番号列・原稿用紙字間/行間の9種別で、破線のダッシュ長・間隔を線幅倍率で個別設定。
- プレビュー／印刷の両経路に反映。`getDashProps` 拡張・`getLineDashRatio` 追加・`LineStylePicker` に倍率スライダー。
- `BorderConfig` に18フィールド追加（既定 dash3/gap2）しDB永続化。

### B) 原稿用紙の区切り罫線・文字数ガイド余白
- 数字ガイドと区切り罫線を1リストに統合（ラベル空＝罫線のみ／線種なし＝ガイドのみ）。
- 区切り罫線は内部マス罫線を**置き換え**描画（破線でも下の線が透けない）。行末の小計・大問罫線は置き換えない（UIに明示）。
- 区切り罫線も破線長・間隔を倍率指定可。文字数ガイドの余白を相対値（マス比）化。

### C) ヘルプ文書の更新
- 各ページのヘルプ内容更新＋共通 `DocComponents` 追加。

## DB / マイグレーション
- 手書きマイグレーション2件（`20260613170000` = manuscriptGuidePadding、`20260613180000` = dash/gap 倍率18列）。ADD COLUMN のみで既存データ保持。次回起動時に migrationDeployer が自動適用。

## テスト
- `npm run typecheck`（Next.js + electron-src）／`npm run lint` 通過。ASB関連テスト緑。

## コミット構成
1. `feat:` A+B（ASB罫線・原稿用紙、共有ファイルで分離不可のため統合）
2. `docs:` C（ヘルプ文書）

🤖 Generated with [Claude Code](https://claude.com/claude-code)