### PR TITLE
fix(omr): カスタムラベル選択不可と1択になる不正プリセットを修正

### DIFF
--- a/src/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
@@ -46,12 +46,6 @@ const CHOICE_LABEL_PRESETS: {
     isCommonTest: true,
   },
   {
-    value: "minus",
-    displayName: "−（負の符号）",
-    labels: ["−"],
-    isCommonTest: true,
-  },
-  {
     value: "digit-minus",
     displayName: "0〜9,−（数値+符号）",
     labels: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "−"],
@@ -245,11 +239,19 @@ function ChoiceConfigFields({
   config: OMRChoiceConfig
   onChange: (config: OMRCellConfig) => void
 }) {
-  const currentPresetValue = useMemo(
+  const detectedPresetValue = useMemo(
     () => detectPreset(config.labels),
     [config.labels]
   )
-  const isCustom = currentPresetValue === "custom"
+
+  // 「カスタム」を明示的に選択中かどうか。
+  // detectPreset はラベルがどのプリセットにも一致しない場合のみ "custom" を返すため、
+  // プリセット由来のラベルからカスタムへ切り替えるにはこのフラグが必要。
+  const [forceCustom, setForceCustom] = useState(
+    () => detectedPresetValue === "custom"
+  )
+  const isCustom = forceCustom || detectedPresetValue === "custom"
+  const currentPresetValue = isCustom ? "custom" : detectedPresetValue
 
   // カスタム入力用のローカルステート
   const [customInput, setCustomInput] = useState(() =>
@@ -267,9 +269,11 @@ function ChoiceConfigFields({
           value={currentPresetValue}
           onValueChange={(preset) => {
             if (preset === "custom") {
+              setForceCustom(true)
               setCustomInput(config.labels.join(","))
               return
             }
+            setForceCustom(false)
             const p = CHOICE_LABEL_PRESETS.find((pr) => pr.value === preset)
             if (p) {
               const labels = p.labels.slice(0, Math.max(2, p.labels.length))


### PR DESCRIPTION
## 概要

答案用紙ビルダーのOMRセル設定フォーム（`OMRCellConfigForm`）の不具合2件を修正します。

Closes #875

## 変更内容

### 1. 「カスタム（コンマ区切り）」を選択できるように修正
- `detectPreset(config.labels)` の逆算のみに依存していたのをやめ、`forceCustom` ローカルstateで「カスタム選択中」を明示管理。
- カスタム選択時に `setForceCustom(true)`、他プリセット選択時に `setForceCustom(false)` を設定。
- これにより「カスタム」を選ぶと入力欄が表示され、コンマ区切りで任意ラベル（例: `+,-,±`）を入力できるようになった。

### 2. 「−（負の符号）」プリセットを削除
- ラベルが `["−"]` の1個のみで `numChoices: 1` の1択セルを生成してしまう不正なプリセットを削除。
- フォーム自身の最低2択ルールと矛盾していた。符号は「0〜9,−（数値+符号）」プリセットや複合回答で扱う。

## テスト

- `npx eslint` … エラーなし
- `npx prettier --check` … フォーマット済み

## 対象ファイル

- `src/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)