### PR TITLE
feat(exam): 学級統計の再設計（受験日統一・複数学級比較・出力スコープのフラグ化）

### DIFF
--- a/__tests__/calculations/classAverageRows.test.ts
+++ b/__tests__/calculations/classAverageRows.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Excel 学級平均行（Phase 4・主成果）のテスト
+ *
+ * appendClassAverageRows が
+ * - 全体平均行（受験者＝合計点 non-null）
+ * - teacherStat 学級ごとの学級平均行（母集団=学級全体、重複カウント）
+ * を正しい列に出すことを検証する。
+ */
+import * as ExcelJS from "exceljs"
+import { describe, expect, it } from "vitest"
+
+import { appendClassAverageRows } from "@/electron-src/lib/export/excel/averageRows"
+import type { ExamClassMembers } from "@/electron-src/lib/prisma/examClass"
+import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
+
+function makeStudent(
+  id: string,
+  totalScore: number | null,
+  q1: number | null
+): ScoringData {
+  return {
+    studentId: id,
+    studentName: id,
+    studentNumber: id,
+    scores: [
+      {
+        questionId: "q1",
+        questionLabel: "問1",
+        score: q1,
+        maxScore: 10,
+        status: q1 === null ? "unscored" : "correct",
+      },
+    ],
+    totalScore,
+    totalMaxScore: 10,
+    subtotalScores: [],
+  }
+}
+
+const QUESTION_REGIONS = [
+  { id: "q1", label: "問1", orderIndex: 0 },
+] as unknown as Parameters<typeof appendClassAverageRows>[4]
+
+/** ヘッダー列: 受験状態,順位,学年,学級,出席番号,学籍番号,氏名(7),合計点(8),...設問 */
+const NAME_COL = 7
+const TOTAL_COL = 8
+
+describe("appendClassAverageRows", () => {
+  it("全体平均と teacherStat 学級平均を正しい列・値で出す", () => {
+    const wb = new ExcelJS.Workbook()
+    const ws = wb.addWorksheet("点数一覧")
+    ws.addRow([
+      "受験状態",
+      "順位",
+      "学年",
+      "学級",
+      "出席番号",
+      "学籍番号",
+      "氏名",
+      "合計点",
+      "問1",
+    ])
+
+    // S1,S2 が classA。S3 は学級なし。全体平均=(60+80+40)/3=60、classA平均=(60+80)/2=70
+    const all = [
+      makeStudent("S1", 60, 6),
+      makeStudent("S2", 80, 8),
+      makeStudent("S3", 40, 4),
+    ]
+    const classes: ExamClassMembers[] = [
+      {
+        examClassId: "ec1",
+        classId: "cA",
+        className: "3-A組",
+        classCode: null,
+        grade: 3,
+        order: 0,
+        administered: true,
+        teacherStat: true,
+        studentReport: true,
+        studentIds: ["S1", "S2"],
+      },
+    ]
+
+    appendClassAverageRows(ws, all, classes, [], QUESTION_REGIONS)
+
+    // 空行 + 全体平均 + 3-A組平均
+    const overall = ws.getRow(3) // header=1, 空行=2, 全体平均=3
+    expect(overall.getCell(NAME_COL).value).toBe("全体平均")
+    expect(overall.getCell(TOTAL_COL).value).toBe(60)
+
+    const classRow = ws.getRow(4)
+    expect(classRow.getCell(NAME_COL).value).toBe("3-A組平均")
+    expect(classRow.getCell(TOTAL_COL).value).toBe(70)
+  })
+
+  it("未採点(totalScore null)は平均母数から除外される", () => {
+    const wb = new ExcelJS.Workbook()
+    const ws = wb.addWorksheet("点数一覧")
+    ws.addRow([
+      "受験状態",
+      "順位",
+      "学年",
+      "学級",
+      "出席番号",
+      "学籍番号",
+      "氏名",
+      "合計点",
+      "問1",
+    ])
+
+    // S3 は未採点(null) → 全体平均は (60+80)/2=70
+    const all = [
+      makeStudent("S1", 60, 6),
+      makeStudent("S2", 80, 8),
+      makeStudent("S3", null, null),
+    ]
+    appendClassAverageRows(ws, all, [], [], QUESTION_REGIONS)
+    expect(ws.getRow(3).getCell(TOTAL_COL).value).toBe(70)
+  })
+
+  it("空データなら何も追加しない", () => {
+    const wb = new ExcelJS.Workbook()
+    const ws = wb.addWorksheet("点数一覧")
+    ws.addRow(["氏名", "合計点"])
+    appendClassAverageRows(ws, [], [], [], QUESTION_REGIONS)
+    expect(ws.rowCount).toBe(1)
+  })
+})

--- a/__tests__/calculations/computeReportData.test.ts
+++ b/__tests__/calculations/computeReportData.test.ts
@@ -27,16 +27,22 @@ function createMinimalStats(): StatisticsData {
       boxPlot: { min: 50, q1: 60, median: 70, q3: 80, max: 90 },
       total: 3,
     },
-    class: {
-      average: 70,
-      stdDev: 10,
-      boxPlot: { min: 50, q1: 60, median: 70, q3: 80, max: 90 },
-      total: 3,
-    },
+    classes: [
+      {
+        classId: "cA",
+        className: "A",
+        grade: "1",
+        memberStudentIds: ["s1", "s2", "s3"],
+        average: 70,
+        stdDev: 10,
+        boxPlot: { min: 50, q1: 60, median: 70, q3: 80, max: 90 },
+        total: 3,
+        rank: 1,
+      },
+    ],
     personal: {
       deviation: 50,
       overallRank: 1,
-      classRank: 1,
     },
     questionCorrectRates: {},
     questionScoreRates: {},
@@ -178,7 +184,7 @@ describe("computeFilteredStats", () => {
 
     expect(result.personal.deviation).toBe(0)
     expect(result.personal.overallRank).toBe(0)
-    expect(result.personal.classRank).toBe(0)
+    expect(result.classes[0].rank).toBe(0)
   })
 
   it("全ステータス有効時はフィルタリングせず元の統計を返す", () => {

--- a/__tests__/calculations/statisticsCalculator.test.ts
+++ b/__tests__/calculations/statisticsCalculator.test.ts
@@ -236,6 +236,23 @@ describe("collectSubtotalRawScores", () => {
 describe("calculateStatisticsForStudent", () => {
   const emptyRates: Record<string, number> = {}
 
+  /** allData 全員を母集団とする単一学級を作る（学級統計テスト用） */
+  const classOf = (
+    allData: ScoringData[]
+  ): {
+    classId: string
+    className: string
+    grade: string | null
+    memberStudentIds: string[]
+  }[] => [
+    {
+      classId: "c1",
+      className: "1組",
+      grade: null,
+      memberStudentIds: allData.map((d) => d.studentId),
+    },
+  ]
+
   it("totalScore が null の生徒は偏差値0・順位0", () => {
     const allData: ScoringData[] = [
       createScoringData({ studentId: "s1", totalScore: 80 }),
@@ -247,14 +264,14 @@ describe("calculateStatisticsForStudent", () => {
       "s2",
       null,
       allData,
-      allData,
+      classOf(allData),
       emptyRates,
       emptyRates
     )
 
     expect(result.personal.deviation).toBe(0)
     expect(result.personal.overallRank).toBe(0)
-    expect(result.personal.classRank).toBe(0)
+    expect(result.classes[0].rank).toBe(0)
   })
 
   it("totalScore が null の生徒は全体・学級統計から除外される", () => {
@@ -268,13 +285,15 @@ describe("calculateStatisticsForStudent", () => {
       "s1",
       80,
       allData,
-      allData,
+      classOf(allData),
       emptyRates,
       emptyRates
     )
 
     // s2(null)を除外して s1(80) と s3(60) のみで平均 = 70
     expect(result.overall.average).toBe(70)
+    // 学級平均も同じ母集団なので 70
+    expect(result.classes[0].average).toBe(70)
   })
 
   it("全員 null の場合は平均0・標準偏差0", () => {
@@ -287,7 +306,7 @@ describe("calculateStatisticsForStudent", () => {
       "s1",
       null,
       allData,
-      allData,
+      classOf(allData),
       emptyRates,
       emptyRates
     )
@@ -308,7 +327,7 @@ describe("calculateStatisticsForStudent", () => {
       "s1",
       0,
       allData,
-      allData,
+      classOf(allData),
       emptyRates,
       emptyRates
     )
@@ -317,5 +336,60 @@ describe("calculateStatisticsForStudent", () => {
     expect(result.overall.average).toBe(50)
     // 0点の生徒は順位2位
     expect(result.personal.overallRank).toBe(2)
+  })
+
+  it("studentReport 学級が未選択（空配列）なら学級統計は空", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: 80 }),
+      createScoringData({ studentId: "s2", totalScore: 60 }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s1",
+      80,
+      allData,
+      [],
+      emptyRates,
+      emptyRates
+    )
+
+    expect(result.classes).toEqual([])
+  })
+
+  it("複数の studentReport 学級に属する生徒は学級ごとの統計を持つ", () => {
+    const allData: ScoringData[] = [
+      createScoringData({ studentId: "s1", totalScore: 80 }),
+      createScoringData({ studentId: "s2", totalScore: 60 }),
+      createScoringData({ studentId: "s3", totalScore: 40 }),
+    ]
+
+    const result = calculateStatisticsForStudent(
+      "s1",
+      80,
+      allData,
+      [
+        {
+          classId: "cA",
+          className: "A組",
+          grade: null,
+          memberStudentIds: ["s1", "s2"], // 平均=70・s1は1位
+        },
+        {
+          classId: "cB",
+          className: "B組",
+          grade: null,
+          memberStudentIds: ["s1", "s3"], // 平均=60・s1は1位
+        },
+      ],
+      emptyRates,
+      emptyRates
+    )
+
+    expect(result.classes).toHaveLength(2)
+    expect(result.classes[0].average).toBe(70)
+    expect(result.classes[0].rank).toBe(1)
+    expect(result.classes[0].total).toBe(2)
+    expect(result.classes[1].average).toBe(60)
+    expect(result.classes[1].rank).toBe(1)
   })
 })

--- a/__tests__/exam/integration/examStudentClass.test.ts
+++ b/__tests__/exam/integration/examStudentClass.test.ts
@@ -17,7 +17,12 @@ vi.mock("../../../electron-src/lib/prisma/client", async () => {
   }
 })
 
-import { addStudentsFromClass } from "@/electron-src/lib/prisma/examClass"
+import {
+  addStudentsFromClass,
+  getClassMembersForExam,
+  getStudentClassInfo,
+  getStudentClassInfoForExam,
+} from "@/electron-src/lib/prisma/examClass"
 import {
   getClassesNotInExam,
   getStudentsForExam,
@@ -220,6 +225,76 @@ describe("Exam 在籍フィルタ", () => {
 
       // active は追加済みなので候補に残らない
       expect(result.students).toHaveLength(0)
+    })
+  })
+
+  // P3修正: 在籍解決（採番・表示）も受験日基準で判定する
+  describe("getStudentClassInfoForExam（受験日スナップショット）", () => {
+    it("受験日時点で在籍する生徒のみ学級情報を解決する", async () => {
+      const { exam, classA, active, left } = await createTestData()
+      // administered=true の ExamClass を作る（両方を受験者に追加）
+      await addStudentsFromClass(exam.id, classA.id, false)
+
+      const info = await getStudentClassInfoForExam(exam.id)
+
+      // 受験日(2024-04-10)に在籍中の active のみ解決。転出済み left は除外
+      expect(Object.keys(info)).toEqual([active.id])
+      expect(info[active.id].className).toBe("3年A組")
+      expect(info[active.id].attendanceNumber).toBe(1)
+      expect(info[left.id]).toBeUndefined()
+    })
+
+    it("getStudentClassInfo は受験日に在籍しない生徒へ null を返す", async () => {
+      const { exam, classA, active, left } = await createTestData()
+      await addStudentsFromClass(exam.id, classA.id, false)
+
+      const activeInfo = await getStudentClassInfo(exam.id, active.id)
+      expect(activeInfo.className).toBe("3年A組")
+      expect(activeInfo.attendanceNumber).toBe(1)
+
+      const leftInfo = await getStudentClassInfo(exam.id, left.id)
+      expect(leftInfo.className).toBeNull()
+      expect(leftInfo.attendanceNumber).toBeNull()
+    })
+  })
+
+  // Phase 1: 登録学級ごとの集計エンジン（受験日基準・重複カウント）
+  describe("getClassMembersForExam（集計エンジン）", () => {
+    it("登録学級ごとに受験日所属生徒を返し、1人が複数学級に重複カウントされる", async () => {
+      const { exam, classA, active, left } = await createTestData()
+
+      // 第2学級（バスケ部）を作り、active を classA/classB の両方に所属させる
+      const classB = await testPrisma.class.create({
+        data: { name: "バスケ部", grade: 3 },
+      })
+      await testPrisma.studentClassMembership.create({
+        data: {
+          studentId: active.id,
+          classId: classB.id,
+          attendanceNumber: 5,
+          startDate: new Date("2024-04-01"),
+        },
+      })
+
+      // 両学級を試験へ登録
+      await addStudentsFromClass(exam.id, classA.id, false)
+      await addStudentsFromClass(exam.id, classB.id, false)
+
+      const members = await getClassMembersForExam(exam.id)
+
+      const a = members.find((m) => m.classId === classA.id)!
+      const b = members.find((m) => m.classId === classB.id)!
+
+      // classA: 受験日在籍の active のみ（転出済み left は除外）
+      expect(a.studentIds).toEqual([active.id])
+      // classB: active（複数学級に重複カウント）
+      expect(b.studentIds).toEqual([active.id])
+      // left はどの学級の集計にも含まれない
+      expect(members.flatMap((m) => m.studentIds)).not.toContain(left.id)
+      // 生徒ごと追加した学級は teacherStat / studentReport が true
+      expect(a.teacherStat).toBe(true)
+      expect(a.studentReport).toBe(true)
+      expect(b.teacherStat).toBe(true)
     })
   })
 })

--- a/__tests__/exam/integration/subtotalGroupSelection.test.ts
+++ b/__tests__/exam/integration/subtotalGroupSelection.test.ts
@@ -1,0 +1,101 @@
+/**
+ * 小計グループ出力選択フラグ（Phase 4c）の統合テスト
+ *
+ * source of truth は ExamSubtotalGroup.selectedForTable/selectedForBoxPlot。
+ * get/set がフラグを正しく往復し、enabled とは独立に保持されることを検証する。
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import {
+  getSubtotalGroupSelection,
+  setSubtotalGroupSelection,
+} from "@/electron-src/lib/prisma/subtotalGroup"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 試験 + 小計グループ3つ + ExamSubtotalGroup junction を作成 */
+async function createTestData() {
+  const exam = await testPrisma.exam.create({
+    data: { examName: "テスト試験", examDate: new Date("2024-04-10") },
+  })
+
+  const groupIds: string[] = []
+  for (const name of ["国語", "数学", "英語"]) {
+    const group = await testPrisma.subtotalGroup.create({ data: { name } })
+    await testPrisma.examSubtotalGroup.create({
+      data: { examId: exam.id, subtotalGroupId: group.id },
+    })
+    groupIds.push(group.id)
+  }
+
+  return { exam, groupIds }
+}
+
+describe("小計グループ出力選択フラグ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("初期状態は全フラグ false（空配列）", async () => {
+    const { exam } = await createTestData()
+    const sel = await getSubtotalGroupSelection(exam.id)
+    expect(sel.success).toBe(true)
+    expect(sel.tableGroupIds).toEqual([])
+    expect(sel.boxPlotGroupIds).toEqual([])
+  })
+
+  it("set した選択が get で往復する", async () => {
+    const { exam, groupIds } = await createTestData()
+    const [g1, g2, g3] = groupIds
+
+    await setSubtotalGroupSelection(exam.id, [g1, g2], [g3])
+
+    const sel = await getSubtotalGroupSelection(exam.id)
+    expect(sel.tableGroupIds.sort()).toEqual([g1, g2].sort())
+    expect(sel.boxPlotGroupIds).toEqual([g3])
+  })
+
+  it("set は指定外グループのフラグを false にリセットする", async () => {
+    const { exam, groupIds } = await createTestData()
+    const [g1, g2] = groupIds
+
+    await setSubtotalGroupSelection(exam.id, [g1, g2], [])
+    await setSubtotalGroupSelection(exam.id, [g1], []) // g2 を外す
+
+    const sel = await getSubtotalGroupSelection(exam.id)
+    expect(sel.tableGroupIds).toEqual([g1])
+  })
+
+  it("空配列を set すると全フラグが false になる", async () => {
+    const { exam, groupIds } = await createTestData()
+    await setSubtotalGroupSelection(exam.id, groupIds, groupIds)
+    await setSubtotalGroupSelection(exam.id, [], [])
+
+    const sel = await getSubtotalGroupSelection(exam.id)
+    expect(sel.tableGroupIds).toEqual([])
+    expect(sel.boxPlotGroupIds).toEqual([])
+  })
+})

--- a/__tests__/helpers/testExamBuilder.ts
+++ b/__tests__/helpers/testExamBuilder.ts
@@ -260,7 +260,8 @@ export async function createFullTestExam(
       examId: exam.id,
       classId: cls.id,
       administered: true,
-      statistics: true,
+      teacherStat: true,
+      studentReport: true,
       order: 0,
     },
   })

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -423,7 +423,8 @@ export async function seedExamWithScoring(
         examId,
         classId,
         administered: true,
-        statistics: true,
+        teacherStat: true,
+        studentReport: true,
       },
     })
   }
@@ -730,7 +731,8 @@ export async function seedSimpleExam(
       examId,
       classId: classAId,
       administered: true,
-      statistics: true,
+      teacherStat: true,
+      studentReport: true,
     },
   })
   await db.examPage.create({

--- a/docs/class-statistics-redesign.md
+++ b/docs/class-statistics-redesign.md
@@ -3,7 +3,7 @@
 試験(Exam)における「学級」の扱い — 採番・統計・出力 — を作り直すための設計文書。
 成績(Grade)・資料(Coursework)への共通化も含む。
 
-最終更新: 2026-06-29 / ステータス: 設計確定。学級再設計(Phase 0-5)は未実装。統計強化(11章)は **#833/#838/#834 すべて実装完了**（α係数・D値・S-P表・得点度数分布・R/exametrikaエクスポート。Excel/プレビュー配線済、typecheck・lint・テスト86件パス）。
+最終更新: 2026-06-30 / ステータス: 統計強化(11章 #833/#838/#834)は実装完了・コミット済(`3c99fc8a`)。**学級再設計は Phase 0〜4c 実装完了・未コミット**（受験日統一/集計エンジン/スキーマ＋移行/statistics削除/05簡素化/08統計対象学級タブ/Excel学級平均行/個人成績表の複数学級比較/小計グループのフラグ移行）。フルテスト 862 passed・1 failed(既存の grade 日付相対・無関係)、typecheck クリーン。**残り: Phase 5(UI共通化＋削除2段階modal)。詳細は 12 章。**
 
 ---
 
@@ -362,9 +362,24 @@ CLAUDE.md の規則に従う（`prisma migrate dev` / 手書き migration.sql＋
   - **テスト**: `__tests__/calculations/itemAnalysisStats.test.ts`（11件）/`spAnalysis.test.ts`（8件）。
     `npx vitest run __tests__/calculations/` で計86件パス。typecheck・lint クリーン。
 
-### 12.2 次にやること
+### 12.1.5 学級再設計 Phase 0〜4a 実装完了（2026-06-29、未コミット）
 
-1. **学級統計の再設計本体**: Phase 0（受験日統一）→ 1 →（2 スキーマ）→ 3 → 4 → 5。統計強化(#833-834)とは独立。
+すべて作業ツリーに保持（未コミット）。フルテスト 856 passed / 1 failed（残り1件は既存の日付相対 grade テスト `gradeStudentCrud`、本変更前から失敗・無関係）。typecheck クリーン、自分のファイルは lint クリーン。
+
+- **Phase 0 受験日統一（P3）**: `examClass.ts` の在籍解決 `getStudentClassInfoForExam`/`getStudentClassInfo` ＋一覧系 `getExamClasses`/`getAdministeredClasses`（旧 `endDate:null`）を `membershipFilterAt(getExamReferenceDate(examId))` に統一。テスト `__tests__/exam/integration/examStudentClass.test.ts`。
+- **Phase 1 集計エンジン（P1/P2）**: `examClass.ts` に `getClassMembersForExam`（登録学級→受験日所属生徒・**重複カウント**）新設。`excel/dataFetcher.ts` の表示用学級情報を `memberships[0]` → order解決値へ（individual-report も `fetchExportData` 経由で是正）。フォールバック付き。
+- **Phase 2 スキーマ＋移行**: `ExamClass` に `teacherStat`/`studentReport`、`ExamSubtotalGroup` に `selectedForTable`/`selectedForBoxPlot` 追加。migration `20260629120000_class_output_flags`（列追加＋ `teacherStat=旧statistics` / `studentReport=administered` の値移行）。archive `CURRENT_VERSION 1.15.0`（新フラグ optional、creator は旧フラグから補完、トランスフォーマー不要＝範囲方式）。
+  - **⚠️ 実DBに適用済み**: `npm run dev` 起動時に `migrationDeployer` が `data/database.db` へ自動適用済み（teacherStat/studentReport あり、statistics 無し）。コードは未コミットだが**DBは先行**している。
+- **Phase 3 statistics 完全削除＋UI**: schema から `statistics` 削除＋ `20260629130000_drop_examclass_statistics`（実DB適用済み）。`getStatisticsClasses` 関数・IPC・preload・d.ts・05チェックボックスを全撤去。05は「再採番」のみに簡素化。08左カードに **「統計対象学級」タブ**（`StatClassSelector`、教員集計/生徒表示の2列チェック）を追加。
+  - **⚠️ 消し残り注意**: `statistics` 書き込みは examClass.ts だけでなく `import/exam-archive/dataCreator.ts`・`import/merge/idIntegrationImporter.ts`・テストヘルパー（`testExamBuilder`/`seed-in-test`）にも在った。Prisma7 の create 入力型が緩く typecheck で全部は捕捉できない→ **grep で全 `statistics:` 書き込みを洗うこと**。
+- **Phase 4a Excel学級平均行（主成果）**: `excel/averageRows.ts` `appendClassAverageRows`（全体平均＋teacherStat学級ごとの平均、母集団=学級全体・全受験生徒データから集計）。`sheetCreators.createScoreSheet` に配線、`excelExportMain` で `fetchExportData(examId,[])`＋teacherStat学級を取得して渡す。テスト `__tests__/calculations/classAverageRows.test.ts`。
+- **Phase 4b 個人成績表の複数学級比較（2026-06-30 実装）**: `StatisticsData.class`（単一）→ `classes: ClassStatEntry[]`（学級ごと average/stdDev/boxPlot/total/rank＋`memberStudentIds`）。`personal.classRank` 廃止→各エントリ `rank` へ。`statisticsCalculator.calculateStatisticsForStudent` は第4引数を `StudentClassForStats[]` に変更し学級ごと算出。`dataFetcher` が `getClassMembersForExam(examId).filter(studentReport)` ∩ 本人所属で `studentClasses` を構築。renderer `computeReportData.computeFilteredStats` は `memberStudentIds` で母集団を絞って再計算、`buildStatsItems` は学級ごとに「学級平均/順位」を展開（複数時は学級名付きラベル）。**消費は types/statisticsCalculator/dataFetcher/computeReportData の4ファイルのみ**（BoxPlotChart/ScoreTablePreview は `statistics.class` 不使用、generatePrintHtml は buildStatsItems 経由で自動対応）。テスト更新 `statisticsCalculator.test.ts`/`computeReportData.test.ts`（複数学級・空学級ケース追加）。
+- **Phase 4c 小計グループのフラグ移行（2026-06-30 実装）**: source of truth を settingsJson から `ExamSubtotalGroup.selectedForTable/selectedForBoxPlot` へ。prisma `getSubtotalGroupSelection`/`setSubtotalGroupSelection`（指定外を false リセット）＋IPC `get/set-subtotal-group-selection`＋preload＋`cropRegionApi.d.ts`。`useExportPage`：読込時にフラグから `selectedGroupIds` を hydrate、保存時に `setSubtotalGroupSelection` 書込＋JSONから `selectedGroupIds` を `[]` 除去（`enabled` は JSON 維持）。migration `20260629140000_backfill_subtotal_selection_flags`（`json_each` で enabled=true の選択のみバックフィル、deployer の `;` 分割で2文・temp DB 検証済み）。レンダリングフィルタ `filterSubtotalScores` は selectedGroupIds 流用で無改修。アーカイブは Phase 2 で対応済み（dataCollector/dataCreator/型）。亡霊IDは ExamSubtotalGroup の FK カスケード削除で解消。テスト `__tests__/exam/integration/subtotalGroupSelection.test.ts`（4件）。
+  - **フルテスト 862 passed / 1 failed**（残り1件は既存の日付相対 grade `gradeStudentCrud`、無関係）。typecheck クリーン。
+
+### 12.2 次にやること（Phase 5）
+
+- **Phase 5 UI共通化**: `src/components/common/class-roster/ClassRosterManager.tsx` 抽出（flagColumns 可変＝試験は再採番1列・成績/資料は0列）、3エンティティ（試験/成績/資料）の学級登録UI移行、**削除2段階modal**（3章：所属データ有無で分岐）、grade/coursework に class reorder API（`setClassOrders`）。教員用/生徒用フラグ(teacherStat/studentReport)は05に出さず08側UIで操作（既存）。
 
 ### 12.3 実装上の不変条件（壊さないこと）
 
@@ -373,4 +388,6 @@ CLAUDE.md の規則に従う（`prisma migrate dev` / 手書き migration.sql＋
 - 学級平均の母集団は **学級全体**（生徒選択チェックは母集団に無関係、5.1）。
 - 用途1（採番）は1人1学級、用途2/3（教員/生徒統計）は重複カウント（2.4）。
 - エンティティ参照はJSONに入れない（4.1）。
+- 既定値（合意 2026-06-29）: **teacherStat=旧statistics**（生徒ごと追加=true/登録だけ=false）、**studentReport=administered**。`statistics` は廃止。
+- **並行セッション注意**: 別 Claude が同一ツリーで grade/coursework を編集中。schema.prisma・テストDB(`data/test-database.db`) を共有し、同時テストで `prisma db push` が "table User already exists" で衝突する。git 操作・テストは衝突回避を意識。自分のファイルのみ add。
 - 検証は常に `npx vitest run` ＋ `npm run typecheck`。

--- a/electron-src/ipc-handlers/examClassHandlers.ts
+++ b/electron-src/ipc-handlers/examClassHandlers.ts
@@ -5,7 +5,6 @@ import {
   getAdministeredClasses,
   getAvailableClassesForExam,
   getExamClasses,
-  getStatisticsClasses,
   getStudentClassInfo,
   getStudentClassInfoForExam,
   removeExamClass,
@@ -27,11 +26,6 @@ export function setupExamClassHandlers(): void {
   // Get administered classes (for adding students)
   registerHandler("exam-class:get-administered", async (examId: string) => {
     return await getAdministeredClasses(examId)
-  })
-
-  // Get statistics classes (for aggregation)
-  registerHandler("exam-class:get-statistics", async (examId: string) => {
-    return await getStatisticsClasses(examId)
   })
 
   // Add a class to a exam

--- a/electron-src/ipc-handlers/subtotalGroupHandlers.ts
+++ b/electron-src/ipc-handlers/subtotalGroupHandlers.ts
@@ -5,7 +5,9 @@ import {
   getActiveSubtotalGroupsForExam,
   getAvailableSubtotalGroupsForExam,
   getSubtotalGroups,
+  getSubtotalGroupSelection,
   removeSubtotalGroupFromExam,
+  setSubtotalGroupSelection,
   updateSubtotalGroup,
 } from "../lib/prisma/subtotalGroup"
 import { registerSafeHandler } from "./ipcHandlerUtils"
@@ -82,6 +84,30 @@ export function setupSubtotalGroupHandlers(): void {
     "remove-subtotal-group-from-exam",
     async (examId: string, subtotalGroupId: string) => {
       return await removeSubtotalGroupFromExam(examId, subtotalGroupId)
+    }
+  )
+
+  // 小計グループの出力選択フラグ取得（個人成績表のテーブル/箱ひげ図）
+  registerSafeHandler(
+    "get-subtotal-group-selection",
+    async (examId: string) => {
+      return await getSubtotalGroupSelection(examId)
+    }
+  )
+
+  // 小計グループの出力選択フラグ設定
+  registerSafeHandler(
+    "set-subtotal-group-selection",
+    async (
+      examId: string,
+      tableGroupIds: string[],
+      boxPlotGroupIds: string[]
+    ) => {
+      return await setSubtotalGroupSelection(
+        examId,
+        tableGroupIds,
+        boxPlotGroupIds
+      )
     }
   )
 }

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -533,6 +533,8 @@ export async function collectExamData(
             id: psg.id,
             examId: psg.examId,
             subtotalGroupId: psg.subtotalGroupId,
+            selectedForTable: psg.selectedForTable,
+            selectedForBoxPlot: psg.selectedForBoxPlot,
             createdAt: psg.createdAt.toISOString(),
             updatedAt: psg.updatedAt.toISOString(),
           }))
@@ -544,7 +546,8 @@ export async function collectExamData(
             examId: pc.examId,
             classId: pc.classId,
             administered: pc.administered,
-            statistics: pc.statistics,
+            teacherStat: pc.teacherStat,
+            studentReport: pc.studentReport,
             order: pc.order,
             createdAt: pc.createdAt.toISOString(),
             updatedAt: pc.updatedAt.toISOString(),

--- a/electron-src/lib/export/excel/averageRows.ts
+++ b/electron-src/lib/export/excel/averageRows.ts
@@ -1,0 +1,109 @@
+import type { CropRegion } from "@prisma/client"
+import * as ExcelJS from "exceljs"
+
+import type { ExamClassMembers } from "../../prisma/examClass"
+import type { ScoringData } from "../../shared/types/exportTypes"
+import { applyCellStyle } from "../../shared/utilities/excelUtilities"
+import type { SubtotalColumn } from "./dataFetcher"
+
+/** null を除いた平均（小数1桁）。対象が無ければ null */
+function average(values: (number | null | undefined)[]): number | null {
+  const v = values.filter((x): x is number => x != null)
+  if (v.length === 0) return null
+  return Math.round((v.reduce((a, b) => a + b, 0) / v.length) * 10) / 10
+}
+
+/** 指定生徒集合の 合計点／小計／設問 の平均行（ヘッダー列順）を作る */
+function buildAverageRow(
+  label: string,
+  students: ScoringData[],
+  subtotalColumns: SubtotalColumn[],
+  questionRegions: CropRegion[]
+): (string | number)[] {
+  const totalAvg = average(students.map((s) => s.totalScore))
+  const subtotalAvgs = subtotalColumns.map((col) =>
+    average(
+      students.map(
+        (s) =>
+          s.subtotalScores.find((x) => x.subtotalId === col.subtotalId)?.score
+      )
+    )
+  )
+  const questionAvgs = questionRegions.map((region) =>
+    average(
+      students.map((s) => {
+        const sc = s.scores.find((x) => x.questionId === region.id)
+        // 未採点は集計から除外（null）
+        return sc && sc.status !== "unscored" ? sc.score : null
+      })
+    )
+  )
+
+  // 列順: 受験状態,順位,学年,学級,出席番号,学籍番号,氏名,合計点,...小計,...設問
+  return [
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    label,
+    totalAvg ?? "",
+    ...subtotalAvgs.map((v) => v ?? ""),
+    ...questionAvgs.map((v) => v ?? ""),
+  ]
+}
+
+/**
+ * 学級平均行を点数一覧シートへ追加する（Phase 4・主成果）
+ *
+ * - 1行目: 全体平均（受験者＝合計点 non-null）
+ * - 以降: teacherStat=true の登録学級ごとの学級平均
+ *   母集団は「学級全体」（受験日所属者・getClassMembersForExam）。生徒選択チェックとは無関係。
+ *   1人の生徒は所属する全学級の平均に重複カウントされる。
+ *
+ * @param allScoringData 全受験生徒の採点データ（選択生徒ではなく試験全体）
+ * @param teacherStatClasses teacherStat=true の登録学級（受験日所属生徒つき）
+ */
+export function appendClassAverageRows(
+  worksheet: ExcelJS.Worksheet,
+  allScoringData: ScoringData[],
+  teacherStatClasses: ExamClassMembers[],
+  subtotalColumns: SubtotalColumn[],
+  questionRegions: CropRegion[]
+): void {
+  if (allScoringData.length === 0) return
+
+  // 区切りの空行
+  worksheet.addRow([])
+
+  // 全体平均
+  const overallRow = worksheet.addRow(
+    buildAverageRow(
+      "全体平均",
+      allScoringData,
+      subtotalColumns,
+      questionRegions
+    )
+  )
+  overallRow.eachCell((cell) => applyCellStyle(cell, "total"))
+
+  // 学級ごとの平均（teacherStat=true）
+  const byId = new Map(allScoringData.map((s) => [s.studentId, s]))
+  for (const cls of teacherStatClasses) {
+    const members = cls.studentIds
+      .map((id) => byId.get(id))
+      .filter((s): s is ScoringData => s !== undefined)
+    if (members.length === 0) continue
+
+    const row = worksheet.addRow(
+      buildAverageRow(
+        `${cls.className}平均`,
+        members,
+        subtotalColumns,
+        questionRegions
+      )
+    )
+    row.eachCell((cell) => applyCellStyle(cell, "subtotal"))
+  }
+}

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -2,6 +2,7 @@ import type { CropRegion, Exam, ExamStudent, Student } from "@prisma/client"
 
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
 import { getExamById } from "../../prisma/exam"
+import { getStudentClassInfoForExam } from "../../prisma/examClass"
 import { getStudentsForExam } from "../../prisma/examStudent"
 import { getQuestionScoresForExam } from "../../prisma/questionScore"
 import { getScoreDecisionsForExam } from "../../prisma/scoreDecision"
@@ -78,6 +79,10 @@ export async function fetchExportData(
       return { success: false, error: "生徒データの取得に失敗しました" }
     }
 
+    // 表示用の学級・出席番号は受験日スナップショット＋order解決で決定（P1修正）。
+    // memberships[0]（startDate降順の先頭＝偶然の値）には依存しない。
+    const classInfoMap = await getStudentClassInfoForExam(examId)
+
     const cropRegions = await getCropRegionsByExamId(examId)
     const questionScoresResult = await getQuestionScoresForExam(examId)
     const decisionsResult = await getScoreDecisionsForExam(examId)
@@ -104,7 +109,10 @@ export async function fetchExportData(
           selectedStudentIds.includes(student.id)
       )
       .map((student) => {
-        // 最新の学級情報を取得（memberships配列の最初の要素）
+        // 受験日スナップショット＋order優先で解決した学級情報を使う（P1修正）
+        const resolved = classInfoMap[student.id]
+
+        // 解決不能時（administered学級に未所属等）は memberships[0] へフォールバック
         const studentWithMemberships = student as typeof student & {
           memberships?: Array<{
             attendanceNumber?: number | null
@@ -115,14 +123,19 @@ export async function fetchExportData(
             }
           }>
         }
-        const latestMembership = studentWithMemberships.memberships?.[0]
-        const classInfo = latestMembership?.class
+        const fallbackMembership = studentWithMemberships.memberships?.[0]
+        const fallbackClass = fallbackMembership?.class
+
+        const grade = resolved?.grade ?? fallbackClass?.grade ?? null
+        const className = resolved?.className ?? fallbackClass?.name
+        const attendanceNumber =
+          resolved?.attendanceNumber ?? fallbackMembership?.attendanceNumber
 
         return {
           ...student,
-          grade: classInfo?.grade?.toString(),
-          className: classInfo?.name,
-          attendanceNumber: latestMembership?.attendanceNumber,
+          grade: grade != null ? grade.toString() : undefined,
+          className: className ?? undefined,
+          attendanceNumber: attendanceNumber ?? undefined,
         }
       })
       .sort((a, b) => {

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -1,5 +1,6 @@
 import * as ExcelJS from "exceljs"
 
+import { getClassMembersForExam } from "../../prisma/examClass"
 import {
   ExportGradingDataOptions,
   ExportResult,
@@ -61,15 +62,30 @@ export async function exportGradingDataExcel(
       }
     }
 
+    // 学級平均行の母集団は「試験全体」（生徒選択に無関係）。全受験生徒の採点データと
+    // teacherStat=true の登録学級（受験日所属生徒つき）を取得する。
+    const allDataResult =
+      selectedStudentIds.length === 0
+        ? dataResult
+        : await fetchExportData(examId, [])
+    const allScoringData = allDataResult.success
+      ? (allDataResult.scoringData ?? [])
+      : []
+    const teacherStatClasses = (await getClassMembersForExam(examId)).filter(
+      (c) => c.teacherStat
+    )
+
     // Excelワークブック作成
     const workbook = new ExcelJS.Workbook()
 
-    // 点数一覧シート作成
+    // 点数一覧シート作成（全体平均・学級平均行つき）
     await createScoreSheet(
       workbook,
       dataResult.questionRegions,
       dataResult.subtotalColumns,
-      dataResult.scoringData
+      dataResult.scoringData,
+      allScoringData,
+      teacherStatClasses
     )
 
     // 正誤一覧シート作成

--- a/electron-src/lib/export/excel/sheetCreators.ts
+++ b/electron-src/lib/export/excel/sheetCreators.ts
@@ -1,8 +1,10 @@
 import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
+import type { ExamClassMembers } from "../../prisma/examClass"
 import { ScoringData } from "../../shared/types/exportTypes"
 import { autoFitColumns } from "../../shared/utilities/excelUtilities"
+import { appendClassAverageRows } from "./averageRows"
 import type { SubtotalColumn } from "./dataFetcher"
 import { createSheetHeaders } from "./headerCreators"
 import { createDataRows } from "./rowCreators"
@@ -20,7 +22,11 @@ export async function createScoreSheet(
   workbook: ExcelJS.Workbook,
   questionRegions: CropRegion[],
   subtotalColumns: SubtotalColumn[],
-  scoringData: ScoringData[]
+  scoringData: ScoringData[],
+  /** 学級平均行の母集団（試験全体の採点データ。選択生徒ではない） */
+  allScoringData: ScoringData[] = [],
+  /** teacherStat=true の登録学級（受験日所属生徒つき） */
+  teacherStatClasses: ExamClassMembers[] = []
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("点数一覧")
 
@@ -29,6 +35,15 @@ export async function createScoreSheet(
 
   // データ行の作成
   await createDataRows(worksheet, scoringData, subtotalColumns, true)
+
+  // 全体平均・学級平均行（Phase 4・主成果）
+  appendClassAverageRows(
+    worksheet,
+    allScoringData,
+    teacherStatClasses,
+    subtotalColumns,
+    questionRegions
+  )
 
   // スタイル適用
   autoFitColumns(worksheet)

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -6,6 +6,7 @@ import type { CropRegion } from "@prisma/client"
 
 import prisma from "../../prisma/client"
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
+import { getClassMembersForExam } from "../../prisma/examClass"
 import { getQuestionScoresForExam } from "../../prisma/questionScore"
 import { getScoreDecisionsForExam } from "../../prisma/scoreDecision"
 import { getActiveSubtotalGroupsForExam } from "../../prisma/subtotalGroup"
@@ -24,6 +25,7 @@ import {
   calculateQuestionCorrectRates,
   calculateQuestionScoreRates,
   calculateStatisticsForStudent,
+  type StudentClassForStats,
 } from "./statisticsCalculator"
 import type {
   ExamInfoForReport,
@@ -126,6 +128,12 @@ export async function fetchIndividualReportData(
     const questionCorrectRates = calculateQuestionCorrectRates(allScoringData)
     const questionScoreRates = calculateQuestionScoreRates(allScoringData)
 
+    // 生徒表示（studentReport）対象の登録学級と、その受験日所属生徒を取得。
+    // 各生徒の学級比較は「studentReport 選択学級 ∩ 本人の所属学級」（複数学級対応）。
+    const studentReportClasses = (await getClassMembersForExam(examId)).filter(
+      (c) => c.studentReport
+    )
+
     // 各生徒のレポートデータを構築
     const reports: IndividualReportData[] = selectedScoringData.map(
       (scoringData) => {
@@ -139,19 +147,22 @@ export async function fetchIndividualReportData(
           attendanceNumber: scoringData.attendanceNumber ?? null,
         }
 
-        // 学級データを抽出（同じ学級の生徒のスコア）
-        const classScoringData = allScoringData.filter(
-          (d) =>
-            d.className === scoringData.className &&
-            d.grade === scoringData.grade
-        )
+        // 本人が所属する studentReport 学級を抽出（複数学級対応）
+        const studentClasses: StudentClassForStats[] = studentReportClasses
+          .filter((c) => c.studentIds.includes(scoringData.studentId))
+          .map((c) => ({
+            classId: c.classId,
+            className: c.className,
+            grade: c.grade != null ? String(c.grade) : null,
+            memberStudentIds: c.studentIds,
+          }))
 
         // 統計データ（subtotalScoresから直接グループ情報を取得可能）
         const statistics = calculateStatisticsForStudent(
           scoringData.studentId,
           scoringData.totalScore,
           allScoringData,
-          classScoringData,
+          studentClasses,
           questionCorrectRates,
           questionScoreRates
         )

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -8,11 +8,23 @@ import type {
 } from "../../shared/types/exportTypes"
 import type {
   BoxPlotData,
+  ClassStatEntry,
   RawTotalScoreEntry,
   StatisticsData,
   SubtotalRawScores,
   SubtotalStatistics,
 } from "./types"
+
+/**
+ * 統計算出に渡す学級情報（studentReport 選択学級 ∩ 本人の受験日所属学級）
+ */
+export interface StudentClassForStats {
+  classId: string
+  className: string
+  grade: string | null
+  /** 当該学級の受験日所属生徒ID（学級全体が母集団） */
+  memberStudentIds: string[]
+}
 
 /**
  * 配列の平均値を計算
@@ -323,20 +335,20 @@ export function getDiscriminationLevel(r: number | null): DiscriminationLevel {
 
 /**
  * 特定の生徒の統計データを計算
+ *
+ * @param studentClasses - studentReport 選択学級 ∩ 本人の受験日所属学級。
+ *   各学級全体を母集団として学級平均・順位を算出（複数学級対応）。
  */
 export function calculateStatisticsForStudent(
   _studentId: string,
   studentScore: number | null,
   allScoringData: ScoringData[],
-  classScoringData: ScoringData[],
+  studentClasses: StudentClassForStats[],
   questionCorrectRates: Record<string, number>,
   questionScoreRates: Record<string, number>
 ): StatisticsData {
   // 全体のスコア配列（null を除外）
   const allScores = allScoringData
-    .map((d) => d.totalScore)
-    .filter((s): s is number => s !== null)
-  const classScores = classScoringData
     .map((d) => d.totalScore)
     .filter((s): s is number => s !== null)
 
@@ -345,10 +357,34 @@ export function calculateStatisticsForStudent(
   const overallStdDev = calculateStdDev(allScores)
   const overallBoxPlot = calculateBoxPlotData(allScores)
 
-  // 学級統計
-  const classAverage = calculateAverage(classScores)
-  const classStdDev = calculateStdDev(classScores)
-  const classBoxPlot = calculateBoxPlotData(classScores)
+  // studentId → 合計点の索引（学級母集団の絞り込み用）
+  const scoreByStudentId = new Map(
+    allScoringData.map((d) => [d.studentId, d.totalScore] as const)
+  )
+
+  // 学級別統計（studentReport 選択学級ごと。母集団＝当該学級全体）
+  const classes: ClassStatEntry[] = studentClasses.map((cls) => {
+    // allScoringData に存在する所属生徒のみ（在籍はするが採点対象外を除外）
+    const presentIds = cls.memberStudentIds.filter((id) =>
+      scoreByStudentId.has(id)
+    )
+    const classScores = presentIds
+      .map((id) => scoreByStudentId.get(id) ?? null)
+      .filter((s): s is number => s !== null)
+
+    return {
+      classId: cls.classId,
+      className: cls.className,
+      grade: cls.grade,
+      memberStudentIds: cls.memberStudentIds,
+      average: calculateAverage(classScores),
+      stdDev: calculateStdDev(classScores),
+      boxPlot: calculateBoxPlotData(classScores),
+      total: presentIds.length,
+      rank:
+        studentScore !== null ? calculateRank(studentScore, classScores) : 0,
+    }
+  })
 
   // 個人統計（studentScore === null の場合は deviation=0, rank=0）
   const deviation =
@@ -357,8 +393,6 @@ export function calculateStatisticsForStudent(
       : 0
   const overallRank =
     studentScore !== null ? calculateRank(studentScore, allScores) : 0
-  const classRank =
-    studentScore !== null ? calculateRank(studentScore, classScores) : 0
 
   // 小計別統計（SubtotalScoreから直接グループ情報を取得）
   const subtotalStatistics = calculateSubtotalStatistics(allScoringData)
@@ -382,16 +416,10 @@ export function calculateStatisticsForStudent(
       boxPlot: overallBoxPlot,
       total: allScoringData.length,
     },
-    class: {
-      average: classAverage,
-      stdDev: classStdDev,
-      boxPlot: classBoxPlot,
-      total: classScoringData.length,
-    },
+    classes,
     personal: {
       deviation,
       overallRank,
-      classRank,
     },
     questionCorrectRates,
     questionScoreRates,

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -188,6 +188,30 @@ export interface SubtotalGroupSelection {
   selectedGroupIds: string[]
 }
 
+/**
+ * 学級別統計（個人成績表の複数学級比較用）
+ *
+ * 母集団は「studentReport 選択学級 ∩ 本人の受験日所属学級」の各学級全体。
+ * 1人の生徒が複数の studentReport 学級に属する場合は複数エントリになる。
+ */
+export interface ClassStatEntry {
+  classId: string
+  className: string
+  grade: string | null
+  /**
+   * 当該学級の受験日所属生徒ID（renderer 側の受験状態フィルタ再計算用の母集団）。
+   * rawTotalScores を studentId で絞り込むためのキー。
+   */
+  memberStudentIds: string[]
+  average: number
+  stdDev: number
+  boxPlot: BoxPlotData
+  /** 母集団サイズ（受験状態フィルタ前の在籍生徒数。順位の分母表示に使用） */
+  total: number
+  /** この生徒の当該学級内順位（同点同順位。0=未採点・対象外） */
+  rank: number
+}
+
 /** 統計データ */
 export interface StatisticsData {
   // 全体統計
@@ -198,19 +222,13 @@ export interface StatisticsData {
     total: number
   }
 
-  // 学級統計
-  class: {
-    average: number
-    stdDev: number
-    boxPlot: BoxPlotData
-    total: number
-  }
+  // 学級統計（studentReport 選択学級ごと。複数学級対応）
+  classes: ClassStatEntry[]
 
   // 個人統計
   personal: {
     deviation: number
     overallRank: number
-    classRank: number
   }
 
   // 設問別正答率

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -296,6 +296,9 @@ export async function createImportedData(
               id: remapIdRequired(psg.id, mappings.examSubtotalGroup),
               examId: newExamId,
               subtotalGroupId: newSubtotalGroupId,
+              // v1.15.0+。旧アーカイブには無いので false 既定
+              selectedForTable: psg.selectedForTable ?? false,
+              selectedForBoxPlot: psg.selectedForBoxPlot ?? false,
             },
           })
         }
@@ -311,7 +314,10 @@ export async function createImportedData(
               examId: newExamId,
               classId: newClassId,
               administered: pc.administered,
-              statistics: pc.statistics,
+              // v1.15.0+。旧アーカイブには無いので旧フラグ(statistics/administered)から補完
+              // 教員集計 = 旧 statistics、生徒表示 = 再採番(administered)
+              teacherStat: pc.teacherStat ?? pc.statistics ?? false,
+              studentReport: pc.studentReport ?? pc.administered ?? false,
               order: pc.order,
             },
           })

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -1237,7 +1237,9 @@ async function processExamClasses(
           examId: newExamId,
           classId: newClassId,
           administered: pc.administered,
-          statistics: pc.statistics,
+          // v1.15.0+。旧アーカイブは旧フラグ(statistics/administered)から補完
+          teacherStat: pc.teacherStat ?? pc.statistics ?? false,
+          studentReport: pc.studentReport ?? pc.administered ?? false,
           order: pc.order,
         },
       })

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -40,6 +40,7 @@ import type {
  * - 1.12.0: v0.12.x (Exam.markerCorrectionEnabled 追加 — ASB由来試験のマーク補正既定ONフラグ)
  * - 1.13.0: v0.12.x (ScoreDecision 追加 — OWNERによる確定スコア。QuestionScoreのstatus proposed/final廃止)
  * - 1.14.0: v0.13.x (ReturnSnapshot 追加 — 答案返却版スナップショット。返却後の採点修正差分検出用)
+ * - 1.15.0: v0.14.x (ExamClass に teacherStat/studentReport、ExamSubtotalGroup に selectedForTable/selectedForBoxPlot 追加 — 学級統計再設計。statistics 廃止)
  */
 export type ArchiveVersion =
   | "1.0.0"
@@ -57,9 +58,10 @@ export type ArchiveVersion =
   | "1.12.0"
   | "1.13.0"
   | "1.14.0"
+  | "1.15.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.14.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.15.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -78,6 +80,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.12.0",
   "1.13.0",
   "1.14.0",
+  "1.15.0",
 ] as const
 
 // =============================================================================

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -38,13 +38,15 @@ export interface AddExamClassOptions {
   examId: string
   classId: string
   administered?: boolean
-  statistics?: boolean
+  teacherStat?: boolean
+  studentReport?: boolean
 }
 
 export interface UpdateExamClassOptions {
   id: string
   administered?: boolean
-  statistics?: boolean
+  teacherStat?: boolean
+  studentReport?: boolean
   order?: number
 }
 
@@ -60,13 +62,15 @@ export const getExamClasses = async (
   examId: string
 ): Promise<ExamClassWithClass[]> => {
   try {
+    // 受験日時点で在籍する所属のみ表示（受験日スナップショット）
+    const referenceDate = await getExamReferenceDate(examId)
     return await prisma.examClass.findMany({
       where: { examId },
       include: {
         class: {
           include: {
             memberships: {
-              where: { endDate: null }, // Current memberships only
+              where: membershipFilterAt(referenceDate),
               include: {
                 student: true,
               },
@@ -93,6 +97,8 @@ export const getAdministeredClasses = async (
   examId: string
 ): Promise<ExamClassWithClass[]> => {
   try {
+    // 受験日時点で在籍する所属のみ（受験日スナップショット）
+    const referenceDate = await getExamReferenceDate(examId)
     return await prisma.examClass.findMany({
       where: {
         examId,
@@ -102,7 +108,7 @@ export const getAdministeredClasses = async (
         class: {
           include: {
             memberships: {
-              where: { endDate: null },
+              where: membershipFilterAt(referenceDate),
               include: {
                 student: true,
               },
@@ -123,48 +129,18 @@ export const getAdministeredClasses = async (
 }
 
 /**
- * Get classes marked for statistics aggregation
- */
-export const getStatisticsClasses = async (
-  examId: string
-): Promise<ExamClassWithClass[]> => {
-  try {
-    return await prisma.examClass.findMany({
-      where: {
-        examId,
-        statistics: true,
-      },
-      include: {
-        class: {
-          include: {
-            memberships: {
-              where: { endDate: null },
-              include: {
-                student: true,
-              },
-              orderBy: [
-                { attendanceNumber: "asc" },
-                { student: { studentNumber: "asc" } },
-              ],
-            },
-          },
-        },
-      },
-      orderBy: { createdAt: "asc" },
-    })
-  } catch (error) {
-    console.error(`Failed to get statistics classes for ${examId}:`, error)
-    throw error
-  }
-}
-
-/**
  * Add a class to a exam
  */
 export const addExamClass = async (
   options: AddExamClassOptions
 ): Promise<ExamClassWithDetails> => {
-  const { examId, classId, administered = false, statistics = false } = options
+  const {
+    examId,
+    classId,
+    administered = false,
+    teacherStat = false,
+    studentReport = false,
+  } = options
 
   try {
     // 現在の最大orderを取得して次の順序を決定
@@ -179,7 +155,8 @@ export const addExamClass = async (
         examId,
         classId,
         administered,
-        statistics,
+        teacherStat,
+        studentReport,
         order: nextOrder,
       },
       include: {
@@ -210,14 +187,15 @@ export const addExamClass = async (
 export const updateExamClass = async (
   options: UpdateExamClassOptions
 ): Promise<ExamClassWithDetails> => {
-  const { id, administered, statistics, order } = options
+  const { id, administered, teacherStat, studentReport, order } = options
 
   try {
     return await prisma.examClass.update({
       where: { id },
       data: {
         ...(administered !== undefined && { administered }),
-        ...(statistics !== undefined && { statistics }),
+        ...(teacherStat !== undefined && { teacherStat }),
+        ...(studentReport !== undefined && { studentReport }),
         ...(order !== undefined && { order }),
       },
       include: {
@@ -409,9 +387,12 @@ export const addStudentsFromClass = async (
         examId,
         classId,
         administered: true,
-        statistics: true,
+        teacherStat: true, // 生徒ごと追加した学級は教員集計の対象
+        studentReport: true, // administered なので生徒表示の対象
         order: nextOrder,
       },
+      // 再追加では構造（administered）のみ再宣言し、出力フラグ（teacherStat/studentReport）は
+      // 08 画面で設定したユーザーの選択を尊重して触らない
       update: {
         administered: true,
       },
@@ -495,6 +476,9 @@ export const getStudentClassInfoForExam = async (
   examId: string
 ): Promise<Record<string, StudentClassInfo>> => {
   try {
+    // 受験日時点で在籍する所属のみを解決対象とする（受験日スナップショット）
+    const referenceDate = await getExamReferenceDate(examId)
+
     // 1. administered=true の ExamClass を order 順で取得
     const examClasses = await prisma.examClass.findMany({
       where: {
@@ -505,6 +489,7 @@ export const getStudentClassInfoForExam = async (
         class: {
           include: {
             memberships: {
+              where: membershipFilterAt(referenceDate),
               include: {
                 student: true,
               },
@@ -550,6 +535,9 @@ export const getStudentClassInfo = async (
   studentId: string
 ): Promise<StudentClassInfo> => {
   try {
+    // 受験日時点で在籍する所属のみを解決対象とする（受験日スナップショット）
+    const referenceDate = await getExamReferenceDate(examId)
+
     // administered=true の ExamClass を order 順で取得
     const examClasses = await prisma.examClass.findMany({
       where: {
@@ -560,7 +548,7 @@ export const getStudentClassInfo = async (
         class: {
           include: {
             memberships: {
-              where: { studentId },
+              where: { studentId, ...membershipFilterAt(referenceDate) },
             },
           },
         },
@@ -595,6 +583,76 @@ export const getStudentClassInfo = async (
       `Failed to get student class info for student ${studentId} in exam ${examId}:`,
       error
     )
+    throw error
+  }
+}
+
+/**
+ * 登録学級ごとの所属生徒（集計エンジン・Phase 1）
+ *
+ * 試験に登録された各 ExamClass について、**受験日時点で在籍する**生徒のIDを集める。
+ * 採番（getStudentClassInfoForExam）と異なり、**1人の生徒は所属する全学級に重複カウント**される
+ * （用途2/3の学級平均は「学級全体」を母集団とするため、order優先の単一化はしない）。
+ *
+ * Excel学級平均行（teacherStat）・個人成績表の複数学級比較（studentReport）の土台。
+ * フラグ（teacherStat/studentReport）はPhase 2のスキーマ追加後に拡張する。現状は order 昇順の
+ * 全登録学級を返し、消費側がフィルタする。
+ */
+export interface ExamClassMembers {
+  examClassId: string
+  classId: string
+  className: string
+  classCode: string | null
+  grade: number | null
+  order: number
+  administered: boolean
+  /** 教員集計（Excel学級平均行）の対象か */
+  teacherStat: boolean
+  /** 生徒表示（個人成績表の学級比較）の対象か */
+  studentReport: boolean
+  /** 受験日時点で在籍する生徒ID（出席番号→学籍番号順） */
+  studentIds: string[]
+}
+
+export const getClassMembersForExam = async (
+  examId: string
+): Promise<ExamClassMembers[]> => {
+  try {
+    const referenceDate = await getExamReferenceDate(examId)
+
+    const examClasses = await prisma.examClass.findMany({
+      where: { examId },
+      include: {
+        class: {
+          include: {
+            memberships: {
+              where: membershipFilterAt(referenceDate),
+              orderBy: [
+                { attendanceNumber: "asc" },
+                { student: { studentNumber: "asc" } },
+              ],
+              select: { studentId: true },
+            },
+          },
+        },
+      },
+      orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+    })
+
+    return examClasses.map((ec) => ({
+      examClassId: ec.id,
+      classId: ec.classId,
+      className: ec.class.name,
+      classCode: ec.class.classCode,
+      grade: ec.class.grade,
+      order: ec.order,
+      administered: ec.administered,
+      teacherStat: ec.teacherStat,
+      studentReport: ec.studentReport,
+      studentIds: ec.class.memberships.map((m) => m.studentId),
+    }))
+  } catch (error) {
+    console.error(`Failed to get class members for exam ${examId}:`, error)
     throw error
   }
 }

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -441,6 +441,88 @@ export const getSubtotalGroupsByExamId = async (examId: string) => {
   return []
 }
 
+/**
+ * 小計グループの出力選択フラグを取得する（個人成績表のテーブル/箱ひげ図）。
+ * source of truth は ExamSubtotalGroup.selectedForTable/selectedForBoxPlot（settingsJson ではない）。
+ */
+export async function getSubtotalGroupSelection(examId: string) {
+  try {
+    const links = await prisma.examSubtotalGroup.findMany({
+      where: { examId },
+      select: {
+        subtotalGroupId: true,
+        selectedForTable: true,
+        selectedForBoxPlot: true,
+      },
+    })
+    return {
+      success: true as const,
+      tableGroupIds: links
+        .filter((l) => l.selectedForTable)
+        .map((l) => l.subtotalGroupId),
+      boxPlotGroupIds: links
+        .filter((l) => l.selectedForBoxPlot)
+        .map((l) => l.subtotalGroupId),
+    }
+  } catch (error) {
+    console.error("Error getting subtotal group selection:", error)
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : "Unknown error",
+      tableGroupIds: [],
+      boxPlotGroupIds: [],
+    }
+  }
+}
+
+/**
+ * 小計グループの出力選択フラグを設定する（個人成績表のテーブル/箱ひげ図）。
+ * 指定 ID をフラグ true、それ以外を false にする（亡霊ID排除のため relational に保持）。
+ *
+ * @param tableGroupIds - 小計点テーブルに含める subtotalGroupId 群
+ * @param boxPlotGroupIds - 箱ひげ図に含める subtotalGroupId 群
+ */
+export async function setSubtotalGroupSelection(
+  examId: string,
+  tableGroupIds: string[],
+  boxPlotGroupIds: string[]
+) {
+  try {
+    const tableSet = new Set(tableGroupIds)
+    const boxPlotSet = new Set(boxPlotGroupIds)
+
+    await prisma.$transaction(async (tx) => {
+      const links = await tx.examSubtotalGroup.findMany({
+        where: { examId },
+        select: { id: true, subtotalGroupId: true },
+      })
+      for (const link of links) {
+        await tx.examSubtotalGroup.update({
+          where: { id: link.id },
+          data: {
+            selectedForTable: tableSet.has(link.subtotalGroupId),
+            selectedForBoxPlot: boxPlotSet.has(link.subtotalGroupId),
+          },
+        })
+      }
+    })
+
+    await recordAuditLog({
+      action: "subtotal_group.selection_update",
+      entityType: "ExamSubtotalGroup",
+      entityId: examId,
+    })
+
+    return { success: true as const }
+  } catch (error) {
+    console.error("Error setting subtotal group selection:", error)
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
 /** IDで小計点グループを取得する（subtotals・examSubtotalGroups含む） */
 export const getSubtotalGroupById = async (id: string) => {
   return prisma.subtotalGroup.findUnique({

--- a/electron-src/preload-apis/examClassApi.ts
+++ b/electron-src/preload-apis/examClassApi.ts
@@ -9,20 +9,20 @@ export function createExamClassApi() {
         ipcRenderer.invoke("exam-class:get-all", examId),
       getAdministered: (examId: string) =>
         ipcRenderer.invoke("exam-class:get-administered", examId),
-      getStatistics: (examId: string) =>
-        ipcRenderer.invoke("exam-class:get-statistics", examId),
       getAvailable: (examId: string) =>
         ipcRenderer.invoke("exam-class:get-available", examId),
       add: (options: {
         examId: string
         classId: string
         administered?: boolean
-        statistics?: boolean
+        teacherStat?: boolean
+        studentReport?: boolean
       }) => ipcRenderer.invoke("exam-class:add", options),
       update: (options: {
         id: string
         administered?: boolean
-        statistics?: boolean
+        teacherStat?: boolean
+        studentReport?: boolean
         order?: number
       }) => ipcRenderer.invoke("exam-class:update", options),
       remove: (id: string) => ipcRenderer.invoke("exam-class:remove", id),

--- a/electron-src/preload-apis/subtotalApi.ts
+++ b/electron-src/preload-apis/subtotalApi.ts
@@ -34,6 +34,19 @@ export function createSubtotalApi() {
         examId,
         subtotalGroupId
       ),
+    getSubtotalGroupSelection: (examId: string) =>
+      ipcRenderer.invoke("get-subtotal-group-selection", examId),
+    setSubtotalGroupSelection: (
+      examId: string,
+      tableGroupIds: string[],
+      boxPlotGroupIds: string[]
+    ) =>
+      ipcRenderer.invoke(
+        "set-subtotal-group-selection",
+        examId,
+        tableGroupIds,
+        boxPlotGroupIds
+      ),
 
     // Subtotal related (renamed from QuestionGroupItem)
     createSubtotal: (data: Prisma.SubtotalUncheckedCreateInput) =>

--- a/prisma/migrations/20260629120000_class_output_flags/migration.sql
+++ b/prisma/migrations/20260629120000_class_output_flags/migration.sql
@@ -1,0 +1,14 @@
+-- ExamClass: 教員集計（teacherStat）・生徒表示（studentReport）フラグを追加
+ALTER TABLE "ExamClass" ADD COLUMN "teacherStat" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "ExamClass" ADD COLUMN "studentReport" BOOLEAN NOT NULL DEFAULT false;
+
+-- ExamSubtotalGroup: 小計テーブル・箱ひげ図の選択フラグを追加
+-- （settingsJson の selectedGroupIds からの値移行・読み取り切替は Phase 4 で実施）
+ALTER TABLE "ExamSubtotalGroup" ADD COLUMN "selectedForTable" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "ExamSubtotalGroup" ADD COLUMN "selectedForBoxPlot" BOOLEAN NOT NULL DEFAULT false;
+
+-- データ移行（既存挙動を保つ）
+-- 教員集計 = 旧 statistics（生徒ごと追加した学級=true、登録だけの学級=false）
+UPDATE "ExamClass" SET "teacherStat" = "statistics";
+-- 生徒表示 = 再採番（administered）の学級のみ
+UPDATE "ExamClass" SET "studentReport" = "administered";

--- a/prisma/migrations/20260629130000_drop_examclass_statistics/migration.sql
+++ b/prisma/migrations/20260629130000_drop_examclass_statistics/migration.sql
@@ -1,0 +1,2 @@
+-- 旧・死にフラグ statistics を削除（値は 20260629120000 で teacherStat へ移行済み）
+ALTER TABLE "ExamClass" DROP COLUMN "statistics";

--- a/prisma/migrations/20260629140000_backfill_subtotal_selection_flags/migration.sql
+++ b/prisma/migrations/20260629140000_backfill_subtotal_selection_flags/migration.sql
@@ -1,0 +1,24 @@
+-- 小計グループ選択を settingsJson から ExamSubtotalGroup フラグへ移行（P5: 亡霊ID排除）
+-- 旧: ExamExportSettings.settingsJson.individualReportOptions.{table,boxPlot}SubtotalGroupSelection.selectedGroupIds
+-- 新: ExamSubtotalGroup.selectedForTable / selectedForBoxPlot
+-- enabled=true の選択のみ移行（enabled=false は「全グループ表示」なのでフラグを立てない）
+
+UPDATE "ExamSubtotalGroup"
+SET "selectedForTable" = 1
+WHERE EXISTS (
+  SELECT 1 FROM "ExamExportSettings" es,
+    json_each(json_extract(es."settingsJson", '$.individualReportOptions.tableSubtotalGroupSelection.selectedGroupIds')) je
+  WHERE es."examId" = "ExamSubtotalGroup"."examId"
+    AND json_extract(es."settingsJson", '$.individualReportOptions.tableSubtotalGroupSelection.enabled') = 1
+    AND je.value = "ExamSubtotalGroup"."subtotalGroupId"
+);
+
+UPDATE "ExamSubtotalGroup"
+SET "selectedForBoxPlot" = 1
+WHERE EXISTS (
+  SELECT 1 FROM "ExamExportSettings" es,
+    json_each(json_extract(es."settingsJson", '$.individualReportOptions.boxPlotSubtotalGroupSelection.selectedGroupIds')) je
+  WHERE es."examId" = "ExamSubtotalGroup"."examId"
+    AND json_extract(es."settingsJson", '$.individualReportOptions.boxPlotSubtotalGroupSelection.enabled') = 1
+    AND je.value = "ExamSubtotalGroup"."subtotalGroupId"
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,13 +241,15 @@ model UserExam {
 }
 
 model ExamSubtotalGroup {
-  id              String        @id @default(uuid())
-  examId          String
-  subtotalGroupId String
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @default(now()) @updatedAt
-  exam            Exam          @relation(fields: [examId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  subtotalGroup   SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id                 String        @id @default(uuid())
+  examId             String
+  subtotalGroupId    String
+  selectedForTable   Boolean       @default(false) // 小計点テーブルに含めるグループ
+  selectedForBoxPlot Boolean       @default(false) // 箱ひげ図に含めるグループ
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @default(now()) @updatedAt
+  exam               Exam          @relation(fields: [examId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  subtotalGroup      SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 }
 
 model QuestionScore {
@@ -393,14 +395,15 @@ model AuditLog {
 }
 
 model ExamClass {
-  id           String   @id @default(uuid())
-  examId       String
-  classId      String
-  administered Boolean  @default(false) // 学級・出席番号表示の対象
-  statistics   Boolean  @default(false) // 統計集計の対象
-  order        Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id            String   @id @default(uuid())
+  examId        String
+  classId       String
+  administered  Boolean  @default(false) // 学級・出席番号表示（再採番）の対象
+  teacherStat   Boolean  @default(false) // 教員集計対象（Excel学級平均行）
+  studentReport Boolean  @default(false) // 生徒表示対象（個人成績表の学級比較）
+  order         Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   exam  Exam  @relation(fields: [examId], references: [id], onDelete: Cascade)
   class Class @relation(fields: [classId], references: [id], onDelete: Cascade)

--- a/src/components/exams/05-students/components/ClassExamManager.tsx
+++ b/src/components/exams/05-students/components/ClassExamManager.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { DragEndEvent } from "@dnd-kit/core"
-import { BarChart3, Plus, Trash2, UserPlus } from "lucide-react"
+import { Plus, Trash2, UserPlus } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 
 import {
@@ -38,7 +38,7 @@ interface ClassExamManagerProps {
   onRemoveClass: (examClassId: string) => Promise<boolean>
   onUpdateClass: (
     examClassId: string,
-    options: { administered?: boolean; statistics?: boolean }
+    options: { administered?: boolean }
   ) => Promise<unknown>
   onClassesChanged?: () => void
   showAddDialog?: boolean
@@ -48,14 +48,12 @@ interface ClassExamManagerProps {
 interface SortableClassRowProps {
   examClass: ExamClassWithClass
   onAdministeredChange: (id: string, checked: boolean) => void
-  onStatisticsChange: (id: string, checked: boolean) => void
   onRemove: (id: string) => void
 }
 
 function SortableClassRow({
   examClass,
   onAdministeredChange,
-  onStatisticsChange,
   onRemove,
 }: SortableClassRowProps) {
   const { setNodeRef, style, dragHandleProps } = useSortableRow(examClass.id)
@@ -84,14 +82,6 @@ function SortableClassRow({
           checked={examClass.administered}
           onCheckedChange={(checked) =>
             onAdministeredChange(examClass.id, checked === true)
-          }
-        />
-      </TableCell>
-      <TableCell className="text-center">
-        <Checkbox
-          checked={examClass.statistics}
-          onCheckedChange={(checked) =>
-            onStatisticsChange(examClass.id, checked === true)
           }
         />
       </TableCell>
@@ -202,7 +192,6 @@ export function ClassExamManager({
           examId,
           classId,
           administered: true,
-          statistics: true,
         })
       }
 
@@ -236,14 +225,6 @@ export function ClassExamManager({
     await onUpdateClass(examClassId, { administered: checked })
   }
 
-  // statistics切り替え
-  const handleStatisticsChange = async (
-    examClassId: string,
-    checked: boolean
-  ) => {
-    await onUpdateClass(examClassId, { statistics: checked })
-  }
-
   // クラスを削除
   const handleRemoveClass = async (examClassId: string) => {
     await onRemoveClass(examClassId)
@@ -258,9 +239,9 @@ export function ClassExamManager({
     <div className="space-y-4">
       {/* ヘッダー行 */}
       <p className="text-muted-foreground text-sm">
-        学級表示・統計集計の対象クラスを管理します。生徒の追加は「生徒を追加」から行います。
+        再採番（並べ替え・出席番号）の対象クラスを管理します。生徒の追加は「生徒を追加」から行います。
         {localClasses.length > 0 && (
-          <> • 学級表示対象: {administeredClassCount}クラス</>
+          <> • 再採番対象: {administeredClassCount}クラス</>
         )}
       </p>
 
@@ -288,13 +269,7 @@ export function ClassExamManager({
                   <TableHead className="text-center">
                     <div className="flex items-center justify-center gap-1">
                       <UserPlus className="h-4 w-4" />
-                      <span>学級表示</span>
-                    </div>
-                  </TableHead>
-                  <TableHead className="text-center">
-                    <div className="flex items-center justify-center gap-1">
-                      <BarChart3 className="h-4 w-4" />
-                      <span>統計集計</span>
+                      <span>再採番</span>
                     </div>
                   </TableHead>
                   <TableHead className="w-20"></TableHead>
@@ -306,7 +281,6 @@ export function ClassExamManager({
                     key={examClass.id}
                     examClass={examClass}
                     onAdministeredChange={handleAdministeredChange}
-                    onStatisticsChange={handleStatisticsChange}
                     onRemove={handleRemoveClass}
                   />
                 ))}

--- a/src/components/exams/05-students/components/exam-students-page/components/ClassStatisticsCards.tsx
+++ b/src/components/exams/05-students/components/exam-students-page/components/ClassStatisticsCards.tsx
@@ -11,7 +11,7 @@ export function ClassStatisticsCards({
 }: ClassStatisticsCardsProps) {
   const totalClasses = examClasses.length
   const administeredClasses = examClasses.filter((pc) => pc.administered).length
-  const statisticsClasses = examClasses.filter((pc) => pc.statistics).length
+  const teacherStatClasses = examClasses.filter((pc) => pc.teacherStat).length
 
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-4">
@@ -23,16 +23,16 @@ export function ClassStatisticsCards({
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-gray-600">学級表示</span>
+        <span className="text-sm font-medium text-gray-600">再採番</span>
         <span className="rounded-md border border-green-200 bg-green-100 px-3 text-lg font-bold text-green-700">
           {administeredClasses}
         </span>
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-gray-600">統計集計</span>
+        <span className="text-sm font-medium text-gray-600">教員集計</span>
         <span className="rounded-md border border-blue-200 bg-blue-100 px-3 text-lg font-bold text-blue-700">
-          {statisticsClasses}
+          {teacherStatClasses}
         </span>
       </div>
     </div>

--- a/src/components/exams/05-students/hooks/useExamClasses.ts
+++ b/src/components/exams/05-students/hooks/useExamClasses.ts
@@ -23,7 +23,11 @@ interface UseExamClassesReturn {
   /** クラス設定を更新 */
   updateClass: (
     examClassId: string,
-    options: { administered?: boolean; statistics?: boolean }
+    options: {
+      administered?: boolean
+      teacherStat?: boolean
+      studentReport?: boolean
+    }
   ) => Promise<ExamClassWithDetails | null>
 }
 
@@ -76,7 +80,11 @@ export function useExamClasses({
   const updateClass = useCallback(
     async (
       examClassId: string,
-      options: { administered?: boolean; statistics?: boolean }
+      options: {
+        administered?: boolean
+        teacherStat?: boolean
+        studentReport?: boolean
+      }
     ): Promise<ExamClassWithDetails | null> => {
       try {
         const result = await window.electronAPI.examClass.update({

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -797,6 +797,7 @@ export default function ExportMainView() {
         <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2">
           <div className="h-full min-h-0">
             <StudentSelectionCard
+              examId={exam?.id}
               students={students} // 受験生徒順（customOrder）でソート済み
               availableClasses={availableClasses}
               searchTerm={searchTerm}

--- a/src/components/exams/08-export/components/StatClassSelector.tsx
+++ b/src/components/exams/08-export/components/StatClassSelector.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { BarChart3, GraduationCap, Users } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { ExamClassWithClass } from "@/types/electron/examClassApi"
+
+interface StatClassSelectorProps {
+  examId: string
+}
+
+/**
+ * 統計対象学級の選択（Phase 3）
+ *
+ * 試験に登録された学級ごとに「教員集計(teacherStat)」「生徒表示(studentReport)」を切り替える。
+ * - 教員集計: Excel の学級平均行に出す学級
+ * - 生徒表示: 個人成績表の学級比較に出す学級（生徒に渡るので慎重に）
+ * どちらも複数選択可（1人の生徒が複数学級の平均に数えられる）。受験生徒画面(05)の再採番とは別軸。
+ */
+export function StatClassSelector({ examId }: StatClassSelectorProps) {
+  const [classes, setClasses] = useState<ExamClassWithClass[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchClasses = useCallback(async () => {
+    if (!examId) return
+    setLoading(true)
+    try {
+      const result = await window.electronAPI.examClass.getAll(examId)
+      setClasses(result ?? [])
+    } catch (err) {
+      console.error("Failed to load exam classes:", err)
+    } finally {
+      setLoading(false)
+    }
+  }, [examId])
+
+  useEffect(() => {
+    fetchClasses()
+  }, [fetchClasses])
+
+  const updateFlag = useCallback(
+    async (
+      examClassId: string,
+      patch: { teacherStat?: boolean; studentReport?: boolean }
+    ) => {
+      // 楽観的更新
+      setClasses((prev) =>
+        prev.map((c) => (c.id === examClassId ? { ...c, ...patch } : c))
+      )
+      try {
+        await window.electronAPI.examClass.update({ id: examClassId, ...patch })
+      } catch (err) {
+        console.error("Failed to update exam class flags:", err)
+        // 失敗時は再取得して整合
+        fetchClasses()
+      }
+    },
+    [fetchClasses]
+  )
+
+  if (loading) {
+    return (
+      <p className="text-muted-foreground p-4 text-center text-sm">
+        読み込み中...
+      </p>
+    )
+  }
+
+  if (classes.length === 0) {
+    return (
+      <div className="text-muted-foreground rounded-md border py-8 text-center text-sm">
+        <p>統計対象にできる学級がありません</p>
+        <p className="mt-1">受験生徒画面で学級を登録してください</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-muted-foreground px-1 text-xs">
+        学級ごとに平均点を出す対象を選びます。
+        <span className="text-foreground font-medium">教員集計</span>
+        はExcelの学級平均行、
+        <span className="text-foreground font-medium">生徒表示</span>
+        は個人成績表の学級比較に出ます（生徒に渡るので慎重に）。
+      </p>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>学級</TableHead>
+              <TableHead className="text-center">生徒数</TableHead>
+              <TableHead className="text-center">
+                <div className="flex items-center justify-center gap-1">
+                  <BarChart3 className="h-4 w-4" />
+                  <span>教員集計</span>
+                </div>
+              </TableHead>
+              <TableHead className="text-center">
+                <div className="flex items-center justify-center gap-1">
+                  <GraduationCap className="h-4 w-4" />
+                  <span>生徒表示</span>
+                </div>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {classes.map((ec) => (
+              <TableRow key={ec.id}>
+                <TableCell className="font-medium">
+                  {ec.class.name}
+                  {ec.class.grade != null && (
+                    <span className="text-muted-foreground ml-2 text-xs">
+                      {ec.class.grade}年
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-center text-xs">
+                  <span className="inline-flex items-center gap-1">
+                    <Users className="h-3 w-3" />
+                    {ec.class.memberships.length}
+                  </span>
+                </TableCell>
+                <TableCell className="text-center">
+                  <Checkbox
+                    checked={ec.teacherStat}
+                    onCheckedChange={(checked) =>
+                      updateFlag(ec.id, { teacherStat: checked === true })
+                    }
+                  />
+                </TableCell>
+                <TableCell className="text-center">
+                  <Checkbox
+                    checked={ec.studentReport}
+                    onCheckedChange={(checked) =>
+                      updateFlag(ec.id, { studentReport: checked === true })
+                    }
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/exams/08-export/components/StudentSelectionCard.tsx
+++ b/src/components/exams/08-export/components/StudentSelectionCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  BarChart3,
   Check,
   CheckSquare,
   Eye,
@@ -40,8 +41,10 @@ import { ExcelPreview } from "./ExcelPreview"
 import type { ExportTabType } from "./ExportOptionsCard"
 import { IndividualReportPreview } from "./individual-report/IndividualReportPreview"
 import { ScoredAnswerPreview } from "./ScoredAnswerPreview"
+import { StatClassSelector } from "./StatClassSelector"
 
 interface StudentSelectionCardProps {
+  examId?: string
   students: Student[]
   availableClasses: Array<{ id: string; name: string }>
   searchTerm: string
@@ -74,6 +77,7 @@ interface StudentSelectionCardProps {
 }
 
 export function StudentSelectionCard({
+  examId,
   students,
   availableClasses,
   searchTerm,
@@ -101,9 +105,9 @@ export function StudentSelectionCard({
   isExcelPreviewLoading,
   excelPreviewError,
 }: StudentSelectionCardProps) {
-  const [activeTab, setActiveTab] = useState<"selection" | "preview">(
-    "selection"
-  )
+  const [activeTab, setActiveTab] = useState<
+    "class-stats" | "selection" | "preview"
+  >("selection")
 
   // exportTabからpreviewTypeを導出
   const previewType =
@@ -155,11 +159,17 @@ export function StudentSelectionCard({
   return (
     <Tabs
       value={activeTab}
-      onValueChange={(v) => setActiveTab(v as "selection" | "preview")}
+      onValueChange={(v) =>
+        setActiveTab(v as "class-stats" | "selection" | "preview")
+      }
       className="flex h-full flex-col"
     >
       {/* タブヘッダー */}
-      <TabsList className="mb-2 grid w-full grid-cols-2">
+      <TabsList className="mb-2 grid w-full grid-cols-3">
+        <TabsTrigger value="class-stats" className="gap-1">
+          <BarChart3 className="h-4 w-4" />
+          統計対象学級
+        </TabsTrigger>
         <TabsTrigger value="selection" className="gap-1">
           <Users className="h-4 w-4" />
           生徒選択
@@ -169,6 +179,20 @@ export function StudentSelectionCard({
           プレビュー
         </TabsTrigger>
       </TabsList>
+
+      {/* 統計対象学級タブ（教員集計 / 生徒表示の学級選択） */}
+      <TabsContent
+        value="class-stats"
+        className="mt-0 min-h-0 flex-1 overflow-auto"
+      >
+        {examId ? (
+          <StatClassSelector examId={examId} />
+        ) : (
+          <p className="text-muted-foreground p-4 text-center text-sm">
+            試験が読み込まれていません
+          </p>
+        )}
+      </TabsContent>
 
       {/* 生徒選択タブ */}
       <TabsContent

--- a/src/components/exams/08-export/components/individual-report/computeReportData.ts
+++ b/src/components/exams/08-export/components/individual-report/computeReportData.ts
@@ -68,15 +68,6 @@ export function computeFilteredStats(
     .map((e) => e.totalScore)
     .filter((s): s is number => s !== null)
 
-  const filteredClass = filteredAll.filter(
-    (e) =>
-      e.className === report.studentInfo.className &&
-      e.grade === report.studentInfo.grade
-  )
-  const classScores = filteredClass
-    .map((e) => e.totalScore)
-    .filter((s): s is number => s !== null)
-
   const avg = (arr: number[]) =>
     arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
   const stdDevFn = (arr: number[]) => {
@@ -99,6 +90,24 @@ export function computeFilteredStats(
         : 50
       : Math.round(((studentScore - overallAvg) / overallStd) * 10 + 50)
 
+  // 学級別統計を受験状態フィルタ付きで再計算（学級ごとに memberStudentIds で母集団を絞る）
+  const classes = report.statistics.classes.map((cls) => {
+    const memberSet = new Set(cls.memberStudentIds)
+    const filteredMembers = filteredAll.filter((e) =>
+      memberSet.has(e.studentId)
+    )
+    const classScores = filteredMembers
+      .map((e) => e.totalScore)
+      .filter((s): s is number => s !== null)
+    return {
+      ...cls,
+      average: avg(classScores),
+      stdDev: stdDevFn(classScores),
+      total: filteredMembers.length,
+      rank: studentScore !== null ? rankFn(studentScore, classScores) : 0,
+    }
+  })
+
   return {
     ...report.statistics,
     overall: {
@@ -107,17 +116,11 @@ export function computeFilteredStats(
       stdDev: overallStd,
       total: filteredAll.length,
     },
-    class: {
-      ...report.statistics.class,
-      average: avg(classScores),
-      stdDev: stdDevFn(classScores),
-      total: filteredClass.length,
-    },
+    classes,
     personal: {
       ...report.statistics.personal,
       deviation,
       overallRank: studentScore !== null ? rankFn(studentScore, allScores) : 0,
-      classRank: studentScore !== null ? rankFn(studentScore, classScores) : 0,
     },
   }
 }
@@ -401,12 +404,19 @@ export function buildStatsItems(
     })
   }
 
+  // 複数学級時はラベルに学級名を付して区別する（単一学級なら従来どおり「学級平均」）
+  const multipleClasses = filteredStats.classes.length > 1
+  const classLabel = (className: string, suffix: string) =>
+    multipleClasses ? `${className}${suffix}` : `学級${suffix}`
+
   if (options.showAverage !== "none") {
     if (options.showAverage === "class" || options.showAverage === "both") {
-      items.push({
-        label: "学級平均",
-        value: filteredStats.class.average.toFixed(1),
-      })
+      for (const cls of filteredStats.classes) {
+        items.push({
+          label: classLabel(cls.className, "平均"),
+          value: cls.average.toFixed(1),
+        })
+      }
     }
     if (options.showAverage === "overall" || options.showAverage === "both") {
       items.push({
@@ -425,10 +435,12 @@ export function buildStatsItems(
 
   if (options.showRank) {
     if (options.rankType === "class" || options.rankType === "both") {
-      items.push({
-        label: "学級順位",
-        value: `${filteredStats.personal.classRank} / ${filteredStats.class.total}`,
-      })
+      for (const cls of filteredStats.classes) {
+        items.push({
+          label: classLabel(cls.className, "順位"),
+          value: `${cls.rank} / ${cls.total}`,
+        })
+      }
     }
     if (options.rankType === "overall" || options.rankType === "both") {
       items.push({

--- a/src/components/exams/08-export/hooks/useExportPage.ts
+++ b/src/components/exams/08-export/hooks/useExportPage.ts
@@ -67,30 +67,48 @@ export function useExportPage() {
         try {
           const result =
             await window.electronAPI.settings.getExamExportSettings(examId)
-          if (result.success && result.settings) {
-            if (result.settings.scoringMarkConfig) {
-              const saved = result.settings
-                .scoringMarkConfig as Partial<ScoringMarkConfig>
-              // 後方互換性: subtotalScore/totalScore がない場合、summaryScore からフォールバック
-              const mergedConfig: ScoringMarkConfig = {
-                ...defaultScoringMarkConfig,
-                ...saved,
-              }
-              if (!saved.subtotalScore && saved.summaryScore) {
-                mergedConfig.subtotalScore = { ...saved.summaryScore }
-              }
-              if (!saved.totalScore && saved.summaryScore) {
-                mergedConfig.totalScore = { ...saved.summaryScore }
-              }
-              setScoringMarkConfigState(mergedConfig)
+          if (result.success && result.settings?.scoringMarkConfig) {
+            const saved = result.settings
+              .scoringMarkConfig as Partial<ScoringMarkConfig>
+            // 後方互換性: subtotalScore/totalScore がない場合、summaryScore からフォールバック
+            const mergedConfig: ScoringMarkConfig = {
+              ...defaultScoringMarkConfig,
+              ...saved,
             }
-            if (result.settings.individualReportOptions) {
-              setIndividualReportOptionsState({
-                ...DEFAULT_INDIVIDUAL_REPORT_OPTIONS,
-                ...result.settings.individualReportOptions,
-              })
+            if (!saved.subtotalScore && saved.summaryScore) {
+              mergedConfig.subtotalScore = { ...saved.summaryScore }
+            }
+            if (!saved.totalScore && saved.summaryScore) {
+              mergedConfig.totalScore = { ...saved.summaryScore }
+            }
+            setScoringMarkConfigState(mergedConfig)
+          }
+
+          // 個人成績表オプション（JSON）を基にしつつ、小計グループ選択は
+          // source of truth である ExamSubtotalGroup フラグから hydrate する（P5: 亡霊ID排除）
+          let baseOptions = DEFAULT_INDIVIDUAL_REPORT_OPTIONS
+          if (result.success && result.settings?.individualReportOptions) {
+            baseOptions = {
+              ...DEFAULT_INDIVIDUAL_REPORT_OPTIONS,
+              ...result.settings.individualReportOptions,
             }
           }
+          const selection =
+            await window.electronAPI.getSubtotalGroupSelection(examId)
+          if (selection.success) {
+            baseOptions = {
+              ...baseOptions,
+              tableSubtotalGroupSelection: {
+                ...baseOptions.tableSubtotalGroupSelection,
+                selectedGroupIds: selection.tableGroupIds,
+              },
+              boxPlotSubtotalGroupSelection: {
+                ...baseOptions.boxPlotSubtotalGroupSelection,
+                selectedGroupIds: selection.boxPlotGroupIds,
+              },
+            }
+          }
+          setIndividualReportOptionsState(baseOptions)
         } catch (error) {
           console.error("試験設定の読み込みに失敗しました:", error)
         }
@@ -144,13 +162,32 @@ export function useExportPage() {
 
       if (examId && window.electronAPI?.settings) {
         try {
+          // 小計グループ選択は relational フラグへ書き込み（source of truth）
+          await window.electronAPI.setSubtotalGroupSelection(
+            examId,
+            newOptions.tableSubtotalGroupSelection.selectedGroupIds,
+            newOptions.boxPlotSubtotalGroupSelection.selectedGroupIds
+          )
+
           const result =
             await window.electronAPI.settings.getExamExportSettings(examId)
           const currentSettings =
             result.success && result.settings ? result.settings : {}
+          // JSON には selectedGroupIds（エンティティ参照）を残さない。
+          // enabled などの非参照設定のみ保持し、ID はフラグから hydrate する。
           await window.electronAPI.settings.saveExamExportSettings(examId, {
             ...currentSettings,
-            individualReportOptions: newOptions,
+            individualReportOptions: {
+              ...newOptions,
+              tableSubtotalGroupSelection: {
+                ...newOptions.tableSubtotalGroupSelection,
+                selectedGroupIds: [],
+              },
+              boxPlotSubtotalGroupSelection: {
+                ...newOptions.boxPlotSubtotalGroupSelection,
+                selectedGroupIds: [],
+              },
+            },
           })
         } catch (error) {
           console.error("個人成績表オプションの保存に失敗しました:", error)

--- a/src/types/electron/cropRegionApi.d.ts
+++ b/src/types/electron/cropRegionApi.d.ts
@@ -147,6 +147,20 @@ export interface CropRegionAPI {
     success: boolean
     error?: string
   }>
+  getSubtotalGroupSelection: (examId: string) => Promise<{
+    success: boolean
+    tableGroupIds: string[]
+    boxPlotGroupIds: string[]
+    error?: string
+  }>
+  setSubtotalGroupSelection: (
+    examId: string,
+    tableGroupIds: string[],
+    boxPlotGroupIds: string[]
+  ) => Promise<{
+    success: boolean
+    error?: string
+  }>
 
   // Subtotal related
   createSubtotal: (

--- a/src/types/electron/examClassApi.d.ts
+++ b/src/types/electron/examClassApi.d.ts
@@ -10,7 +10,8 @@ export interface ExamClassWithDetails {
   examId: string
   classId: string
   administered: boolean
-  statistics: boolean
+  teacherStat: boolean
+  studentReport: boolean
   order: number
   createdAt: Date
   updatedAt: Date
@@ -26,7 +27,8 @@ export interface ExamClassWithClass {
   examId: string
   classId: string
   administered: boolean
-  statistics: boolean
+  teacherStat: boolean
+  studentReport: boolean
   order: number
   createdAt: Date
   updatedAt: Date
@@ -72,11 +74,6 @@ export interface ExamClassAPI {
     getAdministered: (examId: string) => Promise<ExamClassWithClass[]>
 
     /**
-     * 統計集計用クラスを取得 (statistics=true)
-     */
-    getStatistics: (examId: string) => Promise<ExamClassWithClass[]>
-
-    /**
      * 試験に追加可能なクラスを取得（まだExamClassに含まれていないクラス）
      */
     getAvailable: (examId: string) => Promise<AvailableClass[]>
@@ -88,7 +85,8 @@ export interface ExamClassAPI {
       examId: string
       classId: string
       administered?: boolean
-      statistics?: boolean
+      teacherStat?: boolean
+      studentReport?: boolean
     }) => Promise<ExamClassWithDetails>
 
     /**
@@ -97,7 +95,8 @@ export interface ExamClassAPI {
     update: (options: {
       id: string
       administered?: boolean
-      statistics?: boolean
+      teacherStat?: boolean
+      studentReport?: boolean
       order?: number
     }) => Promise<ExamClassWithDetails>
 

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -755,6 +755,10 @@ export interface ArchiveExamData {
     id: string
     examId: string
     subtotalGroupId: string
+    /** v1.15.0+ 小計点テーブル選択 */
+    selectedForTable?: boolean
+    /** v1.15.0+ 箱ひげ図選択 */
+    selectedForBoxPlot?: boolean
     createdAt: string
     updatedAt: string
   }>
@@ -764,7 +768,12 @@ export interface ArchiveExamData {
     examId: string
     classId: string
     administered: boolean
-    statistics: boolean
+    /** 〜v1.14.0 の旧フラグ（v1.15.0 で teacherStat へ移行）。旧アーカイブ読込時のみ存在 */
+    statistics?: boolean
+    /** v1.15.0+ 教員集計対象 */
+    teacherStat?: boolean
+    /** v1.15.0+ 生徒表示対象 */
+    studentReport?: boolean
     order: number
     createdAt: string
     updatedAt: string


### PR DESCRIPTION
Closes #891

試験における「学級」の扱い（採番・統計・出力）を作り直す。設計文書: `docs/class-statistics-redesign.md`

## 変更内容（Phase 0〜4c）
| Phase | 内容 |
| --- | --- |
| 0 | 受験日統一: 在籍解決を `membershipFilterAt(examDate)` へ（P3） |
| 1 | 集計エンジン: `getClassMembersForExam`（受験日所属・重複カウント） |
| 2 | スキーマ＋移行: `ExamClass.teacherStat/studentReport`・`ExamSubtotalGroup.selectedForTable/selectedForBoxPlot`、archive 1.15.0 |
| 3 | statistics 廃止＋UI: 3スイッチ分離、05簡素化＋08「統計対象学級」タブ |
| 4a | Excel 学級平均行（母集団=学級全体） |
| 4b | 個人成績表の複数学級比較（studentReport 学級 ∩ 本人所属） |
| 4c | 小計グループ選択のフラグ化（亡霊ID排除、json_each で移行） |

## 設計上のポイント
- 学級母集団は**受験日スナップショット**で判定
- 採番(1人1学級)と統計(重複カウント)を分離
- エンティティ参照は JSON でなく**関係列**で保持（亡霊ID排除）
- archive はバージョン比較＋optional フィールド方式（additive-only パターン踏襲、transformer 不要）

## マイグレーション（手書き・Prisma7）
- `20260629120000_class_output_flags`（列追加＋値移行）
- `20260629130000_drop_examclass_statistics`
- `20260629140000_backfill_subtotal_selection_flags`（json_each バックフィル）

## テスト・検証
- フルテスト **862 passed / 1 failed**（残り1件は既存の日付相対 grade テスト・無関係）
- typecheck・lint クリーン
- 並列レビュー（バグ走査・CLAUDE.md準拠・データフロー整合性）実施、`SUPPORTED_VERSIONS` 整合を修正済
- マイグレーションは空DBへ昇順適用・deployer 分割ロジックで検証済

## 残作業（別PR）
- **Phase 5** UI共通化（ClassRosterManager 抽出・削除2段階modal・class reorder API）

🤖 Generated with [Claude Code](https://claude.com/claude-code)