### PR TITLE
feat: Discord風の監査ログ機能を実装

### DIFF
--- a/__tests__/audit/auditLog.test.ts
+++ b/__tests__/audit/auditLog.test.ts
@@ -1,0 +1,330 @@
+/**
+ * 監査ログ 統合テスト
+ *
+ * recordAuditLog（操作者補完・ベストエフォート）、集約（同一キーの上書き）、
+ * getAuditLogs（フィルタ/ページネーション/操作者付与）、pruneAuditLogs を検証する。
+ * Electron依存を回避するため prisma/client をテスト用クライアントでモックする。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../data/test-database.db")
+
+vi.mock("../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+// 操作者の自動補完（認証ストア）は常に null を返すようにして、テストを決定的にする
+vi.mock("../../electron-src/lib/prisma/auditActor", () => ({
+  getCurrentActorUserId: () => null,
+}))
+
+import { diffFields, recordAuditLog } from "@/electron-src/lib/prisma/auditLog"
+import {
+  getAuditLogs,
+  pruneAuditLogs,
+} from "@/electron-src/lib/prisma/auditQuery"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  createTestUser,
+  disconnectTestPrisma,
+} from "../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+describe("監査ログ recordAuditLog", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+    await testPrisma.$disconnect()
+  })
+
+  it("1件記録し、getAuditLogsで取得できる（カテゴリ・verbが付与される）", async () => {
+    await recordAuditLog({
+      action: "exam.create",
+      userId: null,
+      entityType: "Exam",
+      entityId: "exam-1",
+      scopeId: "exam-1",
+      scopeLabel: "数学 期末",
+      target: "数学 期末",
+    })
+
+    const page = await getAuditLogs()
+    expect(page.total).toBe(1)
+    const e = page.entries[0]
+    expect(e.action).toBe("exam.create")
+    expect(e.category).toBe("exam")
+    expect(e.verb).toBe("create")
+    expect(e.scopeLabel).toBe("数学 期末")
+    expect(e.occurrences).toBe(1)
+    expect(e.summary).toContain("数学 期末")
+  })
+
+  it("操作者名が userId から解決されて付与される", async () => {
+    const user = await createTestUser({ name: "山田 太郎" })
+    await recordAuditLog({
+      action: "exam.update",
+      userId: user.id,
+      entityType: "Exam",
+      entityId: "exam-1",
+    })
+
+    const page = await getAuditLogs()
+    expect(page.entries[0].actorName).toBe("山田 太郎")
+  })
+
+  it("未知のアクションでも例外を投げず、category は system にフォールバックする", async () => {
+    await expect(
+      recordAuditLog({
+        action: "totally.unknown.action",
+        userId: null,
+        entityType: "X",
+        entityId: "x-1",
+      })
+    ).resolves.toBeUndefined()
+
+    const page = await getAuditLogs()
+    expect(page.total).toBe(1)
+    expect(page.entries[0].category).toBe("system")
+  })
+
+  it("changes は metadata に格納される", async () => {
+    await recordAuditLog({
+      action: "exam.update",
+      userId: null,
+      entityType: "Exam",
+      entityId: "exam-1",
+      changes: [
+        { field: "examName", label: "試験名", before: "旧", after: "新" },
+      ],
+    })
+    const page = await getAuditLogs()
+    const changes = page.entries[0].metadata?.changes as
+      | { before: unknown; after: unknown }[]
+      | undefined
+    expect(changes?.[0].before).toBe("旧")
+    expect(changes?.[0].after).toBe("新")
+  })
+})
+
+describe("監査ログ 集約（coalesce）", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  it("同一キー・同一操作者の連続操作は1行に集約され、occurrences が増え after が上書きされる", async () => {
+    const key = "annotation.update:mark-1"
+    await recordAuditLog({
+      action: "exam.annotation.update",
+      userId: "u-1",
+      entityType: "DrawingAnnotation",
+      entityId: "mark-1",
+      coalesceKey: key,
+      changes: [{ field: "text", label: "テキスト", before: null, after: "A" }],
+    })
+    await recordAuditLog({
+      action: "exam.annotation.update",
+      userId: "u-1",
+      entityType: "DrawingAnnotation",
+      entityId: "mark-1",
+      coalesceKey: key,
+      changes: [{ field: "text", label: "テキスト", before: null, after: "B" }],
+    })
+
+    const page = await getAuditLogs()
+    expect(page.total).toBe(1)
+    expect(page.entries[0].occurrences).toBe(2)
+    const changes = page.entries[0].metadata?.changes as
+      | { after: unknown }[]
+      | undefined
+    expect(changes?.[0].after).toBe("B") // after は最新で上書き
+  })
+
+  it("操作者が異なれば別行になる", async () => {
+    const key = "annotation.update:mark-1"
+    await recordAuditLog({
+      action: "exam.annotation.update",
+      userId: "u-1",
+      entityType: "DrawingAnnotation",
+      entityId: "mark-1",
+      coalesceKey: key,
+    })
+    await recordAuditLog({
+      action: "exam.annotation.update",
+      userId: "u-2",
+      entityType: "DrawingAnnotation",
+      entityId: "mark-1",
+      coalesceKey: key,
+    })
+    const page = await getAuditLogs()
+    expect(page.total).toBe(2)
+  })
+
+  it("coalesceKey が無ければ毎回新規行になる", async () => {
+    for (let i = 0; i < 3; i++) {
+      await recordAuditLog({
+        action: "exam.annotation.create",
+        userId: "u-1",
+        entityType: "DrawingAnnotation",
+        entityId: `mark-${i}`,
+      })
+    }
+    const page = await getAuditLogs()
+    expect(page.total).toBe(3)
+  })
+
+  it("時間窓を過ぎた同一キーは集約せず新規行になる", async () => {
+    const key = "marking_format:exam-1"
+    await recordAuditLog({
+      action: "exam.marking_format.update",
+      userId: "u-1",
+      entityType: "ExamMarkingFormat",
+      entityId: "exam-1",
+      coalesceKey: key,
+    })
+    // 既存行の updatedAt を6分前に後退させる（窓=5分）
+    const past = new Date(Date.now() - 6 * 60 * 1000).toISOString()
+    await testPrisma.$executeRawUnsafe(
+      `UPDATE "AuditLog" SET "updatedAt" = ? WHERE "coalesceKey" = ?`,
+      past,
+      key
+    )
+    await recordAuditLog({
+      action: "exam.marking_format.update",
+      userId: "u-1",
+      entityType: "ExamMarkingFormat",
+      entityId: "exam-1",
+      coalesceKey: key,
+    })
+    const page = await getAuditLogs()
+    expect(page.total).toBe(2)
+  })
+})
+
+describe("監査ログ getAuditLogs フィルタ/ページネーション", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+    await recordAuditLog({
+      action: "exam.create",
+      userId: "u-1",
+      entityType: "Exam",
+      entityId: "e1",
+      summary: "試験Aを作成しました",
+    })
+    await recordAuditLog({
+      action: "grade.create",
+      userId: "u-2",
+      entityType: "Grade",
+      entityId: "g1",
+      summary: "成績Bを作成しました",
+    })
+    await recordAuditLog({
+      action: "student.create",
+      userId: "u-1",
+      entityType: "Student",
+      entityId: "s1",
+      summary: "生徒Cを登録しました",
+    })
+  })
+
+  it("カテゴリで絞り込める", async () => {
+    const page = await getAuditLogs({ category: "grade" })
+    expect(page.total).toBe(1)
+    expect(page.entries[0].action).toBe("grade.create")
+  })
+
+  it("操作者で絞り込める", async () => {
+    const page = await getAuditLogs({ userId: "u-1" })
+    expect(page.total).toBe(2)
+  })
+
+  it("サマリ部分一致で検索できる", async () => {
+    const page = await getAuditLogs({ search: "成績B" })
+    expect(page.total).toBe(1)
+  })
+
+  it("limit/offset でページングでき、total は全件数を返す", async () => {
+    const page1 = await getAuditLogs({ limit: 2, offset: 0 })
+    expect(page1.total).toBe(3)
+    expect(page1.entries).toHaveLength(2)
+    const page2 = await getAuditLogs({ limit: 2, offset: 2 })
+    expect(page2.entries).toHaveLength(1)
+  })
+})
+
+describe("監査ログ pruneAuditLogs", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  it("保持期間より古い行を削除する", async () => {
+    await recordAuditLog({
+      action: "exam.create",
+      userId: null,
+      entityType: "Exam",
+      entityId: "old",
+    })
+    await recordAuditLog({
+      action: "exam.create",
+      userId: null,
+      entityType: "Exam",
+      entityId: "new",
+    })
+    // 1件を400日前に後退
+    const old = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString()
+    await testPrisma.$executeRawUnsafe(
+      `UPDATE "AuditLog" SET "updatedAt" = ? WHERE "entityId" = 'old'`,
+      old
+    )
+
+    const deleted = await pruneAuditLogs(365)
+    expect(deleted).toBe(1)
+    const page = await getAuditLogs()
+    expect(page.total).toBe(1)
+    expect(page.entries[0].entityId).toBe("new")
+  })
+
+  it("retentionDays が不正なら何もしない", async () => {
+    await recordAuditLog({
+      action: "exam.create",
+      userId: null,
+      entityType: "Exam",
+      entityId: "e1",
+    })
+    expect(await pruneAuditLogs(0)).toBe(0)
+    expect(await pruneAuditLogs(-5)).toBe(0)
+    const page = await getAuditLogs()
+    expect(page.total).toBe(1)
+  })
+})
+
+describe("diffFields", () => {
+  it("変化したフィールドのみ返す", () => {
+    const changes = diffFields(
+      { a: 1, b: "x", c: true },
+      { a: 2, b: "x", c: false },
+      [
+        { field: "a", label: "A" },
+        { field: "b", label: "B" },
+        { field: "c", label: "C" },
+      ]
+    )
+    expect(changes.map((c) => c.field).sort()).toEqual(["a", "c"])
+  })
+
+  it("変化が無ければ空配列", () => {
+    const changes = diffFields({ a: 1 }, { a: 1 }, [{ field: "a" }])
+    expect(changes).toHaveLength(0)
+  })
+})

--- a/__tests__/helpers/testPrismaClient.ts
+++ b/__tests__/helpers/testPrismaClient.ts
@@ -78,6 +78,8 @@ export async function cleanupTestDatabase(): Promise<void> {
   await prisma.userKeyboardShortcut.deleteMany()
   await prisma.userPreference.deleteMany()
   await prisma.user.deleteMany()
+  // 監査ログ（FKなし・追記専用）。テスト間の混入を防ぐため最後に削除
+  await prisma.auditLog.deleteMany()
 }
 
 /**

--- a/electron-src/ipc-handlers/auditLogHandlers.ts
+++ b/electron-src/ipc-handlers/auditLogHandlers.ts
@@ -1,0 +1,23 @@
+/**
+ * 監査ログ IPCハンドラー
+ */
+
+import {
+  type AuditLogQueryOptions,
+  getAuditLogs,
+  getAuditLogScopes,
+} from "../lib/prisma/auditQuery"
+import { registerHandler } from "./ipcHandlerUtils"
+
+export function setupAuditLogHandlers(): void {
+  registerHandler(
+    "audit:getLogs",
+    async (options: AuditLogQueryOptions = {}) => {
+      return await getAuditLogs(options)
+    }
+  )
+
+  registerHandler("audit:getScopes", async () => {
+    return await getAuditLogScopes()
+  })
+}

--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -1,5 +1,6 @@
 import { setupAnswerSheetBuilderHandlers } from "./answerSheetBuilderHandlers"
 import { registerArchiveHandlers } from "./archiveHandlers"
+import { setupAuditLogHandlers } from "./auditLogHandlers"
 import { setupAuthHandlers } from "./authHandlers"
 import { setupCropRegionHandlers } from "./cropRegionHandlers"
 import { setupDrawingHandlers } from "./drawingHandlers"
@@ -45,4 +46,5 @@ export function setupAllIPCHandlers(): void {
   setupOmrConfigHandlers()
   registerStudentArchiveHandlers()
   setupSyncHandlers()
+  setupAuditLogHandlers()
 }

--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -236,6 +236,14 @@ export class DatabaseSetup {
         }
       }
 
+      // 監査ログの保持期間プルーニング（ベストエフォート。失敗しても起動を妨げない）
+      try {
+        const { pruneAuditLogs } = await import("./prisma/auditQuery")
+        await pruneAuditLogs()
+      } catch (pruneError) {
+        console.error("Audit log pruning skipped:", pruneError)
+      }
+
       return setupPerformed
     } catch (error) {
       console.error("❌ Database setup failed:", error)

--- a/electron-src/lib/export/asb-archive/index.ts
+++ b/electron-src/lib/export/asb-archive/index.ts
@@ -5,6 +5,7 @@
 import { dialog } from "electron"
 
 import { getAsbDefinition } from "../../prisma/asbDefinition"
+import { recordAuditLog } from "../../prisma/auditLog"
 import { createAsbArchive, generateAsbExportFileName } from "./archiveCreator"
 import { collectAsbData } from "./dataCollector"
 
@@ -37,7 +38,21 @@ export async function exportAsbDefinition(
     }
 
     // 4. アーカイブを作成
-    return await createAsbArchive(collected, result.filePath)
+    const archiveResult = await createAsbArchive(collected, result.filePath)
+
+    if (archiveResult.success) {
+      await recordAuditLog({
+        action: "answer_sheet.export",
+        entityType: "AsbDefinition",
+        entityId: definitionId,
+        scopeId: definitionId,
+        scopeLabel: definition.name,
+        target: definition.name,
+        extra: { outputPath: archiveResult.outputPath },
+      })
+    }
+
+    return archiveResult
   } catch (error) {
     console.error("Error exporting ASB definition:", error)
     return {

--- a/electron-src/lib/export/exam-archive/index.ts
+++ b/electron-src/lib/export/exam-archive/index.ts
@@ -10,6 +10,7 @@ import type {
   ExportExamOptions,
   ExportExamResult,
 } from "../../../../src/types/examArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import { getExamById } from "../../prisma/exam"
 import { createArchive, generateExportFileName } from "./archiveCreator"
 import { collectExamData } from "./dataCollector"
@@ -66,6 +67,17 @@ export async function exportExam(
     if (!archiveResult.success) {
       return { success: false, error: archiveResult.error }
     }
+
+    // 監査ログ: 試験エクスポート（操作者は認証ストアから自動補完。userIdは対象データの絞り込み用）
+    await recordAuditLog({
+      action: "exam.export",
+      entityType: "Exam",
+      entityId: examId,
+      scopeId: examId,
+      scopeLabel: exam.examName,
+      target: exam.examName,
+      extra: { exportMode, outputPath: archiveResult.outputPath },
+    })
 
     // 5. マニフェストを返す
     return {

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -7,6 +7,7 @@ import { app } from "electron"
 import * as fs from "fs"
 
 import type { GradeArchiveManifest } from "../../../../src/types/gradeArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import { collectGradeArchiveData } from "./gradeArchiveDataCollector"
 
 function getAppVersion(): string {
@@ -39,6 +40,16 @@ export async function createGradeArchive(
 
     return new Promise((resolve, reject) => {
       output.on("close", () => {
+        // 監査ログ: 成績エクスポート（ベストエフォート）
+        void recordAuditLog({
+          action: "grade.export",
+          entityType: "Grade",
+          entityId: gradeId,
+          scopeId: gradeId,
+          scopeLabel: data.gradeData.grade.name,
+          target: data.gradeData.grade.name,
+          extra: { outputPath },
+        })
         resolve({ success: true })
       })
 

--- a/electron-src/lib/export/student-archive/index.ts
+++ b/electron-src/lib/export/student-archive/index.ts
@@ -10,6 +10,7 @@ import type {
   ExportStudentsArchiveOptions,
   ExportStudentsArchiveResult,
 } from "../../../../src/types/studentArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import {
   createStudentArchive,
   generateStudentExportFileName,
@@ -56,6 +57,18 @@ export async function exportStudentsArchive(
     if (!archiveResult.success) {
       return { success: false, error: archiveResult.error }
     }
+
+    await recordAuditLog({
+      action: "student.export",
+      entityType: "Student",
+      entityId: "student-archive",
+      summary: `生徒を${studentIds.length}名エクスポートしました`,
+      extra: {
+        studentCount: studentIds.length,
+        classCount: classIds?.length ?? 0,
+        outputPath: archiveResult.outputPath,
+      },
+    })
 
     return {
       success: true,

--- a/electron-src/lib/import/asb-archive/index.ts
+++ b/electron-src/lib/import/asb-archive/index.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AsbArchiveManifest } from "../../../../src/types/asbArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import { transformAsbToLatest } from "../asb-transformers"
 import {
   cleanupAsbTempDir,
@@ -75,6 +76,16 @@ export async function importAsbDefinition(
 
     // 7. DB保存
     await createImportedAsbDefinition(remapped, userId)
+
+    await recordAuditLog({
+      action: "answer_sheet.import",
+      userId,
+      entityType: "AsbDefinition",
+      entityId: remapped.id,
+      scopeId: remapped.id,
+      scopeLabel: remapped.name,
+      target: remapped.name,
+    })
 
     return {
       success: true,

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -8,6 +8,7 @@ import type {
   GradeArchiveData,
   GradeArchiveImportPreview,
 } from "../../../../src/types/gradeArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
 
 /**
@@ -77,269 +78,283 @@ export async function importGradeArchive(
   examMapping?: Record<string, string>
 ): Promise<{ success: boolean; gradeId?: string; error?: string }> {
   try {
-    return await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-      const { gradeData, manualScoresData, boundariesData } = data
+    const result = await prisma.$transaction(
+      async (tx: Prisma.TransactionClient) => {
+        const { gradeData, manualScoresData, boundariesData } = data
 
-      // 1. Grade作成
-      const gp = await tx.grade.create({
-        data: {
-          name: gradeData.grade.name,
-          description: gradeData.grade.description,
-          // v1.2.0+: 基準日（古いアーカイブではundefined → null）
-          referenceDate: gradeData.grade.referenceDate
-            ? new Date(gradeData.grade.referenceDate)
-            : null,
-        },
-      })
-
-      // 1.5. GradeExportSettings作成 (v1.2.0+、Gradeと1:1)
-      if (gradeData.exportSettings) {
-        await tx.gradeExportSettings.create({
+        // 1. Grade作成
+        const gp = await tx.grade.create({
           data: {
-            gradeId: gp.id,
-            settingsJson: gradeData.exportSettings.settingsJson,
-          },
-        })
-      }
-
-      // 2. Class照合→GradeClass作成
-      for (let i = 0; i < gradeData.classRefs.length; i++) {
-        const ref = gradeData.classRefs[i]
-        const cls = await tx.class.findUnique({
-          where: { name: ref.name },
-        })
-        if (cls) {
-          await tx.gradeClass.create({
-            data: {
-              gradeId: gp.id,
-              classId: cls.id,
-              order: i,
-            },
-          })
-        }
-      }
-
-      // 3. Student照合→GradeStudent作成
-      for (const studentRef of gradeData.studentRefs) {
-        const student = await tx.student.findUnique({
-          where: { studentNumber: studentRef.studentNumber },
-        })
-        if (student) {
-          await tx.gradeStudent.create({
-            data: {
-              gradeId: gp.id,
-              studentId: student.id,
-              customOrder: studentRef.customOrder,
-            },
-          })
-        }
-      }
-
-      // 4. GradeItem + DataSource作成
-      // gradeItemName+dataSourceName → dataSourceId のマッピング
-      const dsKeyToId = new Map<string, string>()
-
-      for (const giData of gradeData.gradeItems) {
-        const gi = await tx.gradeItem.create({
-          data: {
-            gradeId: gp.id,
-            name: giData.name,
-            order: giData.order,
+            name: gradeData.grade.name,
+            description: gradeData.grade.description,
+            // v1.2.0+: 基準日（古いアーカイブではundefined → null）
+            referenceDate: gradeData.grade.referenceDate
+              ? new Date(gradeData.grade.referenceDate)
+              : null,
           },
         })
 
-        for (const dsData of giData.dataSources) {
-          // 旧アーカイブ互換: project_total → exam_total
-          if (dsData.type === "project_total") {
-            dsData.type = "exam_total"
-          }
+        // 1.5. GradeExportSettings作成 (v1.2.0+、Gradeと1:1)
+        if (gradeData.exportSettings) {
+          await tx.gradeExportSettings.create({
+            data: {
+              gradeId: gp.id,
+              settingsJson: gradeData.exportSettings.settingsJson,
+            },
+          })
+        }
 
-          let examId: string | null = null
-          if (
-            dsData.examName &&
-            (dsData.type === "exam_total" ||
-              dsData.type === "subtotal" ||
-              dsData.type === "crop_region")
-          ) {
-            examId = examMapping?.[dsData.examName] ?? null
-            if (!examId) {
-              const exams = await tx.exam.findMany({
-                where: { examName: dsData.examName },
-                select: { id: true },
-              })
-              examId = exams[0]?.id ?? null
-            }
-          }
-
-          // Subtotal照合（名前ベース）
-          let subtotalId: string | null = null
-          if (dsData.type === "subtotal" && dsData.subtotalName && examId) {
-            const subtotals = await tx.subtotal.findMany({
-              where: { name: dsData.subtotalName },
-            })
-            subtotalId = subtotals[0]?.id ?? null
-          }
-
-          // CropRegion照合（ラベルベース）
-          let cropRegionId: string | null = null
-          if (
-            dsData.type === "crop_region" &&
-            dsData.cropRegionLabel &&
-            examId
-          ) {
-            const regions = await tx.cropRegion.findMany({
-              where: {
-                label: dsData.cropRegionLabel,
-                examPage: { examId: examId },
+        // 2. Class照合→GradeClass作成
+        for (let i = 0; i < gradeData.classRefs.length; i++) {
+          const ref = gradeData.classRefs[i]
+          const cls = await tx.class.findUnique({
+            where: { name: ref.name },
+          })
+          if (cls) {
+            await tx.gradeClass.create({
+              data: {
+                gradeId: gp.id,
+                classId: cls.id,
+                order: i,
               },
             })
-            cropRegionId = regions[0]?.id ?? null
+          }
+        }
+
+        // 3. Student照合→GradeStudent作成
+        for (const studentRef of gradeData.studentRefs) {
+          const student = await tx.student.findUnique({
+            where: { studentNumber: studentRef.studentNumber },
+          })
+          if (student) {
+            await tx.gradeStudent.create({
+              data: {
+                gradeId: gp.id,
+                studentId: student.id,
+                customOrder: studentRef.customOrder,
+              },
+            })
+          }
+        }
+
+        // 4. GradeItem + DataSource作成
+        // gradeItemName+dataSourceName → dataSourceId のマッピング
+        const dsKeyToId = new Map<string, string>()
+
+        for (const giData of gradeData.gradeItems) {
+          const gi = await tx.gradeItem.create({
+            data: {
+              gradeId: gp.id,
+              name: giData.name,
+              order: giData.order,
+            },
+          })
+
+          for (const dsData of giData.dataSources) {
+            // 旧アーカイブ互換: project_total → exam_total
+            if (dsData.type === "project_total") {
+              dsData.type = "exam_total"
+            }
+
+            let examId: string | null = null
+            if (
+              dsData.examName &&
+              (dsData.type === "exam_total" ||
+                dsData.type === "subtotal" ||
+                dsData.type === "crop_region")
+            ) {
+              examId = examMapping?.[dsData.examName] ?? null
+              if (!examId) {
+                const exams = await tx.exam.findMany({
+                  where: { examName: dsData.examName },
+                  select: { id: true },
+                })
+                examId = exams[0]?.id ?? null
+              }
+            }
+
+            // Subtotal照合（名前ベース）
+            let subtotalId: string | null = null
+            if (dsData.type === "subtotal" && dsData.subtotalName && examId) {
+              const subtotals = await tx.subtotal.findMany({
+                where: { name: dsData.subtotalName },
+              })
+              subtotalId = subtotals[0]?.id ?? null
+            }
+
+            // CropRegion照合（ラベルベース）
+            let cropRegionId: string | null = null
+            if (
+              dsData.type === "crop_region" &&
+              dsData.cropRegionLabel &&
+              examId
+            ) {
+              const regions = await tx.cropRegion.findMany({
+                where: {
+                  label: dsData.cropRegionLabel,
+                  examPage: { examId: examId },
+                },
+              })
+              cropRegionId = regions[0]?.id ?? null
+            }
+
+            const ds = await tx.gradeDataSource.create({
+              data: {
+                gradeItemId: gi.id,
+                type: dsData.type,
+                examId,
+                subtotalId,
+                cropRegionId,
+                name: dsData.name,
+                maxScore: dsData.maxScore,
+                weight: dsData.weight,
+                order: dsData.order,
+                absentMethod: dsData.absentMethod ?? "null",
+                absentRatio: dsData.absentRatio ?? 1.0,
+                absentOffset: dsData.absentOffset ?? 0,
+                treatExpectedAsMissing: dsData.treatExpectedAsMissing ?? false,
+                estimationMode: dsData.estimationMode ?? "all",
+                estimationSourceIds: JSON.stringify(
+                  dsData.estimationSourceIds ?? []
+                ),
+              },
+            })
+            dsKeyToId.set(`${giData.name}:${dsData.name}`, ds.id)
+          }
+        }
+
+        // 5. ManualScore挿入
+        for (const msData of manualScoresData.manualScores) {
+          const dsId = dsKeyToId.get(
+            `${msData.gradeItemName}:${msData.dataSourceName}`
+          )
+          if (!dsId) continue
+
+          const student = await tx.student.findUnique({
+            where: { studentNumber: msData.studentNumber },
+          })
+          if (!student) continue
+
+          await tx.manualScore.create({
+            data: {
+              gradeDataSourceId: dsId,
+              studentId: student.id,
+              score: msData.score,
+            },
+          })
+        }
+
+        // 6. BoundarySet/Boundary挿入
+        for (const bsData of boundariesData.boundarySets) {
+          let gradeItemId: string | null = null
+          if (bsData.gradeItemName) {
+            // GradeItem名で照合（同じ試験内）
+            const gi = await tx.gradeItem.findFirst({
+              where: {
+                gradeId: gp.id,
+                name: bsData.gradeItemName,
+              },
+            })
+            gradeItemId = gi?.id ?? null
+            if (!gradeItemId) continue
           }
 
-          const ds = await tx.gradeDataSource.create({
-            data: {
-              gradeItemId: gi.id,
-              type: dsData.type,
-              examId,
-              subtotalId,
-              cropRegionId,
-              name: dsData.name,
-              maxScore: dsData.maxScore,
-              weight: dsData.weight,
-              order: dsData.order,
-              absentMethod: dsData.absentMethod ?? "null",
-              absentRatio: dsData.absentRatio ?? 1.0,
-              absentOffset: dsData.absentOffset ?? 0,
-              treatExpectedAsMissing: dsData.treatExpectedAsMissing ?? false,
-              estimationMode: dsData.estimationMode ?? "all",
-              estimationSourceIds: JSON.stringify(
-                dsData.estimationSourceIds ?? []
-              ),
-            },
-          })
-          dsKeyToId.set(`${giData.name}:${dsData.name}`, ds.id)
-        }
-      }
-
-      // 5. ManualScore挿入
-      for (const msData of manualScoresData.manualScores) {
-        const dsId = dsKeyToId.get(
-          `${msData.gradeItemName}:${msData.dataSourceName}`
-        )
-        if (!dsId) continue
-
-        const student = await tx.student.findUnique({
-          where: { studentNumber: msData.studentNumber },
-        })
-        if (!student) continue
-
-        await tx.manualScore.create({
-          data: {
-            gradeDataSourceId: dsId,
-            studentId: student.id,
-            score: msData.score,
-          },
-        })
-      }
-
-      // 6. BoundarySet/Boundary挿入
-      for (const bsData of boundariesData.boundarySets) {
-        let gradeItemId: string | null = null
-        if (bsData.gradeItemName) {
-          // GradeItem名で照合（同じ試験内）
-          const gi = await tx.gradeItem.findFirst({
-            where: {
-              gradeId: gp.id,
-              name: bsData.gradeItemName,
-            },
-          })
-          gradeItemId = gi?.id ?? null
-          if (!gradeItemId) continue
-        }
-
-        const bs = await tx.gradeBoundarySet.create({
-          data: {
-            gradeId: gp.id,
-            targetType: bsData.targetType,
-            gradeItemId,
-          },
-        })
-
-        if (bsData.boundaries.length > 0) {
-          await tx.gradeBoundary.createMany({
-            data: bsData.boundaries.map((b) => ({
-              gradeBoundarySetId: bs.id,
-              label: b.label,
-              minPercentage: b.minPercentage,
-              order: b.order,
-            })),
-          })
-        }
-      }
-
-      // 7. GradeItemExclusion挿入（後方互換: optionalフィールド）
-      if (
-        gradeData.gradeItemExclusions &&
-        gradeData.gradeItemExclusions.length > 0
-      ) {
-        for (const excl of gradeData.gradeItemExclusions) {
-          const student = await tx.student.findUnique({
-            where: { studentNumber: excl.studentNumber },
-          })
-          if (!student) continue
-
-          const gradeItem = await tx.gradeItem.findFirst({
-            where: {
-              gradeId: gp.id,
-              name: excl.gradeItemName,
-            },
-          })
-          if (!gradeItem) continue
-
-          await tx.gradeItemExclusion.create({
+          const bs = await tx.gradeBoundarySet.create({
             data: {
               gradeId: gp.id,
-              studentId: student.id,
-              gradeItemId: gradeItem.id,
+              targetType: bsData.targetType,
+              gradeItemId,
             },
           })
+
+          if (bsData.boundaries.length > 0) {
+            await tx.gradeBoundary.createMany({
+              data: bsData.boundaries.map((b) => ({
+                gradeBoundarySetId: bs.id,
+                label: b.label,
+                minPercentage: b.minPercentage,
+                order: b.order,
+              })),
+            })
+          }
         }
-      }
 
-      // 8. GradeOverride挿入（後方互換: optionalフィールド）
-      if (gradeData.gradeOverrides && gradeData.gradeOverrides.length > 0) {
-        for (const ov of gradeData.gradeOverrides) {
-          const student = await tx.student.findUnique({
-            where: { studentNumber: ov.studentNumber },
-          })
-          if (!student) continue
+        // 7. GradeItemExclusion挿入（後方互換: optionalフィールド）
+        if (
+          gradeData.gradeItemExclusions &&
+          gradeData.gradeItemExclusions.length > 0
+        ) {
+          for (const excl of gradeData.gradeItemExclusions) {
+            const student = await tx.student.findUnique({
+              where: { studentNumber: excl.studentNumber },
+            })
+            if (!student) continue
 
-          let gradeItemId: string | null = null
-          if (ov.gradeItemName) {
             const gradeItem = await tx.gradeItem.findFirst({
               where: {
                 gradeId: gp.id,
-                name: ov.gradeItemName,
+                name: excl.gradeItemName,
               },
             })
             if (!gradeItem) continue
-            gradeItemId = gradeItem.id
+
+            await tx.gradeItemExclusion.create({
+              data: {
+                gradeId: gp.id,
+                studentId: student.id,
+                gradeItemId: gradeItem.id,
+              },
+            })
           }
-
-          await tx.gradeOverride.create({
-            data: {
-              gradeId: gp.id,
-              studentId: student.id,
-              targetType: ov.targetType,
-              gradeItemId,
-              overrideLabel: ov.overrideLabel,
-            },
-          })
         }
-      }
 
-      return { success: true, gradeId: gp.id }
+        // 8. GradeOverride挿入（後方互換: optionalフィールド）
+        if (gradeData.gradeOverrides && gradeData.gradeOverrides.length > 0) {
+          for (const ov of gradeData.gradeOverrides) {
+            const student = await tx.student.findUnique({
+              where: { studentNumber: ov.studentNumber },
+            })
+            if (!student) continue
+
+            let gradeItemId: string | null = null
+            if (ov.gradeItemName) {
+              const gradeItem = await tx.gradeItem.findFirst({
+                where: {
+                  gradeId: gp.id,
+                  name: ov.gradeItemName,
+                },
+              })
+              if (!gradeItem) continue
+              gradeItemId = gradeItem.id
+            }
+
+            await tx.gradeOverride.create({
+              data: {
+                gradeId: gp.id,
+                studentId: student.id,
+                targetType: ov.targetType,
+                gradeItemId,
+                overrideLabel: ov.overrideLabel,
+              },
+            })
+          }
+        }
+
+        return { success: true, gradeId: gp.id }
+      }
+    )
+
+    // 監査ログ: 成績インポート
+    await recordAuditLog({
+      action: "grade.import",
+      entityType: "Grade",
+      entityId: result.gradeId ?? "",
+      scopeId: result.gradeId ?? null,
+      scopeLabel: data.gradeData.grade.name,
+      target: data.gradeData.grade.name,
     })
+
+    return result
   } catch (error) {
     console.error("Error importing grade archive:", error)
     return {

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -18,6 +18,7 @@ import type {
   ScoringConflictConfig,
   UpdateDecisions,
 } from "../../../../src/types/examArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
 import { isNewerByLww } from "./decisionMergePolicy"
@@ -282,6 +283,18 @@ export async function executeIdIntegrationImport(
       )
       console.error("Image copy failed:", copyError)
     }
+
+    // 監査ログ: 試験インポート
+    const importedExamName = data.examData.exam.examName
+    await recordAuditLog({
+      action: "exam.import",
+      userId: currentUserId,
+      entityType: "Exam",
+      entityId: newExamId,
+      scopeId: newExamId,
+      scopeLabel: importedExamName,
+      target: importedExamName,
+    })
 
     return {
       success: true,

--- a/electron-src/lib/import/student-archive/index.ts
+++ b/electron-src/lib/import/student-archive/index.ts
@@ -12,6 +12,7 @@ import type {
   StudentArchiveImportResult,
   StudentArchiveManifest,
 } from "../../../../src/types/studentArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
 import { executeIdChanges } from "../merge/idChangeExecutor"
@@ -182,6 +183,15 @@ export async function executeStudentImport(
     // memberships のカウントはprocessMembershipでは集計されないため
     // idMappings.membership のサイズで推定
     counts.created.memberships = Object.keys(idMappings.membership).length
+
+    const importedStudents = counts.created.students + counts.updated.students
+    await recordAuditLog({
+      action: "student.import",
+      entityType: "Student",
+      entityId: "student-archive",
+      summary: `生徒を${importedStudents}名インポートしました`,
+      extra: { counts },
+    })
 
     return {
       success: true,

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -23,6 +23,7 @@ import {
   dbToDefinition,
   flattenGlobalSettings,
 } from "./asbDefinitionConverters"
+import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 // =============================================================================
@@ -193,6 +194,10 @@ export async function saveAsbDefinition(
   definition: AnswerSheetDefinition,
   userId: string
 ): Promise<void> {
+  // 新規/更新の判定（saveは delete→recreate のため、事前に存在確認）
+  const existed =
+    (await prisma.asbDefinition.count({ where: { id: definition.id } })) > 0
+
   await prisma.$transaction(async (tx) => {
     // 既存があれば子テーブルごと削除（Cascade）
     await tx.asbDefinition.deleteMany({ where: { id: definition.id } })
@@ -384,6 +389,17 @@ export async function saveAsbDefinition(
       }
     }
   })
+
+  // 監査ログ: 解答用紙の作成/更新
+  await recordAuditLog({
+    action: existed ? "answer_sheet.update" : "answer_sheet.create",
+    userId,
+    entityType: "AsbDefinition",
+    entityId: definition.id,
+    scopeId: definition.id,
+    scopeLabel: definition.name,
+    target: definition.name,
+  })
 }
 
 // =============================================================================
@@ -393,7 +409,21 @@ export async function saveAsbDefinition(
 /** 解答用紙定義を削除する */
 export async function deleteAsbDefinition(id: string): Promise<boolean> {
   try {
+    const before = await prisma.asbDefinition.findUnique({
+      where: { id },
+      select: { name: true },
+    })
     await prisma.asbDefinition.delete({ where: { id } })
+
+    await recordAuditLog({
+      action: "answer_sheet.delete",
+      entityType: "AsbDefinition",
+      entityId: id,
+      scopeId: id,
+      scopeLabel: before?.name ?? null,
+      target: before?.name ?? null,
+    })
+
     return true
   } catch {
     return false

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -1,0 +1,526 @@
+/**
+ * @fileoverview 監査ログのアクションカタログ
+ * @description Discord風監査ログで記録する全アクションの一元定義。
+ *   アクションキーは `domain.entity.verb` 形式の名前空間付き文字列。
+ *   記録側（auditLog.ts）はこのカタログから category とサマリ用ラベルを解決し、
+ *   表示側（UI）は category / verb でフィルタ・アイコン分けを行う。
+ *
+ *   ※閲覧（read/view）は記録対象外。状態を変える操作とエクスポートのみを定義する。
+ */
+
+/** 監査ログのカテゴリ（作業領域単位。UIフィルタの最上位軸） */
+export type AuditCategory =
+  | "exam" // 試験
+  | "grade" // 成績
+  | "answer_sheet" // 解答用紙作成
+  | "student" // 生徒・学級・小計グループ
+  | "user" // ユーザー・権限
+  | "system" // システム・その他
+
+/** アクションの種別（アイコン・色分け用） */
+export type AuditVerb =
+  | "create"
+  | "update"
+  | "delete"
+  | "export"
+  | "import"
+  | "other"
+
+export interface AuditActionDef {
+  category: AuditCategory
+  verb: AuditVerb
+  /**
+   * サマリ用の日本語ラベル。`{target}` は対象ラベル（scopeLabel/target）に置換される。
+   * 操作者名は含めない（UIが actor を前置して文を組み立てる）。
+   */
+  label: string
+}
+
+/**
+ * 全アクションの定義表。網羅的に対応できるよう主要ドメインを定義する。
+ * 新しい操作を計装する際はここにキーを追加する（これが記録の契約）。
+ */
+export const AUDIT_ACTIONS = {
+  // ── 試験（exam） ─────────────────────────────────────────────
+  "exam.create": {
+    category: "exam",
+    verb: "create",
+    label: "試験「{target}」を作成しました",
+  },
+  "exam.update": {
+    category: "exam",
+    verb: "update",
+    label: "試験「{target}」を編集しました",
+  },
+  "exam.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "試験「{target}」を削除しました",
+  },
+  "exam.export": {
+    category: "exam",
+    verb: "export",
+    label: "試験「{target}」をエクスポートしました",
+  },
+  "exam.import": {
+    category: "exam",
+    verb: "import",
+    label: "試験「{target}」をインポートしました",
+  },
+
+  "exam.page.upload": {
+    category: "exam",
+    verb: "create",
+    label: "模範解答ページをアップロードしました",
+  },
+  "exam.page.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "模範解答ページを削除しました",
+  },
+  "exam.page.reorder": {
+    category: "exam",
+    verb: "update",
+    label: "模範解答ページを並び替えました",
+  },
+
+  "exam.region.create": {
+    category: "exam",
+    verb: "create",
+    label: "採点領域を作成しました",
+  },
+  "exam.region.update": {
+    category: "exam",
+    verb: "update",
+    label: "採点領域を編集しました",
+  },
+  "exam.region.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "採点領域を削除しました",
+  },
+  "exam.region_info.update": {
+    category: "exam",
+    verb: "update",
+    label: "領域情報を更新しました",
+  },
+
+  "exam.question_group.create": {
+    category: "exam",
+    verb: "create",
+    label: "設問グループ「{target}」を作成しました",
+  },
+  "exam.question_group.update": {
+    category: "exam",
+    verb: "update",
+    label: "設問グループ「{target}」を編集しました",
+  },
+  "exam.question_group.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "設問グループ「{target}」を削除しました",
+  },
+
+  "exam.student.add": {
+    category: "exam",
+    verb: "create",
+    label: "受験生徒「{target}」を追加しました",
+  },
+  "exam.student.remove": {
+    category: "exam",
+    verb: "delete",
+    label: "受験生徒「{target}」を削除しました",
+  },
+  "exam.student.attendance_update": {
+    category: "exam",
+    verb: "update",
+    label: "「{target}」の受験状態を変更しました",
+  },
+  "exam.student.reorder": {
+    category: "exam",
+    verb: "update",
+    label: "受験生徒の並び順を変更しました",
+  },
+
+  "exam.answer.upload": {
+    category: "exam",
+    verb: "create",
+    label: "生徒答案をアップロードしました",
+  },
+  "exam.answer.assign": {
+    category: "exam",
+    verb: "update",
+    label: "生徒答案を割り当てました",
+  },
+  "exam.answer.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "生徒答案を削除しました",
+  },
+
+  "exam.score.propose": {
+    category: "exam",
+    verb: "create",
+    label: "採点を提案しました",
+  },
+  "exam.score.update": {
+    category: "exam",
+    verb: "update",
+    label: "採点提案を変更しました",
+  },
+  "exam.score.decide": {
+    category: "exam",
+    verb: "update",
+    label: "採点を確定しました",
+  },
+  "exam.score.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "採点提案を削除しました",
+  },
+  "exam.score.batch": {
+    category: "exam",
+    verb: "update",
+    label: "採点を一括反映しました",
+  },
+
+  "exam.annotation.create": {
+    category: "exam",
+    verb: "create",
+    label: "採点マークを追加しました",
+  },
+  "exam.annotation.update": {
+    category: "exam",
+    verb: "update",
+    label: "採点マークを編集しました",
+  },
+  "exam.annotation.delete": {
+    category: "exam",
+    verb: "delete",
+    label: "採点マークを削除しました",
+  },
+
+  "exam.marking_format.update": {
+    category: "exam",
+    verb: "update",
+    label: "採点マーク設定を更新しました",
+  },
+  "exam.export_settings.update": {
+    category: "exam",
+    verb: "update",
+    label: "出力設定を更新しました",
+  },
+  "exam.class.assign": {
+    category: "exam",
+    verb: "create",
+    label: "学級「{target}」を試験に割り当てました",
+  },
+  "exam.class.unassign": {
+    category: "exam",
+    verb: "delete",
+    label: "学級の試験割り当てを解除しました",
+  },
+  "exam.subtotal_assignment.update": {
+    category: "exam",
+    verb: "update",
+    label: "設問と小計の対応を更新しました",
+  },
+  "exam.omr_config.update": {
+    category: "exam",
+    verb: "update",
+    label: "OMR設定を更新しました",
+  },
+  "exam.compound_answer.update": {
+    category: "exam",
+    verb: "update",
+    label: "複合解答スコアを更新しました",
+  },
+  "exam.region.reorder": {
+    category: "exam",
+    verb: "update",
+    label: "採点領域を並び替えました",
+  },
+
+  "exam.user.invite": {
+    category: "exam",
+    verb: "create",
+    label: "「{target}」を試験に招待しました",
+  },
+  "exam.user.role_update": {
+    category: "exam",
+    verb: "update",
+    label: "「{target}」の試験ロールを変更しました",
+  },
+  "exam.user.remove": {
+    category: "exam",
+    verb: "delete",
+    label: "「{target}」を試験から外しました",
+  },
+
+  // ── 成績（grade） ────────────────────────────────────────────
+  "grade.create": {
+    category: "grade",
+    verb: "create",
+    label: "成績「{target}」を作成しました",
+  },
+  "grade.update": {
+    category: "grade",
+    verb: "update",
+    label: "成績「{target}」を編集しました",
+  },
+  "grade.delete": {
+    category: "grade",
+    verb: "delete",
+    label: "成績「{target}」を削除しました",
+  },
+  "grade.export": {
+    category: "grade",
+    verb: "export",
+    label: "成績「{target}」をエクスポートしました",
+  },
+  "grade.import": {
+    category: "grade",
+    verb: "import",
+    label: "成績「{target}」をインポートしました",
+  },
+
+  "grade.student.add": {
+    category: "grade",
+    verb: "create",
+    label: "成績対象生徒「{target}」を追加しました",
+  },
+  "grade.student.remove": {
+    category: "grade",
+    verb: "delete",
+    label: "成績対象生徒「{target}」を削除しました",
+  },
+  "grade.data_source.add": {
+    category: "grade",
+    verb: "create",
+    label: "データソースを追加しました",
+  },
+  "grade.data_source.update": {
+    category: "grade",
+    verb: "update",
+    label: "データソースを更新しました",
+  },
+  "grade.data_source.remove": {
+    category: "grade",
+    verb: "delete",
+    label: "データソースを削除しました",
+  },
+  "grade.manual_score.update": {
+    category: "grade",
+    verb: "update",
+    label: "手動スコアを更新しました",
+  },
+  "grade.boundary.update": {
+    category: "grade",
+    verb: "update",
+    label: "境界設定を更新しました",
+  },
+  "grade.boundary.delete": {
+    category: "grade",
+    verb: "delete",
+    label: "境界セットを削除しました",
+  },
+  "grade.item.create": {
+    category: "grade",
+    verb: "create",
+    label: "成績項目「{target}」を作成しました",
+  },
+  "grade.item.update": {
+    category: "grade",
+    verb: "update",
+    label: "成績項目「{target}」を編集しました",
+  },
+  "grade.item.delete": {
+    category: "grade",
+    verb: "delete",
+    label: "成績項目「{target}」を削除しました",
+  },
+  "grade.override.delete": {
+    category: "grade",
+    verb: "delete",
+    label: "成績の上書きを削除しました",
+  },
+  "grade.item.reorder": {
+    category: "grade",
+    verb: "update",
+    label: "成績項目の並び順を変更しました",
+  },
+  "grade.student.reorder": {
+    category: "grade",
+    verb: "update",
+    label: "成績対象生徒の並び順を変更しました",
+  },
+  "grade.override.update": {
+    category: "grade",
+    verb: "update",
+    label: "成績の上書きを更新しました",
+  },
+
+  // ── 解答用紙作成（answer_sheet） ─────────────────────────────
+  "answer_sheet.create": {
+    category: "answer_sheet",
+    verb: "create",
+    label: "解答用紙「{target}」を作成しました",
+  },
+  "answer_sheet.update": {
+    category: "answer_sheet",
+    verb: "update",
+    label: "解答用紙「{target}」を編集しました",
+  },
+  "answer_sheet.delete": {
+    category: "answer_sheet",
+    verb: "delete",
+    label: "解答用紙「{target}」を削除しました",
+  },
+  "answer_sheet.export": {
+    category: "answer_sheet",
+    verb: "export",
+    label: "解答用紙「{target}」をエクスポートしました",
+  },
+  "answer_sheet.import": {
+    category: "answer_sheet",
+    verb: "import",
+    label: "解答用紙「{target}」をインポートしました",
+  },
+
+  // ── 生徒・学級・小計グループ（student） ──────────────────────
+  "student.create": {
+    category: "student",
+    verb: "create",
+    label: "生徒「{target}」を登録しました",
+  },
+  "student.update": {
+    category: "student",
+    verb: "update",
+    label: "生徒「{target}」を編集しました",
+  },
+  "student.delete": {
+    category: "student",
+    verb: "delete",
+    label: "生徒「{target}」を削除しました",
+  },
+  "student.import": {
+    category: "student",
+    verb: "import",
+    label: "生徒をインポートしました",
+  },
+  "student.export": {
+    category: "student",
+    verb: "export",
+    label: "生徒をエクスポートしました",
+  },
+
+  "class.create": {
+    category: "student",
+    verb: "create",
+    label: "学級「{target}」を作成しました",
+  },
+  "class.update": {
+    category: "student",
+    verb: "update",
+    label: "学級「{target}」を編集しました",
+  },
+  "class.delete": {
+    category: "student",
+    verb: "delete",
+    label: "学級「{target}」を削除しました",
+  },
+  "class.membership.add": {
+    category: "student",
+    verb: "create",
+    label: "「{target}」を学級に追加しました",
+  },
+  "class.membership.remove": {
+    category: "student",
+    verb: "delete",
+    label: "「{target}」を学級から削除しました",
+  },
+
+  "subtotal_group.create": {
+    category: "student",
+    verb: "create",
+    label: "小計グループ「{target}」を作成しました",
+  },
+  "subtotal_group.update": {
+    category: "student",
+    verb: "update",
+    label: "小計グループ「{target}」を編集しました",
+  },
+  "subtotal_group.delete": {
+    category: "student",
+    verb: "delete",
+    label: "小計グループ「{target}」を削除しました",
+  },
+
+  "tag.create": {
+    category: "student",
+    verb: "create",
+    label: "タグ「{target}」を作成しました",
+  },
+  "tag.update": {
+    category: "student",
+    verb: "update",
+    label: "タグ「{target}」を編集しました",
+  },
+  "tag.delete": {
+    category: "student",
+    verb: "delete",
+    label: "タグ「{target}」を削除しました",
+  },
+  "tag.reorder": {
+    category: "student",
+    verb: "update",
+    label: "タグの並び順を変更しました",
+  },
+
+  // ── ユーザー・権限（user） ───────────────────────────────────
+  "user.create": {
+    category: "user",
+    verb: "create",
+    label: "ユーザー「{target}」を作成しました",
+  },
+  "user.update": {
+    category: "user",
+    verb: "update",
+    label: "ユーザー「{target}」を編集しました",
+  },
+  "user.delete": {
+    category: "user",
+    verb: "delete",
+    label: "ユーザー「{target}」を削除しました",
+  },
+} as const satisfies Record<string, AuditActionDef>
+
+/** 定義済みアクションキーの型 */
+export type AuditActionKey = keyof typeof AUDIT_ACTIONS
+
+/** 未知アクション用のフォールバック定義 */
+const FALLBACK_ACTION: AuditActionDef = {
+  category: "system",
+  verb: "other",
+  label: "{target}",
+}
+
+/** アクションキーから定義を取得（未知のキーはフォールバック） */
+export const getAuditActionDef = (action: string): AuditActionDef => {
+  return (
+    (AUDIT_ACTIONS as Record<string, AuditActionDef>)[action] ?? FALLBACK_ACTION
+  )
+}
+
+/** サマリ文字列を生成（{target} を対象ラベルに置換） */
+export const buildAuditSummary = (
+  action: string,
+  target?: string | null
+): string => {
+  const def = getAuditActionDef(action)
+  const label = def.label
+  if (label.includes("{target}")) {
+    return label.replace("{target}", target ?? "（不明）")
+  }
+  return target ? `${label}（${target}）` : label
+}

--- a/electron-src/lib/prisma/auditActor.ts
+++ b/electron-src/lib/prisma/auditActor.ts
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview 監査ログの操作者(actor)解決
+ * @description メインプロセスの認証ストアから現在ログイン中のユーザーIDを取得する。
+ *   認証トークンは userId そのもの（AuthContext がトークン=userIdとして扱う）なので、
+ *   これを使えば各IPC・各mutationのシグネチャを変えずに操作者を記録できる。
+ *
+ *   electron/認証ストアが利用できない環境（テスト等）では null を返す（ベストエフォート）。
+ */
+
+let cachedReader: (() => string | null) | null = null
+
+/** 現在ログイン中の操作者ユーザーIDを返す（取得不能時は null） */
+export function getCurrentActorUserId(): string | null {
+  try {
+    if (!cachedReader) {
+      // 遅延require: electron非搭載環境（vitest等）でのトップレベル副作用を避ける
+      const { AuthStoreManager } =
+        require("../authStore") as typeof import("../authStore")
+      cachedReader = () => AuthStoreManager.getAuthToken()
+    }
+    return cachedReader()
+  } catch {
+    return null
+  }
+}

--- a/electron-src/lib/prisma/auditLog.ts
+++ b/electron-src/lib/prisma/auditLog.ts
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview 監査ログ記録サービス
+ * @description Discord風監査ログの追記専用書き込み。各mutationから明示的に呼ぶ。
+ *   記録は「ベストエフォート」: 失敗しても主操作を壊さないよう例外を握りつぶす
+ *   （ログ欠落 < 主操作の失敗）。アクション定義は auditActions.ts を参照。
+ */
+
+import type { PrismaClient } from "@prisma/client"
+
+import {
+  type AuditActionKey,
+  buildAuditSummary,
+  getAuditActionDef,
+} from "./auditActions"
+import { getCurrentActorUserId } from "./auditActor"
+import prisma from "./client"
+
+type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+
+/** 単一フィールドの変更（before→after 差分） */
+export interface AuditChange {
+  field: string
+  /** UI表示用の日本語ラベル（省略時は field を表示） */
+  label?: string
+  before: unknown
+  after: unknown
+}
+
+export interface RecordAuditLogInput {
+  /** アクションキー（カタログ参照。型補完のため AuditActionKey を推奨） */
+  action: AuditActionKey | (string & {})
+  /**
+   * 操作者ID。未指定（undefined）の場合は認証ストアから現在の操作者を自動補完する。
+   * システム操作として明示的に actor 無しにしたい場合は null を渡す。
+   */
+  userId?: string | null
+  /** 変更対象のテーブル名 */
+  entityType: string
+  /** 変更対象のレコードID */
+  entityId: string
+  /** 絞り込み用の親エンティティID（examId / gradeId / definitionId 等） */
+  scopeId?: string | null
+  /** 表示用スナップショット（対象作業領域のラベル。"数学 期末" 等） */
+  scopeLabel?: string | null
+  /** 対象ラベル（サマリ生成用。生徒名・設問名等） */
+  target?: string | null
+  /** before→after の差分（更新系で使用） */
+  changes?: AuditChange[]
+  /** metadata に追加する任意情報 */
+  extra?: Record<string, unknown>
+  /** 明示指定すればこのサマリを使う（省略時はカタログから自動生成） */
+  summary?: string
+  /**
+   * 連続操作の集約キー。指定すると、時間窓内の同一キー・同一操作者の既存行があれば
+   * 新規挿入せず、その行の after を上書き＋ occurrences を加算＋ updatedAt を更新する。
+   * （例: "annotation.update:<注釈id>:<操作者>"）
+   */
+  coalesceKey?: string
+  /** トランザクション内で記録する場合に渡す */
+  tx?: Tx
+}
+
+/** 連続操作とみなす集約の時間窓（ミリ秒） */
+const COALESCE_WINDOW_MS = 5 * 60_000
+
+/**
+ * 監査ログを1件記録する。
+ * 失敗しても例外を投げない（主操作を妨げないため、エラーはログ出力のみ）。
+ */
+export async function recordAuditLog(
+  input: RecordAuditLogInput
+): Promise<void> {
+  try {
+    const def = getAuditActionDef(input.action)
+    // userId 未指定なら認証ストアから現在の操作者を補完（明示的な null はそのまま尊重）
+    const userId =
+      input.userId !== undefined ? input.userId : getCurrentActorUserId()
+    const summary =
+      input.summary ?? buildAuditSummary(input.action, input.target)
+
+    const client = input.tx ?? prisma
+
+    // 連続操作の集約: 時間窓内に同一キー・同一操作者の行があれば上書き更新する。
+    // coalesceKey はインデックス付き専用カラムなので一致検索は高速。
+    if (input.coalesceKey) {
+      const windowStart = new Date(Date.now() - COALESCE_WINDOW_MS)
+      const match = await client.auditLog.findFirst({
+        where: {
+          coalesceKey: input.coalesceKey,
+          userId: userId ?? null,
+          updatedAt: { gte: windowStart },
+        },
+        orderBy: { updatedAt: "desc" },
+      })
+      if (match) {
+        const meta = JSON.parse(match.metadata ?? "{}") as {
+          changes?: AuditChange[]
+          occurrences?: number
+          [key: string]: unknown
+        }
+        meta.occurrences = (meta.occurrences ?? 1) + 1
+        // 連続操作は after のみ上書き（before は初回値を維持）
+        if (input.changes && input.changes.length > 0) {
+          if (meta.changes && meta.changes.length > 0) {
+            meta.changes[0] = {
+              ...meta.changes[0],
+              after: input.changes[0].after,
+            }
+          } else {
+            meta.changes = input.changes
+          }
+        }
+        // updatedAt は @updatedAt により自動更新される
+        await client.auditLog.update({
+          where: { id: match.id },
+          data: { metadata: JSON.stringify(meta) },
+        })
+        return
+      }
+    }
+
+    const metadataObj: Record<string, unknown> = {}
+    if (input.changes && input.changes.length > 0) {
+      metadataObj.changes = input.changes
+    }
+    if (input.target) {
+      metadataObj.target = { type: input.entityType, label: input.target }
+    }
+    if (input.coalesceKey) {
+      metadataObj.occurrences = 1
+    }
+    if (input.extra) {
+      Object.assign(metadataObj, input.extra)
+    }
+    const metadata =
+      Object.keys(metadataObj).length > 0 ? JSON.stringify(metadataObj) : null
+
+    await client.auditLog.create({
+      data: {
+        action: input.action,
+        category: def.category,
+        userId: userId ?? null,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        scopeId: input.scopeId ?? null,
+        scopeLabel: input.scopeLabel ?? null,
+        summary,
+        metadata,
+        coalesceKey: input.coalesceKey ?? null,
+      },
+    })
+  } catch (error) {
+    // ベストエフォート: 記録失敗は主操作を壊さない
+    console.error("recordAuditLog failed:", input.action, error)
+  }
+}
+
+/**
+ * 監視対象フィールドの before→after を比較し、変化した項目のみ AuditChange[] を返す。
+ * 値の比較は JSON 文字列化による浅い等価判定（プリミティブ/日付/単純オブジェクト向け）。
+ */
+export function diffFields<T extends Record<string, unknown>>(
+  before: T | null | undefined,
+  after: T | null | undefined,
+  watched: Array<{ field: keyof T & string; label?: string }>
+): AuditChange[] {
+  const changes: AuditChange[] = []
+  for (const { field, label } of watched) {
+    const b = before?.[field]
+    const a = after?.[field]
+    if (!isEqual(b, a)) {
+      changes.push({ field, label, before: b ?? null, after: a ?? null })
+    }
+  }
+  return changes
+}
+
+const isEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime()
+  }
+  // null/undefined を同一視
+  if (a == null && b == null) return true
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}

--- a/electron-src/lib/prisma/auditQuery.ts
+++ b/electron-src/lib/prisma/auditQuery.ts
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview 監査ログ取得サービス
+ * @description Discord風監査ログの読み出し。フィルタ・ページネーションに対応し、
+ *   操作者（actor）の表示情報をサーバー側で付与して返す。
+ */
+
+import type { Prisma } from "@prisma/client"
+
+import {
+  type AuditCategory,
+  type AuditVerb,
+  getAuditActionDef,
+} from "./auditActions"
+import prisma from "./client"
+
+export interface AuditLogFilter {
+  userId?: string
+  category?: AuditCategory
+  /** 完全一致のアクションキー */
+  action?: string
+  /** 親エンティティID（特定の試験・成績などに絞る） */
+  scopeId?: string
+  /** ISO文字列。この日時以降 */
+  dateFrom?: string
+  /** ISO文字列。この日時以前 */
+  dateTo?: string
+  /** サマリ部分一致 */
+  search?: string
+}
+
+export interface AuditLogQueryOptions extends AuditLogFilter {
+  /** 取得件数（既定50、最大200） */
+  limit?: number
+  /** オフセット（既定0） */
+  offset?: number
+}
+
+/** UIへ返す1件分の監査ログ（操作者情報・カテゴリ・verbを付与済み） */
+export interface AuditLogEntry {
+  id: string
+  createdAt: string // ISO（初回操作時刻）
+  updatedAt: string // ISO（最終更新時刻。集約された場合は createdAt より後）
+  occurrences: number // 集約回数（連続操作のまとめ件数。1なら単発）
+  action: string
+  category: AuditCategory
+  verb: AuditVerb
+  userId: string | null
+  actorName: string | null
+  actorUsername: string | null
+  entityType: string
+  entityId: string
+  scopeId: string | null
+  scopeLabel: string | null
+  summary: string
+  /** パース済み metadata（changes / target 等） */
+  metadata: Record<string, unknown> | null
+}
+
+export interface AuditLogPage {
+  entries: AuditLogEntry[]
+  total: number
+  limit: number
+  offset: number
+}
+
+const buildWhere = (filter: AuditLogFilter): Prisma.AuditLogWhereInput => {
+  const where: Prisma.AuditLogWhereInput = {}
+  if (filter.userId) where.userId = filter.userId
+  if (filter.category) where.category = filter.category
+  if (filter.action) where.action = filter.action
+  if (filter.scopeId) where.scopeId = filter.scopeId
+  if (filter.search) where.summary = { contains: filter.search }
+  if (filter.dateFrom || filter.dateTo) {
+    const createdAt: Prisma.DateTimeFilter = {}
+    if (filter.dateFrom) createdAt.gte = new Date(filter.dateFrom)
+    if (filter.dateTo) createdAt.lte = new Date(filter.dateTo)
+    where.createdAt = createdAt
+  }
+  return where
+}
+
+const parseMetadata = (raw: string | null): Record<string, unknown> | null => {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 監査ログをフィルタ・ページネーションして取得する。
+ * 操作者名は userId からまとめて解決して付与する。
+ */
+export async function getAuditLogs(
+  options: AuditLogQueryOptions = {}
+): Promise<AuditLogPage> {
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 200)
+  const offset = Math.max(options.offset ?? 0, 0)
+  const where = buildWhere(options)
+
+  const [rows, total] = await Promise.all([
+    prisma.auditLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.auditLog.count({ where }),
+  ])
+
+  // 操作者情報を一括解決
+  const userIds = Array.from(
+    new Set(rows.map((r) => r.userId).filter((id): id is string => !!id))
+  )
+  const users =
+    userIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: userIds } },
+          select: { id: true, name: true, username: true },
+        })
+      : []
+  const userMap = new Map(users.map((u) => [u.id, u]))
+
+  const toIso = (v: Date | string): string =>
+    v instanceof Date ? v.toISOString() : String(v)
+
+  const entries: AuditLogEntry[] = rows.map((r) => {
+    const def = getAuditActionDef(r.action)
+    const actor = r.userId ? userMap.get(r.userId) : undefined
+    const metadata = parseMetadata(r.metadata)
+    const occurrences =
+      typeof metadata?.occurrences === "number" ? metadata.occurrences : 1
+    return {
+      id: r.id,
+      createdAt: toIso(r.createdAt),
+      updatedAt: toIso(r.updatedAt),
+      occurrences,
+      action: r.action,
+      category: def.category,
+      verb: def.verb,
+      userId: r.userId,
+      actorName: actor?.name ?? null,
+      actorUsername: actor?.username ?? null,
+      entityType: r.entityType,
+      entityId: r.entityId,
+      scopeId: r.scopeId,
+      scopeLabel: r.scopeLabel,
+      summary: r.summary,
+      metadata,
+    }
+  })
+
+  return { entries, total, limit, offset }
+}
+
+/** フィルタUI用のファセット（出現したscopeの一覧をカテゴリ別に返す） */
+export interface AuditScopeFacet {
+  scopeId: string
+  scopeLabel: string | null
+  category: string
+}
+
+export async function getAuditLogScopes(): Promise<AuditScopeFacet[]> {
+  const rows = await prisma.auditLog.findMany({
+    where: { scopeId: { not: null } },
+    distinct: ["scopeId"],
+    select: { scopeId: true, scopeLabel: true, category: true },
+    orderBy: { createdAt: "desc" },
+  })
+  return rows
+    .filter(
+      (
+        r
+      ): r is {
+        scopeId: string
+        scopeLabel: string | null
+        category: string
+      } => !!r.scopeId
+    )
+    .map((r) => ({
+      scopeId: r.scopeId,
+      scopeLabel: r.scopeLabel,
+      category: r.category,
+    }))
+}
+
+/** 監査ログの既定保持日数（これより古いエントリは起動時プルーニングの対象） */
+export const DEFAULT_AUDIT_RETENTION_DAYS = 730 // 2年
+
+/**
+ * 保持期間を超えた監査ログを削除する（無制限な肥大化の防止）。
+ *
+ * 注意（同期との関係）: AuditLog は同期設定で deleteProtected のため、
+ * ローカル削除は他端末/NASへ伝播せず、再同期で復活し得る。
+ * 本プルーニングは「各端末でローカルに古い行を整理する」ベストエフォートであり、
+ * 全端末が同じ保持日数で実行することで実質的に収束する。
+ * 失敗しても起動を妨げないよう、呼び出し側で例外を握りつぶすこと。
+ *
+ * @returns 削除した件数
+ */
+export async function pruneAuditLogs(
+  retentionDays: number = DEFAULT_AUDIT_RETENTION_DAYS
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0
+  const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000)
+  const result = await prisma.auditLog.deleteMany({
+    where: { updatedAt: { lt: cutoff } },
+  })
+  if (result.count > 0) {
+    console.info(
+      `pruneAuditLogs: ${result.count}件の監査ログ（${retentionDays}日より前）を削除しました`
+    )
+  }
+  return result.count
+}

--- a/electron-src/lib/prisma/auditScope.ts
+++ b/electron-src/lib/prisma/auditScope.ts
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview 監査ログのスコープ・対象ラベル解決ヘルパー
+ * @description 計装時に scopeLabel（試験名・成績名等）や対象ラベル（生徒名）を
+ *   解決するための軽量クエリ群。失敗時は null を返す（ベストエフォート）。
+ */
+
+import prisma from "./client"
+
+/** examId から監査ログ用スコープを解決（試験名スナップショット付き） */
+export async function resolveExamScope(
+  examId: string
+): Promise<{ scopeId: string; scopeLabel: string | null }> {
+  try {
+    const exam = await prisma.exam.findUnique({
+      where: { id: examId },
+      select: { examName: true },
+    })
+    return { scopeId: examId, scopeLabel: exam?.examName ?? null }
+  } catch {
+    return { scopeId: examId, scopeLabel: null }
+  }
+}
+
+/** gradeId から監査ログ用スコープを解決（成績名スナップショット付き） */
+export async function resolveGradeScope(
+  gradeId: string
+): Promise<{ scopeId: string; scopeLabel: string | null }> {
+  try {
+    const grade = await prisma.grade.findUnique({
+      where: { id: gradeId },
+      select: { name: true },
+    })
+    return { scopeId: gradeId, scopeLabel: grade?.name ?? null }
+  } catch {
+    return { scopeId: gradeId, scopeLabel: null }
+  }
+}
+
+/** gradeItemId から成績スコープを解決 */
+export async function resolveGradeScopeByItem(
+  gradeItemId: string
+): Promise<{ scopeId: string | null; scopeLabel: string | null }> {
+  try {
+    const item = await prisma.gradeItem.findUnique({
+      where: { id: gradeItemId },
+      select: { gradeId: true, grade: { select: { name: true } } },
+    })
+    return {
+      scopeId: item?.gradeId ?? null,
+      scopeLabel: item?.grade?.name ?? null,
+    }
+  } catch {
+    return { scopeId: null, scopeLabel: null }
+  }
+}
+
+/** gradeDataSourceId から成績スコープを解決 */
+export async function resolveGradeScopeByDataSource(
+  dataSourceId: string
+): Promise<{ scopeId: string | null; scopeLabel: string | null }> {
+  try {
+    const ds = await prisma.gradeDataSource.findUnique({
+      where: { id: dataSourceId },
+      select: {
+        gradeItem: {
+          select: { gradeId: true, grade: { select: { name: true } } },
+        },
+      },
+    })
+    return {
+      scopeId: ds?.gradeItem.gradeId ?? null,
+      scopeLabel: ds?.gradeItem.grade?.name ?? null,
+    }
+  } catch {
+    return { scopeId: null, scopeLabel: null }
+  }
+}
+
+/** examPageId から試験スコープを解決 */
+export async function resolveExamScopeByPage(
+  examPageId: string
+): Promise<{ scopeId: string | null; scopeLabel: string | null }> {
+  try {
+    const page = await prisma.examPage.findUnique({
+      where: { id: examPageId },
+      select: { examId: true, exam: { select: { examName: true } } },
+    })
+    return {
+      scopeId: page?.examId ?? null,
+      scopeLabel: page?.exam?.examName ?? null,
+    }
+  } catch {
+    return { scopeId: null, scopeLabel: null }
+  }
+}
+
+/** cropRegionId から試験スコープを解決 */
+export async function resolveExamScopeByCropRegion(
+  cropRegionId: string
+): Promise<{ scopeId: string | null; scopeLabel: string | null }> {
+  try {
+    const region = await prisma.cropRegion.findUnique({
+      where: { id: cropRegionId },
+      select: {
+        examPage: {
+          select: { examId: true, exam: { select: { examName: true } } },
+        },
+      },
+    })
+    const examId = region?.examPage.examId ?? null
+    return {
+      scopeId: examId,
+      scopeLabel: region?.examPage.exam?.examName ?? null,
+    }
+  } catch {
+    return { scopeId: null, scopeLabel: null }
+  }
+}
+
+/** questionScoreId から試験スコープを解決（採点マーク用） */
+export async function resolveExamScopeByQuestionScore(
+  questionScoreId: string
+): Promise<{ scopeId: string | null; scopeLabel: string | null }> {
+  try {
+    const qs = await prisma.questionScore.findUnique({
+      where: { id: questionScoreId },
+      select: {
+        cropRegion: {
+          select: {
+            examPage: {
+              select: {
+                examId: true,
+                exam: { select: { examName: true } },
+              },
+            },
+          },
+        },
+      },
+    })
+    const examId = qs?.cropRegion.examPage.examId ?? null
+    return {
+      scopeId: examId,
+      scopeLabel: qs?.cropRegion.examPage.exam?.examName ?? null,
+    }
+  } catch {
+    return { scopeId: null, scopeLabel: null }
+  }
+}
+
+/** studentId から「姓 名」ラベルを解決 */
+export async function resolveStudentLabel(
+  studentId: string
+): Promise<string | null> {
+  try {
+    const s = await prisma.student.findUnique({
+      where: { id: studentId },
+      select: { lastName: true, firstName: true },
+    })
+    if (!s) return null
+    return `${s.lastName} ${s.firstName}`.trim()
+  } catch {
+    return null
+  }
+}
+
+/** userId から表示名を解決 */
+export async function resolveUserLabel(userId: string): Promise<string | null> {
+  try {
+    const u = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { name: true },
+    })
+    return u?.name ?? null
+  } catch {
+    return null
+  }
+}

--- a/electron-src/lib/prisma/class.ts
+++ b/electron-src/lib/prisma/class.ts
@@ -1,5 +1,6 @@
 import { Class, Prisma } from "@prisma/client"
 
+import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 type ClassWithMemberships = Prisma.ClassGetPayload<{
@@ -40,7 +41,7 @@ export const createClass = async (
   classData: Prisma.ClassCreateInput
 ): Promise<ClassWithMemberships> => {
   try {
-    return await prisma.class.create({
+    const created = await prisma.class.create({
       data: classData,
       include: {
         memberships: {
@@ -55,6 +56,15 @@ export const createClass = async (
         },
       },
     })
+
+    await recordAuditLog({
+      action: "class.create",
+      entityType: "Class",
+      entityId: created.id,
+      target: created.name,
+    })
+
+    return created
   } catch (error) {
     console.error("Failed to create class:", error)
     throw error
@@ -67,7 +77,12 @@ export const updateClass = async (
 ): Promise<ClassWithMemberships> => {
   const { id, ...data } = classData
   try {
-    return await prisma.class.update({
+    const before = await prisma.class.findUnique({
+      where: { id },
+      select: { name: true, grade: true, classCode: true, description: true },
+    })
+
+    const updated = await prisma.class.update({
       where: { id },
       data,
       include: {
@@ -83,6 +98,30 @@ export const updateClass = async (
         },
       },
     })
+
+    await recordAuditLog({
+      action: "class.update",
+      entityType: "Class",
+      entityId: updated.id,
+      target: updated.name,
+      changes: diffFields(
+        before ?? undefined,
+        {
+          name: updated.name,
+          grade: updated.grade,
+          classCode: updated.classCode,
+          description: updated.description,
+        },
+        [
+          { field: "name", label: "学級名" },
+          { field: "grade", label: "学年" },
+          { field: "classCode", label: "学級コード" },
+          { field: "description", label: "説明" },
+        ]
+      ),
+    })
+
+    return updated
   } catch (error) {
     console.error(`Failed to update class ${id}:`, error)
     throw error
@@ -104,7 +143,16 @@ export const deleteClass = async (classId: string): Promise<Class | void> => {
         `学級を削除できません: ${membershipCount} 人の生徒がまだ所属しています。`
       )
     }
-    return await prisma.class.delete({ where: { id: classId } })
+    const deleted = await prisma.class.delete({ where: { id: classId } })
+
+    await recordAuditLog({
+      action: "class.delete",
+      entityType: "Class",
+      entityId: classId,
+      target: deleted.name,
+    })
+
+    return deleted
   } catch (error) {
     console.error(`Failed to delete class ${classId}:`, error)
     throw error

--- a/electron-src/lib/prisma/compoundAnswer.ts
+++ b/electron-src/lib/prisma/compoundAnswer.ts
@@ -10,6 +10,8 @@ import type {
   Prisma,
 } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScopeByPage } from "./auditScope"
 import prisma from "./client"
 
 export type CompoundAnswerWithMembers = CompoundAnswer & {
@@ -45,7 +47,7 @@ export interface CreateCompoundAnswerData {
 export async function createCompoundAnswer(
   data: CreateCompoundAnswerData
 ): Promise<CompoundAnswerWithMembers> {
-  return prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     const compoundAnswer = await tx.compoundAnswer.create({
       data: {
         examPageId: data.examPageId,
@@ -79,13 +81,42 @@ export async function createCompoundAnswer(
       },
     })
   })
+
+  const scope = await resolveExamScopeByPage(data.examPageId)
+  await recordAuditLog({
+    action: "exam.compound_answer.update",
+    entityType: "CompoundAnswer",
+    entityId: result.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    target: result.label,
+  })
+
+  return result
 }
 
 /**
  * 複合回答を削除
  */
 export async function deleteCompoundAnswer(id: string): Promise<void> {
+  const before = await prisma.compoundAnswer.findUnique({
+    where: { id },
+    select: { examPageId: true, label: true },
+  })
+
   await prisma.compoundAnswer.delete({ where: { id } })
+
+  if (before) {
+    const scope = await resolveExamScopeByPage(before.examPageId)
+    await recordAuditLog({
+      action: "exam.compound_answer.update",
+      entityType: "CompoundAnswer",
+      entityId: id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: `複合解答「${before.label}」を削除しました`,
+    })
+  }
 }
 
 /**
@@ -135,7 +166,7 @@ export async function upsertCompoundAnswerScore(data: {
   status: string
   partialScore?: Prisma.Decimal | null
 }): Promise<CompoundAnswerScore> {
-  return prisma.compoundAnswerScore.upsert({
+  const result = await prisma.compoundAnswerScore.upsert({
     where: {
       compoundAnswerId_studentId: {
         compoundAnswerId: data.compoundAnswerId,
@@ -157,4 +188,25 @@ export async function upsertCompoundAnswerScore(data: {
       partialScore: data.partialScore ?? null,
     },
   })
+
+  // 採点（複合解答）。同じ複合解答×操作者の連続採点を集約する。
+  const ca = await prisma.compoundAnswer.findUnique({
+    where: { id: data.compoundAnswerId },
+    select: { examPageId: true },
+  })
+  const scope = ca
+    ? await resolveExamScopeByPage(ca.examPageId)
+    : { scopeId: null, scopeLabel: null }
+  await recordAuditLog({
+    action: "exam.compound_answer.update",
+    userId: data.userId,
+    entityType: "CompoundAnswerScore",
+    entityId: result.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    summary: "複合解答を採点しました",
+    coalesceKey: `compound_score:${data.compoundAnswerId}:${data.userId}`,
+  })
+
+  return result
 }

--- a/electron-src/lib/prisma/cropRegion.ts
+++ b/electron-src/lib/prisma/cropRegion.ts
@@ -1,5 +1,11 @@
 import type { CropRegion, Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import {
+  resolveExamScope,
+  resolveExamScopeByCropRegion,
+  resolveExamScopeByPage,
+} from "./auditScope"
 import prisma from "./client"
 
 /** 設問領域を作成する（orderIndex未指定時は自動採番、examPage・cropSubtotals リレーション含む） */
@@ -37,7 +43,7 @@ export const createCropRegion = async (
     orderIndex = currentMax + 1
   }
 
-  return prisma.cropRegion.create({
+  const region = await prisma.cropRegion.create({
     data: {
       ...data,
       orderIndex,
@@ -51,15 +57,42 @@ export const createCropRegion = async (
       },
     },
   })
+
+  const scope = await resolveExamScope(examPage.examId)
+  await recordAuditLog({
+    action: "exam.region.create",
+    entityType: "CropRegion",
+    entityId: region.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    target: region.label || null,
+  })
+
+  return region
 }
 
 /** 複数の設問領域を一括作成する */
 export const createManyCropRegions = async (
   data: Prisma.CropRegionCreateManyInput[]
 ) => {
-  return prisma.cropRegion.createMany({
+  const result = await prisma.cropRegion.createMany({
     data,
   })
+
+  if (data.length > 0) {
+    const scope = await resolveExamScopeByPage(data[0].examPageId)
+    await recordAuditLog({
+      action: "exam.region.create",
+      entityType: "CropRegion",
+      entityId: data[0].examPageId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: `採点領域を${data.length}個作成しました`,
+      extra: { count: data.length },
+    })
+  }
+
+  return result
 }
 
 /** 設問領域を更新する（examPage・cropSubtotals リレーション含む） */
@@ -67,7 +100,7 @@ export const updateCropRegion = async (
   id: string,
   data: Prisma.CropRegionUpdateInput
 ) => {
-  return prisma.cropRegion.update({
+  const region = await prisma.cropRegion.update({
     where: { id },
     data,
     include: {
@@ -79,13 +112,42 @@ export const updateCropRegion = async (
       },
     },
   })
+
+  const scope = await resolveExamScope(region.examPage.examId)
+  await recordAuditLog({
+    action: "exam.region.update",
+    entityType: "CropRegion",
+    entityId: region.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    target: region.label || null,
+  })
+
+  return region
 }
 
 /** 設問領域を削除する */
 export const deleteCropRegion = async (id: string) => {
-  return prisma.cropRegion.delete({
+  const scope = await resolveExamScopeByCropRegion(id)
+  const before = await prisma.cropRegion.findUnique({
+    where: { id },
+    select: { label: true },
+  })
+
+  const region = await prisma.cropRegion.delete({
     where: { id },
   })
+
+  await recordAuditLog({
+    action: "exam.region.delete",
+    entityType: "CropRegion",
+    entityId: id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    target: before?.label || null,
+  })
+
+  return region
 }
 
 /** 試験IDで全設問領域を取得する（orderIndexがnullの場合は自動設定、examPage・cropSubtotals・questionScores リレーション含む） */
@@ -234,7 +296,21 @@ export const updateCropRegionOrders = async (
     })
   )
 
-  return Promise.all(updatePromises)
+  const result = await Promise.all(updatePromises)
+
+  if (updates.length > 0) {
+    const scope = await resolveExamScopeByCropRegion(updates[0].id)
+    await recordAuditLog({
+      action: "exam.region.reorder",
+      entityType: "CropRegion",
+      entityId: scope.scopeId ?? updates[0].id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      coalesceKey: `region_reorder:${scope.scopeId ?? updates[0].id}`,
+    })
+  }
+
+  return result
 }
 
 export type CropRegionWithDetails = Prisma.CropRegionGetPayload<{

--- a/electron-src/lib/prisma/cropRegionOmrConfig.ts
+++ b/electron-src/lib/prisma/cropRegionOmrConfig.ts
@@ -8,6 +8,8 @@ import type {
   CropRegionOmrDigitBox,
 } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScopeByCropRegion } from "./auditScope"
 import prisma from "./client"
 
 export type CropRegionOmrConfigWithOptions = CropRegionOmrConfig & {
@@ -49,7 +51,7 @@ export interface UpsertOmrConfigData {
 export async function upsertOmrConfig(
   data: UpsertOmrConfigData
 ): Promise<CropRegionOmrConfigWithOptions> {
-  return prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
     // 既存のconfigを検索
     const existing = await tx.cropRegionOmrConfig.findUnique({
       where: { cropRegionId: data.cropRegionId },
@@ -135,6 +137,18 @@ export async function upsertOmrConfig(
       },
     })
   })
+
+  const scope = await resolveExamScopeByCropRegion(data.cropRegionId)
+  await recordAuditLog({
+    action: "exam.omr_config.update",
+    entityType: "CropRegionOmrConfig",
+    entityId: result.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    coalesceKey: `omr_config:${data.cropRegionId}`,
+  })
+
+  return result
 }
 
 /**
@@ -143,6 +157,16 @@ export async function upsertOmrConfig(
 export async function deleteOmrConfig(cropRegionId: string): Promise<void> {
   await prisma.cropRegionOmrConfig.deleteMany({
     where: { cropRegionId },
+  })
+
+  const scope = await resolveExamScopeByCropRegion(cropRegionId)
+  await recordAuditLog({
+    action: "exam.omr_config.update",
+    entityType: "CropRegionOmrConfig",
+    entityId: cropRegionId,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    summary: "OMR設定を削除しました",
   })
 }
 

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -11,6 +11,8 @@ import type {
   DrawingType,
   DrawingUpdateData,
 } from "../../../src/types/drawingAnnotation.types"
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope, resolveExamScopeByQuestionScore } from "./auditScope"
 import prisma from "./client"
 import {
   recordDeletion,
@@ -163,6 +165,19 @@ export async function createDrawingAnnotation(
           },
         },
       },
+    })
+
+    // 監査ログ: 採点マーク追加（マークごとに個別記録。集約は同一idの連続操作のみ）
+    const scope = await resolveExamScopeByQuestionScore(
+      createData.questionScoreId
+    )
+    await recordAuditLog({
+      action: "exam.annotation.create",
+      userId: createData.userId,
+      entityType: "DrawingAnnotation",
+      entityId: result.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
     })
 
     return result as DrawingAnnotation
@@ -437,6 +452,31 @@ export async function updateDrawingAnnotation(
       },
     })
 
+    // 監査ログ: 採点マーク編集。同じマークの連続編集（移動・色変更等）は集約する。
+    const scope = await resolveExamScopeByQuestionScore(result.questionScore.id)
+    await recordAuditLog({
+      action: "exam.annotation.update",
+      userId: result.userId,
+      entityType: "DrawingAnnotation",
+      entityId: result.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      coalesceKey: `annotation.update:${result.id}`,
+      // テキスト注釈は after（最新テキスト）を上書き表示
+      ...(typeof data.text === "string"
+        ? {
+            changes: [
+              {
+                field: "text",
+                label: "テキスト",
+                before: null,
+                after: data.text,
+              },
+            ],
+          }
+        : {}),
+    })
+
     return result as DrawingAnnotation
   } catch (error) {
     console.error("描画アノテーション更新エラー:", error)
@@ -478,6 +518,16 @@ export async function deleteDrawingAnnotation(id: string): Promise<void> {
     if (annotation) {
       const examId = annotation.questionScore.cropRegion.examPage.examId
       await recordDeletion("DrawingAnnotation", id, { examId })
+
+      // 監査ログ: 採点マーク削除（個別記録）
+      const scope = await resolveExamScope(examId)
+      await recordAuditLog({
+        action: "exam.annotation.delete",
+        entityType: "DrawingAnnotation",
+        entityId: id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+      })
     }
   } catch (error) {
     console.error("描画アノテーション削除エラー:", error)
@@ -577,6 +627,22 @@ export async function batchUpdateDrawingAnnotations(
         })
       })
     )
+
+    // 監査ログ: 各マークの編集を同一id単位で集約（連続するドラッグ等をまとめる）
+    for (const result of results) {
+      const scope = await resolveExamScopeByQuestionScore(
+        result.questionScore.id
+      )
+      await recordAuditLog({
+        action: "exam.annotation.update",
+        userId: result.userId,
+        entityType: "DrawingAnnotation",
+        entityId: result.id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        coalesceKey: `annotation.update:${result.id}`,
+      })
+    }
 
     return results as DrawingAnnotation[]
   } catch (error) {

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -1,5 +1,6 @@
 import type { Prisma as PrismaTypes } from "@prisma/client"
 
+import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 /** 試験一覧用の軽量クエリ（ステップ判定に必要な最小限のデータのみ取得、ユーザーでフィルタリング） */
@@ -212,7 +213,7 @@ export const createExam = async (
   data: Omit<PrismaTypes.ExamCreateInput, "userExams">,
   userId: string
 ) => {
-  return prisma.exam.create({
+  const exam = await prisma.exam.create({
     data: {
       ...data,
       userExams: {
@@ -255,6 +256,19 @@ export const createExam = async (
       },
     },
   })
+
+  // 監査ログ（リファレンス計装）。失敗しても主操作は壊さない。
+  await recordAuditLog({
+    action: "exam.create",
+    userId,
+    entityType: "Exam",
+    entityId: exam.id,
+    scopeId: exam.id,
+    scopeLabel: exam.examName,
+    target: exam.examName,
+  })
+
+  return exam
 }
 
 /** 試験情報を更新する */
@@ -262,15 +276,61 @@ export const updateExam = async (
   id: string,
   data: PrismaTypes.ExamUpdateInput
 ) => {
-  return prisma.exam.update({
+  // 差分記録用に変更前を取得
+  const before = await prisma.exam.findUnique({
+    where: { id },
+    select: { examName: true, examDate: true, description: true },
+  })
+
+  const exam = await prisma.exam.update({
     where: { id },
     data,
   })
+
+  await recordAuditLog({
+    action: "exam.update",
+    entityType: "Exam",
+    entityId: exam.id,
+    scopeId: exam.id,
+    scopeLabel: exam.examName,
+    target: exam.examName,
+    changes: diffFields(
+      before ?? undefined,
+      {
+        examName: exam.examName,
+        examDate: exam.examDate,
+        description: exam.description,
+      },
+      [
+        { field: "examName", label: "試験名" },
+        { field: "examDate", label: "試験日" },
+        { field: "description", label: "説明" },
+      ]
+    ),
+  })
+
+  return exam
 }
 
 /** 試験を削除する */
 export const deleteExam = async (id: string) => {
-  return prisma.exam.delete({
+  const before = await prisma.exam.findUnique({
+    where: { id },
+    select: { examName: true },
+  })
+
+  const exam = await prisma.exam.delete({
     where: { id },
   })
+
+  await recordAuditLog({
+    action: "exam.delete",
+    entityType: "Exam",
+    entityId: id,
+    scopeId: id,
+    scopeLabel: before?.examName ?? null,
+    target: before?.examName ?? null,
+  })
+
+  return exam
 }

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -2,6 +2,8 @@ import { ExamClass, Prisma } from "@prisma/client"
 
 import type { StudentClassInfo } from "@/types/electron/examClassApi"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope } from "./auditScope"
 import prisma from "./client"
 import { getExamReferenceDate } from "./examStudent"
 import { membershipFilterAt } from "./membershipFilter"
@@ -172,7 +174,7 @@ export const addExamClass = async (
     })
     const nextOrder = (maxOrderResult._max.order ?? -1) + 1
 
-    return await prisma.examClass.create({
+    const examClass = await prisma.examClass.create({
       data: {
         examId,
         classId,
@@ -185,6 +187,17 @@ export const addExamClass = async (
         exam: true,
       },
     })
+
+    await recordAuditLog({
+      action: "exam.class.assign",
+      entityType: "ExamClass",
+      entityId: examClass.id,
+      scopeId: examId,
+      scopeLabel: examClass.exam?.examName ?? null,
+      target: examClass.class?.name ?? null,
+    })
+
+    return examClass
   } catch (error) {
     console.error(`Failed to add class ${classId} to exam ${examId}:`, error)
     throw error
@@ -246,9 +259,26 @@ export const reorderExamClasses = async (
  */
 export const removeExamClass = async (id: string): Promise<ExamClass> => {
   try {
-    return await prisma.examClass.delete({
+    const before = await prisma.examClass.findUnique({
+      where: { id },
+      select: { examId: true, class: { select: { name: true } } },
+    })
+
+    const deleted = await prisma.examClass.delete({
       where: { id },
     })
+
+    const scope = before ? await resolveExamScope(before.examId) : null
+    await recordAuditLog({
+      action: "exam.class.unassign",
+      entityType: "ExamClass",
+      entityId: id,
+      scopeId: scope?.scopeId ?? null,
+      scopeLabel: scope?.scopeLabel ?? null,
+      target: before?.class.name ?? null,
+    })
+
+    return deleted
   } catch (error) {
     console.error(`Failed to remove exam class ${id}:`, error)
     throw error
@@ -263,11 +293,28 @@ export const removeExamClassByIds = async (
   classId: string
 ): Promise<ExamClass> => {
   try {
-    return await prisma.examClass.delete({
+    const cls = await prisma.class.findUnique({
+      where: { id: classId },
+      select: { name: true },
+    })
+
+    const deleted = await prisma.examClass.delete({
       where: {
         examId_classId: { examId, classId },
       },
     })
+
+    const scope = await resolveExamScope(examId)
+    await recordAuditLog({
+      action: "exam.class.unassign",
+      entityType: "ExamClass",
+      entityId: deleted.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: cls?.name ?? null,
+    })
+
+    return deleted
   } catch (error) {
     console.error(
       `Failed to remove class ${classId} from exam ${examId}:`,

--- a/electron-src/lib/prisma/examPage.ts
+++ b/electron-src/lib/prisma/examPage.ts
@@ -1,12 +1,14 @@
 import type { ExamPage, Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope, resolveExamScopeByPage } from "./auditScope"
 import prisma from "./client"
 
 /** 試験ページを作成する（masterImages・studentAnswerImages・cropRegions リレーション含む） */
 export const createExamPage = async (
   data: Prisma.ExamPageUncheckedCreateInput
 ) => {
-  return prisma.examPage.create({
+  const page = await prisma.examPage.create({
     data,
     include: {
       masterImages: true,
@@ -14,15 +16,41 @@ export const createExamPage = async (
       cropRegions: true,
     },
   })
+
+  const scope = await resolveExamScope(page.examId)
+  await recordAuditLog({
+    action: "exam.page.upload",
+    entityType: "ExamPage",
+    entityId: page.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+  })
+
+  return page
 }
 
 /** 複数の試験ページを一括作成する */
 export const createManyExamPages = async (
   data: Prisma.ExamPageCreateManyInput[]
 ) => {
-  return prisma.examPage.createMany({
+  const result = await prisma.examPage.createMany({
     data,
   })
+
+  if (data.length > 0) {
+    const scope = await resolveExamScope(data[0].examId)
+    await recordAuditLog({
+      action: "exam.page.upload",
+      entityType: "ExamPage",
+      entityId: data[0].examId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: `模範解答ページを${data.length}枚アップロードしました`,
+      extra: { count: data.length },
+    })
+  }
+
+  return result
 }
 
 /** 試験ページを更新する（masterImages・studentAnswerImages・cropRegions リレーション含む） */
@@ -43,10 +71,22 @@ export const updateExamPage = async (
 
 /** 試験ページを削除する（関連するMasterImage・StudentAnswerImage・CropRegionもCascade削除） */
 export const deleteExamPage = async (id: string) => {
+  const scope = await resolveExamScopeByPage(id)
+
   // 関連する MasterImage, StudentAnswerImage, CropRegion も削除される（onDelete: Cascade 設定済み）
-  return prisma.examPage.delete({
+  const page = await prisma.examPage.delete({
     where: { id },
   })
+
+  await recordAuditLog({
+    action: "exam.page.delete",
+    entityType: "ExamPage",
+    entityId: id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+  })
+
+  return page
 }
 
 /** 試験IDで全ページを取得する（masterImages・studentAnswerImages.student・cropRegions リレーション含む、ページ番号順） */

--- a/electron-src/lib/prisma/examSettings.ts
+++ b/electron-src/lib/prisma/examSettings.ts
@@ -2,6 +2,8 @@
  * 試験設定関連のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope } from "./auditScope"
 import prisma from "./client"
 
 // =============================================================================
@@ -37,7 +39,7 @@ export async function upsertExamMarkingFormat(
   examId: string,
   data: MarkingFormatData
 ) {
-  return prisma.examMarkingFormat.upsert({
+  const format = await prisma.examMarkingFormat.upsert({
     where: {
       examId_markType: { examId, markType: data.markType },
     },
@@ -52,6 +54,18 @@ export async function upsertExamMarkingFormat(
       ...data,
     },
   })
+
+  const scope = await resolveExamScope(examId)
+  await recordAuditLog({
+    action: "exam.marking_format.update",
+    entityType: "ExamMarkingFormat",
+    entityId: format.id,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    coalesceKey: `marking_format:${examId}`,
+  })
+
+  return format
 }
 
 /** 複数の採点マーク設定を一括で作成または更新する（トランザクション内で実行） */
@@ -76,7 +90,20 @@ export async function bulkUpsertExamMarkingFormats(
       },
     })
   )
-  return prisma.$transaction(operations)
+  const result = await prisma.$transaction(operations)
+
+  const scope = await resolveExamScope(examId)
+  await recordAuditLog({
+    action: "exam.marking_format.update",
+    entityType: "ExamMarkingFormat",
+    entityId: examId,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    summary: `採点マーク設定を更新しました（${formats.length}種別）`,
+    extra: { count: formats.length },
+  })
+
+  return result
 }
 
 /** 指定マーク種別の採点マーク設定を削除する */
@@ -112,11 +139,23 @@ export async function upsertExamExportSettings(
   settings: Record<string, unknown>
 ) {
   const settingsJson = JSON.stringify(settings)
-  return prisma.examExportSettings.upsert({
+  const result = await prisma.examExportSettings.upsert({
     where: { examId },
     update: { settingsJson },
     create: { examId, settingsJson },
   })
+
+  const scope = await resolveExamScope(examId)
+  await recordAuditLog({
+    action: "exam.export_settings.update",
+    entityType: "ExamExportSettings",
+    entityId: examId,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    coalesceKey: `export_settings:${examId}`,
+  })
+
+  return result
 }
 
 /** 試験のエクスポート設定を削除する */

--- a/electron-src/lib/prisma/examStudent.ts
+++ b/electron-src/lib/prisma/examStudent.ts
@@ -1,3 +1,5 @@
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope, resolveStudentLabel } from "./auditScope"
 import { getAvailableClassesForTarget } from "./availableClasses"
 import { getAvailableStudentsForTarget } from "./availableStudents"
 import prisma from "./client"
@@ -108,6 +110,23 @@ export async function addStudentsToExam(examId: string, studentIds: string[]) {
       await prisma.examStudent.createMany({
         data: createData,
       })
+
+      // 監査ログ: 受験生徒の追加（追加分をまとめて1件）
+      const scope = await resolveExamScope(examId)
+      const firstLabel = await resolveStudentLabel(newStudentIds[0])
+      const summary =
+        newStudentIds.length === 1 && firstLabel
+          ? `受験生徒「${firstLabel}」を追加しました`
+          : `受験生徒を${newStudentIds.length}名追加しました`
+      await recordAuditLog({
+        action: "exam.student.add",
+        entityType: "ExamStudent",
+        entityId: examId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary,
+        extra: { studentIds: newStudentIds, count: newStudentIds.length },
+      })
     }
     return {
       success: true,
@@ -154,6 +173,23 @@ export async function removeStudentsFromExam(
       },
     })
 
+    // 監査ログ: 受験生徒の削除
+    const scope = await resolveExamScope(examId)
+    const firstLabel = await resolveStudentLabel(studentIds[0])
+    const summary =
+      studentIds.length === 1 && firstLabel
+        ? `受験生徒「${firstLabel}」を削除しました`
+        : `受験生徒を${studentIds.length}名削除しました`
+    await recordAuditLog({
+      action: "exam.student.remove",
+      entityType: "ExamStudent",
+      entityId: examId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary,
+      extra: { studentIds, count: studentIds.length },
+    })
+
     return {
       success: true,
     }
@@ -186,6 +222,26 @@ export async function updateStudentExamStatus(
       data: {
         status: enumStatus,
       },
+    })
+
+    // 監査ログ: 受験状態の変更
+    const scope = await resolveExamScope(examId)
+    const studentLabel = await resolveStudentLabel(studentId)
+    const statusJa: Record<string, string> = {
+      participating: "受験",
+      expected: "見込",
+      absent: "欠席",
+    }
+    await recordAuditLog({
+      action: "exam.student.attendance_update",
+      entityType: "ExamStudent",
+      entityId: examId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: studentLabel,
+      summary: studentLabel
+        ? `「${studentLabel}」の受験状態を「${statusJa[status] ?? status}」に変更しました`
+        : `受験状態を「${statusJa[status] ?? status}」に変更しました`,
     })
 
     return {
@@ -223,6 +279,16 @@ export async function updateStudentOrders(
         },
       })
     }
+
+    const scope = await resolveExamScope(examId)
+    await recordAuditLog({
+      action: "exam.student.reorder",
+      entityType: "ExamStudent",
+      entityId: examId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      coalesceKey: `student_reorder:${examId}`,
+    })
 
     return {
       success: true,

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -2,6 +2,7 @@
  * Grade（成績算出試験）のPrisma操作関数
  */
 
+import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 /** Prisma Decimal等の非シリアライズ型をプレーン値に変換 */
@@ -150,6 +151,16 @@ export async function createGrade(data: {
         },
       },
     })
+
+    await recordAuditLog({
+      action: "grade.create",
+      entityType: "Grade",
+      entityId: grade.id,
+      scopeId: grade.id,
+      scopeLabel: grade.name,
+      target: grade.name,
+    })
+
     return {
       success: true,
       grade: deserializeDataSources(serialize(grade)),
@@ -184,6 +195,10 @@ export async function updateGrade(
         ? new Date(data.referenceDate)
         : null
     }
+    const before = await prisma.grade.findUnique({
+      where: { id },
+      select: { name: true, description: true },
+    })
     const grade = await prisma.grade.update({
       where: { id },
       data: updateData,
@@ -198,6 +213,24 @@ export async function updateGrade(
         },
       },
     })
+
+    await recordAuditLog({
+      action: "grade.update",
+      entityType: "Grade",
+      entityId: grade.id,
+      scopeId: grade.id,
+      scopeLabel: grade.name,
+      target: grade.name,
+      changes: diffFields(
+        before ?? undefined,
+        { name: grade.name, description: grade.description },
+        [
+          { field: "name", label: "成績名" },
+          { field: "description", label: "説明" },
+        ]
+      ),
+    })
+
     return {
       success: true,
       grade: deserializeDataSources(serialize(grade)),
@@ -216,7 +249,21 @@ export async function updateGrade(
  */
 export async function deleteGrade(id: string) {
   try {
+    const before = await prisma.grade.findUnique({
+      where: { id },
+      select: { name: true },
+    })
     await prisma.grade.delete({ where: { id } })
+
+    await recordAuditLog({
+      action: "grade.delete",
+      entityType: "Grade",
+      entityId: id,
+      scopeId: id,
+      scopeLabel: before?.name ?? null,
+      target: before?.name ?? null,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error deleting grade exam:", error)

--- a/electron-src/lib/prisma/gradeBoundary.ts
+++ b/electron-src/lib/prisma/gradeBoundary.ts
@@ -4,6 +4,8 @@
 
 import type { Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
 
 /** Prisma Decimal等の非シリアライズ型をプレーン値に変換 */
@@ -94,6 +96,16 @@ export async function upsertBoundarySet(data: {
         })
       }
     )
+
+    const scope = await resolveGradeScope(data.gradeId)
+    await recordAuditLog({
+      action: "grade.boundary.update",
+      entityType: "GradeBoundarySet",
+      entityId: result?.id ?? data.gradeId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+    })
+
     return { success: true, boundarySet: serialize(result) }
   } catch (error) {
     console.error("Error upserting boundary set:", error)
@@ -109,7 +121,22 @@ export async function upsertBoundarySet(data: {
  */
 export async function deleteBoundarySet(id: string) {
   try {
+    const before = await prisma.gradeBoundarySet.findUnique({
+      where: { id },
+      select: { gradeId: true },
+    })
+
     await prisma.gradeBoundarySet.delete({ where: { id } })
+
+    const scope = before ? await resolveGradeScope(before.gradeId) : null
+    await recordAuditLog({
+      action: "grade.boundary.delete",
+      entityType: "GradeBoundarySet",
+      entityId: id,
+      scopeId: scope?.scopeId ?? null,
+      scopeLabel: scope?.scopeLabel ?? null,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error deleting boundary set:", error)

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -2,6 +2,8 @@
  * GradeDataSource（成績データソース）のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScopeByItem } from "./auditScope"
 import prisma from "./client"
 
 /** Prisma Decimal等の非シリアライズ型をプレーン値に変換 */
@@ -97,6 +99,17 @@ export async function createDataSource(data: {
         cropRegion: { select: { id: true, label: true, points: true } },
       },
     })
+
+    const scope = await resolveGradeScopeByItem(data.gradeItemId)
+    await recordAuditLog({
+      action: "grade.data_source.add",
+      entityType: "GradeDataSource",
+      entityId: dataSource.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: data.name,
+    })
+
     return { success: true, dataSource: serialize(dataSource) }
   } catch (error) {
     console.error("Error creating data source:", error)
@@ -139,6 +152,17 @@ export async function updateDataSource(
         cropRegion: { select: { id: true, label: true, points: true } },
       },
     })
+
+    const scope = await resolveGradeScopeByItem(dataSource.gradeItemId)
+    await recordAuditLog({
+      action: "grade.data_source.update",
+      entityType: "GradeDataSource",
+      entityId: dataSource.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: dataSource.name,
+    })
+
     return { success: true, dataSource: serialize(dataSource) }
   } catch (error) {
     console.error("Error updating data source:", error)
@@ -154,7 +178,25 @@ export async function updateDataSource(
  */
 export async function deleteDataSource(id: string) {
   try {
+    const before = await prisma.gradeDataSource.findUnique({
+      where: { id },
+      select: { name: true, gradeItemId: true },
+    })
+
     await prisma.gradeDataSource.delete({ where: { id } })
+
+    const scope = before
+      ? await resolveGradeScopeByItem(before.gradeItemId)
+      : null
+    await recordAuditLog({
+      action: "grade.data_source.remove",
+      entityType: "GradeDataSource",
+      entityId: id,
+      scopeId: scope?.scopeId ?? null,
+      scopeLabel: scope?.scopeLabel ?? null,
+      target: before?.name ?? null,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error deleting data source:", error)

--- a/electron-src/lib/prisma/gradeItem.ts
+++ b/electron-src/lib/prisma/gradeItem.ts
@@ -2,6 +2,8 @@
  * GradeItem（評価項目）のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScope, resolveGradeScopeByItem } from "./auditScope"
 import prisma from "./client"
 
 /** Prisma Decimal等の非シリアライズ型をプレーン値に変換 */
@@ -71,6 +73,17 @@ export async function createGradeItem(data: { gradeId: string; name: string }) {
         },
       },
     })
+
+    const scope = await resolveGradeScope(data.gradeId)
+    await recordAuditLog({
+      action: "grade.item.create",
+      entityType: "GradeItem",
+      entityId: gradeItem.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: gradeItem.name,
+    })
+
     return { success: true, gradeItem: serialize(gradeItem) }
   } catch (error) {
     console.error("Error creating grade item:", error)
@@ -102,6 +115,17 @@ export async function updateGradeItem(id: string, data: { name?: string }) {
         },
       },
     })
+
+    const scope = await resolveGradeScope(gradeItem.gradeId)
+    await recordAuditLog({
+      action: "grade.item.update",
+      entityType: "GradeItem",
+      entityId: gradeItem.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: gradeItem.name,
+    })
+
     return { success: true, gradeItem: serialize(gradeItem) }
   } catch (error) {
     console.error("Error updating grade item:", error)
@@ -117,7 +141,23 @@ export async function updateGradeItem(id: string, data: { name?: string }) {
  */
 export async function deleteGradeItem(id: string) {
   try {
+    const before = await prisma.gradeItem.findUnique({
+      where: { id },
+      select: { name: true, gradeId: true },
+    })
+
     await prisma.gradeItem.delete({ where: { id } })
+
+    const scope = before ? await resolveGradeScope(before.gradeId) : null
+    await recordAuditLog({
+      action: "grade.item.delete",
+      entityType: "GradeItem",
+      entityId: id,
+      scopeId: scope?.scopeId ?? null,
+      scopeLabel: scope?.scopeLabel ?? null,
+      target: before?.name ?? null,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error deleting grade item:", error)
@@ -143,6 +183,19 @@ export async function reorderGradeItems(
         })
       )
     )
+
+    if (items.length > 0) {
+      const scope = await resolveGradeScopeByItem(items[0].id)
+      await recordAuditLog({
+        action: "grade.item.reorder",
+        entityType: "GradeItem",
+        entityId: scope.scopeId ?? items[0].id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        coalesceKey: `grade_item_reorder:${scope.scopeId ?? items[0].id}`,
+      })
+    }
+
     return { success: true }
   } catch (error) {
     console.error("Error reordering grade items:", error)

--- a/electron-src/lib/prisma/gradeOverride.ts
+++ b/electron-src/lib/prisma/gradeOverride.ts
@@ -4,6 +4,8 @@
 
 import type { Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
 
 /**
@@ -64,6 +66,16 @@ export async function upsertGradeOverride(data: {
         }
       }
     )
+
+    const scope = await resolveGradeScope(data.gradeId)
+    await recordAuditLog({
+      action: "grade.override.update",
+      entityType: "GradeOverride",
+      entityId: result.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+    })
+
     return { success: true, override: result }
   } catch (error) {
     console.error("Error upserting grade override:", error)
@@ -94,6 +106,15 @@ export async function deleteGradeOverride(data: {
     })
     if (existing) {
       await prisma.gradeOverride.delete({ where: { id: existing.id } })
+
+      const scope = await resolveGradeScope(data.gradeId)
+      await recordAuditLog({
+        action: "grade.override.delete",
+        entityType: "GradeOverride",
+        entityId: existing.id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+      })
     }
     return { success: true }
   } catch (error) {

--- a/electron-src/lib/prisma/gradeStudent.ts
+++ b/electron-src/lib/prisma/gradeStudent.ts
@@ -2,6 +2,8 @@
  * GradeStudent / GradeClass のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScope } from "./auditScope"
 import { getAvailableClassesForTarget } from "./availableClasses"
 import { getAvailableStudentsForTarget } from "./availableStudents"
 import prisma from "./client"
@@ -229,6 +231,17 @@ export async function addStudentsFromClassToGrade(
           customOrder,
         })),
       })
+
+      const scope = await resolveGradeScope(gradeId)
+      await recordAuditLog({
+        action: "grade.student.add",
+        entityType: "GradeStudent",
+        entityId: gradeId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary: `学級から成績対象生徒を${toAdd.length}名追加しました`,
+        extra: { count: toAdd.length, classId },
+      })
     }
 
     return {
@@ -277,6 +290,17 @@ export async function addStudentsToGrade(
           customOrder: orderOffset++,
         })),
       })
+
+      const scope = await resolveGradeScope(gradeId)
+      await recordAuditLog({
+        action: "grade.student.add",
+        entityType: "GradeStudent",
+        entityId: gradeId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary: `成績対象生徒を${newStudentIds.length}名追加しました`,
+        extra: { count: newStudentIds.length },
+      })
     }
 
     return {
@@ -307,6 +331,17 @@ export async function updateGradeStudentOrders(
         data: { customOrder },
       })
     }
+
+    const scope = await resolveGradeScope(gradeId)
+    await recordAuditLog({
+      action: "grade.student.reorder",
+      entityType: "GradeStudent",
+      entityId: gradeId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      coalesceKey: `grade_student_reorder:${gradeId}`,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error updating grade exam student orders:", error)
@@ -357,6 +392,17 @@ export async function removeClassFromGrade(gradeId: string, classId: string) {
         where: { gradeId_classId: { gradeId, classId } },
       }),
     ])
+
+    const scope = await resolveGradeScope(gradeId)
+    await recordAuditLog({
+      action: "grade.student.remove",
+      entityType: "GradeClass",
+      entityId: gradeId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: `学級を成績から外し、生徒${studentsToRemove.length}名を削除しました`,
+      extra: { removedStudents: studentsToRemove.length, classId },
+    })
 
     return { success: true, removedStudents: studentsToRemove.length }
   } catch (error) {

--- a/electron-src/lib/prisma/manualScore.ts
+++ b/electron-src/lib/prisma/manualScore.ts
@@ -2,6 +2,8 @@
  * ManualScore（外部成績・手動入力スコア）のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScopeByDataSource } from "./auditScope"
 import prisma from "./client"
 
 /** Prisma Decimal等の非シリアライズ型をプレーン値に変換 */
@@ -69,6 +71,23 @@ export async function batchUpsertManualScores(
         })
       )
     )
+
+    // 監査ログ: 手動スコアの一括更新（1件にまとめて記録）
+    if (scores.length > 0) {
+      const scope = await resolveGradeScopeByDataSource(
+        scores[0].gradeDataSourceId
+      )
+      await recordAuditLog({
+        action: "grade.manual_score.update",
+        entityType: "ManualScore",
+        entityId: scores[0].gradeDataSourceId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary: `手動スコアを更新しました（${scores.length}件）`,
+        extra: { count: scores.length },
+      })
+    }
+
     return { success: true }
   } catch (error) {
     console.error("Error batch upserting manual scores:", error)

--- a/electron-src/lib/prisma/questionGroup.ts
+++ b/electron-src/lib/prisma/questionGroup.ts
@@ -1,17 +1,27 @@
 import type { Prisma, SubtotalGroup } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 /** 設問グループ（SubtotalGroup）を作成する（subtotals含む） */
 export const createQuestionGroup = async (
   data: Prisma.SubtotalGroupUncheckedCreateInput
 ) => {
-  return prisma.subtotalGroup.create({
+  const group = await prisma.subtotalGroup.create({
     data,
     include: {
       subtotals: true, // 作成後にsubtotalsも返す
     },
   })
+
+  await recordAuditLog({
+    action: "exam.question_group.create",
+    entityType: "SubtotalGroup",
+    entityId: group.id,
+    target: group.name,
+  })
+
+  return group
 }
 
 /** 設問グループ（SubtotalGroup）を更新する（subtotals含む） */
@@ -19,22 +29,45 @@ export const updateQuestionGroup = async (
   id: string,
   data: Prisma.SubtotalGroupUpdateInput
 ) => {
-  return prisma.subtotalGroup.update({
+  const group = await prisma.subtotalGroup.update({
     where: { id },
     data,
     include: {
       subtotals: true,
     },
   })
+
+  await recordAuditLog({
+    action: "exam.question_group.update",
+    entityType: "SubtotalGroup",
+    entityId: group.id,
+    target: group.name,
+  })
+
+  return group
 }
 
 /** 設問グループ（SubtotalGroup）を削除する（関連Subtotalはカスケード削除） */
 export const deleteQuestionGroup = async (id: string) => {
+  const before = await prisma.subtotalGroup.findUnique({
+    where: { id },
+    select: { name: true },
+  })
+
   // 関連する Subtotal, CropSubtotal も削除されるか確認
   // (onDelete: Cascade が設定されていれば自動)
-  return prisma.subtotalGroup.delete({
+  const deleted = await prisma.subtotalGroup.delete({
     where: { id },
   })
+
+  await recordAuditLog({
+    action: "exam.question_group.delete",
+    entityType: "SubtotalGroup",
+    entityId: id,
+    target: before?.name ?? null,
+  })
+
+  return deleted
 }
 
 /** 試験IDで設問グループ一覧を取得する（ExamSubtotalGroup経由、subtotals含む） */

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -1,7 +1,62 @@
 import { Decimal } from "@prisma/client/runtime/client"
 
+import { type AuditChange, recordAuditLog } from "./auditLog"
+import { resolveExamScopeByCropRegion, resolveStudentLabel } from "./auditScope"
 import prisma from "./client"
 import { recordDrawingAnnotationDeletionsForQuestionScores } from "./deletedRecord"
+
+/** QuestionScore.status を日本語表示に変換（監査ログ差分用） */
+const scoreStatusLabel = (s: string | null | undefined): string => {
+  switch (s) {
+    case "correct":
+      return "正解"
+    case "incorrect":
+      return "不正解"
+    case "partial":
+      return "部分点"
+    case "pending":
+      return "保留"
+    case "no_answer":
+      return "無答"
+    case "double_mark":
+      return "複数マーク"
+    case "unscored":
+      return "未採点"
+    default:
+      return s ?? "（なし）"
+  }
+}
+
+/** 採点提案の監査ログを記録（ベストエフォート） */
+async function recordScoreAudit(opts: {
+  action: "exam.score.propose" | "exam.score.update" | "exam.score.delete"
+  scoreId: string
+  cropRegionId: string
+  studentId: string
+  userId: string
+  changes?: AuditChange[]
+}): Promise<void> {
+  const scope = await resolveExamScopeByCropRegion(opts.cropRegionId)
+  const studentLabel = await resolveStudentLabel(opts.studentId)
+  const verb =
+    opts.action === "exam.score.propose"
+      ? "提案しました"
+      : opts.action === "exam.score.delete"
+        ? "削除しました"
+        : "変更しました"
+  await recordAuditLog({
+    action: opts.action,
+    userId: opts.userId,
+    entityType: "QuestionScore",
+    entityId: opts.scoreId,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    summary: studentLabel
+      ? `「${studentLabel}」の採点を${verb}`
+      : `採点を${verb}`,
+    changes: opts.changes,
+  })
+}
 
 /**
  * 実際の得点を計算する関数
@@ -215,6 +270,35 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
           user: true,
         },
       })
+
+      await recordScoreAudit({
+        action: "exam.score.update",
+        scoreId: updated.id,
+        cropRegionId: data.cropRegionId,
+        studentId: data.studentId,
+        userId: data.userId,
+        changes: [
+          {
+            field: "status",
+            label: "採点",
+            before: scoreStatusLabel(existing.status),
+            after: scoreStatusLabel(data.status),
+          },
+          {
+            field: "partialScore",
+            label: "部分点",
+            before:
+              existing.partialScore != null
+                ? Number(existing.partialScore)
+                : null,
+            after:
+              data.partialScore != null && data.partialScore !== undefined
+                ? data.partialScore
+                : null,
+          },
+        ],
+      })
+
       return { success: true, score: updated }
     } else {
       // 新規作成
@@ -235,6 +319,23 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
           user: true,
         },
       })
+
+      await recordScoreAudit({
+        action: "exam.score.propose",
+        scoreId: created.id,
+        cropRegionId: data.cropRegionId,
+        studentId: data.studentId,
+        userId: data.userId,
+        changes: [
+          {
+            field: "status",
+            label: "採点",
+            before: null,
+            after: scoreStatusLabel(data.status),
+          },
+        ],
+      })
+
       return { success: true, score: created }
     }
   } catch (error) {
@@ -279,6 +380,12 @@ export const updateQuestionScore = async (
       */
     }
 
+    // 差分記録用に変更前を取得
+    const before = await prisma.questionScore.findUnique({
+      where: { id },
+      select: { status: true, partialScore: true },
+    })
+
     const updated = await prisma.questionScore.update({
       where: { id },
       data: {
@@ -293,6 +400,30 @@ export const updateQuestionScore = async (
         cropRegion: true,
         user: true,
       },
+    })
+
+    await recordScoreAudit({
+      action: "exam.score.update",
+      scoreId: updated.id,
+      cropRegionId: updated.cropRegionId,
+      studentId: updated.studentId,
+      userId: updated.userId,
+      changes: [
+        {
+          field: "status",
+          label: "採点",
+          before: scoreStatusLabel(before?.status),
+          after: scoreStatusLabel(updated.status),
+        },
+        {
+          field: "partialScore",
+          label: "部分点",
+          before:
+            before?.partialScore != null ? Number(before.partialScore) : null,
+          after:
+            updated.partialScore != null ? Number(updated.partialScore) : null,
+        },
+      ],
     })
 
     return { success: true, score: updated }
@@ -310,12 +441,41 @@ export const updateQuestionScore = async (
  */
 export const deleteQuestionScore = async (id: string) => {
   try {
+    // 監査ログ用に削除前の情報を取得
+    const before = await prisma.questionScore.findUnique({
+      where: { id },
+      select: {
+        cropRegionId: true,
+        studentId: true,
+        userId: true,
+        status: true,
+      },
+    })
+
     // cascade削除前にDrawingAnnotationのtombstoneを記録
     await recordDrawingAnnotationDeletionsForQuestionScores([id])
 
     await prisma.questionScore.delete({
       where: { id },
     })
+
+    if (before) {
+      await recordScoreAudit({
+        action: "exam.score.delete",
+        scoreId: id,
+        cropRegionId: before.cropRegionId,
+        studentId: before.studentId,
+        userId: before.userId,
+        changes: [
+          {
+            field: "status",
+            label: "採点",
+            before: scoreStatusLabel(before.status),
+            after: null,
+          },
+        ],
+      })
+    }
 
     return { success: true }
   } catch (error) {
@@ -569,6 +729,21 @@ export async function batchUpdateQuestionScores(
         updatedCount++
       }
     })
+
+    // 監査ログ: 一括反映（OMR自動採点等）。1件にまとめて記録する。
+    if (entries.length > 0) {
+      const scope = await resolveExamScopeByCropRegion(entries[0].cropRegionId)
+      await recordAuditLog({
+        action: "exam.score.batch",
+        userId: entries[0].userId,
+        entityType: "QuestionScore",
+        entityId: entries[0].cropRegionId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary: `採点を一括反映しました（${updatedCount}件）`,
+        extra: { count: updatedCount },
+      })
+    }
 
     return { success: true, updatedCount }
   } catch (error) {

--- a/electron-src/lib/prisma/questionSubtotalAssignment.ts
+++ b/electron-src/lib/prisma/questionSubtotalAssignment.ts
@@ -1,34 +1,61 @@
 import type { CropSubtotal, Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScopeByCropRegion } from "./auditScope"
 import prisma from "./client"
+
+/** 設問-小計マッピング変更を試験スコープで集約記録する */
+async function recordSubtotalAssignmentAudit(cropRegionId: string) {
+  const scope = await resolveExamScopeByCropRegion(cropRegionId)
+  await recordAuditLog({
+    action: "exam.subtotal_assignment.update",
+    entityType: "CropSubtotal",
+    entityId: scope.scopeId ?? cropRegionId,
+    scopeId: scope.scopeId,
+    scopeLabel: scope.scopeLabel,
+    coalesceKey: `subtotal_assignment:${scope.scopeId ?? cropRegionId}`,
+  })
+}
 
 /** 採点領域と小計項目の関連付け（CropSubtotal）を作成する（cropRegion・subtotal含む） */
 export const createQuestionSubtotalAssignment = async (
   data: Prisma.CropSubtotalUncheckedCreateInput // cropRegionId と subtotalId を直接含める
 ) => {
-  return prisma.cropSubtotal.create({
+  const result = await prisma.cropSubtotal.create({
     data,
     include: {
       cropRegion: true,
       subtotal: true,
     },
   })
+  await recordSubtotalAssignmentAudit(data.cropRegionId)
+  return result
 }
 
 /** 採点領域と小計項目の関連付けを一括作成する */
 export const createManyQuestionSubtotalAssignments = async (
   assignments: Prisma.CropSubtotalUncheckedCreateInput[]
 ) => {
-  return prisma.cropSubtotal.createMany({
+  const result = await prisma.cropSubtotal.createMany({
     data: assignments,
   })
+  if (assignments.length > 0) {
+    await recordSubtotalAssignmentAudit(assignments[0].cropRegionId)
+  }
+  return result
 }
 
 /** IDで採点領域と小計項目の関連付けを削除する */
 export const deleteQuestionSubtotalAssignment = async (id: string) => {
-  return prisma.cropSubtotal.delete({
+  const before = await prisma.cropSubtotal.findUnique({
+    where: { id },
+    select: { cropRegionId: true },
+  })
+  const result = await prisma.cropSubtotal.delete({
     where: { id },
   })
+  if (before) await recordSubtotalAssignmentAudit(before.cropRegionId)
+  return result
 }
 
 /** 採点領域IDに紐づく全ての小計関連付けを削除する */

--- a/electron-src/lib/prisma/scoreDecision.ts
+++ b/electron-src/lib/prisma/scoreDecision.ts
@@ -1,6 +1,28 @@
 import { Decimal } from "@prisma/client/runtime/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScopeByCropRegion, resolveStudentLabel } from "./auditScope"
 import prisma from "./client"
+
+/** verdict コードを日本語表示に変換（監査ログ差分用） */
+const verdictLabel = (v: string | null | undefined): string => {
+  switch (v) {
+    case "correct":
+      return "正解"
+    case "incorrect":
+      return "不正解"
+    case "partial":
+      return "部分点"
+    case "pending":
+      return "保留"
+    case "no_answer":
+      return "無答"
+    case "double_mark":
+      return "複数マーク"
+    default:
+      return v ?? "（なし）"
+  }
+}
 
 export interface UpsertScoreDecisionData {
   cropRegionId: string
@@ -68,6 +90,17 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
         ? new Decimal(data.score)
         : null
 
+    // 差分記録用に変更前の確定を取得
+    const previous = await prisma.scoreDecision.findUnique({
+      where: {
+        cropRegionId_studentId: {
+          cropRegionId: data.cropRegionId,
+          studentId: data.studentId,
+        },
+      },
+      select: { verdict: true, score: true },
+    })
+
     const decision = await prisma.scoreDecision.upsert({
       where: {
         cropRegionId_studentId: {
@@ -96,6 +129,32 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
       include: {
         decidedBy: true,
       },
+    })
+
+    // 監査ログ: 採点確定（OWNERによる確定。提案連打は記録しない）
+    const scope = await resolveExamScopeByCropRegion(data.cropRegionId)
+    const studentLabel = await resolveStudentLabel(data.studentId)
+    const prevScore = previous?.score != null ? Number(previous.score) : null
+    const newScore = score != null ? Number(score) : null
+    await recordAuditLog({
+      action: "exam.score.decide",
+      userId: data.decidedByUserId,
+      entityType: "ScoreDecision",
+      entityId: decision.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: studentLabel
+        ? `「${studentLabel}」の採点を確定しました`
+        : "採点を確定しました",
+      changes: [
+        {
+          field: "verdict",
+          label: "判定",
+          before: previous ? verdictLabel(previous.verdict) : null,
+          after: verdictLabel(data.verdict),
+        },
+        { field: "score", label: "得点", before: prevScore, after: newScore },
+      ],
     })
 
     return { success: true, decision }

--- a/electron-src/lib/prisma/student.ts
+++ b/electron-src/lib/prisma/student.ts
@@ -1,6 +1,10 @@
 import { Prisma } from "@prisma/client"
 
+import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
+
+const studentLabel = (s: { lastName: string; firstName: string }): string =>
+  `${s.lastName} ${s.firstName}`.trim()
 
 type StudentWithMemberships = Prisma.StudentGetPayload<{
   include: {
@@ -43,7 +47,7 @@ export const createStudent = async (
   studentData: Prisma.StudentCreateInput
 ): Promise<StudentWithMemberships> => {
   try {
-    return await prisma.student.create({
+    const student = await prisma.student.create({
       data: studentData,
       include: {
         memberships: {
@@ -59,6 +63,15 @@ export const createStudent = async (
         },
       },
     })
+
+    await recordAuditLog({
+      action: "student.create",
+      entityType: "Student",
+      entityId: student.id,
+      target: studentLabel(student),
+    })
+
+    return student
   } catch (error) {
     console.error("Failed to create student:", error)
     throw error
@@ -71,7 +84,19 @@ export const updateStudent = async (
   studentData: Prisma.StudentUpdateInput
 ): Promise<StudentWithMemberships> => {
   try {
-    return await prisma.student.update({
+    const before = await prisma.student.findUnique({
+      where: { id },
+      select: {
+        lastName: true,
+        firstName: true,
+        lastNameKana: true,
+        firstNameKana: true,
+        studentNumber: true,
+        enrollmentYear: true,
+      },
+    })
+
+    const student = await prisma.student.update({
       where: { id },
       data: studentData,
       include: {
@@ -88,6 +113,34 @@ export const updateStudent = async (
         },
       },
     })
+
+    await recordAuditLog({
+      action: "student.update",
+      entityType: "Student",
+      entityId: student.id,
+      target: studentLabel(student),
+      changes: diffFields(
+        before ?? undefined,
+        {
+          lastName: student.lastName,
+          firstName: student.firstName,
+          lastNameKana: student.lastNameKana,
+          firstNameKana: student.firstNameKana,
+          studentNumber: student.studentNumber,
+          enrollmentYear: student.enrollmentYear,
+        },
+        [
+          { field: "lastName", label: "姓" },
+          { field: "firstName", label: "名" },
+          { field: "lastNameKana", label: "姓（かな）" },
+          { field: "firstNameKana", label: "名（かな）" },
+          { field: "studentNumber", label: "学籍番号" },
+          { field: "enrollmentYear", label: "入学年度" },
+        ]
+      ),
+    })
+
+    return student
   } catch (error) {
     console.error("Failed to update student:", error)
     throw error
@@ -97,7 +150,19 @@ export const updateStudent = async (
 /** 生徒を削除する */
 export const deleteStudent = async (id: string): Promise<void> => {
   try {
+    const before = await prisma.student.findUnique({
+      where: { id },
+      select: { lastName: true, firstName: true },
+    })
+
     await prisma.student.delete({ where: { id } })
+
+    await recordAuditLog({
+      action: "student.delete",
+      entityType: "Student",
+      entityId: id,
+      target: before ? studentLabel(before) : null,
+    })
   } catch (error) {
     console.error("Failed to delete student:", error)
     throw error

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -17,6 +17,8 @@ import {
 } from "../../dataManager"
 import { detectCornerMarkers } from "../../omr/cornerMarkerDetector"
 import { correctImage } from "../../omr/imageCorrector"
+import { recordAuditLog } from "../auditLog"
+import { resolveExamScope, resolveExamScopeByPage } from "../auditScope"
 import prisma from "../client"
 
 /** ページごとのマスターマーカーキャッシュ */
@@ -247,6 +249,19 @@ export async function uploadStudentAnswers(
       }
     }
 
+    if (uploadedSheets.length > 0) {
+      const scope = await resolveExamScope(examId)
+      await recordAuditLog({
+        action: "exam.answer.upload",
+        entityType: "StudentAnswerImage",
+        entityId: examId,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+        summary: `生徒答案を${uploadedSheets.length}件アップロードしました`,
+        extra: { count: uploadedSheets.length },
+      })
+    }
+
     return { success: true, answerSheets: uploadedSheets }
   } catch (error) {
     console.error("Error uploading answer sheets:", error)
@@ -335,6 +350,15 @@ export async function deleteStudentAnswer(answerSheetId: string) {
       where: { id: answerSheetId },
     })
 
+    const scope = await resolveExamScopeByPage(answerSheet.examPageId)
+    await recordAuditLog({
+      action: "exam.answer.delete",
+      entityType: "StudentAnswerImage",
+      entityId: answerSheetId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+    })
+
     return { success: true }
   } catch (error) {
     console.error("Error deleting answer sheet:", error)
@@ -365,6 +389,18 @@ export async function associateStudentAnswerWithStudent(
           },
         },
       },
+    })
+
+    const studentName = answerSheet.student
+      ? `${answerSheet.student.lastName} ${answerSheet.student.firstName}`.trim()
+      : null
+    await recordAuditLog({
+      action: "exam.answer.assign",
+      entityType: "StudentAnswerImage",
+      entityId: answerSheetId,
+      scopeId: answerSheet.examPage.examId,
+      scopeLabel: answerSheet.examPage.exam?.examName ?? null,
+      target: studentName,
     })
 
     return { success: true, answerSheet }

--- a/electron-src/lib/prisma/studentClassMembership.ts
+++ b/electron-src/lib/prisma/studentClassMembership.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 type StudentClassMembershipWithDetails =
@@ -79,7 +80,27 @@ export const deleteStudentClassMembership = async (
   id: string
 ): Promise<void> => {
   try {
+    const before = await prisma.studentClassMembership.findUnique({
+      where: { id },
+      select: {
+        classId: true,
+        class: { select: { name: true } },
+        student: { select: { lastName: true, firstName: true } },
+      },
+    })
+
     await prisma.studentClassMembership.delete({ where: { id } })
+
+    await recordAuditLog({
+      action: "class.membership.remove",
+      entityType: "StudentClassMembership",
+      entityId: id,
+      scopeId: before?.classId ?? null,
+      scopeLabel: before?.class.name ?? null,
+      target: before
+        ? `${before.student.lastName} ${before.student.firstName}`.trim()
+        : null,
+    })
   } catch (error) {
     console.error("Failed to delete student class membership:", error)
     throw error
@@ -185,6 +206,15 @@ export const addStudentToClass = async (
       startDate,
       attendanceNumber,
       notes,
+    })
+
+    await recordAuditLog({
+      action: "class.membership.add",
+      entityType: "StudentClassMembership",
+      entityId: result.id,
+      scopeId: classId,
+      scopeLabel: result.class?.name ?? null,
+      target: `${result.student.lastName} ${result.student.firstName}`.trim(),
     })
 
     return result

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 /**
@@ -64,6 +65,13 @@ export async function createSubtotalGroup(data: {
       },
     })
 
+    await recordAuditLog({
+      action: "subtotal_group.create",
+      entityType: "SubtotalGroup",
+      entityId: subtotalGroup.id,
+      target: subtotalGroup.name,
+    })
+
     return {
       success: true,
       subtotalGroup,
@@ -116,6 +124,13 @@ export async function updateSubtotalGroup(
         })
       }
     )
+
+    await recordAuditLog({
+      action: "subtotal_group.update",
+      entityType: "SubtotalGroup",
+      entityId: subtotalGroup.id,
+      target: subtotalGroup.name,
+    })
 
     return {
       success: true,
@@ -198,6 +213,11 @@ export async function deleteSubtotalGroup(id: string) {
       }
     }
 
+    const before = await prisma.subtotalGroup.findUnique({
+      where: { id },
+      select: { name: true },
+    })
+
     // 試験に追加されているが実際には使用されていない場合はExamSubtotalGroupも削除
     await prisma.$transaction(async (tx) => {
       // ExamSubtotalGroupを削除
@@ -209,6 +229,13 @@ export async function deleteSubtotalGroup(id: string) {
       await tx.subtotalGroup.delete({
         where: { id },
       })
+    })
+
+    await recordAuditLog({
+      action: "subtotal_group.delete",
+      entityType: "SubtotalGroup",
+      entityId: id,
+      target: before?.name ?? null,
     })
 
     return {

--- a/electron-src/lib/prisma/tag.ts
+++ b/electron-src/lib/prisma/tag.ts
@@ -2,6 +2,7 @@
  * Tag（タグ）のPrisma操作関数
  */
 
+import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 /**
@@ -46,13 +47,22 @@ export async function getTagsBySubtotalGroupIds(subtotalGroupIds: string[]) {
 export async function createTag(data: { name: string; color?: string }) {
   const maxOrder = await prisma.tag.aggregate({ _max: { order: true } })
   const nextOrder = (maxOrder._max.order ?? -1) + 1
-  return prisma.tag.create({
+  const tag = await prisma.tag.create({
     data: {
       name: data.name,
       color: data.color ?? null,
       order: nextOrder,
     },
   })
+
+  await recordAuditLog({
+    action: "tag.create",
+    entityType: "Tag",
+    entityId: tag.id,
+    target: tag.name,
+  })
+
+  return tag
 }
 
 /**
@@ -62,19 +72,42 @@ export async function updateTag(
   id: string,
   data: { name?: string; color?: string | null }
 ) {
-  return prisma.tag.update({
+  const tag = await prisma.tag.update({
     where: { id },
     data,
   })
+
+  await recordAuditLog({
+    action: "tag.update",
+    entityType: "Tag",
+    entityId: tag.id,
+    target: tag.name,
+  })
+
+  return tag
 }
 
 /**
  * タグを削除
  */
 export async function deleteTag(id: string) {
-  return prisma.tag.delete({
+  const before = await prisma.tag.findUnique({
+    where: { id },
+    select: { name: true },
+  })
+
+  const tag = await prisma.tag.delete({
     where: { id },
   })
+
+  await recordAuditLog({
+    action: "tag.delete",
+    entityType: "Tag",
+    entityId: id,
+    target: before?.name ?? null,
+  })
+
+  return tag
 }
 
 /**
@@ -97,7 +130,7 @@ export async function findOrCreateTag(name: string) {
  * タグの並び順を一括更新
  */
 export async function reorderTags(tagIds: string[]) {
-  return prisma.$transaction(
+  const result = await prisma.$transaction(
     tagIds.map((id, index) =>
       prisma.tag.update({
         where: { id },
@@ -105,4 +138,13 @@ export async function reorderTags(tagIds: string[]) {
       })
     )
   )
+
+  await recordAuditLog({
+    action: "tag.reorder",
+    entityType: "Tag",
+    entityId: "tag-order",
+    coalesceKey: "tag_reorder",
+  })
+
+  return result
 }

--- a/electron-src/lib/prisma/user.ts
+++ b/electron-src/lib/prisma/user.ts
@@ -1,6 +1,7 @@
 import { User } from "@prisma/client"
 import bcrypt from "bcrypt"
 
+import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 
 export const fetchUsers = async (): Promise<User[]> => {
@@ -35,7 +36,7 @@ export const createUser = async (userData: {
         ? await bcrypt.hash(userData.passcode, 10)
         : null
 
-    return await prisma.user.create({
+    const user = await prisma.user.create({
       data: {
         username: userData.username,
         name: userData.name,
@@ -43,6 +44,15 @@ export const createUser = async (userData: {
         passcodeType: userData.passcodeType || "none",
       },
     })
+
+    await recordAuditLog({
+      action: "user.create",
+      entityType: "User",
+      entityId: user.id,
+      target: user.name,
+    })
+
+    return user
   } catch (error) {
     console.error("Failed to create user:", error)
     throw error
@@ -77,13 +87,35 @@ export const updateUser = async (
   }
 ): Promise<User> => {
   try {
-    return await prisma.user.update({
+    const before = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { username: true, name: true },
+    })
+
+    const user = await prisma.user.update({
       where: { id: userId },
       data: {
         ...(userData.username && { username: userData.username }),
         ...(userData.name && { name: userData.name }),
       },
     })
+
+    await recordAuditLog({
+      action: "user.update",
+      entityType: "User",
+      entityId: user.id,
+      target: user.name,
+      changes: diffFields(
+        before ?? undefined,
+        { username: user.username, name: user.name },
+        [
+          { field: "name", label: "名前" },
+          { field: "username", label: "ユーザー名" },
+        ]
+      ),
+    })
+
+    return user
   } catch (error) {
     console.error("Failed to update user:", error)
     throw error
@@ -101,13 +133,24 @@ export const updateUserPasscode = async (
         ? await bcrypt.hash(passcode, 10)
         : null
 
-    return await prisma.user.update({
+    const user = await prisma.user.update({
       where: { id: userId },
       data: {
         passcode: hashedPasscode,
         passcodeType: passcodeType || "none",
       },
     })
+
+    // 監査ログ: パスコード変更（パスコード値そのものは記録しない）
+    await recordAuditLog({
+      action: "user.update",
+      entityType: "User",
+      entityId: user.id,
+      target: user.name,
+      summary: `ユーザー「${user.name}」のパスコードを変更しました`,
+    })
+
+    return user
   } catch (error) {
     console.error("Failed to update user passcode:", error)
     throw error

--- a/electron-src/lib/prisma/userExam.ts
+++ b/electron-src/lib/prisma/userExam.ts
@@ -1,5 +1,7 @@
 import { Prisma, UserExam } from "@prisma/client"
 
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope, resolveUserLabel } from "./auditScope"
 import prisma from "./client"
 
 // Types for UserExam with relations
@@ -150,7 +152,7 @@ export const inviteExamMember = async (
       throw new Error("User is already a member of this exam")
     }
 
-    return await prisma.userExam.create({
+    const created = await prisma.userExam.create({
       data: {
         examId,
         userId,
@@ -162,6 +164,20 @@ export const inviteExamMember = async (
         inviter: true,
       },
     })
+
+    // 監査ログ: 試験への招待
+    const scope = await resolveExamScope(examId)
+    await recordAuditLog({
+      action: "exam.user.invite",
+      userId: invitedBy,
+      entityType: "UserExam",
+      entityId: created.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: created.user?.name ?? null,
+    })
+
+    return created
   } catch (error) {
     console.error(`Failed to invite member ${userId} to ${examId}:`, error)
     throw error
@@ -199,11 +215,26 @@ export const removeExamMember = async (
       throw new Error("Exam owner cannot be removed")
     }
 
-    return await prisma.userExam.delete({
+    const removed = await prisma.userExam.delete({
       where: {
         userId_examId: { userId, examId },
       },
     })
+
+    // 監査ログ: 試験メンバーの削除
+    const scope = await resolveExamScope(examId)
+    const targetName = await resolveUserLabel(userId)
+    await recordAuditLog({
+      action: "exam.user.remove",
+      userId: removedBy,
+      entityType: "UserExam",
+      entityId: removed.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: targetName,
+    })
+
+    return removed
   } catch (error) {
     console.error(`Failed to remove member ${userId} from ${examId}:`, error)
     throw error
@@ -253,6 +284,25 @@ export const transferOwnership = async (
         data: { role: "OWNER", invitedBy: null },
       }),
     ])
+
+    // 監査ログ: 所有権の移譲（ロール変更）
+    const scope = await resolveExamScope(examId)
+    const newOwnerName = await resolveUserLabel(newOwnerId)
+    await recordAuditLog({
+      action: "exam.user.role_update",
+      userId: currentOwnerId,
+      entityType: "UserExam",
+      entityId: newOwner.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      target: newOwnerName,
+      summary: newOwnerName
+        ? `「${newOwnerName}」に試験の所有権を移譲しました`
+        : "試験の所有権を移譲しました",
+      changes: [
+        { field: "role", label: "権限", before: "GRADER", after: "OWNER" },
+      ],
+    })
 
     return { previousOwner, newOwner }
   } catch (error) {

--- a/electron-src/lib/sync/syncTableConfig.ts
+++ b/electron-src/lib/sync/syncTableConfig.ts
@@ -30,4 +30,10 @@ export const SYNC_TABLE_OPTIONS: Record<string, TableOptions> = {
     timestampColumn: "deletedAt",
     deleteProtected: true,
   },
+  // 監査ログ。連続操作の集約で既存行を上書きするため、LWWは updatedAt で収束させる。
+  // 削除はされない（deleteProtected）。
+  AuditLog: {
+    timestampColumn: "updatedAt",
+    deleteProtected: true,
+  },
 }

--- a/electron-src/preload-apis/auditLogApi.ts
+++ b/electron-src/preload-apis/auditLogApi.ts
@@ -1,0 +1,23 @@
+/**
+ * 監査ログ Preload API
+ */
+
+import { ipcRenderer } from "electron"
+
+import type {
+  AuditLogPage,
+  AuditLogQueryOptions,
+  AuditScopeFacet,
+} from "../lib/prisma/auditQuery"
+
+export function createAuditLogApi() {
+  return {
+    audit: {
+      getLogs: (options?: AuditLogQueryOptions): Promise<AuditLogPage> =>
+        ipcRenderer.invoke("audit:getLogs", options),
+
+      getScopes: (): Promise<AuditScopeFacet[]> =>
+        ipcRenderer.invoke("audit:getScopes"),
+    },
+  }
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -3,6 +3,7 @@ import { contextBridge, IpcRenderer, ipcRenderer } from "electron"
 import { createAnswerSheetApi } from "./preload-apis/answerSheetApi"
 import { createAnswerSheetBuilderApi } from "./preload-apis/answerSheetBuilderApi"
 import { createArchiveApi } from "./preload-apis/archiveApi"
+import { createAuditLogApi } from "./preload-apis/auditLogApi"
 import { createAuthApi } from "./preload-apis/authApi"
 import { createCropRegionApi } from "./preload-apis/cropRegionApi"
 import { createDrawingApi } from "./preload-apis/drawingApi"
@@ -51,6 +52,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   ...createAnswerSheetBuilderApi(),
   ...createMiscApi(),
   ...createSyncApi(),
+  ...createAuditLogApi(),
 })
 
 process.once("loaded", () => {

--- a/prisma/migrations/20260614120000_add_audit_log/migration.sql
+++ b/prisma/migrations/20260614120000_add_audit_log/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable: 監査ログ（Discord風の操作履歴）。追記専用・不変。
+-- 状態を変える全操作とエクスポートを記録する（閲覧は対象外）。
+-- userIdはFKを張らず素の文字列とし、ユーザー削除後もログが残るようにする。
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT,
+    "action" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "scopeId" TEXT,
+    "scopeLabel" TEXT,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "metadata" TEXT
+);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_userId_idx" ON "AuditLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_category_idx" ON "AuditLog"("category");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_scopeId_idx" ON "AuditLog"("scopeId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_action_idx" ON "AuditLog"("action");

--- a/prisma/migrations/20260614130000_audit_log_updated_at/migration.sql
+++ b/prisma/migrations/20260614130000_audit_log_updated_at/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: 監査ログに updatedAt を追加。
+-- 連続する同種操作の「集約」時に新規行を足さず既存行を上書き更新するため、
+-- 最終更新時刻を保持する。LWW同期のタイムスタンプ列としても使用する。
+-- 既存行は createdAt 相当（= 現在時刻のデフォルト）で初期化される。
+ALTER TABLE "AuditLog" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE INDEX "AuditLog_updatedAt_idx" ON "AuditLog"("updatedAt");

--- a/prisma/migrations/20260614140000_audit_log_coalesce_key/migration.sql
+++ b/prisma/migrations/20260614140000_audit_log_coalesce_key/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: 監査ログの集約キーを列化（メタデータJSON内からカラムへ昇格）。
+-- 同一キーの行を時間窓内で一致検索するため、インデックス付きの専用カラムにする。
+ALTER TABLE "AuditLog" ADD COLUMN "coalesceKey" TEXT;
+
+-- CreateIndex
+CREATE INDEX "AuditLog_coalesceKey_idx" ON "AuditLog"("coalesceKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -335,6 +335,33 @@ model DeletedRecord {
   @@index([deletedAt])
 }
 
+/// 監査ログ（Discord風の操作履歴）。
+/// 追記専用・不変。状態を変える全操作とエクスポートを記録する（閲覧は対象外）。
+/// userIdはFKを張らず素の文字列とし、ユーザー削除後もログが残るようにする（DeletedRecord同様）。
+model AuditLog {
+  id         String   @id @default(uuid())
+  createdAt  DateTime @default(now()) // 初回操作日時（ISO text）
+  updatedAt  DateTime @updatedAt // 最終更新日時。連続操作の集約時に上書きされる（LWW同期のタイムスタンプ列）
+  userId     String? // 操作者。システム操作はnull
+  action     String // "exam.update" / "grade.boundary.update" 等の名前空間付きアクション
+  category   String // "exam" | "grade" | "answer_sheet" | "student" | "user" | "system"
+  scopeId    String? // 絞り込み用の親エンティティID（examId / gradeId / definitionId 等）
+  scopeLabel String? // 表示用スナップショット（対象が消えても残す。"数学 期末" 等）
+  entityType  String // 変更対象のテーブル名（"Exam" 等）
+  entityId    String // 変更対象のレコードID
+  summary     String // 人間可読の要約（構造化レンダリングのフォールバック）
+  metadata    String? // JSON: { changes:[{field,label,before,after}], occurrences, target:{...} }
+  coalesceKey String? // 連続操作の集約キー（同一キーの行を窓内で上書き更新）。indexで高速一致
+
+  @@index([createdAt])
+  @@index([updatedAt])
+  @@index([userId])
+  @@index([category])
+  @@index([scopeId])
+  @@index([action])
+  @@index([coalesceKey])
+}
+
 model ExamClass {
   id           String   @id @default(uuid())
   examId       String

--- a/src/app/settings/components/AuditLogsTab.tsx
+++ b/src/app/settings/components/AuditLogsTab.tsx
@@ -1,0 +1,317 @@
+"use client"
+
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  FilePlus2,
+  FileX2,
+  History,
+  Pencil,
+  Upload,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+
+import { useAuditLogs } from "@/app/settings/hooks/useAuditLogs"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import type {
+  AuditCategory,
+  AuditLogEntry,
+  AuditVerb,
+} from "@/types/electron/auditLogApi"
+
+const CATEGORY_LABELS: Record<AuditCategory, string> = {
+  exam: "試験",
+  grade: "成績",
+  answer_sheet: "解答用紙",
+  student: "生徒・学級",
+  user: "ユーザー",
+  system: "システム",
+}
+
+const VERB_META: Record<
+  AuditVerb,
+  { label: string; className: string; Icon: typeof Pencil }
+> = {
+  create: { label: "作成", className: "text-emerald-600", Icon: FilePlus2 },
+  update: { label: "更新", className: "text-blue-600", Icon: Pencil },
+  delete: { label: "削除", className: "text-red-600", Icon: FileX2 },
+  export: { label: "出力", className: "text-violet-600", Icon: Download },
+  import: { label: "取込", className: "text-amber-600", Icon: Upload },
+  other: { label: "操作", className: "text-muted-foreground", Icon: History },
+}
+
+interface SimpleUser {
+  id: string
+  name: string
+}
+
+const initials = (name: string | null): string => {
+  if (!name) return "?"
+  const trimmed = name.trim()
+  return trimmed.length > 0 ? trimmed.slice(0, 2) : "?"
+}
+
+const formatRelativeTime = (iso: string): string => {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ""
+  const diffSec = Math.floor((Date.now() - then) / 1000)
+  if (diffSec < 60) return "たった今"
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}分前`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}時間前`
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}日前`
+  return new Date(iso).toLocaleDateString("ja-JP")
+}
+
+const formatAbsoluteTime = (iso: string): string =>
+  new Date(iso).toLocaleString("ja-JP")
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") return "（なし）"
+  if (typeof value === "boolean") return value ? "はい" : "いいえ"
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+function ChangeDiff({ entry }: { entry: AuditLogEntry }) {
+  const changes = entry.metadata?.changes
+  if (!changes || changes.length === 0) {
+    return (
+      <div className="text-muted-foreground mt-2 ml-11 text-sm">
+        詳細な変更内容は記録されていません。
+      </div>
+    )
+  }
+  return (
+    <div className="mt-2 ml-11 space-y-1.5">
+      {changes.map((change, i) => (
+        <div key={i} className="text-sm">
+          <span className="text-muted-foreground">
+            {change.label ?? change.field}:{" "}
+          </span>
+          <span className="text-red-600 line-through">
+            {formatValue(change.before)}
+          </span>
+          <span className="text-muted-foreground mx-1.5">→</span>
+          <span className="text-emerald-600">{formatValue(change.after)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function AuditLogItem({ entry }: { entry: AuditLogEntry }) {
+  const [expanded, setExpanded] = useState(false)
+  const verb = VERB_META[entry.verb] ?? VERB_META.other
+  const { Icon } = verb
+  const hasChanges = (entry.metadata?.changes?.length ?? 0) > 0
+  const actor = entry.actorName ?? "不明なユーザー"
+
+  return (
+    <div className="hover:bg-muted/40 rounded-md px-2 py-2.5 transition-colors">
+      <div className="flex items-start gap-3">
+        <Avatar className="mt-0.5 h-8 w-8 shrink-0">
+          <AvatarFallback className="text-xs">
+            {initials(entry.actorName)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+            <Icon className={`h-3.5 w-3.5 shrink-0 ${verb.className}`} />
+            <span className="font-semibold">{actor}</span>
+            <span className="text-foreground">が {entry.summary}</span>
+          </div>
+          <div className="text-muted-foreground mt-0.5 flex flex-wrap items-center gap-2 text-xs">
+            <Badge variant="secondary" className="font-normal">
+              {CATEGORY_LABELS[entry.category] ?? entry.category}
+            </Badge>
+            {entry.scopeLabel && (
+              <span className="truncate">{entry.scopeLabel}</span>
+            )}
+            <span title={formatAbsoluteTime(entry.updatedAt)}>
+              {formatRelativeTime(entry.updatedAt)}
+            </span>
+            {entry.occurrences > 1 && (
+              <span className="text-muted-foreground/80">
+                ・{entry.occurrences}回
+              </span>
+            )}
+          </div>
+          {hasChanges && expanded && <ChangeDiff entry={entry} />}
+        </div>
+        {hasChanges && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 px-2"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <span className="ml-1 text-xs">変更内容</span>
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ALL = "__all__"
+
+export function AuditLogsTab() {
+  const {
+    entries,
+    total,
+    loading,
+    loadingMore,
+    error,
+    filter,
+    setFilter,
+    hasMore,
+    loadMore,
+  } = useAuditLogs()
+  const [users, setUsers] = useState<SimpleUser[]>([])
+  const [searchText, setSearchText] = useState("")
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const data = await window.electronAPI.fetchUsers()
+        setUsers(data.map((u) => ({ id: u.id, name: u.name })))
+      } catch (e) {
+        console.error("Failed to load users for audit filter:", e)
+      }
+    })()
+  }, [])
+
+  // 検索テキストはデバウンスしてフィルタへ反映
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setFilter({ ...filter, search: searchText || undefined })
+    }, 300)
+    return () => clearTimeout(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchText])
+
+  const categoryOptions = useMemo(
+    () => Object.entries(CATEGORY_LABELS) as [AuditCategory, string][],
+    []
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={filter.category ?? ALL}
+          onValueChange={(v) =>
+            setFilter({
+              ...filter,
+              category: v === ALL ? undefined : (v as AuditCategory),
+            })
+          }
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="カテゴリ" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>すべてのカテゴリ</SelectItem>
+            {categoryOptions.map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filter.userId ?? ALL}
+          onValueChange={(v) =>
+            setFilter({ ...filter, userId: v === ALL ? undefined : v })
+          }
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="ユーザー" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>すべてのユーザー</SelectItem>
+            {users.map((u) => (
+              <SelectItem key={u.id} value={u.id}>
+                {u.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Input
+          placeholder="内容で検索..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="w-56"
+        />
+
+        <span className="text-muted-foreground ml-auto text-sm">
+          {total} 件
+        </span>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="text-muted-foreground flex flex-col items-center justify-center gap-2 py-16">
+          <History className="h-8 w-8 opacity-50" />
+          <p className="text-sm">記録された操作はありません。</p>
+        </div>
+      ) : (
+        <div className="divide-border/60 divide-y">
+          {entries.map((entry) => (
+            <AuditLogItem key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
+
+      {hasMore && !loading && (
+        <div className="flex justify-center pt-2">
+          <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
+            {loadingMore ? "読み込み中..." : "さらに表示"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/settings/hooks/useAuditLogs.ts
+++ b/src/app/settings/hooks/useAuditLogs.ts
@@ -1,0 +1,109 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import type {
+  AuditLogEntry,
+  AuditLogFilter,
+} from "@/types/electron/auditLogApi"
+
+const PAGE_SIZE = 50
+
+interface UseAuditLogsResult {
+  entries: AuditLogEntry[]
+  total: number
+  loading: boolean
+  loadingMore: boolean
+  error: string | null
+  filter: AuditLogFilter
+  setFilter: (filter: AuditLogFilter) => void
+  hasMore: boolean
+  loadMore: () => void
+  reload: () => void
+}
+
+/**
+ * 監査ログの取得フック。フィルタ変更で先頭から再取得し、
+ * loadMore でオフセットを進めて追記する。
+ */
+export function useAuditLogs(): UseAuditLogsResult {
+  const [entries, setEntries] = useState<AuditLogEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilterState] = useState<AuditLogFilter>({})
+
+  const fetchPage = useCallback(
+    (offset: number, currentFilter: AuditLogFilter) =>
+      window.electronAPI.audit.getLogs({
+        ...currentFilter,
+        limit: PAGE_SIZE,
+        offset,
+      }),
+    []
+  )
+
+  const reload = useCallback(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    void (async () => {
+      try {
+        const page = await fetchPage(0, filter)
+        if (cancelled) return
+        setEntries(page.entries)
+        setTotal(page.total)
+      } catch (e) {
+        if (cancelled) return
+        setError(
+          e instanceof Error ? e.message : "監査ログの取得に失敗しました"
+        )
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [fetchPage, filter])
+
+  useEffect(() => {
+    const cleanup = reload()
+    return cleanup
+  }, [reload])
+
+  const loadMore = useCallback(() => {
+    setLoadingMore(true)
+    void (async () => {
+      try {
+        const page = await fetchPage(entries.length, filter)
+        setEntries((prev) => [...prev, ...page.entries])
+        setTotal(page.total)
+      } catch (e) {
+        setError(
+          e instanceof Error ? e.message : "監査ログの取得に失敗しました"
+        )
+      } finally {
+        setLoadingMore(false)
+      }
+    })()
+  }, [entries.length, fetchPage, filter])
+
+  const setFilter = useCallback((next: AuditLogFilter) => {
+    setFilterState(next)
+  }, [])
+
+  return {
+    entries,
+    total,
+    loading,
+    loadingMore,
+    error,
+    filter,
+    setFilter,
+    hasMore: entries.length < total,
+    loadMore,
+    reload,
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,9 +1,17 @@
 "use client"
 
-import { FolderSync, Keyboard, Monitor, Palette, Users } from "lucide-react"
+import {
+  FolderSync,
+  History,
+  Keyboard,
+  Monitor,
+  Palette,
+  Users,
+} from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
+import { AuditLogsTab } from "@/app/settings/components/AuditLogsTab"
 import { DisplaySettingsTab } from "@/app/settings/components/DisplaySettingsTab"
 import { KeyboardShortcutSection } from "@/app/settings/components/KeyboardShortcutSection"
 import { ScreenControlTab } from "@/app/settings/components/ScreenControlTab"
@@ -109,6 +117,10 @@ export default function SettingsPage() {
               <FolderSync className="h-4 w-4" />
               同期設定
             </TabsTrigger>
+            <TabsTrigger value="audit" className="gap-2">
+              <History className="h-4 w-4" />
+              監査ログ
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="keyboard">
@@ -143,6 +155,10 @@ export default function SettingsPage() {
 
           <TabsContent value="sync">
             <SyncSettingsTab />
+          </TabsContent>
+
+          <TabsContent value="audit">
+            <AuditLogsTab />
           </TabsContent>
         </Tabs>
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,6 +12,7 @@
 
 import type { AnswerSheetBuilderAPI } from "./electron/answerSheetBuilderApi"
 import type { ArchiveAPI } from "./electron/archiveApi"
+import type { AuditLogAPI } from "./electron/auditLogApi"
 import type { ClassStudentAPI } from "./electron/classStudentApi"
 import type { CropRegionAPI } from "./electron/cropRegionApi"
 import type { DataManagementAPI } from "./electron/dataManagementApi"
@@ -90,7 +91,8 @@ export interface MyAPI
     AnswerSheetBuilderAPI,
     OmrAPI,
     DataManagementAPI,
-    SyncAPI {}
+    SyncAPI,
+    AuditLogAPI {}
 
 // ---------------------------------------------------------------------------
 // Global Window declarations

--- a/src/types/electron/auditLogApi.d.ts
+++ b/src/types/electron/auditLogApi.d.ts
@@ -1,0 +1,94 @@
+/**
+ * 監査ログ API 型定義（Discord風 操作履歴）
+ *
+ * electron-src/lib/prisma/auditQuery.ts および auditActions.ts と対応する
+ * フロントエンド側の契約。
+ */
+
+export type AuditCategory =
+  | "exam"
+  | "grade"
+  | "answer_sheet"
+  | "student"
+  | "user"
+  | "system"
+
+export type AuditVerb =
+  | "create"
+  | "update"
+  | "delete"
+  | "export"
+  | "import"
+  | "other"
+
+/** before→after の単一フィールド差分 */
+export interface AuditChange {
+  field: string
+  label?: string
+  before: unknown
+  after: unknown
+}
+
+/** metadata のパース済み構造 */
+export interface AuditMetadata {
+  changes?: AuditChange[]
+  target?: { type: string; label: string }
+  occurrences?: number
+  coalesceKey?: string
+  [key: string]: unknown
+}
+
+/** 1件分の監査ログ（操作者情報・カテゴリ・verb付与済み） */
+export interface AuditLogEntry {
+  id: string
+  createdAt: string
+  updatedAt: string
+  occurrences: number
+  action: string
+  category: AuditCategory
+  verb: AuditVerb
+  userId: string | null
+  actorName: string | null
+  actorUsername: string | null
+  entityType: string
+  entityId: string
+  scopeId: string | null
+  scopeLabel: string | null
+  summary: string
+  metadata: AuditMetadata | null
+}
+
+export interface AuditLogFilter {
+  userId?: string
+  category?: AuditCategory
+  action?: string
+  scopeId?: string
+  dateFrom?: string
+  dateTo?: string
+  search?: string
+}
+
+export interface AuditLogQueryOptions extends AuditLogFilter {
+  limit?: number
+  offset?: number
+}
+
+export interface AuditLogPage {
+  entries: AuditLogEntry[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface AuditScopeFacet {
+  scopeId: string
+  scopeLabel: string | null
+  category: string
+}
+
+export interface AuditLogAPI {
+  audit: {
+    getLogs(options?: AuditLogQueryOptions): Promise<AuditLogPage>
+    getScopes(): Promise<AuditScopeFacet[]>
+  }
+}


### PR DESCRIPTION
Closes #843

## 概要
状態を変える操作を横断的に記録するDiscord風の監査ログを実装。設定画面でフィード表示・フィルタ・差分確認ができる。

## 主な変更
- `AuditLog` モデル＋マイグレーション3本（基本 / `updatedAt` / `coalesceKey`）
- 記録基盤 `recordAuditLog`：操作者を認証ストアから自動補完、ベストエフォート（主操作を妨げない）
- 連続する同一操作の集約（同一 `coalesceKey`・操作者・時間窓内で `after`/`updatedAt` 上書き、`occurrences` 加算）
- 計装：試験 / 採点（提案・更新・削除・一括・確定）/ 採点マーク / 答案 / 受験生徒 / 権限 / 生徒 / 学級 / ユーザー / 成績および下位項目 / 解答用紙 / 設問・小計 / OMR / 複合解答 / エクスポート・インポート / 並び替え
- 保持プルーニング `pruneAuditLogs`（既定730日、起動時ベストエフォート）
- 設定画面にDiscord風フィードUI（フィルタ・差分展開・集約回数表示）
- IPC（`audit:getLogs` / `audit:getScopes`）、NAS同期は `updatedAt` で LWW 収束

## テスト
- 監査ログ統合テスト **16件** 合格
- 既存 grade/omr **169件**、import-export **207件** 回帰なし
- `npm run typecheck` exit 0、変更ファイル ESLINT CLEAN

## 既知の制限
- 同期 `deleteProtected` のためプルーニングのローカル削除は他端末へ非伝播（全端末同一保持日数で実質収束）
- 採点マークの追加/削除はマークごと個別記録（同一idの連続編集のみ集約）

🤖 Generated with [Claude Code](https://claude.com/claude-code)