### PR TITLE
fix: アーカイブimport/exportの取りこぼしとカスケード削除を修正

### DIFF
--- a/__tests__/helpers/testDataFactory.ts
+++ b/__tests__/helpers/testDataFactory.ts
@@ -393,6 +393,12 @@ export function createEmptyIdMappings(): IdMappings {
     questionScore: {},
     drawingAnnotation: {},
     membership: {},
+    cropRegionOmrConfig: {},
+    cropRegionOmrChoiceOption: {},
+    compoundAnswer: {},
+    compoundAnswerMember: {},
+    compoundAnswerScore: {},
+    scoreDecision: {},
   }
 }
 

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -1,0 +1,130 @@
+/**
+ * grade-archive のラウンドトリップ統合テスト
+ *
+ * テスト対象:
+ *   electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+ *   electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+ *
+ * 実SQLiteで「収集(export) → インポート(import)」を一周し、特に v1.2.0 で追加した
+ * Grade.referenceDate と GradeExportSettings が往復で保持されることを検証する。
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { GradeArchiveData } from "../../../src/types/gradeArchive.types"
+import {
+  cleanupTestDatabase,
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+
+vi.mock("../../../electron-src/lib/prisma/client", () => {
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { collectGradeArchiveData } from "../../../electron-src/lib/export/grade-archive/gradeArchiveDataCollector"
+import { importGradeArchive } from "../../../electron-src/lib/import/grade-archive/gradeArchiveImporter"
+
+const prisma = getTestPrismaClient()
+
+/** 収集結果をアーカイブ全体データに包む（manifestはテスト用に手組み） */
+function toArchive(
+  gradeId: string,
+  collected: Awaited<ReturnType<typeof collectGradeArchiveData>>
+): GradeArchiveData {
+  return {
+    manifest: {
+      version: "1.2.0",
+      appVersion: "test",
+      exportedAt: new Date("2026-06-14T00:00:00.000Z").toISOString(),
+      gradeId,
+      gradeName: collected.gradeData.grade.name,
+      counts: collected.counts,
+    },
+    gradeData: collected.gradeData,
+    manualScoresData: collected.manualScoresData,
+    boundariesData: collected.boundariesData,
+  }
+}
+
+describe("grade-archive ラウンドトリップ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  it("Grade.referenceDate と GradeExportSettings が往復で保持される (v1.2.0)", async () => {
+    const referenceDate = new Date("2026-04-01T00:00:00.000Z")
+    const settingsJson = JSON.stringify({ includeKana: true, format: "pdf" })
+
+    const grade = await prisma.grade.create({
+      data: {
+        name: `成績_${Date.now()}`,
+        description: "説明",
+        referenceDate,
+      },
+    })
+    await prisma.gradeExportSettings.create({
+      data: { gradeId: grade.id, settingsJson },
+    })
+    // 最低限の中身も持たせる（空でないことの確認）
+    await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+
+    // 収集（export）
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.grade.referenceDate).toBe(
+      referenceDate.toISOString()
+    )
+    expect(collected.gradeData.exportSettings?.settingsJson).toBe(settingsJson)
+
+    // インポート（新規Gradeとして作成される）
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+    expect(result.gradeId).toBeDefined()
+
+    const imported = await prisma.grade.findUnique({
+      where: { id: result.gradeId! },
+    })
+    expect(imported).not.toBeNull()
+    expect(imported!.referenceDate?.toISOString()).toBe(
+      referenceDate.toISOString()
+    )
+
+    const importedSettings = await prisma.gradeExportSettings.findUnique({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(importedSettings).not.toBeNull()
+    expect(importedSettings!.settingsJson).toBe(settingsJson)
+  })
+
+  it("referenceDate/exportSettings が無いGradeも問題なく往復する（後方互換）", async () => {
+    const grade = await prisma.grade.create({
+      data: { name: `成績_min_${Date.now()}` },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.grade.referenceDate).toBeNull()
+    expect(collected.gradeData.exportSettings).toBeNull()
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    const imported = await prisma.grade.findUnique({
+      where: { id: result.gradeId! },
+    })
+    expect(imported!.referenceDate).toBeNull()
+
+    const importedSettings = await prisma.gradeExportSettings.findUnique({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(importedSettings).toBeNull()
+  })
+})

--- a/__tests__/import-export/integration/idChangeExecutor.test.ts
+++ b/__tests__/import-export/integration/idChangeExecutor.test.ts
@@ -311,6 +311,110 @@ describe("executeIdChanges", () => {
       // 警告なし
       expect(warnings).toHaveLength(0)
     })
+
+    it("ScoreDecision/CompoundAnswerScore がカスケード削除されず新IDへ移し替えられる", async () => {
+      const existingStudentId = generateId()
+      const newStudentId = generateId()
+      const examId = generateId()
+      const pageId = generateId()
+      const regionId = generateId()
+      const userId = generateId()
+      const compoundId = generateId()
+
+      await prisma.user.create({
+        data: { id: userId, username: `u_${Date.now()}`, name: "採点者" },
+      })
+      await prisma.student.create({
+        data: {
+          id: existingStudentId,
+          studentNumber: "SD001",
+          lastName: "佐藤",
+          firstName: "花子",
+          lastNameKana: "サトウ",
+          firstNameKana: "ハナコ",
+          enrollmentYear: 2024,
+        },
+      })
+      await prisma.exam.create({ data: { id: examId, examName: "確定テスト" } })
+      await prisma.examPage.create({
+        data: { id: pageId, examId, pageNumber: 1 },
+      })
+      await prisma.cropRegion.create({
+        data: {
+          id: regionId,
+          examPageId: pageId,
+          label: "問1",
+          type: "rectangle",
+          x: 0,
+          y: 0,
+          width: 10,
+          height: 10,
+        },
+      })
+
+      // ScoreDecision（student に onDelete:Cascade）
+      const decisionId = generateId()
+      await prisma.scoreDecision.create({
+        data: {
+          id: decisionId,
+          cropRegionId: regionId,
+          studentId: existingStudentId,
+          verdict: "correct",
+          score: 10,
+          decidedByUserId: userId,
+        },
+      })
+
+      // CompoundAnswer + CompoundAnswerScore（student に onDelete:Cascade）
+      await prisma.compoundAnswer.create({
+        data: {
+          id: compoundId,
+          examPageId: pageId,
+          label: "複合",
+          answerFormat: "fraction",
+          correctAnswer: "1/2",
+          points: 5,
+        },
+      })
+      const casId = generateId()
+      await prisma.compoundAnswerScore.create({
+        data: {
+          id: casId,
+          compoundAnswerId: compoundId,
+          studentId: existingStudentId,
+          userId,
+          status: "correct",
+        },
+      })
+
+      const targets: IdChangeTarget[] = [
+        {
+          category: "student",
+          existingId: existingStudentId,
+          newId: newStudentId,
+        },
+      ]
+      const idMappings = createEmptyIdMappings()
+      const warnings: string[] = []
+
+      await prisma.$transaction(async (tx) => {
+        await executeIdChanges(targets, idMappings, warnings, tx)
+      })
+
+      // ScoreDecision は削除されず、新IDへ移し替えられている
+      const decision = await prisma.scoreDecision.findUnique({
+        where: { id: decisionId },
+      })
+      expect(decision).not.toBeNull()
+      expect(decision!.studentId).toBe(newStudentId)
+
+      // CompoundAnswerScore も同様
+      const cas = await prisma.compoundAnswerScore.findUnique({
+        where: { id: casId },
+      })
+      expect(cas).not.toBeNull()
+      expect(cas!.studentId).toBe(newStudentId)
+    })
   })
 
   // =========================================================================

--- a/__tests__/import-export/integration/idIntegrationImporter.test.ts
+++ b/__tests__/import-export/integration/idIntegrationImporter.test.ts
@@ -1500,4 +1500,541 @@ describe("executeIdIntegrationImport", () => {
     expect(afterStudents).toBe(beforeStudents)
     expect(afterExams).toBe(beforeExams)
   })
+
+  /**
+   * 全件noMatchのpreMatchを作るヘルパー（新規インポート用）
+   */
+  function buildNoMatchPreMatch(
+    data: ReturnType<typeof createBasicTestData>["data"],
+    examId: string
+  ) {
+    return createFileOverviewData({
+      student: createPreMatchingResult({
+        noMatch: data.studentsData.students.map((s) => ({
+          importId: s.id,
+          importData: { ...s },
+          displayLabel: s.lastName,
+        })),
+      }),
+      class: createPreMatchingResult({
+        noMatch: data.classesData.classes.map((c) => ({
+          importId: c.id,
+          importData: { ...c },
+          displayLabel: c.name,
+        })),
+      }),
+      subtotalGroup: createPreMatchingResult({
+        noMatch: data.subtotalsData.subtotalGroups.map((g) => ({
+          importId: g.id,
+          importData: { ...g },
+          displayLabel: g.name,
+        })),
+      }),
+      exam: {
+        isIdMatch: false,
+        importExamId: examId,
+        importData: {},
+        displayLabel: "テスト",
+      },
+    })
+  }
+
+  // II-20: v1.7.0/v1.11.0: OMR設定（Config/ChoiceOption/DigitBox）が作成される
+  it("II-20: OMR設定一式がmerge経路で作成される", async () => {
+    const { data, examId, regionId } = createBasicTestData()
+
+    const cfgId = generateId()
+    const now = new Date().toISOString()
+    data.examData.omrConfigs = [
+      {
+        id: cfgId,
+        cropRegionId: regionId,
+        type: "choice",
+        numChoices: 4,
+        choiceLayout: "horizontal",
+        numDigits: null,
+        correctAnswer: "1",
+        colorThreshold: null,
+        areaThreshold: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.omrChoiceOptions = [
+      {
+        id: generateId(),
+        omrConfigId: cfgId,
+        choiceIndex: 0,
+        label: "1",
+        isCorrect: true,
+        shape: "circle",
+        normalizedCx: 0.5,
+        normalizedCy: 0.5,
+        normalizedWidth: 0.1,
+        normalizedHeight: 0.1,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.omrDigitBoxes = [
+      {
+        id: generateId(),
+        omrConfigId: cfgId,
+        digitIndex: 0,
+        normalizedX: 0.1,
+        normalizedY: 0.1,
+        normalizedW: 0.1,
+        normalizedH: 0.1,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    const result = await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result.success).toBe(true)
+
+    const configs = await prisma.cropRegionOmrConfig.findMany({
+      where: { cropRegionId: regionId },
+    })
+    expect(configs.length).toBe(1)
+    const options = await prisma.cropRegionOmrChoiceOption.findMany({
+      where: { omrConfigId: configs[0].id },
+    })
+    expect(options.length).toBe(1)
+    expect(options[0].shape).toBe("circle")
+    const boxes = await prisma.cropRegionOmrDigitBox.findMany({
+      where: { omrConfigId: configs[0].id },
+    })
+    expect(boxes.length).toBe(1)
+  })
+
+  // II-21: v1.11.0: 複合解答（CompoundAnswer/Member/Score）が作成される
+  it("II-21: 複合解答一式がmerge経路で作成される", async () => {
+    const { data, examId, regionId, studentId } = createBasicTestData()
+
+    const pageId = data.examData.examPages[0].id
+    const caId = generateId()
+    const now = new Date().toISOString()
+    data.examData.compoundAnswers = [
+      {
+        id: caId,
+        examPageId: pageId,
+        label: "複合1",
+        answerFormat: "fraction",
+        correctAnswer: "1/2",
+        points: 5,
+        orderIndex: 0,
+        alternativeAnswers: null,
+        requireReduced: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.compoundAnswerMembers = [
+      {
+        id: generateId(),
+        compoundAnswerId: caId,
+        cropRegionId: regionId,
+        order: 0,
+        roleLabel: "分子",
+        separator: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.compoundAnswerScores = [
+      {
+        id: generateId(),
+        compoundAnswerId: caId,
+        studentId,
+        userId: currentUser.id,
+        recognizedAnswer: "1/2",
+        status: "correct",
+        partialScore: "5",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    const result = await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result.success).toBe(true)
+
+    const cas = await prisma.compoundAnswer.findMany({ where: { id: caId } })
+    expect(cas.length).toBe(1)
+    const members = await prisma.compoundAnswerMember.findMany({
+      where: { compoundAnswerId: caId },
+    })
+    expect(members.length).toBe(1)
+    const scores = await prisma.compoundAnswerScore.findMany({
+      where: { compoundAnswerId: caId, studentId },
+    })
+    expect(scores.length).toBe(1)
+    // userIdは現在のユーザーで上書きされる
+    expect(scores[0].userId).toBe(currentUser.id)
+  })
+
+  // II-22: v1.13.0: ScoreDecisionが作成される
+  it("II-22: ScoreDecisionがmerge経路で作成される", async () => {
+    const { data, examId, regionId, studentId } = createBasicTestData()
+
+    const sdId = generateId()
+    const now = new Date().toISOString()
+    data.scoresData.scoreDecisions = [
+      {
+        id: sdId,
+        cropRegionId: regionId,
+        studentId,
+        verdict: "correct",
+        score: "10",
+        comment: null,
+        decidedByUserId: currentUser.id,
+        decidedAt: now,
+        sourceQuestionScoreId: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    const result = await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result.success).toBe(true)
+
+    const decisions = await prisma.scoreDecision.findMany({
+      where: { cropRegionId: regionId, studentId },
+    })
+    expect(decisions.length).toBe(1)
+    expect(decisions[0].verdict).toBe("correct")
+    expect(decisions[0].decidedByUserId).toBe(currentUser.id)
+  })
+
+  // II-23: ScoreDecisionのLWW競合解決（decidedAtが新しい方を採用）
+  it("II-23: ScoreDecision競合はdecidedAtが新しい方を採用する（LWW）", async () => {
+    const { data, examId, studentId, regionId, classId, groupId } =
+      createBasicTestData()
+
+    const sdId = generateId()
+    const oldDate = new Date("2025-06-01T00:00:00.000Z").toISOString()
+    data.scoresData.scoreDecisions = [
+      {
+        id: sdId,
+        cropRegionId: regionId,
+        studentId,
+        verdict: "incorrect",
+        score: "0",
+        comment: "旧",
+        decidedByUserId: currentUser.id,
+        decidedAt: oldDate,
+        sourceQuestionScoreId: null,
+        createdAt: oldDate,
+        updatedAt: oldDate,
+      },
+    ]
+
+    // 初回インポート（古い確定）
+    await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    // 2回目: 新しいdecidedAtの確定で同一試験に再インポート
+    const newDate = new Date("2025-12-01T00:00:00.000Z").toISOString()
+    data.scoresData.scoreDecisions[0].verdict = "correct"
+    data.scoresData.scoreDecisions[0].score = "10"
+    data.scoresData.scoreDecisions[0].comment = "新"
+    data.scoresData.scoreDecisions[0].decidedAt = newDate
+
+    const preMatch2 = createFileOverviewData({
+      student: createPreMatchingResult({
+        byId: [
+          createMatchedItem({ importId: studentId, existingId: studentId }),
+        ],
+      }),
+      class: createPreMatchingResult({
+        byId: [createMatchedItem({ importId: classId, existingId: classId })],
+      }),
+      subtotalGroup: createPreMatchingResult({
+        byId: [createMatchedItem({ importId: groupId, existingId: groupId })],
+      }),
+      exam: {
+        isIdMatch: true,
+        importExamId: examId,
+        existingExamId: examId,
+        importData: {},
+        existingData: {},
+        displayLabel: "テスト",
+      },
+    })
+
+    const result2 = await executeIdIntegrationImport(
+      data,
+      preMatch2,
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result2.success).toBe(true)
+
+    // 確定は1件のまま（重複なし）、新しい方が採用される
+    const decisions = await prisma.scoreDecision.findMany({
+      where: { cropRegionId: regionId, studentId },
+    })
+    expect(decisions.length).toBe(1)
+    expect(decisions[0].verdict).toBe("correct")
+    expect(decisions[0].comment).toBe("新")
+  })
+
+  // II-24: ScoreDecisionのLWW（既存が新しい場合は上書きしない）
+  it("II-24: ScoreDecision競合で既存が新しければ上書きしない（LWW）", async () => {
+    const { data, examId, studentId, regionId, classId, groupId } =
+      createBasicTestData()
+
+    const sdId = generateId()
+    const newDate = new Date("2025-12-01T00:00:00.000Z").toISOString()
+    data.scoresData.scoreDecisions = [
+      {
+        id: sdId,
+        cropRegionId: regionId,
+        studentId,
+        verdict: "correct",
+        score: "10",
+        comment: "新しい既存",
+        decidedByUserId: currentUser.id,
+        decidedAt: newDate,
+        sourceQuestionScoreId: null,
+        createdAt: newDate,
+        updatedAt: newDate,
+      },
+    ]
+
+    await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    // 2回目: 古いdecidedAtの確定 → 上書きされないはず
+    const oldDate = new Date("2025-06-01T00:00:00.000Z").toISOString()
+    data.scoresData.scoreDecisions[0].verdict = "incorrect"
+    data.scoresData.scoreDecisions[0].comment = "古い取り込み"
+    data.scoresData.scoreDecisions[0].decidedAt = oldDate
+
+    const preMatch2 = createFileOverviewData({
+      student: createPreMatchingResult({
+        byId: [
+          createMatchedItem({ importId: studentId, existingId: studentId }),
+        ],
+      }),
+      class: createPreMatchingResult({
+        byId: [createMatchedItem({ importId: classId, existingId: classId })],
+      }),
+      subtotalGroup: createPreMatchingResult({
+        byId: [createMatchedItem({ importId: groupId, existingId: groupId })],
+      }),
+      exam: {
+        isIdMatch: true,
+        importExamId: examId,
+        existingExamId: examId,
+        importData: {},
+        existingData: {},
+        displayLabel: "テスト",
+      },
+    })
+
+    const result2 = await executeIdIntegrationImport(
+      data,
+      preMatch2,
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result2.success).toBe(true)
+
+    const decisions = await prisma.scoreDecision.findMany({
+      where: { cropRegionId: regionId, studentId },
+    })
+    expect(decisions.length).toBe(1)
+    // 既存（新しい方）が維持される
+    expect(decisions[0].verdict).toBe("correct")
+    expect(decisions[0].comment).toBe("新しい既存")
+  })
+
+  // II-25: 新しめモデル全部入りのアーカイブが1回のmergeで全て復元される
+  // （merge経路が将来モデルをサイレントに取りこぼさないことの網羅regression）
+  it("II-25: OMR・複合解答・確定スコアを含む全モデルがmergeで復元される", async () => {
+    const { data, examId, regionId, studentId } = createBasicTestData()
+    const now = new Date().toISOString()
+    const pageId = data.examData.examPages[0].id
+
+    // OMR一式
+    const cfgId = generateId()
+    data.examData.omrConfigs = [
+      {
+        id: cfgId,
+        cropRegionId: regionId,
+        type: "choice",
+        numChoices: 4,
+        choiceLayout: "horizontal",
+        numDigits: null,
+        correctAnswer: "1",
+        colorThreshold: null,
+        areaThreshold: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.omrChoiceOptions = [
+      {
+        id: generateId(),
+        omrConfigId: cfgId,
+        choiceIndex: 0,
+        label: "1",
+        isCorrect: true,
+        shape: "circle",
+        normalizedCx: 0.5,
+        normalizedCy: 0.5,
+        normalizedWidth: 0.1,
+        normalizedHeight: 0.1,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.omrDigitBoxes = [
+      {
+        id: generateId(),
+        omrConfigId: cfgId,
+        digitIndex: 0,
+        normalizedX: 0.1,
+        normalizedY: 0.1,
+        normalizedW: 0.1,
+        normalizedH: 0.1,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    // 複合解答一式
+    const caId = generateId()
+    data.examData.compoundAnswers = [
+      {
+        id: caId,
+        examPageId: pageId,
+        label: "複合1",
+        answerFormat: "fraction",
+        correctAnswer: "1/2",
+        points: 5,
+        orderIndex: 0,
+        alternativeAnswers: null,
+        requireReduced: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.compoundAnswerMembers = [
+      {
+        id: generateId(),
+        compoundAnswerId: caId,
+        cropRegionId: regionId,
+        order: 0,
+        roleLabel: "分子",
+        separator: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+    data.examData.compoundAnswerScores = [
+      {
+        id: generateId(),
+        compoundAnswerId: caId,
+        studentId,
+        userId: currentUser.id,
+        recognizedAnswer: "1/2",
+        status: "correct",
+        partialScore: "5",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    // 確定スコア
+    data.scoresData.scoreDecisions = [
+      {
+        id: generateId(),
+        cropRegionId: regionId,
+        studentId,
+        verdict: "correct",
+        score: "10",
+        comment: null,
+        decidedByUserId: currentUser.id,
+        decidedAt: now,
+        sourceQuestionScoreId: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    const result = await executeIdIntegrationImport(
+      data,
+      buildNoMatchPreMatch(data, examId),
+      createIdIntegrationConfig(),
+      currentUser.id
+    )
+
+    expect(result.success).toBe(true)
+
+    // 全7モデルが復元されていること
+    expect(
+      await prisma.cropRegionOmrConfig.count({
+        where: { cropRegionId: regionId },
+      })
+    ).toBe(1)
+    const cfg = await prisma.cropRegionOmrConfig.findFirst({
+      where: { cropRegionId: regionId },
+    })
+    expect(
+      await prisma.cropRegionOmrChoiceOption.count({
+        where: { omrConfigId: cfg!.id },
+      })
+    ).toBe(1)
+    expect(
+      await prisma.cropRegionOmrDigitBox.count({
+        where: { omrConfigId: cfg!.id },
+      })
+    ).toBe(1)
+    expect(await prisma.compoundAnswer.count({ where: { id: caId } })).toBe(1)
+    expect(
+      await prisma.compoundAnswerMember.count({
+        where: { compoundAnswerId: caId },
+      })
+    ).toBe(1)
+    expect(
+      await prisma.compoundAnswerScore.count({
+        where: { compoundAnswerId: caId, studentId },
+      })
+    ).toBe(1)
+    expect(
+      await prisma.scoreDecision.count({
+        where: { cropRegionId: regionId, studentId },
+      })
+    ).toBe(1)
+  })
 })

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -1,0 +1,78 @@
+/**
+ * ID変更時のカスケード網羅性テスト（schema.prisma 駆動 / convention-as-code）
+ *
+ * 「書き出したPCに合わせる」(idChangeExecutor) は対象レコードを削除して作り直すため、
+ * 対象に onDelete:Cascade で紐づく子テーブルを削除前に移し替えないとカスケード削除される。
+ *
+ * このテストは schema.prisma を直接解析して各対象の onDelete:Cascade 子テーブルを
+ * 列挙し、idChangeExecutor のレジストリ（*_CASCADE_MOVERS）と完全一致することを検証する。
+ * 新しいカスケードFKを schema に追加してレジストリへの登録を忘れると、このテストが
+ * 失敗して気付ける（規約をコードで強制する仕組み）。
+ */
+
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import { describe, expect, it } from "vitest"
+
+import {
+  CLASS_CASCADE_MOVERS,
+  STUDENT_CASCADE_MOVERS,
+  SUBTOTAL_GROUP_CASCADE_MOVERS,
+} from "../../../electron-src/lib/import/merge/idChangeExecutor"
+
+/**
+ * schema.prisma を解析し、target モデルへ onDelete:Cascade で参照している
+ * （FKを持つ＝owning側の）モデル名の集合を返す。
+ */
+function cascadeChildrenFromSchema(target: string): string[] {
+  const src = readFileSync(
+    resolve(process.cwd(), "prisma/schema.prisma"),
+    "utf8"
+  )
+  const modelRe = /^model\s+(\w+)\s*\{([\s\S]*?)^\}/gm
+  const found = new Set<string>()
+  let m: RegExpExecArray | null
+  while ((m = modelRe.exec(src)) !== null) {
+    const modelName = m[1]
+    const body = m[2]
+    for (const line of body.split("\n")) {
+      // 例: "  student   Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)"
+      const rel = line.match(/^\s*\w+\s+(\w+)\??\s+@relation\(([^)]*)\)/)
+      if (!rel) continue
+      const relType = rel[1]
+      const args = rel[2]
+      if (relType !== target) continue
+      // owning側（FKを持つ側）かつ onDelete:Cascade のみ対象
+      if (!/fields:\s*\[/.test(args)) continue
+      if (!/onDelete:\s*Cascade/.test(args)) continue
+      found.add(modelName)
+    }
+  }
+  return [...found].sort()
+}
+
+describe("ID変更時のカスケード網羅性（schema.prisma駆動）", () => {
+  const cases = [
+    { target: "Student", movers: STUDENT_CASCADE_MOVERS },
+    { target: "Class", movers: CLASS_CASCADE_MOVERS },
+    { target: "SubtotalGroup", movers: SUBTOTAL_GROUP_CASCADE_MOVERS },
+  ]
+
+  for (const { target, movers } of cases) {
+    it(`${target} の onDelete:Cascade 子テーブルが全てレジストリに登録されている`, () => {
+      const expected = cascadeChildrenFromSchema(target)
+      const actual = movers.map((mv) => mv.model).sort()
+
+      // 漏れ（schemaにあるがレジストリに無い）→ カスケード削除バグになる
+      // 余分（レジストリにあるがschemaに無い）→ 不要な処理 or リネーム漏れ
+      expect(actual).toEqual(expected)
+    })
+  }
+
+  it("解析が機能していることの保証（Studentは複数のカスケード子を持つ）", () => {
+    // 解析が壊れて空集合になっても上のテストが通ってしまう事故を防ぐ
+    expect(cascadeChildrenFromSchema("Student").length).toBeGreaterThanOrEqual(
+      5
+    )
+  })
+})

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -25,7 +25,8 @@ export async function createGradeArchive(
     const data = await collectGradeArchiveData(gradeId)
 
     const manifest: GradeArchiveManifest = {
-      version: "1.1.0",
+      // v1.2.0: Grade.referenceDate と GradeExportSettings を追加
+      version: "1.2.0",
       appVersion: getAppVersion(),
       exportedAt: new Date().toISOString(),
       gradeId,

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -81,6 +81,7 @@ export async function collectGradeArchiveData(
           gradeItem: { select: { name: true } },
         },
       },
+      exportSettings: true,
     },
   })
 
@@ -197,7 +198,11 @@ export async function collectGradeArchiveData(
       grade: {
         name: gp.name,
         description: gp.description,
+        referenceDate: gp.referenceDate?.toISOString() ?? null,
       },
+      exportSettings: gp.exportSettings
+        ? { settingsJson: gp.exportSettings.settingsJson }
+        : null,
       gradeItems,
       classRefs,
       examRefs,

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -433,6 +433,7 @@ export async function createImportedData(
         if (newOmrConfigId) {
           await tx.cropRegionOmrDigitBox.create({
             data: {
+              id: remapIdRequired(box.id, mappings.cropRegionOmrDigitBox),
               omrConfigId: newOmrConfigId,
               digitIndex: box.digitIndex,
               normalizedX: box.normalizedX,

--- a/electron-src/lib/import/exam-archive/idRemapper.ts
+++ b/electron-src/lib/import/exam-archive/idRemapper.ts
@@ -68,6 +68,8 @@ export interface IdMappings {
   cropRegionOmrConfig: Record<string, string>
   /** CropRegionOmrChoiceOption ID: 旧ID -> 新ID (v1.7.0+) */
   cropRegionOmrChoiceOption: Record<string, string>
+  /** CropRegionOmrDigitBox ID: 旧ID -> 新ID (v1.11.0+) */
+  cropRegionOmrDigitBox: Record<string, string>
   /** CompoundAnswer ID: 旧ID -> 新ID (v1.11.0+) */
   compoundAnswer: Record<string, string>
   /** CompoundAnswerMember ID: 旧ID -> 新ID (v1.11.0+) */
@@ -114,6 +116,7 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     examTag: {},
     cropRegionOmrConfig: {},
     cropRegionOmrChoiceOption: {},
+    cropRegionOmrDigitBox: {},
     compoundAnswer: {},
     compoundAnswerMember: {},
     compoundAnswerScore: {},
@@ -241,6 +244,11 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // v1.7.0+: CropRegionOmrChoiceOption
   for (const opt of data.examData.omrChoiceOptions || []) {
     mappings.cropRegionOmrChoiceOption[opt.id] = randomUUID()
+  }
+
+  // v1.11.0+: CropRegionOmrDigitBox
+  for (const box of data.examData.omrDigitBoxes || []) {
+    mappings.cropRegionOmrDigitBox[box.id] = randomUUID()
   }
 
   // v1.11.0+: CompoundAnswer

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -85,8 +85,22 @@ export async function importGradeArchive(
         data: {
           name: gradeData.grade.name,
           description: gradeData.grade.description,
+          // v1.2.0+: 基準日（古いアーカイブではundefined → null）
+          referenceDate: gradeData.grade.referenceDate
+            ? new Date(gradeData.grade.referenceDate)
+            : null,
         },
       })
+
+      // 1.5. GradeExportSettings作成 (v1.2.0+、Gradeと1:1)
+      if (gradeData.exportSettings) {
+        await tx.gradeExportSettings.create({
+          data: {
+            gradeId: gp.id,
+            settingsJson: gradeData.exportSettings.settingsJson,
+          },
+        })
+      }
 
       // 2. Class照合→GradeClass作成
       for (let i = 0; i < gradeData.classRefs.length; i++) {

--- a/electron-src/lib/import/merge/decisionMergePolicy.ts
+++ b/electron-src/lib/import/merge/decisionMergePolicy.ts
@@ -1,0 +1,32 @@
+/**
+ * 確定レイヤーのマージ競合解決ポリシー（convention-as-code）
+ *
+ * 「確定」性データ（権限保持者が下す最終結果）のマージ競合解決は LWW（Last-Write-Wins）
+ * で一本化する。これは ScoreDecision・CompoundAnswerScore など確定レイヤーすべてに
+ * 共通の一貫方針であり、個別に別戦略を持ち込まないこと。
+ *
+ * 【軸の分離 — 重要】
+ * - 「どう解決するか」= 常に LWW（このモジュール）。
+ * - 「誰が確定を書けるか」= 権限(authority)の話で、競合解決とは独立した別レイヤー。
+ *   現状は OWNER のみだが、将来 OWNER 以外にも付与可能にする想定。権限制御を足すときも
+ *   競合解決ポリシー（LWW）は変えないこと。
+ *
+ * cf. 採点者の「提案」レイヤー（QuestionScore）の競合解決は scoringConflictResolver.ts。
+ *     提案レイヤーはユーザーが選んだ戦略（existing/import/newer_wins）に従うが、
+ *     確定レイヤーは常に LWW。両者を混同しないこと。
+ */
+
+/**
+ * 取り込み側（アーカイブ）の確定が既存ローカルの確定より新しいか（LWW判定）。
+ *
+ * 真なら取り込み側で上書きすべき。等しい/古い場合は既存を維持する。
+ *
+ * @param incomingTimestamp - 取り込み側の更新時刻（ScoreDecision.decidedAt 等）
+ * @param existingTimestamp - 既存ローカルの更新時刻
+ */
+export function isNewerByLww(
+  incomingTimestamp: Date,
+  existingTimestamp: Date
+): boolean {
+  return incomingTimestamp.getTime() > existingTimestamp.getTime()
+}

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -2,14 +2,227 @@
  * ID変更処理
  *
  * 「書き出したPCに合わせる」を選んだ場合、既存IDを.scoreのIDに変更する。
- * FK制約があるため、関連テーブルも連鎖的に更新する。
+ * 旧レコードを削除して新IDで作り直す方式のため、対象（Student/Class/SubtotalGroup）に
+ * onDelete:Cascade で紐づく子テーブルは、旧レコード削除の前に必ず新IDへ移し替える
+ * 必要がある。移し替え漏れがあると旧レコード削除時にサイレントにカスケード削除される。
  *
- * UNIQUE制約のあるフィールド（Student.studentNumber, Class.name）は
- * temp-value方式で回避: 既存レコードのUNIQUEフィールドを一時値に変更してから
- * 新レコードを作成し、旧レコードを削除する。
+ * 【規約 / convention-as-code】
+ * 対象への onDelete:Cascade 子テーブルを schema.prisma に追加したら、必ず対応する
+ * CascadeMover を下記レジストリ（STUDENT/CLASS/SUBTOTAL_GROUP_CASCADE_MOVERS）へ
+ * 追加すること。レジストリと schema のカスケード子が一致しているかは
+ * __tests__/import-export/unit/cascadeCoverage.test.ts が schema.prisma を解析して
+ * 自動検証する（追加忘れはテストが赤くなって検出される）。
+ *
+ * UNIQUE制約のあるフィールド（Student.studentNumber, Class.name）は temp-value方式で回避:
+ * 既存レコードのUNIQUEフィールドを一時値に変更してから新レコードを作成し、旧を削除する。
  */
 
 import type { IdChangeTarget, IdMappings, PrismaTransaction } from "./types"
+
+/**
+ * カスケード子テーブルを旧ID→新IDへ移し替える1単位。
+ *
+ * `model` はスキーマ上のモデル名（PascalCase）。cascadeCoverage テストが
+ * schema.prisma のカスケード子集合と突合するためのキーとして使う。
+ */
+export interface CascadeMover {
+  model: string
+  move: (
+    tx: PrismaTransaction,
+    fromId: string,
+    toId: string
+  ) => Promise<unknown>
+}
+
+/**
+ * Student に onDelete:Cascade で紐づく子テーブル全件。
+ * schema.prisma の Student へのカスケードFKと一致していること（テストで強制）。
+ */
+export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
+  {
+    model: "StudentClassMembership",
+    move: (tx, from, to) =>
+      tx.studentClassMembership.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "ExamStudent",
+    move: (tx, from, to) =>
+      tx.examStudent.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    // UNIQUE([examPageId, studentId]) があるため移行先の重複を回避しつつ更新する
+    model: "StudentAnswerImage",
+    move: async (tx, from, to) => {
+      const images = await tx.studentAnswerImage.findMany({
+        where: { studentId: from },
+      })
+      for (const img of images) {
+        const duplicate = await tx.studentAnswerImage.findFirst({
+          where: { examPageId: img.examPageId, studentId: to },
+        })
+        if (duplicate) {
+          await tx.studentAnswerImage.delete({ where: { id: img.id } })
+        } else {
+          await tx.studentAnswerImage.update({
+            where: { id: img.id },
+            data: { studentId: to },
+          })
+        }
+      }
+    },
+  },
+  {
+    model: "QuestionScore",
+    move: (tx, from, to) =>
+      tx.questionScore.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "ScoreDecision",
+    move: (tx, from, to) =>
+      tx.scoreDecision.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "CompoundAnswerScore",
+    move: (tx, from, to) =>
+      tx.compoundAnswerScore.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "GradeStudent",
+    move: (tx, from, to) =>
+      tx.gradeStudent.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "ManualScore",
+    move: (tx, from, to) =>
+      tx.manualScore.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "GradeOverride",
+    move: (tx, from, to) =>
+      tx.gradeOverride.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+  {
+    model: "GradeItemExclusion",
+    move: (tx, from, to) =>
+      tx.gradeItemExclusion.updateMany({
+        where: { studentId: from },
+        data: { studentId: to },
+      }),
+  },
+]
+
+/**
+ * Class に onDelete:Cascade で紐づく子テーブル全件。
+ */
+export const CLASS_CASCADE_MOVERS: CascadeMover[] = [
+  {
+    model: "StudentClassMembership",
+    move: (tx, from, to) =>
+      tx.studentClassMembership.updateMany({
+        where: { classId: from },
+        data: { classId: to },
+      }),
+  },
+  {
+    model: "ExamClass",
+    move: (tx, from, to) =>
+      tx.examClass.updateMany({
+        where: { classId: from },
+        data: { classId: to },
+      }),
+  },
+  {
+    model: "GradeClass",
+    move: (tx, from, to) =>
+      tx.gradeClass.updateMany({
+        where: { classId: from },
+        data: { classId: to },
+      }),
+  },
+]
+
+/**
+ * SubtotalGroup に onDelete:Cascade で紐づく子テーブル全件。
+ */
+export const SUBTOTAL_GROUP_CASCADE_MOVERS: CascadeMover[] = [
+  {
+    model: "ExamSubtotalGroup",
+    move: (tx, from, to) =>
+      tx.examSubtotalGroup.updateMany({
+        where: { subtotalGroupId: from },
+        data: { subtotalGroupId: to },
+      }),
+  },
+  {
+    model: "Subtotal",
+    move: (tx, from, to) =>
+      tx.subtotal.updateMany({
+        where: { subtotalGroupId: from },
+        data: { subtotalGroupId: to },
+      }),
+  },
+  {
+    model: "TagSubtotalGroup",
+    move: (tx, from, to) =>
+      tx.tagSubtotalGroup.updateMany({
+        where: { subtotalGroupId: from },
+        data: { subtotalGroupId: to },
+      }),
+  },
+]
+
+/**
+ * カスケード子テーブルを全件移し替える（旧ID削除前に必ず呼ぶ）。
+ */
+async function moveCascadeChildren(
+  movers: CascadeMover[],
+  tx: PrismaTransaction,
+  fromId: string,
+  toId: string
+): Promise<void> {
+  for (const mover of movers) {
+    await mover.move(tx, fromId, toId)
+  }
+}
+
+/**
+ * idMappings 内で existingId を指す全エントリを newId に張り替える。
+ */
+function remapMappingValues(
+  mapping: Record<string, string>,
+  existingId: string,
+  newId: string
+): void {
+  for (const [importId, mappedId] of Object.entries(mapping)) {
+    if (mappedId === existingId) {
+      mapping[importId] = newId
+    }
+  }
+}
 
 /**
  * ID変更処理を実行
@@ -40,11 +253,8 @@ export async function executeIdChanges(
 }
 
 /**
- * 生徒IDの変更
- * FK: StudentClassMembership.studentId, ExamStudent.studentId,
- *     StudentAnswerImage.studentId, QuestionScore.studentId
- *
- * temp-value方式: studentNumber（UNIQUE制約）を一時値に変更してから新レコードを作成
+ * 生徒IDの変更（temp-value方式 + カスケード子の移し替え）
+ * 移し替え対象は STUDENT_CASCADE_MOVERS を参照（schema と一致をテストで強制）。
  */
 async function changeStudentId(
   tx: PrismaTransaction,
@@ -59,10 +269,9 @@ async function changeStudentId(
   if (!existingStudent) return
 
   // 1. UNIQUE制約のあるstudentNumberを一時値に変更
-  const tempStudentNumber = `__TEMP_${target.existingId}`
   await tx.student.update({
     where: { id: target.existingId },
-    data: { studentNumber: tempStudentNumber },
+    data: { studentNumber: `__TEMP_${target.existingId}` },
   })
 
   // 2. 新しいIDで元のstudentNumberを使ってレコード作成
@@ -80,63 +289,24 @@ async function changeStudentId(
     },
   })
 
-  // 3. FK参照を更新
-  await tx.studentClassMembership.updateMany({
-    where: { studentId: target.existingId },
-    data: { studentId: target.newId },
-  })
-
-  await tx.examStudent.updateMany({
-    where: { studentId: target.existingId },
-    data: { studentId: target.newId },
-  })
-
-  // StudentAnswerImage: 重複を回避しつつstudentIdを更新
-  const existingAnswerImages = await tx.studentAnswerImage.findMany({
-    where: { studentId: target.existingId },
-  })
-  for (const img of existingAnswerImages) {
-    // 移行先のstudentIdで同じexamPageIdのレコードが既に存在するか確認
-    const duplicate = await tx.studentAnswerImage.findFirst({
-      where: {
-        examPageId: img.examPageId,
-        studentId: target.newId,
-      },
-    })
-    if (duplicate) {
-      // 重複する場合は古い方を削除
-      await tx.studentAnswerImage.delete({ where: { id: img.id } })
-    } else {
-      await tx.studentAnswerImage.update({
-        where: { id: img.id },
-        data: { studentId: target.newId },
-      })
-    }
-  }
-
-  await tx.questionScore.updateMany({
-    where: { studentId: target.existingId },
-    data: { studentId: target.newId },
-  })
+  // 3. カスケード子を全件移し替え（旧生徒削除前に必須）
+  await moveCascadeChildren(
+    STUDENT_CASCADE_MOVERS,
+    tx,
+    target.existingId,
+    target.newId
+  )
 
   // 4. 古いレコードを削除
-  await tx.student.delete({
-    where: { id: target.existingId },
-  })
+  await tx.student.delete({ where: { id: target.existingId } })
 
   // 5. マッピングを更新
-  for (const [importId, mappedId] of Object.entries(idMappings.student)) {
-    if (mappedId === target.existingId) {
-      idMappings.student[importId] = target.newId
-    }
-  }
+  remapMappingValues(idMappings.student, target.existingId, target.newId)
 }
 
 /**
- * 学級IDの変更
- * FK: StudentClassMembership.classId, ExamClass.classId
- *
- * temp-value方式: name（UNIQUE制約）を一時値に変更してから新レコードを作成
+ * 学級IDの変更（temp-value方式 + カスケード子の移し替え）
+ * 移し替え対象は CLASS_CASCADE_MOVERS を参照（schema と一致をテストで強制）。
  */
 async function changeClassId(
   tx: PrismaTransaction,
@@ -151,10 +321,9 @@ async function changeClassId(
   if (!existingClass) return
 
   // 1. UNIQUE制約のあるnameを一時値に変更
-  const tempName = `__TEMP_${target.existingId}`
   await tx.class.update({
     where: { id: target.existingId },
-    data: { name: tempName },
+    data: { name: `__TEMP_${target.existingId}` },
   })
 
   // 2. 新しいIDで元のnameを使ってレコード作成
@@ -170,34 +339,24 @@ async function changeClassId(
     },
   })
 
-  // 3. FK参照を更新
-  await tx.studentClassMembership.updateMany({
-    where: { classId: target.existingId },
-    data: { classId: target.newId },
-  })
-
-  await tx.examClass.updateMany({
-    where: { classId: target.existingId },
-    data: { classId: target.newId },
-  })
+  // 3. カスケード子を全件移し替え（旧学級削除前に必須）
+  await moveCascadeChildren(
+    CLASS_CASCADE_MOVERS,
+    tx,
+    target.existingId,
+    target.newId
+  )
 
   // 4. 古いレコードを削除
-  await tx.class.delete({
-    where: { id: target.existingId },
-  })
+  await tx.class.delete({ where: { id: target.existingId } })
 
   // 5. マッピングを更新
-  for (const [importId, mappedId] of Object.entries(idMappings.class)) {
-    if (mappedId === target.existingId) {
-      idMappings.class[importId] = target.newId
-    }
-  }
+  remapMappingValues(idMappings.class, target.existingId, target.newId)
 }
 
 /**
- * 小計グループIDの変更
- * FK: ExamSubtotalGroup.subtotalGroupId, Subtotal.subtotalGroupId,
- *     TagSubtotalGroup.subtotalGroupId
+ * 小計グループIDの変更（カスケード子の移し替え）
+ * 移し替え対象は SUBTOTAL_GROUP_CASCADE_MOVERS を参照（schema と一致をテストで強制）。
  */
 async function changeSubtotalGroupId(
   tx: PrismaTransaction,
@@ -220,28 +379,15 @@ async function changeSubtotalGroupId(
     },
   })
 
-  await tx.examSubtotalGroup.updateMany({
-    where: { subtotalGroupId: target.existingId },
-    data: { subtotalGroupId: target.newId },
-  })
+  // カスケード子を全件移し替え（旧グループ削除前に必須）
+  await moveCascadeChildren(
+    SUBTOTAL_GROUP_CASCADE_MOVERS,
+    tx,
+    target.existingId,
+    target.newId
+  )
 
-  await tx.subtotal.updateMany({
-    where: { subtotalGroupId: target.existingId },
-    data: { subtotalGroupId: target.newId },
-  })
+  await tx.subtotalGroup.delete({ where: { id: target.existingId } })
 
-  await tx.tagSubtotalGroup.updateMany({
-    where: { subtotalGroupId: target.existingId },
-    data: { subtotalGroupId: target.newId },
-  })
-
-  await tx.subtotalGroup.delete({
-    where: { id: target.existingId },
-  })
-
-  for (const [importId, mappedId] of Object.entries(idMappings.subtotalGroup)) {
-    if (mappedId === target.existingId) {
-      idMappings.subtotalGroup[importId] = target.newId
-    }
-  }
+  remapMappingValues(idMappings.subtotalGroup, target.existingId, target.newId)
 }

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -20,6 +20,7 @@ import type {
 } from "../../../../src/types/examArchive.types"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
+import { isNewerByLww } from "./decisionMergePolicy"
 import { executeIdChanges } from "./idChangeExecutor"
 import { copyImportImages, createImportImageRecords } from "./imageImporter"
 import {
@@ -89,6 +90,12 @@ export async function executeIdIntegrationImport(
     questionScore: {},
     drawingAnnotation: {},
     membership: {},
+    cropRegionOmrConfig: {},
+    cropRegionOmrChoiceOption: {},
+    compoundAnswer: {},
+    compoundAnswerMember: {},
+    compoundAnswerScore: {},
+    scoreDecision: {},
   }
 
   // ID変更が必要なもの（Stage 2で処理）
@@ -199,6 +206,12 @@ export async function executeIdIntegrationImport(
         // 10e. ExamClass (v1.1.0+)
         await processExamClasses(data, newExamId, idMappings, tx)
 
+        // 10f. OMR設定（CropRegionOmrConfig/ChoiceOption/DigitBox） (v1.7.0+/v1.11.0+)
+        await processOmrConfigs(data, idMappings, tx)
+
+        // 10g. 複合解答（CompoundAnswer/Member） (v1.11.0+)
+        await processCompoundAnswers(data, idMappings, tx)
+
         // 11. CropSubtotal
         await processCropSubtotals(
           data,
@@ -216,6 +229,18 @@ export async function executeIdIntegrationImport(
           idMappings,
           counts,
           scoringConflictConfig,
+          tx
+        )
+
+        // 12b. ScoreDecision（OWNER確定スコア。decidedAt LWWで競合解決） (v1.13.0+)
+        await processScoreDecisions(data, currentUserId, idMappings, counts, tx)
+
+        // 12c. CompoundAnswerScore（複合解答スコア。updatedAt LWWで競合解決） (v1.11.0+)
+        await processCompoundAnswerScores(
+          data,
+          currentUserId,
+          idMappings,
+          counts,
           tx
         )
 
@@ -1204,5 +1229,306 @@ async function processExamClasses(
         },
       })
     }
+  }
+}
+
+/**
+ * OMR設定（CropRegionOmrConfig＋ChoiceOption＋DigitBox）を処理
+ *
+ * CropRegionが新規作成された場合のみ作成する。既存リージョンにマッチした場合は
+ * 対象側に既にOMR設定が存在するため作成しない（重複防止）。
+ * 子（ChoiceOption/DigitBox）は親configを新規作成したときだけ併せて作成する。
+ */
+async function processOmrConfigs(
+  data: ExtractedArchiveData,
+  idMappings: IdMappings,
+  tx: Tx
+): Promise<void> {
+  for (const cfg of data.examData.omrConfigs ?? []) {
+    const newCropRegionId = idMappings.cropRegion[cfg.cropRegionId]
+    if (!newCropRegionId) continue
+
+    // 対象リージョンに既にOMR設定があればスキップ（リージョンは1:1）
+    const existingForRegion = await tx.cropRegionOmrConfig.findFirst({
+      where: { cropRegionId: newCropRegionId },
+    })
+    if (existingForRegion) {
+      idMappings.cropRegionOmrConfig[cfg.id] = existingForRegion.id
+      continue
+    }
+
+    const existingById = await tx.cropRegionOmrConfig.findUnique({
+      where: { id: cfg.id },
+    })
+    if (existingById) {
+      idMappings.cropRegionOmrConfig[cfg.id] = cfg.id
+      continue
+    }
+
+    await tx.cropRegionOmrConfig.create({
+      data: {
+        id: cfg.id,
+        cropRegionId: newCropRegionId,
+        type: cfg.type,
+        numChoices: cfg.numChoices,
+        choiceLayout: cfg.choiceLayout,
+        numDigits: cfg.numDigits,
+        correctAnswer: cfg.correctAnswer,
+        colorThreshold: cfg.colorThreshold,
+        areaThreshold: cfg.areaThreshold,
+      },
+    })
+    idMappings.cropRegionOmrConfig[cfg.id] = cfg.id
+
+    // 新規作成したconfig配下のChoiceOptionを作成
+    for (const opt of data.examData.omrChoiceOptions ?? []) {
+      if (opt.omrConfigId !== cfg.id) continue
+      await tx.cropRegionOmrChoiceOption.create({
+        data: {
+          id: opt.id,
+          omrConfigId: cfg.id,
+          choiceIndex: opt.choiceIndex,
+          label: opt.label,
+          isCorrect: opt.isCorrect,
+          shape: opt.shape ?? null,
+          normalizedCx: opt.normalizedCx ?? null,
+          normalizedCy: opt.normalizedCy ?? null,
+          normalizedWidth: opt.normalizedWidth ?? null,
+          normalizedHeight: opt.normalizedHeight ?? null,
+        },
+      })
+      idMappings.cropRegionOmrChoiceOption[opt.id] = opt.id
+    }
+
+    // 新規作成したconfig配下のDigitBoxを作成
+    for (const box of data.examData.omrDigitBoxes ?? []) {
+      if (box.omrConfigId !== cfg.id) continue
+      await tx.cropRegionOmrDigitBox.create({
+        data: {
+          id: box.id,
+          omrConfigId: cfg.id,
+          digitIndex: box.digitIndex,
+          normalizedX: box.normalizedX,
+          normalizedY: box.normalizedY,
+          normalizedW: box.normalizedW,
+          normalizedH: box.normalizedH,
+        },
+      })
+    }
+  }
+}
+
+/**
+ * 複合解答（CompoundAnswer＋Member）を処理
+ *
+ * ExamPageが新規作成された場合のみ作成する。既存（同一ID）があればスキップ。
+ * Memberは親CompoundAnswerを新規作成したときだけ併せて作成する。
+ */
+async function processCompoundAnswers(
+  data: ExtractedArchiveData,
+  idMappings: IdMappings,
+  tx: Tx
+): Promise<void> {
+  for (const ca of data.examData.compoundAnswers ?? []) {
+    const newExamPageId = idMappings.examPage[ca.examPageId]
+    if (!newExamPageId) continue
+
+    const existingById = await tx.compoundAnswer.findUnique({
+      where: { id: ca.id },
+    })
+    if (existingById) {
+      idMappings.compoundAnswer[ca.id] = ca.id
+      continue
+    }
+
+    await tx.compoundAnswer.create({
+      data: {
+        id: ca.id,
+        examPageId: newExamPageId,
+        label: ca.label,
+        answerFormat: ca.answerFormat,
+        correctAnswer: ca.correctAnswer,
+        points: ca.points,
+        orderIndex: ca.orderIndex,
+        alternativeAnswers: ca.alternativeAnswers,
+        requireReduced: ca.requireReduced,
+      },
+    })
+    idMappings.compoundAnswer[ca.id] = ca.id
+
+    // 新規作成したCompoundAnswer配下のMemberを作成
+    for (const cam of data.examData.compoundAnswerMembers ?? []) {
+      if (cam.compoundAnswerId !== ca.id) continue
+      const newCropRegionId = idMappings.cropRegion[cam.cropRegionId]
+      if (!newCropRegionId) continue
+      await tx.compoundAnswerMember.create({
+        data: {
+          id: cam.id,
+          compoundAnswerId: ca.id,
+          cropRegionId: newCropRegionId,
+          order: cam.order,
+          roleLabel: cam.roleLabel,
+          separator: cam.separator,
+        },
+      })
+      idMappings.compoundAnswerMember[cam.id] = cam.id
+    }
+  }
+}
+
+/**
+ * ScoreDecision（OWNER確定スコア）を処理
+ *
+ * 設問×生徒で高々1件（@@unique）。同一キーがローカルに既存の場合は
+ * decidedAt の新しい方を採用（LWW）。userIdは現在のユーザーで上書き。
+ */
+async function processScoreDecisions(
+  data: ExtractedArchiveData,
+  currentUserId: string,
+  idMappings: IdMappings,
+  counts: ImportCounts,
+  tx: Tx
+): Promise<void> {
+  for (const sd of data.scoresData.scoreDecisions ?? []) {
+    const newRegionId = idMappings.cropRegion[sd.cropRegionId]
+    const newStudentId = idMappings.student[sd.studentId]
+    if (!newRegionId || !newStudentId) continue
+
+    const newSourceQsId = sd.sourceQuestionScoreId
+      ? (idMappings.questionScore[sd.sourceQuestionScoreId] ?? null)
+      : null
+    const incomingDecidedAt = new Date(sd.decidedAt)
+
+    const existing = await tx.scoreDecision.findUnique({
+      where: {
+        cropRegionId_studentId: {
+          cropRegionId: newRegionId,
+          studentId: newStudentId,
+        },
+      },
+    })
+
+    if (existing) {
+      // 確定レイヤーの競合解決はLWW（decisionMergePolicy参照）
+      if (isNewerByLww(incomingDecidedAt, existing.decidedAt)) {
+        await tx.scoreDecision.update({
+          where: { id: existing.id },
+          data: {
+            verdict: sd.verdict,
+            score: sd.score ? parseFloat(sd.score) : null,
+            comment: sd.comment,
+            decidedByUserId: currentUserId,
+            decidedAt: incomingDecidedAt,
+            sourceQuestionScoreId: newSourceQsId,
+          },
+        })
+        counts.updated.scores++
+      } else {
+        counts.skipped.scores++
+      }
+      idMappings.scoreDecision[sd.id] = existing.id
+      continue
+    }
+
+    const existingById = await tx.scoreDecision.findUnique({
+      where: { id: sd.id },
+    })
+    if (existingById) {
+      idMappings.scoreDecision[sd.id] = sd.id
+      counts.unchanged.scores++
+      continue
+    }
+
+    await tx.scoreDecision.create({
+      data: {
+        id: sd.id,
+        cropRegionId: newRegionId,
+        studentId: newStudentId,
+        verdict: sd.verdict,
+        score: sd.score ? parseFloat(sd.score) : null,
+        comment: sd.comment,
+        decidedByUserId: currentUserId,
+        decidedAt: incomingDecidedAt,
+        sourceQuestionScoreId: newSourceQsId,
+      },
+    })
+    idMappings.scoreDecision[sd.id] = sd.id
+    counts.created.scores++
+  }
+}
+
+/**
+ * CompoundAnswerScore（複合解答スコア）を処理
+ *
+ * 複合解答×生徒で高々1件（@@unique）。同一キーがローカルに既存の場合は
+ * updatedAt の新しい方を採用（LWW）。userIdは現在のユーザーで上書き。
+ */
+async function processCompoundAnswerScores(
+  data: ExtractedArchiveData,
+  currentUserId: string,
+  idMappings: IdMappings,
+  counts: ImportCounts,
+  tx: Tx
+): Promise<void> {
+  for (const cas of data.examData.compoundAnswerScores ?? []) {
+    const newCompoundAnswerId = idMappings.compoundAnswer[cas.compoundAnswerId]
+    const newStudentId = idMappings.student[cas.studentId]
+    if (!newCompoundAnswerId || !newStudentId) continue
+
+    const incomingUpdatedAt = new Date(cas.updatedAt)
+
+    const existing = await tx.compoundAnswerScore.findUnique({
+      where: {
+        compoundAnswerId_studentId: {
+          compoundAnswerId: newCompoundAnswerId,
+          studentId: newStudentId,
+        },
+      },
+    })
+
+    if (existing) {
+      // 確定レイヤーの競合解決はLWW（decisionMergePolicy参照）
+      if (isNewerByLww(incomingUpdatedAt, existing.updatedAt)) {
+        await tx.compoundAnswerScore.update({
+          where: { id: existing.id },
+          data: {
+            userId: currentUserId,
+            recognizedAnswer: cas.recognizedAnswer,
+            status: cas.status,
+            partialScore: cas.partialScore
+              ? parseFloat(cas.partialScore)
+              : null,
+          },
+        })
+        counts.updated.scores++
+      } else {
+        counts.skipped.scores++
+      }
+      idMappings.compoundAnswerScore[cas.id] = existing.id
+      continue
+    }
+
+    const existingById = await tx.compoundAnswerScore.findUnique({
+      where: { id: cas.id },
+    })
+    if (existingById) {
+      idMappings.compoundAnswerScore[cas.id] = cas.id
+      counts.unchanged.scores++
+      continue
+    }
+
+    await tx.compoundAnswerScore.create({
+      data: {
+        id: cas.id,
+        compoundAnswerId: newCompoundAnswerId,
+        studentId: newStudentId,
+        userId: currentUserId,
+        recognizedAnswer: cas.recognizedAnswer,
+        status: cas.status,
+        partialScore: cas.partialScore ? parseFloat(cas.partialScore) : null,
+      },
+    })
+    idMappings.compoundAnswerScore[cas.id] = cas.id
+    counts.created.scores++
   }
 }

--- a/electron-src/lib/import/merge/types.ts
+++ b/electron-src/lib/import/merge/types.ts
@@ -23,6 +23,12 @@ export interface IdMappings {
   questionScore: Record<string, string>
   drawingAnnotation: Record<string, string>
   membership: Record<string, string>
+  cropRegionOmrConfig: Record<string, string>
+  cropRegionOmrChoiceOption: Record<string, string>
+  compoundAnswer: Record<string, string>
+  compoundAnswerMember: Record<string, string>
+  compoundAnswerScore: Record<string, string>
+  scoreDecision: Record<string, string>
 }
 
 /** ID変更対象 */

--- a/electron-src/lib/import/student-archive/index.ts
+++ b/electron-src/lib/import/student-archive/index.ts
@@ -110,6 +110,12 @@ export async function executeStudentImport(
     questionScore: {},
     drawingAnnotation: {},
     membership: {},
+    cropRegionOmrConfig: {},
+    cropRegionOmrChoiceOption: {},
+    compoundAnswer: {},
+    compoundAnswerMember: {},
+    compoundAnswerScore: {},
+    scoreDecision: {},
   }
 
   const idChangeTargets: IdChangeTarget[] = []

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -30,7 +30,11 @@ export interface ArchiveGradeData {
   grade: {
     name: string
     description: string | null
+    /** 基準日（後方互換: v1.2.0+。古いアーカイブではundefined） */
+    referenceDate?: string | null
   }
+  /** 成績出力設定（後方互換: v1.2.0+。GradeExportSettingsと1:1） */
+  exportSettings?: { settingsJson: string } | null
   gradeItems: ArchiveGradeItem[]
   classRefs: { name: string }[]
   examRefs: {


### PR DESCRIPTION
## 概要

スキーマと全アーカイブ（exam / asb / student / grade）の import/export 整合監査で見つかった負債（サイレントなデータ損失）を修正する。

Closes #841

## 変更内容

### merge（ID統合）経路 `idIntegrationImporter.ts`
- OMR設定（Config/ChoiceOption/DigitBox）・複合解答（Answer/Member/Score）・ScoreDecision のマージを追加。スキーマ追加後ずっと未対応で、協調採点の統合時にこれら7モデルがサイレント欠落していた。
- 確定レイヤーの競合解決（LWW）を `decisionMergePolicy.ts` に集約。「解決方法＝LWW」と「権限＝誰が確定を書けるか」を別軸として明示。

### idChangeExecutor（「書き出したPCに合わせる」）
- 対象を delete + 再作成する方式で、移し替えていない `onDelete: Cascade` 子テーブルがカスケード削除される問題を修正。
  - 生徒ID変更: ScoreDecision / CompoundAnswerScore / GradeStudent / ManualScore / GradeOverride / GradeItemExclusion の漏れ
  - 学級ID変更: GradeClass の漏れ
- カスケード移し替えを**レジストリ駆動**化。`schema.prisma` を解析してカスケード子の網羅性を自動検証するテストを追加し、規約をコードで強制（新カスケードFK追加時に登録漏れがあるとテストが赤くなる）。

### exam-archive
- `CropRegionOmrDigitBox` の id を export と揃えて remap 保存（id整合性の統一）。

### grade-archive（アーカイブ版 v1.1.0 → v1.2.0）
- `Grade.referenceDate` と `GradeExportSettings` の取りこぼしを修正（後方互換の optional）。

## 監査結果
| アーカイブ | 結果 |
| --- | --- |
| exam-archive | 上記を修正・堅牢化 |
| asb-archive | フィールド網羅確認済み（問題なし） |
| student-archive | 全フィールド網羅・問題なし |
| grade-archive | 2件修正（v1.2.0） |

## テスト
- `npm run typecheck`: ✅
- import-export 全 **207テスト** ✅（+9: merge全モデル網羅 / cascade網羅(schema駆動) / grade往復＋後方互換）
- 変更ファイルの prettier / eslint: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
