### PR TITLE
fix: 在籍フィルタが将来始まる所属を在籍中に誤判定する不具合を修正

### DIFF
--- a/__tests__/exam/integration/examStudentClass.test.ts
+++ b/__tests__/exam/integration/examStudentClass.test.ts
@@ -66,7 +66,12 @@ async function createTestData() {
   })
 
   await testPrisma.studentClassMembership.create({
-    data: { studentId: active.id, classId: classA.id, attendanceNumber: 1 },
+    data: {
+      studentId: active.id,
+      classId: classA.id,
+      attendanceNumber: 1,
+      startDate: new Date("2024-04-01"), // examDate(2024-04-10)より前に開始
+    },
   })
   await testPrisma.studentClassMembership.create({
     data: {
@@ -129,6 +134,62 @@ describe("Exam 在籍フィルタ", () => {
 
       const allResult = await getClassesNotInExam(exam.id, false)
       expect(allResult.classes!.map((c) => c.name)).toContain("3年A組")
+    })
+  })
+
+  describe("将来始まる所属（基準日より後に入学/転入）", () => {
+    /** examDate(2024-04-10) より後に始まる所属を持つ生徒を classA に追加 */
+    async function addFutureStudent(classId: string) {
+      const future = await testPrisma.student.create({
+        data: {
+          studentNumber: "E003",
+          lastName: "転入",
+          firstName: "次郎",
+          lastNameKana: "テンニュウ",
+          firstNameKana: "ジロウ",
+        },
+      })
+      await testPrisma.studentClassMembership.create({
+        data: {
+          studentId: future.id,
+          classId,
+          attendanceNumber: 3,
+          startDate: new Date("2024-05-01"), // examDate より後に開始
+          endDate: null,
+        },
+      })
+      return { future }
+    }
+
+    it("activeOnly=true は将来始まる所属の生徒を追加しない", async () => {
+      const { exam, classA } = await createTestData()
+      await addFutureStudent(classA.id)
+
+      const result = await addStudentsFromClass(exam.id, classA.id, true)
+
+      // 在籍中の active のみ。転入予定(E003)も転出済み(E002)も除外
+      expect(result.added).toBe(1)
+      const students = await getStudentsForExam(exam.id)
+      expect(students.students!.map((s) => s.studentNumber)).toEqual(["E001"])
+    })
+
+    it("activeOnly=true の個別追加候補に将来始まる所属の生徒は含まれない", async () => {
+      const { exam, classA } = await createTestData()
+      await addFutureStudent(classA.id)
+
+      const result = await getStudentsNotInExam(exam.id, true)
+
+      expect(result.students!.map((s) => s.studentNumber)).toEqual(["E001"])
+    })
+
+    it("activeOnly=false なら将来始まる所属の生徒も対象になる", async () => {
+      const { exam, classA } = await createTestData()
+      await addFutureStudent(classA.id)
+
+      const result = await getStudentsNotInExam(exam.id, false)
+
+      const numbers = result.students!.map((s) => s.studentNumber).sort()
+      expect(numbers).toEqual(["E001", "E002", "E003"])
     })
   })
 

--- a/__tests__/grade/integration/gradeStudentCrud.test.ts
+++ b/__tests__/grade/integration/gradeStudentCrud.test.ts
@@ -359,6 +359,64 @@ describe("GradeStudent / GradeClass", () => {
       expect(result.students).toHaveLength(1)
       expect(result.students![0].studentNumber).toBe("S003")
     })
+
+    it("activeOnly=true は基準日より後に始まる所属の生徒を除外する", async () => {
+      // referenceDate(2024-04-01) を基準に、開始済み/将来開始の生徒を判定する
+      const grade = await testPrisma.grade.create({
+        data: { name: "基準日PJ", referenceDate: new Date("2024-04-01") },
+      })
+      const classX = await testPrisma.class.create({
+        data: { name: "2年X組", grade: 2 },
+      })
+      // 基準日より前に開始済み（在籍中）
+      const current = await testPrisma.student.create({
+        data: {
+          studentNumber: "S301",
+          lastName: "在籍",
+          firstName: "太郎",
+          lastNameKana: "ザイセキ",
+          firstNameKana: "タロウ",
+        },
+      })
+      await testPrisma.studentClassMembership.create({
+        data: {
+          studentId: current.id,
+          classId: classX.id,
+          attendanceNumber: 1,
+          startDate: new Date("2023-04-01"),
+          endDate: null,
+        },
+      })
+      // 基準日より後に開始（転入予定）
+      const future = await testPrisma.student.create({
+        data: {
+          studentNumber: "S300",
+          lastName: "転入",
+          firstName: "三郎",
+          lastNameKana: "テンニュウ",
+          firstNameKana: "サブロウ",
+        },
+      })
+      await testPrisma.studentClassMembership.create({
+        data: {
+          studentId: future.id,
+          classId: classX.id,
+          attendanceNumber: 60,
+          startDate: new Date("2024-05-01"), // 基準日より後に開始
+          endDate: null,
+        },
+      })
+
+      const activeResult = await getAvailableStudentsForGrade(grade.id, true)
+      const activeNumbers = activeResult.students!.map((s) => s.studentNumber)
+      // 在籍中の S301 のみ。将来開始の S300 は除外
+      expect(activeNumbers).toContain("S301")
+      expect(activeNumbers).not.toContain("S300")
+
+      const allResult = await getAvailableStudentsForGrade(grade.id, false)
+      // activeOnly=false なら将来開始の生徒も含む
+      expect(allResult.students!.map((s) => s.studentNumber)).toContain("S300")
+    })
   })
 
   describe("getAvailableClassesForGrade（在籍フィルタ）", () => {

--- a/electron-src/lib/prisma/membershipFilter.ts
+++ b/electron-src/lib/prisma/membershipFilter.ts
@@ -11,7 +11,10 @@ import { Prisma } from "@prisma/client"
 /**
  * 基準日時点で有効なmembershipの条件
  *
- * endDateがnull（継続中）、または基準日以降に終了予定のものを在籍中とみなす。
+ * 在籍中とみなすのは「基準日に既に始まっており（startDate <= 基準日）、
+ * かつまだ終了していない（endDateがnull、または基準日以降に終了予定）」所属。
+ * startDate を見ないと、基準日より後に始まる将来の所属（転入・進級先など）まで
+ * 「在籍中」に混入してしまうため、両側を必ず判定する。
  * 基準日未指定なら現在日時を使う。
  *
  * 注: DateTimeはISO text前提。Date を渡すと Prisma の driver adapter が
@@ -22,6 +25,7 @@ export function membershipFilterAt(
 ): Prisma.StudentClassMembershipWhereInput {
   const date = referenceDate ?? new Date()
   return {
+    startDate: { lte: date },
     OR: [{ endDate: null }, { endDate: { gte: date } }],
   }
 }


### PR DESCRIPTION
## 概要

「在籍中の生徒のみ追加」が、基準日より後に始まる所属（転入予定・進級先など）の生徒を誤って「在籍中」として含めてしまう不具合を修正する。

Closes #863

## 原因

在籍判定の核心 `membershipFilterAt`（`electron-src/lib/prisma/membershipFilter.ts`）が `endDate` のみで判定し `startDate` を見ていなかった。退出済みは除外できるが将来始まる所属を除外できない非対称なフィルタになっていた。

## 変更内容

- `membershipFilterAt` に `startDate: { lte: date }` を追加し、「基準日に既に始まっており、かつ未終了」の所属のみを在籍中とする。
- 共有関数経由のため exam / grade の一括追加・個別追加候補・学級候補の全経路が同時に修正される。
- 回帰テストを追加（exam / grade 両方）：基準日より後に始まる所属の生徒が `activeOnly=true` で除外され、`false` なら含まれることを検証。
- 既存 exam テストの `active` 生徒は `startDate` 未指定でデフォルト `now()` になり過去の `examDate` より後になる非現実的データだったため、現実的な開始日を設定し直した。

## テスト

- 対象テスト 32 件すべてパス（新規 4 件含む）。
- 型チェック（`npm run typecheck`）パス。

## 補足

`normalizeDatetime.test.ts` の失敗（`ReturnSnapshot`/`AuditLog`/`GradeLetterScale`）は本変更と無関係な既知の pre-existing 誤検知（スキーマ・migration は未変更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)