### PR TITLE
fix(exam): 学級統計再設計のレビュー指摘修正（取込フラグ・出力既定・性能・型規約）

### DIFF
--- a/__tests__/calculations/classAverageRows.test.ts
+++ b/__tests__/calculations/classAverageRows.test.ts
@@ -10,8 +10,32 @@ import * as ExcelJS from "exceljs"
 import { describe, expect, it } from "vitest"
 
 import { appendClassAverageRows } from "@/electron-src/lib/export/excel/averageRows"
-import type { ExamClassMembers } from "@/electron-src/lib/prisma/examClass"
 import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
+import type { ExamClassWithMembers } from "@/types/prismaExtensions"
+
+/** ExamClassWithMembers の最小モック（テストで使う teacherStat / class.name / memberships のみ） */
+function makeClass(
+  name: string,
+  studentIds: string[],
+  teacherStat = true
+): ExamClassWithMembers {
+  return {
+    id: `ec-${name}`,
+    examId: "e1",
+    classId: `c-${name}`,
+    administered: true,
+    teacherStat,
+    studentReport: true,
+    order: 0,
+    class: {
+      id: `c-${name}`,
+      name,
+      classCode: null,
+      grade: 3,
+      memberships: studentIds.map((studentId) => ({ studentId })),
+    },
+  } as unknown as ExamClassWithMembers
+}
 
 function makeStudent(
   id: string,
@@ -67,20 +91,7 @@ describe("appendClassAverageRows", () => {
       makeStudent("S2", 80, 8),
       makeStudent("S3", 40, 4),
     ]
-    const classes: ExamClassMembers[] = [
-      {
-        examClassId: "ec1",
-        classId: "cA",
-        className: "3-A組",
-        classCode: null,
-        grade: 3,
-        order: 0,
-        administered: true,
-        teacherStat: true,
-        studentReport: true,
-        studentIds: ["S1", "S2"],
-      },
-    ]
+    const classes = [makeClass("3-A組", ["S1", "S2"])]
 
     appendClassAverageRows(ws, all, classes, [], QUESTION_REGIONS)
 

--- a/__tests__/exam/integration/examStudentClass.test.ts
+++ b/__tests__/exam/integration/examStudentClass.test.ts
@@ -281,16 +281,18 @@ describe("Exam 在籍フィルタ", () => {
       await addStudentsFromClass(exam.id, classB.id, false)
 
       const members = await getClassMembersForExam(exam.id)
+      const idsOf = (m: (typeof members)[number]) =>
+        m.class.memberships.map((x) => x.studentId)
 
       const a = members.find((m) => m.classId === classA.id)!
       const b = members.find((m) => m.classId === classB.id)!
 
       // classA: 受験日在籍の active のみ（転出済み left は除外）
-      expect(a.studentIds).toEqual([active.id])
+      expect(idsOf(a)).toEqual([active.id])
       // classB: active（複数学級に重複カウント）
-      expect(b.studentIds).toEqual([active.id])
+      expect(idsOf(b)).toEqual([active.id])
       // left はどの学級の集計にも含まれない
-      expect(members.flatMap((m) => m.studentIds)).not.toContain(left.id)
+      expect(members.flatMap(idsOf)).not.toContain(left.id)
       // 生徒ごと追加した学級は teacherStat / studentReport が true
       expect(a.teacherStat).toBe(true)
       expect(a.studentReport).toBe(true)

--- a/electron-src/lib/export/excel/averageRows.ts
+++ b/electron-src/lib/export/excel/averageRows.ts
@@ -1,16 +1,18 @@
 import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
-import type { ExamClassMembers } from "../../prisma/examClass"
+import type { ExamClassWithMembers } from "@/types/prismaExtensions"
+
+import { average as mean } from "../../shared/calculations/numericStats"
 import type { ScoringData } from "../../shared/types/exportTypes"
 import { applyCellStyle } from "../../shared/utilities/excelUtilities"
 import type { SubtotalColumn } from "./dataFetcher"
 
-/** null を除いた平均（小数1桁）。対象が無ければ null */
+/** null を除いた平均（小数1桁）。対象が無ければ null（セル空欄用） */
 function average(values: (number | null | undefined)[]): number | null {
   const v = values.filter((x): x is number => x != null)
   if (v.length === 0) return null
-  return Math.round((v.reduce((a, b) => a + b, 0) / v.length) * 10) / 10
+  return Math.round(mean(v) * 10) / 10
 }
 
 /** 指定生徒集合の 合計点／小計／設問 の平均行（ヘッダー列順）を作る */
@@ -68,7 +70,7 @@ function buildAverageRow(
 export function appendClassAverageRows(
   worksheet: ExcelJS.Worksheet,
   allScoringData: ScoringData[],
-  teacherStatClasses: ExamClassMembers[],
+  teacherStatClasses: ExamClassWithMembers[],
   subtotalColumns: SubtotalColumn[],
   questionRegions: CropRegion[]
 ): void {
@@ -91,14 +93,14 @@ export function appendClassAverageRows(
   // 学級ごとの平均（teacherStat=true）
   const byId = new Map(allScoringData.map((s) => [s.studentId, s]))
   for (const cls of teacherStatClasses) {
-    const members = cls.studentIds
-      .map((id) => byId.get(id))
+    const members = cls.class.memberships
+      .map((m) => byId.get(m.studentId))
       .filter((s): s is ScoringData => s !== undefined)
     if (members.length === 0) continue
 
     const row = worksheet.addRow(
       buildAverageRow(
-        `${cls.className}平均`,
+        `${cls.class.name}平均`,
         members,
         subtotalColumns,
         questionRegions

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -28,8 +28,9 @@ export async function exportGradingDataExcel(
   try {
     const { examId, selectedStudentIds } = options
 
-    // データの取得
-    const dataResult = await fetchExportData(examId, selectedStudentIds)
+    // 学級平均行の母集団は「試験全体」（生徒選択に無関係）なので、全受験生徒データを
+    // 1回だけ取得し、選択生徒分は in-memory で絞る（部分出力時の二重フェッチを回避）。
+    const dataResult = await fetchExportData(examId, [])
     if (!dataResult.success) {
       return { success: false, error: dataResult.error }
     }
@@ -43,14 +44,21 @@ export async function exportGradingDataExcel(
       return { success: false, error: "必要なデータの取得に失敗しました" }
     }
 
+    const allScoringData = dataResult.scoringData
+    const selectedSet = new Set(selectedStudentIds)
+    const scoringData =
+      selectedStudentIds.length === 0
+        ? allScoringData
+        : allScoringData.filter((d) => selectedSet.has(d.studentId))
+    if (scoringData.length === 0) {
+      return { success: false, error: "選択された生徒が見つかりません" }
+    }
+
     // 採点データの検証と警告の生成（強制実行でない場合のみ）
     if (!options.forceExport) {
       const validationResult = validateScoringData(
-        dataResult.scoringData,
-        buildConflictIdentifiers(
-          dataResult.scoringData,
-          dataResult.scoreConflicts ?? []
-        )
+        scoringData,
+        buildConflictIdentifiers(scoringData, dataResult.scoreConflicts ?? [])
       )
       if (validationResult.hasWarnings) {
         return {
@@ -62,15 +70,7 @@ export async function exportGradingDataExcel(
       }
     }
 
-    // 学級平均行の母集団は「試験全体」（生徒選択に無関係）。全受験生徒の採点データと
-    // teacherStat=true の登録学級（受験日所属生徒つき）を取得する。
-    const allDataResult =
-      selectedStudentIds.length === 0
-        ? dataResult
-        : await fetchExportData(examId, [])
-    const allScoringData = allDataResult.success
-      ? (allDataResult.scoringData ?? [])
-      : []
+    // teacherStat=true の登録学級（受験日所属生徒つき）= 学級平均行の対象
     const teacherStatClasses = (await getClassMembersForExam(examId)).filter(
       (c) => c.teacherStat
     )
@@ -83,7 +83,7 @@ export async function exportGradingDataExcel(
       workbook,
       dataResult.questionRegions,
       dataResult.subtotalColumns,
-      dataResult.scoringData,
+      scoringData,
       allScoringData,
       teacherStatClasses
     )
@@ -93,21 +93,21 @@ export async function exportGradingDataExcel(
       workbook,
       dataResult.questionRegions,
       dataResult.subtotalColumns,
-      dataResult.scoringData
+      scoringData
     )
 
     // 問題分析シート作成
     await createItemAnalysisSheet(
       workbook,
       dataResult.questionRegions,
-      dataResult.scoringData
+      scoringData
     )
 
     // S-P表シート作成（#838）
-    await createSpTableSheet(workbook, dataResult.scoringData)
+    await createSpTableSheet(workbook, scoringData)
 
     // 得点度数分布シート作成（#838）
-    await createFrequencyDistributionSheet(workbook, dataResult.scoringData)
+    await createFrequencyDistributionSheet(workbook, scoringData)
 
     // ファイル保存
     const examName = dataResult.exam?.examName

--- a/electron-src/lib/export/excel/sheetCreators.ts
+++ b/electron-src/lib/export/excel/sheetCreators.ts
@@ -1,7 +1,8 @@
 import type { CropRegion } from "@prisma/client"
 import * as ExcelJS from "exceljs"
 
-import type { ExamClassMembers } from "../../prisma/examClass"
+import type { ExamClassWithMembers } from "@/types/prismaExtensions"
+
 import { ScoringData } from "../../shared/types/exportTypes"
 import { autoFitColumns } from "../../shared/utilities/excelUtilities"
 import { appendClassAverageRows } from "./averageRows"
@@ -26,7 +27,7 @@ export async function createScoreSheet(
   /** 学級平均行の母集団（試験全体の採点データ。選択生徒ではない） */
   allScoringData: ScoringData[] = [],
   /** teacherStat=true の登録学級（受験日所属生徒つき） */
-  teacherStatClasses: ExamClassMembers[] = []
+  teacherStatClasses: ExamClassWithMembers[] = []
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("点数一覧")
 

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -22,6 +22,7 @@ import type { SubtotalScore } from "../../shared/types/exportTypes"
 import { fetchExportData } from "../excel/dataFetcher"
 import { generateLearningAdvice } from "./adviceGenerator"
 import {
+  buildScoreByStudentId,
   calculateQuestionCorrectRates,
   calculateQuestionScoreRates,
   calculateStatisticsForStudent,
@@ -134,6 +135,27 @@ export async function fetchIndividualReportData(
       (c) => c.studentReport
     )
 
+    // studentId → 本人が所属する studentReport 学級（複数学級対応）。学級ごとに
+    // 1回だけ変換し、生徒ごとの走査（O(学級×学級人数)）を避ける。
+    const studentClassesByStudentId = new Map<string, StudentClassForStats[]>()
+    for (const c of studentReportClasses) {
+      const memberStudentIds = c.class.memberships.map((m) => m.studentId)
+      const entry: StudentClassForStats = {
+        classId: c.classId,
+        className: c.class.name,
+        grade: c.class.grade != null ? String(c.class.grade) : null,
+        memberStudentIds,
+      }
+      for (const sid of memberStudentIds) {
+        const list = studentClassesByStudentId.get(sid)
+        if (list) list.push(entry)
+        else studentClassesByStudentId.set(sid, [entry])
+      }
+    }
+
+    // 全生徒の合計点索引を1回だけ構築し、各生徒の統計算出で共有（再構築の O(N^2) 回避）
+    const scoreByStudentId = buildScoreByStudentId(allScoringData)
+
     // 各生徒のレポートデータを構築
     const reports: IndividualReportData[] = selectedScoringData.map(
       (scoringData) => {
@@ -147,15 +169,9 @@ export async function fetchIndividualReportData(
           attendanceNumber: scoringData.attendanceNumber ?? null,
         }
 
-        // 本人が所属する studentReport 学級を抽出（複数学級対応）
-        const studentClasses: StudentClassForStats[] = studentReportClasses
-          .filter((c) => c.studentIds.includes(scoringData.studentId))
-          .map((c) => ({
-            classId: c.classId,
-            className: c.className,
-            grade: c.grade != null ? String(c.grade) : null,
-            memberStudentIds: c.studentIds,
-          }))
+        // 本人が所属する studentReport 学級（事前構築した Map から O(1) 取得）
+        const studentClasses =
+          studentClassesByStudentId.get(scoringData.studentId) ?? []
 
         // 統計データ（subtotalScoresから直接グループ情報を取得可能）
         const statistics = calculateStatisticsForStudent(
@@ -164,7 +180,8 @@ export async function fetchIndividualReportData(
           allScoringData,
           studentClasses,
           questionCorrectRates,
-          questionScoreRates
+          questionScoreRates,
+          scoreByStudentId
         )
 
         // 学習アドバイス

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -2,12 +2,17 @@
  * 個人成績表用統計計算ロジック
  */
 
+import {
+  average as calculateAverage,
+  boxPlot as calculateBoxPlotData,
+  rank as calculateRank,
+  stdDev as calculateStdDev,
+} from "../../shared/calculations/numericStats"
 import type {
   DiscriminationLevel,
   ScoringData,
 } from "../../shared/types/exportTypes"
 import type {
-  BoxPlotData,
   ClassStatEntry,
   RawTotalScoreEntry,
   StatisticsData,
@@ -27,68 +32,14 @@ export interface StudentClassForStats {
 }
 
 /**
- * 配列の平均値を計算
+ * studentId → 合計点の索引を構築する。
+ * 生徒ごとに calculateStatisticsForStudent を呼ぶ際、呼び出し側で一度だけ構築し
+ * 渡すことで O(生徒数^2) の再構築を避ける。
  */
-function calculateAverage(values: number[]): number {
-  if (values.length === 0) return 0
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}
-
-/**
- * 配列の標準偏差を計算
- */
-function calculateStdDev(values: number[]): number {
-  if (values.length === 0) return 0
-  const avg = calculateAverage(values)
-  const squaredDiffs = values.map((v) => Math.pow(v - avg, 2))
-  return Math.sqrt(squaredDiffs.reduce((sum, v) => sum + v, 0) / values.length)
-}
-
-/**
- * 配列をソートして四分位数・中央値を計算（箱ひげ図用）
- * Tukey法: データを半分に分けて中央値を取る方法
- * 全数調査（試験の成績など）に適した計算方法
- */
-function calculateBoxPlotData(values: number[]): BoxPlotData {
-  if (values.length === 0) {
-    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
-  }
-
-  const sorted = [...values].sort((a, b) => a - b)
-  const n = sorted.length
-
-  const min = sorted[0]
-  const max = sorted[n - 1]
-  const median = calculateMedian(sorted)
-
-  // Tukey法: データを下位半分と上位半分に分けて、それぞれの中央値を取る
-  // nが奇数の場合、中央値は両方の半分から除外する
-  const midIndex = Math.floor(n / 2)
-  const lowerHalf = sorted.slice(0, midIndex)
-  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
-
-  const q1 = calculateMedian(lowerHalf)
-  const q3 = calculateMedian(upperHalf)
-
-  return { min, q1, median, q3, max }
-}
-
-/**
- * 配列の中央値を計算
- */
-function calculateMedian(sortedValues: number[]): number {
-  const n = sortedValues.length
-  if (n === 0) return 0
-  if (n === 1) return sortedValues[0]
-
-  const mid = Math.floor(n / 2)
-  if (n % 2 === 0) {
-    // 偶数個: 中央2つの平均
-    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
-  } else {
-    // 奇数個: 中央の値
-    return sortedValues[mid]
-  }
+export function buildScoreByStudentId(
+  allScoringData: ScoringData[]
+): Map<string, number | null> {
+  return new Map(allScoringData.map((d) => [d.studentId, d.totalScore]))
 }
 
 /**
@@ -101,14 +52,6 @@ function calculateDeviation(
 ): number {
   if (stdDev === 0) return 50
   return Math.round(((score - average) / stdDev) * 10 + 50)
-}
-
-/**
- * 順位を計算（同点は同順位）
- */
-function calculateRank(score: number, allScores: number[]): number {
-  const sorted = [...allScores].sort((a, b) => b - a)
-  return sorted.findIndex((s) => s <= score) + 1
 }
 
 /**
@@ -345,7 +288,13 @@ export function calculateStatisticsForStudent(
   allScoringData: ScoringData[],
   studentClasses: StudentClassForStats[],
   questionCorrectRates: Record<string, number>,
-  questionScoreRates: Record<string, number>
+  questionScoreRates: Record<string, number>,
+  /**
+   * studentId → 合計点の索引（学級母集団の絞り込み用）。生徒ごとに本関数を
+   * 呼ぶ呼び出し側で一度だけ構築して渡せば O(生徒数^2) の再構築を避けられる。
+   * 省略時は allScoringData から内部構築する（buildScoreByStudentId と同一）。
+   */
+  scoreByStudentId?: Map<string, number | null>
 ): StatisticsData {
   // 全体のスコア配列（null を除外）
   const allScores = allScoringData
@@ -358,18 +307,14 @@ export function calculateStatisticsForStudent(
   const overallBoxPlot = calculateBoxPlotData(allScores)
 
   // studentId → 合計点の索引（学級母集団の絞り込み用）
-  const scoreByStudentId = new Map(
-    allScoringData.map((d) => [d.studentId, d.totalScore] as const)
-  )
+  const scoreById = scoreByStudentId ?? buildScoreByStudentId(allScoringData)
 
   // 学級別統計（studentReport 選択学級ごと。母集団＝当該学級全体）
   const classes: ClassStatEntry[] = studentClasses.map((cls) => {
     // allScoringData に存在する所属生徒のみ（在籍はするが採点対象外を除外）
-    const presentIds = cls.memberStudentIds.filter((id) =>
-      scoreByStudentId.has(id)
-    )
+    const presentIds = cls.memberStudentIds.filter((id) => scoreById.has(id))
     const classScores = presentIds
-      .map((id) => scoreByStudentId.get(id) ?? null)
+      .map((id) => scoreById.get(id) ?? null)
       .filter((s): s is number => s !== null)
 
     return {

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -4,6 +4,7 @@
 
 import type { SubtotalGroup } from "@prisma/client"
 
+import type { BoxPlotData } from "../../shared/calculations/numericStats"
 import type { ScoringData } from "../../shared/types/exportTypes"
 
 // ================== 表示モード関連 ==================
@@ -132,15 +133,6 @@ export interface ExamInfoForReport {
   examName: string
   examDate: Date | null
   tags: string[]
-}
-
-/** 箱ひげ図用統計データ */
-export interface BoxPlotData {
-  min: number
-  q1: number
-  median: number
-  q3: number
-  max: number
 }
 
 /** 生徒ごとの小計点データ（renderer側計算用） */

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto"
 
 import type { ArchiveDataCounts } from "../../../../src/types/examArchive.types"
 import prisma from "../../prisma/client"
+import { resolveExamClassOutputFlags } from "../examClassFlags"
 import type { ExtractedArchiveData } from "./archiveExtractor"
 import type { IdMappings } from "./idRemapper"
 import { remapId, remapIdRequired } from "./idRemapper"
@@ -314,10 +315,8 @@ export async function createImportedData(
               examId: newExamId,
               classId: newClassId,
               administered: pc.administered,
-              // v1.15.0+。旧アーカイブには無いので旧フラグ(statistics/administered)から補完
-              // 教員集計 = 旧 statistics、生徒表示 = 再採番(administered)
-              teacherStat: pc.teacherStat ?? pc.statistics ?? false,
-              studentReport: pc.studentReport ?? pc.administered ?? false,
+              // v1.15.0+。旧アーカイブは旧フラグ(statistics/administered)から補完
+              ...resolveExamClassOutputFlags(pc),
               order: pc.order,
             },
           })

--- a/electron-src/lib/import/examClassFlags.ts
+++ b/electron-src/lib/import/examClassFlags.ts
@@ -1,0 +1,20 @@
+/**
+ * アーカイブの ExamClass 出力フラグ（teacherStat/studentReport）を解決する。
+ *
+ * v1.15.0+ は明示フィールドを持つ。旧アーカイブには無いので旧フラグから補完する：
+ * 教員集計 = 旧 statistics、生徒表示 = 再採番(administered)。
+ *
+ * import の2経路（exam-archive/dataCreator・merge/idIntegrationImporter）で共有し、
+ * 補完規則の重複・ドリフトを防ぐ。
+ */
+export function resolveExamClassOutputFlags(pc: {
+  teacherStat?: boolean | null
+  studentReport?: boolean | null
+  statistics?: boolean | null
+  administered?: boolean | null
+}): { teacherStat: boolean; studentReport: boolean } {
+  return {
+    teacherStat: pc.teacherStat ?? pc.statistics ?? false,
+    studentReport: pc.studentReport ?? pc.administered ?? false,
+  }
+}

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -21,6 +21,7 @@ import type {
 import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
+import { resolveExamClassOutputFlags } from "../examClassFlags"
 import { isNewerByLww } from "./decisionMergePolicy"
 import { executeIdChanges } from "./idChangeExecutor"
 import { copyImportImages, createImportImageRecords } from "./imageImporter"
@@ -632,6 +633,8 @@ async function processExamSubtotalGroups(
               id: psg.id,
               examId: newExamId,
               subtotalGroupId: newGroupId,
+              selectedForTable: psg.selectedForTable ?? false,
+              selectedForBoxPlot: psg.selectedForBoxPlot ?? false,
             },
           })
           idMappings.examSubtotalGroup[psg.id] = psg.id
@@ -1238,8 +1241,7 @@ async function processExamClasses(
           classId: newClassId,
           administered: pc.administered,
           // v1.15.0+。旧アーカイブは旧フラグ(statistics/administered)から補完
-          teacherStat: pc.teacherStat ?? pc.statistics ?? false,
-          studentReport: pc.studentReport ?? pc.administered ?? false,
+          ...resolveExamClassOutputFlags(pc),
           order: pc.order,
         },
       })

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -1,6 +1,7 @@
 import { ExamClass, Prisma } from "@prisma/client"
 
 import type { StudentClassInfo } from "@/types/electron/examClassApi"
+import type { ExamClassWithMembers } from "@/types/prismaExtensions"
 
 import { recordAuditLog } from "./auditLog"
 import { resolveExamScope } from "./auditScope"
@@ -590,37 +591,23 @@ export const getStudentClassInfo = async (
 /**
  * 登録学級ごとの所属生徒（集計エンジン・Phase 1）
  *
- * 試験に登録された各 ExamClass について、**受験日時点で在籍する**生徒のIDを集める。
- * 採番（getStudentClassInfoForExam）と異なり、**1人の生徒は所属する全学級に重複カウント**される
+ * 試験に登録された各 ExamClass について、**受験日時点で在籍する**生徒（class.memberships）を
+ * 含む Prisma payload（{@link ExamClassWithMembers}）をそのまま返す。memberships は受験日
+ * スナップショットで where 絞り込み・出席番号→学籍番号順にソート済み。採番
+ * （getStudentClassInfoForExam）と異なり**1人の生徒は所属する全学級に重複カウント**される
  * （用途2/3の学級平均は「学級全体」を母集団とするため、order優先の単一化はしない）。
  *
- * Excel学級平均行（teacherStat）・個人成績表の複数学級比較（studentReport）の土台。
- * フラグ（teacherStat/studentReport）はPhase 2のスキーマ追加後に拡張する。現状は order 昇順の
- * 全登録学級を返し、消費側がフィルタする。
+ * order 昇順の全登録学級を返し、消費側が用途別にフィルタする
+ * （Excel は teacherStat、個人成績表は studentReport）。所属生徒IDは
+ * `ec.class.memberships.map((m) => m.studentId)` で取得する。
  */
-export interface ExamClassMembers {
-  examClassId: string
-  classId: string
-  className: string
-  classCode: string | null
-  grade: number | null
-  order: number
-  administered: boolean
-  /** 教員集計（Excel学級平均行）の対象か */
-  teacherStat: boolean
-  /** 生徒表示（個人成績表の学級比較）の対象か */
-  studentReport: boolean
-  /** 受験日時点で在籍する生徒ID（出席番号→学籍番号順） */
-  studentIds: string[]
-}
-
 export const getClassMembersForExam = async (
   examId: string
-): Promise<ExamClassMembers[]> => {
+): Promise<ExamClassWithMembers[]> => {
   try {
     const referenceDate = await getExamReferenceDate(examId)
 
-    const examClasses = await prisma.examClass.findMany({
+    return await prisma.examClass.findMany({
       where: { examId },
       include: {
         class: {
@@ -638,19 +625,6 @@ export const getClassMembersForExam = async (
       },
       orderBy: [{ order: "asc" }, { createdAt: "asc" }],
     })
-
-    return examClasses.map((ec) => ({
-      examClassId: ec.id,
-      classId: ec.classId,
-      className: ec.class.name,
-      classCode: ec.class.classCode,
-      grade: ec.class.grade,
-      order: ec.order,
-      administered: ec.administered,
-      teacherStat: ec.teacherStat,
-      studentReport: ec.studentReport,
-      studentIds: ec.class.memberships.map((m) => m.studentId),
-    }))
   } catch (error) {
     console.error(`Failed to get class members for exam ${examId}:`, error)
     throw error

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -488,21 +488,23 @@ export async function setSubtotalGroupSelection(
   boxPlotGroupIds: string[]
 ) {
   try {
-    const tableSet = new Set(tableGroupIds)
-    const boxPlotSet = new Set(boxPlotGroupIds)
-
     await prisma.$transaction(async (tx) => {
-      const links = await tx.examSubtotalGroup.findMany({
+      // 一旦全フラグを false にし、指定IDのみ true へ。行ごとの update（N+1）を
+      // 定数本数の updateMany に集約する。
+      await tx.examSubtotalGroup.updateMany({
         where: { examId },
-        select: { id: true, subtotalGroupId: true },
+        data: { selectedForTable: false, selectedForBoxPlot: false },
       })
-      for (const link of links) {
-        await tx.examSubtotalGroup.update({
-          where: { id: link.id },
-          data: {
-            selectedForTable: tableSet.has(link.subtotalGroupId),
-            selectedForBoxPlot: boxPlotSet.has(link.subtotalGroupId),
-          },
+      if (tableGroupIds.length > 0) {
+        await tx.examSubtotalGroup.updateMany({
+          where: { examId, subtotalGroupId: { in: tableGroupIds } },
+          data: { selectedForTable: true },
+        })
+      }
+      if (boxPlotGroupIds.length > 0) {
+        await tx.examSubtotalGroup.updateMany({
+          where: { examId, subtotalGroupId: { in: boxPlotGroupIds } },
+          data: { selectedForBoxPlot: true },
         })
       }
     })

--- a/electron-src/lib/shared/calculations/numericStats.ts
+++ b/electron-src/lib/shared/calculations/numericStats.ts
@@ -1,0 +1,71 @@
+/**
+ * 数値統計のプリミティブ（平均・標準偏差・中央値・箱ひげ図・順位）
+ *
+ * 個人成績表（statisticsCalculator / computeReportData）と Excel 学級平均行
+ * （averageRows）で同一実装を共有し、複数箇所での再実装ドリフトを防ぐ。
+ * いずれも全数調査（試験の成績）向けの母集団統計。
+ */
+
+/** 箱ひげ図データ（Tukey法） */
+export interface BoxPlotData {
+  min: number
+  q1: number
+  median: number
+  q3: number
+  max: number
+}
+
+/** 母集団の平均（空配列は0） */
+export function average(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((sum, v) => sum + v, 0) / values.length
+}
+
+/** 母標準偏差（空配列は0） */
+export function stdDev(values: number[]): number {
+  if (values.length === 0) return 0
+  const avg = average(values)
+  const squaredDiffs = values.map((v) => (v - avg) ** 2)
+  return Math.sqrt(squaredDiffs.reduce((sum, v) => sum + v, 0) / values.length)
+}
+
+/** ソート済み配列の中央値（空配列は0） */
+export function median(sortedValues: number[]): number {
+  const n = sortedValues.length
+  if (n === 0) return 0
+  if (n === 1) return sortedValues[0]
+  const mid = Math.floor(n / 2)
+  if (n % 2 === 0) {
+    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
+  }
+  return sortedValues[mid]
+}
+
+/**
+ * 箱ひげ図データを計算（Tukey法）
+ * データを下位半分と上位半分に分けてそれぞれの中央値を Q1/Q3 とする。
+ * n が奇数の場合、中央値は両半分から除外する。
+ */
+export function boxPlot(values: number[]): BoxPlotData {
+  if (values.length === 0) {
+    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const n = sorted.length
+  const midIndex = Math.floor(n / 2)
+  const lowerHalf = sorted.slice(0, midIndex)
+  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
+  return {
+    min: sorted[0],
+    q1: median(lowerHalf),
+    median: median(sorted),
+    q3: median(upperHalf),
+    max: sorted[n - 1],
+  }
+}
+
+/** 順位（同点同順位。降順ソートで score 以下になる最初の位置+1） */
+export function rank(score: number, allScores: number[]): number {
+  const sorted = [...allScores].sort((a, b) => b - a)
+  return sorted.findIndex((s) => s <= score) + 1
+}

--- a/prisma/migrations/20260630010000_rebackfill_subtotal_selection_flags/migration.sql
+++ b/prisma/migrations/20260630010000_rebackfill_subtotal_selection_flags/migration.sql
@@ -1,0 +1,28 @@
+-- 20260629140000 の再バックフィル（enabled 条件を外して整合させる）
+--
+-- 旧移行は settingsJson の enabled=1 の選択のみフラグ化していたが、実行時の
+-- setSubtotalGroupSelection は enabled に関係なく「フラグ＝選択ID」を書き込む
+-- （enabled は JSON 側で『適用するか』を制御するだけ）。よってフラグは enabled に
+-- 依存せず selectedGroupIds を反映すべき。enabled=false で保存していた選択が
+-- 移行されず失われる不具合（次回保存で JSON の selectedGroupIds が [] へ strip される）を防ぐ。
+--
+-- 冪等: 既に true の行へ再度 true を立てるだけ。selectedGroupIds が JSON から
+-- strip 済み（[] / 欠落）の試験は json_each が0行となり無変更。
+
+UPDATE "ExamSubtotalGroup"
+SET "selectedForTable" = 1
+WHERE EXISTS (
+  SELECT 1 FROM "ExamExportSettings" es,
+    json_each(json_extract(es."settingsJson", '$.individualReportOptions.tableSubtotalGroupSelection.selectedGroupIds')) je
+  WHERE es."examId" = "ExamSubtotalGroup"."examId"
+    AND je.value = "ExamSubtotalGroup"."subtotalGroupId"
+);
+
+UPDATE "ExamSubtotalGroup"
+SET "selectedForBoxPlot" = 1
+WHERE EXISTS (
+  SELECT 1 FROM "ExamExportSettings" es,
+    json_each(json_extract(es."settingsJson", '$.individualReportOptions.boxPlotSubtotalGroupSelection.selectedGroupIds')) je
+  WHERE es."examId" = "ExamSubtotalGroup"."examId"
+    AND je.value = "ExamSubtotalGroup"."subtotalGroupId"
+);

--- a/src/components/exams/05-students/components/ClassExamManager.tsx
+++ b/src/components/exams/05-students/components/ClassExamManager.tsx
@@ -188,10 +188,14 @@ export function ClassExamManager({
 
     try {
       for (const classId of selectedClassIds) {
+        // administered の学級は既定で教員集計・生徒表示の対象（移行の
+        // studentReport=administered と整合）。出力スコープは後から08で調整可能。
         await window.electronAPI.examClass.add({
           examId,
           classId,
           administered: true,
+          teacherStat: true,
+          studentReport: true,
         })
       }
 

--- a/src/components/exams/08-export/components/individual-report/computeReportData.ts
+++ b/src/components/exams/08-export/components/individual-report/computeReportData.ts
@@ -2,6 +2,12 @@
  * 個人成績表の共通計算ロジック
  * プレビュー（React）とPDF出力（renderToStaticMarkup）の両方で使用
  */
+import {
+  average,
+  boxPlot,
+  rank,
+  stdDev,
+} from "@/electron-src/lib/shared/calculations/numericStats"
 import type {
   IndividualReportData,
   IndividualReportOptions,
@@ -68,20 +74,8 @@ export function computeFilteredStats(
     .map((e) => e.totalScore)
     .filter((s): s is number => s !== null)
 
-  const avg = (arr: number[]) =>
-    arr.length === 0 ? 0 : arr.reduce((s, v) => s + v, 0) / arr.length
-  const stdDevFn = (arr: number[]) => {
-    if (arr.length === 0) return 0
-    const a = avg(arr)
-    return Math.sqrt(arr.reduce((s, v) => s + (v - a) ** 2, 0) / arr.length)
-  }
-  const rankFn = (score: number, scores: number[]) => {
-    const sorted = [...scores].sort((a, b) => b - a)
-    return sorted.findIndex((s) => s <= score) + 1
-  }
-
-  const overallAvg = avg(allScores)
-  const overallStd = stdDevFn(allScores)
+  const overallAvg = average(allScores)
+  const overallStd = stdDev(allScores)
   const studentScore = report.scoringData.totalScore
   const deviation =
     studentScore === null || overallStd === 0
@@ -101,10 +95,10 @@ export function computeFilteredStats(
       .filter((s): s is number => s !== null)
     return {
       ...cls,
-      average: avg(classScores),
-      stdDev: stdDevFn(classScores),
+      average: average(classScores),
+      stdDev: stdDev(classScores),
       total: filteredMembers.length,
-      rank: studentScore !== null ? rankFn(studentScore, classScores) : 0,
+      rank: studentScore !== null ? rank(studentScore, classScores) : 0,
     }
   })
 
@@ -120,47 +114,14 @@ export function computeFilteredStats(
     personal: {
       ...report.statistics.personal,
       deviation,
-      overallRank: studentScore !== null ? rankFn(studentScore, allScores) : 0,
+      overallRank: studentScore !== null ? rank(studentScore, allScores) : 0,
     },
   }
 }
 
 // ============================
-// 箱ひげ図統計計算
+// 箱ひげ図統計計算（プリミティブは numericStats を共用）
 // ============================
-
-function calculateMedian(sortedValues: number[]): number {
-  const n = sortedValues.length
-  if (n === 0) return 0
-  if (n === 1) return sortedValues[0]
-  const mid = Math.floor(n / 2)
-  if (n % 2 === 0) {
-    return (sortedValues[mid - 1] + sortedValues[mid]) / 2
-  }
-  return sortedValues[mid]
-}
-
-function calculateAverage(values: number[]): number {
-  if (values.length === 0) return 0
-  return values.reduce((sum, v) => sum + v, 0) / values.length
-}
-
-function calculateBoxPlotData(values: number[]) {
-  if (values.length === 0) {
-    return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
-  }
-  const sorted = [...values].sort((a, b) => a - b)
-  const n = sorted.length
-  const min = sorted[0]
-  const max = sorted[n - 1]
-  const median = calculateMedian(sorted)
-  const midIndex = Math.floor(n / 2)
-  const lowerHalf = sorted.slice(0, midIndex)
-  const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
-  const q1 = calculateMedian(lowerHalf)
-  const q3 = calculateMedian(upperHalf)
-  return { min, q1, median, q3, max }
-}
 
 /**
  * 小計点箱ひげ図の統計を受験状態フィルタ付きで再計算
@@ -214,8 +175,8 @@ export function computeFilteredSubtotalStats(
       subtotalId: stat.subtotalId,
       subtotalLabel: stat.subtotalLabel,
       subtotalGroupId: stat.subtotalGroupId,
-      boxPlot: calculateBoxPlotData(filteredScores),
-      average: calculateAverage(filteredScores),
+      boxPlot: boxPlot(filteredScores),
+      average: average(filteredScores),
       maxScore: stat.maxScore,
     }
   })
@@ -249,9 +210,9 @@ export function computeFilteredOverallStat(
     subtotalGroupId: "__overall__",
     boxPlot:
       filteredScores.length > 0
-        ? calculateBoxPlotData(filteredScores)
+        ? boxPlot(filteredScores)
         : { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
-    average: calculateAverage(filteredScores),
+    average: average(filteredScores),
     maxScore: totalMaxScore,
   }
 }

--- a/src/types/prismaExtensions.ts
+++ b/src/types/prismaExtensions.ts
@@ -27,6 +27,26 @@ export type ClassWithMemberships = Prisma.ClassGetPayload<{
 }>
 
 /**
+ * 受験日所属生徒（studentId のみ）を含む ExamClass 型。
+ *
+ * getClassMembersForExam が返す集計エンジンの基本型
+ * （Excel学級平均行・個人成績表の学級比較）。memberships は受験日スナップショットで
+ * where 絞り込み・出席番号→学籍番号順にソート済み。所属生徒IDは
+ * `ec.class.memberships.map((m) => m.studentId)` で取得する。
+ */
+export type ExamClassWithMembers = Prisma.ExamClassGetPayload<{
+  include: {
+    class: {
+      include: {
+        memberships: {
+          select: { studentId: true }
+        }
+      }
+    }
+  }
+}>
+
+/**
  * 学級所属情報を含む生徒型
  */
 export type StudentWithMemberships = Prisma.StudentGetPayload<{


### PR DESCRIPTION
Closes #893

PR #892 への高リコールコードレビューで検出した実バグ3件・性能4件・型規約/保守性4件に対応。

## 実バグ
- merge取込が ExamSubtotalGroup 選択フラグを落としていたのを修正（データ損失）
- 05追加学級が teacherStat/studentReport=false 既定で統計除外されていたのを administered 整合の既定へ
- enabled=false の小計選択がアップグレードで消失していたのを enabled非依存の再バックフィルmigrationで修正

## 性能
- Excel部分出力の二重fetch解消 / 個人成績表のMap再構築解消 / includes走査→Map事前構築 / N+1→updateMany

## 型規約・保守性（ご指摘反映）
- **getClassMembersForExam を Prisma payload型 `ExamClassWithMembers` へ**（studentIds平坦化のflat DTOを廃し include で memberships を直接保持）
- 統計プリミティブを numericStats へ集約（3重実装＋BoxPlotData重複を解消）
- フラグ補完を共有ヘルパ化 / SUPPORTED_VERSIONS整合 / 陳腐化コメント是正

## 検証
フルテスト 862 passed / 1 failed（既存の日付相対 grade のみ・無関係）、typecheck・lint クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)