### PR TITLE
fix: 採点済み答案書き出しの生徒ページ順を customOrder 順に統一

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -414,11 +414,14 @@ export async function getPdfExportData(options: {
       }
     }
 
-    // ページを生徒順・ページ番号順でソート
+    // ページを生徒順（customOrder順）・ページ番号順でソート
+    // selectedStudents は getStudentsForExam が customOrder 順で返すため、
+    // その順序を生徒の並び順として使う（選択操作の順序には依存させない）
+    const orderedStudentIds = selectedStudents.map((s) => s.id)
     pages.sort((a, b) => {
       const studentCompare =
-        selectedStudentIds.indexOf(a.studentId) -
-        selectedStudentIds.indexOf(b.studentId)
+        orderedStudentIds.indexOf(a.studentId) -
+        orderedStudentIds.indexOf(b.studentId)
       if (studentCompare !== 0) return studentCompare
       return a.pageNumber - b.pageNumber
     })


### PR DESCRIPTION
## 概要

採点済み答案の書き出しで、複数生徒のページ（＝生徒）の並び順が UI の選択操作順に依存していた問題を修正し、個人成績表と同じ **customOrder 順** に統一しました。

Closes #849

## 背景

- `pdfExport.ts` はページの生徒順を `selectedStudentIds`（フロントの `Set` の挿入順）から決定していた。
  - 全員選択時は名簿順になるが、個別選択・再選択では **クリック順** になり名簿順から崩れる。
- 個人成績表（`excel/dataFetcher.ts`）は常に **customOrder 順** に再ソートしており、両者の並びが食い違っていた。

## 変更内容

- `electron-src/lib/prisma/pdfExport.ts` のページソートを、`getStudentsForExam` が customOrder 順（`orderBy: [customOrder asc, studentNumber asc]`）で返す `selectedStudents` の順序を基準にするよう変更。
- 選択操作の順序に依存せず、採点済み答案書き出しと個人成績表の生徒順が一致するようになった。
- `getPdfExportData` はプレビュー（`useScoredAnswerPreview`）でも使われるため、プレビューと実出力の双方に反映される。

## 確認

- `npx eslint electron-src/lib/prisma/pdfExport.ts` → エラーなし
- electron-src の型チェック → エラーなし