### PR TITLE
fix: 学級所属の編集機能と在籍中フィルタの整合性を改善

### DIFF
--- a/electron-src/lib/prisma/studentClassMembership.ts
+++ b/electron-src/lib/prisma/studentClassMembership.ts
@@ -30,9 +30,6 @@ type ClassWithMemberships = Prisma.ClassGetPayload<{
       include: {
         student: true
       }
-      where: {
-        endDate: null // 現在所属中のみ
-      }
     }
   }
 }>

--- a/src/app/classes/[classId]/page.tsx
+++ b/src/app/classes/[classId]/page.tsx
@@ -42,6 +42,7 @@ export default function ClassDetailPage() {
     setIsStudentImportModalOpen,
     isMembershipModalOpen,
     setIsMembershipModalOpen,
+    membershipToEdit,
     setMembershipToEdit,
     handleSaveClass,
     handleStudentImportSuccess,
@@ -55,6 +56,11 @@ export default function ClassDetailPage() {
     useClassExamResults(classId)
 
   const handleEditMembership = (membership: Membership) => {
+    setMembershipToEdit(membership)
+    setIsMembershipModalOpen(true)
+  }
+
+  const handleViewStudent = (membership: Membership) => {
     router.push(`/students/${membership.student.id}`)
   }
 
@@ -203,6 +209,7 @@ export default function ClassDetailPage() {
                 <MembershipTable
                   memberships={classData.memberships}
                   onEdit={handleEditMembership}
+                  onViewStudent={handleViewStudent}
                   onDelete={handleDeleteMembership}
                   onBulkDelete={handleBulkDeleteMemberships}
                 />
@@ -231,9 +238,11 @@ export default function ClassDetailPage() {
           isOpen={isMembershipModalOpen}
           onClose={() => setIsMembershipModalOpen(false)}
           onSave={handleSaveMembership}
+          studentId={membershipToEdit?.studentId}
           classId={classId}
           availableStudents={students}
           availableClasses={[]}
+          membershipToEdit={membershipToEdit}
         />
       </div>
     </ProtectedRoute>

--- a/src/app/students/[studentId]/components/MembershipsCard.tsx
+++ b/src/app/students/[studentId]/components/MembershipsCard.tsx
@@ -14,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { isCurrentMembership } from "@/lib/membership"
 import type {
   StudentClassMembershipWithDetails,
   StudentWithMemberships,
@@ -24,11 +25,6 @@ interface MembershipsCardProps {
   onAddMembership: () => void
   onEditMembership: (membership: StudentClassMembershipWithDetails) => void
   onEndMembership: (membershipId: string) => void
-}
-
-const isCurrentMembership = (m: { endDate?: Date | null }) => {
-  if (!m.endDate) return true
-  return new Date(m.endDate) >= new Date()
 }
 
 const formatDate = (date: Date) => new Date(date).toLocaleDateString("ja-JP")

--- a/src/components/class/ClassManagementTable.tsx
+++ b/src/components/class/ClassManagementTable.tsx
@@ -20,6 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { useTableSort } from "@/hooks/useTableSort"
+import { isCurrentMembership } from "@/lib/membership"
 import type { ClassWithMemberships } from "@/types/prismaExtensions"
 
 // ソート用の型
@@ -78,7 +79,7 @@ export default function ClassManagementTable() {
       name: classItem.name,
       classCode: classItem.classCode ?? null,
       grade: classItem.grade ?? null,
-      memberCount: classItem.memberships.length,
+      memberCount: classItem.memberships.filter(isCurrentMembership).length,
       original: classItem,
     }))
   }, [filteredClasses])

--- a/src/components/class/MembershipTable.tsx
+++ b/src/components/class/MembershipTable.tsx
@@ -1,12 +1,19 @@
 "use client"
 
-import { Calendar, Edit, Trash2 } from "lucide-react"
+import { Calendar, Edit, Trash2, User } from "lucide-react"
 import { useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { SortableTableHead } from "@/components/ui/SortableTableHead"
 import {
   Table,
@@ -18,11 +25,13 @@ import {
 } from "@/components/ui/table"
 import { Membership } from "@/hooks/useClassManagement"
 import { useTableSort } from "@/hooks/useTableSort"
+import { isCurrentMembership } from "@/lib/membership"
 import { cn } from "@/lib/utils"
 
 interface MembershipTableProps {
   memberships: Membership[]
   onEdit: (membership: Membership) => void
+  onViewStudent: (membership: Membership) => void
   onDelete: (membershipId: string) => void
   onBulkDelete?: (membershipIds: string[]) => void
 }
@@ -42,16 +51,14 @@ interface MembershipSortable {
 export default function MembershipTable({
   memberships,
   onEdit,
+  onViewStudent,
   onDelete,
   onBulkDelete,
 }: MembershipTableProps) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-
-  // 現在所属中かどうかを判定するヘルパー関数
-  const isCurrentMembership = (m: { endDate?: Date | null }) => {
-    if (!m.endDate) return true
-    return new Date(m.endDate) >= new Date()
-  }
+  const [statusFilter, setStatusFilter] = useState<"current" | "ended" | "all">(
+    "current"
+  )
 
   // ソート用のデータ変換
   const sortableData = useMemo<MembershipSortable[]>(() => {
@@ -72,18 +79,29 @@ export default function MembershipTable({
     defaultSort: { key: "attendanceNumber", direction: "asc" },
   })
 
+  // ステータスフィルター適用（既定は在籍中のみ）
+  const filteredData = useMemo(() => {
+    if (statusFilter === "current") {
+      return sortedData.filter((m) => m.isCurrent)
+    }
+    if (statusFilter === "ended") {
+      return sortedData.filter((m) => !m.isCurrent)
+    }
+    return sortedData
+  }, [sortedData, statusFilter])
+
   // 現在の所属を優先表示（ソート後）
   const displayData = useMemo(() => {
     // デフォルトソートの場合のみ、現在の所属を優先
     if (sortConfig.key === "attendanceNumber" || sortConfig.key === null) {
-      return [...sortedData].sort((a, b) => {
+      return [...filteredData].sort((a, b) => {
         if (a.isCurrent && !b.isCurrent) return -1
         if (!a.isCurrent && b.isCurrent) return 1
         return 0
       })
     }
-    return sortedData
-  }, [sortedData, sortConfig.key])
+    return filteredData
+  }, [filteredData, sortConfig.key])
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
@@ -127,16 +145,34 @@ export default function MembershipTable({
                 ({displayData.length}名)
               </span>
             </CardTitle>
-            {selectedIds.size > 0 && (
-              <Button
-                variant="destructive"
-                className="rounded-lg"
-                onClick={handleBulkDelete}
+            <div className="flex items-center gap-2">
+              <Select
+                value={statusFilter}
+                onValueChange={(value) => {
+                  setStatusFilter(value as "current" | "ended" | "all")
+                  setSelectedIds(new Set())
+                }}
               >
-                <Trash2 className="mr-2 h-4 w-4" />
-                選択した{selectedIds.size}件を削除
-              </Button>
-            )}
+                <SelectTrigger className="w-36 rounded-lg">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="current">在籍中のみ</SelectItem>
+                  <SelectItem value="ended">終了済みのみ</SelectItem>
+                  <SelectItem value="all">すべて</SelectItem>
+                </SelectContent>
+              </Select>
+              {selectedIds.size > 0 && (
+                <Button
+                  variant="destructive"
+                  className="rounded-lg"
+                  onClick={handleBulkDelete}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  選択した{selectedIds.size}件を削除
+                </Button>
+              )}
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -263,7 +299,17 @@ export default function MembershipTable({
                             variant="ghost"
                             size="icon"
                             className="hover:bg-muted h-8 w-8 rounded-lg transition-colors"
+                            onClick={() => onViewStudent(membership)}
+                            title="個人ページを開く"
+                          >
+                            <User className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="hover:bg-muted h-8 w-8 rounded-lg transition-colors"
                             onClick={() => onEdit(membership)}
+                            title="所属を編集"
                           >
                             <Edit className="h-4 w-4" />
                           </Button>

--- a/src/components/student/StudentClassMembershipModal.tsx
+++ b/src/components/student/StudentClassMembershipModal.tsx
@@ -172,15 +172,17 @@ export default function StudentClassMembershipModal({
               生徒
             </Label>
             <div className="col-span-3 space-y-2">
-              <div className="relative">
-                <Search className="text-muted-foreground absolute top-2.5 left-2 h-4 w-4" />
-                <Input
-                  placeholder="生徒名または学籍番号で検索"
-                  value={studentSearchTerm}
-                  onChange={(e) => setStudentSearchTerm(e.target.value)}
-                  className="pl-8"
-                />
-              </div>
+              {!initialStudentId && (
+                <div className="relative">
+                  <Search className="text-muted-foreground absolute top-2.5 left-2 h-4 w-4" />
+                  <Input
+                    placeholder="生徒名または学籍番号で検索"
+                    value={studentSearchTerm}
+                    onChange={(e) => setStudentSearchTerm(e.target.value)}
+                    className="pl-8"
+                  />
+                </div>
+              )}
               <Select
                 value={studentId}
                 onValueChange={setStudentId}

--- a/src/components/student/StudentTable.tsx
+++ b/src/components/student/StudentTable.tsx
@@ -40,6 +40,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { useTableSort } from "@/hooks/useTableSort"
+import { isCurrentMembership } from "@/lib/membership"
 import type {
   ClassWithMemberships,
   StudentWithMemberships,
@@ -60,7 +61,7 @@ export default function StudentTable() {
   const [classes, setClasses] = useState<ClassWithMemberships[]>([])
   const [searchTerm, setSearchTerm] = useState("")
   const [filterMembershipStatus, setFilterMembershipStatus] =
-    useState<string>("all")
+    useState<string>("current")
   const [filterClassId, setFilterClassId] = useState<string>("all")
 
   // Selection states
@@ -94,12 +95,6 @@ export default function StudentTable() {
     }
     fetchData()
   }, [])
-
-  // 現在所属中かどうかを判定するヘルパー関数
-  const isCurrentMembership = (m: { endDate?: Date | null }) => {
-    if (!m.endDate) return true
-    return new Date(m.endDate) >= new Date()
-  }
 
   // Filter students
   const filteredStudents = useMemo(() => {

--- a/src/hooks/useClassManagement.ts
+++ b/src/hooks/useClassManagement.ts
@@ -11,11 +11,12 @@ import type {
 /** 所属関係情報（UI用 — 新規作成時のstudentId指定を含む） */
 interface Membership {
   id: string
+  classId: string
   startDate: Date
   endDate?: Date | null
   attendanceNumber?: number | null
   notes?: string | null
-  studentId?: string // 新規作成時に使用
+  studentId: string
   student: {
     id: string
     studentNumber: string
@@ -95,11 +96,13 @@ export function useClassManagement(classId: string) {
     try {
       if (membershipToEdit) {
         // 既存のmembershipを更新
+        // 空欄は null で明示的にクリアする（undefined はPrismaでは「変更しない」）。
+        // startDate は必須項目のため、未指定時は既存値を維持する（undefined のまま）。
         const updateInput: Prisma.StudentClassMembershipUpdateInput = {
-          attendanceNumber: membershipData.attendanceNumber,
-          notes: membershipData.notes,
+          attendanceNumber: membershipData.attendanceNumber ?? null,
+          notes: membershipData.notes ?? null,
           startDate: membershipData.startDate,
-          endDate: membershipData.endDate,
+          endDate: membershipData.endDate ?? null,
         }
         await window.electronAPI.updateStudentClassMembership(
           membershipToEdit.id,
@@ -195,6 +198,7 @@ export function useClassManagement(classId: string) {
     setIsStudentImportModalOpen,
     isMembershipModalOpen,
     setIsMembershipModalOpen,
+    membershipToEdit,
     setMembershipToEdit,
     handleSaveClass,
     handleStudentImportSuccess,

--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -1,0 +1,8 @@
+/**
+ * 学級所属が在籍中かどうかを判定する。
+ * 終了日が未設定、または終了日が今日以降であれば在籍中とみなす。
+ */
+export const isCurrentMembership = (m: { endDate?: Date | null }): boolean => {
+  if (!m.endDate) return true
+  return new Date(m.endDate) >= new Date()
+}

--- a/src/types/prismaExtensions.ts
+++ b/src/types/prismaExtensions.ts
@@ -22,9 +22,6 @@ export type ClassWithMemberships = Prisma.ClassGetPayload<{
       include: {
         student: true
       }
-      where: {
-        endDate: null
-      }
     }
   }
 }>
@@ -37,9 +34,6 @@ export type StudentWithMemberships = Prisma.StudentGetPayload<{
     memberships: {
       include: {
         class: true
-      }
-      where: {
-        endDate: null
       }
       orderBy: {
         startDate: "desc"


### PR DESCRIPTION
## 概要
学級所属（StudentClassMembership）の編集機能の不具合修正と、在籍中/終了済みの扱いをページ間で統一する変更です。

Closes #867

## 変更内容

### 編集機能の修正（学級詳細ページ）
- 所属の編集ボタンが個人ページへ遷移するだけだった不具合を修正し、編集モーダルを開くように変更
- 個人ページへの遷移は専用ボタン（👤）に分離
- 編集時に空欄フィールドを `null` で明示的にクリアできるよう修正（終了日の解除＝在籍復帰が可能に）
- 編集時は生徒セレクトと検索ボックスを無効化/非表示にし、保存されない変更ができないように修正

### 在籍中フィルタの整合性
- 生徒・学級一覧で所属を全件取得し、在籍中/終了済み/すべての絞り込みUIを追加（既定は在籍中のみ）
- 学級一覧の「所属数」を在籍中のみカウントするよう修正
- 在籍判定 `isCurrentMembership` を `src/lib/membership.ts` に共通化（3箇所の重複を解消）
- 型定義の実態と合わない `where` 飾りを削除

## テスト
- `npx tsc --noEmit`（変更ファイルに型エラーなし）
- `npx eslint`（変更ファイルに lint エラーなし）
- `npx prettier --check`（フォーマット済み）

## 補足
本PRは学級/所属関連の変更のみを対象としています（並行作業中の成績/Coursework関連の変更は含みません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)