### PR TITLE
fix: 採点済み答案の書き出し用紙サイズを個別表示と一致させる

### DIFF
--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -63,6 +63,8 @@ export interface PdfExportPageData {
   pageNumber: number
   imagePath: string
   imageUrl: string // file:// URL形式
+  // 用紙サイズ（mm→px変換基準。個別表示と一致させるため MasterImage.pageSize を反映）
+  pageSize: string
   scoringData: Array<{
     questionScoreId: string
     status: string
@@ -147,6 +149,18 @@ export async function getPdfExportData(options: {
     const exam = await getExamById(examId)
     if (!exam) {
       return { success: false, error: "試験が見つかりません" }
+    }
+
+    // 用紙サイズ（MasterImageのpageSizeフィールドから取得、デフォルトA4）
+    // 個別表示（ScoringMainView）と同一ロジックで算出し、フォント・線幅の
+    // mm→px変換基準を一致させる
+    let pageSize = "A4"
+    for (const page of exam.examPages ?? []) {
+      const masterImage = page.masterImages?.[0]
+      if (masterImage?.pageSize) {
+        pageSize = masterImage.pageSize
+        break
+      }
     }
 
     // 採点領域を取得
@@ -404,6 +418,7 @@ export async function getPdfExportData(options: {
           pageNumber,
           imagePath,
           imageUrl,
+          pageSize,
           scoringData,
           subtotalData,
           totalScoreData,

--- a/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -26,6 +26,8 @@ export interface PdfExportPageData {
   pageNumber: number
   imagePath: string
   imageUrl: string
+  /** 用紙サイズ（mm→px変換基準。個別表示と一致させるため getPdfExportData が付与） */
+  pageSize: string
   scoringData: Array<{
     questionScoreId: string
     status: string
@@ -339,7 +341,7 @@ export function PdfCanvasRenderer({
         subtotalDataForPdf,
         totalScoreDataForPdf,
         page.pageNumber,
-        pageSize
+        page.pageSize ?? pageSize
       )
 
       const arrayBuffer = await blob.arrayBuffer()

--- a/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
@@ -260,7 +260,7 @@ export function useScoredAnswerPreview({
             subtotalDataForPdf,
             totalScoreDataForPdf,
             page.pageNumber,
-            (page as { pageSize?: string }).pageSize ?? "A4"
+            page.pageSize ?? "A4"
           )
 
           if (cancelled) return

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -39,6 +39,7 @@ export interface ExportAPI {
         pageNumber: number
         imagePath: string
         imageUrl: string
+        pageSize: string
         scoringData: Array<{
           questionScoreId: string
           status: string


### PR DESCRIPTION
## 概要

書き出しプレビュー/PDF出力でアノテーション（テキスト・線）の mm→px 変換に使う用紙サイズ(pageSize)が常に "A4" にフォールバックしていたため、個別表示が使う実際の用紙サイズ（`MasterImage.pageSize`）と食い違い、A4より大きい用紙（B4/A3 等）でプレビューのフォント・線幅が個別表示より大きく描画されていた問題を修正する。

Closes #855

## 原因

`mmToPixels` によるテキストの相対サイズは `mm ÷ 用紙幅(mm)` で決まり用紙サイズに依存する。`getPdfExportData`（`pdfExport.ts`）がページごとの `pageSize` を返しておらず、プレビュー(`useScoredAnswerPreview`)も実PDF(`PdfCanvasRenderer`)も "A4" 固定になっていた。

## 変更内容

- **pdfExport.ts**: `PdfExportPageData` に `pageSize` を追加。個別表示(`ScoringMainView`)と同一ロジックで `MasterImage.pageSize` を算出し各ページへ付与
- **exportApi.d.ts**: IPC 戻り値型に `pageSize` を追加
- **PdfCanvasRenderer.tsx**: 描画で `page.pageSize ?? pageSize` を使用（実PDF出力も修正）
- **useScoredAnswerPreview.ts**: `page.pageSize` を直接参照

## 確認

- `npm run typecheck`（Next.js + electron-src）パス
- 変更ファイルの eslint / prettier クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)