### PR TITLE
feat(coursework): 点数入力のキーボード移動・無効値表示・保存漏れ対策

### DIFF
--- a/src/components/common/EditableTable.tsx
+++ b/src/components/common/EditableTable.tsx
@@ -46,38 +46,85 @@ function EditableCell<T>({
     meta?.updateData(row.index, column.id, String(value ?? ""))
   }
 
+  const moveFocus = (target: HTMLInputElement) => {
+    target.focus()
+    target.select()
+  }
+
   const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-      inputRef.current?.blur()
-    }
-    if (e.key === "Tab") {
+    // IME変換確定のEnter/Tabではセル移動しない
+    if (e.nativeEvent.isComposing) return
+
+    const currentCell = inputRef.current
+    if (!currentCell) return
+
+    if (e.key === "Enter") {
+      // 同じ列の上下行へ移動（Shift+Enterで上）
       e.preventDefault()
-      const currentCell = inputRef.current
-      if (currentCell) {
-        const table = currentCell.closest("table")
-        if (table) {
-          const cells = Array.from(table.querySelectorAll("input"))
-          const currentIndex = cells.indexOf(currentCell)
-          const nextIndex = e.shiftKey ? currentIndex - 1 : currentIndex + 1
-          if (nextIndex >= 0 && nextIndex < cells.length) {
-            ;(cells[nextIndex] as HTMLInputElement).focus()
-          }
-        }
+      const table = currentCell.closest("table")
+      if (!table) return
+      const rows = Array.from(table.querySelectorAll("tbody tr"))
+      const currentRow = currentCell.closest("tr")
+      const rowIndex = currentRow ? rows.indexOf(currentRow) : -1
+      if (rowIndex < 0 || !currentRow) return
+      const colIndex = Array.from(currentRow.querySelectorAll("input")).indexOf(
+        currentCell
+      )
+      if (colIndex < 0) return
+
+      const targetRowIndex = e.shiftKey ? rowIndex - 1 : rowIndex + 1
+      if (targetRowIndex < 0 || targetRowIndex >= rows.length) return
+      const targetInputs = Array.from(
+        rows[targetRowIndex].querySelectorAll("input")
+      )
+      const target =
+        targetInputs[colIndex] ?? targetInputs[targetInputs.length - 1]
+      if (target) moveFocus(target)
+      return
+    }
+
+    if (e.key === "Tab") {
+      // 左右へ移動。行末は次行の先頭、行頭は前行の末尾へ（Shift+Tabで逆）
+      e.preventDefault()
+      const table = currentCell.closest("table")
+      if (!table) return
+      const cells = Array.from(
+        table.querySelectorAll("tbody input")
+      ) as HTMLInputElement[]
+      const currentIndex = cells.indexOf(currentCell)
+      if (currentIndex < 0) return
+      const nextIndex = e.shiftKey ? currentIndex - 1 : currentIndex + 1
+      if (nextIndex >= 0 && nextIndex < cells.length) {
+        moveFocus(cells[nextIndex])
       }
     }
   }
 
-  const meta = column.columnDef.meta as { placeholder?: string } | undefined
+  const meta = column.columnDef.meta as
+    | { placeholder?: string; validate?: (value: string) => boolean }
+    | undefined
+
+  // 非空かつ検証NGのセルは赤背景で警告（保存されない入力を可視化）
+  const strValue = String(value ?? "")
+  const isInvalid =
+    strValue.trim() !== "" && meta?.validate ? !meta.validate(strValue) : false
 
   return (
     <input
       ref={inputRef}
-      value={String(value ?? "")}
+      value={strValue}
       onChange={(e) => setValue(e.target.value)}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
-      className="absolute inset-0 h-full w-full border-none bg-transparent px-4 py-2 text-sm focus:bg-white focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      className={`absolute inset-0 h-full w-full border-none px-4 py-2 text-sm focus:ring-1 focus:ring-blue-500 focus:outline-none ${
+        isInvalid
+          ? "bg-red-100 text-red-700 focus:bg-red-50"
+          : "bg-transparent focus:bg-white"
+      }`}
       placeholder={meta?.placeholder || ""}
+      title={
+        isInvalid ? "無効な値です（このままでは保存されません）" : undefined
+      }
     />
   )
 }

--- a/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
+++ b/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
@@ -111,6 +111,7 @@ export function CourseworkScoresContainer({
       (item): ColumnDef<ScoreRow>[] => {
         const isLetter = item.inputMode === "letter"
         const validLabels = item.letterScales.map((ls) => ls.label).join("/")
+        const validLabelSet = new Set(item.letterScales.map((ls) => ls.label))
         return [
           {
             id: item.id,
@@ -123,6 +124,14 @@ export function CourseworkScoresContainer({
               placeholder: isLetter
                 ? validLabels || "評価記号"
                 : `0-${item.maxScore}`,
+              // 文字評価は定義済みラベル、数値は0〜満点の範囲のみ有効
+              validate: (value: string) => {
+                const trimmed = value.trim()
+                if (trimmed === "") return true
+                if (isLetter) return validLabelSet.has(trimmed)
+                const num = Number(trimmed)
+                return !isNaN(num) && num >= 0 && num <= item.maxScore
+              },
             },
           },
           {
@@ -130,7 +139,16 @@ export function CourseworkScoresContainer({
             header: `${item.name}·加減点`,
             accessorKey: adjColId(item.id),
             size: 90,
-            meta: { placeholder: "±0" },
+            meta: {
+              placeholder: "±0",
+              // 加減点は有限の数値のみ有効
+              validate: (value: string) => {
+                const trimmed = value.trim()
+                if (trimmed === "") return true
+                const num = Number(trimmed)
+                return !isNaN(num) && isFinite(num)
+              },
+            },
           },
           {
             id: reasonColId(item.id),

--- a/src/components/coursework/04-scores/hooks/useCourseworkScores.ts
+++ b/src/components/coursework/04-scores/hooks/useCourseworkScores.ts
@@ -146,6 +146,19 @@ export function useCourseworkScores(courseworkId: string) {
     loadData()
   }, [loadData])
 
+  // 未保存の変更を即座にDBへ反映する（デバウンス完了時・アンマウント時に使用）
+  const flushPending = useCallback(async () => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = null
+    }
+    const pending = Array.from(pendingChanges.current.values())
+    pendingChanges.current.clear()
+    if (pending.length > 0) {
+      await window.electronAPI.coursework.batchUpsertScores(pending)
+    }
+  }, [])
+
   const bulkUpdateCells = useCallback(
     (
       changes: {
@@ -197,25 +210,19 @@ export function useCourseworkScores(courseworkId: string) {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current)
       }
-      saveTimeoutRef.current = setTimeout(async () => {
-        const pending = Array.from(pendingChanges.current.values())
-        pendingChanges.current.clear()
-        if (pending.length > 0) {
-          await window.electronAPI.coursework.batchUpsertScores(pending)
-        }
+      saveTimeoutRef.current = setTimeout(() => {
+        void flushPending()
       }, 500)
     },
-    []
+    [flushPending]
   )
 
-  // クリーンアップ
+  // アンマウント時、未保存の変更が残っていれば即座にフラッシュする
   useEffect(() => {
     return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current)
-      }
+      void flushPending()
     }
-  }, [])
+  }, [flushPending])
 
   return {
     items,


### PR DESCRIPTION
## 概要

試験外成績資料の点数入力の操作性と信頼性を改善する。

Closes #885

## 変更内容

### 1. キーボードでのセル移動（`EditableTable`）
- **Enter**: 同じ列の下のセルへ（**Shift+Enter** で上）
- **Tab**: 右のセルへ、行末は次行先頭へ（**Shift+Tab** で逆）
- 移動先は値を全選択して上書き入力しやすく
- **IME配慮**: 変換確定の Enter ではセル移動せず、通常の確定動作に委ねる（`nativeEvent.isComposing` 判定）

### 2. 無効値の赤背景表示
- 列ごとに `meta.validate` を渡せるようにし、非空かつ検証NGのセルを赤背景・赤文字で警告表示（ツールチップ付き）
- 点数列: `0〜満点` の範囲／定義済み評価記号のみ有効
- 加減点列: 有限な数値のみ有効
- 既存の保存判定（無視条件）とロジックを一致させ「赤＝保存されない値」を可視化

### 3. 保存漏れ対策（`useCourseworkScores`）
- `flushPending` を新設し、デバウンス完了時とアンマウント時で共通化
- アンマウント時に未保存のデバウンス変更をフラッシュし、編集直後の画面遷移による保存漏れを防止

## 影響範囲

`EditableTable` は生徒インポート等でも共有されるが、Enter/Tab移動はスプレッドシート標準の自然な挙動。赤背景は `validate` を渡した列のみ対象のため他の利用箇所には影響しない。

## 確認

- `npm run lint` 通過
- `npm run typecheck`（tsc --noEmit）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)