### PR TITLE
feat: 答案返却版との差分検出による変更生徒の再印刷機能

### DIFF
--- a/__tests__/exam/integration/returnSnapshot.test.ts
+++ b/__tests__/exam/integration/returnSnapshot.test.ts
@@ -1,0 +1,157 @@
+/**
+ * ReturnSnapshot（答案返却版スナップショット）統合テスト
+ *
+ * captureReturnSnapshot / getReturnDiff の差分検出を検証する:
+ * - 記録直後は差分なし
+ * - スコア変更（status）を検知し before→after を返す
+ * - 注釈の編集・削除を annotationChanged で検知する
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import {
+  captureReturnSnapshot,
+  getReturnDiff,
+} from "@/electron-src/lib/prisma/returnSnapshot"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+describe("ReturnSnapshot capture/diff", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("記録直後は差分が無い", async () => {
+    const fx = await createFullTestExam(testPrisma, {
+      includeScores: true,
+      includeAnnotations: true,
+    })
+    const studentIds = fx.students.map((s) => s.id)
+
+    const cap = await captureReturnSnapshot({
+      examId: fx.exam.id,
+      studentIds,
+    })
+    expect(cap.success).toBe(true)
+    expect(cap.capturedCount).toBe(studentIds.length)
+
+    const diff = await getReturnDiff(fx.exam.id)
+    expect(diff.success).toBe(true)
+    expect(diff.hasAnySnapshot).toBe(true)
+    for (const d of diff.diffs) {
+      expect(d.hasSnapshot).toBe(true)
+      expect(d.changed).toBe(false)
+      expect(d.scoreChanges).toHaveLength(0)
+      expect(d.annotationChanged).toBe(false)
+    }
+  })
+
+  it("スコア変更を before→after で検知する", async () => {
+    const fx = await createFullTestExam(testPrisma, { includeScores: true })
+    const studentIds = fx.students.map((s) => s.id)
+    await captureReturnSnapshot({ examId: fx.exam.id, studentIds })
+
+    // 1件の採点を correct → incorrect に変更
+    const target = fx.questionScores[0]
+    await testPrisma.questionScore.update({
+      where: { id: target.id },
+      data: { status: "incorrect", updatedAt: new Date() },
+    })
+
+    const diff = await getReturnDiff(fx.exam.id)
+    const changed = diff.diffs.filter((d) => d.changed)
+    expect(changed).toHaveLength(1)
+
+    const d = changed[0]
+    expect(d.studentId).toBe(target.studentId)
+    const cell = d.scoreChanges.find(
+      (c) => c.cropRegionId === target.cropRegionId
+    )
+    expect(cell).toBeDefined()
+    expect(cell?.before?.status).toBe("correct")
+    expect(cell?.before?.value).toBe(10)
+    expect(cell?.after?.status).toBe("incorrect")
+    expect(cell?.after?.value).toBe(0)
+    expect(d.annotationChanged).toBe(false)
+  })
+
+  it("注釈の編集を annotationChanged で検知する", async () => {
+    const fx = await createFullTestExam(testPrisma, {
+      includeScores: true,
+      includeAnnotations: true,
+    })
+    const studentIds = fx.students.map((s) => s.id)
+    await captureReturnSnapshot({ examId: fx.exam.id, studentIds })
+
+    // 注釈のテキストを変更
+    const annotation = fx.drawingAnnotations[0]
+    await testPrisma.drawingAnnotation.update({
+      where: { id: annotation.id },
+      data: { text: "変更後コメント", updatedAt: new Date() },
+    })
+
+    const diff = await getReturnDiff(fx.exam.id)
+    const changed = diff.diffs.filter((d) => d.changed)
+    expect(changed).toHaveLength(1)
+    expect(changed[0].annotationChanged).toBe(true)
+    expect(changed[0].scoreChanges).toHaveLength(0)
+  })
+
+  it("注釈の削除を annotationChanged で検知する", async () => {
+    const fx = await createFullTestExam(testPrisma, {
+      includeScores: true,
+      includeAnnotations: true,
+    })
+    const studentIds = fx.students.map((s) => s.id)
+    await captureReturnSnapshot({ examId: fx.exam.id, studentIds })
+
+    await testPrisma.drawingAnnotation.delete({
+      where: { id: fx.drawingAnnotations[0].id },
+    })
+
+    const diff = await getReturnDiff(fx.exam.id)
+    const changed = diff.diffs.filter((d) => d.changed)
+    expect(changed).toHaveLength(1)
+    expect(changed[0].annotationChanged).toBe(true)
+  })
+
+  it("スナップショット未記録の生徒は hasSnapshot=false", async () => {
+    const fx = await createFullTestExam(testPrisma, { includeScores: true })
+    // 1人だけ返却版として記録する
+    const [first, ...rest] = fx.students.map((s) => s.id)
+    await captureReturnSnapshot({ examId: fx.exam.id, studentIds: [first] })
+
+    const diff = await getReturnDiff(fx.exam.id)
+    const firstDiff = diff.diffs.find((d) => d.studentId === first)
+    expect(firstDiff?.hasSnapshot).toBe(true)
+    for (const id of rest) {
+      const d = diff.diffs.find((x) => x.studentId === id)
+      expect(d?.hasSnapshot).toBe(false)
+      expect(d?.changed).toBe(false)
+    }
+  })
+})

--- a/__tests__/import-export/integration/collectExamDataExportMode.test.ts
+++ b/__tests__/import-export/integration/collectExamDataExportMode.test.ts
@@ -114,6 +114,31 @@ describe("collectExamData - エクスポートモード", () => {
       expect(data.examData.examSubtotalGroups.length).toBe(1)
       expect(data.tagsData.tags.length).toBeGreaterThan(0)
     })
+
+    it("EM-F3: ReturnSnapshot（返却版）がfullモードで収集される", async () => {
+      // 返却版スナップショットを1件作成
+      await getTestPrismaClient().returnSnapshot.create({
+        data: {
+          examId: testExam.exam.id,
+          studentId: testExam.students[0].id,
+          scoresJson: JSON.stringify({ v: 1, scores: [], annotations: [] }),
+          totalScore: 42,
+          capturedByUserId: testExam.user.id,
+        },
+      })
+
+      const result = await collectExamData(
+        testExam.exam.id,
+        testExam.user.id,
+        "full"
+      )
+
+      expect(result.success).toBe(true)
+      const snapshots = result.data!.scoresData.returnSnapshots ?? []
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0].studentId).toBe(testExam.students[0].id)
+      expect(snapshots[0].totalScore).toBe("42")
+    })
   })
 
   // ==========================================================================
@@ -166,6 +191,27 @@ describe("collectExamData - エクスポートモード", () => {
       expect(data.scoresData.drawingAnnotations).toEqual([])
       expect(data.counts.scores).toBe(0)
       expect(data.counts.annotations).toBe(0)
+    })
+
+    it("EM-T3b: ReturnSnapshot（返却版）もtemplateモードで空になる", async () => {
+      await getTestPrismaClient().returnSnapshot.create({
+        data: {
+          examId: testExam.exam.id,
+          studentId: testExam.students[0].id,
+          scoresJson: JSON.stringify({ v: 1, scores: [], annotations: [] }),
+          totalScore: 42,
+          capturedByUserId: testExam.user.id,
+        },
+      })
+
+      const result = await collectExamData(
+        testExam.exam.id,
+        testExam.user.id,
+        "template"
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.data!.scoresData.returnSnapshots).toEqual([])
     })
 
     it("EM-T4: 答案画像が空になる", async () => {

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -17,6 +17,10 @@ import {
   getPdfExportData,
 } from "../lib/prisma/pdfExport"
 import {
+  captureReturnSnapshot,
+  getReturnDiff,
+} from "../lib/prisma/returnSnapshot"
+import {
   buildConflictIdentifiers,
   validateScoringData,
 } from "../lib/shared/utilities/validateScoringData"
@@ -665,4 +669,20 @@ export function setupExportHandlers(): void {
       }
     }
   )
+
+  // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録する
+  registerSafeHandler(
+    "export:captureReturnSnapshot",
+    async (options: { examId: string; studentIds: string[] }) => {
+      return await captureReturnSnapshot({
+        examId: options.examId,
+        studentIds: options.studentIds,
+      })
+    }
+  )
+
+  // 返却版と現在状態の差分（変更があった生徒の検出）
+  registerSafeHandler("export:getReturnDiff", async (examId: string) => {
+    return await getReturnDiff(examId)
+  })
 }

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -251,6 +251,7 @@ export async function collectExamData(
     const questionScores: ArchiveScoresData["questionScores"] = []
     const drawingAnnotations: ArchiveScoresData["drawingAnnotations"] = []
     const scoreDecisions: ArchiveScoresData["scoreDecisions"] = []
+    const returnSnapshots: ArchiveScoresData["returnSnapshots"] = []
 
     if (!isTemplate) {
       for (const page of exam.examPages) {
@@ -328,6 +329,25 @@ export async function collectExamData(
           sourceQuestionScoreId: d.sourceQuestionScoreId,
           createdAt: d.createdAt.toISOString(),
           updatedAt: d.updatedAt.toISOString(),
+        })
+      }
+
+      // 9.6. ReturnSnapshot（返却版スナップショット）を収集 (v1.14.0+)
+      // 返却版は試験ごとに1セット（生徒×試験で1行）なので採点者フィルタはしない
+      const snapshots = await prisma.returnSnapshot.findMany({
+        where: { examId },
+      })
+      for (const s of snapshots) {
+        returnSnapshots.push({
+          id: s.id,
+          examId: s.examId,
+          studentId: s.studentId,
+          scoresJson: s.scoresJson,
+          totalScore: s.totalScore?.toString() ?? null,
+          capturedByUserId: s.capturedByUserId,
+          capturedAt: s.capturedAt.toISOString(),
+          createdAt: s.createdAt.toISOString(),
+          updatedAt: s.updatedAt.toISOString(),
         })
       }
     }
@@ -642,6 +662,7 @@ export async function collectExamData(
       questionScores,
       drawingAnnotations,
       scoreDecisions,
+      returnSnapshots,
     }
 
     const tagsData: ArchiveTagsData = {

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -576,6 +576,27 @@ export async function createImportedData(
         }
       }
 
+      // 14.6. ReturnSnapshot（返却版スナップショット）を作成 (v1.14.0+)
+      // capturedByUserId は現在のログインユーザーで上書き
+      for (const rs of data.scoresData.returnSnapshots || []) {
+        const newExamId = remapId(rs.examId, mappings.exam)
+        const newStudentId = remapId(rs.studentId, mappings.student)
+
+        if (newExamId && newStudentId) {
+          await tx.returnSnapshot.create({
+            data: {
+              id: remapIdRequired(rs.id, mappings.returnSnapshot),
+              examId: newExamId,
+              studentId: newStudentId,
+              scoresJson: rs.scoresJson,
+              totalScore: rs.totalScore ? parseFloat(rs.totalScore) : null,
+              capturedByUserId: currentUserId,
+              capturedAt: new Date(rs.capturedAt),
+            },
+          })
+        }
+      }
+
       // 15. DrawingAnnotationを作成
       // v0.3.0以降: userIdを現在のログインユーザーで上書き
       for (const da of data.scoresData.drawingAnnotations) {

--- a/electron-src/lib/import/exam-archive/idRemapper.ts
+++ b/electron-src/lib/import/exam-archive/idRemapper.ts
@@ -50,6 +50,8 @@ export interface IdMappings {
   questionScore: Record<string, string>
   /** ScoreDecision ID: 旧ID -> 新ID (v1.13.0+) */
   scoreDecision: Record<string, string>
+  /** ReturnSnapshot ID: 旧ID -> 新ID (v1.14.0+) */
+  returnSnapshot: Record<string, string>
   /** DrawingAnnotation ID: 旧ID -> 新ID */
   drawingAnnotation: Record<string, string>
   /** ExamMarkingFormat ID: 旧ID -> 新ID (v1.4.0+) */
@@ -107,6 +109,7 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
     cropSubtotal: {},
     questionScore: {},
     scoreDecision: {},
+    returnSnapshot: {},
     drawingAnnotation: {},
     examMarkingFormat: {},
     examExportSettings: {},
@@ -213,6 +216,11 @@ export function generateNewIdMappings(data: ExtractedArchiveData): IdMappings {
   // v1.13.0+: ScoreDecision
   for (const sd of data.scoresData.scoreDecisions || []) {
     mappings.scoreDecision[sd.id] = randomUUID()
+  }
+
+  // v1.14.0+: ReturnSnapshot
+  for (const rs of data.scoresData.returnSnapshots || []) {
+    mappings.returnSnapshot[rs.id] = randomUUID()
   }
 
   // DrawingAnnotation

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -39,6 +39,7 @@ import type {
  * - 1.11.0: v0.10.x (OMRバブル位置永続化, CropRegionOmrDigitBox追加, CompoundAnswer追加, cellGeometryJson削除)
  * - 1.12.0: v0.12.x (Exam.markerCorrectionEnabled 追加 — ASB由来試験のマーク補正既定ONフラグ)
  * - 1.13.0: v0.12.x (ScoreDecision 追加 — OWNERによる確定スコア。QuestionScoreのstatus proposed/final廃止)
+ * - 1.14.0: v0.13.x (ReturnSnapshot 追加 — 答案返却版スナップショット。返却後の採点修正差分検出用)
  */
 export type ArchiveVersion =
   | "1.0.0"
@@ -55,9 +56,10 @@ export type ArchiveVersion =
   | "1.11.0"
   | "1.12.0"
   | "1.13.0"
+  | "1.14.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.13.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.14.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -75,6 +77,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.11.0",
   "1.12.0",
   "1.13.0",
+  "1.14.0",
 ] as const
 
 // =============================================================================

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -200,6 +200,12 @@ export const AUDIT_ACTIONS = {
     label: "採点マークを削除しました",
   },
 
+  "exam.return.capture": {
+    category: "exam",
+    verb: "export",
+    label: "返却版として記録しました",
+  },
+
   "exam.marking_format.update": {
     category: "exam",
     verb: "update",

--- a/electron-src/lib/prisma/returnSnapshot.ts
+++ b/electron-src/lib/prisma/returnSnapshot.ts
@@ -1,0 +1,470 @@
+/**
+ * 答案返却スナップショット（ReturnSnapshot）の記録と差分検出。
+ *
+ * 「返却版として記録」操作で、その時点の有効スコア（resolveEffectiveScores の出力）と
+ * 印刷対象の手書き注釈（DrawingAnnotation）を正規化シリアライズし、生徒×試験ごとに
+ * 1行 upsert する（最新の返却版のみ保持）。
+ *
+ * 再印刷時は getReturnDiff で現在状態とスナップショットを「直接比較」し、
+ * スコアまたは注釈に変更があった生徒を絞り込む。スコアはセル単位の before→after を、
+ * 注釈は変更有無のフラグを返す（手描き図形の幾何差分は表示しない）。
+ */
+
+import { Decimal } from "@prisma/client/runtime/client"
+
+import {
+  calculateEffectiveScoreValue,
+  type EffectiveScore,
+  resolveEffectiveScores,
+} from "../shared/calculations/scoreResolution"
+import { recordAuditLog } from "./auditLog"
+import { resolveExamScope } from "./auditScope"
+import prisma from "./client"
+import { getCropRegionsByExamId } from "./cropRegion"
+import { getQuestionScoresForExam } from "./questionScore"
+import { getScoreDecisionsForExam } from "./scoreDecision"
+
+// ---- シリアライズ構造（scoresJson の中身） ----
+
+/** 現在のスナップショットフォーマットのバージョン */
+const SNAPSHOT_VERSION = 1
+
+interface SnapshotScoreCell {
+  /** cropRegionId */
+  r: string
+  /** status */
+  s: string
+  /** partialScore */
+  p: number | null
+}
+
+// 捕捉する注釈フィールドは「実際にPDF印刷で使われるもの」に限定する
+// （pdfExport.ts の annotations payload = pdfCanvasRenderer.ts の drawElement と一致）。
+// textBoxWidth/Height・horizontalAlign/verticalAlign・isFavorite 等は印刷描画に
+// 使われないため除外する（含めると印刷が同一でも誤検知になる）。出力経路がこれらを
+// 使うようになったらここにも追加すること。
+interface SnapshotAnnotation {
+  r: string // cropRegionId
+  t: string // type
+  x: number
+  y: number
+  ex: number // endX
+  ey: number // endY
+  w: number // width
+  h: number // height
+  c: string // color
+  sw: number // strokeWidth
+  ls: string // lineStyle
+  tx: string // text
+  fs: number // fontSize
+  dx: number // displayX
+  dy: number // displayY
+  ad: string // anchorDirection
+}
+
+interface SnapshotContent {
+  v: number
+  scores: SnapshotScoreCell[]
+  annotations: SnapshotAnnotation[]
+}
+
+// ---- 公開する差分結果の型 ----
+
+export interface ReturnScoreCellState {
+  status: string
+  partialScore: number | null
+  /** 配点に基づく実得点（unscored は null） */
+  value: number | null
+}
+
+export interface ReturnScoreChange {
+  cropRegionId: string
+  label: string | null
+  before: ReturnScoreCellState | null
+  after: ReturnScoreCellState | null
+}
+
+export interface ReturnStudentDiff {
+  studentId: string
+  /** この生徒に返却版スナップショットが存在するか */
+  hasSnapshot: boolean
+  /** スコアまたは注釈に変更があったか（hasSnapshot が false の場合は常に false） */
+  changed: boolean
+  /** スナップショット記録日時（ISO text）。無ければ null */
+  capturedAt: string | null
+  /** セル単位のスコア差分（変更があったセルのみ） */
+  scoreChanges: ReturnScoreChange[]
+  /** 手書き注釈に変更があったか */
+  annotationChanged: boolean
+  /** 現在の合計点 */
+  currentTotal: number | null
+  /** 返却時点の合計点 */
+  snapshotTotal: number | null
+}
+
+export interface ReturnDiffResult {
+  success: boolean
+  error?: string
+  /** 1件でも返却版スナップショットが存在するか */
+  hasAnySnapshot: boolean
+  diffs: ReturnStudentDiff[]
+}
+
+export interface CaptureReturnSnapshotResult {
+  success: boolean
+  error?: string
+  /** 記録した生徒数 */
+  capturedCount: number
+}
+
+// ---- 内部ヘルパー ----
+
+/** float のノイズによる誤検知を防ぐため小数4桁に丸める */
+const round = (n: number): number => Math.round(n * 1e4) / 1e4
+
+/** 試験の現在状態（有効スコア・注釈・領域）をまとめて読み込む */
+interface ExamState {
+  /** cropRegionId -> { label, maxScore } */
+  regions: Map<string, { label: string | null; maxScore: number | null }>
+  /** studentId -> 有効スコア配列 */
+  effectiveByStudent: Map<string, EffectiveScore[]>
+  /** studentId -> 正規化済み注釈配列（印刷対象のみ） */
+  annotationsByStudent: Map<string, SnapshotAnnotation[]>
+}
+
+const loadExamState = async (examId: string): Promise<ExamState> => {
+  const cropRegions = await getCropRegionsByExamId(examId)
+  const regions = new Map<
+    string,
+    { label: string | null; maxScore: number | null }
+  >()
+  for (const r of cropRegions) {
+    regions.set(r.id, {
+      label: r.label ?? null,
+      maxScore:
+        r.points !== null && r.points !== undefined ? Number(r.points) : null,
+    })
+  }
+
+  const scoresResult = await getQuestionScoresForExam(examId)
+  const decisionsResult = await getScoreDecisionsForExam(examId)
+  const { resolved } = resolveEffectiveScores(
+    scoresResult.success ? (scoresResult.scores ?? []) : [],
+    decisionsResult.success ? (decisionsResult.decisions ?? []) : []
+  )
+
+  const effectiveByStudent = new Map<string, EffectiveScore[]>()
+  const effectiveQsIds = new Set<string>()
+  for (const eff of resolved) {
+    const list = effectiveByStudent.get(eff.studentId)
+    if (list) list.push(eff)
+    else effectiveByStudent.set(eff.studentId, [eff])
+    if (eff.questionScoreId) effectiveQsIds.add(eff.questionScoreId)
+  }
+
+  // 印刷対象の注釈のみ（有効スコアとして採用された QuestionScore に紐づくもの）を取得
+  const annotationRows = await prisma.drawingAnnotation.findMany({
+    where: { questionScore: { cropRegion: { examPage: { examId } } } },
+    select: {
+      questionScoreId: true,
+      type: true,
+      x: true,
+      y: true,
+      endX: true,
+      endY: true,
+      width: true,
+      height: true,
+      color: true,
+      strokeWidth: true,
+      lineStyle: true,
+      text: true,
+      fontSize: true,
+      displayX: true,
+      displayY: true,
+      anchorDirection: true,
+      questionScore: { select: { studentId: true, cropRegionId: true } },
+    },
+  })
+
+  const annotationsByStudent = new Map<string, SnapshotAnnotation[]>()
+  for (const a of annotationRows) {
+    if (!effectiveQsIds.has(a.questionScoreId)) continue // 印刷されない注釈は除外
+    const normalized: SnapshotAnnotation = {
+      r: a.questionScore.cropRegionId,
+      t: a.type,
+      x: round(a.x),
+      y: round(a.y),
+      ex: round(a.endX),
+      ey: round(a.endY),
+      w: round(a.width),
+      h: round(a.height),
+      c: a.color,
+      sw: round(a.strokeWidth),
+      ls: a.lineStyle,
+      tx: a.text,
+      fs: round(a.fontSize),
+      dx: round(a.displayX),
+      dy: round(a.displayY),
+      ad: a.anchorDirection,
+    }
+    const studentId = a.questionScore.studentId
+    const list = annotationsByStudent.get(studentId)
+    if (list) list.push(normalized)
+    else annotationsByStudent.set(studentId, [normalized])
+  }
+
+  return { regions, effectiveByStudent, annotationsByStudent }
+}
+
+/** 1生徒分の正規化済みスナップショット内容を構築する */
+const buildContent = (
+  effective: EffectiveScore[],
+  annotations: SnapshotAnnotation[]
+): SnapshotContent => {
+  const scores: SnapshotScoreCell[] = effective
+    .filter((e) => e.status !== "unscored")
+    .map((e) => ({ r: e.cropRegionId, s: e.status, p: e.partialScore }))
+    .sort((a, b) => (a.r < b.r ? -1 : a.r > b.r ? 1 : 0))
+
+  // 注釈は id を含めず内容で安定ソート（削除+同内容再作成は「変更なし」とみなす）
+  const sortedAnnotations = [...annotations].sort((a, b) => {
+    const ka = JSON.stringify(a)
+    const kb = JSON.stringify(b)
+    return ka < kb ? -1 : ka > kb ? 1 : 0
+  })
+
+  return { v: SNAPSHOT_VERSION, scores, annotations: sortedAnnotations }
+}
+
+/** 正規化内容を決定的なJSON文字列にする（直接比較用） */
+const serializeContent = (content: SnapshotContent): string =>
+  JSON.stringify(content)
+
+/** 1生徒分の合計点を計算する */
+const computeTotal = (
+  effective: EffectiveScore[],
+  regions: ExamState["regions"]
+): number | null => {
+  let total = 0
+  let hasAny = false
+  for (const e of effective) {
+    const maxScore = regions.get(e.cropRegionId)?.maxScore ?? 0
+    const value = calculateEffectiveScoreValue(e, maxScore)
+    if (value !== null) {
+      total += value
+      hasAny = true
+    }
+  }
+  return hasAny ? total : null
+}
+
+// ---- 公開API ----
+
+/**
+ * 指定生徒の現在の有効スコア＋注釈を「返却版」としてスナップショット記録する（upsert）。
+ */
+export const captureReturnSnapshot = async (options: {
+  examId: string
+  studentIds: string[]
+  capturedByUserId?: string | null
+}): Promise<CaptureReturnSnapshotResult> => {
+  const { examId, studentIds, capturedByUserId = null } = options
+  try {
+    const state = await loadExamState(examId)
+    const now = new Date()
+
+    let capturedCount = 0
+    for (const studentId of studentIds) {
+      const effective = state.effectiveByStudent.get(studentId) ?? []
+      const annotations = state.annotationsByStudent.get(studentId) ?? []
+      const content = buildContent(effective, annotations)
+      const scoresJson = serializeContent(content)
+      const total = computeTotal(effective, state.regions)
+      const totalScore = total !== null ? new Decimal(total) : null
+
+      await prisma.returnSnapshot.upsert({
+        where: { examId_studentId: { examId, studentId } },
+        create: {
+          examId,
+          studentId,
+          scoresJson,
+          totalScore,
+          capturedByUserId,
+          capturedAt: now,
+        },
+        update: {
+          scoresJson,
+          totalScore,
+          capturedByUserId,
+          capturedAt: now,
+        },
+      })
+      capturedCount++
+    }
+
+    // 監査ログ: 返却版として記録（生徒ごとではなく操作単位で1件）
+    const scope = await resolveExamScope(examId)
+    await recordAuditLog({
+      action: "exam.return.capture",
+      userId: capturedByUserId,
+      entityType: "ReturnSnapshot",
+      entityId: examId,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+      summary: `${capturedCount}名の答案を返却版として記録しました`,
+      extra: { studentCount: capturedCount },
+    })
+
+    return { success: true, capturedCount }
+  } catch (error) {
+    console.error("Failed to capture return snapshot:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      capturedCount: 0,
+    }
+  }
+}
+
+const toCellState = (
+  cell: SnapshotScoreCell | undefined,
+  maxScore: number | null
+): ReturnScoreCellState | null => {
+  if (!cell) return null
+  return {
+    status: cell.s,
+    partialScore: cell.p,
+    value: calculateEffectiveScoreValue(
+      { status: cell.s, partialScore: cell.p },
+      maxScore ?? 0
+    ),
+  }
+}
+
+/**
+ * 現在の有効スコア＋注釈と、記録済み返却版スナップショットの差分を返す。
+ * 返却版が存在する生徒について、スコア（セル単位 before→after）と注釈の変更有無を判定する。
+ */
+export const getReturnDiff = async (
+  examId: string
+): Promise<ReturnDiffResult> => {
+  try {
+    const state = await loadExamState(examId)
+
+    const snapshots = await prisma.returnSnapshot.findMany({
+      where: { examId },
+      select: {
+        studentId: true,
+        scoresJson: true,
+        totalScore: true,
+        capturedAt: true,
+      },
+    })
+    const snapshotByStudent = new Map(snapshots.map((s) => [s.studentId, s]))
+
+    // スナップショットを持つ生徒 ∪ 現在の採点データを持つ生徒
+    const studentIds = new Set<string>([
+      ...snapshotByStudent.keys(),
+      ...state.effectiveByStudent.keys(),
+    ])
+
+    const diffs: ReturnStudentDiff[] = []
+    for (const studentId of studentIds) {
+      const effective = state.effectiveByStudent.get(studentId) ?? []
+      const annotations = state.annotationsByStudent.get(studentId) ?? []
+      const currentContent = buildContent(effective, annotations)
+      const currentTotal = computeTotal(effective, state.regions)
+
+      const snapshot = snapshotByStudent.get(studentId)
+      if (!snapshot) {
+        diffs.push({
+          studentId,
+          hasSnapshot: false,
+          changed: false,
+          capturedAt: null,
+          scoreChanges: [],
+          annotationChanged: false,
+          currentTotal,
+          snapshotTotal: null,
+        })
+        continue
+      }
+
+      let snapshotContent: SnapshotContent
+      try {
+        snapshotContent = JSON.parse(snapshot.scoresJson) as SnapshotContent
+      } catch {
+        // 壊れたスナップショットは差分不能 → 変更扱いで安全側に倒す
+        diffs.push({
+          studentId,
+          hasSnapshot: true,
+          changed: true,
+          capturedAt: toIso(snapshot.capturedAt),
+          scoreChanges: [],
+          annotationChanged: false,
+          currentTotal,
+          snapshotTotal:
+            snapshot.totalScore !== null ? Number(snapshot.totalScore) : null,
+        })
+        continue
+      }
+
+      // スコアのセル単位差分
+      const beforeScores = new Map(snapshotContent.scores.map((c) => [c.r, c]))
+      const afterScores = new Map(currentContent.scores.map((c) => [c.r, c]))
+      const cellIds = new Set<string>([
+        ...beforeScores.keys(),
+        ...afterScores.keys(),
+      ])
+      const scoreChanges: ReturnScoreChange[] = []
+      for (const cropRegionId of cellIds) {
+        const before = beforeScores.get(cropRegionId)
+        const after = afterScores.get(cropRegionId)
+        const same =
+          before && after && before.s === after.s && before.p === after.p
+        if (same) continue
+        const maxScore = state.regions.get(cropRegionId)?.maxScore ?? null
+        scoreChanges.push({
+          cropRegionId,
+          label: state.regions.get(cropRegionId)?.label ?? null,
+          before: toCellState(before, maxScore),
+          after: toCellState(after, maxScore),
+        })
+      }
+
+      // 注釈差分（内容ベースの直接比較）
+      const annotationChanged =
+        JSON.stringify(snapshotContent.annotations) !==
+        JSON.stringify(currentContent.annotations)
+
+      diffs.push({
+        studentId,
+        hasSnapshot: true,
+        changed: scoreChanges.length > 0 || annotationChanged,
+        capturedAt: toIso(snapshot.capturedAt),
+        scoreChanges,
+        annotationChanged,
+        currentTotal,
+        snapshotTotal:
+          snapshot.totalScore !== null ? Number(snapshot.totalScore) : null,
+      })
+    }
+
+    return {
+      success: true,
+      hasAnySnapshot: snapshots.length > 0,
+      diffs,
+    }
+  } catch (error) {
+    console.error("Failed to compute return diff:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      hasAnySnapshot: false,
+      diffs: [],
+    }
+  }
+}
+
+const toIso = (value: Date | string): string =>
+  typeof value === "string" ? value : value.toISOString()

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -91,6 +91,14 @@ export function createExportApi() {
         pageSize?: "A4" | "Letter" | { width: number; height: number }
         landscape?: boolean
       }) => ipcRenderer.invoke("export:openPrintDialog", options),
+      // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録
+      captureReturnSnapshot: (options: {
+        examId: string
+        studentIds: string[]
+      }) => ipcRenderer.invoke("export:captureReturnSnapshot", options),
+      // 返却版と現在状態の差分（変更があった生徒の検出）
+      getReturnDiff: (examId: string) =>
+        ipcRenderer.invoke("export:getReturnDiff", examId),
     },
 
     // Excel Export related

--- a/prisma/migrations/20260615000000_add_return_snapshot/migration.sql
+++ b/prisma/migrations/20260615000000_add_return_snapshot/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable: 答案返却（公式出力）時点の有効スコア＋手書き注釈のスナップショット。
+-- 「返却版として記録」操作のたびに生徒×試験ごとに1行を upsert で上書きする
+-- （最新の返却版のみ保持）。再印刷時はこれを基準に現在状態との差分を取り、
+-- 変更があった生徒だけを絞り込む。
+CREATE TABLE "ReturnSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "examId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "scoresJson" TEXT NOT NULL,
+    "totalScore" DECIMAL,
+    "capturedByUserId" TEXT,
+    "capturedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReturnSnapshot_examId_fkey" FOREIGN KEY ("examId") REFERENCES "Exam" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ReturnSnapshot_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReturnSnapshot_examId_studentId_key" ON "ReturnSnapshot"("examId", "studentId");
+
+-- CreateIndex
+CREATE INDEX "ReturnSnapshot_studentId_idx" ON "ReturnSnapshot"("studentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model Student {
   gradeItemExclusions  GradeItemExclusion[]
   compoundAnswerScores CompoundAnswerScore[]
   scoreDecisions       ScoreDecision[]
+  returnSnapshots      ReturnSnapshot[]
 }
 
 model StudentClassMembership {
@@ -102,6 +103,7 @@ model Exam {
   exportSettings     ExamExportSettings?
   gradeDataSources   GradeDataSource[]
   examTags           ExamTag[]
+  returnSnapshots    ReturnSnapshot[]
 }
 
 model ExamStudent {
@@ -320,6 +322,32 @@ model DrawingAnnotation {
   @@index([type])
   @@index([createdAt])
   @@index([isFavorite])
+}
+
+/// 答案返却（公式出力）時点の有効スコア＋手書き注釈のスナップショット。
+/// 「返却版として記録」操作のたびに生徒×試験ごとに1行を upsert で上書きする
+/// （最新の返却版のみ保持）。再印刷時はこれを基準に現在状態との差分を取り、
+/// 変更があった生徒だけを絞り込む。scoresJson は resolveEffectiveScores() の出力と
+/// 印刷対象の DrawingAnnotation を正規化シリアライズした文字列。
+model ReturnSnapshot {
+  id               String   @id @default(uuid())
+  examId           String
+  studentId        String
+  /// 有効スコア＋注釈の正規化JSON（直接比較で差分判定する）
+  scoresJson       String
+  /// 返却時点の合計点（表示用。null可）
+  totalScore       Decimal?
+  /// 返却操作を行った操作者。システム操作はnull
+  capturedByUserId String?
+  /// 返却版として記録した日時（ISO text）
+  capturedAt       DateTime @default(now())
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @default(now()) @updatedAt
+  exam             Exam     @relation(fields: [examId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  student          Student  @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([examId, studentId])
+  @@index([studentId])
 }
 
 model DeletedRecord {

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -18,6 +18,7 @@ import {
   PdfCanvasRenderer,
   type PdfExportPageData,
 } from "@/components/exams/08-export/components/PdfCanvasRenderer"
+import { ReturnDiffPanel } from "@/components/exams/08-export/components/ReturnDiffPanel"
 import { StudentSelectionCard } from "@/components/exams/08-export/components/StudentSelectionCard"
 import { useExcelPreview } from "@/components/exams/08-export/hooks/useExcelPreview"
 import { useExportPage } from "@/components/exams/08-export/hooks/useExportPage"
@@ -762,8 +763,15 @@ export default function ExportMainView() {
     <div className="flex h-full flex-col">
       <PageHeader title="採点結果のファイル出力" helpButton={helpButton} />
 
-      <div className="container mx-auto min-h-0 flex-1 px-4 py-6">
-        <div className="grid h-full grid-cols-1 gap-6 lg:grid-cols-2">
+      <div className="container mx-auto flex min-h-0 flex-1 flex-col gap-6 px-4 py-6">
+        <ReturnDiffPanel
+          examId={exam?.id ?? ""}
+          students={students}
+          selectedStudents={selectedStudents}
+          setSelectedStudents={setSelectedStudents}
+        />
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2">
           <div className="h-full min-h-0">
             <StudentSelectionCard
               students={students} // 受験生徒順（customOrder）でソート済み

--- a/src/components/exams/08-export/components/ReturnDiffPanel.tsx
+++ b/src/components/exams/08-export/components/ReturnDiffPanel.tsx
@@ -1,0 +1,204 @@
+"use client"
+
+import { ArrowRight, FileCheck, Filter, PencilLine } from "lucide-react"
+import { useState } from "react"
+
+import type { Student } from "@/app/exams/[examId]/08-export/types"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import type {
+  ReturnScoreCellState,
+  ReturnStudentDiff,
+} from "@/electron-src/lib/prisma/returnSnapshot"
+
+import { useReturnDiff } from "../hooks/useReturnDiff"
+
+/** 採点判定コードを日本語表示に変換 */
+const statusLabel = (status: string): string => {
+  switch (status) {
+    case "correct":
+      return "正解"
+    case "incorrect":
+      return "不正解"
+    case "partial":
+      return "部分点"
+    case "pending":
+      return "保留"
+    case "no_answer":
+      return "無答"
+    case "double_mark":
+      return "二重マーク"
+    case "unscored":
+      return "未採点"
+    default:
+      return status
+  }
+}
+
+/** セル状態を「判定（得点）」形式の文字列にする */
+const cellText = (cell: ReturnScoreCellState | null): string => {
+  if (!cell) return "（なし）"
+  const label = statusLabel(cell.status)
+  if (cell.value !== null) return `${label}（${cell.value}点）`
+  return label
+}
+
+interface ReturnDiffPanelProps {
+  examId: string
+  /** 表示名解決用の生徒一覧（フィルタ前の全件が望ましい） */
+  students: Student[]
+  selectedStudents: Set<string>
+  setSelectedStudents: (students: Set<string>) => void
+}
+
+/**
+ * 答案返却・差分パネル。
+ * 「返却版として記録」と、前回返却分から変更があった生徒の検出・絞り込みを行う。
+ */
+export function ReturnDiffPanel({
+  examId,
+  students,
+  selectedStudents,
+  setSelectedStudents,
+}: ReturnDiffPanelProps) {
+  const {
+    diffByStudent,
+    changedStudentIds,
+    hasAnySnapshot,
+    capturing,
+    capture,
+  } = useReturnDiff(examId)
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const studentName = (id: string): string => {
+    const s = students.find((st) => st.id === id)
+    return s ? `${s.lastName} ${s.firstName}` : id
+  }
+
+  // 変更があった生徒の差分（名前順は students の並びに従う）
+  const changedDiffs: ReturnStudentDiff[] = students
+    .map((s) => diffByStudent.get(s.id))
+    .filter((d): d is ReturnStudentDiff => !!d && d.changed)
+
+  const selectChangedOnly = () => {
+    setSelectedStudents(new Set(changedStudentIds))
+  }
+
+  const handleCapture = async () => {
+    await capture(Array.from(selectedStudents))
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FileCheck className="h-4 w-4" />
+          答案返却・差分
+        </CardTitle>
+        <CardDescription>
+          現在の採点内容を「返却版」として記録すると、以降に採点（スコア・採点マーク）を
+          修正した生徒だけを抽出して再印刷できます。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCapture}
+            disabled={capturing || selectedStudents.size === 0}
+          >
+            <FileCheck className="mr-1 h-4 w-4" />
+            選択中の{selectedStudents.size}名を返却版として記録
+          </Button>
+
+          {hasAnySnapshot && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={selectChangedOnly}
+              disabled={changedStudentIds.size === 0}
+            >
+              <Filter className="mr-1 h-4 w-4" />
+              変更があった生徒のみ選択（{changedStudentIds.size}名）
+            </Button>
+          )}
+        </div>
+
+        {hasAnySnapshot ? (
+          changedDiffs.length > 0 ? (
+            <Collapsible open={detailOpen} onOpenChange={setDetailOpen}>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm" className="px-2">
+                  {detailOpen ? "変更内容を隠す" : "変更内容を表示"}（
+                  {changedDiffs.length}名）
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2 max-h-64 space-y-3 overflow-y-auto pr-1">
+                {changedDiffs.map((diff) => (
+                  <div
+                    key={diff.studentId}
+                    className="border-border rounded-md border p-3 text-sm"
+                  >
+                    <div className="mb-1 flex items-center gap-2 font-medium">
+                      {studentName(diff.studentId)}
+                      {diff.annotationChanged && (
+                        <Badge variant="secondary" className="gap-1">
+                          <PencilLine className="h-3 w-3" />
+                          採点マーク変更
+                        </Badge>
+                      )}
+                    </div>
+                    {diff.scoreChanges.length > 0 ? (
+                      <ul className="text-muted-foreground space-y-0.5">
+                        {diff.scoreChanges.map((c) => (
+                          <li
+                            key={c.cropRegionId}
+                            className="flex items-center gap-1.5"
+                          >
+                            <span className="text-foreground">
+                              {c.label || "設問"}:
+                            </span>
+                            <span>{cellText(c.before)}</span>
+                            <ArrowRight className="h-3 w-3 shrink-0" />
+                            <span className="text-foreground">
+                              {cellText(c.after)}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="text-muted-foreground">
+                        採点マークのみ変更
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              前回返却時から変更があった生徒はいません。
+            </p>
+          )
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            まだ返却版が記録されていません。出力対象の生徒を選んで「返却版として記録」してください。
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/exams/08-export/hooks/useReturnDiff.ts
+++ b/src/components/exams/08-export/hooks/useReturnDiff.ts
@@ -1,0 +1,94 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import type {
+  ReturnDiffResult,
+  ReturnStudentDiff,
+} from "@/electron-src/lib/prisma/returnSnapshot"
+
+/**
+ * 答案返却スナップショットの記録と差分検出を管理するフック。
+ *
+ * - capture: 選択中の生徒を「返却版」として記録する
+ * - diffByStudent: 生徒ID → 差分（返却版との比較結果）
+ * - changedStudentIds: 返却版から変更があった生徒IDの集合
+ */
+export function useReturnDiff(examId: string) {
+  const [diffByStudent, setDiffByStudent] = useState<
+    Map<string, ReturnStudentDiff>
+  >(new Map())
+  const [hasAnySnapshot, setHasAnySnapshot] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [capturing, setCapturing] = useState(false)
+
+  const refresh = useCallback(async () => {
+    if (!examId || !window.electronAPI?.export?.getReturnDiff) return
+    setLoading(true)
+    try {
+      const result: ReturnDiffResult =
+        await window.electronAPI.export.getReturnDiff(examId)
+      if (result.success) {
+        setDiffByStudent(new Map(result.diffs.map((d) => [d.studentId, d])))
+        setHasAnySnapshot(result.hasAnySnapshot)
+      } else {
+        console.error("返却差分の取得に失敗しました:", result.error)
+      }
+    } catch (error) {
+      console.error("返却差分の取得に失敗しました:", error)
+    } finally {
+      setLoading(false)
+    }
+  }, [examId])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  /** 指定生徒を返却版として記録する */
+  const capture = useCallback(
+    async (studentIds: string[]): Promise<boolean> => {
+      if (!examId || studentIds.length === 0) return false
+      setCapturing(true)
+      try {
+        const result = await window.electronAPI.export.captureReturnSnapshot({
+          examId,
+          studentIds,
+        })
+        if (result.success) {
+          toast.success(`${result.capturedCount}名を返却版として記録しました`)
+          await refresh()
+          return true
+        }
+        toast.error(`返却版の記録に失敗しました: ${result.error ?? ""}`)
+        return false
+      } catch (error) {
+        console.error("返却版の記録に失敗しました:", error)
+        toast.error("返却版の記録に失敗しました")
+        return false
+      } finally {
+        setCapturing(false)
+      }
+    },
+    [examId, refresh]
+  )
+
+  const changedStudentIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const diff of diffByStudent.values()) {
+      if (diff.changed) ids.add(diff.studentId)
+    }
+    return ids
+  }, [diffByStudent])
+
+  return {
+    diffByStudent,
+    changedStudentIds,
+    hasAnySnapshot,
+    loading,
+    capturing,
+    capture,
+    refresh,
+  }
+}

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -3,6 +3,10 @@ import type {
   IndividualReportOptions,
   SubtotalGroupsForReportResult,
 } from "@/electron-src/lib/export/individual-report/types"
+import type {
+  CaptureReturnSnapshotResult,
+  ReturnDiffResult,
+} from "@/electron-src/lib/prisma/returnSnapshot"
 
 /**
  * エクスポート（PDF/Excel/印刷）関連API
@@ -299,6 +303,15 @@ export interface ExportAPI {
       success: boolean
       error?: string
     }>
+
+    // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録
+    captureReturnSnapshot: (options: {
+      examId: string
+      studentIds: string[]
+    }) => Promise<CaptureReturnSnapshotResult>
+
+    // 返却版と現在状態の差分（変更があった生徒の検出）
+    getReturnDiff: (examId: string) => Promise<ReturnDiffResult>
   }
 
   // Excel Export related

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -944,6 +944,18 @@ export interface ArchiveScoresData {
     createdAt: string
     updatedAt: string
   }>
+  /** v1.14.0+ 答案返却版スナップショット（生徒×試験で1行）。旧バージョンのアーカイブには存在しない */
+  returnSnapshots?: Array<{
+    id: string
+    examId: string
+    studentId: string
+    scoresJson: string
+    totalScore: string | null // Decimal as string
+    capturedByUserId: string | null
+    capturedAt: string
+    createdAt: string
+    updatedAt: string
+  }>
 }
 
 /**


### PR DESCRIPTION
## 概要

答案返却後に採点を修正した生徒だけを抽出して再印刷できる機能を実装する。ある時点の採点内容を「返却版」として記録し、その後の変更（スコア・手書き注釈）を検出する。

Closes #857

## 変更内容

- **スキーマ**: `ReturnSnapshot` モデル新設（`@@unique([examId, studentId])` で最新版1行upsert）＋手書きマイグレーション `20260615000000_add_return_snapshot`
- **lib**: `captureReturnSnapshot` / `getReturnDiff`（`resolveEffectiveScores` を流用）。注釈は印刷描画で使う15フィールドに限定して正規化・直接比較
- **IPC/preload/型**: `export:captureReturnSnapshot` / `export:getReturnDiff`
- **UI**: 08-export に `ReturnDiffPanel` / `useReturnDiff`（返却記録・差分表示・変更生徒の絞り込み）
- **監査**: アクション `exam.return.capture`
- **アーカイブ**: Import/Export 対応（`CURRENT_VERSION` 1.14.0、`returnSnapshots`）
- **テスト**: capture/diff（スコア変更・注釈編集/削除・未記録）、collector 収集

## 設計上のポイント

- 記録は明示的な「返却版として記録」操作のみ／最新版1行のみ保持。
- 差分対象は実際に印刷される内容（スコア＋手書き注釈）に限定。採点マーク色は全生徒共通設定のため対象外。
- 印刷描画に使われない注釈フィールド（textBox/align 等）は除外し誤検知を防止。

## 確認事項

- `npm run check-all`（型チェック両方＋eslint＋prettier）通過
- 関連テスト全パス（returnSnapshot / collectExamDataExportMode / 監査 / アーカイブ round-trip）

## 関連

- 調査中に判明した `CropRegionMarkingOverride`（機能H）の孤立問題は #852 で別途起票済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
