### PR TITLE
feat(coursework): 評価項目編集のインライン逐次保存・DnD並べ替え・小数対応

### DIFF
--- a/src/components/common/letter-scale-editor/LetterScaleEditor.tsx
+++ b/src/components/common/letter-scale-editor/LetterScaleEditor.tsx
@@ -1,7 +1,14 @@
 "use client"
 
+import type { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
 import { Plus, X } from "lucide-react"
 
+import {
+  DragHandle,
+  SortableTableProvider,
+  useSortableRow,
+} from "@/components/common/sortable-table"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
@@ -23,9 +30,53 @@ export const DEFAULT_LETTER_SCALES: LetterScaleDraft[] = [
   { label: "C", score: "60" },
 ]
 
+interface ScaleRowProps {
+  id: string
+  scale: LetterScaleDraft
+  index: number
+  onUpdate: (index: number, patch: Partial<LetterScaleDraft>) => void
+  onRemove: (index: number) => void
+}
+
+/** ドラッグ&ドロップで並べ替え可能な変換表の1行 */
+function ScaleRow({ id, scale, index, onUpdate, onRemove }: ScaleRowProps) {
+  const { setNodeRef, style, dragHandleProps } = useSortableRow(id)
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      <DragHandle dragHandleProps={dragHandleProps} />
+      <Input
+        value={scale.label}
+        onChange={(e) => onUpdate(index, { label: e.target.value })}
+        className="h-7 w-20 text-xs"
+        placeholder="記号"
+      />
+      <span className="text-muted-foreground text-xs">=</span>
+      <Input
+        value={scale.score}
+        onChange={(e) => onUpdate(index, { score: e.target.value })}
+        className="h-7 w-24 text-xs"
+        type="number"
+        step="any"
+        placeholder="点数"
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={() => onRemove(index)}
+        title="削除"
+      >
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  )
+}
+
 /**
  * 文字評価（A/B/C 等）→ 点数の変換表エディタ
  * manual型データソース + 文字モード時に使用する。
+ * 行はドラッグ&ドロップで並べ替えできる（順番が保存時の order になる）。
  */
 export function LetterScaleEditor({
   scales,
@@ -43,38 +94,36 @@ export function LetterScaleEditor({
     onChange([...scales, { label: "", score: "" }])
   }
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = Number(active.id)
+    const newIndex = Number(over.id)
+    if (isNaN(oldIndex) || isNaN(newIndex)) return
+    onChange(arrayMove(scales, oldIndex, newIndex))
+  }
+
+  // 行のID（配列インデックスベース。並べ替えで配列順=order が決まる）
+  const rowIds = scales.map((_, i) => String(i))
+
   return (
     <div className="bg-muted/30 space-y-2 rounded border border-dashed p-2">
       <p className="text-muted-foreground text-xs font-medium">
         評価記号 → 点数の変換表
       </p>
       <div className="space-y-1">
-        {scales.map((scale, index) => (
-          <div key={index} className="flex items-center gap-2">
-            <Input
-              value={scale.label}
-              onChange={(e) => updateRow(index, { label: e.target.value })}
-              className="h-7 w-20 text-xs"
-              placeholder="記号"
+        <SortableTableProvider items={rowIds} onDragEnd={handleDragEnd}>
+          {scales.map((scale, index) => (
+            <ScaleRow
+              key={index}
+              id={String(index)}
+              scale={scale}
+              index={index}
+              onUpdate={updateRow}
+              onRemove={removeRow}
             />
-            <span className="text-muted-foreground text-xs">=</span>
-            <Input
-              value={scale.score}
-              onChange={(e) => updateRow(index, { score: e.target.value })}
-              className="h-7 w-24 text-xs"
-              type="number"
-              placeholder="点数"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6"
-              onClick={() => removeRow(index)}
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          </div>
-        ))}
+          ))}
+        </SortableTableProvider>
       </div>
       <Button
         variant="ghost"

--- a/src/components/coursework/03-items/CourseworkItemsContainer.tsx
+++ b/src/components/coursework/03-items/CourseworkItemsContainer.tsx
@@ -1,16 +1,10 @@
 "use client"
 
-import {
-  ChevronDown,
-  ChevronUp,
-  Pencil,
-  Plus,
-  Save,
-  Trash2,
-  X,
-} from "lucide-react"
+import type { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+import { Plus, Trash2 } from "lucide-react"
 import Link from "next/link"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -19,7 +13,11 @@ import {
   type LetterScaleDraft,
   LetterScaleEditor,
 } from "@/components/common/letter-scale-editor/LetterScaleEditor"
-import { Badge } from "@/components/ui/badge"
+import {
+  DragHandle,
+  SortableTableProvider,
+  useSortableRow,
+} from "@/components/common/sortable-table"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -61,28 +59,147 @@ function toDraft(item: CourseworkItemWithDetails): ItemDraft {
   }
 }
 
+/** ドラフトが保存可能（=有効）かを判定する */
+function isDraftValid(draft: ItemDraft): boolean {
+  if (!draft.name.trim()) return false
+  const maxScore = Number(draft.maxScore)
+  if (isNaN(maxScore) || maxScore <= 0) return false
+  if (
+    draft.inputMode === "letter" &&
+    draftsToLetterScales(draft.letterScales).length === 0
+  ) {
+    return false
+  }
+  return true
+}
+
+interface SortableItemRowProps {
+  item: CourseworkItemWithDetails
+  draft: ItemDraft
+  onUpdate: (itemId: string, patch: Partial<ItemDraft>) => void
+  onDelete: (item: CourseworkItemWithDetails) => void
+}
+
+/** ドラッグ&ドロップで並べ替え可能な、常時インライン編集の評価項目1行 */
+function SortableItemRow({
+  item,
+  draft,
+  onUpdate,
+  onDelete,
+}: SortableItemRowProps) {
+  const { setNodeRef, style, dragHandleProps } = useSortableRow(item.id)
+  const maxScoreNum = Number(draft.maxScore)
+  const maxScoreInvalid =
+    draft.maxScore.trim() === "" || isNaN(maxScoreNum) || maxScoreNum <= 0
+
+  return (
+    <div ref={setNodeRef} style={style} className="rounded-lg border p-4">
+      <div className="flex items-start gap-3">
+        <DragHandle dragHandleProps={dragHandleProps} className="mt-5" />
+
+        <div className="flex-1 space-y-3">
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">項目名</Label>
+              <Input
+                value={draft.name}
+                onChange={(e) => onUpdate(item.id, { name: e.target.value })}
+                className="h-8 w-48"
+                placeholder="項目名"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">満点</Label>
+              <Input
+                value={draft.maxScore}
+                onChange={(e) =>
+                  onUpdate(item.id, { maxScore: e.target.value })
+                }
+                type="number"
+                step="any"
+                className={`h-8 w-24 ${
+                  maxScoreInvalid ? "border-red-400 bg-red-50 text-red-700" : ""
+                }`}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">入力方式</Label>
+              <Select
+                value={draft.inputMode}
+                onValueChange={(v) =>
+                  onUpdate(item.id, { inputMode: v as InputMode })
+                }
+              >
+                <SelectTrigger className="h-8 w-28 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="numeric">数値</SelectItem>
+                  <SelectItem value="letter">文字評価</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {draft.inputMode === "letter" && (
+            <LetterScaleEditor
+              scales={draft.letterScales}
+              onChange={(scales) => onUpdate(item.id, { letterScales: scales })}
+            />
+          )}
+        </div>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive mt-5 h-7 w-7"
+          onClick={() => onDelete(item)}
+          title="削除"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 /**
  * 試験外成績資料の評価項目管理コンテナ
  *
  * 評価項目の追加・編集（満点・数値/文字モード・文字評価変換表）・並べ替え・削除を行う。
+ * 各項目は常時インライン編集で、変更はデバウンスで自動保存される。
+ * 並べ替えはドラッグ&ドロップ。
  * 成績算出から参照中の項目は削除をブロックし、参照元をトーストで通知する。
  */
 export function CourseworkItemsContainer({
   courseworkId,
 }: CourseworkItemsContainerProps) {
   const [items, setItems] = useState<CourseworkItemWithDetails[]>([])
+  const [drafts, setDrafts] = useState<Record<string, ItemDraft>>({})
   const [loading, setLoading] = useState(true)
-
   const [newItemName, setNewItemName] = useState("")
-  const [editingItemId, setEditingItemId] = useState<string | null>(null)
-  const [draft, setDraft] = useState<ItemDraft | null>(null)
+
+  // 自動保存用：最新ドラフトの参照と項目ごとのデバウンスタイマー
+  const draftsRef = useRef<Record<string, ItemDraft>>({})
+  const saveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map()
+  )
+
+  const setDraftsSynced = useCallback((next: Record<string, ItemDraft>) => {
+    draftsRef.current = next
+    setDrafts(next)
+  }, [])
 
   const loadItems = useCallback(async () => {
     try {
       const result = await window.electronAPI.coursework.getById(courseworkId)
       if (result.success && result.coursework) {
-        setItems(
-          result.coursework.items.slice().sort((a, b) => a.order - b.order)
+        const sorted = result.coursework.items
+          .slice()
+          .sort((a, b) => a.order - b.order)
+        setItems(sorted)
+        setDraftsSynced(
+          Object.fromEntries(sorted.map((item) => [item.id, toDraft(item)]))
         )
       }
     } catch (error) {
@@ -90,14 +207,76 @@ export function CourseworkItemsContainer({
     } finally {
       setLoading(false)
     }
-  }, [courseworkId])
+  }, [courseworkId, setDraftsSynced])
 
   useEffect(() => {
     loadItems()
   }, [loadItems])
 
+  /** 指定項目の最新ドラフトをDBへ保存する（無効なドラフトはスキップ） */
+  const saveItem = useCallback(async (itemId: string) => {
+    const draft = draftsRef.current[itemId]
+    if (!draft || !isDraftValid(draft)) return
+    const result = await window.electronAPI.coursework.updateItem(itemId, {
+      name: draft.name.trim(),
+      maxScore: Number(draft.maxScore),
+      inputMode: draft.inputMode,
+      letterScales: draftsToLetterScales(draft.letterScales),
+    })
+    if (!result.success) {
+      toast.error("保存に失敗しました", { description: result.error })
+    }
+  }, [])
+
+  /** 保留中の全保存を即座に実行する（並べ替え/追加/削除/離脱前のフラッシュ） */
+  const flushAll = useCallback(async () => {
+    const ids = Array.from(saveTimers.current.keys())
+    for (const id of ids) {
+      const timer = saveTimers.current.get(id)
+      if (timer) clearTimeout(timer)
+      saveTimers.current.delete(id)
+      await saveItem(id)
+    }
+  }, [saveItem])
+
+  // アンマウント時に未保存分をフラッシュ
+  useEffect(() => {
+    const timers = saveTimers.current
+    return () => {
+      for (const [id, timer] of timers) {
+        clearTimeout(timer)
+        void saveItem(id)
+      }
+      timers.clear()
+    }
+  }, [saveItem])
+
+  /** ドラフトを部分更新し、その項目の保存をデバウンス予約する */
+  const updateDraft = useCallback(
+    (itemId: string, patch: Partial<ItemDraft>) => {
+      const current = draftsRef.current[itemId]
+      if (!current) return
+      setDraftsSynced({
+        ...draftsRef.current,
+        [itemId]: { ...current, ...patch },
+      })
+
+      const existing = saveTimers.current.get(itemId)
+      if (existing) clearTimeout(existing)
+      saveTimers.current.set(
+        itemId,
+        setTimeout(() => {
+          saveTimers.current.delete(itemId)
+          void saveItem(itemId)
+        }, 500)
+      )
+    },
+    [saveItem, setDraftsSynced]
+  )
+
   const handleAddItem = async () => {
     if (!newItemName.trim()) return
+    await flushAll()
     const result = await window.electronAPI.coursework.createItem({
       courseworkId,
       name: newItemName.trim(),
@@ -112,47 +291,8 @@ export function CourseworkItemsContainer({
     }
   }
 
-  const handleStartEdit = (item: CourseworkItemWithDetails) => {
-    setEditingItemId(item.id)
-    setDraft(toDraft(item))
-  }
-
-  const handleCancelEdit = () => {
-    setEditingItemId(null)
-    setDraft(null)
-  }
-
-  const handleSaveEdit = async () => {
-    if (!editingItemId || !draft) return
-    if (!draft.name.trim()) return
-    const maxScore = Number(draft.maxScore)
-    if (isNaN(maxScore) || maxScore <= 0) {
-      toast.error("満点は正の数で入力してください")
-      return
-    }
-    const letterScales = draftsToLetterScales(draft.letterScales)
-    if (draft.inputMode === "letter" && letterScales.length === 0) {
-      toast.error("文字評価モードでは変換表を1件以上設定してください")
-      return
-    }
-    const result = await window.electronAPI.coursework.updateItem(
-      editingItemId,
-      {
-        name: draft.name.trim(),
-        maxScore,
-        inputMode: draft.inputMode,
-        letterScales,
-      }
-    )
-    if (result.success) {
-      handleCancelEdit()
-      await loadItems()
-    } else {
-      toast.error("保存に失敗しました", { description: result.error })
-    }
-  }
-
   const handleDelete = async (item: CourseworkItemWithDetails) => {
+    await flushAll()
     const result = await window.electronAPI.coursework.deleteItem(item.id)
     if (result.success) {
       await loadItems()
@@ -166,12 +306,13 @@ export function CourseworkItemsContainer({
     }
   }
 
-  const handleMove = async (index: number, direction: -1 | 1) => {
-    const target = index + direction
-    if (target < 0 || target >= items.length) return
-    const reordered = items.slice()
-    const [moved] = reordered.splice(index, 1)
-    reordered.splice(target, 0, moved)
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = items.findIndex((i) => i.id === active.id)
+    const newIndex = items.findIndex((i) => i.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    const reordered = arrayMove(items, oldIndex, newIndex)
     setItems(reordered)
     const result = await window.electronAPI.coursework.reorderItems(
       reordered.map((item, i) => ({ id: item.id, order: i }))
@@ -195,7 +336,7 @@ export function CourseworkItemsContainer({
       <div className="mb-6">
         <h2 className="text-lg font-semibold">評価項目</h2>
         <p className="text-muted-foreground mt-1 text-sm">
-          点数を入力する評価項目を作成してください。満点・入力方式（数値／文字評価）を設定できます。
+          点数を入力する評価項目を作成してください。満点・入力方式（数値／文字評価）を設定できます。変更は自動保存されます。
         </p>
       </div>
 
@@ -220,159 +361,31 @@ export function CourseworkItemsContainer({
         </Button>
       </div>
 
-      {/* 評価項目リスト */}
+      {/* 評価項目リスト（常時インライン編集・DnD並べ替え） */}
       {items.length === 0 ? (
         <div className="text-muted-foreground py-8 text-center text-sm">
           評価項目がありません。上のフォームから追加してください。
         </div>
       ) : (
         <div className="space-y-3">
-          {items.map((item, index) => {
-            const isEditing = editingItemId === item.id && draft
-
-            return (
-              <div key={item.id} className="rounded-lg border p-4">
-                {isEditing ? (
-                  <div className="space-y-3">
-                    <div className="flex flex-wrap items-end gap-3">
-                      <div className="space-y-1">
-                        <Label className="text-xs">項目名</Label>
-                        <Input
-                          value={draft.name}
-                          onChange={(e) =>
-                            setDraft({ ...draft, name: e.target.value })
-                          }
-                          className="h-8 w-48"
-                          autoFocus
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">満点</Label>
-                        <Input
-                          value={draft.maxScore}
-                          onChange={(e) =>
-                            setDraft({ ...draft, maxScore: e.target.value })
-                          }
-                          type="number"
-                          className="h-8 w-24"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">入力方式</Label>
-                        <Select
-                          value={draft.inputMode}
-                          onValueChange={(v) =>
-                            setDraft({ ...draft, inputMode: v as InputMode })
-                          }
-                        >
-                          <SelectTrigger className="h-8 w-28 text-xs">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="numeric">数値</SelectItem>
-                            <SelectItem value="letter">文字評価</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-
-                    {draft.inputMode === "letter" && (
-                      <LetterScaleEditor
-                        scales={draft.letterScales}
-                        onChange={(scales) =>
-                          setDraft({ ...draft, letterScales: scales })
-                        }
-                      />
-                    )}
-
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleCancelEdit}
-                      >
-                        <X className="mr-1 h-4 w-4" />
-                        取消
-                      </Button>
-                      <Button size="sm" onClick={handleSaveEdit}>
-                        <Save className="mr-1 h-4 w-4" />
-                        保存
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <div className="flex flex-col">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-4 w-6"
-                          disabled={index === 0}
-                          onClick={() => handleMove(index, -1)}
-                        >
-                          <ChevronUp className="h-3 w-3" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-4 w-6"
-                          disabled={index === items.length - 1}
-                          onClick={() => handleMove(index, 1)}
-                        >
-                          <ChevronDown className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-semibold text-blue-600">
-                            {item.name}
-                          </span>
-                          {item.inputMode === "letter" ? (
-                            <Badge variant="outline" className="text-xs">
-                              文字評価
-                            </Badge>
-                          ) : (
-                            <Badge variant="outline" className="text-xs">
-                              満点 {item.maxScore}
-                            </Badge>
-                          )}
-                        </div>
-                        {item.inputMode === "letter" &&
-                          item.letterScales.length > 0 && (
-                            <div className="text-muted-foreground mt-1 text-xs">
-                              {item.letterScales
-                                .slice()
-                                .sort((a, b) => a.order - b.order)
-                                .map((ls) => `${ls.label}=${ls.score}`)
-                                .join(" / ")}
-                            </div>
-                          )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => handleStartEdit(item)}
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-destructive h-7 w-7"
-                        onClick={() => handleDelete(item)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )
-          })}
+          <SortableTableProvider
+            items={items.map((i) => i.id)}
+            onDragEnd={handleDragEnd}
+          >
+            {items.map((item) => {
+              const draft = drafts[item.id]
+              if (!draft) return null
+              return (
+                <SortableItemRow
+                  key={item.id}
+                  item={item}
+                  draft={draft}
+                  onUpdate={updateDraft}
+                  onDelete={handleDelete}
+                />
+              )
+            })}
+          </SortableTableProvider>
         </div>
       )}
 


### PR DESCRIPTION
## 概要

試験外成績資料の評価項目編集と評価記号変換表エディタの操作性を改善する。

Closes #888

## 変更内容

### 1. 常時インライン編集 + 逐次保存（03-items）
- 鉛筆/保存/取消方式を廃止し、各評価項目を**常に直接編集可能**に。
- 項目ごとに**500msデバウンスで自動保存**。無効ドラフト（名前空・満点≤0・文字モードで変換表0件）は保存スキップ。満点欄は無効時に赤表示。
- 追加/削除/離脱前の**フラッシュ**＋**アンマウント時フラッシュ**で保存漏れを防止（点数入力で得た対策を踏襲）。

### 2. DnD並べ替えへ統一
- 共通 `sortable-table`（`SortableTableProvider` / `useSortableRow` / `DragHandle`）を使用し、アプリ内の他機能と同じ**グリップハンドルのドラッグ&ドロップ**に統一。
- **評価項目リスト**・**評価記号→点数変換表（`LetterScaleEditor`）**の両方に適用。配列順がそのまま `order` として保存される。

### 3. 小数対応
- 満点・評価記号点数の数値入力に `step="any"` を付与し小数入力をクリーンに。
- DBは既に `Decimal` のため**マイグレーション不要**。コード経路も全て `Number()` ベースで小数を保持。

## 影響範囲

`LetterScaleEditor` は成績（grades manual型）でも共用のため、DnD並べ替え・小数対応は成績側の評価記号エディタにも反映される（自然な改善方向）。

## 確認

- 対象2ファイルの `eslint` / `tsc --noEmit` 通過（リポジトリ内の他ファイルには別作業中の差分があるため、本PRの対象ファイルにスコープして確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
