### PR TITLE
feat(export): 試験統計の充実（α係数・D値・S-P表・度数分布・R/exametrika出力）

### DIFF
--- a/__tests__/calculations/itemAnalysisStats.test.ts
+++ b/__tests__/calculations/itemAnalysisStats.test.ts
@@ -1,0 +1,143 @@
+/**
+ * 項目分析の拡張統計（#833）のテスト
+ *
+ * テスト対象: 共有モジュール computeItemAnalysis
+ * - cronbachAlpha: テスト全体の信頼性係数（α、complete-case・母分散）
+ * - items[].dValue: 設問ごとの古典的識別力（上位/下位27%群の得点率差、complete-case）
+ * - 欠測（score===null）の除外、部分点の比例反映
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+  computeItemAnalysis,
+  type ItemAnalysisInputStudent,
+} from "@/electron-src/lib/shared/calculations/itemAnalysis"
+
+// ================== ヘルパー ==================
+
+/**
+ * 二値（正誤）パターンから入力を作る。1=正答, 0=誤答, null=欠測（未採点/未確定）。
+ * maxScores 省略時は全設問1点満点。
+ */
+function makeStudent(
+  pattern: (number | null)[],
+  opts?: { maxScores?: number[]; partialAt?: number[] }
+): ItemAnalysisInputStudent {
+  return {
+    items: pattern.map((v, i) => ({
+      questionId: `q${i + 1}`,
+      label: `q${i + 1}`,
+      maxScore: opts?.maxScores?.[i] ?? 1,
+      score: v,
+      // partialAt に含まれる設問は部分点（正答ではない）扱い
+      isCorrect:
+        v !== null &&
+        v === (opts?.maxScores?.[i] ?? 1) &&
+        !(opts?.partialAt ?? []).includes(i),
+    })),
+  }
+}
+
+function dValueOf(
+  result: ReturnType<typeof computeItemAnalysis>,
+  questionId: string
+): number | null {
+  return result!.items.find((it) => it.questionId === questionId)!.dValue
+}
+
+// ================== クロンバックα係数 ==================
+
+describe("computeItemAnalysis - cronbachAlpha", () => {
+  it("手計算と一致する（3生徒×2設問）", () => {
+    // S1:[1,1] S2:[1,0] S3:[0,0] → α=2/3
+    const data = [makeStudent([1, 1]), makeStudent([1, 0]), makeStudent([0, 0])]
+    const result = computeItemAnalysis(data)
+    expect(result).not.toBeNull()
+    expect(result!.cronbachAlpha as number).toBeCloseTo(2 / 3, 4)
+  })
+
+  it("設問が1問なら cronbachAlpha は null（k<2）", () => {
+    const data = [makeStudent([1]), makeStudent([0]), makeStudent([1])]
+    expect(computeItemAnalysis(data)!.cronbachAlpha).toBeNull()
+  })
+
+  it("complete-case が3人未満なら null", () => {
+    const data = [makeStudent([1, 1]), makeStudent([1, 0])]
+    expect(computeItemAnalysis(data)!.cronbachAlpha).toBeNull()
+  })
+
+  it("合計点の分散が0なら null（全員同じ得点）", () => {
+    const data = [makeStudent([1, 0]), makeStudent([1, 0]), makeStudent([1, 0])]
+    expect(computeItemAnalysis(data)!.cronbachAlpha).toBeNull()
+  })
+
+  it("欠測（未採点・保留=score null）を含む生徒は complete-case から除外", () => {
+    // S4 は q2 が欠測 → 除外。残り3人で α=2/3
+    const data = [
+      makeStudent([1, 1]),
+      makeStudent([1, 0]),
+      makeStudent([0, 0]),
+      makeStudent([1, null]),
+    ]
+    const result = computeItemAnalysis(data)
+    expect(result!.completeCaseCount).toBe(3)
+    expect(result!.cronbachAlpha as number).toBeCloseTo(2 / 3, 4)
+  })
+
+  it("空配列なら null", () => {
+    expect(computeItemAnalysis([])).toBeNull()
+  })
+})
+
+// ================== D値（得点率差） ==================
+
+describe("computeItemAnalysis - dValue", () => {
+  it("上位群が正答・下位群が誤答の設問は D=1", () => {
+    const data = [
+      makeStudent([1, 1, 1]), // total 3
+      makeStudent([1, 1, 0]), // total 2
+      makeStudent([1, 0, 0]), // total 1
+      makeStudent([0, 0, 0]), // total 0
+    ]
+    expect(dValueOf(computeItemAnalysis(data), "q1")).toBeCloseTo(1, 6)
+  })
+
+  it("全員正答の設問は識別力なし D=0", () => {
+    const data = [
+      makeStudent([1, 1]),
+      makeStudent([1, 1]),
+      makeStudent([1, 0]),
+      makeStudent([1, 0]),
+    ]
+    expect(dValueOf(computeItemAnalysis(data), "q1")).toBeCloseTo(0, 6)
+  })
+
+  it("下位群が正答・上位群が誤答なら負のD値", () => {
+    const data = [
+      makeStudent([0, 1, 1]), // total 2（最上位）
+      makeStudent([0, 1, 0]),
+      makeStudent([1, 0, 0]),
+      makeStudent([1, 0, 0]), // total 1 だが q1 正答
+    ]
+    expect(dValueOf(computeItemAnalysis(data), "q1") as number).toBeLessThan(0)
+  })
+
+  it("部分点は得点率として比例反映される（=誤答0ではない）", () => {
+    // q1 は2点満点。S1 は部分点1点(rate .5, 正答ではない)、S4 は0点
+    const data = [
+      makeStudent([1, 1], { maxScores: [2, 1], partialAt: [0] }), // total 2（上位）
+      makeStudent([0, 1], { maxScores: [2, 1] }), // total 1
+      makeStudent([0, 1], { maxScores: [2, 1] }), // total 1
+      makeStudent([0, 0], { maxScores: [2, 1] }), // total 0（下位）
+    ]
+    // 上位S1 q1得点率=0.5, 下位S4 q1得点率=0 → D=0.5（二値正答率なら0になるはず）
+    expect(dValueOf(computeItemAnalysis(data), "q1")).toBeCloseTo(0.5, 6)
+  })
+
+  it("complete-case が少なく群サイズ0なら dValue は null", () => {
+    const data = [makeStudent([1, 0])]
+    const result = computeItemAnalysis(data)
+    expect(dValueOf(result, "q1")).toBeNull()
+    expect(dValueOf(result, "q2")).toBeNull()
+  })
+})

--- a/__tests__/calculations/spAnalysis.test.ts
+++ b/__tests__/calculations/spAnalysis.test.ts
@@ -1,0 +1,128 @@
+/**
+ * S-P表・得点度数分布（#838）のテスト
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+  computeFrequencyDistribution,
+  computeSpTable,
+  type SpInputStudent,
+} from "@/electron-src/lib/shared/calculations/spAnalysis"
+
+// ================== ヘルパー ==================
+
+/** 二値パターンから SpInputStudent を作る。1=正答, 0=誤答, null=未採点 */
+function makeStudent(
+  studentId: string,
+  pattern: (0 | 1 | null)[]
+): SpInputStudent {
+  return {
+    studentId,
+    studentName: studentId,
+    items: pattern.map((v, i) => ({
+      questionId: `q${i + 1}`,
+      label: `q${i + 1}`,
+      isCorrect: v === 1,
+      isScored: v !== null,
+    })),
+  }
+}
+
+// ================== S-P表 ==================
+
+describe("computeSpTable", () => {
+  it("完全Guttonパターンでは注意係数が0（分母0の最上位はnull）", () => {
+    const data = [
+      makeStudent("S1", [1, 1, 1]),
+      makeStudent("S2", [1, 1, 0]),
+      makeStudent("S3", [1, 0, 0]),
+    ]
+    const result = computeSpTable(data)
+    expect(result).not.toBeNull()
+    const r = result!
+    // 生徒は正答数降順
+    expect(r.students.map((s) => s.studentId)).toEqual(["S1", "S2", "S3"])
+    expect(r.students[0].correctCount).toBe(3)
+    // S1(n=3)は分母0→null、S2/S3はGuttman一致で0
+    expect(r.students[0].cautionIndex).toBeNull()
+    expect(r.students[1].cautionIndex).toBeCloseTo(0, 6)
+    expect(r.students[2].cautionIndex).toBeCloseTo(0, 6)
+  })
+
+  it("逸脱した応答パターンの生徒は高い注意係数になる", () => {
+    // S3 は難問p3だけ正答・易問p1p2を落とす逸脱パターン
+    const data = [
+      makeStudent("S1", [1, 1, 1]), // 3
+      makeStudent("S2", [1, 1, 0]), // 2
+      makeStudent("S3", [0, 0, 1]), // 1（逸脱）
+      makeStudent("S4", [1, 0, 0]), // 1（一致）
+    ]
+    const result = computeSpTable(data)!
+    // colSum: p1=3, p2=2, p3=2 → 設問は p1,p2,p3 の順
+    expect(result.problems.map((p) => p.questionId)).toEqual(["q1", "q2", "q3"])
+    expect(result.problems[0].correctCount).toBe(3)
+
+    const s3 = result.students.find((s) => s.studentId === "S3")!
+    const s4 = result.students.find((s) => s.studentId === "S4")!
+    // 手計算: S3 CS=1.5, S4 CS=0
+    expect(s3.cautionIndex).toBeCloseTo(1.5, 6)
+    expect(s4.cautionIndex).toBeCloseTo(0, 6)
+  })
+
+  it("cells は設問の並び（正答者数降順）に揃う", () => {
+    const data = [
+      makeStudent("S1", [1, 1, 1]),
+      makeStudent("S2", [1, 1, 0]),
+      makeStudent("S3", [1, 0, 0]),
+    ]
+    const r = computeSpTable(data)!
+    // S2 は p1,p2 正答・p3 誤答（並びは p1,p2,p3）
+    const s2 = r.students.find((s) => s.studentId === "S2")!
+    expect(s2.cells).toEqual([true, true, false])
+  })
+
+  it("全問未採点の生徒は母集団から除外される", () => {
+    const data = [
+      makeStudent("S1", [1, 1, 1]),
+      makeStudent("S2", [1, 1, 0]),
+      makeStudent("S3", [1, 0, 0]),
+      makeStudent("S4", [null, null, null]),
+    ]
+    const r = computeSpTable(data)!
+    expect(r.studentCount).toBe(3)
+    expect(r.students.find((s) => s.studentId === "S4")).toBeUndefined()
+  })
+
+  it("有効生徒が居なければ null", () => {
+    expect(computeSpTable([])).toBeNull()
+    expect(computeSpTable([makeStudent("S1", [null, null])])).toBeNull()
+  })
+})
+
+// ================== 得点度数分布 ==================
+
+describe("computeFrequencyDistribution", () => {
+  it("満点は最終階級に入り、平均・標準偏差は母分散", () => {
+    const result = computeFrequencyDistribution([0, 50, 100], 100)!
+    // binWidth=10, 階級は [0,10)…[90,100] の10個
+    expect(result.bins.length).toBe(10)
+    expect(result.maxScore).toBe(100)
+    expect(result.count).toBe(3)
+    // 0→bin0, 50→bin5, 100→最終bin9
+    expect(result.bins[0].count).toBe(1)
+    expect(result.bins[5].count).toBe(1)
+    expect(result.bins[9].count).toBe(1)
+    expect(result.mean).toBeCloseTo(50, 6)
+    // 母分散 = ((50)^2+0+(50)^2)/3 = 1666.67 → sd ≈ 40.8248
+    expect(result.stdDev).toBeCloseTo(40.8248, 3)
+  })
+
+  it("null（未採点・欠席）は除外される", () => {
+    const result = computeFrequencyDistribution([10, null, 20], 100)!
+    expect(result.count).toBe(2)
+  })
+
+  it("全てnullなら null", () => {
+    expect(computeFrequencyDistribution([null, null], 100)).toBeNull()
+  })
+})

--- a/docs/class-statistics-redesign.md
+++ b/docs/class-statistics-redesign.md
@@ -1,0 +1,376 @@
+# 学級統計の再設計
+
+試験(Exam)における「学級」の扱い — 採番・統計・出力 — を作り直すための設計文書。
+成績(Grade)・資料(Coursework)への共通化も含む。
+
+最終更新: 2026-06-29 / ステータス: 設計確定。学級再設計(Phase 0-5)は未実装。統計強化(11章)は **#833/#838/#834 すべて実装完了**（α係数・D値・S-P表・得点度数分布・R/exametrikaエクスポート。Excel/プレビュー配線済、typecheck・lint・テスト86件パス）。
+
+---
+
+## 1. 背景と動機
+
+「学級の関連付け」が成績出力にどう使われているかの調査から始まり、以下の問題が判明した。
+
+### 1.1 発見した問題
+
+| #   | 問題                                                                                                                                                                                                           | 箇所                                                                   |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| P1  | 学級平均の母集団が **`memberships[0]`（startDate降順の先頭）** で決まる。終了した在籍も含み、登録順という偶然で母集団が散る                                                                                    | `individual-report/dataFetcher.ts:143-147`、`excel/dataFetcher.ts:118` |
+| P2  | `ExamClass.statistics` フラグが定義・UIはあるのに **どの計算からも読まれていない**（死んでいる）                                                                                                               | `examClass.ts:128` の `getStatisticsClasses` が未呼び出し              |
+| P3  | **再採番（並び順リセット）が受験日基準でない**。追加時(`addStudentsFromClass`)は `membershipFilterAt(examDate)` を使うのに、表示・採番の解決(`getStudentClassInfoForExam`)は日付フィルタなしで全membership取得 | `examClass.ts:499-517`                                                 |
+| P4  | **学級削除に確認ダイアログが無い**。さらに3エンティティで挙動がバラバラ（試験=リンクのみ削除／成績・資料=専属生徒を無確認削除）                                                                                | `ClassExamManager.tsx:99`、`rosterManager.ts:224`                      |
+| P5  | **エンティティ参照をJSONに押し付け**。小計グループ選択 `selectedGroupIds: string[]` が settingsJson に保存され、亡霊ID（削除後も残る）が発生しうる                                                             | `individual-report/types.ts:191`                                       |
+
+### 1.2 本来やりたかったこと
+
+指定した学級を母集団として**学級平均等を算出し出力する**。Excel の学級平均行/学級別集計と、個人成績表の学級比較。
+（当初は独立PDF「学級成績表」も検討したが、5.2の判断で見送り。）
+
+---
+
+## 2. 確定した概念モデル
+
+### 2.1 「学級」とは
+
+在籍学級(3-A組)だけでなく、**生徒の任意のグルーピング**を含む: 部活動・習熟度別・昨年度学級など。
+**1人の生徒は複数の学級に同時に所属する**のが普通。
+
+### 2.2 在籍(StudentClassMembership)
+
+生徒と学級の結びつきの記録。**期間(startDate/endDate)** と **学級ごとの出席番号** を持つ。
+過去の所属も履歴として残る。
+
+### 2.3 試験-学級(ExamClass)と試験-生徒(ExamStudent)
+
+- **ExamStudent** = 採点の本体（点数・答案がぶら下がる確定記録）。在籍の変化では壊れない。
+- **ExamClass** = 試験への学級登録。生徒の一括取り込み口＋並び順(`order`)を与える便宜的なまとまり。
+
+### 2.4 学級の「3つの使い道」＝3つの独立スイッチ
+
+| #   | 使い道               | 誰のため     | 学級の扱い                               | 操作画面     | 保存先                                     |
+| --- | -------------------- | ------------ | ---------------------------------------- | ------------ | ------------------------------------------ |
+| 1   | **再採番・配置**     | 採点作業     | 1人=1学級（order優先で確定、重複は無視） | 受験生徒(05) | `ExamClass.administered` + `order`（既存） |
+| 2   | **教員が見る集計**   | 教員の分析   | 複数OK（重複カウント）                   | 結果出力(08) | `ExamClass.teacherStat`（新規）            |
+| 3   | **生徒に見せる比較** | 生徒の成績表 | 複数OK・慎重に絞る                       | 結果出力(08) | `ExamClass.studentReport`（新規）          |
+
+**重要**: 同じ「生徒×学級」データでも、用途1は重複を潰し（1人1学級）、用途2/3は重複を活かす（全所属学級にカウント）。処理ロジックが逆になる。
+
+例:
+
+```
+3-A組(在籍)  再採番☑  教員☑  生徒☑   ← 全部
+バスケ部      再採番☐  教員☑  生徒☑   ← 番号は振らないが平均は両方に
+数学上位     再採番☐  教員☑  生徒☐   ← 教員は見るが生徒には出さない
+```
+
+### 2.5 役割分担（操作画面の分離）
+
+- **受験生徒画面(05) = 構造を作る**: 学級登録・order並び替え・再採番(administered)
+- **結果出力画面(08) = 出力を決める**: 教員用(teacherStat)・生徒用(studentReport)の学級選択
+
+2画面はUIが異なってよい（むしろ異なるべき）。05はフル管理テーブル、08は軽量チェックリスト。
+
+### 2.6 受験日スナップショット（在籍判定の統一原則）
+
+学級の所属は「今」ではなく **受験日(`exam.examDate`)時点** で判定する。
+②の在籍期間を使い `membershipFilterAt(examDate)` を通す。
+**追加・再採番・表示・統計の全経路をこの基準に統一**（P3の修正）。
+
+### 2.7 学級平均の母集団（P1/P2の修正）
+
+`memberships[0]` 依存を廃止。**登録学級ごとに、受験日時点で所属する生徒を集めて集計**する。
+1人の生徒は所属する全学級の平均に重複カウントされる。
+
+---
+
+## 3. 削除の安全仕様（P4の修正）
+
+学級削除時、消える対象（その学級にしか属さない生徒）を**答案/採点データの有無で仕分け**する。
+
+```
+[学級の削除ボタン]
+   ↓
+① 1回目modal：外し方を選択
+   (a) 学級登録だけ解除（生徒は受験者に残す）   ← 既定・推奨（試験の現挙動）
+   (b) 学級登録を解除し、専属の生徒も削除
+       → △名が削除されます（うち □名 はデータあり）
+   ↓ (b) かつ □≧1 のとき
+② 2回目modal：生徒データ削除の確認
+   「□名 の答案・採点データも削除されます。取り消せません。本当に削除しますか？」
+   ↓
+   実行
+```
+
+- データなしの生徒のみ → 1回目で実行可（誤登録のお掃除）
+- データありの生徒がいる → 2回目で明示確認
+- **試験・成績・資料の3エンティティで共通挙動に統一**
+
+---
+
+## 4. データモデル変更（JSON脱却・関係テーブル化）
+
+### 4.1 原則
+
+**他のエンティティ（学級・小計グループ等）を参照するものはスキーマで持つ。**
+JSONでよいのは「他を参照しない表示設定」（マーク色・トグル・enum）のみ。
+
+### 4.2 スキーマ変更
+
+| テーブル            | 追加カラム                   | 用途                                                        |
+| ------------------- | ---------------------------- | ----------------------------------------------------------- |
+| `ExamClass`         | `teacherStat Boolean`        | 教員集計対象（Excel学級平均行。PDF学級成績表は5.2で見送り） |
+| `ExamClass`         | `studentReport Boolean`      | 生徒表示対象（個人成績表の学級比較）                        |
+| `ExamSubtotalGroup` | `selectedForTable Boolean`   | 小計点テーブルに含めるグループ                              |
+| `ExamSubtotalGroup` | `selectedForBoxPlot Boolean` | 箱ひげ図に含めるグループ                                    |
+
+- `ExamClass.statistics`（旧・死フラグ）は `teacherStat` へ意味継承し、整理（不要化）。
+- `SubtotalGroupSelection.enabled`（master toggle、参照なし）は **JSONのまま**。`selectedGroupIds` のみ昇格。
+
+### 4.3 JSONに残すもの（参照を含まない表示設定）
+
+- `scoringMarkConfig`（採点マークの色・サイズ・位置）
+- `individualReportOptions` の各トグル（`showAverage: "class"|"overall"|"both"|"none"`、`rankType`、各 `show*: boolean` 等）
+- `SubtotalGroupSelection.enabled`
+
+→ これらは正当なJSON。**昇格不要**。
+
+### 4.4 触らないもの（永続化されない実行時データ）
+
+- `GetIndividualReportDataOptions.selectedStudentIds`（出力時の実行時パラメータ）
+
+### 4.5 ついでに除去したデッドコード/原則違反（2026-06-29 実施済）
+
+- `SubtotalGroupInfo.subtotalIds`：どこからも読まれない死にフィールドだった上、
+  Prisma `SubtotalGroup` とほぼ1:1なのに手書き interface＝「Prisma型を最優先」違反でもあった。
+  - 死にフィールドを除去（`dataFetcher.ts` の `subtotals.map(s => s.id)` 生成も削除）
+  - `export type SubtotalGroupInfo = Pick<SubtotalGroup, "id" | "name">` へ（Prisma派生）
+  - 教訓: エンティティの member-ID を素の `string[]` で状態管理しない。必要ならPrismaのリレーション型
+    （`Prisma.SubtotalGroupGetPayload<{ include: { subtotals: true } }>` 等）を使う。
+
+---
+
+## 5. 出力
+
+**重要な前提**: 既存の出力は3タブ（`scored-answers` / `grading-data`=Excel / `individual-reports`=個人成績表PDF）。
+Excelはデータシート3枚（点数一覧 / 正誤一覧 / 問題分析）。PDF帳票は個人成績表のみ。**全体成績表PDFも学級成績表PDFも存在しない**。
+また、チェックボックスの生徒選択は「誰を出力するか」を決めるだけで、**統計母集団は常に全試験**（選択は母集団を変えない）。
+→ 統計は「母集団=全試験＋グループ別サブ統計」で出来ており、**全体/学級/設問/個人は別帳票ではなく"グループ化の粒度"違い**。
+
+### 5.1 Excel（学級別集計＝今回の主成果）
+
+全体平均行に加え、**登録学級ごとの学級平均行/学級別集計**を追加（`teacherStat=true` の学級）。
+これは新帳票ではなく**既存Excel集計への学級グループ化拡張**（Phase 1の集計修正の延長）。
+既存の問題分析シート（正答率・得点率・I-T相関＝識別係数）と並ぶ、教員向け分析データ。
+
+```
+全体平均     65.2
+3-A組平均    68.0
+バスケ部平均  72.3
+数学上位平均  81.1
+```
+
+**学級平均の母集団＝学級全体**（受験日所属者・受験状態フィルタ適用）。
+2種類のチェックボックスを混同しないこと:
+
+- 生徒選択（StudentSelectionCard）＝どの生徒を行に出すか。**母集団に無関係**
+- 統計対象学級（新タブ・teacherStat）＝どの学級の平均行を出すか。**出す対象の選択**
+
+母集団の唯一の調整は受験状態フィルタ（受験/見込/欠席、既存 `boxPlotIncludeStatuses` を共有設定に格上げ）。
+
+> teacherStat が痩せ細った点に注意: PDF学級成績表を見送った結果、teacherStat の唯一の用途は
+> この Excel 学級平均行になった。これをやる前提で teacherStat を残す（A 案採用、2026-06-29）。
+
+### 5.2 学級成績表（PDF帳票）＝ 今回は見送り
+
+独立したPDF学級成績表は**作らない**。判断（2026-06-29）:
+
+- 教員の分析需要は Excel(5.1) ＋ 既存の問題分析（識別係数等）で足りている。
+- PDF帳票の価値は「**グラフ等の可視化を入れたい**」となって初めて出る。今その需要はない。
+- 統計の充実（α係数・D値・S-P表・得点度数分布ヒストグラム）自体は **11章で本作業として実装する**（教員向けExcel/プレビュー）。
+  ただしそれらは Excel・出力プレビューに出すものであり、**生徒に配るPDF帳票としての「学級成績表」とは別物**。
+- 見送るのは「学級を主語にした生徒配布用PDF帳票」。これが要るのは生徒配布物にグラフを載せたくなったときで、今は需要なし。
+- R / exametrika 向けエクスポートは #834（11.3、優先度低）。
+
+→ 本設計のスコープからPDF学級成績表（生徒配布帳票）を外す。将来やるなら個人成績表機構の主語替えで実装可能。
+
+### 5.3 個人成績表（既存PDFの拡張）
+
+`showAverage`(JSON, on/off) × `studentReport`選択(関係テーブル, どの学級) の組み合わせ。
+各生徒に「生徒用に選んだ学級 ∩ 本人の受験日所属学級」の比較を併記（複数学級対応）。
+※ 新帳票ではなく既存の個人成績表への拡張。Phase 1の集計修正がそのまま効く。
+
+---
+
+## 6. UI共通化
+
+3エンティティ(試験・成績・資料)の学級登録UIを共通コンポーネント化する。
+
+- 新規 `src/components/common/class-roster/ClassRosterManager.tsx`
+  - 登録リスト＋order D&D並び替え＋追加＋削除（4.3の削除2段階modalを内包）
+  - `flagColumns` で可変のフラグ列を差し込み: **試験=再採番(administered)1列のみ**、成績/資料=0列
+- 成績/資料に欠けている **class reorder API** を `rosterManager` の adapter に追加（`setClassOrders`）
+- 教員用/生徒用フラグ(teacherStat/studentReport)は**05では出さず**、08-export側の出力スコープUIで操作
+
+---
+
+## 7. 実装フェーズ
+
+依存を踏まえた推奨順。
+
+### Phase 0 — 受験日統一（P3バグ修正・独立）
+
+- `getStudentClassInfoForExam` 等、全在籍解決に `membershipFilterAt(exam.examDate)` を適用
+- 回帰の土台。単独でマージ可能
+
+### Phase 1 — 集計エンジンの作り直し（P1/P2・土台）
+
+- `examClass.ts`: 登録学級→所属生徒（受験日基準・重複カウント）のマップを返す関数を新設
+- `excel/dataFetcher.ts`: 表示用 className/grade/出席番号を `memberships[0]` → order解決値へ
+- `individual-report/dataFetcher.ts` / `statisticsCalculator.ts` / `computeReportData.ts`: 母集団を「指定学級の所属生徒」へ。複数学級対応
+
+### Phase 2 — スキーマ変更とデータ移行（4章・P5）
+
+- migration: `ExamClass`(+2列)、`ExamSubtotalGroup`(+2列)
+- データ移行:
+  - `ExamClass.statistics` → `teacherStat`（列コピー）、`studentReport` は既定（例: administered相当）
+  - **`ExamSubtotalGroup`: 既存 settingsJson を読み `selectedGroupIds` をパースしてフラグへ（JSON解釈が必要なのはここだけ）**
+- アーカイブ: バージョン更新＋transformer。古いアーカイブの settingsJson も解釈して新フラグへ変換
+- コード: 個人成績表の小計選択読み取りをフラグ参照へ。08-export UIをフラグ書き込みへ
+
+### Phase 3 — 出力スコープUI（05/08）
+
+- 05: 学級登録テーブルを再採番(administered)のみに簡素化（旧statisticsチェック撤去）
+- 08: **左カード(StudentSelectionCard)のタブ列に「統計対象学級」タブを追加**（既存タブ `[選択][プレビュー]` → `[統計対象学級][生徒選択][プレビュー]`）
+  - 教員用(teacherStat)/生徒用(studentReport)の2列チェックリスト
+  - 既定アクティブは `生徒選択` のまま（統計対象学級は低頻度・永続設定）
+  - 新タブ列を作らず既存タブ列を拡張するため、画面の縦圧迫もタブ二重化も起きない
+
+### Phase 4 — 出力実装（5章）
+
+- **Excel 学級平均行/学級別集計**（5.1・今回の主成果）／ 個人成績表の複数学級比較（5.3）
+- **PDF学級成績表は作らない**（5.2・見送り）。統計充実＋可視化は別トラック #833/#838
+
+### Phase 5 — UI共通化（6章）
+
+- `ClassRosterManager` 抽出、3エンティティ移行、削除2段階modal、class reorder API
+
+---
+
+## 8. マイグレーション・アーカイブの注意
+
+CLAUDE.md の規則に従う（`prisma migrate dev` / 手書き migration.sql＋`migrationDeployer`、`CURRENT_ARCHIVE_VERSION` 更新＋transformer 追加）。
+
+- **JSON解釈が必要なのは小計グループ昇格の移行・transformerのみ**。学級側は列移行でJSON解釈なし。
+- 既存試験で `teacherStat` 等が未設定でも壊れないよう、移行時に妥当な既定値を入れる（学級平均が消えない）。
+- 関連メモ: [手書きマイグレーション運用](../) `project_prisma7_handauthored_migrations`、[マイグレーション順序破壊](../) `project_migration_ordering_hazard`、[規約テストの誤検知](../) `project_stale_schema_convention_tests`。
+
+---
+
+## 9. リスク
+
+| リスク                                                                       | 対策                                                                     |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| 表示学級が `memberships[0]`→order解決に変わり、複数所属生徒のExcel表示が変化 | 意図的修正。回帰テストで差分確認、解決不能時は membership フォールバック |
+| 既存試験の学級平均が新ロジックで変わる                                       | むしろ正常化。移行の既定値をテストで固定                                 |
+| 協調採点の競合生徒                                                           | totalScore=null で平均除外（既存踏襲）。Excel学級集計にも警告            |
+| 小計グループ昇格のJSON解釈漏れ                                               | 移行・transformer双方にテスト。パース失敗時は空選択へフォールバック      |
+
+---
+
+## 10. テスト方針
+
+- 受験日スナップショット解決（Phase 0）
+- 登録学級ごとの集計・複数学級重複カウント（Phase 1）
+- スキーマ移行: statistics→teacherStat の列コピー、settingsJson→ExamSubtotalGroupフラグのJSON解釈（Phase 2）
+- アーカイブ往復（新フラグ・transformer）
+- 削除2段階modalのデータ有無分岐（Phase 5）
+- `npx vitest run` ＋ `npm run typecheck`
+
+---
+
+## 11. 統計強化issue（#833 / #838 / #834）の対応 — スキーマ変更ゼロ・トグルなし
+
+本再設計の統計充実を、**追加のスキーマ変更を一切出さない**方針で同時に対応する。
+必要データは既存 `ScoringData`（`scores[]`＝設問別得点/正誤、`totalScore`、`status`）に全て揃っており、
+**新規テーブル・カラム・マイグレーションは不要**。
+
+### 11.0 表示制御の方針：トグルなし・常時出力（重要決定 2026-06-29）
+
+これらは**教員向けの分析データ**（Excel・出力プレビュー）。生徒に配るものではない（α/D値/S-P表は生徒PDFに載せない）。
+
+- **on/offトグルを作らない**。不要な列・シートは教員が読み飛ばせばよいので、DB保存もJSON設定も**追加しない**。
+- 例外: 将来シート/列が増えすぎたら **per-statではなく「拡張分析を含める」マスタートグル1個**で束ねて切る。今は不要。
+- → `IndividualReportOptions` などの設定変更は **行わない**。純粋に計算関数＋Excel/プレビュー出力を足すだけ。
+
+### 11.1 #833 クロンバックα係数・D値 ✅ 実装完了（コードレビュー指摘反映済み）
+
+- **計算は共有純粋モジュール `electron-src/lib/shared/calculations/itemAnalysis.ts` に集約**（#838 の `spAnalysis.ts` と同じ方針）。
+  `computeItemAnalysis(students)` が正答率・得点率・識別係数・D値・α を一括算出し、**Excel シートと出力プレビューが同一実装を共用**（ドリフト防止）。
+  - **complete-case = `score===null` 除外**で統一（未採点に加え保留/未確定も除外、`no_answer`/`double_mark` は確定0として母集団に残す）。
+  - **識別係数・D値・α は complete-case**（全 score 非null）で算出 → 採点途中の合計点による母集団の歪みを防止。
+  - **D値は得点率差**（上位/下位27%群の `score/maxScore` 平均差）。二値設問では従来の正答率差と一致、部分点も比例反映。
+  - Excel/プレビューとも識別係数・D値の**各セルを判定帯（0.2/0.3/0.4）で着色**（曖昧な単一「判定」列は廃止）。
+  - 個人成績表向け `statisticsCalculator.ts` の `calculateDiscriminationIndices`/`getDiscriminationLevel` 等は**別消費者のため温存**（既存テスト維持）。`calculateCronbachAlpha`/`calculateDValues` は共有モジュールへ移設。
+- **テスト**: `__tests__/calculations/itemAnalysisStats.test.ts`（α手計算=2/3、complete-case除外、部分点得点率差を検証）。`discriminationIndex.test.ts` は無改修で維持。
+- サンプル不足時は `null`/「判定不可」表示。トグルなし。
+
+### 11.2 #838 S-P表・得点度数分布ヒストグラム ✅ 実装完了
+
+- 計算は共有純粋モジュール `electron-src/lib/shared/calculations/spAnalysis.ts` に集約し電子・フロント双方で共用
+  （`src/` は `@/electron-src/...` で純粋モジュールを import 可。`learningAdviceCalculator.ts` が前例）。
+  - `computeSpTable`: 生徒（正答数降順）×設問（正答者数降順）の二値マトリクス＋**佐藤の注意係数**（CS/CP、分母0は null）。
+  - `computeFrequencyDistribution`: 合計点を約10階級に等分、母平均・母標準偏差。満点は最終階級。
+- Excel: `spTableSheetCreator.ts`（S曲線=行右罫線/P曲線=列下罫線、注意係数列・行）、`frequencyDistributionSheetCreator.ts`（度数・割合・簡易バー・平均/SD）。`excelExportMain.ts` に配線（計5シート）。
+- プレビュー: `useSpAnalysis.ts`＋`SpTablePreview.tsx`/`FrequencyDistributionChart.tsx`。`ExcelPreview.tsx` を grid-cols-3→5 にし「S-P表」「得点分布」タブ追加。
+- トグルなし（常時出力）。テスト `spAnalysis.test.ts`（8件、注意係数の手計算検証含む）。
+
+### 11.3 #834 R / exametrika 向けエクスポート ✅ 実装完了
+
+- `electron-src/lib/export/r-exametrika/rDataExporter.ts`（設問×生徒の正誤行列を CSV/JSON、保存ダイアログ付き）
+- 欠席/未採点は欠測（CSV空欄・JSON `binary:null`）、無回答は誤答(0)。JSONは元の `status` も保持し再コード可能
+- IPC `export-r-data`（`exportHandlers.ts`）＋ preload `exportRData`（`exportApi.ts`/`exportApi.d.ts`）
+- UI: 採点データExcelタブ内に CSV/JSON ボタン（`ExportOptionsCard.onExportRData`＋`ExportMainView.handleExportRData`）。新タブは作らず「オプション」路線で低リスク化
+- `exportHandlers.ts` にIPC、`ExportOptionsCard.tsx` に出力導線（新タブ or オプション）
+
+### 11.4 スキーマ判定
+
+| issue | 新規テーブル | 新規カラム | マイグレーション | JSON設定 |
+| ----- | ------------ | ---------- | ---------------- | -------- |
+| #833  | なし         | なし       | **不要**         | なし     |
+| #838  | なし         | なし       | **不要**         | なし     |
+| #834  | なし         | なし       | **不要**         | なし     |
+
+→ 学級統計の再設計（Phase 2でスキーマ変更あり）とは**完全に独立**。統計強化は純計算で完結。#833 → #838 → #834 の順に**すべて実装完了**。
+
+---
+
+## 12. 実装進捗と再開手順（コンパクション越しの継続用）
+
+### 12.1 完了済み
+
+- **設計合意**: 1〜11章すべて（3スイッチ・役割分担・受験日統一・memberships[0]廃止・削除2段階modal・JSON脱却B・PDF学級成績表見送り・統計強化はトグルなし）。
+- **統計強化 #833/#838/#834 すべて実装完了**（スキーマ・JSON設定・トグルなし）:
+  - **#833 α係数・D値**: `statisticsCalculator.ts` に `calculateCronbachAlpha`/`calculateDValues`。
+    Excel `itemAnalysisSheetCreator.ts`（α行＋D値列）、`useItemAnalysis.ts`（`ItemAnalysisResult`+`dValue`）、`ItemAnalysisPreview.tsx`。
+  - **#838 S-P表・得点度数分布**: 共有純粋計算 `electron-src/lib/shared/calculations/spAnalysis.ts`
+    （`computeSpTable`＝佐藤の注意係数 / `computeFrequencyDistribution`）を電子・フロント双方で共用。
+    Excel `spTableSheetCreator.ts`/`frequencyDistributionSheetCreator.ts`（`excelExportMain.ts` に配線）、
+    プレビュー `useSpAnalysis.ts`＋`SpTablePreview.tsx`/`FrequencyDistributionChart.tsx`（`ExcelPreview.tsx` に S-P表/得点分布タブ追加）。
+  - **#834 R/exametrikaエクスポート**: `electron-src/lib/export/r-exametrika/rDataExporter.ts`（設問×生徒の正誤行列をCSV/JSON、欠席/未採点は欠測）。
+    IPC `export-r-data`（`exportHandlers.ts`）、preload `exportRData`（`exportApi.ts`＋`exportApi.d.ts`）、
+    UI は採点データExcelタブ内に CSV/JSON ボタン（`ExportOptionsCard.tsx`＋`ExportMainView.handleExportRData`）。
+  - **テスト**: `__tests__/calculations/itemAnalysisStats.test.ts`（11件）/`spAnalysis.test.ts`（8件）。
+    `npx vitest run __tests__/calculations/` で計86件パス。typecheck・lint クリーン。
+
+### 12.2 次にやること
+
+1. **学級統計の再設計本体**: Phase 0（受験日統一）→ 1 →（2 スキーマ）→ 3 → 4 → 5。統計強化(#833-834)とは独立。
+
+### 12.3 実装上の不変条件（壊さないこと）
+
+- 統計強化(#833/#838/#834)は **スキーマ変更ゼロ・JSON設定追加なし・トグルなし**（11.0）。
+- 学級の母集団は **受験日スナップショット**（`membershipFilterAt(exam.examDate)`）で判定（2.6）。
+- 学級平均の母集団は **学級全体**（生徒選択チェックは母集団に無関係、5.1）。
+- 用途1（採番）は1人1学級、用途2/3（教員/生徒統計）は重複カウント（2.4）。
+- エンティティ参照はJSONに入れない（4.1）。
+- 検証は常に `npx vitest run` ＋ `npm run typecheck`。

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -6,6 +6,10 @@ import {
   fetchIndividualReportData,
   fetchSubtotalGroupsForReport,
 } from "../lib/export/individual-report"
+import {
+  exportRData,
+  type ExportRDataOptions,
+} from "../lib/export/r-exametrika/rDataExporter"
 import { resolveMathJaxSrc, waitForRendering } from "../lib/printUtils"
 import { exportGradingDataExcel } from "../lib/prisma/excelExport"
 import {
@@ -245,6 +249,11 @@ export function setupExportHandlers(): void {
       return await exportGradingDataExcel(options)
     }
   )
+
+  // R / exametrika 向けデータ出力（#834）
+  registerSafeHandler("export-r-data", async (options: ExportRDataOptions) => {
+    return await exportRData(options)
+  })
 
   // Excelプレビュー用データ取得
   registerSafeHandler(

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -10,8 +10,10 @@ import {
 } from "../../shared/utilities/validateScoringData"
 import { fetchExportData } from "./dataFetcher"
 import { saveWorkbook } from "./fileSaver"
+import { createFrequencyDistributionSheet } from "./frequencyDistributionSheetCreator"
 import { createItemAnalysisSheet } from "./itemAnalysisSheetCreator"
 import { createResultSheet, createScoreSheet } from "./sheetCreators"
+import { createSpTableSheet } from "./spTableSheetCreator"
 
 /**
  * Excel出力のメイン処理
@@ -84,6 +86,12 @@ export async function exportGradingDataExcel(
       dataResult.questionRegions,
       dataResult.scoringData
     )
+
+    // S-P表シート作成（#838）
+    await createSpTableSheet(workbook, dataResult.scoringData)
+
+    // 得点度数分布シート作成（#838）
+    await createFrequencyDistributionSheet(workbook, dataResult.scoringData)
 
     // ファイル保存
     const examName = dataResult.exam?.examName

--- a/electron-src/lib/export/excel/frequencyDistributionSheetCreator.ts
+++ b/electron-src/lib/export/excel/frequencyDistributionSheetCreator.ts
@@ -1,0 +1,65 @@
+import * as ExcelJS from "exceljs"
+
+import { computeFrequencyDistribution } from "../../shared/calculations/spAnalysis"
+import type { ScoringData } from "../../shared/types/exportTypes"
+import {
+  applyCellStyle,
+  autoFitColumns,
+} from "../../shared/utilities/excelUtilities"
+
+/**
+ * 得点度数分布シートを作成する（#838）
+ * 合計点を約10階級に等分した度数・割合と、簡易バー、平均・標準偏差を出力。
+ */
+export async function createFrequencyDistributionSheet(
+  workbook: ExcelJS.Workbook,
+  scoringData: ScoringData[]
+): Promise<ExcelJS.Worksheet> {
+  const worksheet = workbook.addWorksheet("得点度数分布")
+
+  const totalScores = scoringData.map((d) => d.totalScore)
+  const maxScore = scoringData[0]?.totalMaxScore ?? 0
+  const result = computeFrequencyDistribution(totalScores, maxScore)
+
+  if (!result) {
+    const row = worksheet.addRow(["度数分布を作成できる得点データがありません"])
+    applyCellStyle(row.getCell(1), "data")
+    return worksheet
+  }
+
+  // 平均・標準偏差を上部に表示
+  const meanRow = worksheet.addRow([
+    "平均",
+    Math.round(result.mean * 10) / 10,
+    "標準偏差",
+    Math.round(result.stdDev * 10) / 10,
+  ])
+  meanRow.eachCell((cell) => applyCellStyle(cell, "total"))
+  worksheet.addRow([])
+
+  // ヘッダー
+  const headerRow = worksheet.addRow(["得点階級", "度数", "割合(%)", "分布"])
+  headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
+
+  const maxCount = Math.max(...result.bins.map((b) => b.count), 1)
+
+  for (const bin of result.bins) {
+    const ratio = result.count > 0 ? (bin.count / result.count) * 100 : 0
+    const barLength = Math.round((bin.count / maxCount) * 20)
+    const row = worksheet.addRow([
+      bin.label,
+      bin.count,
+      Math.round(ratio * 10) / 10,
+      "■".repeat(barLength),
+    ])
+    row.eachCell((cell) => applyCellStyle(cell, "data"))
+  }
+
+  // 合計
+  const totalRow = worksheet.addRow(["合計", result.count, 100, ""])
+  totalRow.eachCell((cell) => applyCellStyle(cell, "total"))
+
+  autoFitColumns(worksheet)
+
+  return worksheet
+}

--- a/electron-src/lib/export/excel/itemAnalysisSheetCreator.ts
+++ b/electron-src/lib/export/excel/itemAnalysisSheetCreator.ts
@@ -1,19 +1,20 @@
 import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
-import type { ScoringData } from "../../shared/types/exportTypes"
+import {
+  computeItemAnalysis,
+  type ItemAnalysisInputStudent,
+} from "../../shared/calculations/itemAnalysis"
+import type {
+  DiscriminationLevel,
+  ScoringData,
+} from "../../shared/types/exportTypes"
 import {
   applyCellStyle,
   autoFitColumns,
 } from "../../shared/utilities/excelUtilities"
-import {
-  calculateDiscriminationIndices,
-  calculateQuestionCorrectRates,
-  calculateQuestionScoreRates,
-  getDiscriminationLevel,
-} from "../individual-report/statisticsCalculator"
 
-const DISCRIMINATION_LABEL: Record<string, string> = {
+const DISCRIMINATION_LABEL: Record<DiscriminationLevel, string> = {
   good: "良好",
   acceptable: "許容",
   marginal: "要確認",
@@ -22,7 +23,7 @@ const DISCRIMINATION_LABEL: Record<string, string> = {
   insufficient: "---",
 }
 
-const DISCRIMINATION_COLOR: Record<string, string> = {
+const DISCRIMINATION_COLOR: Record<DiscriminationLevel, string> = {
   good: "FF92D050",
   acceptable: "FF5B9BD5",
   marginal: "FFFFEB9C",
@@ -31,8 +32,44 @@ const DISCRIMINATION_COLOR: Record<string, string> = {
   insufficient: "FFC0C0C0",
 }
 
+/** 判定帯で着色する（負・低は白文字） */
+function colorByLevel(cell: ExcelJS.Cell, level: DiscriminationLevel): void {
+  cell.fill = {
+    type: "pattern",
+    pattern: "solid",
+    fgColor: { argb: DISCRIMINATION_COLOR[level] },
+  }
+  if (level === "negative" || level === "poor") {
+    cell.font = { ...cell.font, color: { argb: "FFFFFFFF" } }
+  }
+}
+
+/** ScoringData を項目分析入力へ正規化（設問の並び・ラベル・配点は CropRegion 基準） */
+function toItemAnalysisInput(
+  questionRegions: CropRegion[],
+  scoringData: ScoringData[]
+): ItemAnalysisInputStudent[] {
+  return scoringData.map((sd) => {
+    const byId = new Map(sd.scores.map((s) => [s.questionId, s]))
+    return {
+      items: questionRegions.map((region) => {
+        const s = byId.get(region.id)
+        return {
+          questionId: region.id,
+          label: region.label || `問${(region.orderIndex ?? 0) + 1}`,
+          maxScore: region.points ?? 0,
+          score: s?.score ?? null,
+          isCorrect: s?.status === "correct",
+        }
+      }),
+    }
+  })
+}
+
 /**
  * 問題分析シートを作成する
+ * 設問別の正答率・得点率・識別係数（点双列相関）・D値（得点率差）と、テスト全体のα係数を出力。
+ * 識別係数・D値は各セルを判定帯で着色する（単一の「判定」列は持たない）。
  */
 export async function createItemAnalysisSheet(
   workbook: ExcelJS.Workbook,
@@ -41,83 +78,98 @@ export async function createItemAnalysisSheet(
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("問題分析")
 
-  // 統計データ計算
-  const correctRates = calculateQuestionCorrectRates(scoringData)
-  const scoreRates = calculateQuestionScoreRates(scoringData)
-  const discriminationIndices = calculateDiscriminationIndices(scoringData)
+  const analysis = computeItemAnalysis(
+    toItemAnalysisInput(questionRegions, scoringData)
+  )
+
+  if (!analysis) {
+    const row = worksheet.addRow(["問題分析を作成できる採点データがありません"])
+    applyCellStyle(row.getCell(1), "data")
+    return worksheet
+  }
+
+  // テスト全体の信頼性係数（クロンバックα）をシート上部に1値表示
+  const alphaRow = worksheet.addRow([
+    "クロンバックα係数",
+    analysis.cronbachAlpha !== null
+      ? Math.round(analysis.cronbachAlpha * 1000) / 1000
+      : "判定不可",
+  ])
+  alphaRow.eachCell((cell) => applyCellStyle(cell, "total"))
+  worksheet.addRow([]) // 区切りの空行
 
   // ヘッダー行
-  const headers = ["設問", "配点", "正答率(%)", "得点率(%)", "識別係数", "判定"]
+  const headers = ["設問", "配点", "正答率(%)", "得点率(%)", "識別係数", "D値"]
   const headerRow = worksheet.addRow(headers)
   headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
 
-  // データ行
   let correctRateSum = 0
   let scoreRateSum = 0
   let discrimSum = 0
   let discrimCount = 0
+  let dValueSum = 0
+  let dValueCount = 0
 
-  for (const region of questionRegions) {
-    const qId = region.id
-    const label = region.label || `問${(region.orderIndex ?? 0) + 1}`
-    const maxScore = region.points ?? 0
-    const cr = correctRates[qId] ?? 0
-    const sr = scoreRates[qId] ?? 0
-    const di = discriminationIndices[qId] ?? null
-    const level = getDiscriminationLevel(di)
-
-    correctRateSum += cr
-    scoreRateSum += sr
-    if (di !== null) {
-      discrimSum += di
+  for (const item of analysis.items) {
+    correctRateSum += item.correctRate
+    scoreRateSum += item.scoreRate
+    if (item.discriminationIndex !== null) {
+      discrimSum += item.discriminationIndex
       discrimCount++
+    }
+    if (item.dValue !== null) {
+      dValueSum += item.dValue
+      dValueCount++
     }
 
     const row = worksheet.addRow([
-      label,
-      maxScore,
-      Math.round(cr * 10) / 10,
-      Math.round(sr * 10) / 10,
-      di !== null ? Math.round(di * 1000) / 1000 : "---",
-      DISCRIMINATION_LABEL[level],
+      item.label,
+      item.maxScore,
+      Math.round(item.correctRate * 10) / 10,
+      Math.round(item.scoreRate * 10) / 10,
+      item.discriminationIndex !== null
+        ? Math.round(item.discriminationIndex * 1000) / 1000
+        : "---",
+      item.dValue !== null ? Math.round(item.dValue * 1000) / 1000 : "---",
     ])
 
     row.eachCell((cell, colNumber) => {
       applyCellStyle(cell, "data")
-      if (colNumber === 6) {
-        cell.fill = {
-          type: "pattern",
-          pattern: "solid",
-          fgColor: { argb: DISCRIMINATION_COLOR[level] },
-        }
-        if (level === "negative" || level === "poor") {
-          cell.font = { ...cell.font, color: { argb: "FFFFFFFF" } }
-        }
-      }
+      // 5列目=識別係数、6列目=D値 を各々の判定帯で着色
+      if (colNumber === 5) colorByLevel(cell, item.discriminationLevel)
+      if (colNumber === 6) colorByLevel(cell, item.dValueLevel)
     })
   }
 
   // サマリー行
-  const questionCount = questionRegions.length
+  const questionCount = analysis.items.length
   if (questionCount > 0) {
-    const avgCorrectRate =
-      Math.round((correctRateSum / questionCount) * 10) / 10
-    const avgScoreRate = Math.round((scoreRateSum / questionCount) * 10) / 10
     const avgDiscrim =
       discrimCount > 0
         ? Math.round((discrimSum / discrimCount) * 1000) / 1000
+        : "---"
+    const avgDValue =
+      dValueCount > 0
+        ? Math.round((dValueSum / dValueCount) * 1000) / 1000
         : "---"
 
     const summaryRow = worksheet.addRow([
       "平均",
       "",
-      avgCorrectRate,
-      avgScoreRate,
+      Math.round((correctRateSum / questionCount) * 10) / 10,
+      Math.round((scoreRateSum / questionCount) * 10) / 10,
       avgDiscrim,
-      "",
+      avgDValue,
     ])
     summaryRow.eachCell((cell) => applyCellStyle(cell, "total"))
   }
+
+  // 判定帯の凡例
+  worksheet.addRow([])
+  const legendRow = worksheet.addRow([
+    `判定（識別係数・D値の着色）: ${DISCRIMINATION_LABEL.good}≥0.4 / ${DISCRIMINATION_LABEL.acceptable}≥0.3 / ${DISCRIMINATION_LABEL.marginal}≥0.2 / ${DISCRIMINATION_LABEL.poor}<0.2 / ${DISCRIMINATION_LABEL.negative}<0`,
+  ])
+  applyCellStyle(legendRow.getCell(1), "data")
 
   autoFitColumns(worksheet)
 

--- a/electron-src/lib/export/excel/spTableSheetCreator.ts
+++ b/electron-src/lib/export/excel/spTableSheetCreator.ts
@@ -1,0 +1,135 @@
+import * as ExcelJS from "exceljs"
+
+import {
+  computeSpTable,
+  type SpInputStudent,
+} from "../../shared/calculations/spAnalysis"
+import type { ScoringData } from "../../shared/types/exportTypes"
+import {
+  applyCellStyle,
+  autoFitColumns,
+} from "../../shared/utilities/excelUtilities"
+
+/** ScoringData を S-P表入力（二値）へ正規化 */
+function toSpInput(scoringData: ScoringData[]): SpInputStudent[] {
+  return scoringData.map((d) => ({
+    studentId: d.studentId,
+    studentName: d.studentName,
+    items: d.scores.map((s) => ({
+      questionId: s.questionId,
+      label: s.questionLabel,
+      isCorrect: s.status === "correct",
+      isScored: s.status !== "unscored",
+    })),
+  }))
+}
+
+const MEDIUM_BORDER: Partial<ExcelJS.Border> = {
+  style: "medium",
+  color: { argb: "FF333333" },
+}
+
+/**
+ * S-P表シートを作成する（#838）
+ * 生徒（正答数降順）×設問（正答者数降順）の正誤マトリクスと、佐藤の注意係数を出力。
+ * S曲線（行ごとの正答数境界）・P曲線（列ごとの正答者数境界）を罫線で表現する。
+ */
+export async function createSpTableSheet(
+  workbook: ExcelJS.Workbook,
+  scoringData: ScoringData[]
+): Promise<ExcelJS.Worksheet> {
+  const worksheet = workbook.addWorksheet("S-P表")
+
+  const result = computeSpTable(toSpInput(scoringData))
+  if (!result) {
+    const row = worksheet.addRow(["S-P表を作成できる採点データがありません"])
+    applyCellStyle(row.getCell(1), "data")
+    return worksheet
+  }
+
+  const { students, problems } = result
+
+  // ヘッダー行: 生徒 | 各設問 | 正答数 | 注意係数
+  const headers = [
+    "生徒",
+    ...problems.map((p) => p.label),
+    "正答数",
+    "注意係数",
+  ]
+  const headerRow = worksheet.addRow(headers)
+  headerRow.eachCell((cell) => applyCellStyle(cell, "header"))
+
+  const headerRowNumber = headerRow.number
+  const firstProblemCol = 2 // 1列目は生徒名
+
+  // 生徒行
+  students.forEach((student) => {
+    const cautionText =
+      student.cautionIndex !== null
+        ? Math.round(student.cautionIndex * 1000) / 1000
+        : "---"
+    const row = worksheet.addRow([
+      student.studentName,
+      ...student.cells.map((c) => (c ? "○" : "")),
+      student.correctCount,
+      cautionText,
+    ])
+
+    row.eachCell((cell, colNumber) => {
+      applyCellStyle(cell, "data")
+      // 正答セルを淡く着色
+      if (
+        colNumber >= firstProblemCol &&
+        colNumber < firstProblemCol + problems.length
+      ) {
+        const j = colNumber - firstProblemCol
+        if (student.cells[j]) {
+          cell.fill = {
+            type: "pattern",
+            pattern: "solid",
+            fgColor: { argb: "FFE2EFDA" },
+          }
+        }
+      }
+    })
+
+    // S曲線: 正答数 c の右側に縦境界（c 個目の設問セルの右罫線）
+    if (student.correctCount > 0 && student.correctCount <= problems.length) {
+      const cell = row.getCell(firstProblemCol + student.correctCount - 1)
+      cell.border = { ...cell.border, right: MEDIUM_BORDER }
+    }
+  })
+
+  // P曲線: 各設問列で正答者数 m の行の下に横境界
+  problems.forEach((problem, colIdx) => {
+    if (problem.correctCount > 0 && problem.correctCount <= students.length) {
+      const rowNumber = headerRowNumber + problem.correctCount
+      const cell = worksheet.getRow(rowNumber).getCell(firstProblemCol + colIdx)
+      cell.border = { ...cell.border, bottom: MEDIUM_BORDER }
+    }
+  })
+
+  // 正答者数の行
+  const correctCountRow = worksheet.addRow([
+    "正答者数",
+    ...problems.map((p) => p.correctCount),
+    "",
+    "",
+  ])
+  correctCountRow.eachCell((cell) => applyCellStyle(cell, "total"))
+
+  // 設問の注意係数の行
+  const problemCautionRow = worksheet.addRow([
+    "注意係数",
+    ...problems.map((p) =>
+      p.cautionIndex !== null ? Math.round(p.cautionIndex * 1000) / 1000 : "---"
+    ),
+    "",
+    "",
+  ])
+  problemCautionRow.eachCell((cell) => applyCellStyle(cell, "total"))
+
+  autoFitColumns(worksheet)
+
+  return worksheet
+}

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -325,7 +325,6 @@ export async function fetchSubtotalGroupsForReport(
       activeGroupsResult.examSubtotalGroups.map((psg) => ({
         id: psg.subtotalGroup.id,
         name: psg.subtotalGroup.name,
-        subtotalIds: psg.subtotalGroup.subtotals.map((s) => s.id),
       }))
 
     return {

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -2,6 +2,8 @@
  * 個人成績表PDF出力機能の型定義
  */
 
+import type { SubtotalGroup } from "@prisma/client"
+
 import type { ScoringData } from "../../shared/types/exportTypes"
 
 // ================== 表示モード関連 ==================
@@ -177,13 +179,8 @@ export interface SubtotalStatistics {
   subtotalGroupName: string
 }
 
-/** SubtotalGroup情報（選択UI用） */
-export interface SubtotalGroupInfo {
-  id: string
-  name: string
-  /** このグループに属するSubtotalのID */
-  subtotalIds: string[]
-}
+/** SubtotalGroup選択UI用（Prisma型のサブセット。id/name のみ使用） */
+export type SubtotalGroupInfo = Pick<SubtotalGroup, "id" | "name">
 
 /** SubtotalGroup選択オプション */
 export interface SubtotalGroupSelection {

--- a/electron-src/lib/export/r-exametrika/rDataExporter.ts
+++ b/electron-src/lib/export/r-exametrika/rDataExporter.ts
@@ -1,0 +1,166 @@
+/**
+ * R / exametrika 向けデータエクスポート（#834）
+ *
+ * 設問×生徒の得点行列を CSV / JSON で出力する。
+ * 正誤の二値（1/0）に加え、欠席・未採点・無回答を区別できるよう
+ * 元の status を保持する（JSON）。CSV は欠席/未採点を欠測値（空欄）とする。
+ */
+import { dialog } from "electron"
+import * as fs from "fs/promises"
+
+import type { ExportResult } from "../../shared/types/exportTypes"
+import { fetchExportData } from "../excel/dataFetcher"
+
+export interface ExportRDataOptions {
+  examId: string
+  selectedStudentIds: string[]
+  format: "csv" | "json"
+  outputPath?: string
+}
+
+/** ファイル名として安全でない文字を置換する */
+function sanitizeFileName(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, "_").trim()
+}
+
+/**
+ * 設問の正誤を二値（1=正答, 0=誤答）へ。
+ * 未採点・欠席は欠測（null）として扱う。無回答は誤答(0)。
+ */
+function toBinary(status: string, studentAbsent: boolean): number | null {
+  if (studentAbsent) return null
+  if (status === "unscored") return null
+  if (status === "correct") return 1
+  return 0
+}
+
+/** CSVセルのエスケープ（カンマ・引用符・改行を含む場合は引用） */
+function csvCell(value: string | number): string {
+  const s = String(value)
+  if (/[",\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+/**
+ * R / exametrika 向けデータをエクスポート
+ */
+export async function exportRData(
+  options: ExportRDataOptions
+): Promise<ExportResult> {
+  try {
+    const { examId, selectedStudentIds, format } = options
+
+    const dataResult = await fetchExportData(examId, selectedStudentIds)
+    if (!dataResult.success || !dataResult.scoringData) {
+      return {
+        success: false,
+        error: dataResult.error || "データ取得に失敗しました",
+      }
+    }
+
+    const scoringData = dataResult.scoringData
+    if (scoringData.length === 0) {
+      return { success: false, error: "出力対象の生徒がいません" }
+    }
+
+    // 設問列は最初の生徒の並びを基準にする
+    const questions = scoringData[0].scores.map((s) => ({
+      questionId: s.questionId,
+      label: s.questionLabel,
+      maxScore: s.maxScore,
+    }))
+
+    let content: string
+    if (format === "json") {
+      content = JSON.stringify(
+        {
+          exam: { examName: dataResult.exam?.examName ?? "" },
+          questions,
+          students: scoringData.map((sd) => {
+            const absent = sd.status === "absent"
+            return {
+              studentId: sd.studentId,
+              studentName: sd.studentName,
+              studentNumber: sd.studentNumber,
+              status: sd.status ?? "participating",
+              totalScore: sd.totalScore,
+              totalMaxScore: sd.totalMaxScore,
+              responses: sd.scores.map((s) => ({
+                questionId: s.questionId,
+                status: s.status,
+                score: s.score,
+                binary: toBinary(s.status, absent),
+              })),
+            }
+          }),
+        },
+        null,
+        2
+      )
+    } else {
+      // CSV: 出席番号・氏名 + 各設問の二値（欠測は空欄）
+      const header = [
+        "studentNumber",
+        "studentName",
+        ...questions.map((q) => q.label),
+      ]
+      const lines = [header.map(csvCell).join(",")]
+      for (const sd of scoringData) {
+        const absent = sd.status === "absent"
+        const cells = [
+          csvCell(sd.studentNumber),
+          csvCell(sd.studentName),
+          ...sd.scores.map((s) => {
+            const b = toBinary(s.status, absent)
+            return b === null ? "" : String(b)
+          }),
+        ]
+        lines.push(cells.join(","))
+      }
+      // BOM付きUTF-8（Excel/R双方で文字化けを避ける）
+      content = "﻿" + lines.join("\r\n")
+    }
+
+    // 保存先の決定
+    let finalOutputPath = options.outputPath
+    if (!finalOutputPath) {
+      const dateStr = new Date().toISOString().slice(0, 10)
+      const safeExamName = dataResult.exam?.examName
+        ? sanitizeFileName(dataResult.exam.examName)
+        : null
+      const ext = format === "json" ? "json" : "csv"
+      const fileName = safeExamName
+        ? `分析用データ_${safeExamName}_${dateStr}.${ext}`
+        : `分析用データ_${dateStr}.${ext}`
+
+      const result = await dialog.showSaveDialog({
+        title: "R / exametrika 向けデータの出力先を選択",
+        defaultPath: fileName,
+        filters: [
+          format === "json"
+            ? { name: "JSONファイル", extensions: ["json"] }
+            : { name: "CSVファイル", extensions: ["csv"] },
+        ],
+      })
+      if (result.canceled) {
+        return { success: false, error: "出力がキャンセルされました" }
+      }
+      finalOutputPath = result.filePath
+    }
+
+    if (!finalOutputPath) {
+      return { success: false, error: "出力パスが指定されていません" }
+    }
+
+    await fs.writeFile(finalOutputPath, content, "utf-8")
+    return { success: true, outputPath: finalOutputPath }
+  } catch (error) {
+    console.error("R data export error:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "出力に失敗しました",
+    }
+  }
+}

--- a/electron-src/lib/shared/calculations/itemAnalysis.ts
+++ b/electron-src/lib/shared/calculations/itemAnalysis.ts
@@ -1,0 +1,231 @@
+/**
+ * 項目分析（item analysis）の純粋計算ロジック（#833）
+ *
+ * Excel「問題分析」シートと出力プレビューの双方から利用するため、Node/Electron依存を
+ * 持たない純関数のみで構成する。入力は最小形（{@link ItemAnalysisInputStudent}）へ正規化して渡す。
+ *
+ * 設計メモ:
+ * - 欠測（未採点・保留など score===null）の判定は **score===null** に統一する。
+ *   - `no_answer`/`double_mark` は確定的に0点なので欠測ではなく0として母集団に含む。
+ *   - `unscored` と未確定の `hold`/`pending`（partialScore 未設定で score===null）は欠測として除外。
+ * - 識別係数・D値・α は **complete-case**（全設問が採点済み = 全 score 非null の生徒）で算出する。
+ *   採点途中の合計点（未採点を0と合算した値）で順位付けして母集団が歪むのを防ぐ。
+ * - 個人成績表向けの `statisticsCalculator.ts`（`calculateDiscriminationIndices` 等）とは
+ *   消費者・集計セマンティクスが異なるため別実装。こちらは「シートとプレビューの一致」を担保する。
+ */
+
+import type { DiscriminationLevel } from "../types/exportTypes"
+
+/** 設問1問分の生徒応答（正規化済み） */
+export interface ItemAnalysisInputItem {
+  questionId: string
+  label: string
+  maxScore: number
+  /** 得点。欠測（未採点・未確定）は null */
+  score: number | null
+  /** 正答（status === "correct"）なら true */
+  isCorrect: boolean
+}
+
+/** 生徒1人分の入力 */
+export interface ItemAnalysisInputStudent {
+  items: ItemAnalysisInputItem[]
+}
+
+/** 設問1問分の分析結果 */
+export interface ItemAnalysisItem {
+  questionId: string
+  label: string
+  maxScore: number
+  /** 正答率(%) */
+  correctRate: number
+  /** 得点率(%) */
+  scoreRate: number
+  /** 識別係数（補正済み項目合計相関、complete-case）。判定不可は null */
+  discriminationIndex: number | null
+  discriminationLevel: DiscriminationLevel
+  /** D値（上位/下位27%群の得点率差、complete-case）。判定不可は null */
+  dValue: number | null
+  dValueLevel: DiscriminationLevel
+}
+
+export interface ItemAnalysisResult {
+  items: ItemAnalysisItem[]
+  /** クロンバックのα係数（テスト全体の信頼性係数）。判定不可は null */
+  cronbachAlpha: number | null
+  /** complete-case（全設問採点済み）生徒数 */
+  completeCaseCount: number
+}
+
+/** 識別係数・D値の判定帯（0.2/0.3/0.4） */
+export function getDiscriminationLevel(r: number | null): DiscriminationLevel {
+  if (r === null) return "insufficient"
+  if (r < 0) return "negative"
+  if (r < 0.2) return "poor"
+  if (r < 0.3) return "marginal"
+  if (r < 0.4) return "acceptable"
+  return "good"
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}
+
+/** 母標準偏差（n で割る） */
+function stdDev(values: number[]): number {
+  if (values.length === 0) return 0
+  const avg = average(values)
+  return Math.sqrt(average(values.map((v) => (v - avg) ** 2)))
+}
+
+/**
+ * 正規化済み入力から項目分析（正答率・得点率・識別係数・D値・α）を一括算出する。
+ * 生徒0人・設問0問なら null。
+ */
+export function computeItemAnalysis(
+  students: ItemAnalysisInputStudent[]
+): ItemAnalysisResult | null {
+  if (students.length === 0) return null
+
+  const questions = students[0].items.map((it) => ({
+    questionId: it.questionId,
+    label: it.label,
+    maxScore: it.maxScore,
+  }))
+  const k = questions.length
+  if (k === 0) return null
+
+  // 各生徒の設問→item を Map 化（O(生徒×k) に抑える）
+  const studentMaps = students.map((s) => {
+    const m = new Map<string, ItemAnalysisInputItem>()
+    for (const it of s.items) m.set(it.questionId, it)
+    return m
+  })
+
+  // complete-case: 全設問が採点済み（全 score 非null）の生徒
+  const completeMaps = studentMaps.filter((m) =>
+    questions.every((q) => (m.get(q.questionId)?.score ?? null) !== null)
+  )
+  const completeCaseCount = completeMaps.length
+
+  // complete-case の合計点（行和）
+  const completeTotals = completeMaps.map((m) =>
+    questions.reduce((sum, q) => sum + (m.get(q.questionId)?.score ?? 0), 0)
+  )
+
+  // D値: complete-case を合計点降順に並べ上位/下位27%群の得点率差
+  const order = completeMaps
+    .map((_, i) => i)
+    .sort((a, b) => completeTotals[b] - completeTotals[a])
+  const groupSize = Math.round(completeMaps.length * 0.27)
+  const upperIdx = order.slice(0, groupSize)
+  const lowerIdx = order.slice(order.length - groupSize)
+
+  const groupScoreRate = (
+    idxs: number[],
+    questionId: string,
+    maxScore: number
+  ): number | null => {
+    if (maxScore <= 0) return null
+    const rates: number[] = []
+    for (const i of idxs) {
+      const score = completeMaps[i].get(questionId)?.score
+      if (score == null) continue
+      rates.push(score / maxScore)
+    }
+    return rates.length > 0 ? average(rates) : null
+  }
+
+  const items: ItemAnalysisItem[] = questions.map((q) => {
+    // 正答率・得点率（score 非null の生徒を母数）
+    let correctCount = 0
+    let scoredCount = 0
+    let scoreRateSum = 0
+    for (const m of studentMaps) {
+      const it = m.get(q.questionId)
+      if (!it || it.score === null) continue
+      scoredCount++
+      if (it.isCorrect) correctCount++
+      if (q.maxScore > 0) scoreRateSum += it.score / q.maxScore
+    }
+    const correctRate = scoredCount > 0 ? (correctCount / scoredCount) * 100 : 0
+    const scoreRate = scoredCount > 0 ? (scoreRateSum / scoredCount) * 100 : 0
+
+    // 識別係数（complete-case の補正済み項目合計相関）
+    let discriminationIndex: number | null = null
+    if (completeMaps.length >= 3) {
+      const itemScores: number[] = []
+      const correctedTotals: number[] = []
+      completeMaps.forEach((m, i) => {
+        const s = m.get(q.questionId)?.score ?? 0
+        itemScores.push(s)
+        correctedTotals.push(completeTotals[i] - s)
+      })
+      const itemSd = stdDev(itemScores)
+      const totalSd = stdDev(correctedTotals)
+      if (itemSd > 0 && totalSd > 0) {
+        const itemMean = average(itemScores)
+        const totalMean = average(correctedTotals)
+        let cov = 0
+        for (let i = 0; i < itemScores.length; i++) {
+          cov += (itemScores[i] - itemMean) * (correctedTotals[i] - totalMean)
+        }
+        cov /= itemScores.length
+        discriminationIndex = cov / (itemSd * totalSd)
+      }
+    }
+
+    // D値（得点率差）
+    let dValue: number | null = null
+    if (groupSize >= 1) {
+      const up = groupScoreRate(upperIdx, q.questionId, q.maxScore)
+      const low = groupScoreRate(lowerIdx, q.questionId, q.maxScore)
+      dValue = up !== null && low !== null ? up - low : null
+    }
+
+    return {
+      questionId: q.questionId,
+      label: q.label,
+      maxScore: q.maxScore,
+      correctRate,
+      scoreRate,
+      discriminationIndex,
+      discriminationLevel: getDiscriminationLevel(discriminationIndex),
+      dValue,
+      dValueLevel: getDiscriminationLevel(dValue),
+    }
+  })
+
+  const cronbachAlpha = computeCronbachAlpha(
+    completeMaps,
+    completeTotals,
+    questions
+  )
+
+  return { items, cronbachAlpha, completeCaseCount }
+}
+
+/**
+ * クロンバックのα係数（complete-case・母分散）。
+ * k<2 / 対象<3人 / 合計点分散0 で null。
+ */
+function computeCronbachAlpha(
+  completeMaps: Map<string, ItemAnalysisInputItem>[],
+  completeTotals: number[],
+  questions: { questionId: string }[]
+): number | null {
+  const k = questions.length
+  if (k < 2) return null
+  if (completeMaps.length < 3) return null
+
+  let sumItemVariance = 0
+  for (const q of questions) {
+    const itemScores = completeMaps.map((m) => m.get(q.questionId)?.score ?? 0)
+    sumItemVariance += stdDev(itemScores) ** 2
+  }
+  const totalVariance = stdDev(completeTotals) ** 2
+  if (totalVariance === 0) return null
+
+  return (k / (k - 1)) * (1 - sumItemVariance / totalVariance)
+}

--- a/electron-src/lib/shared/calculations/spAnalysis.ts
+++ b/electron-src/lib/shared/calculations/spAnalysis.ts
@@ -1,0 +1,223 @@
+/**
+ * S-P表（Student-Problem chart）と得点度数分布の純粋計算ロジック（#838）
+ *
+ * 電子側（Excel出力）とフロント側（プレビュー）の双方から利用するため、
+ * Node/Electron依存を一切持たない純関数のみで構成する。
+ * 入力は最小形（{@link SpInputStudent}）に正規化してから渡す。
+ */
+
+// ================== S-P表 ==================
+
+/** 設問1問分の生徒応答（正誤の二値） */
+export interface SpInputItem {
+  questionId: string
+  label: string
+  /** 正答なら true */
+  isCorrect: boolean
+  /** 採点済み（unscored でない）なら true */
+  isScored: boolean
+}
+
+/** 生徒1人分の入力 */
+export interface SpInputStudent {
+  studentId: string
+  studentName: string
+  items: SpInputItem[]
+}
+
+/** S-P表の生徒行（合計正答数の降順に並ぶ） */
+export interface SpStudentRow {
+  studentId: string
+  studentName: string
+  /** 正答数（行和 n_i） */
+  correctCount: number
+  /** 生徒の注意係数 CS（判定不可は null） */
+  cautionIndex: number | null
+  /** 設問列（problems と同順）の正誤 */
+  cells: boolean[]
+}
+
+/** S-P表の設問列（正答者数の降順に並ぶ） */
+export interface SpProblemColumn {
+  questionId: string
+  label: string
+  /** 正答者数（列和 m_j） */
+  correctCount: number
+  /** 設問の注意係数 CP（判定不可は null） */
+  cautionIndex: number | null
+}
+
+export interface SpTableResult {
+  students: SpStudentRow[]
+  problems: SpProblemColumn[]
+  /** 母集団となった生徒数 */
+  studentCount: number
+  /** 設問数 */
+  problemCount: number
+}
+
+/**
+ * S-P表（佐藤の注意係数つき）を計算
+ *
+ * - 母集団は「採点済みの設問を1問以上持つ生徒」（全問未採点・欠席は除外）。
+ * - 注意係数（Sato 1975）:
+ *   CS_i = 1 − (実際 − 期待) / (理想 − 期待)
+ *     実際 = Σ_j x_ij · m_j（正答した設問の正答者数の総和）
+ *     理想 = 正答者数 m を降順に並べた上位 n_i 個の和（Guttman完全パターン）
+ *     期待 = n_i · m̄
+ *   分母が0（n_i=0、全問正答、全設問の正答者数が同一等）の場合は null。
+ *   CP_j も生徒/設問を入れ替えて同様。
+ * - 設問数0、または有効生徒0なら null。
+ */
+export function computeSpTable(input: SpInputStudent[]): SpTableResult | null {
+  const students = input.filter((s) => s.items.some((it) => it.isScored))
+  if (students.length === 0) return null
+
+  const problemIds = students[0].items.map((it) => it.questionId)
+  const problemLabels = students[0].items.map((it) => it.label)
+  const m = problemIds.length
+  if (m === 0) return null
+
+  const n = students.length
+
+  // 二値行列 x[i][j]（正答=1, それ以外=0）
+  const x: number[][] = students.map((s) =>
+    problemIds.map((qid) => {
+      const it = s.items.find((p) => p.questionId === qid)
+      return it && it.isCorrect ? 1 : 0
+    })
+  )
+
+  const rowSum = x.map((row) => row.reduce((a, b) => a + b, 0))
+  const colSum = problemIds.map((_, j) => x.reduce((a, row) => a + row[j], 0))
+
+  const colMean = colSum.reduce((a, b) => a + b, 0) / m
+  const rowMean = rowSum.reduce((a, b) => a + b, 0) / n
+  const colSumDesc = [...colSum].sort((a, b) => b - a)
+  const rowSumDesc = [...rowSum].sort((a, b) => b - a)
+
+  const studentCaution = (i: number): number | null => {
+    const ni = rowSum[i]
+    const actual = x[i].reduce((sum, xij, j) => sum + xij * colSum[j], 0)
+    const ideal = colSumDesc.slice(0, ni).reduce((a, b) => a + b, 0)
+    const expected = ni * colMean
+    const denom = ideal - expected
+    if (denom === 0) return null
+    return 1 - (actual - expected) / denom
+  }
+
+  const problemCaution = (j: number): number | null => {
+    const mj = colSum[j]
+    const actual = x.reduce((sum, row, i) => sum + row[j] * rowSum[i], 0)
+    const ideal = rowSumDesc.slice(0, mj).reduce((a, b) => a + b, 0)
+    const expected = mj * rowMean
+    const denom = ideal - expected
+    if (denom === 0) return null
+    return 1 - (actual - expected) / denom
+  }
+
+  // 生徒は正答数の降順、設問は正答者数の降順に並べる
+  const studentOrder = students
+    .map((_, i) => i)
+    .sort((a, b) => rowSum[b] - rowSum[a])
+  const problemOrder = problemIds
+    .map((_, j) => j)
+    .sort((a, b) => colSum[b] - colSum[a])
+
+  const problems: SpProblemColumn[] = problemOrder.map((j) => ({
+    questionId: problemIds[j],
+    label: problemLabels[j],
+    correctCount: colSum[j],
+    cautionIndex: problemCaution(j),
+  }))
+
+  const studentRows: SpStudentRow[] = studentOrder.map((i) => ({
+    studentId: students[i].studentId,
+    studentName: students[i].studentName,
+    correctCount: rowSum[i],
+    cautionIndex: studentCaution(i),
+    cells: problemOrder.map((j) => x[i][j] === 1),
+  }))
+
+  return {
+    students: studentRows,
+    problems,
+    studentCount: n,
+    problemCount: m,
+  }
+}
+
+// ================== 得点度数分布 ==================
+
+export interface FrequencyBin {
+  /** 階級の下限（含む） */
+  lower: number
+  /** 階級の上限（最終階級以外は含まない） */
+  upper: number
+  count: number
+  label: string
+}
+
+export interface FrequencyDistributionResult {
+  bins: FrequencyBin[]
+  mean: number
+  /** 母標準偏差 */
+  stdDev: number
+  /** 階級の上端（満点） */
+  maxScore: number
+  /** 集計対象の生徒数 */
+  count: number
+}
+
+/**
+ * 得点度数分布（ヒストグラム階級）を計算
+ *
+ * - null（未採点・欠席）は除外。
+ * - 0〜満点を約10階級に等分（階級幅 = ceil(満点/10), 最小1）。
+ * - 平均・標準偏差は母分散（n で割る）。
+ */
+export function computeFrequencyDistribution(
+  totalScores: (number | null)[],
+  maxScore: number
+): FrequencyDistributionResult | null {
+  const scores = totalScores.filter((s): s is number => s !== null)
+  if (scores.length === 0) return null
+
+  const top = maxScore > 0 ? maxScore : Math.max(...scores)
+  const numBins = 10
+  const binWidth = Math.max(1, Math.ceil(top / numBins))
+
+  const bins: FrequencyBin[] = []
+  for (let lo = 0; lo < top; lo += binWidth) {
+    const hi = lo + binWidth
+    bins.push({
+      lower: lo,
+      upper: hi,
+      count: 0,
+      label: `${lo}–${Math.min(hi, top)}`,
+    })
+  }
+  // 満点が0、または階級が作られなかった場合の単一階級フォールバック
+  if (bins.length === 0) {
+    bins.push({ lower: 0, upper: top, count: 0, label: `0–${top}` })
+  }
+
+  for (const s of scores) {
+    let idx = Math.floor(s / binWidth)
+    if (idx >= bins.length) idx = bins.length - 1
+    if (idx < 0) idx = 0
+    bins[idx].count++
+  }
+
+  const mean = scores.reduce((a, b) => a + b, 0) / scores.length
+  const variance =
+    scores.reduce((a, b) => a + (b - mean) ** 2, 0) / scores.length
+
+  return {
+    bins,
+    mean,
+    stdDev: Math.sqrt(variance),
+    maxScore: top,
+    count: scores.length,
+  }
+}

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -1,5 +1,7 @@
 import { ipcRenderer } from "electron"
 
+import type { ExportRDataOptions } from "../lib/export/r-exametrika/rDataExporter"
+
 /** 出力機能のIPC API（PDF/Excel出力・ストリーミング生成・個人成績表・印刷） */
 export function createExportApi() {
   return {
@@ -107,6 +109,10 @@ export function createExportApi() {
       selectedStudentIds: string[]
       outputPath?: string
     }) => ipcRenderer.invoke("export-grading-data-excel", options),
+
+    // R / exametrika 向けデータ出力（#834）
+    exportRData: (options: ExportRDataOptions) =>
+      ipcRenderer.invoke("export-r-data", options),
 
     // Progress listeners
     onExportProgress: (

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
 
 import type {
   RenderedPageData,
@@ -670,6 +671,28 @@ export default function ExportMainView() {
     }
   }
 
+  const handleExportRData = async (format: "csv" | "json") => {
+    setIsExporting(true)
+    try {
+      const selectedStudentIds = Array.from(selectedStudents)
+      const result = await window.electronAPI.exportRData({
+        examId: exam.id,
+        selectedStudentIds,
+        format,
+      })
+      if (result.success) {
+        toast.success(`分析用データを出力しました: ${result.outputPath}`)
+      } else if (result.error !== "出力がキャンセルされました") {
+        toast.error(`出力に失敗しました: ${result.error ?? ""}`)
+      }
+    } catch (error) {
+      console.error("R data export error:", error)
+      toast.error("出力中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   const handleContinueExport = async () => {
     setShowWarningModal(false)
     const exportType = pendingExportType
@@ -821,6 +844,7 @@ export default function ExportMainView() {
               isExporting={isExporting}
               onExportScoredAnswers={handleExportScoredAnswers}
               onExportGradingData={handleExportGradingData}
+              onExportRData={handleExportRData}
               onExportIndividualReports={handleExportIndividualReports}
               activeTab={exportTab}
               onTabChange={setExportTab}

--- a/src/components/exams/08-export/components/ExcelPreview.tsx
+++ b/src/components/exams/08-export/components/ExcelPreview.tsx
@@ -6,7 +6,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import type { ExcelPreviewData } from "../hooks/useExcelPreview"
 import { useItemAnalysis } from "../hooks/useItemAnalysis"
+import { useSpAnalysis } from "../hooks/useSpAnalysis"
+import { FrequencyDistributionChart } from "./FrequencyDistributionChart"
 import { ItemAnalysisPreview } from "./ItemAnalysisPreview"
+import { SpTablePreview } from "./SpTablePreview"
 
 function getStatusSymbol(status: string, score?: number | null): string {
   switch (status) {
@@ -44,11 +47,17 @@ interface ExcelPreviewProps {
   data: ExcelPreviewData
 }
 
+type SheetTab =
+  | "scores"
+  | "results"
+  | "item-analysis"
+  | "sp-table"
+  | "frequency"
+
 export function ExcelPreview({ data }: ExcelPreviewProps) {
-  const [sheetTab, setSheetTab] = useState<
-    "scores" | "results" | "item-analysis"
-  >("scores")
+  const [sheetTab, setSheetTab] = useState<SheetTab>("scores")
   const itemAnalysisData = useItemAnalysis(data)
+  const spAnalysis = useSpAnalysis(data)
 
   const hasSubtotals = data.headers.subtotalLabels.length > 0
 
@@ -56,10 +65,10 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
     <div className="flex h-full flex-col">
       <Tabs
         value={sheetTab}
-        onValueChange={(v) => setSheetTab(v as "scores" | "results")}
+        onValueChange={(v) => setSheetTab(v as SheetTab)}
         className="flex flex-1 flex-col"
       >
-        <TabsList className="mb-1 grid w-full grid-cols-3">
+        <TabsList className="mb-1 grid w-full grid-cols-5">
           <TabsTrigger value="scores" className="text-xs">
             点数一覧
           </TabsTrigger>
@@ -68,6 +77,12 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
           </TabsTrigger>
           <TabsTrigger value="item-analysis" className="text-xs">
             問題分析
+          </TabsTrigger>
+          <TabsTrigger value="sp-table" className="text-xs">
+            S-P表
+          </TabsTrigger>
+          <TabsTrigger value="frequency" className="text-xs">
+            得点分布
           </TabsTrigger>
         </TabsList>
 
@@ -202,6 +217,26 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
           ) : (
             <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
               データがありません
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="sp-table" className="mt-0 flex-1 overflow-auto">
+          {spAnalysis?.spTable ? (
+            <SpTablePreview data={spAnalysis.spTable} />
+          ) : (
+            <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+              S-P表を作成できる採点データがありません
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="frequency" className="mt-0 flex-1 overflow-auto">
+          {spAnalysis?.frequency ? (
+            <FrequencyDistributionChart data={spAnalysis.frequency} />
+          ) : (
+            <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
+              得点分布を作成できる得点データがありません
             </div>
           )}
         </TabsContent>

--- a/src/components/exams/08-export/components/ExportOptionsCard.tsx
+++ b/src/components/exams/08-export/components/ExportOptionsCard.tsx
@@ -33,6 +33,7 @@ interface ExportOptionsCardProps {
   isExporting: boolean
   onExportScoredAnswers: () => void
   onExportGradingData: () => void
+  onExportRData: (format: "csv" | "json") => void
   onExportIndividualReports: () => void
   activeTab: ExportTabType
   onTabChange: (tab: ExportTabType) => void
@@ -50,6 +51,7 @@ export function ExportOptionsCard({
   isExporting,
   onExportScoredAnswers,
   onExportGradingData,
+  onExportRData,
   onExportIndividualReports,
   activeTab,
   onTabChange,
@@ -198,6 +200,36 @@ export function ExportOptionsCard({
           <p className="text-muted-foreground text-sm">
             採点データをExcel形式で出力します。設定は現在ありません。
           </p>
+        </div>
+
+        {/* R / exametrika 向けデータ出力（#834） */}
+        <div className="space-y-3 border-t pt-4">
+          <h4 className="text-base font-semibold">
+            分析用データ（R / exametrika）
+          </h4>
+          <p className="text-muted-foreground text-sm">
+            設問×生徒の正誤行列を出力します。欠席・未採点は欠測値として扱います。
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => onExportRData("csv")}
+              disabled={selectedStudents.size === 0 || isExporting}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              CSV
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => onExportRData("json")}
+              disabled={selectedStudents.size === 0 || isExporting}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              JSON
+            </Button>
+          </div>
         </div>
       </TabsContent>
 

--- a/src/components/exams/08-export/components/FrequencyDistributionChart.tsx
+++ b/src/components/exams/08-export/components/FrequencyDistributionChart.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import type { FrequencyDistributionResult } from "@/electron-src/lib/shared/calculations/spAnalysis"
+
+interface FrequencyDistributionChartProps {
+  data: FrequencyDistributionResult
+}
+
+/**
+ * 得点度数分布ヒストグラム（#838）
+ * 合計点を約10階級に等分した度数を横棒で表示。平均・標準偏差を併記。
+ */
+export function FrequencyDistributionChart({
+  data,
+}: FrequencyDistributionChartProps) {
+  const maxCount = Math.max(...data.bins.map((b) => b.count), 1)
+
+  return (
+    <div className="space-y-2 p-1">
+      <div className="text-muted-foreground flex gap-4 text-[11px]">
+        <span>
+          平均{" "}
+          <span className="text-foreground font-medium">
+            {data.mean.toFixed(1)}
+          </span>
+        </span>
+        <span>
+          標準偏差{" "}
+          <span className="text-foreground font-medium">
+            {data.stdDev.toFixed(1)}
+          </span>
+        </span>
+        <span>
+          人数 <span className="text-foreground font-medium">{data.count}</span>
+        </span>
+      </div>
+      <div className="space-y-0.5">
+        {data.bins.map((bin, i) => {
+          const ratio = data.count > 0 ? (bin.count / data.count) * 100 : 0
+          const widthPct = (bin.count / maxCount) * 100
+          return (
+            <div key={i} className="flex items-center gap-2 text-[10px]">
+              <span className="w-16 text-right tabular-nums">{bin.label}</span>
+              <div className="bg-muted/40 relative h-4 flex-1 rounded-sm">
+                <div
+                  className="bg-primary/70 h-4 rounded-sm"
+                  style={{ width: `${widthPct}%` }}
+                />
+              </div>
+              <span className="w-16 text-right tabular-nums">
+                {bin.count}人 ({ratio.toFixed(1)}%)
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/exams/08-export/components/ItemAnalysisPreview.tsx
+++ b/src/components/exams/08-export/components/ItemAnalysisPreview.tsx
@@ -1,9 +1,7 @@
 "use client"
 
-import type {
-  DiscriminationLevel,
-  ItemAnalysisData,
-} from "../hooks/useItemAnalysis"
+import type { ItemAnalysisResult } from "@/electron-src/lib/shared/calculations/itemAnalysis"
+import type { DiscriminationLevel } from "@/electron-src/lib/shared/types/exportTypes"
 
 const LEVEL_CONFIG: Record<
   DiscriminationLevel,
@@ -18,43 +16,63 @@ const LEVEL_CONFIG: Record<
 }
 
 interface ItemAnalysisPreviewProps {
-  data: ItemAnalysisData[]
+  data: ItemAnalysisResult
+}
+
+/** 識別係数・D値セルを判定帯で着色するクラスを返す */
+function levelCellClass(level: DiscriminationLevel): string {
+  const c = LEVEL_CONFIG[level]
+  return `border px-1 py-0.5 text-right ${c.bg} ${c.text}`
 }
 
 export function ItemAnalysisPreview({ data }: ItemAnalysisPreviewProps) {
-  const avgCorrectRate =
-    data.length > 0
-      ? data.reduce((sum, d) => sum + d.correctRate, 0) / data.length
+  const { items, cronbachAlpha } = data
+
+  const avg = (selector: (i: (typeof items)[number]) => number): number =>
+    items.length > 0
+      ? items.reduce((sum, i) => sum + selector(i), 0) / items.length
       : 0
-  const avgScoreRate =
-    data.length > 0
-      ? data.reduce((sum, d) => sum + d.scoreRate, 0) / data.length
-      : 0
-  const validIndices = data.filter((d) => d.discriminationIndex !== null)
-  const avgDiscrim =
-    validIndices.length > 0
-      ? validIndices.reduce((sum, d) => sum + d.discriminationIndex!, 0) /
-        validIndices.length
+  const avgValid = (
+    selector: (i: (typeof items)[number]) => number | null
+  ): number | null => {
+    const vals = items.map(selector).filter((v): v is number => v !== null)
+    return vals.length > 0
+      ? vals.reduce((s, v) => s + v, 0) / vals.length
       : null
+  }
+
+  const avgCorrectRate = avg((i) => i.correctRate)
+  const avgScoreRate = avg((i) => i.scoreRate)
+  const avgDiscrim = avgValid((i) => i.discriminationIndex)
+  const avgDValue = avgValid((i) => i.dValue)
 
   return (
-    <table className="w-full border-collapse text-[10px]">
-      <thead className="bg-muted sticky top-0">
-        <tr>
-          <th className="border px-1 py-0.5 text-left">設問</th>
-          <th className="border px-1 py-0.5 text-right">配点</th>
-          <th className="border px-1 py-0.5 text-right">正答率(%)</th>
-          <th className="border px-1 py-0.5 text-right">得点率(%)</th>
-          <th className="border px-1 py-0.5 text-right">識別係数</th>
-          <th className="border px-1 py-0.5 text-center">判定</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map((row, i) => {
-          const config = LEVEL_CONFIG[row.level]
-          return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground px-1 text-[11px]">
+        クロンバックα係数:{" "}
+        <span className="text-foreground font-medium">
+          {cronbachAlpha !== null ? cronbachAlpha.toFixed(3) : "判定不可"}
+        </span>
+        <span className="ml-2">
+          （識別係数・D値の色: 良好≥0.4 / 許容≥0.3 / 要確認≥0.2 / 低い&lt;0.2 /
+          要検討&lt;0）
+        </span>
+      </div>
+      <table className="w-full border-collapse text-[10px]">
+        <thead className="bg-muted sticky top-0">
+          <tr>
+            <th className="border px-1 py-0.5 text-left">設問</th>
+            <th className="border px-1 py-0.5 text-right">配点</th>
+            <th className="border px-1 py-0.5 text-right">正答率(%)</th>
+            <th className="border px-1 py-0.5 text-right">得点率(%)</th>
+            <th className="border px-1 py-0.5 text-right">識別係数</th>
+            <th className="border px-1 py-0.5 text-right">D値</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((row, i) => (
             <tr key={i} className="hover:bg-muted/50">
-              <td className="border px-1 py-0.5">{row.questionLabel}</td>
+              <td className="border px-1 py-0.5">{row.label}</td>
               <td className="border px-1 py-0.5 text-right">{row.maxScore}</td>
               <td className="border px-1 py-0.5 text-right">
                 {row.correctRate.toFixed(1)}
@@ -62,34 +80,34 @@ export function ItemAnalysisPreview({ data }: ItemAnalysisPreviewProps) {
               <td className="border px-1 py-0.5 text-right">
                 {row.scoreRate.toFixed(1)}
               </td>
-              <td className="border px-1 py-0.5 text-right">
+              <td className={levelCellClass(row.discriminationLevel)}>
                 {row.discriminationIndex !== null
                   ? row.discriminationIndex.toFixed(3)
                   : "---"}
               </td>
-              <td
-                className={`border px-1 py-0.5 text-center ${config.bg} ${config.text}`}
-              >
-                {config.label}
+              <td className={levelCellClass(row.dValueLevel)}>
+                {row.dValue !== null ? row.dValue.toFixed(3) : "---"}
               </td>
             </tr>
-          )
-        })}
-        <tr className="bg-muted/70 font-medium">
-          <td className="border px-1 py-0.5">平均</td>
-          <td className="border px-1 py-0.5"></td>
-          <td className="border px-1 py-0.5 text-right">
-            {avgCorrectRate.toFixed(1)}
-          </td>
-          <td className="border px-1 py-0.5 text-right">
-            {avgScoreRate.toFixed(1)}
-          </td>
-          <td className="border px-1 py-0.5 text-right">
-            {avgDiscrim !== null ? avgDiscrim.toFixed(3) : "---"}
-          </td>
-          <td className="border px-1 py-0.5"></td>
-        </tr>
-      </tbody>
-    </table>
+          ))}
+          <tr className="bg-muted/70 font-medium">
+            <td className="border px-1 py-0.5">平均</td>
+            <td className="border px-1 py-0.5"></td>
+            <td className="border px-1 py-0.5 text-right">
+              {avgCorrectRate.toFixed(1)}
+            </td>
+            <td className="border px-1 py-0.5 text-right">
+              {avgScoreRate.toFixed(1)}
+            </td>
+            <td className="border px-1 py-0.5 text-right">
+              {avgDiscrim !== null ? avgDiscrim.toFixed(3) : "---"}
+            </td>
+            <td className="border px-1 py-0.5 text-right">
+              {avgDValue !== null ? avgDValue.toFixed(3) : "---"}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/src/components/exams/08-export/components/SpTablePreview.tsx
+++ b/src/components/exams/08-export/components/SpTablePreview.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import type { SpTableResult } from "@/electron-src/lib/shared/calculations/spAnalysis"
+
+interface SpTablePreviewProps {
+  data: SpTableResult
+}
+
+/**
+ * S-P表プレビュー（#838）
+ * 生徒（正答数降順）×設問（正答者数降順）の正誤マトリクス。
+ * S曲線（行の正答数境界）を右の太罫線、P曲線（列の正答者数境界）を下の太罫線で表現。
+ */
+export function SpTablePreview({ data }: SpTablePreviewProps) {
+  const { students, problems } = data
+
+  const fmtCaution = (v: number | null): string =>
+    v !== null ? v.toFixed(3) : "---"
+
+  return (
+    <div className="space-y-2">
+      <p className="text-muted-foreground px-1 text-[11px]">
+        生徒{students.length}名 × 設問{problems.length}問。太線は S曲線（行）/
+        P曲線（列）。注意係数が高いほど応答パターンが非定型。
+      </p>
+      <table className="border-collapse text-[10px]">
+        <thead className="bg-muted sticky top-0">
+          <tr>
+            <th className="border px-1 py-0.5 text-left">生徒</th>
+            {problems.map((p) => (
+              <th
+                key={p.questionId}
+                className="border px-1 py-0.5 text-center"
+                title={`正答者数 ${p.correctCount}`}
+              >
+                {p.label}
+              </th>
+            ))}
+            <th className="border px-1 py-0.5 text-right">正答数</th>
+            <th className="border px-1 py-0.5 text-right">注意係数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {students.map((s, rowIdx) => (
+            <tr key={s.studentId} className="hover:bg-muted/50">
+              <td className="border px-1 py-0.5 whitespace-nowrap">
+                {s.studentName}
+              </td>
+              {s.cells.map((correct, colIdx) => {
+                // S曲線: 正答数 c の右に縦境界
+                const sCurve = colIdx === s.correctCount - 1
+                // P曲線: 設問の正答者数 m の行の下に横境界
+                const pCurve = rowIdx === problems[colIdx].correctCount - 1
+                const borderClass = [
+                  sCurve ? "border-r-2 border-r-gray-700" : "",
+                  pCurve ? "border-b-2 border-b-gray-700" : "",
+                ].join(" ")
+                return (
+                  <td
+                    key={colIdx}
+                    className={`border px-1 py-0.5 text-center ${
+                      correct ? "bg-green-50 text-green-700" : "text-gray-300"
+                    } ${borderClass}`}
+                  >
+                    {correct ? "○" : "・"}
+                  </td>
+                )
+              })}
+              <td className="border px-1 py-0.5 text-right font-medium">
+                {s.correctCount}
+              </td>
+              <td className="border px-1 py-0.5 text-right">
+                {fmtCaution(s.cautionIndex)}
+              </td>
+            </tr>
+          ))}
+          <tr className="bg-muted/70 font-medium">
+            <td className="border px-1 py-0.5">正答者数</td>
+            {problems.map((p) => (
+              <td key={p.questionId} className="border px-1 py-0.5 text-center">
+                {p.correctCount}
+              </td>
+            ))}
+            <td className="border px-1 py-0.5"></td>
+            <td className="border px-1 py-0.5"></td>
+          </tr>
+          <tr className="bg-muted/70 font-medium">
+            <td className="border px-1 py-0.5">注意係数</td>
+            {problems.map((p) => (
+              <td key={p.questionId} className="border px-1 py-0.5 text-center">
+                {fmtCaution(p.cautionIndex)}
+              </td>
+            ))}
+            <td className="border px-1 py-0.5"></td>
+            <td className="border px-1 py-0.5"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/exams/08-export/hooks/useItemAnalysis.ts
+++ b/src/components/exams/08-export/hooks/useItemAnalysis.ts
@@ -2,119 +2,36 @@
 
 import { useMemo } from "react"
 
+import {
+  computeItemAnalysis,
+  type ItemAnalysisInputStudent,
+  type ItemAnalysisResult,
+} from "@/electron-src/lib/shared/calculations/itemAnalysis"
+
 import type { ExcelPreviewData } from "./useExcelPreview"
 
-export type DiscriminationLevel =
-  | "good"
-  | "acceptable"
-  | "marginal"
-  | "poor"
-  | "negative"
-  | "insufficient"
-
-export interface ItemAnalysisData {
-  questionLabel: string
-  maxScore: number
-  correctRate: number
-  scoreRate: number
-  discriminationIndex: number | null
-  level: DiscriminationLevel
-}
-
-function average(values: number[]): number {
-  if (values.length === 0) return 0
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}
-
-function stdDev(values: number[]): number {
-  if (values.length === 0) return 0
-  const avg = average(values)
-  const squaredDiffs = values.map((v) => (v - avg) ** 2)
-  return Math.sqrt(squaredDiffs.reduce((sum, v) => sum + v, 0) / values.length)
-}
-
-function getLevel(r: number | null): DiscriminationLevel {
-  if (r === null) return "insufficient"
-  if (r < 0) return "negative"
-  if (r < 0.2) return "poor"
-  if (r < 0.3) return "marginal"
-  if (r < 0.4) return "acceptable"
-  return "good"
-}
-
-/** 設問ごとの正答率・得点率・識別係数を算出する項目分析フック */
+/**
+ * 設問ごとの正答率・得点率・識別係数・D値とテスト全体のα係数を算出する項目分析フック。
+ * 計算は共有モジュール（`itemAnalysis.ts`）に委譲し、Excel「問題分析」シートと完全に一致させる。
+ */
 export function useItemAnalysis(
   data: ExcelPreviewData | null
-): ItemAnalysisData[] | null {
+): ItemAnalysisResult | null {
   return useMemo(() => {
     if (!data || data.rows.length === 0) return null
+    if (data.headers.questionLabels.length === 0) return null
 
-    const questionCount = data.headers.questionLabels.length
-    if (questionCount === 0) return null
+    const input: ItemAnalysisInputStudent[] = data.rows.map((row) => ({
+      items: row.scores.map((s, qi) => ({
+        questionId: s.questionId,
+        label: data.headers.questionLabels[qi] ?? s.questionLabel,
+        maxScore: data.headers.questionMaxScores[qi] ?? s.maxScore,
+        // 解決済み得点（未採点・未確定は null、無回答は 0）をそのまま使う
+        score: s.score,
+        isCorrect: s.status === "correct",
+      })),
+    }))
 
-    const results: ItemAnalysisData[] = []
-
-    for (let qi = 0; qi < questionCount; qi++) {
-      const label = data.headers.questionLabels[qi]
-      const maxScore = data.headers.questionMaxScores[qi]
-
-      // 採点済みデータのみ集計
-      const itemScores: number[] = []
-      const correctedTotals: number[] = []
-      let correctCount = 0
-      let scoredCount = 0
-      let scoreRateSum = 0
-
-      for (const row of data.rows) {
-        const score = row.scores[qi]
-        if (!score || score.status === "unscored") continue
-
-        scoredCount++
-        const itemScore = score.score ?? 0
-        itemScores.push(itemScore)
-
-        if (score.status === "correct") correctCount++
-        if (maxScore > 0) scoreRateSum += itemScore / maxScore
-
-        if (row.totalScore !== null) {
-          correctedTotals.push(row.totalScore - itemScore)
-        }
-      }
-
-      const correctRate =
-        scoredCount > 0 ? (correctCount / scoredCount) * 100 : 0
-      const scoreRate = scoredCount > 0 ? (scoreRateSum / scoredCount) * 100 : 0
-
-      // 識別係数（補正済み項目合計相関）
-      let discriminationIndex: number | null = null
-      if (
-        itemScores.length >= 3 &&
-        itemScores.length === correctedTotals.length
-      ) {
-        const itemSd = stdDev(itemScores)
-        const totalSd = stdDev(correctedTotals)
-        if (itemSd > 0 && totalSd > 0) {
-          const itemMean = average(itemScores)
-          const totalMean = average(correctedTotals)
-          let cov = 0
-          for (let i = 0; i < itemScores.length; i++) {
-            cov += (itemScores[i] - itemMean) * (correctedTotals[i] - totalMean)
-          }
-          cov /= itemScores.length
-          discriminationIndex = cov / (itemSd * totalSd)
-        }
-      }
-
-      results.push({
-        questionLabel: label,
-        maxScore,
-        correctRate,
-        scoreRate,
-        discriminationIndex,
-        level: getLevel(discriminationIndex),
-      })
-    }
-
-    return results
+    return computeItemAnalysis(input)
   }, [data])
 }

--- a/src/components/exams/08-export/hooks/useSpAnalysis.ts
+++ b/src/components/exams/08-export/hooks/useSpAnalysis.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useMemo } from "react"
+
+import {
+  computeFrequencyDistribution,
+  computeSpTable,
+  type FrequencyDistributionResult,
+  type SpInputStudent,
+  type SpTableResult,
+} from "@/electron-src/lib/shared/calculations/spAnalysis"
+
+import type { ExcelPreviewData } from "./useExcelPreview"
+
+export interface SpAnalysisResult {
+  spTable: SpTableResult | null
+  frequency: FrequencyDistributionResult | null
+}
+
+/** S-P表・得点度数分布をプレビュー用に算出するフック（#838、計算は共有モジュール） */
+export function useSpAnalysis(
+  data: ExcelPreviewData | null
+): SpAnalysisResult | null {
+  return useMemo(() => {
+    if (!data || data.rows.length === 0) return null
+
+    const input: SpInputStudent[] = data.rows.map((row) => ({
+      studentId: row.studentId,
+      studentName: row.studentName,
+      items: row.scores.map((s) => ({
+        questionId: s.questionId,
+        label: s.questionLabel,
+        isCorrect: s.status === "correct",
+        isScored: s.status !== "unscored",
+      })),
+    }))
+
+    const totalScores = data.rows.map((r) => r.totalScore)
+    const maxScore = data.rows[0]?.totalMaxScore ?? 0
+
+    return {
+      spTable: computeSpTable(input),
+      frequency: computeFrequencyDistribution(totalScores, maxScore),
+    }
+  }, [data])
+}

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -3,6 +3,7 @@ import type {
   IndividualReportOptions,
   SubtotalGroupsForReportResult,
 } from "@/electron-src/lib/export/individual-report/types"
+import type { ExportRDataOptions } from "@/electron-src/lib/export/r-exametrika/rDataExporter"
 import type {
   CaptureReturnSnapshotResult,
   ReturnDiffResult,
@@ -339,6 +340,13 @@ export interface ExportAPI {
         conflicted?: string[]
       }
     }
+  }>
+
+  // R / exametrika 向けデータ出力（#834）
+  exportRData: (options: ExportRDataOptions) => Promise<{
+    success: boolean
+    outputPath?: string
+    error?: string
   }>
 
   // Progress listeners


### PR DESCRIPTION
Closes #883

## 概要

試験の結果出力に統計分析機能を追加（#833 / #838 / #834）。スキーマ変更ゼロ・トグルなし。

## 変更点

### #833 クロンバックα係数・D値
- 共有純粋モジュール `electron-src/lib/shared/calculations/itemAnalysis.ts` に集約し、Excel「問題分析」シートとプレビューで同一実装を共用（ドリフト防止）
- complete-case（`score===null` 除外）で算出。`no_answer`/`double_mark` は確定0として母集団に残し、未採点・保留は除外
- D値は得点率差（部分点を比例反映、二値設問は従来の正答率差と一致）
- 識別係数・D値の各セルを判定帯で着色（曖昧な単一「判定」列を廃止）

### #838 S-P表・得点度数分布
- 共有純粋モジュール `spAnalysis.ts`（佐藤の注意係数・度数分布）を電子/フロント共用
- Excel新2シート（S-P表・得点度数分布）＋プレビュー2タブ

### #834 R / exametrika エクスポート
- 設問×生徒の正誤行列を CSV/JSON 出力（欠席・未採点は欠測）
- IPC `export-r-data`＋採点データExcelタブ内に出力導線、結果はトースト通知

### その他
- `SubtotalGroupInfo` を Prisma 派生 Pick 型へ整理（デッドコード除去）
- `ExportRDataOptions` 型を共有して三重定義を解消

## テスト
- `__tests__/calculations/` 計86件パス（α手計算=2/3、注意係数手計算、complete-case除外、部分点得点率差）
- 型チェック・lint クリーン
- コードレビュー（high effort）の指摘を反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)