### PR TITLE
feat(coursework): 試験外成績資料アーカイブ(.coursework)の独立化と成績Export委譲

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,19 @@ export class V1_9_0_to_V1_10_0_Transformer implements VersionTransformer {
 | 1.5.0      | v0.6.x     | Project→Examリネーム             |
 | 1.9.0      | v0.9.x     | DeletedRecord tombstone追加      |
 
+**試験外成績資料アーカイブ（.coursework）** — exam-archive と同型の独立アーカイブ。`electron-src/lib/export|import/coursework-archive/`。id一次照合 + 名前マッチング（付加）+ スコア LWW。トランスフォーマー機構あり（`COURSEWORK_CURRENT_VERSION`、初版 1.0.0 は変換器ゼロ）。
+
+| バージョン | 変更内容                                          |
+| ---------- | ------------------------------------------------- |
+| 1.0.0      | 初版（独立化）。UUID参照 + full生徒/学級/タグ同梱 |
+
+**成績アーカイブ（.grade）の Coursework 内包** — 収集・生成は coursework-archive モジュールへ委譲（二重実装の解消）。
+
+| バージョン | 変更内容                                                                      |
+| ---------- | ----------------------------------------------------------------------------- |
+| 1.4.0      | Coursework を名前ベースで `courseworks.json` に埋め込み（読込互換のみ）       |
+| 1.5.0      | `courseworks.json` を coursework-archive 形式（UUIDベース）へ。旧版は読込互換 |
+
 #### 🔄 多対多関係の強化（2025年7月29日更新）
 
 **Exam-User関係の多対多化**:

--- a/__tests__/import-export/integration/courseworkArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/courseworkArchiveRoundTrip.test.ts
@@ -1,0 +1,253 @@
+/**
+ * coursework-archive ラウンドトリップ統合テスト
+ *
+ * (a) UUID一致での冪等再import (b) クリーンDBでの生徒/学級の新規作成
+ * (c) studentNumber一致・別UUID の名前フォールバック統合 (d) score の LWW
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  type CollectedCourseworkData,
+  COURSEWORK_CURRENT_VERSION,
+  type CourseworkArchiveData,
+} from "../../../src/types/courseworkArchive.types"
+import {
+  cleanupTestDatabase,
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+
+vi.mock("../../../electron-src/lib/prisma/client", () => {
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+// 監査ログは認証ストア依存なので no-op 化
+vi.mock("../../../electron-src/lib/prisma/auditLog", () => ({
+  recordAuditLog: vi.fn(),
+}))
+
+import { collectCourseworkArchiveData } from "../../../electron-src/lib/export/coursework-archive/dataCollector"
+import {
+  importCourseworkArchive,
+  previewCourseworkImport,
+} from "../../../electron-src/lib/import/coursework-archive"
+
+const prisma = getTestPrismaClient()
+
+function toArchive(collected: CollectedCourseworkData): CourseworkArchiveData {
+  return {
+    manifest: {
+      version: COURSEWORK_CURRENT_VERSION,
+      appVersion: "test",
+      exportedAt: new Date("2026-06-29T00:00:00.000Z").toISOString(),
+      counts: collected.counts,
+    },
+    courseworks: collected.courseworks,
+    studentsData: collected.studentsData,
+    classesData: collected.classesData,
+    membershipsData: collected.membershipsData,
+    tagsData: collected.tagsData,
+  }
+}
+
+async function seedCoursework(suffix: number) {
+  const cls = await prisma.class.create({ data: { name: `学級_${suffix}` } })
+  const student = await prisma.student.create({
+    data: {
+      studentNumber: `CW_${suffix}`,
+      lastName: "鈴木",
+      firstName: "一郎",
+      lastNameKana: "スズキ",
+      firstNameKana: "イチロウ",
+    },
+  })
+  await prisma.studentClassMembership.create({
+    data: { classId: cls.id, studentId: student.id, attendanceNumber: 1 },
+  })
+  const tag = await prisma.tag.create({ data: { name: `タグ_${suffix}` } })
+  const coursework = await prisma.coursework.create({
+    data: {
+      name: `第1回レポート_${suffix}`,
+      description: "レポート評価",
+      classes: { create: [{ classId: cls.id, order: 0 }] },
+      tags: { create: [{ tagId: tag.id }] },
+      students: { create: [{ studentId: student.id, customOrder: 0 }] },
+    },
+  })
+  const item = await prisma.courseworkItem.create({
+    data: {
+      courseworkId: coursework.id,
+      name: "提出物",
+      order: 0,
+      maxScore: 100,
+      inputMode: "numeric",
+    },
+  })
+  const score = await prisma.courseworkScore.create({
+    data: {
+      courseworkItemId: item.id,
+      studentId: student.id,
+      score: 85,
+      adjustment: -5,
+      adjustmentReason: "提出遅延",
+      comment: "丁寧にまとめられています",
+    },
+  })
+  return { cls, student, tag, coursework, item, score }
+}
+
+describe("coursework-archive ラウンドトリップ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  it("項目・点数・名簿・タグが収集され、UUID一致で冪等に再インポートできる", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+    expect(collected.courseworks).toHaveLength(1)
+    const cw = collected.courseworks[0]
+    expect(cw.items).toHaveLength(1)
+    expect(cw.items[0].scores[0].updatedAt).toBeDefined()
+    expect(collected.studentsData[0].studentNumber).toBe(`CW_${suffix}`)
+    expect(collected.tagsData[0].name).toBe(`タグ_${suffix}`)
+
+    // UUID一致での再インポート → 重複生成されない
+    const result = await importCourseworkArchive(toArchive(collected))
+    expect(result.success).toBe(true)
+
+    const courseworkCount = await prisma.coursework.count()
+    const studentCount = await prisma.student.count()
+    const scoreCount = await prisma.courseworkScore.count()
+    expect(courseworkCount).toBe(1)
+    expect(studentCount).toBe(1)
+    expect(scoreCount).toBe(1)
+  })
+
+  it("クリーンDBへインポートすると生徒・学級・タグ・点数が復元される", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+
+    // 別環境想定: 関連レコードを全削除
+    await cleanupTestDatabase()
+
+    const result = await importCourseworkArchive(toArchive(collected))
+    expect(result.success).toBe(true)
+
+    const item = await prisma.courseworkItem.findFirst({
+      where: { name: "提出物" },
+      include: { scores: { include: { student: true } } },
+    })
+    expect(item).not.toBeNull()
+    expect(item!.scores).toHaveLength(1)
+    expect(Number(item!.scores[0].score)).toBe(85)
+    expect(Number(item!.scores[0].adjustment)).toBe(-5)
+    expect(item!.scores[0].student.studentNumber).toBe(`CW_${suffix}`)
+
+    const cls = await prisma.class.findUnique({
+      where: { name: `学級_${suffix}` },
+    })
+    expect(cls).not.toBeNull()
+  })
+
+  it("studentNumber一致・別UUIDの生徒は名前フォールバックで統合される", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+
+    // 資料と項目・名簿だけ消し、生徒は残す（別UUIDの状況を作るため生徒も作り直す）
+    await prisma.courseworkScore.deleteMany()
+    await prisma.courseworkItem.deleteMany()
+    await prisma.courseworkStudent.deleteMany()
+    await prisma.courseworkClass.deleteMany()
+    await prisma.courseworkTag.deleteMany()
+    await prisma.coursework.deleteMany()
+    await prisma.courseworkScore.deleteMany()
+    await prisma.studentClassMembership.deleteMany()
+    await prisma.student.delete({ where: { id: seeded.student.id } })
+    // 同じ学籍番号で別UUIDの生徒を作る
+    const reborn = await prisma.student.create({
+      data: {
+        studentNumber: `CW_${suffix}`,
+        lastName: "鈴木",
+        firstName: "一郎",
+        lastNameKana: "スズキ",
+        firstNameKana: "イチロウ",
+      },
+    })
+
+    const result = await importCourseworkArchive(toArchive(collected), {
+      studentMatching: "studentNumber",
+    })
+    expect(result.success).toBe(true)
+
+    // 生徒は新規作成されず、既存（別UUID）へ統合
+    const students = await prisma.student.findMany({
+      where: { studentNumber: `CW_${suffix}` },
+    })
+    expect(students).toHaveLength(1)
+    expect(students[0].id).toBe(reborn.id)
+
+    const score = await prisma.courseworkScore.findFirst({
+      where: { studentId: reborn.id },
+    })
+    expect(score).not.toBeNull()
+    expect(Number(score!.score)).toBe(85)
+  })
+
+  it("点数は updatedAt の LWW で解決される（既存が新しければ上書きしない）", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+
+    // 既存スコアを新しい値に更新（updatedAt も将来に進む）
+    await prisma.courseworkScore.update({
+      where: { id: seeded.score.id },
+      data: { score: 50 },
+    })
+
+    // アーカイブ側 updatedAt を過去にして再インポート → 既存(50)を維持
+    const archive = toArchive(collected)
+    archive.courseworks[0].items[0].scores[0].updatedAt = new Date(
+      "2000-01-01T00:00:00.000Z"
+    ).toISOString()
+    const oldResult = await importCourseworkArchive(archive)
+    expect(oldResult.success).toBe(true)
+    const afterOld = await prisma.courseworkScore.findUnique({
+      where: { id: seeded.score.id },
+    })
+    expect(Number(afterOld!.score)).toBe(50)
+
+    // アーカイブ側 updatedAt を未来にして再インポート → アーカイブ(85)で上書き
+    archive.courseworks[0].items[0].scores[0].updatedAt = new Date(
+      "2099-01-01T00:00:00.000Z"
+    ).toISOString()
+    const newResult = await importCourseworkArchive(archive)
+    expect(newResult.success).toBe(true)
+    const afterNew = await prisma.courseworkScore.findUnique({
+      where: { id: seeded.score.id },
+    })
+    expect(Number(afterNew!.score)).toBe(85)
+  })
+
+  it("previewCourseworkImport が UUID一致と名前候補を返す", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+
+    const preview = await previewCourseworkImport(toArchive(collected))
+    expect(preview.success).toBe(true)
+    expect(preview.preview!.matches).toHaveLength(1)
+    expect(preview.preview!.matches[0].uuidMatch?.id).toBe(seeded.coursework.id)
+  })
+})

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -42,7 +42,7 @@ function toArchive(
 ): GradeArchiveData {
   return {
     manifest: {
-      version: "1.4.0",
+      version: "1.5.0",
       appVersion: "test",
       exportedAt: new Date("2026-06-23T00:00:00.000Z").toISOString(),
       gradeId,
@@ -50,7 +50,7 @@ function toArchive(
       counts: collected.counts,
     },
     gradeData: collected.gradeData,
-    courseworks: collected.courseworksData,
+    courseworkArchive: collected.courseworkArchive,
     boundariesData: collected.boundariesData,
   }
 }
@@ -219,12 +219,14 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // 収集（export）
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.courseworksData).toHaveLength(1)
-    const cw = collected.courseworksData[0]
+    expect(collected.courseworkArchive.courseworks).toHaveLength(1)
+    const cw = collected.courseworkArchive.courseworks[0]
     expect(cw.items).toHaveLength(2)
     expect(cw.classes).toHaveLength(1)
-    expect(cw.tags[0].tagName).toBe(`タグ_${suffix}`)
-    expect(cw.students[0].studentNumber).toBe(`CW_${suffix}`)
+    expect(collected.courseworkArchive.tagsData[0].name).toBe(`タグ_${suffix}`)
+    expect(collected.courseworkArchive.studentsData[0].studentNumber).toBe(
+      `CW_${suffix}`
+    )
     const collectedNumDs = collected.gradeData.gradeItems[0].dataSources.find(
       (d) => d.name === "提出物参照"
     )!
@@ -495,7 +497,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const collected = await collectGradeArchiveData(grade.id)
     expect(collected.gradeData.grade.referenceDate).toBeNull()
     expect(collected.gradeData.exportSettings).toBeNull()
-    expect(collected.courseworksData).toHaveLength(0)
+    expect(collected.courseworkArchive.courseworks).toHaveLength(0)
 
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
@@ -764,5 +766,125 @@ describe("grade-archive ラウンドトリップ", () => {
     })
     expect(ds!.courseworkItem!.name).toBe("新規項目")
     expect(ds!.courseworkItem!.courseworkId).toBe(existing.id)
+  })
+
+  it("旧 v1.4.0（名前ベース courseworks 埋め込み）を後方互換で読み込める", async () => {
+    const suffix = Date.now()
+    // 旧形式は生徒・学級を既存前提で名前 lookup する
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `LEGACY_${suffix}`,
+        lastName: "高橋",
+        firstName: "次郎",
+        lastNameKana: "タカハシ",
+        firstNameKana: "ジロウ",
+      },
+    })
+    await prisma.class.create({ data: { name: `旧学級_${suffix}` } })
+
+    const archiveItemId = "00000000-0000-4000-8000-000000000abc"
+    // v1.4.0 形式の GradeArchiveData を手組み（courseworks は名前ベース配列）
+    const legacy: GradeArchiveData = {
+      manifest: {
+        version: "1.4.0",
+        appVersion: "test",
+        exportedAt: new Date("2026-06-23T00:00:00.000Z").toISOString(),
+        gradeId: "legacy-grade",
+        gradeName: `旧成績_${suffix}`,
+        counts: {
+          gradeItems: 1,
+          dataSources: 1,
+          manualScores: 1,
+          boundarySets: 0,
+          boundaries: 0,
+          classes: 1,
+          students: 1,
+        },
+      },
+      gradeData: {
+        grade: { name: `旧成績_${suffix}`, description: null },
+        gradeItems: [
+          {
+            name: "主体的態度",
+            order: 0,
+            dataSources: [
+              {
+                type: "coursework",
+                name: "旧資料参照",
+                maxScore: 100,
+                weight: 100,
+                order: 0,
+                examName: null,
+                subtotalName: null,
+                cropRegionLabel: null,
+                courseworkItemId: archiveItemId,
+                courseworkName: `旧レポート_${suffix}`,
+                courseworkItemName: "提出物",
+              },
+            ],
+          },
+        ],
+        classRefs: [{ name: `旧学級_${suffix}` }],
+        examRefs: [],
+        studentRefs: [
+          {
+            studentNumber: `LEGACY_${suffix}`,
+            className: `旧学級_${suffix}`,
+            customOrder: 0,
+          },
+        ],
+      },
+      courseworks: [
+        {
+          id: "00000000-0000-4000-8000-0000000000cw",
+          name: `旧レポート_${suffix}`,
+          description: null,
+          date: null,
+          classes: [{ className: `旧学級_${suffix}`, order: 0 }],
+          tags: [],
+          students: [{ studentNumber: `LEGACY_${suffix}`, customOrder: 0 }],
+          items: [
+            {
+              id: archiveItemId,
+              name: "提出物",
+              order: 0,
+              maxScore: 100,
+              inputMode: "numeric",
+              letterScales: [],
+              scores: [
+                {
+                  studentNumber: `LEGACY_${suffix}`,
+                  score: 72,
+                  letterValue: null,
+                  adjustment: null,
+                  adjustmentReason: null,
+                  comment: "旧形式のコメント",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      boundariesData: { boundarySets: [] },
+    }
+
+    const result = await importGradeArchive(legacy)
+    expect(result.success).toBe(true)
+
+    // 旧形式でも Coursework と点数が復元され、DataSource が解決される
+    const score = await prisma.courseworkScore.findFirst({
+      where: { studentId: student.id },
+      include: { item: { include: { coursework: true } } },
+    })
+    expect(score).not.toBeNull()
+    expect(Number(score!.score)).toBe(72)
+    expect(score!.item.coursework.name).toBe(`旧レポート_${suffix}`)
+
+    const ds = await prisma.gradeDataSource.findFirst({
+      where: { gradeItem: { gradeId: result.gradeId! }, name: "旧資料参照" },
+      include: { courseworkItem: true },
+    })
+    expect(ds!.courseworkItem).not.toBeNull()
+    expect(ds!.courseworkItem!.name).toBe("提出物")
   })
 })

--- a/electron-src/ipc-handlers/courseworkHandlers.ts
+++ b/electron-src/ipc-handlers/courseworkHandlers.ts
@@ -2,6 +2,19 @@
  * Coursework（試験外成績資料）IPC ハンドラー
  */
 
+import { dialog, ipcMain } from "electron"
+
+import type {
+  CourseworkImportDecisions,
+  CourseworkMatchingMethod,
+} from "../../src/types/courseworkArchive.types"
+import { exportCoursework } from "../lib/export/coursework-archive"
+import {
+  cleanupCourseworkTempDir,
+  extractCourseworkArchive,
+  importCourseworkArchive,
+  previewCourseworkImport,
+} from "../lib/import/coursework-archive"
 import {
   addStudentsFromClassToCoursework,
   addStudentsToCoursework,
@@ -196,6 +209,93 @@ export function setupCourseworkHandlers(): void {
     "coursework:setTags",
     async (courseworkId: string, tagIds: string[]) => {
       return setCourseworkTags(courseworkId, tagIds)
+    }
+  )
+
+  // ── アーカイブ（.coursework のエクスポート／インポート）────────────
+  // エクスポート（保存ダイアログは exportCoursework 内で表示）
+  registerHandler("coursework:exportArchive", async (courseworkId: string) => {
+    return exportCoursework({ courseworkId })
+  })
+
+  // インポートファイル選択ダイアログ
+  registerHandler("coursework:selectImportFile", async () => {
+    const result = await dialog.showOpenDialog({
+      title: "試験外成績資料をインポート",
+      filters: [
+        { name: "試験外成績資料", extensions: ["coursework"] },
+        { name: "すべてのファイル", extensions: ["*"] },
+      ],
+      properties: ["openFile"],
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return { success: true, canceled: true }
+    }
+    return { success: true, filePath: result.filePaths[0] }
+  })
+
+  // アーカイブ解析（プレビュー）。tempDir を finally で後始末するため手動 handle。
+  ipcMain.handle(
+    "coursework:analyzeArchive",
+    async (_event, options: { archivePath: string }) => {
+      let tempDir: string | null = null
+      try {
+        const ext = await extractCourseworkArchive(options.archivePath)
+        if (!ext.success || !ext.data) {
+          return { success: false, error: ext.error }
+        }
+        tempDir = ext.data.tempDir
+        return await previewCourseworkImport(ext.data.data)
+      } catch (error) {
+        console.error(
+          "Error in IPC handler [coursework:analyzeArchive]:",
+          error
+        )
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "アーカイブ解析に失敗しました",
+        }
+      } finally {
+        if (tempDir) cleanupCourseworkTempDir(tempDir)
+      }
+    }
+  )
+
+  // インポート実行。tempDir を finally で後始末するため手動 handle。
+  ipcMain.handle(
+    "coursework:importArchive",
+    async (
+      _event,
+      options: {
+        archivePath: string
+        courseworkDecisions?: CourseworkImportDecisions
+        studentMatching?: CourseworkMatchingMethod
+      }
+    ) => {
+      let tempDir: string | null = null
+      try {
+        const ext = await extractCourseworkArchive(options.archivePath)
+        if (!ext.success || !ext.data) {
+          return { success: false, error: ext.error }
+        }
+        tempDir = ext.data.tempDir
+        return await importCourseworkArchive(ext.data.data, {
+          courseworkDecisions: options.courseworkDecisions,
+          studentMatching: options.studentMatching,
+        })
+      } catch (error) {
+        console.error("Error in IPC handler [coursework:importArchive]:", error)
+        return {
+          success: false,
+          error:
+            error instanceof Error ? error.message : "インポートに失敗しました",
+        }
+      } finally {
+        if (tempDir) cleanupCourseworkTempDir(tempDir)
+      }
     }
   )
 }

--- a/electron-src/lib/export/coursework-archive/archiveCreator.ts
+++ b/electron-src/lib/export/coursework-archive/archiveCreator.ts
@@ -1,0 +1,109 @@
+/**
+ * 試験外成績資料アーカイブ (.coursework) 作成
+ */
+
+import { ZipArchive } from "archiver"
+import { app } from "electron"
+import * as fs from "fs"
+
+import {
+  COURSEWORK_CURRENT_VERSION,
+  type CourseworkArchiveManifest,
+} from "../../../../src/types/courseworkArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
+import { collectCourseworkArchiveData } from "./dataCollector"
+
+function getAppVersion(): string {
+  try {
+    return app.getVersion()
+  } catch {
+    return "0.0.0"
+  }
+}
+
+/**
+ * 指定 coursework を .coursework アーカイブとして outputPath に書き出す。
+ */
+export async function createCourseworkArchive(
+  courseworkId: string,
+  courseworkName: string,
+  outputPath: string
+): Promise<{
+  success: boolean
+  manifest?: CourseworkArchiveManifest
+  error?: string
+}> {
+  try {
+    const data = await collectCourseworkArchiveData([courseworkId])
+
+    const manifest: CourseworkArchiveManifest = {
+      version: COURSEWORK_CURRENT_VERSION,
+      appVersion: getAppVersion(),
+      exportedAt: new Date().toISOString(),
+      counts: data.counts,
+    }
+
+    const output = fs.createWriteStream(outputPath)
+    const archive = new ZipArchive({ zlib: { level: 9 } })
+
+    return await new Promise((resolve, reject) => {
+      output.on("close", () => {
+        void recordAuditLog({
+          action: "coursework.export",
+          entityType: "Coursework",
+          entityId: courseworkId,
+          scopeId: courseworkId,
+          scopeLabel: courseworkName,
+          target: courseworkName,
+          extra: { outputPath },
+        })
+        resolve({ success: true, manifest })
+      })
+
+      archive.on("error", (err) => {
+        reject(err)
+      })
+
+      archive.pipe(output)
+
+      archive.append(JSON.stringify(manifest, null, 2), {
+        name: "manifest.json",
+      })
+      archive.append(JSON.stringify(data.courseworks, null, 2), {
+        name: "courseworks.json",
+      })
+      archive.append(JSON.stringify(data.studentsData, null, 2), {
+        name: "students.json",
+      })
+      archive.append(JSON.stringify(data.classesData, null, 2), {
+        name: "classes.json",
+      })
+      archive.append(JSON.stringify(data.membershipsData, null, 2), {
+        name: "memberships.json",
+      })
+      archive.append(JSON.stringify(data.tagsData, null, 2), {
+        name: "tags.json",
+      })
+
+      archive.finalize()
+    })
+  } catch (error) {
+    console.error("Error creating coursework archive:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/** エクスポートファイル名を生成 (`{資料名}-yyyy-MM-dd-hh-mm-ss.coursework`) */
+export function generateCourseworkExportFileName(
+  courseworkName: string
+): string {
+  const sanitized =
+    courseworkName.replace(/[\\/:*?"<>|]/g, "_").trim() || "coursework"
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, "0")
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`
+  return `${sanitized}-${stamp}.coursework`
+}

--- a/electron-src/lib/export/coursework-archive/dataCollector.ts
+++ b/electron-src/lib/export/coursework-archive/dataCollector.ts
@@ -1,0 +1,165 @@
+/**
+ * 試験外成績資料（Coursework）アーカイブ用データ収集
+ *
+ * 指定した coursework を、生徒・学級・タグの full レコード（元 UUID 付き）込みで
+ * 自己完結に収集する。grade-archive の内包収集もこの関数へ委譲する。
+ */
+
+import type {
+  ArchiveCourseworkRef,
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+  ArchiveCwTag,
+  CollectedCourseworkData,
+} from "../../../../src/types/courseworkArchive.types"
+import prisma from "../../prisma/client"
+
+/**
+ * 指定 coursework 群を full レコード込みで収集する。
+ *
+ * 外部参照（生徒/学級/タグ）は coursework が参照する範囲のみを集約し、
+ * 重複は UUID で排除する。
+ */
+export async function collectCourseworkArchiveData(
+  courseworkIds: string[]
+): Promise<CollectedCourseworkData> {
+  const rows = await prisma.coursework.findMany({
+    where: { id: { in: courseworkIds } },
+    include: {
+      classes: { orderBy: { order: "asc" } },
+      tags: true,
+      students: {
+        orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
+      },
+      items: {
+        include: {
+          letterScales: { orderBy: { order: "asc" } },
+          scores: true,
+        },
+        orderBy: { order: "asc" },
+      },
+    },
+  })
+
+  const courseworks: ArchiveCourseworkRef[] = rows.map((cw) => ({
+    id: cw.id,
+    name: cw.name,
+    description: cw.description,
+    date: cw.date?.toISOString() ?? null,
+    classes: cw.classes.map((c) => ({ classId: c.classId, order: c.order })),
+    tags: cw.tags.map((t) => ({ tagId: t.tagId })),
+    students: cw.students.map((s) => ({
+      studentId: s.studentId,
+      customOrder: s.customOrder,
+    })),
+    items: cw.items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      order: item.order,
+      maxScore: Number(item.maxScore),
+      inputMode: item.inputMode,
+      letterScales: item.letterScales.map((ls) => ({
+        label: ls.label,
+        score: Number(ls.score),
+        order: ls.order,
+      })),
+      scores: item.scores.map((sc) => ({
+        studentId: sc.studentId,
+        score: sc.score !== null ? Number(sc.score) : null,
+        letterValue: sc.letterValue,
+        adjustment: sc.adjustment !== null ? Number(sc.adjustment) : null,
+        adjustmentReason: sc.adjustmentReason,
+        comment: sc.comment,
+        updatedAt: sc.updatedAt.toISOString(),
+      })),
+    })),
+  }))
+
+  // 参照されている生徒・学級・タグの UUID を集約
+  const studentIds = new Set<string>()
+  const classIds = new Set<string>()
+  const tagIds = new Set<string>()
+  for (const cw of rows) {
+    cw.students.forEach((s) => studentIds.add(s.studentId))
+    cw.classes.forEach((c) => classIds.add(c.classId))
+    cw.tags.forEach((t) => tagIds.add(t.tagId))
+    cw.items.forEach((item) =>
+      item.scores.forEach((sc) => studentIds.add(sc.studentId))
+    )
+  }
+
+  const studentRows = await prisma.student.findMany({
+    where: { id: { in: [...studentIds] } },
+  })
+  const studentsData: ArchiveCwStudent[] = studentRows.map((s) => ({
+    id: s.id,
+    studentNumber: s.studentNumber,
+    lastName: s.lastName,
+    firstName: s.firstName,
+    lastNameKana: s.lastNameKana,
+    firstNameKana: s.firstNameKana,
+    enrollmentYear: s.enrollmentYear,
+    updatedAt: s.updatedAt.toISOString(),
+  }))
+
+  const classRows = await prisma.class.findMany({
+    where: { id: { in: [...classIds] } },
+  })
+  const classesData: ArchiveCwClass[] = classRows.map((c) => ({
+    id: c.id,
+    name: c.name,
+    classCode: c.classCode,
+    grade: c.grade,
+    description: c.description,
+    isVisible: c.isVisible,
+  }))
+
+  // 名簿の裏付けとして、参照生徒×参照学級の所属を収集
+  const membershipRows = await prisma.studentClassMembership.findMany({
+    where: {
+      studentId: { in: [...studentIds] },
+      classId: { in: [...classIds] },
+    },
+  })
+  const membershipsData: ArchiveCwMembership[] = membershipRows.map((m) => ({
+    id: m.id,
+    studentId: m.studentId,
+    classId: m.classId,
+    startDate: m.startDate.toISOString(),
+    endDate: m.endDate?.toISOString() ?? null,
+    attendanceNumber: m.attendanceNumber,
+    notes: m.notes,
+  }))
+
+  const tagRows = await prisma.tag.findMany({
+    where: { id: { in: [...tagIds] } },
+  })
+  const tagsData: ArchiveCwTag[] = tagRows.map((t) => ({
+    id: t.id,
+    name: t.name,
+    order: t.order,
+    color: t.color,
+  }))
+
+  const itemCount = courseworks.reduce((sum, cw) => sum + cw.items.length, 0)
+  const scoreCount = courseworks.reduce(
+    (sum, cw) => sum + cw.items.reduce((s, item) => s + item.scores.length, 0),
+    0
+  )
+
+  return {
+    courseworks,
+    studentsData,
+    classesData,
+    membershipsData,
+    tagsData,
+    counts: {
+      courseworks: courseworks.length,
+      items: itemCount,
+      scores: scoreCount,
+      students: studentsData.length,
+      classes: classesData.length,
+    },
+  }
+}

--- a/electron-src/lib/export/coursework-archive/index.ts
+++ b/electron-src/lib/export/coursework-archive/index.ts
@@ -1,0 +1,65 @@
+/**
+ * 試験外成績資料アーカイブ (.coursework) エクスポートのエントリ
+ */
+
+import { dialog } from "electron"
+
+import type {
+  ExportCourseworkArchiveOptions,
+  ExportCourseworkArchiveResult,
+} from "../../../../src/types/courseworkArchive.types"
+import prisma from "../../prisma/client"
+import {
+  createCourseworkArchive,
+  generateCourseworkExportFileName,
+} from "./archiveCreator"
+
+export {
+  createCourseworkArchive,
+  generateCourseworkExportFileName,
+} from "./archiveCreator"
+export { collectCourseworkArchiveData } from "./dataCollector"
+
+/**
+ * 試験外成績資料を .coursework アーカイブとしてエクスポートする。
+ * outputPath 未指定なら保存ダイアログを表示する。
+ */
+export async function exportCoursework(
+  options: ExportCourseworkArchiveOptions
+): Promise<ExportCourseworkArchiveResult> {
+  const coursework = await prisma.coursework.findUnique({
+    where: { id: options.courseworkId },
+    select: { id: true, name: true },
+  })
+  if (!coursework) {
+    return { success: false, error: "試験外成績資料が見つかりません" }
+  }
+
+  let outputPath = options.outputPath
+  if (!outputPath) {
+    const result = await dialog.showSaveDialog({
+      title: "試験外成績資料をエクスポート",
+      defaultPath: generateCourseworkExportFileName(coursework.name),
+      filters: [{ name: "試験外成績資料", extensions: ["coursework"] }],
+    })
+    if (result.canceled || !result.filePath) {
+      return { success: true, canceled: true }
+    }
+    outputPath = result.filePath
+  }
+
+  const created = await createCourseworkArchive(
+    coursework.id,
+    coursework.name,
+    outputPath
+  )
+  if (!created.success) {
+    return { success: false, error: created.error }
+  }
+
+  return {
+    success: true,
+    outputPath,
+    manifest: created.manifest,
+  }
+}

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -26,11 +26,10 @@ export async function createGradeArchive(
     const data = await collectGradeArchiveData(gradeId)
 
     const manifest: GradeArchiveManifest = {
-      // v1.4.0: 外部成績(manual型 DataSource)を試験外成績資料(Coursework)へ昇格。
-      //   参照中の資料を自己完結で埋め込み、資料/評価項目/DataSource参照に uuid を併記する
-      //   （照合の一次キー。インポートは uuid 一致を優先し、名前照合はユーザー判断の二次フォールバック）。
-      //   ※ v1.3.0 以前の manual-scores は読み取り後方互換のみ。
-      version: "1.4.0",
+      // v1.5.0: 試験外成績資料(Coursework)の内包を独立 coursework-archive モジュールへ委譲。
+      //   courseworks.json は UUID ベースの coursework-archive 形式（生徒/学級/タグの full レコード同梱）。
+      //   ※ v1.4.0（名前ベース埋め込み）/ v1.3.0（manual-scores）は読み取り後方互換のみ。
+      version: "1.5.0",
       appVersion: getAppVersion(),
       exportedAt: new Date().toISOString(),
       gradeId,
@@ -68,7 +67,7 @@ export async function createGradeArchive(
       archive.append(JSON.stringify(data.gradeData, null, 2), {
         name: "grade-exam.json",
       })
-      archive.append(JSON.stringify(data.courseworksData, null, 2), {
+      archive.append(JSON.stringify(data.courseworkArchive, null, 2), {
         name: "courseworks.json",
       })
       archive.append(JSON.stringify(data.boundariesData, null, 2), {

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -2,17 +2,21 @@
  * 成績算出アーカイブ用データ収集
  */
 
+import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
 import type {
   ArchiveBoundariesData,
-  ArchiveCoursework,
   ArchiveGradeData,
 } from "../../../../src/types/gradeArchive.types"
 import prisma from "../../prisma/client"
+import { collectCourseworkArchiveData } from "../coursework-archive/dataCollector"
 
 export interface CollectedGradeData {
   gradeData: ArchiveGradeData
-  /** v1.4.0+: 参照中の試験外成績資料（Coursework）を自己完結で埋め込む */
-  courseworksData: ArchiveCoursework[]
+  /**
+   * v1.5.0+: 参照中の試験外成績資料（Coursework）を coursework-archive と同じ
+   * UUID ベースの形で内包する（独立モジュールの収集ロジックへ委譲）。
+   */
+  courseworkArchive: CollectedCourseworkData
   boundariesData: ArchiveBoundariesData
   counts: {
     gradeItems: number
@@ -159,77 +163,16 @@ export async function collectGradeArchiveData(
     }
   })
 
-  // v1.4.0+: 参照中の試験外成績資料（Coursework）を一意に集めて埋め込む
+  // v1.5.0+: 参照中の試験外成績資料（Coursework）を独立モジュールへ委譲して収集
   const courseworkIds = new Set(
     allDataSources
       .filter((ds) => ds.type === "coursework" && ds.courseworkItem)
       .map((ds) => ds.courseworkItem!.courseworkId)
   )
-
-  const courseworkRows = await prisma.coursework.findMany({
-    where: { id: { in: [...courseworkIds] } },
-    include: {
-      classes: {
-        include: { class: { select: { name: true } } },
-        orderBy: { order: "asc" },
-      },
-      tags: { include: { tag: { select: { name: true } } } },
-      students: {
-        include: { student: { select: { studentNumber: true } } },
-        orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
-      },
-      items: {
-        include: {
-          letterScales: { orderBy: { order: "asc" } },
-          scores: {
-            include: { student: { select: { studentNumber: true } } },
-          },
-        },
-        orderBy: { order: "asc" },
-      },
-    },
-  })
-
-  const courseworksData: ArchiveCoursework[] = courseworkRows.map((cw) => ({
-    id: cw.id,
-    name: cw.name,
-    description: cw.description,
-    date: cw.date?.toISOString() ?? null,
-    classes: cw.classes.map((c) => ({
-      className: c.class.name,
-      order: c.order,
-    })),
-    tags: cw.tags.map((t) => ({ tagName: t.tag.name })),
-    students: cw.students.map((s) => ({
-      studentNumber: s.student.studentNumber,
-      customOrder: s.customOrder,
-    })),
-    items: cw.items.map((item) => ({
-      id: item.id,
-      name: item.name,
-      order: item.order,
-      maxScore: Number(item.maxScore),
-      inputMode: item.inputMode,
-      letterScales: item.letterScales.map((ls) => ({
-        label: ls.label,
-        score: Number(ls.score),
-        order: ls.order,
-      })),
-      scores: item.scores.map((sc) => ({
-        studentNumber: sc.student.studentNumber,
-        score: sc.score !== null ? Number(sc.score) : null,
-        letterValue: sc.letterValue,
-        adjustment: sc.adjustment !== null ? Number(sc.adjustment) : null,
-        adjustmentReason: sc.adjustmentReason,
-        comment: sc.comment,
-      })),
-    })),
-  }))
-
-  const manualScoresCount = courseworksData.reduce(
-    (sum, cw) => sum + cw.items.reduce((s, item) => s + item.scores.length, 0),
-    0
-  )
+  const courseworkArchive = await collectCourseworkArchiveData([
+    ...courseworkIds,
+  ])
+  const manualScoresCount = courseworkArchive.counts.scores
 
   const boundarySets = gp.boundarySets.map((bs) => ({
     targetType: bs.targetType,
@@ -281,7 +224,7 @@ export async function collectGradeArchiveData(
         gradeItemExclusions.length > 0 ? gradeItemExclusions : undefined,
       gradeOverrides: gradeOverrides.length > 0 ? gradeOverrides : undefined,
     },
-    courseworksData,
+    courseworkArchive,
     boundariesData: { boundarySets },
     counts: {
       gradeItems: gradeItems.length,

--- a/electron-src/lib/import/coursework-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/coursework-archive/archiveExtractor.ts
@@ -1,0 +1,141 @@
+/**
+ * 試験外成績資料アーカイブ (.coursework) の展開
+ */
+
+import AdmZip from "adm-zip"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+import type {
+  ArchiveCourseworkRef,
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+  ArchiveCwTag,
+  CourseworkArchiveData,
+  CourseworkArchiveManifest,
+} from "../../../../src/types/courseworkArchive.types"
+
+export interface ExtractedCourseworkArchive {
+  manifest: CourseworkArchiveManifest
+  data: CourseworkArchiveData
+  tempDir: string
+}
+
+function readJsonFile<T>(dir: string, name: string): T | null {
+  const p = path.join(dir, name)
+  if (!fs.existsSync(p)) return null
+  return JSON.parse(fs.readFileSync(p, "utf-8")) as T
+}
+
+/**
+ * .coursework アーカイブを一時ディレクトリへ展開し、各 JSON を読み込む。
+ * 呼び出し側は data.tempDir を cleanupCourseworkTempDir で必ず後始末すること。
+ */
+export async function extractCourseworkArchive(archivePath: string): Promise<{
+  success: boolean
+  data?: ExtractedCourseworkArchive
+  error?: string
+}> {
+  const tempDir = path.join(
+    os.tmpdir(),
+    `coursework-archive-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+  )
+
+  try {
+    if (!fs.existsSync(archivePath)) {
+      return { success: false, error: "アーカイブファイルが見つかりません" }
+    }
+
+    const zip = new AdmZip(archivePath)
+    zip.extractAllTo(tempDir, true)
+
+    const manifest = readJsonFile<CourseworkArchiveManifest>(
+      tempDir,
+      "manifest.json"
+    )
+    if (!manifest) {
+      cleanupCourseworkTempDir(tempDir)
+      return { success: false, error: "マニフェストファイルが見つかりません" }
+    }
+
+    const courseworks =
+      readJsonFile<ArchiveCourseworkRef[]>(tempDir, "courseworks.json") ?? []
+    const studentsData =
+      readJsonFile<ArchiveCwStudent[]>(tempDir, "students.json") ?? []
+    const classesData =
+      readJsonFile<ArchiveCwClass[]>(tempDir, "classes.json") ?? []
+    const membershipsData =
+      readJsonFile<ArchiveCwMembership[]>(tempDir, "memberships.json") ?? []
+    const tagsData = readJsonFile<ArchiveCwTag[]>(tempDir, "tags.json") ?? []
+
+    return {
+      success: true,
+      data: {
+        manifest,
+        data: {
+          manifest,
+          courseworks,
+          studentsData,
+          classesData,
+          membershipsData,
+          tagsData,
+        },
+        tempDir,
+      },
+    }
+  } catch (error) {
+    cleanupCourseworkTempDir(tempDir)
+    console.error("Error extracting coursework archive:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "アーカイブの展開に失敗しました",
+    }
+  }
+}
+
+/** 一時ディレクトリを削除 */
+export function cleanupCourseworkTempDir(tempDir: string): void {
+  try {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  } catch (error) {
+    console.error("Error cleaning up temp directory:", error)
+  }
+}
+
+/** マニフェストのみ読み込む（プレビュー用、全展開なし） */
+export async function readCourseworkManifestOnly(archivePath: string): Promise<{
+  success: boolean
+  manifest?: CourseworkArchiveManifest
+  error?: string
+}> {
+  try {
+    if (!fs.existsSync(archivePath)) {
+      return { success: false, error: "アーカイブファイルが見つかりません" }
+    }
+    const zip = new AdmZip(archivePath)
+    const entry = zip.getEntry("manifest.json")
+    if (!entry) {
+      return { success: false, error: "マニフェストファイルが見つかりません" }
+    }
+    const manifest: CourseworkArchiveManifest = JSON.parse(
+      zip.readAsText(entry)
+    )
+    return { success: true, manifest }
+  } catch (error) {
+    console.error("Error reading coursework manifest:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "マニフェストの読み込みに失敗しました",
+    }
+  }
+}

--- a/electron-src/lib/import/coursework-archive/dataCreator.ts
+++ b/electron-src/lib/import/coursework-archive/dataCreator.ts
@@ -1,0 +1,264 @@
+/**
+ * 試験外成績資料アーカイブの DB 反映（核心）
+ *
+ * - 外部参照（生徒/学級/タグ）は idRemapper で UUID 一次 + 名前マッチング解決。
+ * - 資料本体は UUID 一次照合（decision 未指定）/ ユーザー判断（reuse/new）で流用 or 新規。
+ * - 点数は @@unique([courseworkItemId, studentId]) を updatedAt の LWW で upsert。
+ *
+ * grade-archive はこの importCourseworkData をトランザクション内で呼び出して内包する。
+ */
+
+import { randomUUID } from "crypto"
+
+import type {
+  ArchiveCourseworkItemRef,
+  ArchiveCourseworkRef,
+  CourseworkArchiveData,
+  CourseworkImportOptions,
+} from "../../../../src/types/courseworkArchive.types"
+import type { TransactionClient } from "../exam-archive/uniqueNameGenerators"
+import { isNewerByLww } from "../merge/decisionMergePolicy"
+import {
+  type IdMap,
+  resolveClasses,
+  resolveStudents,
+  resolveTags,
+  restoreMemberships,
+} from "./idRemapper"
+
+export interface ImportCourseworkResult {
+  createdCourseworkIds: string[]
+  /** アーカイブ評価項目 uuid → 実 CourseworkItem.id（grade の DataSource 再リンク用） */
+  itemIdMap: Map<string, string>
+  warnings: string[]
+}
+
+/** importCourseworkData が必要とするデータ断面（manifest 不要）。grade-archive も同形を渡せる。 */
+export type CourseworkImportSections = Pick<
+  CourseworkArchiveData,
+  | "courseworks"
+  | "studentsData"
+  | "classesData"
+  | "membershipsData"
+  | "tagsData"
+>
+
+/**
+ * 試験外成績資料をトランザクション内で DB へ反映する。
+ */
+export async function importCourseworkData(
+  tx: TransactionClient,
+  data: CourseworkImportSections,
+  options: CourseworkImportOptions = {}
+): Promise<ImportCourseworkResult> {
+  const method = options.studentMatching ?? "studentNumber"
+  const allowCreate = options.allowCreate ?? true
+  const decisions = options.courseworkDecisions ?? {}
+  const warnings: string[] = []
+  const createdCourseworkIds: string[] = []
+  const itemIdMap = new Map<string, string>()
+
+  // 1. 外部参照の解決
+  const students = await resolveStudents(tx, data.studentsData, {
+    method,
+    allowCreate,
+  })
+  warnings.push(...students.warnings)
+  const classes = await resolveClasses(tx, data.classesData, { allowCreate })
+  warnings.push(...classes.warnings)
+  const tagMap = await resolveTags(tx, data.tagsData)
+  if (allowCreate) {
+    await restoreMemberships(
+      tx,
+      data.membershipsData,
+      students.map,
+      classes.map
+    )
+  }
+
+  /** 点数を LWW で upsert する */
+  const upsertScores = async (
+    courseworkItemId: string,
+    item: ArchiveCourseworkItemRef,
+    cwName: string
+  ): Promise<void> => {
+    for (const sc of item.scores) {
+      const studentId = students.map.get(sc.studentId)
+      if (!studentId) {
+        warnings.push(
+          `試験外成績資料「${cwName}」評価項目「${item.name}」: 生徒の点数を解決できずスキップしました`
+        )
+        continue
+      }
+      const existing = await tx.courseworkScore.findUnique({
+        where: {
+          courseworkItemId_studentId: { courseworkItemId, studentId },
+        },
+      })
+      const payload = {
+        score: sc.score,
+        letterValue: sc.letterValue,
+        adjustment: sc.adjustment ?? 0,
+        adjustmentReason: sc.adjustmentReason,
+        comment: sc.comment,
+      }
+      if (existing) {
+        if (isNewerByLww(new Date(sc.updatedAt), existing.updatedAt)) {
+          await tx.courseworkScore.update({
+            where: { id: existing.id },
+            data: payload,
+          })
+        }
+      } else {
+        await tx.courseworkScore.create({
+          data: { courseworkItemId, studentId, ...payload },
+        })
+      }
+    }
+  }
+
+  /** 評価項目を作成（変換表も投入）し実 ID を返す */
+  const createItem = async (
+    courseworkId: string,
+    itemId: string | undefined,
+    item: ArchiveCourseworkItemRef
+  ): Promise<string> => {
+    const created = await tx.courseworkItem.create({
+      data: {
+        ...(itemId ? { id: itemId } : {}),
+        courseworkId,
+        name: item.name,
+        order: item.order,
+        maxScore: item.maxScore,
+        inputMode: item.inputMode || "numeric",
+        ...(item.letterScales.length > 0 && {
+          letterScales: {
+            create: item.letterScales.map((ls) => ({
+              label: ls.label,
+              score: ls.score,
+              order: ls.order,
+            })),
+          },
+        }),
+      },
+    })
+    return created.id
+  }
+
+  /** 学級・タグ・名簿の join を冪等に張る */
+  const ensureJoins = async (
+    courseworkId: string,
+    cw: ArchiveCourseworkRef
+  ): Promise<void> => {
+    for (const c of cw.classes) {
+      const classId = classes.map.get(c.classId)
+      if (!classId) continue
+      const exists = await tx.courseworkClass.findUnique({
+        where: { courseworkId_classId: { courseworkId, classId } },
+        select: { id: true },
+      })
+      if (!exists) {
+        await tx.courseworkClass.create({
+          data: { courseworkId, classId, order: c.order },
+        })
+      }
+    }
+    for (const t of cw.tags) {
+      const tagId = tagMap.get(t.tagId)
+      if (!tagId) continue
+      const exists = await tx.courseworkTag.findUnique({
+        where: { courseworkId_tagId: { courseworkId, tagId } },
+        select: { id: true },
+      })
+      if (!exists) {
+        await tx.courseworkTag.create({ data: { courseworkId, tagId } })
+      }
+    }
+    for (const s of cw.students) {
+      const studentId = students.map.get(s.studentId)
+      if (!studentId) continue
+      const exists = await tx.courseworkStudent.findUnique({
+        where: { courseworkId_studentId: { courseworkId, studentId } },
+        select: { id: true },
+      })
+      if (!exists) {
+        await tx.courseworkStudent.create({
+          data: { courseworkId, studentId, customOrder: s.customOrder },
+        })
+      }
+    }
+  }
+
+  // 2. 資料本体
+  for (const cw of data.courseworks) {
+    const decision = decisions[cw.id]
+    let reuseId: string | null = null
+
+    if (decision?.action === "reuse") {
+      const exists = await tx.coursework.findUnique({
+        where: { id: decision.existingId },
+        select: { id: true },
+      })
+      reuseId = exists?.id ?? null
+      if (!reuseId) {
+        warnings.push(
+          `試験外成績資料「${cw.name}」: 指定された統合先が見つからないため新規作成しました`
+        )
+      }
+    } else if (!decision) {
+      const uuidMatch = await tx.coursework.findUnique({
+        where: { id: cw.id },
+        select: { id: true },
+      })
+      reuseId = uuidMatch?.id ?? null
+    }
+
+    if (reuseId) {
+      // 既存資料へ統合: 名簿/学級/タグの不足を補い、項目は名前で突合、点数は LWW
+      await ensureJoins(reuseId, cw)
+      const existing = await tx.coursework.findUnique({
+        where: { id: reuseId },
+        include: { items: { select: { id: true, name: true } } },
+      })
+      const existingByName = new Map(
+        (existing?.items ?? []).map((i) => [i.name, i.id])
+      )
+      for (const item of cw.items) {
+        let actualItemId = existingByName.get(item.name)
+        if (!actualItemId) {
+          actualItemId = await createItem(reuseId, randomUUID(), item)
+        }
+        await upsertScores(actualItemId, item, cw.name)
+        if (item.id) itemIdMap.set(item.id, actualItemId)
+      }
+      continue
+    }
+
+    // 新規作成。decision 未指定（uuid 不一致の初回取込）のみ元 uuid を保持して冪等化。
+    const preserveUuids = !decision
+    const newCourseworkId = preserveUuids ? cw.id : randomUUID()
+    const created = await tx.coursework.create({
+      data: {
+        id: newCourseworkId,
+        name: cw.name,
+        description: cw.description,
+        date: cw.date ? new Date(cw.date) : null,
+      },
+    })
+    createdCourseworkIds.push(created.id)
+    await ensureJoins(created.id, cw)
+    for (const item of cw.items) {
+      const actualItemId = await createItem(
+        created.id,
+        preserveUuids ? item.id : randomUUID(),
+        item
+      )
+      await upsertScores(actualItemId, item, cw.name)
+      if (item.id) itemIdMap.set(item.id, actualItemId)
+    }
+  }
+
+  return { createdCourseworkIds, itemIdMap, warnings }
+}
+
+export type { IdMap }

--- a/electron-src/lib/import/coursework-archive/idRemapper.ts
+++ b/electron-src/lib/import/coursework-archive/idRemapper.ts
@@ -1,0 +1,192 @@
+/**
+ * 試験外成績資料アーカイブの外部参照（生徒・学級・タグ）ID 解決
+ *
+ * exam-archive と同じ「UUID 一次 + 名前マッチング（付加）」モデル:
+ *   生徒  = UUID → 学籍番号 → 氏名
+ *   学級  = UUID → 学級名
+ *   タグ  = UUID → タグ名（無ければ upsert で作成）
+ *
+ * allowCreate=true（単体インポート）では未一致を新規作成（名前衝突はサフィックス回避）。
+ * allowCreate=false（grade-archive 内包）では既存 lookup のみ、未一致はスキップ。
+ */
+
+import type {
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+  ArchiveCwTag,
+  CourseworkMatchingMethod,
+} from "../../../../src/types/courseworkArchive.types"
+import {
+  generateUniqueClassName,
+  generateUniqueStudentNumber,
+  type TransactionClient,
+} from "../exam-archive/uniqueNameGenerators"
+
+/** アーカイブ内 UUID → 実 DB ID のマッピング */
+export type IdMap = Map<string, string>
+
+/**
+ * 生徒を解決する。返り値は archiveStudentId → 実 studentId のマップ。
+ * 未解決（lookup-only で見つからない）生徒はマップに含めない。
+ */
+export async function resolveStudents(
+  tx: TransactionClient,
+  students: ArchiveCwStudent[],
+  options: { method: CourseworkMatchingMethod; allowCreate: boolean }
+): Promise<{ map: IdMap; warnings: string[] }> {
+  const map: IdMap = new Map()
+  const warnings: string[] = []
+  const existing = await tx.student.findMany()
+  const byId = new Map(existing.map((s) => [s.id, s]))
+  const byNumber = new Map(existing.map((s) => [s.studentNumber, s]))
+  const byName = new Map<string, (typeof existing)[number]>()
+  for (const s of existing) {
+    const key = `${s.lastName}|${s.firstName}`
+    if (!byName.has(key)) byName.set(key, s)
+  }
+
+  for (const s of students) {
+    // 1. UUID 一次照合
+    const uuidMatch = byId.get(s.id)
+    if (uuidMatch) {
+      map.set(s.id, uuidMatch.id)
+      continue
+    }
+    // 2. 二次照合
+    let matched: (typeof existing)[number] | undefined
+    if (options.method === "studentNumber") {
+      matched = byNumber.get(s.studentNumber)
+    } else if (options.method === "name") {
+      matched = byName.get(`${s.lastName}|${s.firstName}`)
+    }
+    if (matched) {
+      map.set(s.id, matched.id)
+      continue
+    }
+    // 3. 新規作成 or スキップ
+    if (!options.allowCreate) {
+      warnings.push(
+        `生徒「${s.lastName}${s.firstName}（${s.studentNumber}）」が見つからないためスキップしました`
+      )
+      continue
+    }
+    const uniqueNumber = await generateUniqueStudentNumber(tx, s.studentNumber)
+    const created = await tx.student.create({
+      data: {
+        id: s.id,
+        studentNumber: uniqueNumber,
+        lastName: s.lastName,
+        firstName: s.firstName,
+        lastNameKana: s.lastNameKana,
+        firstNameKana: s.firstNameKana,
+        enrollmentYear: s.enrollmentYear,
+      },
+    })
+    map.set(s.id, created.id)
+  }
+
+  return { map, warnings }
+}
+
+/** 学級を解決する。返り値は archiveClassId → 実 classId のマップ。 */
+export async function resolveClasses(
+  tx: TransactionClient,
+  classes: ArchiveCwClass[],
+  options: { allowCreate: boolean }
+): Promise<{ map: IdMap; warnings: string[] }> {
+  const map: IdMap = new Map()
+  const warnings: string[] = []
+  const existing = await tx.class.findMany()
+  const byId = new Map(existing.map((c) => [c.id, c]))
+  const byName = new Map(existing.map((c) => [c.name, c]))
+
+  for (const c of classes) {
+    const uuidMatch = byId.get(c.id)
+    if (uuidMatch) {
+      map.set(c.id, uuidMatch.id)
+      continue
+    }
+    const nameMatch = byName.get(c.name)
+    if (nameMatch) {
+      map.set(c.id, nameMatch.id)
+      continue
+    }
+    if (!options.allowCreate) {
+      warnings.push(`学級「${c.name}」が見つからないためスキップしました`)
+      continue
+    }
+    const uniqueName = await generateUniqueClassName(tx, c.name)
+    const created = await tx.class.create({
+      data: {
+        id: c.id,
+        name: uniqueName,
+        classCode: c.classCode,
+        grade: c.grade,
+        description: c.description,
+        isVisible: c.isVisible,
+      },
+    })
+    map.set(c.id, created.id)
+  }
+
+  return { map, warnings }
+}
+
+/**
+ * タグを解決する。UUID → タグ名で照合し、無ければ作成（name は unique）。
+ * 返り値は archiveTagId → 実 tagId のマップ。
+ */
+export async function resolveTags(
+  tx: TransactionClient,
+  tags: ArchiveCwTag[]
+): Promise<IdMap> {
+  const map: IdMap = new Map()
+  for (const t of tags) {
+    const byId = await tx.tag.findUnique({ where: { id: t.id } })
+    if (byId) {
+      map.set(t.id, byId.id)
+      continue
+    }
+    const tag = await tx.tag.upsert({
+      where: { name: t.name },
+      create: { name: t.name, order: t.order, color: t.color },
+      update: {},
+    })
+    map.set(t.id, tag.id)
+  }
+  return map
+}
+
+/**
+ * 新規作成された生徒の名簿（membership）を復元する。
+ * 既存 membership がある (studentId, classId) はスキップ（冪等）。
+ * lookup-only（allowCreate=false）では呼ばない想定。
+ */
+export async function restoreMemberships(
+  tx: TransactionClient,
+  memberships: ArchiveCwMembership[],
+  studentMap: IdMap,
+  classMap: IdMap
+): Promise<void> {
+  for (const m of memberships) {
+    const studentId = studentMap.get(m.studentId)
+    const classId = classMap.get(m.classId)
+    if (!studentId || !classId) continue
+    const exists = await tx.studentClassMembership.findFirst({
+      where: { studentId, classId },
+      select: { id: true },
+    })
+    if (exists) continue
+    await tx.studentClassMembership.create({
+      data: {
+        studentId,
+        classId,
+        startDate: new Date(m.startDate),
+        endDate: m.endDate ? new Date(m.endDate) : null,
+        attendanceNumber: m.attendanceNumber,
+        notes: m.notes,
+      },
+    })
+  }
+}

--- a/electron-src/lib/import/coursework-archive/index.ts
+++ b/electron-src/lib/import/coursework-archive/index.ts
@@ -1,0 +1,119 @@
+/**
+ * 試験外成績資料アーカイブ (.coursework) インポートのエントリ
+ */
+
+import type {
+  CourseworkArchiveData,
+  CourseworkArchiveImportPreview,
+  CourseworkArchiveImportResult,
+  CourseworkArchiveMatch,
+  CourseworkImportOptions,
+} from "../../../../src/types/courseworkArchive.types"
+import { recordAuditLog } from "../../prisma/auditLog"
+import prisma from "../../prisma/client"
+import { importCourseworkData } from "./dataCreator"
+import { validateCourseworkManifest } from "./manifestValidator"
+import { transformCourseworkToLatest } from "./transformers"
+
+export type { ExtractedCourseworkArchive } from "./archiveExtractor"
+export {
+  cleanupCourseworkTempDir,
+  extractCourseworkArchive,
+  readCourseworkManifestOnly,
+} from "./archiveExtractor"
+export { importCourseworkData } from "./dataCreator"
+
+/**
+ * インポート前のプレビュー（資料ごとの照合候補）を作る。
+ */
+export async function previewCourseworkImport(
+  data: CourseworkArchiveData
+): Promise<{
+  success: boolean
+  preview?: CourseworkArchiveImportPreview
+  error?: string
+}> {
+  const validation = validateCourseworkManifest(data.manifest)
+  if (!validation.compatible || !validation.manifest) {
+    return { success: false, error: validation.error }
+  }
+
+  const { data: normalized, warnings } = transformCourseworkToLatest(data)
+
+  const matches: CourseworkArchiveMatch[] = []
+  for (const cw of normalized.courseworks) {
+    const uuidMatch = await prisma.coursework.findUnique({
+      where: { id: cw.id },
+      select: { id: true, name: true },
+    })
+    const nameCandidates = await prisma.coursework.findMany({
+      where: { name: cw.name },
+      select: { id: true, name: true },
+    })
+    matches.push({
+      archiveId: cw.id,
+      name: cw.name,
+      itemCount: cw.items.length,
+      studentCount: cw.students.length,
+      uuidMatch: uuidMatch ?? null,
+      nameCandidates,
+    })
+  }
+
+  return {
+    success: true,
+    preview: {
+      manifest: validation.manifest,
+      matches,
+      warnings: [...validation.warnings, ...warnings],
+    },
+  }
+}
+
+/**
+ * 試験外成績資料アーカイブをインポートする（単体・新規トランザクション）。
+ */
+export async function importCourseworkArchive(
+  data: CourseworkArchiveData,
+  options: CourseworkImportOptions = {}
+): Promise<CourseworkArchiveImportResult> {
+  try {
+    const validation = validateCourseworkManifest(data.manifest)
+    if (!validation.compatible) {
+      return { success: false, error: validation.error }
+    }
+    const { data: normalized, warnings: transformWarnings } =
+      transformCourseworkToLatest(data)
+
+    const result = await prisma.$transaction(async (tx) => {
+      return importCourseworkData(tx, normalized, {
+        allowCreate: true,
+        ...options,
+      })
+    })
+
+    // 監査ログ（ベストエフォート）
+    for (const cw of normalized.courseworks) {
+      void recordAuditLog({
+        action: "coursework.import",
+        entityType: "Coursework",
+        entityId: cw.id,
+        scopeLabel: cw.name,
+        target: cw.name,
+      })
+    }
+
+    return {
+      success: true,
+      createdCourseworkIds: result.createdCourseworkIds,
+      warnings: [...transformWarnings, ...result.warnings],
+    }
+  } catch (error) {
+    console.error("Error importing coursework archive:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "インポートに失敗しました",
+    }
+  }
+}

--- a/electron-src/lib/import/coursework-archive/manifestValidator.ts
+++ b/electron-src/lib/import/coursework-archive/manifestValidator.ts
@@ -1,0 +1,81 @@
+/**
+ * 試験外成績資料アーカイブ マニフェスト検証・互換性判定
+ */
+
+import {
+  COURSEWORK_CURRENT_VERSION,
+  COURSEWORK_MIN_SUPPORTED_VERSION,
+  type CourseworkArchiveManifest,
+} from "../../../../src/types/courseworkArchive.types"
+
+function compareVersions(v1: string, v2: string): number {
+  const p1 = v1.split(".").map(Number)
+  const p2 = v2.split(".").map(Number)
+  for (let i = 0; i < Math.max(p1.length, p2.length); i++) {
+    const a = p1[i] ?? 0
+    const b = p2[i] ?? 0
+    if (a !== b) return a > b ? 1 : -1
+  }
+  return 0
+}
+
+export interface CourseworkCompatibilityInfo {
+  compatible: boolean
+  requiresTransform: boolean
+  warnings: string[]
+  error?: string
+}
+
+/**
+ * マニフェストのバージョン互換性を判定する。
+ * - 現行より新しい: 非互換（アプリ更新が必要）
+ * - 最小サポート未満: 非互換
+ * - それ以外で現行未満: 互換（将来トランスフォーマーで吸収）
+ */
+export function validateCourseworkManifest(
+  manifest: unknown
+): CourseworkCompatibilityInfo & { manifest?: CourseworkArchiveManifest } {
+  if (
+    !manifest ||
+    typeof manifest !== "object" ||
+    typeof (manifest as CourseworkArchiveManifest).version !== "string"
+  ) {
+    return {
+      compatible: false,
+      requiresTransform: false,
+      warnings: [],
+      error: "マニフェストが不正です",
+    }
+  }
+
+  const m = manifest as CourseworkArchiveManifest
+  const warnings: string[] = []
+
+  if (compareVersions(m.version, COURSEWORK_CURRENT_VERSION) > 0) {
+    return {
+      compatible: false,
+      requiresTransform: false,
+      warnings,
+      error: `このアーカイブ（v${m.version}）は現在のアプリ（v${COURSEWORK_CURRENT_VERSION}）より新しいため読み込めません。アプリを更新してください。`,
+    }
+  }
+
+  if (compareVersions(m.version, COURSEWORK_MIN_SUPPORTED_VERSION) < 0) {
+    return {
+      compatible: false,
+      requiresTransform: false,
+      warnings,
+      error: `このアーカイブ（v${m.version}）は古すぎるため読み込めません。`,
+    }
+  }
+
+  const requiresTransform =
+    compareVersions(m.version, COURSEWORK_CURRENT_VERSION) < 0
+  if (requiresTransform) {
+    warnings.push(
+      `アーカイブ（v${m.version}）を現行（v${COURSEWORK_CURRENT_VERSION}）へ変換して読み込みます。`
+    )
+  }
+
+  return { compatible: true, requiresTransform, warnings, manifest: m }
+}

--- a/electron-src/lib/import/coursework-archive/transformers/index.ts
+++ b/electron-src/lib/import/coursework-archive/transformers/index.ts
@@ -1,0 +1,44 @@
+/**
+ * 試験外成績資料アーカイブ バージョントランスフォーマー チェーン
+ *
+ * 初版は変換器ゼロ。transformToLatest は素通しする。
+ * 将来 V<FROM>_to_V<TO> を追加したら COURSEWORK_TRANSFORMERS へ登録すること。
+ */
+
+import type { CourseworkArchiveData } from "../../../../../src/types/courseworkArchive.types"
+import {
+  COURSEWORK_CURRENT_VERSION,
+  type CourseworkTransformResult,
+  type CourseworkVersionTransformer,
+} from "./types"
+
+export * from "./types"
+
+/** 登録済みトランスフォーマー（初版は空） */
+export const COURSEWORK_TRANSFORMERS: CourseworkVersionTransformer[] = []
+
+/**
+ * アーカイブを現行バージョンへ変換する。
+ * 該当する変換器が無ければ素通しする。
+ */
+export function transformCourseworkToLatest(
+  data: CourseworkArchiveData
+): CourseworkTransformResult {
+  let current = data
+  const warnings: string[] = []
+
+  // 現行に到達するまでチェーンを辿る（初版は空配列なので即終了）
+  let guard = 0
+  while (current.manifest.version !== COURSEWORK_CURRENT_VERSION) {
+    const transformer = COURSEWORK_TRANSFORMERS.find(
+      (t) => t.fromVersion === current.manifest.version
+    )
+    if (!transformer) break
+    const result = transformer.transform(current)
+    current = result.data
+    warnings.push(...result.warnings)
+    if (++guard > 100) break
+  }
+
+  return { data: current, warnings }
+}

--- a/electron-src/lib/import/coursework-archive/transformers/types.ts
+++ b/electron-src/lib/import/coursework-archive/transformers/types.ts
@@ -1,0 +1,26 @@
+/**
+ * 試験外成績資料アーカイブ バージョントランスフォーマーの型定義
+ *
+ * 初版（v1.0.0）は変換器ゼロ。将来スキーマが変わったら V1_0_0_to_V1_1_0.ts 等を追加し
+ * COURSEWORK_TRANSFORMERS へ登録してチェーン化する（exam-archive の transformers に倣う）。
+ */
+
+import type { CourseworkArchiveData } from "../../../../../src/types/courseworkArchive.types"
+
+export { COURSEWORK_CURRENT_VERSION } from "../../../../../src/types/courseworkArchive.types"
+
+export type CourseworkArchiveVersion = "1.0.0"
+
+export const COURSEWORK_SUPPORTED_VERSIONS: readonly CourseworkArchiveVersion[] =
+  ["1.0.0"]
+
+export interface CourseworkTransformResult {
+  data: CourseworkArchiveData
+  warnings: string[]
+}
+
+export interface CourseworkVersionTransformer {
+  readonly fromVersion: CourseworkArchiveVersion
+  readonly toVersion: CourseworkArchiveVersion
+  transform(data: CourseworkArchiveData): CourseworkTransformResult
+}

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -2,6 +2,7 @@
  * 成績算出アーカイブ (.grade) 展開・解析
  */
 
+import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
 import type {
   ArchiveBoundariesData,
   ArchiveCoursework,
@@ -49,12 +50,19 @@ export async function extractGradeArchive(
     const boundariesData: ArchiveBoundariesData = JSON.parse(
       files["boundaries.json"] ?? '{"boundarySets":[]}'
     )
-    // v1.4.0+: 試験外成績資料の埋め込み
-    const courseworks: ArchiveCoursework[] | undefined = files[
-      "courseworks.json"
-    ]
-      ? JSON.parse(files["courseworks.json"])
-      : undefined
+    // 試験外成績資料の埋め込み。
+    //   v1.5.0+: courseworks.json は coursework-archive 形式のオブジェクト（UUID ベース）。
+    //   v1.4.0 : courseworks.json は名前ベースの ArchiveCoursework[] 配列。
+    let courseworks: ArchiveCoursework[] | undefined
+    let courseworkArchive: CollectedCourseworkData | undefined
+    if (files["courseworks.json"]) {
+      const parsed = JSON.parse(files["courseworks.json"])
+      if (Array.isArray(parsed)) {
+        courseworks = parsed
+      } else if (parsed && typeof parsed === "object") {
+        courseworkArchive = parsed
+      }
+    }
     // 旧 v1.3.0 以前: manual-scores.json があれば後方互換用に読む
     const manualScoresData: ArchiveManualScoresData | undefined = files[
       "manual-scores.json"
@@ -69,6 +77,7 @@ export async function extractGradeArchive(
         gradeData,
         boundariesData,
         courseworks,
+        courseworkArchive,
         manualScoresData,
       },
     }

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../../../src/types/gradeArchive.types"
 import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
+import { importCourseworkData } from "../coursework-archive/dataCreator"
 
 /**
  * インポート前のプレビュー（照合結果）
@@ -47,11 +48,30 @@ export async function previewGradeArchiveImport(
     })
   )
 
+  // 埋め込み資料の照合候補（v1.5.0: courseworkArchive / v1.4.0: courseworks）
+  const cwPreviewItems = data.courseworkArchive
+    ? data.courseworkArchive.courseworks.map((cw) => ({
+        id: cw.id,
+        name: cw.name,
+        itemCount: cw.items.length,
+        studentCount: cw.students.length,
+      }))
+    : (data.courseworks ?? []).map((cw) => ({
+        id: cw.id,
+        name: cw.name,
+        itemCount: cw.items.length,
+        studentCount: cw.students.length,
+      }))
+
   // Student照合
-  const courseworkStudentNumbers = (data.courseworks ?? []).flatMap((cw) => [
-    ...cw.students.map((s) => s.studentNumber),
-    ...cw.items.flatMap((item) => item.scores.map((sc) => sc.studentNumber)),
-  ])
+  const courseworkStudentNumbers = data.courseworkArchive
+    ? data.courseworkArchive.studentsData.map((s) => s.studentNumber)
+    : (data.courseworks ?? []).flatMap((cw) => [
+        ...cw.students.map((s) => s.studentNumber),
+        ...cw.items.flatMap((item) =>
+          item.scores.map((sc) => sc.studentNumber)
+        ),
+      ])
   const studentNumbers = [
     ...new Set(
       (manualScoresData?.manualScores ?? []).map((ms) => ms.studentNumber)
@@ -68,9 +88,9 @@ export async function previewGradeArchiveImport(
     existingStudents.map((s) => s.studentNumber)
   )
 
-  // v1.4.0+: 埋め込み資料のマッチング候補（uuid一次・名前二次）を算出
+  // 埋め込み資料のマッチング候補（uuid一次・名前二次）を算出
   const courseworkMatches = await Promise.all(
-    (data.courseworks ?? []).map(async (cw) => {
+    cwPreviewItems.map(async (cw) => {
       // uuid 完全一致（同一PC由来）
       const uuidMatch = cw.id
         ? await prisma.coursework.findUnique({
@@ -88,8 +108,8 @@ export async function previewGradeArchiveImport(
       return {
         archiveId: cw.id,
         name: cw.name,
-        itemCount: cw.items.length,
-        studentCount: cw.students.length,
+        itemCount: cw.itemCount,
+        studentCount: cw.studentCount,
         uuidMatch: uuidMatch ?? null,
         nameCandidates,
       }
@@ -446,8 +466,33 @@ export async function importGradeArchive(
           }
         }
 
-        if (data.courseworks && data.courseworks.length > 0) {
-          // v1.4.0+: 埋め込み資料を復元（資料ごとのユーザー判断を適用）
+        if (data.courseworkArchive) {
+          // v1.5.0+: 独立 coursework モジュールへ委譲（収集・生成ロジックの二重実装を解消）。
+          //   既存生徒・学級への lookup のみ（allowCreate=false）で grade の従来挙動を維持する。
+          const cwResult = await importCourseworkData(
+            tx,
+            data.courseworkArchive,
+            {
+              allowCreate: false,
+              studentMatching: "studentNumber",
+              courseworkDecisions,
+            }
+          )
+          warnings.push(...cwResult.warnings)
+          // DataSource 再リンク用: アーカイブ項目uuid → 実 CourseworkItem.id
+          for (const [archiveItemId, actualId] of cwResult.itemIdMap) {
+            itemIdToActual.set(archiveItemId, actualId)
+          }
+          // 名前フォールバック（uuid 不一致時）
+          for (const cw of data.courseworkArchive.courseworks) {
+            for (const item of cw.items) {
+              const actual = cwResult.itemIdMap.get(item.id)
+              if (actual)
+                itemNameToActual.set(`${cw.name}:${item.name}`, actual)
+            }
+          }
+        } else if (data.courseworks && data.courseworks.length > 0) {
+          // v1.4.0: 名前ベース埋め込み資料を復元（資料ごとのユーザー判断を適用）
           for (const cw of data.courseworks) {
             await ensureCoursework(cw, courseworkDecisions[cw.id])
           }

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -417,6 +417,16 @@ export const AUDIT_ACTIONS = {
     verb: "update",
     label: "資料の点数を更新しました",
   },
+  "coursework.export": {
+    category: "grade",
+    verb: "export",
+    label: "試験外成績資料「{target}」をエクスポートしました",
+  },
+  "coursework.import": {
+    category: "grade",
+    verb: "import",
+    label: "試験外成績資料「{target}」をインポートしました",
+  },
 
   // ── 解答用紙作成（answer_sheet） ─────────────────────────────
   "answer_sheet.create": {

--- a/electron-src/preload-apis/courseworkApi.ts
+++ b/electron-src/preload-apis/courseworkApi.ts
@@ -111,6 +111,18 @@ export function createCourseworkApi() {
       // タグ
       setTags: (courseworkId: string, tagIds: string[]) =>
         ipcRenderer.invoke("coursework:setTags", courseworkId, tagIds),
+
+      // アーカイブ（.coursework のエクスポート／インポート）
+      exportArchive: (courseworkId: string) =>
+        ipcRenderer.invoke("coursework:exportArchive", courseworkId),
+      selectImportFile: () => ipcRenderer.invoke("coursework:selectImportFile"),
+      analyzeArchive: (options: { archivePath: string }) =>
+        ipcRenderer.invoke("coursework:analyzeArchive", options),
+      importArchive: (options: {
+        archivePath: string
+        courseworkDecisions?: import("../../src/types/courseworkArchive.types").CourseworkImportDecisions
+        studentMatching?: import("../../src/types/courseworkArchive.types").CourseworkMatchingMethod
+      }) => ipcRenderer.invoke("coursework:importArchive", options),
     },
   }
 }

--- a/src/components/coursework/list/CourseworkImportDialog.tsx
+++ b/src/components/coursework/list/CourseworkImportDialog.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import type {
+  CourseworkArchiveImportPreview,
+  CourseworkImportDecision,
+} from "@/types/courseworkArchive.types"
+
+interface CourseworkImportDialogProps {
+  open: boolean
+  preview: CourseworkArchiveImportPreview | null
+  importing: boolean
+  onCancel: () => void
+  onConfirm: (decisions: Record<string, CourseworkImportDecision>) => void
+}
+
+/** 選択値 → 決定。"new" または "reuse:<existingId>" */
+function valueToDecision(value: string): CourseworkImportDecision {
+  if (value === "new") return { action: "new" }
+  return { action: "reuse", existingId: value.slice("reuse:".length) }
+}
+
+/**
+ * 試験外成績資料アーカイブ（.coursework）のインポート確認ウィザード。
+ * 資料ごとに「既存へ統合（uuid一致 / 名前候補）」か「新規作成」かを選ばせる。
+ * uuid一致があれば既定で統合、無ければ新規作成を初期選択にする。
+ */
+export function CourseworkImportDialog({
+  open,
+  preview,
+  importing,
+  onCancel,
+  onConfirm,
+}: CourseworkImportDialogProps) {
+  const [selections, setSelections] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    setSelections({})
+  }, [preview])
+
+  const initialSelections = useMemo(() => {
+    const init: Record<string, string> = {}
+    for (const cw of preview?.matches ?? []) {
+      init[cw.archiveId] = cw.uuidMatch ? `reuse:${cw.uuidMatch.id}` : "new"
+    }
+    return init
+  }, [preview])
+
+  const effectiveSelections = useMemo(
+    () => ({ ...initialSelections, ...selections }),
+    [initialSelections, selections]
+  )
+
+  if (!preview) return null
+
+  const handleConfirm = () => {
+    const decisions: Record<string, CourseworkImportDecision> = {}
+    for (const cw of preview.matches) {
+      decisions[cw.archiveId] = valueToDecision(
+        effectiveSelections[cw.archiveId] ?? "new"
+      )
+    }
+    onConfirm(decisions)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>試験外成績資料のインポート</DialogTitle>
+          <DialogDescription>
+            資料ごとの取り込み方法を選択してください。
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[60vh] pr-4">
+          {preview.matches.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              取り込む試験外成績資料はありません。
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {preview.matches.map((cw) => (
+                <div key={cw.archiveId} className="rounded border p-3">
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="text-sm font-medium">{cw.name}</span>
+                    <span className="text-muted-foreground text-xs">
+                      （評価項目 {cw.itemCount} ・名簿 {cw.studentCount}名）
+                    </span>
+                  </div>
+                  <RadioGroup
+                    value={effectiveSelections[cw.archiveId] ?? "new"}
+                    onValueChange={(v) =>
+                      setSelections((prev) => ({ ...prev, [cw.archiveId]: v }))
+                    }
+                    className="space-y-1"
+                  >
+                    {cw.uuidMatch && (
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value={`reuse:${cw.uuidMatch.id}`}
+                          id={`${cw.archiveId}-uuid`}
+                        />
+                        <Label
+                          htmlFor={`${cw.archiveId}-uuid`}
+                          className="text-sm font-normal"
+                        >
+                          既存へ統合（同一データ・uuid一致）:{" "}
+                          {cw.uuidMatch.name}
+                        </Label>
+                      </div>
+                    )}
+                    {cw.nameCandidates.map((nc) => (
+                      <div key={nc.id} className="flex items-center gap-2">
+                        <RadioGroupItem
+                          value={`reuse:${nc.id}`}
+                          id={`${cw.archiveId}-${nc.id}`}
+                        />
+                        <Label
+                          htmlFor={`${cw.archiveId}-${nc.id}`}
+                          className="text-sm font-normal"
+                        >
+                          既存へ統合（名前一致）: {nc.name}
+                        </Label>
+                      </div>
+                    ))}
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="new" id={`${cw.archiveId}-new`} />
+                      <Label
+                        htmlFor={`${cw.archiveId}-new`}
+                        className="text-sm font-normal"
+                      >
+                        新規作成（別の資料として取り込む）
+                      </Label>
+                    </div>
+                  </RadioGroup>
+                </div>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel} disabled={importing}>
+            キャンセル
+          </Button>
+          <Button onClick={handleConfirm} disabled={importing}>
+            {importing ? "インポート中..." : "インポート"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/coursework/list/CourseworkListContainer.tsx
+++ b/src/components/coursework/list/CourseworkListContainer.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { ClipboardEdit, MoreHorizontal, Plus, Trash2 } from "lucide-react"
+import {
+  ClipboardEdit,
+  FolderInput,
+  FolderOutput,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -21,8 +28,13 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import type { CourseworkSummary } from "@/types/coursework.types"
+import type {
+  CourseworkArchiveImportPreview,
+  CourseworkImportDecision,
+} from "@/types/courseworkArchive.types"
 
 import { CourseworkCreateDialog } from "./CourseworkCreateDialog"
+import { CourseworkImportDialog } from "./CourseworkImportDialog"
 
 /**
  * 試験外成績資料（Coursework）の一覧コンテナ
@@ -35,6 +47,13 @@ export function CourseworkListContainer() {
   const [courseworks, setCourseworks] = useState<CourseworkSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
+  // インポート確認ウィザードの状態
+  const [importPreview, setImportPreview] =
+    useState<CourseworkArchiveImportPreview | null>(null)
+  const [importArchivePath, setImportArchivePath] = useState<string | null>(
+    null
+  )
+  const [importing, setImporting] = useState(false)
 
   const loadCourseworks = useCallback(async () => {
     try {
@@ -77,6 +96,81 @@ export function CourseworkListContainer() {
     }
   }
 
+  const handleExport = async (coursework: CourseworkSummary) => {
+    try {
+      const result = await window.electronAPI.coursework.exportArchive(
+        coursework.id
+      )
+      if (result.success && !result.canceled) {
+        toast.success("資料をエクスポートしました", {
+          description: coursework.name,
+        })
+      } else if (!result.success) {
+        toast.error("エクスポートに失敗しました", {
+          description: result.error,
+        })
+      }
+    } catch (error) {
+      console.error("Error exporting coursework:", error)
+      toast.error("エクスポートに失敗しました")
+    }
+  }
+
+  const handleImport = async () => {
+    const selected = await window.electronAPI.coursework.selectImportFile()
+    if (!selected.success || selected.canceled || !selected.filePath) return
+    const analyzed = await window.electronAPI.coursework.analyzeArchive({
+      archivePath: selected.filePath,
+    })
+    if (!analyzed.success || !analyzed.preview) {
+      toast.error("アーカイブの解析に失敗しました", {
+        description: analyzed.error,
+      })
+      return
+    }
+    setImportArchivePath(selected.filePath)
+    setImportPreview(analyzed.preview)
+  }
+
+  const handleImportConfirm = async (
+    decisions: Record<string, CourseworkImportDecision>
+  ) => {
+    if (!importArchivePath) return
+    setImporting(true)
+    try {
+      const result = await window.electronAPI.coursework.importArchive({
+        archivePath: importArchivePath,
+        courseworkDecisions: decisions,
+      })
+      if (result.success) {
+        if (result.warnings && result.warnings.length > 0) {
+          toast.warning(
+            `インポートは完了しましたが ${result.warnings.length} 件の警告があります`,
+            {
+              description: result.warnings.join("\n"),
+              duration: Infinity,
+              closeButton: true,
+            }
+          )
+        } else {
+          toast.success("資料をインポートしました")
+        }
+        await loadCourseworks()
+      } else {
+        toast.error("インポートに失敗しました", { description: result.error })
+      }
+    } finally {
+      setImporting(false)
+      setImportPreview(null)
+      setImportArchivePath(null)
+    }
+  }
+
+  const handleImportCancel = () => {
+    setImportPreview(null)
+    setImportArchivePath(null)
+  }
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -96,6 +190,14 @@ export function CourseworkListContainer() {
           >
             <Plus className="mr-2 h-4 w-4" />
             新規作成
+          </Button>
+          <Button
+            onClick={handleImport}
+            variant="outline"
+            className="rounded-lg"
+          >
+            <FolderInput className="mr-2 h-4 w-4" />
+            .coursework 読み込み
           </Button>
         </div>
       </div>
@@ -169,6 +271,12 @@ export function CourseworkListContainer() {
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem
+                            onClick={() => handleExport(coursework)}
+                          >
+                            <FolderOutput className="mr-2 h-4 w-4" />
+                            .coursework 書き出し
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
                             className="text-destructive"
                             onClick={() => handleDelete(coursework)}
                           >
@@ -190,6 +298,14 @@ export function CourseworkListContainer() {
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}
         onCreated={handleCreated}
+      />
+
+      <CourseworkImportDialog
+        open={importPreview !== null}
+        preview={importPreview}
+        importing={importing}
+        onCancel={handleImportCancel}
+        onConfirm={handleImportConfirm}
       />
     </div>
   )

--- a/src/types/courseworkArchive.types.ts
+++ b/src/types/courseworkArchive.types.ts
@@ -1,0 +1,188 @@
+/**
+ * 試験外成績資料アーカイブ（.coursework）の型定義
+ *
+ * exam-archive と同型の「id 一次照合 + 名前マッチング（付加）」モデルを採用する。
+ * 生徒・学級・タグは元 UUID 付きの full レコードを carry し、import 時に
+ * UUID 一次 → 学籍番号/学級名/タグ名のフォールバックで既存実体へ統合、
+ * いずれにも一致しなければ（allowCreate 時）新規作成する。
+ *
+ * grade-archive（.grade v1.5.0+）はこの収集・生成ロジックを再利用して内包する。
+ * 旧 .grade（v1.4.0、名前ベース埋め込み）の読込互換は grade 側の legacy 経路で維持。
+ */
+
+/** 現行アーカイブバージョン */
+export const COURSEWORK_CURRENT_VERSION = "1.0.0"
+/** 読込可能な最小バージョン */
+export const COURSEWORK_MIN_SUPPORTED_VERSION = "1.0.0"
+
+export interface CourseworkArchiveManifest {
+  version: string
+  appVersion: string
+  exportedAt: string
+  counts: {
+    courseworks: number
+    items: number
+    scores: number
+    students: number
+    classes: number
+  }
+}
+
+/** 名簿・学級・タグ参照は UUID で持つ（名前は studentsData 等から逆引き可能） */
+export interface ArchiveCourseworkRef {
+  id: string
+  name: string
+  description: string | null
+  date: string | null
+  classes: { classId: string; order: number }[]
+  tags: { tagId: string }[]
+  students: { studentId: string; customOrder: number | null }[]
+  items: ArchiveCourseworkItemRef[]
+}
+
+export interface ArchiveCourseworkItemRef {
+  id: string
+  name: string
+  order: number
+  maxScore: number
+  inputMode: string
+  letterScales: { label: string; score: number; order: number }[]
+  scores: ArchiveCourseworkScoreRef[]
+}
+
+export interface ArchiveCourseworkScoreRef {
+  studentId: string
+  score: number | null
+  letterValue: string | null
+  adjustment: number | null
+  adjustmentReason: string | null
+  comment: string | null
+  /** LWW 競合解決に使用 */
+  updatedAt: string
+}
+
+/** full 生徒レコード（exam-archive ArchiveStudentsData["students"] と同形） */
+export interface ArchiveCwStudent {
+  id: string
+  studentNumber: string
+  lastName: string
+  firstName: string
+  lastNameKana: string
+  firstNameKana: string
+  enrollmentYear: number | null
+  updatedAt: string
+}
+
+/** full 学級レコード */
+export interface ArchiveCwClass {
+  id: string
+  name: string
+  classCode: string | null
+  grade: number | null
+  description: string | null
+  isVisible: boolean
+}
+
+/** 学級所属（名簿復元・名前フォールバックの裏付け） */
+export interface ArchiveCwMembership {
+  id: string
+  studentId: string
+  classId: string
+  startDate: string
+  endDate: string | null
+  attendanceNumber: number | null
+  notes: string | null
+}
+
+export interface ArchiveCwTag {
+  id: string
+  name: string
+  order: number
+  color: string | null
+}
+
+/** アーカイブ全体（manifest + 各セクション）。grade-archive へ内包する際もこの形を流用する。 */
+export interface CourseworkArchiveData {
+  manifest: CourseworkArchiveManifest
+  courseworks: ArchiveCourseworkRef[]
+  studentsData: ArchiveCwStudent[]
+  classesData: ArchiveCwClass[]
+  membershipsData: ArchiveCwMembership[]
+  tagsData: ArchiveCwTag[]
+}
+
+/** dataCollector が返す収集結果（manifest を除いた本体 + counts） */
+export interface CollectedCourseworkData {
+  courseworks: ArchiveCourseworkRef[]
+  studentsData: ArchiveCwStudent[]
+  classesData: ArchiveCwClass[]
+  membershipsData: ArchiveCwMembership[]
+  tagsData: ArchiveCwTag[]
+  counts: CourseworkArchiveManifest["counts"]
+}
+
+/** インポート時に資料ごとにユーザーが選ぶ取り込み方法 */
+export type CourseworkImportDecision =
+  | { action: "reuse"; existingId: string }
+  | { action: "new" }
+
+/** アーカイブ内の資料 uuid → ユーザー決定 */
+export type CourseworkImportDecisions = Record<string, CourseworkImportDecision>
+
+/** 生徒・学級の二次照合方法（UUID 一致は常に優先される） */
+export type CourseworkMatchingMethod = "studentNumber" | "name" | "none"
+
+/** import 実行オプション */
+export interface CourseworkImportOptions {
+  /** 資料ごとの取り込み判断（archiveCourseworkId → 決定）。未指定は uuid 一致なら流用、無ければ新規 */
+  courseworkDecisions?: CourseworkImportDecisions
+  /** 生徒の二次照合方法（既定: studentNumber） */
+  studentMatching?: CourseworkMatchingMethod
+  /**
+   * 未一致の生徒・学級を新規作成するか。
+   * - true（既定・単体インポート）: 名前衝突時サフィックス付きで新規作成
+   * - false（grade-archive 内包）: 既存 lookup のみ、未一致はスキップ + 警告
+   */
+  allowCreate?: boolean
+}
+
+/** 資料1件分のマッチング候補（ウィザードでユーザーに提示） */
+export interface CourseworkArchiveMatch {
+  archiveId: string
+  name: string
+  itemCount: number
+  studentCount: number
+  /** uuid 完全一致した既存資料（同一 PC 由来） */
+  uuidMatch: { id: string; name: string } | null
+  /** 名前一致した既存資料の候補（名前は非ユニークなので複数あり得る） */
+  nameCandidates: { id: string; name: string }[]
+}
+
+/** インポートプレビュー（解析結果） */
+export interface CourseworkArchiveImportPreview {
+  manifest: CourseworkArchiveManifest
+  matches: CourseworkArchiveMatch[]
+  warnings: string[]
+}
+
+export interface ExportCourseworkArchiveOptions {
+  courseworkId: string
+  /** 未指定なら保存ダイアログを表示 */
+  outputPath?: string
+}
+
+export interface ExportCourseworkArchiveResult {
+  success: boolean
+  outputPath?: string
+  canceled?: boolean
+  manifest?: CourseworkArchiveManifest
+  error?: string
+  warnings?: string[]
+}
+
+export interface CourseworkArchiveImportResult {
+  success: boolean
+  createdCourseworkIds?: string[]
+  warnings?: string[]
+  error?: string
+}

--- a/src/types/electron/courseworkApi.d.ts
+++ b/src/types/electron/courseworkApi.d.ts
@@ -193,5 +193,30 @@ export interface CourseworkAPI {
       courseworkId: string,
       tagIds: string[]
     ) => Promise<{ success: boolean; error?: string }>
+
+    // アーカイブ（.coursework のエクスポート／インポート）
+    exportArchive: (
+      courseworkId: string
+    ) => Promise<
+      import("../courseworkArchive.types").ExportCourseworkArchiveResult
+    >
+    selectImportFile: () => Promise<{
+      success: boolean
+      filePath?: string
+      canceled?: boolean
+      error?: string
+    }>
+    analyzeArchive: (options: { archivePath: string }) => Promise<{
+      success: boolean
+      preview?: import("../courseworkArchive.types").CourseworkArchiveImportPreview
+      error?: string
+    }>
+    importArchive: (options: {
+      archivePath: string
+      courseworkDecisions?: import("../courseworkArchive.types").CourseworkImportDecisions
+      studentMatching?: import("../courseworkArchive.types").CourseworkMatchingMethod
+    }) => Promise<
+      import("../courseworkArchive.types").CourseworkArchiveImportResult
+    >
   }
 }

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -2,6 +2,8 @@
  * 成績算出アーカイブ(.grade)の型定義
  */
 
+import type { CollectedCourseworkData } from "./courseworkArchive.types"
+
 export interface GradeArchiveManifest {
   version: string
   appVersion: string
@@ -28,8 +30,16 @@ export interface GradeArchiveData {
    * 旧アーカイブ読込時の後方互換フォールバック用に optional で残す。
    */
   manualScoresData?: ArchiveManualScoresData
-  /** v1.4.0+: 参照中の試験外成績資料（Coursework）を自己完結で埋め込む */
+  /**
+   * v1.4.0: 参照中の試験外成績資料（Coursework）の名前ベース埋め込み。
+   * 読込後方互換用に残す。v1.5.0 以降は courseworkArchive を使う。
+   */
   courseworks?: ArchiveCoursework[]
+  /**
+   * v1.5.0+: 試験外成績資料を coursework-archive と同じ UUID ベースの形で内包する。
+   * 収集・生成ロジックは独立 coursework モジュールへ委譲（二重実装の解消）。
+   */
+  courseworkArchive?: CollectedCourseworkData
   boundariesData: ArchiveBoundariesData
 }
 


### PR DESCRIPTION
## 概要
試験外成績資料(Coursework)を exam-archive と同型の独立アーカイブ `.coursework` として切り出し、Export / Import / バージョントランスフォーマー一式を整備しました。成績アーカイブ(.grade)は収集・生成ロジックを独立モジュールへ委譲し、二重実装を解消しています。

Closes #887

## 主な変更
- **独立 coursework-archive モジュール**
  - `electron-src/lib/export/coursework-archive/`（dataCollector / archiveCreator / index）
  - `electron-src/lib/import/coursework-archive/`（archiveExtractor / manifestValidator / idRemapper / dataCreator / index / transformers）
- **外部参照の解決**: exam-archive 同型の「UUID 一次照合 + 名前マッチング(付加)」。生徒/学級/タグの full レコード(元UUID付き)を carry し、未一致は新規作成 or 既存統合。`uniqueNameGenerators` / `decisionMergePolicy.isNewerByLww` を再利用
- **スコア競合**: `updatedAt` の LWW で解決（`CourseworkScore` の複合ユニークを upsert）
- **トランスフォーマー機構**: `COURSEWORK_CURRENT_VERSION`(初版 1.0.0、変換器ゼロで素通し)
- **grade-archive 委譲化**: 収集を `collectCourseworkArchiveData` へ完全委譲。`.grade` を **v1.4.0 → v1.5.0** に（courseworks.json を UUID ベース形式へ）。旧 v1.4.0(名前ベース) / v1.3.0(manual) の読込後方互換を維持
- **IPC / preload / 型**: `coursework:exportArchive` / `selectImportFile` / `analyzeArchive` / `importArchive` を追加
- **UI**: 試験外成績資料一覧に「.coursework 読み込み / 書き出し」導線 + インポート確認ダイアログ(`CourseworkImportDialog`)を追加
- **ドキュメント**: CLAUDE.md にアーカイブ仕様・バージョン履歴を追記

## UI の補足
インポートUIは成績(grade)アーカイブと同等の簡易ダイアログ（資料ごとに「既存へ統合 / 新規作成」を選択）です。生徒・学級の照合は裏側で自動（UUID一次→学籍番号→氏名）に行います。試験(exam)の多段ID統合ウィザードは採用していません（データ層は exam と同モデル）。

## テスト
- 新規 `courseworkArchiveRoundTrip.test.ts`（UUID冪等再import / クリーンDB復元 / 学籍番号フォールバック統合 / スコアLWW / preview）: 5件通過
- `gradeArchiveRoundTrip.test.ts`: v1.5.0 往復 + v1.4.0 後方互換ケースを追加し計8件通過
- `courseworkCrud.test.ts`: 6件通過（回帰なし）
- 型チェック(electron-src / Next.js)・eslint・prettier: いずれもクリーン

注: 同時並行で別作業（ExamClass 統計再設計）が進行中のため共有テストDBが一時的にスキーマ不整合となり全体スイートは不安定ですが、本PRのアーカイブ系テストは隔離実行で全通過を確認済みです（本PRは ExamClass 関連ファイルを一切含みません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)