### PR TITLE
fix: 配置済み答案の削除後にテーブルが再読み込みされない不具合を修正

### DIFF
--- a/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
+++ b/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
@@ -2,7 +2,7 @@
  * Hooks for 06-student-answers page - quick inline version
  */
 
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import type { ProcessedStudentAnswer } from "@/components/exams/06-student-answers/student-answer-management/types"
@@ -30,12 +30,17 @@ export function useStudentAnswersData(examId: string) {
   >([])
   const [modelAnswerCount, setModelAnswerCount] = useState<number>(0)
   const [isLoading, setIsLoading] = useState(true)
+  // 初回ロードのみ全画面スピナーを表示する。削除・反映後の再取得は
+  // バックグラウンドで差し替え、画面のチラつきを防ぐ。
+  const hasLoadedRef = useRef(false)
 
   const loadData = useCallback(async () => {
     if (!examId) return
 
     try {
-      setIsLoading(true)
+      if (!hasLoadedRef.current) {
+        setIsLoading(true)
+      }
 
       // Load students
       const examStudentsResult =
@@ -133,6 +138,7 @@ export function useStudentAnswersData(examId: string) {
       console.error("Error loading data:", error)
       toast.error("データの読み込みに失敗しました")
     } finally {
+      hasLoadedRef.current = true
       setIsLoading(false)
     }
   }, [examId])

--- a/src/app/exams/[examId]/06-student-answers/page.tsx
+++ b/src/app/exams/[examId]/06-student-answers/page.tsx
@@ -3,7 +3,6 @@
 import { FileEdit } from "lucide-react"
 import { useParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { toast } from "sonner"
 
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
 import { usePageHelp } from "@/components/help/usePageHelp"
@@ -99,13 +98,12 @@ export default function StudentAnswersPage() {
   }, [loadData])
 
   /**
-   * Handles student answer updates in view mode
+   * Handles student answer updates in view mode (e.g. deletion).
+   * Reloads data so the table reflects the current DB state.
    */
   const handleStudentAnswerUpdate = useCallback(() => {
-    toast.info("変更が保存されました", {
-      description: "「変更を反映」ボタンで最新データを確認してください",
-    })
-  }, [])
+    loadData()
+  }, [loadData])
 
   // Show loading spinner while data is loading
   if (isLoading) {

--- a/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 import { FileUploadZone } from "@/components/exams/06-student-answers/student-answer-management/components/FileUploadZone"
 import { useStudentAnswerUpload } from "@/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload"
@@ -61,34 +61,39 @@ export function StudentAnswerUpload({
   )
 
   // 確認モード用の初期化処理
+  // existingStudentAnswers の参照が変わったとき（初回・削除/反映後の再読み込み）に
+  // files を再構築する。ドラッグ操作では existingStudentAnswers は変化しないため、
+  // 配置中の並び替えを巻き込んで再構築することはない。
+  const syncedAnswersRef = useRef<typeof finalExistingAnswers | null>(null)
   useEffect(() => {
-    if (mode === "view" && finalExistingAnswers && files.length === 0) {
-      // 初回のみ既存答案を配置戦略に基づいて配列構築
-      let initialFiles = buildOrderedFileArrayFromStudentAnswers(
-        finalExistingAnswers,
-        students,
-        finalModelAnswerCount,
-        fileOrder
-      )
-      // correctionStatusMapから補正ステータスを注入
-      if (correctionStatusMap && correctionStatusMap.size > 0) {
-        initialFiles = initialFiles.map((file) => {
-          if (file.studentId) {
-            const key = `${file.studentId}-${file.pageNumber}`
-            const status = correctionStatusMap.get(key)
-            if (status) {
-              return { ...file, correctionStatus: status }
-            }
+    if (mode !== "view" || !finalExistingAnswers) return
+    if (syncedAnswersRef.current === finalExistingAnswers) return
+    syncedAnswersRef.current = finalExistingAnswers
+
+    // 既存答案を配置戦略に基づいて配列構築
+    let initialFiles = buildOrderedFileArrayFromStudentAnswers(
+      finalExistingAnswers,
+      students,
+      finalModelAnswerCount,
+      fileOrder
+    )
+    // correctionStatusMapから補正ステータスを注入
+    if (correctionStatusMap && correctionStatusMap.size > 0) {
+      initialFiles = initialFiles.map((file) => {
+        if (file.studentId) {
+          const key = `${file.studentId}-${file.pageNumber}`
+          const status = correctionStatusMap.get(key)
+          if (status) {
+            return { ...file, correctionStatus: status }
           }
-          return file
-        })
-      }
-      setFiles(initialFiles)
+        }
+        return file
+      })
     }
+    setFiles(initialFiles)
   }, [
     mode,
     finalExistingAnswers,
-    files.length,
     students,
     finalModelAnswerCount,
     fileOrder,


### PR DESCRIPTION
## 概要

view モード（「配置済み答案の確認」タブ）でアップロード済みの答案を削除しても状態が更新されず、削除済み答案が残留して「答案画像がない」エラーや空き位置への新規追加不可を招いていた不具合を修正します。

Closes #853

## 原因

1. 削除ハンドラの `onReloadData` が view モードでは `loadData()` を呼ばないコールバック（トースト表示のみ）に繋がっていた。
2. `StudentAnswerUpload.tsx` の view モード初期化が `files.length === 0` ガードのため、再読み込みしてもローカルの `files`（テーブル描画元）を再構築しなかった。

## 変更内容

- **`page.tsx`**: `handleStudentAnswerUpdate` を `loadData()` 呼び出しに変更（誤解を招くトースト・未使用 import を削除）
- **`StudentAnswerUpload.tsx`**: `existingStudentAnswers` の参照変化を検知（`syncedAnswersRef`）して `files` を再構築。ドラッグ操作中（参照不変）は巻き込まない
- **`hooks/index.tsx`**: `loadData` を初回ロードのみ全画面スピナー表示にし、再取得はバックグラウンド差し替えに変更。これにより再マウントに依存せず in-place 再同期が機能し、削除のたびのチラつきも解消

## 検証

- `npm run typecheck` 通過
- 対象 3 ファイルの `eslint` 警告なし
- アップロード後のグリッドクリアは `handleUpload` 内の `setFiles([])` で行われ、再マウント除去の影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)