### PR TITLE
fix(ci): WindowsビルドランナーをVS2022に固定しnode-gypのVS検出失敗を回避

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build:
     name: Build on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
 
     strategy:
       matrix:
@@ -41,6 +41,11 @@ jobs:
             arch: arm64
             artifact_name: score-at-once-mac-arm64
           - os: windows-latest
+            # windows-latest(=windows-2025-vs2026)のVS2026環境ではnode-gypのVS検出が
+            # PowerShell出力のmaxBuffer超過(ERR_CHILD_PROCESS_STDIO_MAXBUFFER)で失敗し、
+            # better-sqlite3のネイティブ再ビルドが落ちる。VS2022の安定環境に固定する。
+            # 注: os ラベルは windows-latest のまま維持（後続の matrix.os 条件分岐が依存）
+            runner: windows-2022
             platform: win
             arch: x64
             artifact_name: score-at-once-windows-x64


### PR DESCRIPTION
Closes #873

## 背景
`windows-latest`（= `windows-2025-vs2026`）のイメージ更新により、VS2026 環境で node-gyp の Visual Studio 検出が PowerShell 出力の maxBuffer 超過（`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`）で失敗し、`better-sqlite3` のネイティブ再ビルドが落ちるようになった（v0.14.0-alpha.0 の Build and Release 失敗）。依存パッケージは前回成功した v0.13.0 と同一で、コード変更は原因ではない。

## 変更
- `runs-on: ${{ matrix.os }}` → `runs-on: ${{ matrix.runner || matrix.os }}`
- Windows の matrix エントリにのみ `runner: windows-2022` を追加
- `matrix.os` ラベルは `windows-latest` のまま維持（後続の `if: matrix.os == 'windows-latest'` 条件分岐が依存するため）

VS2022 は node-gyp が安定検出でき出力も小さいため maxBuffer を超えない。生成バイナリは electron の ABI に対して再ビルドされるためホストの VS バージョン差は影響しない。依存関係は一切変更しない最小修正。

## 検証
- YAML 構文チェック通過
- `npm run lint`（eslint + prettier）通過
- マージ後に Build and Release を再実行して Windows ビルド成功を確認予定