### PR TITLE
fix(students): 生徒一覧・追加パネルの在籍フィルター改善

### DIFF
--- a/electron-src/lib/prisma/availableStudents.ts
+++ b/electron-src/lib/prisma/availableStudents.ts
@@ -1,8 +1,9 @@
 /**
  * 対象（試験・成績）に個別追加できる生徒候補の取得
  *
- * exam / grade で共有する。在籍スイッチON時は「終了していない学級所属が
- * 1件以上ある生徒のみ」に絞る（在籍は生徒単体ではなく所属レコードで決まる）。
+ * exam / grade で共有する。在籍スイッチON時は「未在籍（所属なし）または在籍中
+ * （終了していない所属が1件以上）の生徒のみ」に絞る＝過去在籍（所属はあるが全て
+ * 終了済み）だけを除外する。未在籍・在籍中と過去在籍は全生徒の直和（非交和）。
  */
 
 import { Prisma } from "@prisma/client"
@@ -23,7 +24,7 @@ export type AvailableStudentItem = Prisma.StudentGetPayload<{
  *
  * @param excludeStudentIds 候補から除外する生徒ID（既に対象へ追加済みの生徒）
  * @param referenceDate 在籍判定の基準日（exam=examDate / grade=referenceDate、null可）
- * @param activeOnly true なら「終了していない所属が1件以上ある生徒」のみに絞る
+ * @param activeOnly true なら「未在籍・在籍中の生徒」のみに絞る（過去在籍のみ除外）
  */
 export async function getAvailableStudentsForTarget(params: {
   excludeStudentIds: string[]
@@ -36,9 +37,15 @@ export async function getAvailableStudentsForTarget(params: {
     where: {
       id:
         excludeStudentIds.length > 0 ? { notIn: excludeStudentIds } : undefined,
-      // 在籍中の所属が1件以上ある生徒のみ（activeOnly時）
+      // 未在籍（所属なし）または在籍中（終了していない所属が1件以上）の生徒のみ
+      // （activeOnly時）。過去在籍（所属はあるが全て終了済み）だけを除外する。
       ...(activeOnly
-        ? { memberships: { some: membershipFilterAt(referenceDate) } }
+        ? {
+            OR: [
+              { memberships: { none: {} } },
+              { memberships: { some: membershipFilterAt(referenceDate) } },
+            ],
+          }
         : {}),
     },
     include: {

--- a/src/components/common/student-add-panel/components/StudentAddPanel.tsx
+++ b/src/components/common/student-add-panel/components/StudentAddPanel.tsx
@@ -63,6 +63,8 @@ export function StudentAddPanel({
     loadingClasses,
     loadingStudents,
     isAdding,
+    classEmptyReason,
+    studentEmptyReason,
     selectedClassCount,
     selectedStudentCount,
     handleClassSelection,
@@ -76,6 +78,43 @@ export function StudentAddPanel({
     classActiveOnlyDefault,
     studentActiveOnlyDefault,
   })
+
+  // 学級候補が空のときの理由別メッセージ（スイッチ状態で文言を変える）
+  const classEmptyMessage = (() => {
+    switch (classEmptyReason) {
+      case "noStudents":
+        return "生徒が登録されていません。先に「生徒」ページで生徒を登録してください。"
+      case "noClassMembership":
+        return "学級に所属している生徒がいません。「個別で追加」タブから追加できます。"
+      case "noCurrentInClass":
+        return "在籍中の生徒がいる学級がありません。スイッチをオフにすると、現在在籍していない生徒も表示できます。"
+      case "allAdded":
+        return classActiveOnly
+          ? "在籍中の生徒は全て追加しました。"
+          : "学級に所属する生徒は全て追加しました。"
+      default:
+        return "追加可能な学級がありません"
+    }
+  })()
+
+  // 生徒候補が空のときの理由別メッセージ（スイッチ状態で文言を変える）
+  const studentEmptyMessage = (() => {
+    if (searchTerm || filterClassId !== "all") {
+      return "該当する生徒が見つかりません"
+    }
+    switch (studentEmptyReason) {
+      case "noStudents":
+        return "生徒が登録されていません。先に「生徒」ページで生徒を登録してください。"
+      case "noCurrentEnrollment":
+        return "未在籍・在籍中の生徒がいません。スイッチをオフにすると、現在在籍していない生徒も表示できます。"
+      case "allAdded":
+        return studentActiveOnly
+          ? "未在籍・在籍中の生徒は全て追加しました。"
+          : "すべての生徒を追加しました。"
+      default:
+        return "該当する生徒が見つかりません"
+    }
+  })()
 
   // fillHeight 時はタブ・カードを親の高さいっぱいに広げ、リストを内部スクロールにする
   const tabsClass = fillHeight ? "flex h-full w-full flex-col" : "w-full"
@@ -107,9 +146,9 @@ export function StudentAddPanel({
             checked={classActiveOnly}
             onCheckedChange={setClassActiveOnly}
           />
-          <span>在籍中の生徒のみ追加</span>
+          <span>在籍中の生徒のみ表示</span>
           <span className="text-muted-foreground text-xs">
-            （オフにすると在籍が終了した生徒も対象になります）
+            （オフにすると現在在籍していない生徒も表示します）
           </span>
         </label>
 
@@ -131,7 +170,7 @@ export function StudentAddPanel({
                 <div className="py-4 text-center">読み込み中...</div>
               ) : classes.length === 0 ? (
                 <div className="text-muted-foreground py-4 text-center">
-                  追加可能な学級がありません
+                  {classEmptyMessage}
                 </div>
               ) : (
                 classes.map((classItem) => (
@@ -215,9 +254,9 @@ export function StudentAddPanel({
             checked={studentActiveOnly}
             onCheckedChange={setStudentActiveOnly}
           />
-          <span>在籍中の生徒のみ表示</span>
+          <span>未在籍・在籍中の生徒のみ表示</span>
           <span className="text-muted-foreground text-xs">
-            （オフにすると在籍が終了した生徒・未所属の生徒も表示します）
+            （オフにすると過去に在籍した生徒も表示します）
           </span>
         </label>
 
@@ -259,7 +298,7 @@ export function StudentAddPanel({
               <div className="py-4 text-center">読み込み中...</div>
             ) : filteredStudents.length === 0 ? (
               <div className="text-muted-foreground py-4 text-center">
-                該当する生徒が見つかりません
+                {studentEmptyMessage}
               </div>
             ) : (
               <div className="space-y-2">

--- a/src/components/common/student-add-panel/hooks/useStudentAddPanel.ts
+++ b/src/components/common/student-add-panel/hooks/useStudentAddPanel.ts
@@ -7,6 +7,7 @@ import type {
   AddPanelStudentItem,
   StudentAddPanelAdapter,
 } from "@/components/common/student-add-panel/types/studentAddPanelTypes"
+import { isCurrentMembership } from "@/lib/membership"
 
 interface SelectableClass extends AddPanelClassItem {
   isSelected: boolean
@@ -21,6 +22,67 @@ interface UseStudentAddPanelParams {
   onAdded: () => void
   classActiveOnlyDefault: boolean
   studentActiveOnlyDefault: boolean
+}
+
+/** 学級候補が空になった理由（空表示メッセージの出し分け用） */
+export type ClassEmptyReason =
+  /** システムに生徒が1人も登録されていない（要・生徒登録） */
+  | "noStudents"
+  /** 生徒はいるが、どの学級にも所属していない */
+  | "noClassMembership"
+  /** 学級に所属者はいるが、在籍中（スイッチON条件）が0名 */
+  | "noCurrentInClass"
+  /** 学級に所属する生徒はいるが、追加可能分は全て追加済み */
+  | "allAdded"
+
+/** 生徒候補が空になった理由（空表示メッセージの出し分け用） */
+export type StudentEmptyReason =
+  /** システムに生徒が1人も登録されていない（要・生徒登録） */
+  | "noStudents"
+  /** 未在籍・在籍中（スイッチON条件）が0名で、過去在籍の生徒のみ存在 */
+  | "noCurrentEnrollment"
+  /** 対象生徒は存在するが、全て追加済み */
+  | "allAdded"
+
+/**
+ * 学級候補が0件のときの理由を判定する。
+ *
+ * 対象スコープのアダプタ（未追加候補）だけでは「生徒0人」と「全員追加済み」を
+ * 区別できないため、システム全体の生徒（追加済み含む）を見て判定する。
+ */
+async function resolveClassEmptyReason(
+  adapter: StudentAddPanelAdapter,
+  classActiveOnly: boolean
+): Promise<ClassEmptyReason> {
+  const allStudents = await window.electronAPI.fetchStudents()
+  if (allStudents.length === 0) return "noStudents"
+  const anyInClass = allStudents.some((s) => s.memberships.length > 0)
+  if (!anyInClass) return "noClassMembership"
+  // 学級所属者はいる。未追加の学級候補（在籍条件なし）が残るかで切り分ける
+  const classesAny = await adapter.fetchAvailableClasses(false)
+  if (classActiveOnly && classesAny.length > 0) return "noCurrentInClass"
+  return "allAdded"
+}
+
+/**
+ * 生徒候補が0件のときの理由を判定する。
+ *
+ * システム全体の生徒（追加済み含む）を見て、「生徒0人」「全員追加済み」
+ * 「未在籍・在籍中が元々0名（過去在籍のみ）」を区別する。
+ */
+async function resolveStudentEmptyReason(
+  studentActiveOnly: boolean
+): Promise<StudentEmptyReason> {
+  const allStudents = await window.electronAPI.fetchStudents()
+  if (allStudents.length === 0) return "noStudents"
+  if (studentActiveOnly) {
+    const hasCurrentOrUnassigned = allStudents.some(
+      (s) =>
+        s.memberships.length === 0 || s.memberships.some(isCurrentMembership)
+    )
+    return hasCurrentOrUnassigned ? "allAdded" : "noCurrentEnrollment"
+  }
+  return "allAdded"
 }
 
 /**
@@ -47,12 +109,21 @@ export function useStudentAddPanel({
   const [loadingClasses, setLoadingClasses] = useState(false)
   const [loadingStudents, setLoadingStudents] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
+  const [classEmptyReason, setClassEmptyReason] =
+    useState<ClassEmptyReason | null>(null)
+  const [studentEmptyReason, setStudentEmptyReason] =
+    useState<StudentEmptyReason | null>(null)
 
   const loadClasses = useCallback(async () => {
     setLoadingClasses(true)
     try {
       const result = await adapter.fetchAvailableClasses(classActiveOnly)
       setClasses(result.map((c) => ({ ...c, isSelected: false })))
+      setClassEmptyReason(
+        result.length > 0
+          ? null
+          : await resolveClassEmptyReason(adapter, classActiveOnly)
+      )
     } catch (error) {
       console.error("Failed to fetch available classes:", error)
     } finally {
@@ -65,6 +136,11 @@ export function useStudentAddPanel({
     try {
       const result = await adapter.fetchAvailableStudents(studentActiveOnly)
       setStudents(result.map((s) => ({ ...s, isSelected: false })))
+      setStudentEmptyReason(
+        result.length > 0
+          ? null
+          : await resolveStudentEmptyReason(studentActiveOnly)
+      )
     } catch (error) {
       console.error("Failed to fetch available students:", error)
     } finally {
@@ -182,6 +258,8 @@ export function useStudentAddPanel({
     loadingClasses,
     loadingStudents,
     isAdding,
+    classEmptyReason,
+    studentEmptyReason,
     selectedClassCount,
     selectedStudentCount,
     handleClassSelection,

--- a/src/components/student/StudentTable.tsx
+++ b/src/components/student/StudentTable.tsx
@@ -61,7 +61,7 @@ export default function StudentTable() {
   const [classes, setClasses] = useState<ClassWithMemberships[]>([])
   const [searchTerm, setSearchTerm] = useState("")
   const [filterMembershipStatus, setFilterMembershipStatus] =
-    useState<string>("current")
+    useState<string>("current_unassigned")
   const [filterClassId, setFilterClassId] = useState<string>("all")
 
   // Selection states
@@ -113,7 +113,13 @@ export default function StudentTable() {
         if (!belongsToClass) return false
       }
 
-      if (filterMembershipStatus === "current") {
+      if (filterMembershipStatus === "current_unassigned") {
+        return (
+          matchesSearch &&
+          (student.memberships.length === 0 ||
+            student.memberships.some((m) => isCurrentMembership(m)))
+        )
+      } else if (filterMembershipStatus === "current") {
         return (
           matchesSearch &&
           student.memberships.some((m) => isCurrentMembership(m))
@@ -382,9 +388,10 @@ export default function StudentTable() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">すべて</SelectItem>
-              <SelectItem value="current">現在所属中</SelectItem>
-              <SelectItem value="past">過去の所属</SelectItem>
-              <SelectItem value="unassigned">未所属</SelectItem>
+              <SelectItem value="unassigned">未在籍</SelectItem>
+              <SelectItem value="current">在籍中</SelectItem>
+              <SelectItem value="current_unassigned">未在籍・在籍中</SelectItem>
+              <SelectItem value="past">過去在籍</SelectItem>
             </SelectContent>
           </Select>
           <span className="text-muted-foreground text-sm tabular-nums">


### PR DESCRIPTION
## 概要

学級未所属（未在籍）の生徒が表示・追加できない問題を解消し、在籍フィルターの挙動と空表示メッセージを改善する。

Closes #879

## 変更内容

### 生徒一覧（StudentTable）
- 「未在籍・在籍中」フィルターを新設しデフォルト化（未所属生徒が既定で表示される）
- ラベルを「すべて / 未在籍 / 在籍中 / 未在籍・在籍中 / 過去在籍」に整理
- 「過去在籍」は在籍中を除外。「未在籍・在籍中」と「過去在籍」は全体の直和（非交和）

### 生徒追加パネル（試験・外部資料・成績で共通）
- 個別タブの候補取得を「未在籍・在籍中のみ（過去在籍のみ除外）」に変更
- 学級タブ／個別タブでスイッチ文言を出し分け
- 候補が空のとき「生徒未登録／学級未所属／在籍中0名／全員追加済み」を区別し、スイッチ状態に応じたメッセージを表示

## テスト
- `npm run typecheck` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)