### PR TITLE
fix: AuditLog updatedAt マイグレーションのSQLite非定数デフォルトエラーを修正

### DIFF
--- a/prisma/migrations/20260614130000_audit_log_updated_at/migration.sql
+++ b/prisma/migrations/20260614130000_audit_log_updated_at/migration.sql
@@ -1,8 +1,15 @@
 -- AlterTable: 監査ログに updatedAt を追加。
 -- 連続する同種操作の「集約」時に新規行を足さず既存行を上書き更新するため、
 -- 最終更新時刻を保持する。LWW同期のタイムスタンプ列としても使用する。
--- 既存行は createdAt 相当（= 現在時刻のデフォルト）で初期化される。
-ALTER TABLE "AuditLog" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+--
+-- SQLite は ALTER TABLE ADD COLUMN で CURRENT_TIMESTAMP のような非定数デフォルトを
+-- 許可しないため、定数デフォルト（ISO text のエポック）で列を追加してから、
+-- 既存行を createdAt（ISO text）で初期化する。新規行の値は Prisma の @updatedAt が
+-- アプリ層で設定するため、定数デフォルトはフォールバックにとどまる。
+ALTER TABLE "AuditLog" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00.000Z';
+
+-- 既存行は createdAt 相当で初期化する。
+UPDATE "AuditLog" SET "updatedAt" = "createdAt";
 
 -- CreateIndex
 CREATE INDEX "AuditLog_updatedAt_idx" ON "AuditLog"("updatedAt");


### PR DESCRIPTION
## 概要

監査ログ機能で追加されたマイグレーション `20260614130000_audit_log_updated_at` がSQLiteで失敗し、アプリが起動できない問題を修正する。

closes #845

## 問題

```sql
ALTER TABLE "AuditLog" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
```

SQLite は `ALTER TABLE ADD COLUMN` で `CURRENT_TIMESTAMP` のような非定数デフォルトを許可しないため、`Cannot add a column with non-constant default` で失敗する。さらに `CURRENT_TIMESTAMP` のスペース区切り形式はプロジェクトの ISO text 前提と矛盾する。

## 修正内容

- ISO text の定数デフォルト `'1970-01-01T00:00:00.000Z'` で列を追加
- 既存行は `UPDATE "AuditLog" SET "updatedAt" = "createdAt"` で createdAt（ISO text）をコピー初期化
- 新規行の `updatedAt` は Prisma の `@updatedAt` がアプリ層で設定するため、定数デフォルトはフォールバック

## 補足

- 失敗マイグレーションはロールバック（バックアップ復元）済みで `_prisma_migrations` に記録が無く、再実行で再適用される
- `migrationDeployer.ts` は適用時にファイル内容からチェックサムを再計算するため、broken なマイグレーションSQLの直接修正で問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)