### PR TITLE
feat: 成績算出に文字評価・点数変換・加減点・コメントを追加

### DIFF
--- a/__tests__/grade/integration/manualScoreCrud.test.ts
+++ b/__tests__/grade/integration/manualScoreCrud.test.ts
@@ -26,6 +26,7 @@ import {
   createDataSource,
   getDataSourcesByGradeItemId,
   reorderDataSources,
+  updateDataSource,
 } from "@/electron-src/lib/prisma/gradeDataSource"
 import { createGradeItem } from "@/electron-src/lib/prisma/gradeItem"
 import {
@@ -173,6 +174,132 @@ describe("ManualScore CRUD", () => {
     it("空配列の場合は何も起きない", async () => {
       const result = await batchUpsertManualScores([])
       expect(result.success).toBe(true)
+    })
+
+    it("文字評価・加減点・理由・コメントを保存できる", async () => {
+      const { dataSource, student1 } = await createTestData()
+
+      const result = await batchUpsertManualScores([
+        {
+          gradeDataSourceId: dataSource.id,
+          studentId: student1.id,
+          letterValue: "A",
+          adjustment: -5,
+          adjustmentReason: "期限超過",
+          comment: "丁寧にまとめられています",
+        },
+      ])
+      expect(result.success).toBe(true)
+
+      const scores = await getManualScoresByDataSourceId(dataSource.id)
+      const ms = scores.manualScores![0]
+      expect(ms.letterValue).toBe("A")
+      expect(Number(ms.adjustment)).toBe(-5)
+      expect(ms.adjustmentReason).toBe("期限超過")
+      expect(ms.comment).toBe("丁寧にまとめられています")
+    })
+
+    it("指定フィールドのみ部分更新できる（他フィールドは保持）", async () => {
+      const { dataSource, student1 } = await createTestData()
+
+      // まずスコアとコメントを設定
+      await batchUpsertManualScores([
+        {
+          gradeDataSourceId: dataSource.id,
+          studentId: student1.id,
+          score: 80,
+          comment: "初回コメント",
+        },
+      ])
+
+      // adjustmentのみ更新（score/commentは指定しない）
+      await batchUpsertManualScores([
+        {
+          gradeDataSourceId: dataSource.id,
+          studentId: student1.id,
+          adjustment: 10,
+        },
+      ])
+
+      const scores = await getManualScoresByDataSourceId(dataSource.id)
+      const ms = scores.manualScores![0]
+      expect(Number(ms.score)).toBe(80)
+      expect(Number(ms.adjustment)).toBe(10)
+      expect(ms.comment).toBe("初回コメント")
+    })
+  })
+
+  describe("文字評価データソース", () => {
+    it("inputMode='letter' と変換表を作成・取得できる", async () => {
+      const grade = await testPrisma.grade.create({
+        data: { name: "文字評価PJ" },
+      })
+      const gradeItemResult = await createGradeItem({
+        gradeId: grade.id,
+        name: "授業態度",
+      })
+
+      const dsResult = await createDataSource({
+        gradeItemId: gradeItemResult.gradeItem!.id,
+        type: "manual",
+        name: "観点別評価",
+        maxScore: 100,
+        weight: 100,
+        inputMode: "letter",
+        letterScales: [
+          { label: "A", score: 100, order: 0 },
+          { label: "B", score: 80, order: 1 },
+          { label: "C", score: 60, order: 2 },
+        ],
+      })
+
+      expect(dsResult.success).toBe(true)
+      expect(dsResult.dataSource!.inputMode).toBe("letter")
+      expect(dsResult.dataSource!.letterScales).toHaveLength(3)
+
+      const fetched = await getDataSourcesByGradeItemId(
+        gradeItemResult.gradeItem!.id
+      )
+      const ds = fetched.dataSources![0]
+      expect(ds.letterScales).toHaveLength(3)
+      expect(ds.letterScales[0].label).toBe("A")
+      expect(Number(ds.letterScales[0].score)).toBe(100)
+    })
+
+    it("updateDataSourceで変換表を全置換できる", async () => {
+      const grade = await testPrisma.grade.create({
+        data: { name: "文字評価PJ2" },
+      })
+      const gradeItemResult = await createGradeItem({
+        gradeId: grade.id,
+        name: "観点",
+      })
+      const dsResult = await createDataSource({
+        gradeItemId: gradeItemResult.gradeItem!.id,
+        type: "manual",
+        name: "評価",
+        maxScore: 100,
+        weight: 100,
+        inputMode: "letter",
+        letterScales: [
+          { label: "A", score: 100, order: 0 },
+          { label: "B", score: 80, order: 1 },
+        ],
+      })
+
+      // 2段階の新しい変換表で置換
+      const updated = await updateDataSource(dsResult.dataSource!.id, {
+        letterScales: [{ label: "○", score: 100, order: 0 }],
+      })
+      expect(updated.success).toBe(true)
+      expect(updated.dataSource!.letterScales).toHaveLength(1)
+      expect(updated.dataSource!.letterScales[0].label).toBe("○")
+
+      // DB上も1件のみ（古い2件は削除されている）
+      const remaining = await testPrisma.gradeLetterScale.findMany({
+        where: { gradeDataSourceId: dsResult.dataSource!.id },
+      })
+      expect(remaining).toHaveLength(1)
     })
   })
 

--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -72,7 +72,14 @@ function buildGrade(
         exam?: unknown
         subtotal?: unknown
         cropRegion?: unknown
-        manualScores?: { studentId: string; score: unknown }[]
+        manualScores?: {
+          studentId: string
+          score?: unknown
+          letterValue?: string | null
+          adjustment?: unknown
+          adjustmentReason?: string | null
+          comment?: string | null
+        }[]
         order: number
         absentMethod?: string
         absentRatio?: number
@@ -80,6 +87,8 @@ function buildGrade(
         treatExpectedAsMissing?: boolean
         estimationMode?: string
         estimationSourceIds?: string
+        inputMode?: string
+        letterScales?: { label: string; score: number; order: number }[]
       }[]
     }[]
     boundarySets?: {
@@ -698,6 +707,237 @@ describe("calculateGrades", () => {
     expect(student.gradeItemResults[0].isExcluded).toBe(false)
     expect(student.gradeItemResults[0].weightedScore).toBeCloseTo(80)
     expect(student.overallPercentage).toBeCloseTo(80)
+  })
+
+  // ===========================================================================
+  // 文字評価（letterモード）+ 加減点テスト
+  // ===========================================================================
+
+  it("letterモード: 評価記号を変換表で点数化する", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "授業態度",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              inputMode: "letter",
+              letterScales: [
+                { label: "A", score: 100, order: 0 },
+                { label: "B", score: 80, order: 1 },
+                { label: "C", score: 60, order: 2 },
+              ],
+              manualScores: [{ studentId: "s1", letterValue: "B" }],
+              order: 0,
+            },
+          ],
+        },
+      ],
+      boundarySets: [
+        {
+          id: "bs1",
+          targetType: "grade_item",
+          gradeItemId: "gi1",
+          boundaries: [
+            { label: "A", minPercentage: 90, order: 0 },
+            { label: "B", minPercentage: 70, order: 1 },
+            { label: "C", minPercentage: 0, order: 2 },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+
+    // B → 80点
+    expect(ss.rawScore).toBe(80)
+    expect(ss.letterValue).toBe("B")
+    expect(
+      result.result!.students[0].gradeItemResults[0].percentage
+    ).toBeCloseTo(80)
+    // 80% → 評価B
+    expect(result.result!.students[0].gradeItemResults[0].gradeLabel).toBe("B")
+  })
+
+  it("letterモード: 未定義の評価記号はnull", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "授業態度",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              inputMode: "letter",
+              letterScales: [{ label: "A", score: 100, order: 0 }],
+              manualScores: [{ studentId: "s1", letterValue: "Z" }],
+              order: 0,
+            },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+    expect(ss.rawScore).toBeNull()
+  })
+
+  it("加減点: 数値スコアに加算しクランプする", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "レポート",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              inputMode: "numeric",
+              manualScores: [
+                {
+                  studentId: "s1",
+                  score: 85,
+                  adjustment: -10,
+                  adjustmentReason: "期限超過",
+                },
+              ],
+              order: 0,
+            },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+
+    // 85 - 10 = 75
+    expect(ss.rawScore).toBe(75)
+    expect(ss.adjustment).toBe(-10)
+    expect(ss.adjustmentReason).toBe("期限超過")
+  })
+
+  it("加減点: letterモードの点数にも加算される（上限クランプ）", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "授業態度",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              inputMode: "letter",
+              letterScales: [{ label: "A", score: 100, order: 0 }],
+              manualScores: [
+                { studentId: "s1", letterValue: "A", adjustment: 20 },
+              ],
+              order: 0,
+            },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+
+    // A(100) + 20 = 120 → clamp 100
+    expect(ss.rawScore).toBe(100)
+  })
+
+  it("コメントがsourceScoresに添付される", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "レポート",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              manualScores: [
+                {
+                  studentId: "s1",
+                  score: 90,
+                  comment: "とても良い内容でした",
+                },
+              ],
+              order: 0,
+            },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+    expect(ss.comment).toBe("とても良い内容でした")
   })
 
   it("実スコアがある場合 → isEstimated=false", async () => {

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -105,6 +105,86 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(importedSettings!.settingsJson).toBe(settingsJson)
   })
 
+  it("文字評価変換表・inputMode・加減点・コメントが往復で保持される (v1.3.0)", async () => {
+    const grade = await prisma.grade.create({
+      data: { name: `成績_letter_${Date.now()}` },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "授業態度", order: 0 },
+    })
+    const ds = await prisma.gradeDataSource.create({
+      data: {
+        gradeItemId: gradeItem.id,
+        type: "manual",
+        name: "観点別評価",
+        maxScore: 100,
+        weight: 100,
+        order: 0,
+        inputMode: "letter",
+        letterScales: {
+          create: [
+            { label: "A", score: 100, order: 0 },
+            { label: "B", score: 80, order: 1 },
+            { label: "C", score: 60, order: 2 },
+          ],
+        },
+      },
+    })
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SL_${Date.now()}`,
+        lastName: "鈴木",
+        firstName: "一郎",
+        lastNameKana: "スズキ",
+        firstNameKana: "イチロウ",
+      },
+    })
+    await prisma.manualScore.create({
+      data: {
+        gradeDataSourceId: ds.id,
+        studentId: student.id,
+        letterValue: "B",
+        adjustment: -5,
+        adjustmentReason: "提出遅延",
+        comment: "発表が活発でした",
+      },
+    })
+
+    // 収集（export）
+    const collected = await collectGradeArchiveData(grade.id)
+    const collectedDs = collected.gradeData.gradeItems[0].dataSources[0]
+    expect(collectedDs.inputMode).toBe("letter")
+    expect(collectedDs.letterScales).toHaveLength(3)
+    const collectedMs = collected.manualScoresData.manualScores[0]
+    expect(collectedMs.letterValue).toBe("B")
+    expect(collectedMs.adjustment).toBe(-5)
+    expect(collectedMs.comment).toBe("発表が活発でした")
+
+    // インポート
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    const importedDs = await prisma.gradeDataSource.findFirst({
+      where: {
+        gradeItem: { gradeId: result.gradeId! },
+        name: "観点別評価",
+      },
+      include: { letterScales: { orderBy: { order: "asc" } } },
+    })
+    expect(importedDs!.inputMode).toBe("letter")
+    expect(importedDs!.letterScales).toHaveLength(3)
+    expect(importedDs!.letterScales[0].label).toBe("A")
+    expect(Number(importedDs!.letterScales[0].score)).toBe(100)
+
+    const importedMs = await prisma.manualScore.findFirst({
+      where: { gradeDataSourceId: importedDs!.id },
+    })
+    expect(importedMs!.letterValue).toBe("B")
+    expect(Number(importedMs!.adjustment)).toBe(-5)
+    expect(importedMs!.adjustmentReason).toBe("提出遅延")
+    expect(importedMs!.comment).toBe("発表が活発でした")
+  })
+
   it("referenceDate/exportSettings が無いGradeも問題なく往復する（後方互換）", async () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_min_${Date.now()}` },

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -236,6 +236,8 @@ export function setupGradeHandlers(): void {
       treatExpectedAsMissing?: boolean
       estimationMode?: string
       estimationSourceIds?: string[]
+      inputMode?: string
+      letterScales?: { label: string; score: number; order: number }[]
     }) => {
       return createDataSource(data)
     }
@@ -255,6 +257,8 @@ export function setupGradeHandlers(): void {
         treatExpectedAsMissing?: boolean
         estimationMode?: string
         estimationSourceIds?: string[]
+        inputMode?: string
+        letterScales?: { label: string; score: number; order: number }[]
       }
     ) => {
       return updateDataSource(id, data)
@@ -334,7 +338,11 @@ export function setupGradeHandlers(): void {
       scores: {
         gradeDataSourceId: string
         studentId: string
-        score: number | null
+        score?: number | null
+        letterValue?: string | null
+        adjustment?: number | null
+        adjustmentReason?: string | null
+        comment?: string | null
       }[]
     ) => {
       return batchUpsertManualScores(scores)

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -26,8 +26,9 @@ export async function createGradeArchive(
     const data = await collectGradeArchiveData(gradeId)
 
     const manifest: GradeArchiveManifest = {
-      // v1.2.0: Grade.referenceDate と GradeExportSettings を追加
-      version: "1.2.0",
+      // v1.3.0: 文字評価変換表(GradeLetterScale)・inputMode・
+      //         ManualScoreの加減点/コメント/文字評価を追加
+      version: "1.3.0",
       appVersion: getAppVersion(),
       exportedAt: new Date().toISOString(),
       gradeId,

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -41,6 +41,7 @@ export async function collectGradeArchiveData(
               manualScores: {
                 include: { student: { select: { studentNumber: true } } },
               },
+              letterScales: { orderBy: { order: "asc" } },
             },
             orderBy: { order: "asc" },
           },
@@ -114,6 +115,12 @@ export async function collectGradeArchiveData(
         }
         return []
       })(),
+      inputMode: ds.inputMode,
+      letterScales: ds.letterScales.map((ls) => ({
+        label: ls.label,
+        score: Number(ls.score),
+        order: ls.order,
+      })),
     })),
   }))
 
@@ -157,6 +164,10 @@ export async function collectGradeArchiveData(
           dataSourceName: ds.name,
           studentNumber: ms.student.studentNumber,
           score: ms.score !== null ? Number(ms.score) : null,
+          letterValue: ms.letterValue,
+          adjustment: ms.adjustment !== null ? Number(ms.adjustment) : null,
+          adjustmentReason: ms.adjustmentReason,
+          comment: ms.comment,
         }))
       )
   )

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -217,6 +217,18 @@ export async function importGradeArchive(
                 estimationSourceIds: JSON.stringify(
                   dsData.estimationSourceIds ?? []
                 ),
+                // v1.3.0+: 入力モード・文字評価変換表（古いアーカイブはdefault）
+                inputMode: dsData.inputMode ?? "numeric",
+                ...(dsData.letterScales &&
+                  dsData.letterScales.length > 0 && {
+                    letterScales: {
+                      create: dsData.letterScales.map((ls) => ({
+                        label: ls.label,
+                        score: ls.score,
+                        order: ls.order,
+                      })),
+                    },
+                  }),
               },
             })
             dsKeyToId.set(`${giData.name}:${dsData.name}`, ds.id)
@@ -240,6 +252,11 @@ export async function importGradeArchive(
               gradeDataSourceId: dsId,
               studentId: student.id,
               score: msData.score,
+              // v1.3.0+: 文字評価・加減点・コメント（古いアーカイブはnull/0）
+              letterValue: msData.letterValue ?? null,
+              adjustment: msData.adjustment ?? 0,
+              adjustmentReason: msData.adjustmentReason ?? null,
+              comment: msData.comment ?? null,
             },
           })
         }

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -40,6 +40,7 @@ const gradeItemInclude = {
       exam: { select: { id: true, examName: true, examDate: true } },
       subtotal: { select: { id: true, name: true, order: true } },
       cropRegion: { select: { id: true, label: true, points: true } },
+      letterScales: { orderBy: { order: "asc" as const } },
       _count: { select: { manualScores: true } },
     },
     orderBy: { order: "asc" as const },

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -22,6 +22,7 @@ export async function getDataSourcesByGradeItemId(gradeItemId: string) {
         exam: { select: { id: true, examName: true, examDate: true } },
         subtotal: { select: { id: true, name: true, order: true } },
         cropRegion: { select: { id: true, label: true, points: true } },
+        letterScales: { orderBy: { order: "asc" } },
         _count: { select: { manualScores: true } },
       },
       orderBy: { order: "asc" },
@@ -54,6 +55,8 @@ export async function createDataSource(data: {
   treatExpectedAsMissing?: boolean
   estimationMode?: string
   estimationSourceIds?: string[]
+  inputMode?: string
+  letterScales?: { label: string; score: number; order: number }[]
 }) {
   try {
     // order を自動計算（gradeItem 内）
@@ -92,11 +95,25 @@ export async function createDataSource(data: {
         ...(data.estimationSourceIds !== undefined && {
           estimationSourceIds: JSON.stringify(data.estimationSourceIds),
         }),
+        ...(data.inputMode !== undefined && {
+          inputMode: data.inputMode,
+        }),
+        ...(data.letterScales !== undefined &&
+          data.letterScales.length > 0 && {
+            letterScales: {
+              create: data.letterScales.map((ls) => ({
+                label: ls.label,
+                score: ls.score,
+                order: ls.order,
+              })),
+            },
+          }),
       },
       include: {
         exam: { select: { id: true, examName: true, examDate: true } },
         subtotal: { select: { id: true, name: true, order: true } },
         cropRegion: { select: { id: true, label: true, points: true } },
+        letterScales: { orderBy: { order: "asc" } },
       },
     })
 
@@ -135,13 +152,26 @@ export async function updateDataSource(
     treatExpectedAsMissing?: boolean
     estimationMode?: string
     estimationSourceIds?: string[]
+    inputMode?: string
+    letterScales?: { label: string; score: number; order: number }[]
   }
 ) {
   try {
-    const { estimationSourceIds, ...rest } = data
+    const { estimationSourceIds, letterScales, ...rest } = data
     const updateData: Record<string, unknown> = { ...rest }
     if (estimationSourceIds !== undefined) {
       updateData.estimationSourceIds = JSON.stringify(estimationSourceIds)
+    }
+    // letterScales が指定された場合は全置換（deleteMany → create）
+    if (letterScales !== undefined) {
+      updateData.letterScales = {
+        deleteMany: {},
+        create: letterScales.map((ls) => ({
+          label: ls.label,
+          score: ls.score,
+          order: ls.order,
+        })),
+      }
     }
     const dataSource = await prisma.gradeDataSource.update({
       where: { id },
@@ -150,6 +180,7 @@ export async function updateDataSource(
         exam: { select: { id: true, examName: true, examDate: true } },
         subtotal: { select: { id: true, name: true, order: true } },
         cropRegion: { select: { id: true, label: true, points: true } },
+        letterScales: { orderBy: { order: "asc" } },
       },
     })
 

--- a/electron-src/lib/prisma/manualScore.ts
+++ b/electron-src/lib/prisma/manualScore.ts
@@ -42,18 +42,40 @@ export async function getManualScoresByDataSourceId(gradeDataSourceId: string) {
 
 /**
  * 手動スコアを一括更新（upsert）
+ *
+ * 各フィールドは optional。指定されたフィールドのみ更新する（セル単位編集対応）。
+ * score / letterValue / adjustment / adjustmentReason / comment を扱う。
  */
 export async function batchUpsertManualScores(
   scores: {
     gradeDataSourceId: string
     studentId: string
-    score: number | null
+    score?: number | null
+    letterValue?: string | null
+    adjustment?: number | null
+    adjustmentReason?: string | null
+    comment?: string | null
   }[]
 ) {
   try {
     await prisma.$transaction(
-      scores.map((s) =>
-        prisma.manualScore.upsert({
+      scores.map((s) => {
+        // 指定されたフィールドのみを更新対象に含める
+        const fields: {
+          score?: number | null
+          letterValue?: string | null
+          adjustment?: number | null
+          adjustmentReason?: string | null
+          comment?: string | null
+        } = {}
+        if (s.score !== undefined) fields.score = s.score
+        if (s.letterValue !== undefined) fields.letterValue = s.letterValue
+        if (s.adjustment !== undefined) fields.adjustment = s.adjustment
+        if (s.adjustmentReason !== undefined)
+          fields.adjustmentReason = s.adjustmentReason
+        if (s.comment !== undefined) fields.comment = s.comment
+
+        return prisma.manualScore.upsert({
           where: {
             gradeDataSourceId_studentId: {
               gradeDataSourceId: s.gradeDataSourceId,
@@ -63,13 +85,11 @@ export async function batchUpsertManualScores(
           create: {
             gradeDataSourceId: s.gradeDataSourceId,
             studentId: s.studentId,
-            score: s.score,
+            ...fields,
           },
-          update: {
-            score: s.score,
-          },
+          update: fields,
         })
-      )
+      })
     )
 
     // 監査ログ: 手動スコアの一括更新（1件にまとめて記録）

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -59,6 +59,7 @@ export async function calculateGrades(gradeId: string): Promise<{
                 subtotal: true,
                 cropRegion: true,
                 manualScores: true,
+                letterScales: true,
               },
               orderBy: { order: "asc" },
             },
@@ -317,6 +318,12 @@ export async function calculateGrades(gradeId: string): Promise<{
               ? (rawScore / maxScore) * weight
               : null
 
+          // manual型: 入力された評価記号・加減点・コメントを結果に添付
+          const manualScore =
+            ds.type === "manual"
+              ? ds.manualScores.find((m) => m.studentId === student.id)
+              : undefined
+
           sourceScores.push({
             dataSourceId: ds.id,
             dataSourceName: ds.name,
@@ -326,6 +333,14 @@ export async function calculateGrades(gradeId: string): Promise<{
             weight,
             weightedScore,
             isEstimated,
+            letterValue: manualScore?.letterValue ?? null,
+            adjustment:
+              manualScore?.adjustment !== null &&
+              manualScore?.adjustment !== undefined
+                ? Number(manualScore.adjustment)
+                : null,
+            adjustmentReason: manualScore?.adjustmentReason ?? null,
+            comment: manualScore?.comment ?? null,
           })
         }
 
@@ -477,7 +492,15 @@ async function getRawScore(
     examId: string | null
     subtotalId: string | null
     cropRegionId: string | null
-    manualScores: { studentId: string; score: unknown }[]
+    maxScore: unknown
+    inputMode?: string
+    manualScores: {
+      studentId: string
+      score: unknown
+      letterValue?: string | null
+      adjustment?: unknown
+    }[]
+    letterScales?: { label: string; score: unknown }[]
   },
   examDataCache: Map<string, ExamDataCache>
 ): Promise<number | null> {
@@ -504,12 +527,55 @@ async function getRawScore(
       examDataCache
     )
   } else if (ds.type === "manual") {
-    const ms = ds.manualScores.find((m) => m.studentId === studentId)
-    return ms?.score !== null && ms?.score !== undefined
-      ? Number(ms.score)
-      : null
+    return getManualRawScore(studentId, ds)
   }
   return null
+}
+
+/**
+ * manual型データソースの実スコアを算出する。
+ * - letterモード: 入力された評価記号を変換表で点数化
+ * - numericモード: 入力された数値をそのまま使用
+ * いずれも加点・減点(adjustment)を加算し、[0, maxScore]にクランプする。
+ */
+function getManualRawScore(
+  studentId: string,
+  ds: {
+    maxScore: unknown
+    inputMode?: string
+    manualScores: {
+      studentId: string
+      score: unknown
+      letterValue?: string | null
+      adjustment?: unknown
+    }[]
+    letterScales?: { label: string; score: unknown }[]
+  }
+): number | null {
+  const ms = ds.manualScores.find((m) => m.studentId === studentId)
+  if (!ms) return null
+
+  // 基準スコア（変換前・加減点前）を決定
+  let base: number | null
+  if (ds.inputMode === "letter") {
+    if (ms.letterValue === null || ms.letterValue === undefined) {
+      base = null
+    } else {
+      const scale = ds.letterScales?.find((ls) => ls.label === ms.letterValue)
+      base = scale ? Number(scale.score) : null
+    }
+  } else {
+    base = ms.score !== null && ms.score !== undefined ? Number(ms.score) : null
+  }
+
+  if (base === null || Number.isNaN(base)) return null
+
+  const adjustment =
+    ms.adjustment !== null && ms.adjustment !== undefined
+      ? Number(ms.adjustment)
+      : 0
+  const maxScore = Number(ds.maxScore)
+  return clamp(base + adjustment, 0, maxScore)
 }
 
 /**

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -77,6 +77,8 @@ export function createGradeApi() {
         treatExpectedAsMissing?: boolean
         estimationMode?: string
         estimationSourceIds?: string[]
+        inputMode?: string
+        letterScales?: { label: string; score: number; order: number }[]
       }) => ipcRenderer.invoke("grade:createDataSource", data),
       updateDataSource: (
         id: string,
@@ -90,6 +92,8 @@ export function createGradeApi() {
           treatExpectedAsMissing?: boolean
           estimationMode?: string
           estimationSourceIds?: string[]
+          inputMode?: string
+          letterScales?: { label: string; score: number; order: number }[]
         }
       ) => ipcRenderer.invoke("grade:updateDataSource", id, data),
       deleteDataSource: (id: string) =>
@@ -118,7 +122,11 @@ export function createGradeApi() {
         scores: {
           gradeDataSourceId: string
           studentId: string
-          score: number | null
+          score?: number | null
+          letterValue?: string | null
+          adjustment?: number | null
+          adjustmentReason?: string | null
+          comment?: string | null
         }[]
       ) => ipcRenderer.invoke("grade:batchUpsertManualScores", scores),
       getBoundarySets: (gradeId: string) =>

--- a/prisma/migrations/20260623000000_add_grade_letter_and_comment/migration.sql
+++ b/prisma/migrations/20260623000000_add_grade_letter_and_comment/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable: GradeDataSource に文字評価入力モードを追加
+ALTER TABLE "GradeDataSource" ADD COLUMN "inputMode" TEXT NOT NULL DEFAULT 'numeric';
+
+-- AlterTable: ManualScore に文字評価・加減点・コメントを追加（全てデータソース×生徒単位）
+ALTER TABLE "ManualScore" ADD COLUMN "letterValue" TEXT;
+ALTER TABLE "ManualScore" ADD COLUMN "adjustment" DECIMAL DEFAULT 0;
+ALTER TABLE "ManualScore" ADD COLUMN "adjustmentReason" TEXT;
+ALTER TABLE "ManualScore" ADD COLUMN "comment" TEXT;
+
+-- CreateTable: 文字評価→点数の変換表（manual型データソース単位。例: A=100, B=80, C=60）
+CREATE TABLE "GradeLetterScale" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeDataSourceId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "score" DECIMAL NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeLetterScale_gradeDataSourceId_fkey" FOREIGN KEY ("gradeDataSourceId") REFERENCES "GradeDataSource" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeLetterScale_gradeDataSourceId_label_key" ON "GradeLetterScale"("gradeDataSourceId", "label");
+
+-- CreateIndex
+CREATE INDEX "GradeLetterScale_gradeDataSourceId_idx" ON "GradeLetterScale"("gradeDataSourceId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -731,6 +731,7 @@ model GradeDataSource {
   treatExpectedAsMissing Boolean  @default(false)
   estimationMode         String   @default("all") // "all" | "selected"
   estimationSourceIds    String   @default("[]") // JSON array of DataSource IDs
+  inputMode              String   @default("numeric") // "numeric" | "letter"（manual型のみ有効）
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 
@@ -739,11 +740,28 @@ model GradeDataSource {
   subtotal     Subtotal?    @relation(fields: [subtotalId], references: [id], onDelete: Cascade)
   cropRegion   CropRegion?  @relation(fields: [cropRegionId], references: [id], onDelete: Cascade)
   manualScores ManualScore[]
+  letterScales GradeLetterScale[]
 
   @@index([gradeItemId])
   @@index([examId])
   @@index([subtotalId])
   @@index([cropRegionId])
+}
+
+/// 文字評価→点数の変換表（manual型データソース単位。例: A=100, B=80, C=60）
+model GradeLetterScale {
+  id                String   @id @default(uuid())
+  gradeDataSourceId String
+  label             String
+  score             Decimal
+  order             Int      @default(0)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  gradeDataSource GradeDataSource @relation(fields: [gradeDataSourceId], references: [id], onDelete: Cascade)
+
+  @@unique([gradeDataSourceId, label])
+  @@index([gradeDataSourceId])
 }
 
 /// 外部成績（手動入力スコア）
@@ -752,6 +770,10 @@ model ManualScore {
   gradeDataSourceId String
   studentId         String
   score             Decimal?
+  letterValue       String? // 文字モード時の評価記号（"A"/"B"/"C" 等）
+  adjustment        Decimal? @default(0) // 加点・減点（期限超過等）
+  adjustmentReason  String? // 加減点の理由
+  comment           String? // 成績通知書に表示するコメント
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 

--- a/src/components/grades/03-data-sources/AddDataSourceInline.tsx
+++ b/src/components/grades/03-data-sources/AddDataSourceInline.tsx
@@ -13,6 +13,13 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
+import {
+  DEFAULT_LETTER_SCALES,
+  draftsToLetterScales,
+  type LetterScaleDraft,
+  LetterScaleEditor,
+} from "./LetterScaleEditor"
+
 type DataSourceType = "exam_total" | "subtotal" | "crop_region" | "manual"
 
 interface AddDataSourceInlineProps {
@@ -26,6 +33,8 @@ interface AddDataSourceInlineProps {
     name: string
     maxScore: number
     weight: number
+    inputMode?: string
+    letterScales?: { label: string; score: number; order: number }[]
   }) => Promise<{ success: boolean }>
   onCreated: () => void
 }
@@ -68,6 +77,11 @@ export function AddDataSourceInline({
   const [maxScore, setMaxScore] = useState("")
   const [weight, setWeight] = useState("")
   const [adding, setAdding] = useState(false)
+  // manual型: 入力モードと文字評価変換表
+  const [inputMode, setInputMode] = useState<"numeric" | "letter">("numeric")
+  const [letterScales, setLetterScales] = useState<LetterScaleDraft[]>(
+    DEFAULT_LETTER_SCALES
+  )
 
   // 全試験候補をロード
   useEffect(() => {
@@ -194,6 +208,12 @@ export function AddDataSourceInline({
       if (type === "crop_region") {
         data.cropRegionId = selectedCropRegionId || undefined
       }
+      if (type === "manual") {
+        data.inputMode = inputMode
+        if (inputMode === "letter") {
+          data.letterScales = draftsToLetterScales(letterScales)
+        }
+      }
       const result = await onCreate(data)
       if (result.success) {
         resetForm()
@@ -214,6 +234,8 @@ export function AddDataSourceInline({
     setName("")
     setMaxScore("")
     setWeight("")
+    setInputMode("numeric")
+    setLetterScales(DEFAULT_LETTER_SCALES)
   }
 
   const selectedSubtotals =
@@ -337,7 +359,55 @@ export function AddDataSourceInline({
             </SelectContent>
           </Select>
         )}
+
+        {/* manual型: 入力モード（数値 / 文字評価） */}
+        {type === "manual" && (
+          <Select
+            value={inputMode}
+            onValueChange={(v) => {
+              const mode = v as "numeric" | "letter"
+              setInputMode(mode)
+              // 文字モードへ切替時、満点/換算満点が空なら変換表の最大値で補完
+              if (mode === "letter") {
+                const scores = letterScales
+                  .map((s) => Number(s.score))
+                  .filter((n) => !isNaN(n))
+                if (scores.length > 0) {
+                  const max = Math.max(...scores)
+                  if (!maxScore) setMaxScore(String(max))
+                  if (!weight) setWeight(String(max))
+                }
+              }
+            }}
+          >
+            <SelectTrigger className="h-8 w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="numeric">数値入力</SelectItem>
+              <SelectItem value="letter">文字評価</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
       </div>
+
+      {/* manual型 + 文字モード: 変換表エディタ */}
+      {type === "manual" && inputMode === "letter" && (
+        <LetterScaleEditor
+          scales={letterScales}
+          onChange={(next) => {
+            setLetterScales(next)
+            const scores = next
+              .map((s) => Number(s.score))
+              .filter((n) => !isNaN(n))
+            if (scores.length > 0) {
+              const max = Math.max(...scores)
+              if (!maxScore) setMaxScore(String(max))
+              if (!weight) setWeight(String(max))
+            }
+          }}
+        />
+      )}
 
       <div className="flex items-center gap-2">
         <Input

--- a/src/components/grades/03-data-sources/DataSourceRow.tsx
+++ b/src/components/grades/03-data-sources/DataSourceRow.tsx
@@ -6,9 +6,21 @@ import { useState } from "react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import type { GradeDataSourceWithDetails } from "@/types/grade.types"
 
 import { EstimationSettingsPopover } from "./EstimationSettingsPopover"
+import {
+  draftsToLetterScales,
+  type LetterScaleDraft,
+  LetterScaleEditor,
+} from "./LetterScaleEditor"
 
 const TYPE_LABELS: Record<string, string> = {
   exam_total: "合計",
@@ -48,12 +60,28 @@ export function DataSourceRow({
   const [name, setName] = useState(dataSource.name)
   const [maxScore, setMaxScore] = useState(String(dataSource.maxScore))
   const [weight, setWeight] = useState(String(dataSource.weight))
+  const [inputMode, setInputMode] = useState<"numeric" | "letter">(
+    dataSource.inputMode === "letter" ? "letter" : "numeric"
+  )
+  const [letterScales, setLetterScales] = useState<LetterScaleDraft[]>(
+    dataSource.letterScales.map((ls) => ({
+      label: ls.label,
+      score: String(ls.score),
+    }))
+  )
+
+  const isManual = dataSource.type === "manual"
 
   const handleSave = async () => {
     await onUpdate(dataSource.id, {
       name,
       maxScore: Number(maxScore),
       weight: Number(weight),
+      ...(isManual && {
+        inputMode,
+        letterScales:
+          inputMode === "letter" ? draftsToLetterScales(letterScales) : [],
+      }),
     })
     setEditing(false)
   }
@@ -70,6 +98,20 @@ export function DataSourceRow({
             className="h-8 flex-1"
             placeholder="名前"
           />
+          {isManual && (
+            <Select
+              value={inputMode}
+              onValueChange={(v) => setInputMode(v as "numeric" | "letter")}
+            >
+              <SelectTrigger className="h-8 w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="numeric">数値入力</SelectItem>
+                <SelectItem value="letter">文字評価</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
           <Input
             value={maxScore}
             onChange={(e) => setMaxScore(e.target.value)}
@@ -101,6 +143,9 @@ export function DataSourceRow({
             <X className="h-4 w-4" />
           </Button>
         </div>
+        {isManual && inputMode === "letter" && (
+          <LetterScaleEditor scales={letterScales} onChange={setLetterScales} />
+        )}
       </div>
     )
   }
@@ -125,6 +170,14 @@ export function DataSourceRow({
         <span className="text-sm font-medium">{dataSource.name}</span>
         {sourceRef && (
           <span className="text-muted-foreground text-xs">({sourceRef})</span>
+        )}
+        {isManual && dataSource.inputMode === "letter" && (
+          <Badge variant="outline" className="text-xs font-normal">
+            文字評価:{" "}
+            {dataSource.letterScales
+              .map((ls) => `${ls.label}=${ls.score}`)
+              .join(", ") || "未設定"}
+          </Badge>
         )}
         <EstimationSettingsPopover
           dataSource={dataSource}

--- a/src/components/grades/03-data-sources/LetterScaleEditor.tsx
+++ b/src/components/grades/03-data-sources/LetterScaleEditor.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { Plus, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+/** 文字評価→点数の変換表エディタの行（入力中は文字列で保持） */
+export interface LetterScaleDraft {
+  label: string
+  score: string
+}
+
+interface LetterScaleEditorProps {
+  scales: LetterScaleDraft[]
+  onChange: (scales: LetterScaleDraft[]) => void
+}
+
+/** よく使う3段階プリセット（A=100, B=80, C=60） */
+export const DEFAULT_LETTER_SCALES: LetterScaleDraft[] = [
+  { label: "A", score: "100" },
+  { label: "B", score: "80" },
+  { label: "C", score: "60" },
+]
+
+/**
+ * 文字評価（A/B/C 等）→ 点数の変換表エディタ
+ * manual型データソース + 文字モード時に使用する。
+ */
+export function LetterScaleEditor({
+  scales,
+  onChange,
+}: LetterScaleEditorProps) {
+  const updateRow = (index: number, patch: Partial<LetterScaleDraft>) => {
+    onChange(scales.map((s, i) => (i === index ? { ...s, ...patch } : s)))
+  }
+
+  const removeRow = (index: number) => {
+    onChange(scales.filter((_, i) => i !== index))
+  }
+
+  const addRow = () => {
+    onChange([...scales, { label: "", score: "" }])
+  }
+
+  return (
+    <div className="bg-muted/30 space-y-2 rounded border border-dashed p-2">
+      <p className="text-muted-foreground text-xs font-medium">
+        評価記号 → 点数の変換表
+      </p>
+      <div className="space-y-1">
+        {scales.map((scale, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              value={scale.label}
+              onChange={(e) => updateRow(index, { label: e.target.value })}
+              className="h-7 w-20 text-xs"
+              placeholder="記号"
+            />
+            <span className="text-muted-foreground text-xs">=</span>
+            <Input
+              value={scale.score}
+              onChange={(e) => updateRow(index, { score: e.target.value })}
+              className="h-7 w-24 text-xs"
+              type="number"
+              placeholder="点数"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => removeRow(index)}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground h-6 text-xs"
+        onClick={addRow}
+      >
+        <Plus className="mr-1 h-3 w-3" />
+        評価を追加
+      </Button>
+    </div>
+  )
+}
+
+/** 入力中ドラフトを、保存用の {label, score, order} 配列に変換（無効行は除外） */
+export function draftsToLetterScales(
+  scales: LetterScaleDraft[]
+): { label: string; score: number; order: number }[] {
+  return scales
+    .map((s) => ({
+      label: s.label.trim(),
+      score: Number(s.score),
+    }))
+    .filter((s) => s.label !== "" && !isNaN(s.score))
+    .map((s, index) => ({ label: s.label, score: s.score, order: index }))
+}

--- a/src/components/grades/04-manual-scores/ManualScoresContainer.tsx
+++ b/src/components/grades/04-manual-scores/ManualScoresContainer.tsx
@@ -6,7 +6,9 @@ import { useCallback, useMemo, useRef } from "react"
 
 import { EditableTable } from "@/components/common/EditableTable"
 import { Button } from "@/components/ui/button"
+import type { ManualCellPatch } from "@/hooks/grades/useManualScores"
 import { useManualScores } from "@/hooks/grades/useManualScores"
+import type { GradeDataSourceWithDetails } from "@/types/grade.types"
 
 interface ManualScoresContainerProps {
   gradeId: string
@@ -20,14 +22,19 @@ interface ManualScoreRow {
   [key: string]: string
 }
 
+/** データソースごとの列ID（value列はds.id、補助列は接尾辞付き） */
+const adjColId = (dsId: string) => `${dsId}::adj`
+const reasonColId = (dsId: string) => `${dsId}::reason`
+const commentColId = (dsId: string) => `${dsId}::comment`
+
 /**
  * 外部成績入力コンテナ
  *
- * EditableTable を使用し、各生徒のスコアをExcelコピペ対応で一括入力できる。
- * 変更はデバウンスで自動保存される。
+ * EditableTable を使用し、各生徒の成績（数値 or 文字評価）・加減点・理由・コメントを
+ * Excelコピペ対応で一括入力できる。変更はデバウンスで自動保存される。
  */
 export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
-  const { manualDataSources, studentScores, loading, bulkUpdateScores } =
+  const { manualDataSources, studentScores, loading, bulkUpdateCells } =
     useManualScores(gradeId)
 
   // 前回のテーブルデータを保持（diff検出用）
@@ -45,10 +52,17 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
         studentName: `${student.lastName} ${student.firstName}`,
       }
       for (const dataSource of manualDataSources) {
-        row[dataSource.id] =
-          student.scores[dataSource.id] != null
-            ? String(student.scores[dataSource.id])
-            : ""
+        const cell = student.cells[dataSource.id]
+        // value列: 文字モードは評価記号、数値モードはスコア
+        if (dataSource.inputMode === "letter") {
+          row[dataSource.id] = cell?.letterValue ?? ""
+        } else {
+          row[dataSource.id] = cell?.score != null ? String(cell.score) : ""
+        }
+        row[adjColId(dataSource.id)] =
+          cell?.adjustment != null ? String(cell.adjustment) : ""
+        row[reasonColId(dataSource.id)] = cell?.adjustmentReason ?? ""
+        row[commentColId(dataSource.id)] = cell?.comment ?? ""
       }
       return row
     })
@@ -90,14 +104,49 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
       },
     ]
 
-    const scoreCols: ColumnDef<ManualScoreRow>[] = manualDataSources.map(
-      (dataSource) => ({
-        id: dataSource.id,
-        header: `${dataSource.name} (/${dataSource.maxScore})`,
-        accessorKey: dataSource.id,
-        size: 100,
-        meta: { placeholder: `0-${dataSource.maxScore}` },
-      })
+    const scoreCols: ColumnDef<ManualScoreRow>[] = manualDataSources.flatMap(
+      (dataSource): ColumnDef<ManualScoreRow>[] => {
+        const isLetter = dataSource.inputMode === "letter"
+        const validLabels = dataSource.letterScales
+          .map((ls) => ls.label)
+          .join("/")
+        return [
+          {
+            id: dataSource.id,
+            header: isLetter
+              ? `${dataSource.name} (評価)`
+              : `${dataSource.name} (/${dataSource.maxScore})`,
+            accessorKey: dataSource.id,
+            size: 110,
+            meta: {
+              placeholder: isLetter
+                ? validLabels || "評価記号"
+                : `0-${dataSource.maxScore}`,
+            },
+          },
+          {
+            id: adjColId(dataSource.id),
+            header: `${dataSource.name}·加減点`,
+            accessorKey: adjColId(dataSource.id),
+            size: 90,
+            meta: { placeholder: "±0" },
+          },
+          {
+            id: reasonColId(dataSource.id),
+            header: `${dataSource.name}·理由`,
+            accessorKey: reasonColId(dataSource.id),
+            size: 120,
+            meta: { placeholder: "期限超過 等" },
+          },
+          {
+            id: commentColId(dataSource.id),
+            header: `${dataSource.name}·コメント`,
+            accessorKey: commentColId(dataSource.id),
+            size: 160,
+            meta: { placeholder: "通知書に表示" },
+          },
+        ]
+      }
     )
 
     return [...readOnlyCols, ...scoreCols]
@@ -109,8 +158,16 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
       const changes: {
         dataSourceId: string
         studentId: string
-        score: number | null
+        patch: ManualCellPatch
       }[] = []
+
+      const pushPatch = (
+        dataSource: GradeDataSourceWithDetails,
+        studentId: string,
+        patch: ManualCellPatch
+      ) => {
+        changes.push({ dataSourceId: dataSource.id, studentId, patch })
+      }
 
       for (let i = 0; i < newData.length; i++) {
         const newRow = newData[i]
@@ -119,37 +176,78 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
 
         const studentId = newRow._studentId
         for (const dataSource of manualDataSources) {
-          const newVal = newRow[dataSource.id]
-          const oldVal = oldRow[dataSource.id]
-          if (newVal === oldVal) continue
+          const validLabels = new Set(
+            dataSource.letterScales.map((ls) => ls.label)
+          )
 
-          // バリデーション
-          const trimmed = (newVal ?? "").trim()
-          if (trimmed === "") {
-            changes.push({
-              dataSourceId: dataSource.id,
-              studentId,
-              score: null,
-            })
-          } else {
-            const num = Number(trimmed)
-            if (!isNaN(num) && num >= 0 && num <= Number(dataSource.maxScore)) {
-              changes.push({
-                dataSourceId: dataSource.id,
-                studentId,
-                score: num,
-              })
+          // value列（数値 or 文字評価）
+          const valId = dataSource.id
+          if (newRow[valId] !== oldRow[valId]) {
+            const trimmed = (newRow[valId] ?? "").trim()
+            if (dataSource.inputMode === "letter") {
+              if (trimmed === "") {
+                pushPatch(dataSource, studentId, { letterValue: null })
+              } else if (validLabels.has(trimmed)) {
+                pushPatch(dataSource, studentId, { letterValue: trimmed })
+              }
+              // 未定義の評価記号は無視
+            } else {
+              if (trimmed === "") {
+                pushPatch(dataSource, studentId, { score: null })
+              } else {
+                const num = Number(trimmed)
+                if (
+                  !isNaN(num) &&
+                  num >= 0 &&
+                  num <= Number(dataSource.maxScore)
+                ) {
+                  pushPatch(dataSource, studentId, { score: num })
+                }
+                // 範囲外・無効値は無視
+              }
             }
-            // 無効な値は無視（EditableTableがセル値を保持するので自然にリセットされる）
+          }
+
+          // 加減点列
+          const adjId = adjColId(dataSource.id)
+          if (newRow[adjId] !== oldRow[adjId]) {
+            const trimmed = (newRow[adjId] ?? "").trim()
+            if (trimmed === "") {
+              pushPatch(dataSource, studentId, { adjustment: null })
+            } else {
+              const num = Number(trimmed)
+              if (!isNaN(num) && isFinite(num)) {
+                pushPatch(dataSource, studentId, { adjustment: num })
+              }
+              // 無効値は無視
+            }
+          }
+
+          // 理由列
+          const rsnId = reasonColId(dataSource.id)
+          if (newRow[rsnId] !== oldRow[rsnId]) {
+            const val = (newRow[rsnId] ?? "").trim()
+            pushPatch(dataSource, studentId, {
+              adjustmentReason: val === "" ? null : val,
+            })
+          }
+
+          // コメント列
+          const cmtId = commentColId(dataSource.id)
+          if (newRow[cmtId] !== oldRow[cmtId]) {
+            const val = (newRow[cmtId] ?? "").trim()
+            pushPatch(dataSource, studentId, {
+              comment: val === "" ? null : val,
+            })
           }
         }
       }
 
       if (changes.length > 0) {
-        bulkUpdateScores(changes)
+        bulkUpdateCells(changes)
       }
     },
-    [manualDataSources, bulkUpdateScores]
+    [manualDataSources, bulkUpdateCells]
   )
 
   if (loading) {
@@ -186,16 +284,21 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
     <div className="p-6">
       <h2 className="mb-4 text-lg font-semibold">外部成績入力</h2>
       <p className="text-muted-foreground mb-4 text-sm">
-        各生徒の外部成績（提出物・授業態度等）を入力してください。変更は自動保存されます。
+        各生徒の外部成績（提出物・授業態度等）を入力してください。文字評価のデータソースは
+        評価記号（例:
+        A/B/C）で入力します。加減点・理由・コメントも記入できます。
+        変更は自動保存されます。
       </p>
 
-      <EditableTable
-        data={tableData}
-        columns={columns}
-        onDataChange={handleDataChange}
-        allowInsertRow={false}
-        allowDeleteRow={false}
-      />
+      <div className="overflow-x-auto">
+        <EditableTable
+          data={tableData}
+          columns={columns}
+          onDataChange={handleDataChange}
+          allowInsertRow={false}
+          allowDeleteRow={false}
+        />
+      </div>
 
       <div className="mt-6 flex justify-end">
         <Button asChild>

--- a/src/components/grades/07-export/ExportContainer.tsx
+++ b/src/components/grades/07-export/ExportContainer.tsx
@@ -71,9 +71,24 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
       try {
         const result = await window.electronAPI.grade.getExportSettings(gradeId)
         if (result.success && result.settings?.reportOptions) {
+          const saved = result.settings
+            .reportOptions as Partial<GradeReportOptions>
+          // ネストした列選択は新フィールド欠落を防ぐためデフォルトと深くマージ
           setReportOptionsState({
             ...DEFAULT_GRADE_REPORT_OPTIONS,
-            ...(result.settings.reportOptions as Partial<GradeReportOptions>),
+            ...saved,
+            itemGradeColumns: {
+              ...DEFAULT_GRADE_REPORT_OPTIONS.itemGradeColumns,
+              ...saved.itemGradeColumns,
+            },
+            sourceBreakdownColumns: {
+              ...DEFAULT_GRADE_REPORT_OPTIONS.sourceBreakdownColumns,
+              ...saved.sourceBreakdownColumns,
+            },
+            footer: {
+              ...DEFAULT_GRADE_REPORT_OPTIONS.footer,
+              ...saved.footer,
+            },
           })
         }
       } catch (error) {

--- a/src/components/grades/07-export/IndividualReportTab.tsx
+++ b/src/components/grades/07-export/IndividualReportTab.tsx
@@ -198,6 +198,17 @@ export function IndividualReportTab({
                     }
                     variant="sub"
                   />
+                  <OptionCard
+                    label="コメント"
+                    checked={options.sourceBreakdownColumns.comment}
+                    onChange={(v) =>
+                      updateOption("sourceBreakdownColumns", {
+                        ...options.sourceBreakdownColumns,
+                        comment: v,
+                      })
+                    }
+                    variant="sub"
+                  />
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <div className="bg-muted/50 flex items-center gap-2 rounded-lg border p-2">

--- a/src/components/grades/07-export/generateGradeReportHtml.ts
+++ b/src/components/grades/07-export/generateGradeReportHtml.ts
@@ -295,6 +295,9 @@ function renderSourceBreakdownSection(
     isEstimated: boolean
     weightedScore: number | null
     weight: number
+    letterValue: string | null
+    adjustment: number | null
+    comment: string | null
   }
 
   const allRows: BreakdownRow[] = []
@@ -312,16 +315,26 @@ function renderSourceBreakdownSection(
         isEstimated: source.isEstimated,
         weightedScore: source.weightedScore,
         weight: source.weight,
+        letterValue: source.letterValue,
+        adjustment: source.adjustment,
+        comment: source.comment,
       })
     }
   }
 
   if (allRows.length === 0) return null
 
+  // コメントが1つでもあるか（列の有無判定にも使用）
+  const hasAnyComment = allRows.some(
+    (r) => r.comment !== null && r.comment !== ""
+  )
+  const showComment = srcCols.comment && hasAnyComment
+
   const buildHeaderRow = (): string => {
     const headerCols = [`<th>項目</th>`, `<th>${escapeHtml(label)}</th>`]
     if (srcCols.score) headerCols.push("<th>得点</th>")
     if (srcCols.weight) headerCols.push("<th>換算得点</th>")
+    if (showComment) headerCols.push("<th>コメント</th>")
     return `<tr>${headerCols.join("")}</tr>`
   }
 
@@ -337,14 +350,31 @@ function renderSourceBreakdownSection(
       `<td style="text-align:left">${escapeHtml(row.dataSourceName)}</td>`
     )
     if (srcCols.score) {
-      const score = row.rawScore !== null ? row.rawScore.toFixed(1) : "-"
+      // 文字評価は「記号(換算点)」、数値はそのまま。加減点があれば併記。
+      const scoreText =
+        row.rawScore !== null
+          ? row.letterValue !== null
+            ? `${escapeHtml(row.letterValue)} (${row.rawScore.toFixed(1)})`
+            : row.rawScore.toFixed(1)
+          : "-"
       const estimated = row.isEstimated ? " (推定)" : ""
-      cells.push(`<td>${score}${estimated} / ${row.maxScore.toFixed(1)}</td>`)
+      const adj =
+        row.adjustment !== null && row.adjustment !== 0
+          ? ` <span style="color:#b45309">[${row.adjustment > 0 ? "+" : ""}${row.adjustment}]</span>`
+          : ""
+      cells.push(
+        `<td>${scoreText}${estimated} / ${row.maxScore.toFixed(1)}${adj}</td>`
+      )
     }
     if (srcCols.weight) {
       const weighted =
         row.weightedScore !== null ? row.weightedScore.toFixed(2) : "-"
       cells.push(`<td>${weighted} / ${row.weight.toFixed(2)}</td>`)
+    }
+    if (showComment) {
+      cells.push(
+        `<td style="text-align:left">${escapeHtml(row.comment ?? "")}</td>`
+      )
     }
     return `<tr>${cells.join("")}</tr>`
   }

--- a/src/components/grades/07-export/types.ts
+++ b/src/components/grades/07-export/types.ts
@@ -17,6 +17,8 @@ export interface GradeReportOptions {
   sourceBreakdownColumns: {
     score: boolean
     weight: boolean
+    /** コメント列（外部成績のコメントを表示） */
+    comment: boolean
   }
   /** コメント欄を表示 */
   showCommentSection: boolean
@@ -52,6 +54,7 @@ export const DEFAULT_GRADE_REPORT_OPTIONS: GradeReportOptions = {
   sourceBreakdownColumns: {
     score: true,
     weight: true,
+    comment: false,
   },
   showCommentSection: false,
   showSignatureSection: false,

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -72,6 +72,8 @@ export function useDataSources(gradeId: string) {
       name: string
       maxScore: number
       weight: number
+      inputMode?: string
+      letterScales?: { label: string; score: number; order: number }[]
     }) => {
       const result = await window.electronAPI.grade.createDataSource(data)
       if (result.success) {
@@ -95,6 +97,8 @@ export function useDataSources(gradeId: string) {
         treatExpectedAsMissing?: boolean
         estimationMode?: string
         estimationSourceIds?: string[]
+        inputMode?: string
+        letterScales?: { label: string; score: number; order: number }[]
       }
     ) => {
       const result = await window.electronAPI.grade.updateDataSource(id, data)

--- a/src/hooks/grades/useManualScores.ts
+++ b/src/hooks/grades/useManualScores.ts
@@ -5,6 +5,23 @@ import type {
   ManualScoreWithStudent,
 } from "@/types/grade.types"
 
+/** 1セル分の手動成績（データソース×生徒） */
+export interface ManualCell {
+  /** 数値モードのスコア */
+  score: number | null
+  /** 文字モードの評価記号 */
+  letterValue: string | null
+  /** 加点・減点 */
+  adjustment: number | null
+  /** 加減点の理由 */
+  adjustmentReason: string | null
+  /** コメント（成績通知書に表示） */
+  comment: string | null
+}
+
+/** 手動成績の部分更新（変更されたフィールドのみ） */
+export type ManualCellPatch = Partial<ManualCell>
+
 interface StudentScore {
   studentId: string
   studentNumber: string
@@ -12,16 +29,25 @@ interface StudentScore {
   firstName: string
   attendanceNumber: number | null
   className: string | null
-  scores: Record<string, number | null> // dataSourceId -> score
+  /** dataSourceId -> セル値 */
+  cells: Record<string, ManualCell>
+}
+
+const EMPTY_CELL: ManualCell = {
+  score: null,
+  letterValue: null,
+  adjustment: null,
+  adjustmentReason: null,
+  comment: null,
 }
 
 /**
  * 外部成績（手動スコア）の取得・更新を管理するフック
  *
- * 生徒ごとのスコアデータをロードし、個別更新・一括更新をデバウンス付きで提供する。
+ * 生徒ごとのスコア・文字評価・加減点・コメントをロードし、
+ * 部分更新（セル単位）をデバウンス付きで提供する。
  *
  * @param gradeId - 対象の成績試験ID
- * @returns manualDataSources, studentScores, loading, bulkUpdateScores
  */
 export function useManualScores(gradeId: string) {
   const [manualDataSources, setManualDataSources] = useState<
@@ -32,7 +58,10 @@ export function useManualScores(gradeId: string) {
   const pendingChanges = useRef<
     Map<
       string,
-      { gradeDataSourceId: string; studentId: string; score: number | null }
+      {
+        gradeDataSourceId: string
+        studentId: string
+      } & ManualCellPatch
     >
   >(new Map())
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -72,12 +101,20 @@ export function useManualScores(gradeId: string) {
       // 生徒×データソースのマトリックスを構築
       const students: StudentScore[] = studentsResult.students.map(
         (examStudent) => {
-          const scores: Record<string, number | null> = {}
+          const cells: Record<string, ManualCell> = {}
           for (const dataSource of manualSources) {
             const manualScore = allScores[dataSource.id]?.find(
               (score) => score.studentId === examStudent.student.id
             )
-            scores[dataSource.id] = manualScore?.score ?? null
+            cells[dataSource.id] = manualScore
+              ? {
+                  score: manualScore.score ?? null,
+                  letterValue: manualScore.letterValue ?? null,
+                  adjustment: manualScore.adjustment ?? null,
+                  adjustmentReason: manualScore.adjustmentReason ?? null,
+                  comment: manualScore.comment ?? null,
+                }
+              : { ...EMPTY_CELL }
           }
           // 登録学級内のmembershipを取得
           const membership = examStudent.student.memberships.find(
@@ -90,7 +127,7 @@ export function useManualScores(gradeId: string) {
             firstName: examStudent.student.firstName,
             attendanceNumber: membership?.attendanceNumber ?? null,
             className: membership?.class.name ?? null,
-            scores,
+            cells,
           }
         }
       )
@@ -107,44 +144,50 @@ export function useManualScores(gradeId: string) {
     loadData()
   }, [loadData])
 
-  const bulkUpdateScores = useCallback(
+  const bulkUpdateCells = useCallback(
     (
       changes: {
         dataSourceId: string
         studentId: string
-        score: number | null
+        patch: ManualCellPatch
       }[]
     ) => {
       if (changes.length === 0) return
 
       // ローカル状態を一括更新
       setStudentScores((prev) => {
-        const changeMap = new Map<string, Map<string, number | null>>()
+        const changeMap = new Map<string, Map<string, ManualCellPatch>>()
         for (const change of changes) {
           if (!changeMap.has(change.studentId))
             changeMap.set(change.studentId, new Map())
-          changeMap
-            .get(change.studentId)!
-            .set(change.dataSourceId, change.score)
+          const studentMap = changeMap.get(change.studentId)!
+          studentMap.set(change.dataSourceId, {
+            ...studentMap.get(change.dataSourceId),
+            ...change.patch,
+          })
         }
         return prev.map((student) => {
           const studentChanges = changeMap.get(student.studentId)
           if (!studentChanges) return student
-          const newScores = { ...student.scores }
-          for (const [dataSourceId, score] of studentChanges) {
-            newScores[dataSourceId] = score
+          const newCells = { ...student.cells }
+          for (const [dataSourceId, patch] of studentChanges) {
+            newCells[dataSourceId] = {
+              ...(newCells[dataSourceId] ?? EMPTY_CELL),
+              ...patch,
+            }
           }
-          return { ...student, scores: newScores }
+          return { ...student, cells: newCells }
         })
       })
 
-      // pendingChangesに追加
+      // pendingChangesにマージ
       for (const change of changes) {
         const key = `${change.dataSourceId}:${change.studentId}`
         pendingChanges.current.set(key, {
+          ...pendingChanges.current.get(key),
           gradeDataSourceId: change.dataSourceId,
           studentId: change.studentId,
-          score: change.score,
+          ...change.patch,
         })
       }
 
@@ -176,6 +219,6 @@ export function useManualScores(gradeId: string) {
     manualDataSources,
     studentScores,
     loading,
-    bulkUpdateScores,
+    bulkUpdateCells,
   }
 }

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -163,6 +163,8 @@ export interface GradeAPI {
       treatExpectedAsMissing?: boolean
       estimationMode?: string
       estimationSourceIds?: string[]
+      inputMode?: string
+      letterScales?: { label: string; score: number; order: number }[]
     }) => Promise<{
       success: boolean
       dataSource?: import("../grade.types").GradeDataSourceWithDetails
@@ -180,6 +182,8 @@ export interface GradeAPI {
         treatExpectedAsMissing?: boolean
         estimationMode?: string
         estimationSourceIds?: string[]
+        inputMode?: string
+        letterScales?: { label: string; score: number; order: number }[]
       }
     ) => Promise<{
       success: boolean
@@ -212,7 +216,11 @@ export interface GradeAPI {
       scores: {
         gradeDataSourceId: string
         studentId: string
-        score: number | null
+        score?: number | null
+        letterValue?: string | null
+        adjustment?: number | null
+        adjustmentReason?: string | null
+        comment?: string | null
       }[]
     ) => Promise<{ success: boolean; error?: string }>
     getBoundarySets: (gradeId: string) => Promise<{

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -57,6 +57,8 @@ export interface GradeDataSourceWithDetails {
   treatExpectedAsMissing: boolean
   estimationMode: EstimationMode
   estimationSourceIds: string[]
+  /** manual型の入力モード（"numeric" | "letter"） */
+  inputMode: InputMode
   createdAt: Date
   updatedAt: Date
   exam: { id: string; examName: string; examDate: Date | null } | null
@@ -66,7 +68,21 @@ export interface GradeDataSourceWithDetails {
     label: string
     points: number | null
   } | null
+  /** 文字評価→点数の変換表（manual型 + letterモード時に使用） */
+  letterScales: GradeLetterScaleData[]
   _count?: { manualScores: number }
+}
+
+/** manual型データソースの入力モード */
+export type InputMode = "numeric" | "letter"
+
+/** 文字評価→点数の変換表エントリ */
+export interface GradeLetterScaleData {
+  id: string
+  gradeDataSourceId: string
+  label: string
+  score: number
+  order: number
 }
 
 /** 手動スコア（生徒情報付き） */
@@ -75,6 +91,14 @@ export interface ManualScoreWithStudent {
   gradeDataSourceId: string
   studentId: string
   score: number | null
+  /** 文字モード時の評価記号 */
+  letterValue: string | null
+  /** 加点・減点（期限超過等） */
+  adjustment: number | null
+  /** 加減点の理由 */
+  adjustmentReason: string | null
+  /** 成績通知書に表示するコメント */
+  comment: string | null
   student: {
     id: string
     studentNumber: string
@@ -158,11 +182,20 @@ export interface SourceScoreResult {
   dataSourceId: string
   dataSourceName: string
   type: string
+  /** 最終スコア（manual型は変換・加減点・クランプ適用後） */
   rawScore: number | null
   maxScore: number
   weight: number
   weightedScore: number | null
   isEstimated: boolean
+  /** 文字モード時に入力された評価記号（manual型のみ） */
+  letterValue: string | null
+  /** 適用された加点・減点（manual型のみ。0なら調整なし） */
+  adjustment: number | null
+  /** 加減点の理由（manual型のみ） */
+  adjustmentReason: string | null
+  /** コメント（manual型のみ。成績通知書に表示） */
+  comment: string | null
 }
 
 /** 成績算出結果全体 */

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -82,6 +82,10 @@ export interface ArchiveDataSource {
   treatExpectedAsMissing?: boolean
   estimationMode?: string
   estimationSourceIds?: string[]
+  /** 入力モード（後方互換: v1.3.0+。"numeric" | "letter"） */
+  inputMode?: string
+  /** 文字評価→点数の変換表（後方互換: v1.3.0+） */
+  letterScales?: { label: string; score: number; order: number }[]
 }
 
 export interface ArchiveManualScoresData {
@@ -90,6 +94,14 @@ export interface ArchiveManualScoresData {
     dataSourceName: string
     studentNumber: string
     score: number | null
+    /** 文字評価記号（後方互換: v1.3.0+） */
+    letterValue?: string | null
+    /** 加点・減点（後方互換: v1.3.0+） */
+    adjustment?: number | null
+    /** 加減点の理由（後方互換: v1.3.0+） */
+    adjustmentReason?: string | null
+    /** コメント（後方互換: v1.3.0+） */
+    comment?: string | null
   }[]
 }
 


### PR DESCRIPTION
Closes #861

## 概要
成績算出の外部成績（manual型データソース）を拡張し、文字評価(A/B/C)・点数変換・加減点・コメントに対応しました。コメントは成績通知書のデータソース内訳にも表示できます。

## 変更内容

### スキーマ（手書きマイグレーション `20260623000000_add_grade_letter_and_comment`）
- `GradeDataSource.inputMode`（`"numeric" | "letter"`）
- 新規 `GradeLetterScale`（評価記号→点数の変換表、データソース単位）
- `ManualScore` に `letterValue` / `adjustment` / `adjustmentReason` / `comment`

### 計算エンジン（`gradeCalculator.ts`）
- manual分岐を `getManualRawScore` に分離：文字モードは変換表で点数化、数値モードはそのまま → `+ adjustment` → `[0, maxScore]` でクランプ
- `SourceScoreResult` に `letterValue`/`adjustment`/`adjustmentReason`/`comment` を添付

### UI
- **03-data-sources**: 数値/文字モード切替＋変換表エディタ `LetterScaleEditor`（3段階プリセット付き）。読み取り時はBadge表示
- **04-manual-scores**: データソースごとに「値（数値 or 評価記号、ラベル検証）/加減点/理由/コメント」列。セル単位の部分更新＋デバウンス自動保存
- **07-export**: 通知書のデータソース内訳に「コメント列」（任意ON）、文字評価=`B (80)`／加減点`[-5]` の併記

### 配管・アーカイブ
- IPC / preload / 型定義（`.d.ts`）を全フィールド対応
- grade-archive を **v1.3.0** へ（collector/importer/types、optional+import時default、トランスフォーマー無し方針）

## テスト
- `npm run check-all`（型チェック＋Lint＋Prettier）緑
- 機能テスト 45件パス（計算の文字変換・加減点・クランプ・コメント／manualScore CRUD新フィールド・部分更新・letterScale置換／アーカイブ v1.3.0 往復）

## 補足（既知のpre-existing失敗）
`normalizeDatetime` 網羅性テストと `cascadeCoverage` テストは、本PR以前から `ReturnSnapshot`・`AuditLog`（既存コミット）由来で失敗しています。歴史的な正規化マイグレーションへの追記は本番デプロイ順序で「no such table」を起こすため行いません。本PRの新テーブルは `GradeDataSource` 参照のみで cascade テストとは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)