### PR TITLE
ci: リリースノートのPR一覧を公式generate-notesへ置換しPR自動ラベリングを追加

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# GitHub公式のリリースノート自動生成（generate-notes）の設定。
+# build-and-release.yml の "Generate release notes" ステップが
+# この設定に従ってマージ済みPRを一覧・カテゴリ分けする。
+# 注意: 分類はPRに付与された「ラベル」基準。ラベルが無いPRは
+#       catch-all（"*"）の「その他の変更」にまとめて表示される。
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: 🚀 新機能・改善
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 バグ修正
+      labels:
+        - fix
+        - bug
+    - title: ⬆️ 依存関係の更新
+      labels:
+        - dependencies
+    - title: その他の変更
+      labels:
+        - "*"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -306,151 +306,42 @@ jobs:
       - name: Generate release notes
         id: release_notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # デバッグ: Token存在確認
-          if [ -z "$GITHUB_TOKEN" ]; then
-            echo "::warning::GITHUB_TOKEN is not set - API calls may fail"
-          else
-            echo "GITHUB_TOKEN is configured (length: ${#GITHUB_TOKEN})"
-          fi
-
           RELEASE_TYPE="${{ steps.vars.outputs.release_type }}"
           VERSION="${{ steps.vars.outputs.version }}"
+          TAG_NAME="${{ steps.vars.outputs.tag_name }}"
 
-          # Get recent changes from git log since last tag
-          # Get the second most recent tag (the one before current release)
+          # 直近の前回タグ（現在のタグ自身は除外）を求める
           CURRENT_TAG=$(git tag --sort=-version:refname | head -n 1)
           LAST_TAG=$(git tag --sort=-version:refname | head -n 2 | tail -n 1)
-
-          # If current tag is the same as last tag, get the third most recent
           if [ "$CURRENT_TAG" = "$LAST_TAG" ]; then
             LAST_TAG=$(git tag --sort=-version:refname | head -n 3 | tail -n 1)
           fi
-
           echo "Last tag: $LAST_TAG"
 
+          # GitHub公式のリリースノート自動生成APIでマージ済みPR一覧を取得する。
+          # カテゴリ分け・除外は .github/release.yml の設定に従う。
+          # 自前のPR解析・API個別呼び出し・フォールバックは廃止。
+          GEN_ARGS=(
+            -X POST
+            "repos/${{ github.repository }}/releases/generate-notes"
+            -f "tag_name=$TAG_NAME"
+            -f "target_commitish=${{ github.sha }}"
+          )
           if [ -n "$LAST_TAG" ]; then
-            # Get all commits since last tag with detailed info
-            echo "Getting commits since $LAST_TAG..."
-            COMMIT_INFO=$(git log --pretty=format:"%H|%s|%an|%ad" --date=short $LAST_TAG..HEAD | head -15)
-
-            # If no commits since last tag, get commits from the last tag and before
-            if [ -z "$COMMIT_INFO" ]; then
-              echo "No commits since last tag, getting commits including the tag..."
-              COMMIT_INFO=$(git log --pretty=format:"%H|%s|%an|%ad" --date=short -5)
-            fi
-          else
-            # Get last 15 commits if no previous tag
-            echo "No previous tag found, getting last 15 commits..."
-            COMMIT_INFO=$(git log --pretty=format:"%H|%s|%an|%ad" --date=short -15)
+            GEN_ARGS+=(-f "previous_tag_name=$LAST_TAG")
           fi
 
-          echo "Raw commit info:"
-          echo "$COMMIT_INFO"
+          CHANGES=$(gh api "${GEN_ARGS[@]}" -q .body || true)
 
-          CHANGES=""
-          processed_prs=""
-
-          # Check if we have any commits to process
-          if [ -z "$COMMIT_INFO" ]; then
-            echo "No commit information available"
+          if [ -z "$CHANGES" ]; then
+            echo "::warning::generate-notes API returned empty - using default message"
             CHANGES="- バグ修正と機能改善"
-          else
-            # Process each commit
-            while IFS='|' read -r commit_hash commit_msg author date; do
-              # Skip empty lines
-              if [ -z "$commit_hash" ] || [ -z "$commit_msg" ]; then
-                continue
-              fi
-
-              echo "Processing: $commit_msg"
-
-            # Check if it's a merge commit from a PR
-            if [[ $commit_msg =~ ^Merge\ pull\ request\ #([0-9]+)\ from\ (.+)$ ]]; then
-              pr_number="${BASH_REMATCH[1]}"
-              branch_info="${BASH_REMATCH[2]}"
-
-              # Skip if we've already processed this PR
-              if [[ "$processed_prs" =~ $pr_number ]]; then
-                continue
-              fi
-              processed_prs="$processed_prs $pr_number"
-
-              echo "Found PR #$pr_number"
-
-              # Try to get PR title from GitHub API with proper error handling
-              echo "Fetching PR #$pr_number from API..."
-
-              # Use -w to get HTTP status code
-              response=$(curl -s -w "\n%{http_code}" \
-                -H "Authorization: token $GITHUB_TOKEN" \
-                -H "Accept: application/vnd.github.v3+json" \
-                "https://api.github.com/repos/${{ github.repository }}/pulls/$pr_number")
-
-              http_code=$(echo "$response" | tail -n1)
-              pr_data=$(echo "$response" | sed '$d')
-
-              echo "API Response status: $http_code"
-
-              if [ "$http_code" = "200" ] && [ -n "$pr_data" ]; then
-                pr_title=$(echo "$pr_data" | jq -r '.title // empty')
-
-                if [ -n "$pr_title" ] && [ "$pr_title" != "null" ] && [ "$pr_title" != "empty" ]; then
-                  echo "Got PR title: $pr_title"
-                  CHANGES="$CHANGES### 🔀 $pr_title (PR #$pr_number)\n"
-
-                  # Get commits within this PR for hierarchy
-                  pr_commits=$(git log --pretty=format:"  - %s (%an)" --grep="(#$pr_number)" --oneline | head -5)
-                  if [ -n "$pr_commits" ]; then
-                    CHANGES="$CHANGES$pr_commits\n"
-                  fi
-                  CHANGES="$CHANGES\n"
-                  continue
-                else
-                  echo "::warning::Could not parse PR title from API response"
-                fi
-              else
-                echo "::warning::API call failed for PR #$pr_number (HTTP $http_code)"
-                # Show error message if available
-                error_msg=$(echo "$pr_data" | jq -r '.message // empty' 2>/dev/null)
-                if [ -n "$error_msg" ]; then
-                  echo "API Error: $error_msg"
-                fi
-              fi
-
-              # Fallback: Use PR number and branch name
-              echo "Using fallback for PR #$pr_number"
-              branch_name=$(echo "$branch_info" | sed 's/.*\///' | sed 's/-/ /g' | sed 's/_/ /g')
-              CHANGES="$CHANGES- PR #$pr_number: $branch_name\n"
-
-            elif [[ $commit_msg =~ .*\(#([0-9]+)\)$ ]]; then
-              # Commit with PR reference - skip as it will be included in PR hierarchy
-              continue
-
-            else
-              # Regular direct commit
-              if [[ ! $commit_msg =~ ^(Merge\ branch|Update|Bump\ |chore\(|docs\(|style\() ]]; then
-                # Clean up commit message
-                clean_msg=$(echo "$commit_msg" | sed 's/^fix: //' | sed 's/^feat: //' | sed 's/^refactor: //')
-                CHANGES="$CHANGES- $clean_msg ($author)\n"
-              fi
-            fi
-          done <<< "$COMMIT_INFO"
           fi
 
-          # Format final output
-          CHANGES=$(echo -e "$CHANGES" | sed '/^$/d')
-
-          echo "Final changes:"
+          echo "Generated changes:"
           echo "$CHANGES"
-
-          # If no meaningful changes, provide default message with warning
-          if [ -z "$CHANGES" ] || [ "$(echo "$CHANGES" | wc -l)" -eq 0 ]; then
-            echo "::warning::No PR information could be retrieved - using default message"
-            echo "This might indicate an API authentication or rate limiting issue"
-            CHANGES="- バグ修正と機能改善"
-          fi
 
           if [ "$RELEASE_TYPE" = "prerelease" ]; then
             NOTES=$(VERSION="$VERSION" CHANGES="$CHANGES" node scripts/build-release-notes.js prerelease)

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,48 @@
+name: PR Auto Label
+
+# PRタイトルの Conventional Commits プレフィックスから自動でラベルを付与する。
+# 付与したラベルは .github/release.yml のカテゴリ分けに使われ、
+# リリースノートのPR一覧がセクション分けされる。
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label from title prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # 先頭プレフィックスを抽出: feat / fix / feat(scope) / fix(ci)! など
+          PREFIX=$(printf '%s' "$PR_TITLE" \
+            | sed -nE 's/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/p' \
+            | tr '[:upper:]' '[:lower:]')
+
+          echo "PR #$PR_NUMBER title: $PR_TITLE"
+          echo "Detected prefix: '${PREFIX:-<none>}'"
+
+          # プレフィックス -> 既存ラベルへのマッピング（release.yml と整合）
+          case "$PREFIX" in
+            feat|perf|refactor) LABEL="enhancement" ;;
+            fix)                LABEL="bug" ;;
+            *)                  LABEL="" ;;
+          esac
+
+          if [ -z "$LABEL" ]; then
+            echo "No matching label for prefix '${PREFIX:-<none>}' - skipping"
+            exit 0
+          fi
+
+          echo "Adding label: $LABEL"
+          gh pr edit "$PR_NUMBER" --add-label "$LABEL"


### PR DESCRIPTION
Closes #877

## 概要

リリースノートのPR一覧を、自前bashスクリプト（約160行）から **GitHub公式の `releases/generate-notes` API** へ置き換え、あわせてPRの自動ラベリングを導入する。

## 変更ファイル

| ファイル | 内容 |
| --- | --- |
| `.github/workflows/build-and-release.yml` | 自前のPR解析（マージコミット正規表現／PR個別API／失敗フォールバック）を廃止し公式APIへ置換。日本語体裁・Discord連携は維持 |
| `.github/release.yml`（新規） | PR一覧のカテゴリ分け・除外設定 |
| `.github/workflows/pr-auto-label.yml`（新規） | PRタイトルのプレフィックスから既存ラベルを自動付与 |

## 動作

1. PRをマージ（git-workflow経由で必ずPRを通る）
2. タイトルから自動でラベル付与（`feat:`→enhancement / `fix:`→bug）
3. リリース時に公式generate-notesが`release.yml`に従いPRをセクション分けして一覧
4. 同じ一覧をDiscord通知にも反映

## 注意

- 自動ラベリングは今後のPRが対象（過去PRには遡及しない）。
- `pull_request_target` を使用（PR書き込み権限のため）。タイトル文字列を読むのみでコードのcheckoutは行わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)