### PR TITLE
fix: 生徒ID統合merge時にReturnSnapshotが消失する不具合を修正

### DIFF
--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -186,6 +186,22 @@ describe("DateTime正規化マイグレーション", () => {
     ).toBe(0)
   })
 
+  // normalize_datetime_to_text (20260613144726) より後に追加されたテーブル。
+  // driver adapter 移行後に新設されたため最初から ISO text で生まれ、integer(ms)
+  // の混在が発生しない。よって正規化 UPDATE の対象外（網羅チェックから除外する）。
+  // 歴史migrationは編集禁止のため、ここで明示的にホワイトリスト管理する。
+  const POST_MIGRATION_TABLES = new Set([
+    "AuditLog",
+    "Coursework",
+    "CourseworkClass",
+    "CourseworkItem",
+    "CourseworkLetterScale",
+    "CourseworkScore",
+    "CourseworkStudent",
+    "CourseworkTag",
+    "ReturnSnapshot",
+  ])
+
   it("網羅性: migration.sql が schema.prisma の全 DateTime カラムをカバーする", () => {
     const schemaPath = path.resolve(__dirname, "../../prisma/schema.prisma")
     const schemaText = fs.readFileSync(schemaPath, "utf-8")
@@ -199,6 +215,7 @@ describe("DateTime正規化マイグレーション", () => {
       const body = mm[2]
       const mapMatch = body.match(/@@map\("([^"]+)"\)/)
       const table = mapMatch ? mapMatch[1] : mm[1]
+      if (POST_MIGRATION_TABLES.has(table)) continue
       for (const line of body.split("\n")) {
         const parts = line.trim().split(/\s+/)
         if (parts.length >= 2 && parts[1].startsWith("DateTime")) {

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -102,6 +102,28 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
       }),
   },
   {
+    // UNIQUE([examId, studentId]) があるため移行先の重複を回避しつつ更新する
+    model: "ReturnSnapshot",
+    move: async (tx, from, to) => {
+      const snapshots = await tx.returnSnapshot.findMany({
+        where: { studentId: from },
+      })
+      for (const snap of snapshots) {
+        const duplicate = await tx.returnSnapshot.findFirst({
+          where: { examId: snap.examId, studentId: to },
+        })
+        if (duplicate) {
+          await tx.returnSnapshot.delete({ where: { id: snap.id } })
+        } else {
+          await tx.returnSnapshot.update({
+            where: { id: snap.id },
+            data: { studentId: to },
+          })
+        }
+      }
+    },
+  },
+  {
     model: "GradeStudent",
     move: (tx, from, to) =>
       tx.gradeStudent.updateMany({


### PR DESCRIPTION
## 概要

生徒ID統合merge（delete + 再作成方式）の際に、対象生徒の `ReturnSnapshot`（返却版スナップショット）が cascade 削除されて消失する不具合を修正します。

Closes #865

## 背景

`ReturnSnapshot` は schema 上 `Student` へ `onDelete: Cascade` で紐づく子テーブルですが、`idChangeExecutor.ts` の `STUDENT_CASCADE_MOVERS`（生徒ID統合時に子レコードを新IDへ移し替えるレジストリ）に登録漏れしていました。このため統合時にスナップショットが失われ、「返却版との差分による再印刷」機能が破綻する恐れがありました。

`cascadeCoverage.test.ts`（schema.prisma 駆動の網羅テスト）がこの不在を静的に検出していました。

## 変更内容

- **`electron-src/lib/import/merge/idChangeExecutor.ts`**
  `STUDENT_CASCADE_MOVERS` に `ReturnSnapshot` の mover を追加。`@@unique([examId, studentId])` があるため、移行先に既存スナップショットがある場合は重複を回避（`StudentAnswerImage` と同パターン）。
- **`__tests__/migration/normalizeDatetime.test.ts`**
  網羅性テストに `POST_MIGRATION_TABLES` ホワイトリストを追加。正規化migration（`20260613144726`）以降に追加されISO textで生まれる新テーブル（AuditLog / Coursework系 / ReturnSnapshot）を対象外とした。歴史migrationは非編集。

## 確認

- 全824テスト green
- electron-src 型チェック clean
- lint / prettier クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)