### PR TITLE
feat(grade): 観点間の制約ルールで不適切な成績を着色する機能を追加

### DIFF
--- a/__tests__/grades/gradeConstraints.test.ts
+++ b/__tests__/grades/gradeConstraints.test.ts
@@ -1,0 +1,341 @@
+/**
+ * 観点間の制約ルール評価（src/lib/gradeConstraints.ts）の単体テスト
+ *
+ * 校内ルール例（3観点 A/B/C, 評定1〜5）を、整合ルール・混在禁止・式で表現し、
+ * 不適切な組合せの生徒だけが違反として検出されることを検証する。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  evaluateConstraints,
+  validateConstraintExpression,
+} from "@/lib/gradeConstraints"
+import type {
+  GradeCalculationResult,
+  GradeConstraintData,
+  StudentGradeResult,
+} from "@/types/grade.types"
+
+const GRADE_ITEMS = [
+  { id: "gi-knowledge", name: "知識・技能", order: 0 },
+  { id: "gi-thinking", name: "思考・判断・表現", order: 1 },
+  { id: "gi-attitude", name: "態度", order: 2 },
+]
+
+/** 観点3つのラベルから生徒結果を作る */
+function makeStudent(
+  id: string,
+  labels: [string, string, string]
+): StudentGradeResult {
+  return {
+    studentId: id,
+    studentNumber: id,
+    lastName: id,
+    firstName: "",
+    attendanceNumber: null,
+    className: null,
+    gradeItemResults: GRADE_ITEMS.map((gi, i) => ({
+      gradeItemId: gi.id,
+      gradeItemName: gi.name,
+      isExcluded: false,
+      isAllMissing: false,
+      sourceScores: [],
+      weightedScore: 1,
+      weightedMaxScore: 1,
+      percentage: 50,
+      gradeLabel: labels[i],
+      originalGradeLabel: labels[i],
+      overrideGradeLabel: null,
+    })),
+    overallScore: null,
+    overallMaxScore: 0,
+    overallPercentage: null,
+    overallGradeLabel: null,
+    originalOverallGradeLabel: null,
+    overrideOverallGradeLabel: null,
+  }
+}
+
+function makeResult(students: StudentGradeResult[]): GradeCalculationResult {
+  return {
+    gradeId: "g1",
+    gradeName: "テスト成績",
+    classNames: [],
+    gradeItems: GRADE_ITEMS,
+    students,
+    boundarySets: [],
+  }
+}
+
+function violatedIds(
+  result: GradeCalculationResult,
+  constraints: GradeConstraintData[]
+): string[] {
+  const { violations } = evaluateConstraints(result, constraints)
+  return [...violations.keys()].sort()
+}
+
+const baseConstraint: Omit<
+  GradeConstraintData,
+  "kind" | "config" | "expression"
+> = {
+  id: "c1",
+  gradeId: "g1",
+  name: "ルール",
+  color: "#fecaca",
+  message: null,
+  enabled: true,
+  order: 0,
+}
+
+describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）", () => {
+  // 実データ構成: 知識・技能/思考・判断・表現/態度(A/B/C) + 評定(5..1) の4項目。
+  // すべて GradeItem 同士の比較。評定 GradeItem を比較先にする。
+  const ITEMS_WITH_HYOTEI = [
+    { id: "gi-k", name: "知識・技能", order: 0 },
+    { id: "gi-s", name: "思考・判断・表現", order: 1 },
+    { id: "gi-a", name: "態度", order: 2 },
+    { id: "gi-h", name: "評定", order: 3 },
+  ]
+
+  function makeStudent4(
+    id: string,
+    k: string,
+    s: string,
+    a: string,
+    hyotei: string
+  ): StudentGradeResult {
+    const labels: Record<string, string> = {
+      "gi-k": k,
+      "gi-s": s,
+      "gi-a": a,
+      "gi-h": hyotei,
+    }
+    return {
+      studentId: id,
+      studentNumber: id,
+      lastName: id,
+      firstName: "",
+      attendanceNumber: null,
+      className: null,
+      gradeItemResults: ITEMS_WITH_HYOTEI.map((gi) => ({
+        gradeItemId: gi.id,
+        gradeItemName: gi.name,
+        isExcluded: false,
+        isAllMissing: false,
+        sourceScores: [],
+        weightedScore: 1,
+        weightedMaxScore: 1,
+        percentage: 50,
+        gradeLabel: labels[gi.id],
+        originalGradeLabel: labels[gi.id],
+        overrideGradeLabel: null,
+      })),
+      overallScore: null,
+      overallMaxScore: 1,
+      overallPercentage: null,
+      overallGradeLabel: null, // overall は未設定
+      originalOverallGradeLabel: null,
+      overrideOverallGradeLabel: null,
+    }
+  }
+
+  function makeResult4(students: StudentGradeResult[]): GradeCalculationResult {
+    return {
+      gradeId: "g1",
+      gradeName: "1学期末評定",
+      classNames: [],
+      gradeItems: ITEMS_WITH_HYOTEI,
+      students,
+      boundarySets: [
+        {
+          targetType: "grade_item",
+          gradeItemId: "gi-h",
+          boundaries: [
+            { label: "5", minPercentage: 80 },
+            { label: "4", minPercentage: 65 },
+            { label: "3", minPercentage: 50 },
+            { label: "2", minPercentage: 35 },
+            { label: "1", minPercentage: 0 },
+          ],
+        },
+      ],
+    }
+  }
+
+  const consistencyTargetItem: GradeConstraintData = {
+    ...baseConstraint,
+    kind: "consistency",
+    config: JSON.stringify({
+      labelValues: { A: 5, B: 3, C: 1 },
+      aggregate: "average",
+      tolerance: 1,
+      target: "評定",
+      viewpointItems: ["知識・技能", "思考・判断・表現", "態度"],
+    }),
+    expression: "",
+  }
+
+  it("評定項目と3観点平均の乖離が許容超の生徒だけ違反になる", () => {
+    const result = makeResult4([
+      makeStudent4("aaa-5", "A", "A", "A", "5"), // 平均5, 評定5 → OK
+      makeStudent4("bbb-3", "B", "B", "B", "3"), // 平均3, 評定3 → OK
+      makeStudent4("aaa-3", "A", "A", "A", "3"), // 平均5, 評定3 → 乖離2 違反
+    ])
+    expect(violatedIds(result, [consistencyTargetItem])).toEqual(["aaa-3"])
+  })
+
+  it('式で item("評定") と label(観点) を項目名で参照できる', () => {
+    // 評定5なのに観点にCがある生徒を検出（スケール非依存の判定）
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      config: "{}",
+      expression: 'item("評定") == 5 and has("C")',
+    }
+    const result = makeResult4([
+      makeStudent4("ok", "A", "A", "A", "5"), // 評定5, Cなし → OK
+      makeStudent4("bad", "A", "A", "C", "5"), // 評定5なのにC → 違反
+    ])
+    expect(violatedIds(result, [expr])).toEqual(["bad"])
+  })
+})
+
+describe("gradeConstraints: 混在禁止（mutual_exclusion）", () => {
+  const exclusion: GradeConstraintData = {
+    ...baseConstraint,
+    kind: "mutual_exclusion",
+    config: JSON.stringify({ labels: ["A", "C"] }),
+    expression: "",
+  }
+
+  it("AとCが混在する生徒だけ違反になる", () => {
+    const result = makeResult([
+      makeStudent("mix", ["A", "B", "C"]),
+      makeStudent("pure-ab", ["A", "A", "B"]),
+      makeStudent("pure-bc", ["B", "B", "C"]),
+    ])
+    expect(violatedIds(result, [exclusion])).toEqual(["mix"])
+  })
+})
+
+describe("gradeConstraints: 式（expression）", () => {
+  it('has("A") and has("C") で A・C混在を検出できる', () => {
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      config: "{}",
+      expression: 'has("A") and has("C")',
+    }
+    const result = makeResult([
+      makeStudent("mix", ["A", "B", "C"]),
+      makeStudent("nomix", ["A", "A", "B"]),
+    ])
+    expect(violatedIds(result, [expr])).toEqual(["mix"])
+  })
+
+  it('label("態度") で特定観点を参照できる', () => {
+    // 態度Aだが知識・技能がC（観点間の不整合）を検出
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      config: "{}",
+      expression: 'label("態度") == "A" and label("知識・技能") == "C"',
+    }
+    const result = makeResult([
+      makeStudent("bad", ["C", "C", "A"]), // 知識C・態度A
+      makeStudent("ok", ["A", "A", "A"]),
+    ])
+    expect(violatedIds(result, [expr])).toEqual(["bad"])
+  })
+
+  it("不正な式は違反を出さずエラーとして扱う", () => {
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      config: "{}",
+      expression: "has(", // 構文エラー
+    }
+    const result = makeResult([makeStudent("s", ["A", "B", "C"])])
+    const { violations, errors } = evaluateConstraints(result, [expr])
+    expect(violations.size).toBe(0)
+    expect(errors.has("c1")).toBe(true)
+  })
+
+  it("存在しない項目名を参照する式は無言失火せずエラーになる", () => {
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      config: "{}",
+      // 「知識・技能」の・抜け（タイプミス）
+      expression: 'item("知識技能") < 3',
+    }
+    const result = makeResult([makeStudent("s", ["C", "B", "A"])])
+    const { violations, errors } = evaluateConstraints(result, [expr])
+    expect(violations.size).toBe(0)
+    expect(errors.get("c1")).toContain("知識技能")
+  })
+})
+
+describe("gradeConstraints: 補助", () => {
+  it("validateConstraintExpression は妥当な式に null を返す", () => {
+    expect(validateConstraintExpression('has("A") and has("C")')).toBeNull()
+    expect(
+      validateConstraintExpression('abs(item("評定") - mean()) > 1')
+    ).toBeNull()
+  })
+
+  it("validateConstraintExpression は不正な式にメッセージを返す", () => {
+    expect(validateConstraintExpression("has(")).not.toBeNull()
+    expect(validateConstraintExpression("")).not.toBeNull()
+  })
+
+  it("無効化されたルールは評価されない", () => {
+    const disabled: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "mutual_exclusion",
+      config: JSON.stringify({ labels: ["A", "C"] }),
+      expression: "",
+      enabled: false,
+    }
+    const result = makeResult([makeStudent("mix", ["A", "B", "C"])])
+    expect(violatedIds(result, [disabled])).toEqual([])
+  })
+
+  it("整合ルールの比較先(target)が未選択なら無言失火せずエラーになる", () => {
+    const noTarget: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "consistency",
+      config: JSON.stringify({
+        labelValues: { A: 5, B: 3, C: 1 },
+        aggregate: "average",
+        tolerance: 1,
+        target: "",
+      }),
+      expression: "",
+    }
+    const result = makeResult([makeStudent("s", ["A", "A", "A"])])
+    const { violations, errors } = evaluateConstraints(result, [noTarget])
+    expect(violations.size).toBe(0)
+    expect(errors.get("c1")).toContain("未選択")
+  })
+
+  it("整合ルールの比較先(target)が実在しない項目ならエラーになる", () => {
+    const badTarget: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "consistency",
+      config: JSON.stringify({
+        labelValues: { A: 5, B: 3, C: 1 },
+        aggregate: "average",
+        tolerance: 1,
+        target: "評定", // makeResult の3項目には存在しない
+      }),
+      expression: "",
+    }
+    const result = makeResult([makeStudent("s", ["A", "A", "A"])])
+    const { violations, errors } = evaluateConstraints(result, [badTarget])
+    expect(violations.size).toBe(0)
+    expect(errors.get("c1")).toContain("評定")
+  })
+})

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -927,6 +927,86 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(ds!.courseworkItem!.courseworkId).toBe(existing.id)
   })
 
+  it("観点間の制約ルール(GradeConstraint)が往復で保持される (v1.7.0)", async () => {
+    const suffix = Date.now()
+    const grade = await prisma.grade.create({
+      data: { name: `成績_constraint_${suffix}` },
+    })
+    await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeConstraint.create({
+      data: {
+        gradeId: grade.id,
+        name: "A・C混在禁止",
+        kind: "mutual_exclusion",
+        config: JSON.stringify({ labels: ["A", "C"] }),
+        expression: "",
+        color: "#fecaca",
+        message: "AとCは混在しません",
+        enabled: true,
+        order: 0,
+      },
+    })
+    await prisma.gradeConstraint.create({
+      data: {
+        gradeId: grade.id,
+        name: "評定と観点の整合",
+        kind: "expression",
+        config: "{}",
+        expression: 'abs(item("評定") - mean("知識・技能")) > 1',
+        color: "#fde68a",
+        message: null,
+        enabled: false,
+        order: 1,
+      },
+    })
+
+    // 収集（export）
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.gradeConstraints).toHaveLength(2)
+    const exclusion = collected.gradeData.gradeConstraints!.find(
+      (c) => c.kind === "mutual_exclusion"
+    )!
+    expect(exclusion.name).toBe("A・C混在禁止")
+    expect(exclusion.config).toBe(JSON.stringify({ labels: ["A", "C"] }))
+
+    // インポート（新規Gradeとして作成される）
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    const imported = await prisma.gradeConstraint.findMany({
+      where: { gradeId: result.gradeId! },
+      orderBy: { order: "asc" },
+    })
+    expect(imported).toHaveLength(2)
+    expect(imported[0].name).toBe("A・C混在禁止")
+    expect(imported[0].kind).toBe("mutual_exclusion")
+    expect(imported[0].message).toBe("AとCは混在しません")
+    expect(imported[0].enabled).toBe(true)
+    expect(imported[1].kind).toBe("expression")
+    expect(imported[1].expression).toBe(
+      'abs(item("評定") - mean("知識・技能")) > 1'
+    )
+    expect(imported[1].enabled).toBe(false)
+    expect(imported[1].color).toBe("#fde68a")
+  })
+
+  it("gradeConstraints が無いGradeも問題なく往復する（後方互換）", async () => {
+    const grade = await prisma.grade.create({
+      data: { name: `成績_noconstraint_${Date.now()}` },
+    })
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.gradeConstraints).toBeUndefined()
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+    const imported = await prisma.gradeConstraint.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(imported).toHaveLength(0)
+  })
+
   it("旧 v1.4.0（名前ベース courseworks 埋め込み）を後方互換で読み込める", async () => {
     const suffix = Date.now()
     // 旧形式は生徒・学級を既存前提で名前 lookup する

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -199,6 +199,7 @@ describe("DateTime正規化マイグレーション", () => {
     "CourseworkScore",
     "CourseworkStudent",
     "CourseworkTag",
+    "GradeConstraint",
     "ReturnSnapshot",
   ])
 

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -4,6 +4,7 @@
 
 import { dialog } from "electron"
 
+import type { GradeConstraintInput } from "../../src/types/grade.types"
 import { createGradeArchive } from "../lib/export/grade-archive"
 import { exportGradeExcel } from "../lib/export/gradeExcel"
 import {
@@ -25,6 +26,12 @@ import {
   getBoundarySetsByGradeId,
   upsertBoundarySet,
 } from "../lib/prisma/gradeBoundary"
+import {
+  createGradeConstraint,
+  deleteGradeConstraint,
+  getGradeConstraints,
+  updateGradeConstraint,
+} from "../lib/prisma/gradeConstraint"
 import {
   batchUpdateAbsentPolicy,
   calculateSourceMaxScore,
@@ -381,6 +388,32 @@ export function setupGradeHandlers(): void {
       return deleteGradeOverride(data)
     }
   )
+
+  // =====================================================================
+  // GradeConstraint（観点間の制約ルール）
+  // =====================================================================
+
+  registerHandler("grade:getGradeConstraints", async (gradeId: string) => {
+    return getGradeConstraints(gradeId)
+  })
+
+  registerHandler(
+    "grade:createGradeConstraint",
+    async (data: { gradeId: string; constraint: GradeConstraintInput }) => {
+      return createGradeConstraint(data)
+    }
+  )
+
+  registerHandler(
+    "grade:updateGradeConstraint",
+    async (data: { id: string; constraint: Partial<GradeConstraintInput> }) => {
+      return updateGradeConstraint(data)
+    }
+  )
+
+  registerHandler("grade:deleteGradeConstraint", async (id: string) => {
+    return deleteGradeConstraint(id)
+  })
 
   // =====================================================================
   // GradeItemExclusion

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -84,6 +84,9 @@ export async function collectGradeArchiveData(
           gradeItem: { select: { name: true } },
         },
       },
+      gradeConstraints: {
+        orderBy: { order: "asc" },
+      },
       exportSettings: true,
     },
   })
@@ -206,6 +209,17 @@ export async function collectGradeArchiveData(
     overrideLabel: ov.overrideLabel,
   }))
 
+  const gradeConstraints = gp.gradeConstraints.map((c) => ({
+    name: c.name,
+    kind: c.kind,
+    config: c.config,
+    expression: c.expression,
+    color: c.color,
+    message: c.message,
+    enabled: c.enabled,
+    order: c.order,
+  }))
+
   return {
     gradeData: {
       grade: {
@@ -223,6 +237,8 @@ export async function collectGradeArchiveData(
       gradeItemExclusions:
         gradeItemExclusions.length > 0 ? gradeItemExclusions : undefined,
       gradeOverrides: gradeOverrides.length > 0 ? gradeOverrides : undefined,
+      gradeConstraints:
+        gradeConstraints.length > 0 ? gradeConstraints : undefined,
     },
     courseworkArchive,
     boundariesData: { boundarySets },

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -434,6 +434,28 @@ export async function importGradeArchive(
           }
         }
 
+        // 観点間の制約ルール（v1.7.0+。式は観点名参照のためID再マップ不要）
+        if (
+          gradeData.gradeConstraints &&
+          gradeData.gradeConstraints.length > 0
+        ) {
+          for (const c of gradeData.gradeConstraints) {
+            await tx.gradeConstraint.create({
+              data: {
+                gradeId: gp.id,
+                name: c.name,
+                kind: c.kind,
+                config: c.config,
+                expression: c.expression,
+                color: c.color,
+                message: c.message,
+                enabled: c.enabled,
+                order: c.order,
+              },
+            })
+          }
+        }
+
         return { success: true, gradeId: gp.id }
       }
     )

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -19,12 +19,7 @@ export type AuditCategory =
 
 /** アクションの種別（アイコン・色分け用） */
 export type AuditVerb =
-  | "create"
-  | "update"
-  | "delete"
-  | "export"
-  | "import"
-  | "other"
+  "create" | "update" | "delete" | "export" | "import" | "other"
 
 export interface AuditActionDef {
   category: AuditCategory
@@ -364,6 +359,21 @@ export const AUDIT_ACTIONS = {
     category: "grade",
     verb: "update",
     label: "成績の上書きを更新しました",
+  },
+  "grade.constraint.create": {
+    category: "grade",
+    verb: "create",
+    label: "観点間の制約ルールを作成しました",
+  },
+  "grade.constraint.update": {
+    category: "grade",
+    verb: "update",
+    label: "観点間の制約ルールを更新しました",
+  },
+  "grade.constraint.delete": {
+    category: "grade",
+    verb: "delete",
+    label: "観点間の制約ルールを削除しました",
   },
 
   // ── 試験外成績資料（coursework） ─────────────────────────────

--- a/electron-src/lib/prisma/gradeConstraint.ts
+++ b/electron-src/lib/prisma/gradeConstraint.ts
@@ -1,0 +1,137 @@
+/**
+ * GradeConstraint（観点間の制約ルール）のPrisma操作関数
+ */
+
+import type { GradeConstraintInput } from "../../../src/types/grade.types"
+import { recordAuditLog } from "./auditLog"
+import { resolveGradeScope } from "./auditScope"
+import prisma from "./client"
+
+/**
+ * 成績の全制約ルールを取得（order昇順）
+ */
+export async function getGradeConstraints(gradeId: string) {
+  try {
+    const constraints = await prisma.gradeConstraint.findMany({
+      where: { gradeId },
+      orderBy: { order: "asc" },
+    })
+    return { success: true, constraints }
+  } catch (error) {
+    console.error("Error getting grade constraints:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * 制約ルールを新規作成
+ */
+export async function createGradeConstraint(data: {
+  gradeId: string
+  constraint: GradeConstraintInput
+}) {
+  try {
+    const created = await prisma.gradeConstraint.create({
+      data: {
+        gradeId: data.gradeId,
+        name: data.constraint.name,
+        kind: data.constraint.kind,
+        config: data.constraint.config,
+        expression: data.constraint.expression,
+        color: data.constraint.color,
+        message: data.constraint.message,
+        enabled: data.constraint.enabled,
+        order: data.constraint.order,
+      },
+    })
+
+    const scope = await resolveGradeScope(data.gradeId)
+    await recordAuditLog({
+      action: "grade.constraint.create",
+      entityType: "GradeConstraint",
+      entityId: created.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+    })
+
+    return { success: true, constraint: created }
+  } catch (error) {
+    console.error("Error creating grade constraint:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * 制約ルールを更新
+ */
+export async function updateGradeConstraint(data: {
+  id: string
+  constraint: Partial<GradeConstraintInput>
+}) {
+  try {
+    const updated = await prisma.gradeConstraint.update({
+      where: { id: data.id },
+      data: {
+        name: data.constraint.name,
+        kind: data.constraint.kind,
+        config: data.constraint.config,
+        expression: data.constraint.expression,
+        color: data.constraint.color,
+        message: data.constraint.message,
+        enabled: data.constraint.enabled,
+        order: data.constraint.order,
+      },
+    })
+
+    const scope = await resolveGradeScope(updated.gradeId)
+    await recordAuditLog({
+      action: "grade.constraint.update",
+      entityType: "GradeConstraint",
+      entityId: updated.id,
+      scopeId: scope.scopeId,
+      scopeLabel: scope.scopeLabel,
+    })
+
+    return { success: true, constraint: updated }
+  } catch (error) {
+    console.error("Error updating grade constraint:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * 制約ルールを削除
+ */
+export async function deleteGradeConstraint(id: string) {
+  try {
+    const existing = await prisma.gradeConstraint.findUnique({ where: { id } })
+    if (existing) {
+      await prisma.gradeConstraint.delete({ where: { id } })
+
+      const scope = await resolveGradeScope(existing.gradeId)
+      await recordAuditLog({
+        action: "grade.constraint.delete",
+        entityType: "GradeConstraint",
+        entityId: id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+      })
+    }
+    return { success: true }
+  } catch (error) {
+    console.error("Error deleting grade constraint:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -151,6 +151,36 @@ export function createGradeApi() {
         targetType: string
         gradeItemId: string | null
       }) => ipcRenderer.invoke("grade:deleteGradeOverride", data),
+      getGradeConstraints: (gradeId: string) =>
+        ipcRenderer.invoke("grade:getGradeConstraints", gradeId),
+      createGradeConstraint: (data: {
+        gradeId: string
+        constraint: {
+          name: string
+          kind: string
+          config: string
+          expression: string
+          color: string
+          message: string | null
+          enabled: boolean
+          order: number
+        }
+      }) => ipcRenderer.invoke("grade:createGradeConstraint", data),
+      updateGradeConstraint: (data: {
+        id: string
+        constraint: Partial<{
+          name: string
+          kind: string
+          config: string
+          expression: string
+          color: string
+          message: string | null
+          enabled: boolean
+          order: number
+        }>
+      }) => ipcRenderer.invoke("grade:updateGradeConstraint", data),
+      deleteGradeConstraint: (id: string) =>
+        ipcRenderer.invoke("grade:deleteGradeConstraint", id),
       getGradeItemExclusions: (gradeId: string) =>
         ipcRenderer.invoke("grade:getGradeItemExclusions", gradeId),
       setGradeItemExclusion: (data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "dayjs": "^1.11.21",
         "exceljs": "^4.4.0",
+        "expr-eval": "^2.0.2",
         "input-otp": "^1.4.2",
         "lucide-react": "^1.22.0",
         "next": "^16.2.6",
@@ -12600,6 +12601,12 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/expr-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
+      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
+      "license": "MIT"
     },
     "node_modules/exsolve": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "cmdk": "^1.1.1",
     "dayjs": "^1.11.21",
     "exceljs": "^4.4.0",
+    "expr-eval": "^2.0.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.22.0",
     "next": "^16.2.6",

--- a/prisma/migrations/20260701000000_add_grade_constraint/migration.sql
+++ b/prisma/migrations/20260701000000_add_grade_constraint/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable: 観点間の制約ルール（不適切な観点/評定の組合せを検知して着色）
+-- Grade個別に保持。kind別（consistency / mutual_exclusion / expression）。
+CREATE TABLE "GradeConstraint" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "config" TEXT NOT NULL DEFAULT '{}',
+    "expression" TEXT NOT NULL DEFAULT '',
+    "color" TEXT NOT NULL,
+    "message" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeConstraint_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "GradeConstraint_gradeId_idx" ON "GradeConstraint"("gradeId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -663,7 +663,28 @@ model Grade {
   gradeStudents       GradeStudent[]
   gradeOverrides      GradeOverride[]
   gradeItemExclusions GradeItemExclusion[]
+  gradeConstraints    GradeConstraint[]
   exportSettings      GradeExportSettings?
+}
+
+/// 観点間の制約ルール（不適切な観点/評定の組合せを検知して着色）
+model GradeConstraint {
+  id         String   @id @default(uuid())
+  gradeId    String
+  name       String
+  kind       String // "consistency" | "mutual_exclusion" | "expression"
+  config     String   @default("{}") // ビルダー設定のJSON（kind別）
+  expression String   @default("") // kind="expression" 時のみ使用
+  color      String // 着色色（hex等）
+  message    String?
+  enabled    Boolean  @default(true)
+  order      Int      @default(0)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  grade Grade @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+
+  @@index([gradeId])
 }
 
 /// 評価項目（知識・技能、思考・判断・表現、評定 等）

--- a/src/components/grades/05-boundaries/BoundariesContainer.tsx
+++ b/src/components/grades/05-boundaries/BoundariesContainer.tsx
@@ -1,14 +1,15 @@
 "use client"
 
 import Link from "next/link"
-import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Card } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
 import { useBoundaries } from "@/hooks/grades/useBoundaries"
 
 import { BoundaryEditor } from "./BoundaryEditor"
 import { BoundaryPresetSelector } from "./BoundaryPresetSelector"
+import { ConstraintRulesEditor } from "./ConstraintRulesEditor"
 
 interface BoundariesContainerProps {
   gradeId: string
@@ -17,7 +18,6 @@ interface BoundariesContainerProps {
 export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
   const { exam, boundarySets, loading, saveBoundarySet } =
     useBoundaries(gradeId)
-  const [activeTab, setActiveTab] = useState("")
 
   if (loading || !exam) {
     return (
@@ -28,7 +28,6 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
   }
 
   const gradeItems = exam.gradeItems
-  const effectiveTab = activeTab || gradeItems[0]?.id || ""
 
   const getExistingBoundaries = (
     targetType: string,
@@ -48,14 +47,6 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
     await saveBoundarySet({ targetType, gradeItemId, boundaries })
   }
 
-  const handlePreset = (
-    targetType: string,
-    gradeItemId: string | null,
-    boundaries: { label: string; minPercentage: number; order: number }[]
-  ) => {
-    handleSave(targetType, gradeItemId, boundaries)
-  }
-
   return (
     <div className="p-6">
       <h2 className="mb-4 text-lg font-semibold">成績境界設定</h2>
@@ -63,33 +54,32 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
         各パーセンテージ閾値以上でその成績ラベルが付与されます。
       </p>
 
-      <Tabs value={effectiveTab} onValueChange={setActiveTab}>
-        <TabsList className="w-full">
-          {gradeItems.map((gi) => (
-            <TabsTrigger key={gi.id} value={gi.id}>
-              {gi.name}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-
+      <div className="space-y-4">
         {gradeItems.map((gi) => (
-          <TabsContent key={gi.id} value={gi.id} className="mt-4">
-            <div className="mb-4">
-              <BoundaryPresetSelector
-                onSelect={(boundaries) =>
-                  handlePreset("grade_item", gi.id, boundaries)
-                }
-              />
-            </div>
+          <Card key={gi.id} className="space-y-3 p-4">
+            <h3 className="text-base font-semibold">{gi.name}</h3>
+            <BoundaryPresetSelector
+              onSelect={(boundaries) =>
+                handleSave("grade_item", gi.id, boundaries)
+              }
+            />
             <BoundaryEditor
               boundaries={getExistingBoundaries("grade_item", gi.id)}
               onSave={(boundaries) =>
                 handleSave("grade_item", gi.id, boundaries)
               }
             />
-          </TabsContent>
+          </Card>
         ))}
-      </Tabs>
+      </div>
+
+      <Separator className="my-8" />
+
+      <ConstraintRulesEditor
+        gradeId={gradeId}
+        gradeItems={gradeItems}
+        boundarySets={boundarySets}
+      />
 
       <div className="mt-8 flex justify-end">
         <Button asChild>

--- a/src/components/grades/05-boundaries/ConsistencyFields.tsx
+++ b/src/components/grades/05-boundaries/ConsistencyFields.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { DEFAULT_CONSISTENCY_CONFIG, parseConfig } from "@/lib/gradeConstraints"
+import type { ConsistencyConfig } from "@/types/grade.types"
+
+/** 整合ルールの設定JSONを復元 */
+export function parseConsistency(raw: string): ConsistencyConfig {
+  return parseConfig(raw, DEFAULT_CONSISTENCY_CONFIG)
+}
+
+interface ConsistencyFieldsProps {
+  config: ConsistencyConfig
+  labels: string[]
+  itemNames: string[]
+  onChange: (config: ConsistencyConfig) => void
+}
+
+export function ConsistencyFields({
+  config,
+  labels,
+  itemNames,
+  onChange,
+}: ConsistencyFieldsProps) {
+  // ラベル値は A/B/C 等の非数値ラベルのみ（数値ラベルはそのまま数値化される）
+  const valueLabels = (
+    labels.length > 0 ? labels : Object.keys(config.labelValues)
+  ).filter((l) => Number.isNaN(Number(l)))
+
+  const target = config.target
+  const viewpointNames = itemNames.filter((n) => n !== target)
+  const effectiveViewpoints =
+    config.viewpointItems && config.viewpointItems.length > 0
+      ? config.viewpointItems
+      : viewpointNames
+
+  const toggleViewpoint = (name: string) => {
+    const set = new Set(effectiveViewpoints)
+    if (set.has(name)) set.delete(name)
+    else set.add(name)
+    onChange({ ...config, viewpointItems: [...set] })
+  }
+
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <Label className="text-muted-foreground text-xs">
+            評定（比較先の項目）
+          </Label>
+          <Select
+            value={target}
+            onValueChange={(value) =>
+              onChange({
+                ...config,
+                target: value,
+                viewpointItems: itemNames.filter((n) => n !== value),
+              })
+            }
+          >
+            <SelectTrigger className="mt-1 h-8 w-44">
+              <SelectValue placeholder="項目を選択" />
+            </SelectTrigger>
+            <SelectContent>
+              {itemNames.map((n) => (
+                <SelectItem key={n} value={n}>
+                  {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label className="text-muted-foreground text-xs">集計</Label>
+          <Select
+            value={config.aggregate}
+            onValueChange={(value) =>
+              onChange({
+                ...config,
+                aggregate: value as ConsistencyConfig["aggregate"],
+              })
+            }
+          >
+            <SelectTrigger className="mt-1 h-8 w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="average">平均</SelectItem>
+              <SelectItem value="sum">合計</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label className="text-muted-foreground text-xs">許容差 ±</Label>
+          <Input
+            type="number"
+            step="0.1"
+            value={config.tolerance}
+            onChange={(e) =>
+              onChange({ ...config, tolerance: Number(e.target.value) })
+            }
+            className="mt-1 h-8 w-20"
+          />
+        </div>
+      </div>
+
+      <div>
+        <Label className="text-muted-foreground text-xs">
+          集計する観点（{config.aggregate === "sum" ? "合計" : "平均"}
+          をとる項目）
+        </Label>
+        <div className="mt-1 flex flex-wrap gap-2">
+          {viewpointNames.map((name) => {
+            const active = effectiveViewpoints.includes(name)
+            return (
+              <button
+                key={name}
+                type="button"
+                onClick={() => toggleViewpoint(name)}
+                className={`rounded border px-2 py-1 text-xs ${
+                  active
+                    ? "border-primary bg-primary/10 text-foreground font-medium"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {name}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {valueLabels.length > 0 && (
+        <div>
+          <Label className="text-muted-foreground text-xs">
+            ラベル値（観点の A/B/C 等を数値に換算）
+          </Label>
+          <div className="mt-1 flex flex-wrap gap-2">
+            {valueLabels.map((label) => (
+              <div key={label} className="flex items-center gap-1">
+                <span className="w-5 text-center font-medium">{label}</span>
+                <Input
+                  type="number"
+                  value={config.labelValues[label] ?? 0}
+                  onChange={(e) =>
+                    onChange({
+                      ...config,
+                      labelValues: {
+                        ...config.labelValues,
+                        [label]: Number(e.target.value),
+                      },
+                    })
+                  }
+                  className="h-8 w-16"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <p className="text-muted-foreground text-xs">
+        「{target || "（未選択）"}」と、選んだ観点の
+        {config.aggregate === "sum" ? "合計" : "平均"}の差が {config.tolerance}{" "}
+        を超えたら違反とみなします。
+      </p>
+    </div>
+  )
+}

--- a/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
+++ b/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
@@ -1,0 +1,345 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useGradeConstraints } from "@/hooks/grades/useGradeConstraints"
+import {
+  DEFAULT_CONSISTENCY_CONFIG,
+  DEFAULT_CONSTRAINT_COLOR,
+  DEFAULT_MUTUAL_EXCLUSION_CONFIG,
+  evaluateConstraints,
+  validateConstraintExpression,
+} from "@/lib/gradeConstraints"
+import type {
+  GradeBoundarySetWithDetails,
+  GradeCalculationResult,
+  GradeConstraintData,
+  GradeConstraintInput,
+  GradeConstraintKind,
+} from "@/types/grade.types"
+
+import { ConsistencyFields, parseConsistency } from "./ConsistencyFields"
+import {
+  MutualExclusionFields,
+  parseMutualExclusion,
+} from "./MutualExclusionFields"
+
+interface ConstraintRulesEditorProps {
+  gradeId: string
+  gradeItems: { id: string; name: string; order: number }[]
+  boundarySets: GradeBoundarySetWithDetails[]
+}
+
+const KIND_LABELS: Record<GradeConstraintKind, string> = {
+  consistency: "整合（観点集計と評定）",
+  mutual_exclusion: "混在禁止",
+  expression: "上級: 式",
+}
+
+const EXPRESSION_HELP = [
+  "式が真になった生徒を着色します。関数名は英語、項目名・ラベルはダブルクォートで囲みます。",
+  "すべて GradeItem（評定・観点など）同士の比較です。",
+  '例: has("A") and has("C")   … A と C が混在',
+  '例: label("評定") == "5" and count("A") < 3   … 評定5なのにAが3つ未満',
+  '例: label("態度") == "A" and item("評定") < 4   … 態度Aなのに評定が低い',
+  "使える関数: item(項目) / label(項目) / has(ラベル) / count(ラベル) / sum(項目…) / mean(項目…) / min(項目…) / max(項目…) / abs()",
+  "  ※ item()の数値: 数値ラベル(5..1)はそのまま、A/B/Cは弱→強の順位(1,2,3…)。",
+  "     A=5,B=3,C=1 のような換算で評定と直接比べたい時は「整合ルール」を使ってください。",
+  "演算子: and / or / not / == / != / > / < / >= / <=",
+].join("\n")
+
+/** boundarySets から観点別評価に登場しうるラベルの一覧を作る */
+function collectLabels(boundarySets: GradeBoundarySetWithDetails[]): string[] {
+  const set = new Set<string>()
+  for (const bs of boundarySets) {
+    if (bs.targetType !== "grade_item") continue
+    for (const b of bs.boundaries) set.add(b.label)
+  }
+  return Array.from(set)
+}
+
+/** 「評定」にあたる項目を推測（名前に「評定」を含む最後の項目、無ければ末尾） */
+function guessTargetItem(itemNames: string[]): string {
+  const byName = [...itemNames].reverse().find((n) => n.includes("評定"))
+  return byName ?? itemNames[itemNames.length - 1] ?? ""
+}
+
+function defaultConfigFor(kind: GradeConstraintKind): string {
+  if (kind === "consistency") return JSON.stringify(DEFAULT_CONSISTENCY_CONFIG)
+  if (kind === "mutual_exclusion")
+    return JSON.stringify(DEFAULT_MUTUAL_EXCLUSION_CONFIG)
+  return "{}"
+}
+
+export function ConstraintRulesEditor({
+  gradeId,
+  gradeItems,
+  boundarySets,
+}: ConstraintRulesEditorProps) {
+  const { constraints, createConstraint, updateConstraint, deleteConstraint } =
+    useGradeConstraints(gradeId)
+
+  const [calcResult, setCalcResult] = useState<GradeCalculationResult | null>(
+    null
+  )
+
+  const labels = useMemo(() => collectLabels(boundarySets), [boundarySets])
+  // 項目名は同期的に得られる gradeItems から作る（calcResult の読込を待たない）
+  const itemNames = useMemo(() => gradeItems.map((gi) => gi.name), [gradeItems])
+
+  // プレビュー用に成績算出結果を取得
+  const loadCalc = useCallback(async () => {
+    try {
+      const res = await window.electronAPI.grade.calculateGrades(gradeId)
+      if (res.success && res.result) setCalcResult(res.result)
+    } catch (error) {
+      console.error("Error calculating grades for preview:", error)
+    }
+  }, [gradeId])
+
+  useEffect(() => {
+    loadCalc()
+  }, [loadCalc])
+
+  const evaluation = useMemo(() => {
+    if (!calcResult) return null
+    return evaluateConstraints(calcResult, constraints)
+  }, [calcResult, constraints])
+
+  const handleAdd = async (kind: GradeConstraintKind) => {
+    let config = defaultConfigFor(kind)
+    // 整合ルールは現在の項目構成から「評定」と集計対象を推測して初期化
+    if (kind === "consistency" && itemNames.length > 0) {
+      const target = guessTargetItem(itemNames)
+      config = JSON.stringify({
+        ...DEFAULT_CONSISTENCY_CONFIG,
+        target,
+        viewpointItems: itemNames.filter((n) => n !== target),
+      })
+    }
+    const input: GradeConstraintInput = {
+      name:
+        kind === "consistency"
+          ? "評定と観点の整合"
+          : kind === "mutual_exclusion"
+            ? "A・C混在禁止"
+            : "新しいルール",
+      kind,
+      config,
+      expression: kind === "expression" ? 'has("A") and has("C")' : "",
+      color: DEFAULT_CONSTRAINT_COLOR,
+      message: null,
+      enabled: true,
+      order: constraints.length,
+    }
+    await createConstraint(input)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold">観点間の制約ルール</h3>
+        <p className="text-muted-foreground text-sm">
+          観点別評価と評定の組合せが校内ルールに合わない生徒を、結果表で着色して知らせます。
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleAdd("consistency")}
+        >
+          ＋ 整合ルール
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleAdd("mutual_exclusion")}
+        >
+          ＋ 混在禁止
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => handleAdd("expression")}
+        >
+          ＋ 上級: 式
+        </Button>
+      </div>
+
+      {constraints.length === 0 && (
+        <p className="text-muted-foreground text-sm italic">
+          ルールはまだありません。
+        </p>
+      )}
+
+      <div className="space-y-3">
+        {constraints.map((constraint) => (
+          <ConstraintCard
+            key={constraint.id}
+            constraint={constraint}
+            labels={labels}
+            itemNames={itemNames}
+            hitCount={evaluation?.counts.get(constraint.id) ?? 0}
+            errorMessage={evaluation?.errors.get(constraint.id) ?? null}
+            onUpdate={(patch) => updateConstraint(constraint.id, patch)}
+            onDelete={() => deleteConstraint(constraint.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface ConstraintCardProps {
+  constraint: GradeConstraintData
+  labels: string[]
+  itemNames: string[]
+  hitCount: number
+  errorMessage: string | null
+  onUpdate: (patch: Partial<GradeConstraintInput>) => void
+  onDelete: () => void
+}
+
+function ConstraintCard({
+  constraint,
+  labels,
+  itemNames,
+  hitCount,
+  errorMessage,
+  onUpdate,
+  onDelete,
+}: ConstraintCardProps) {
+  const [name, setName] = useState(constraint.name)
+  const [expression, setExpression] = useState(constraint.expression)
+  const [message, setMessage] = useState(constraint.message ?? "")
+
+  useEffect(() => setName(constraint.name), [constraint.name])
+  useEffect(() => setExpression(constraint.expression), [constraint.expression])
+  useEffect(() => setMessage(constraint.message ?? ""), [constraint.message])
+
+  const exprError =
+    constraint.kind === "expression"
+      ? validateConstraintExpression(expression)
+      : null
+
+  return (
+    <Card className="space-y-3 p-4">
+      <div className="flex items-center gap-2">
+        <div
+          className="h-5 w-5 shrink-0 rounded border"
+          style={{ backgroundColor: constraint.color }}
+        />
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => name !== constraint.name && onUpdate({ name })}
+          className="h-8 flex-1"
+          placeholder="ルール名"
+        />
+        <Badge variant="secondary" className="shrink-0">
+          {KIND_LABELS[constraint.kind]}
+        </Badge>
+        <input
+          type="color"
+          value={constraint.color}
+          onChange={(e) => onUpdate({ color: e.target.value })}
+          className="h-8 w-8 cursor-pointer rounded border"
+          aria-label="着色色"
+        />
+        <Switch
+          checked={constraint.enabled}
+          onCheckedChange={(checked) => onUpdate({ enabled: checked })}
+          aria-label="有効"
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={onDelete}
+          aria-label="削除"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {constraint.kind === "consistency" && (
+        <ConsistencyFields
+          config={parseConsistency(constraint.config)}
+          labels={labels}
+          itemNames={itemNames}
+          onChange={(config) => onUpdate({ config: JSON.stringify(config) })}
+        />
+      )}
+
+      {constraint.kind === "mutual_exclusion" && (
+        <MutualExclusionFields
+          config={parseMutualExclusion(constraint.config)}
+          labels={labels}
+          onChange={(config) => onUpdate({ config: JSON.stringify(config) })}
+        />
+      )}
+
+      {constraint.kind === "expression" && (
+        <div className="space-y-1">
+          <Textarea
+            value={expression}
+            onChange={(e) => setExpression(e.target.value)}
+            onBlur={() =>
+              expression !== constraint.expression && onUpdate({ expression })
+            }
+            className="font-mono text-xs"
+            rows={2}
+            placeholder='has("A") and has("C")'
+          />
+          {exprError && (
+            <p className="text-destructive text-xs">式エラー: {exprError}</p>
+          )}
+          <pre className="text-muted-foreground bg-muted/50 overflow-x-auto rounded p-2 text-[11px] leading-relaxed">
+            {EXPRESSION_HELP}
+          </pre>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Label className="text-muted-foreground shrink-0 text-xs">
+          メッセージ
+        </Label>
+        <Input
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onBlur={() =>
+            (message || null) !== constraint.message &&
+            onUpdate({ message: message || null })
+          }
+          className="h-8"
+          placeholder="違反時にホバーで表示される説明（任意）"
+        />
+      </div>
+
+      <div className="text-muted-foreground text-xs">
+        {errorMessage ? (
+          <span className="text-destructive">評価エラー: {errorMessage}</span>
+        ) : (
+          <>
+            該当:{" "}
+            <span className="text-foreground font-medium">{hitCount}</span> 名
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/src/components/grades/05-boundaries/MutualExclusionFields.tsx
+++ b/src/components/grades/05-boundaries/MutualExclusionFields.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Label } from "@/components/ui/label"
+import {
+  DEFAULT_MUTUAL_EXCLUSION_CONFIG,
+  parseConfig,
+} from "@/lib/gradeConstraints"
+import type { MutualExclusionConfig } from "@/types/grade.types"
+
+/** 混在禁止ルールの設定JSONを復元 */
+export function parseMutualExclusion(raw: string): MutualExclusionConfig {
+  return parseConfig(raw, DEFAULT_MUTUAL_EXCLUSION_CONFIG)
+}
+
+interface MutualExclusionFieldsProps {
+  config: MutualExclusionConfig
+  labels: string[]
+  onChange: (config: MutualExclusionConfig) => void
+}
+
+export function MutualExclusionFields({
+  config,
+  labels,
+  onChange,
+}: MutualExclusionFieldsProps) {
+  const displayLabels = labels.length > 0 ? labels : config.labels
+  const toggle = (label: string) => {
+    const next = config.labels.includes(label)
+      ? config.labels.filter((l) => l !== label)
+      : [...config.labels, label]
+    onChange({ ...config, labels: next })
+  }
+  return (
+    <div className="space-y-2 text-sm">
+      <Label className="text-muted-foreground text-xs">
+        同時に現れてはいけないラベル（2つ以上選択）
+      </Label>
+      <div className="flex flex-wrap gap-2">
+        {displayLabels.map((label) => {
+          const active = config.labels.includes(label)
+          return (
+            <button
+              key={label}
+              type="button"
+              onClick={() => toggle(label)}
+              className={`rounded border px-3 py-1 text-sm ${
+                active
+                  ? "border-primary bg-primary/10 text-foreground font-medium"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+      <p className="text-muted-foreground text-xs">
+        観点の中に選択したラベルのうち2種以上が現れたら違反とみなします。
+      </p>
+    </div>
+  )
+}

--- a/src/components/grades/06-results/ResultsContainer.tsx
+++ b/src/components/grades/06-results/ResultsContainer.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, RefreshCw } from "lucide-react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
+import { useGradeConstraints } from "@/hooks/grades/useGradeConstraints"
 import { useGradeResults } from "@/hooks/grades/useGradeResults"
 
 import { GradeDistributionChart } from "./GradeDistributionChart"
@@ -16,6 +17,7 @@ interface ResultsContainerProps {
 export function ResultsContainer({ gradeId }: ResultsContainerProps) {
   const { result, loading, error, recalculate, setGradeOverride } =
     useGradeResults(gradeId)
+  const { constraints } = useGradeConstraints(gradeId)
 
   if (loading) {
     return (
@@ -68,7 +70,11 @@ export function ResultsContainer({ gradeId }: ResultsContainerProps) {
       </div>
 
       <GradeDistributionChart result={result} />
-      <ResultsTable result={result} onGradeOverride={setGradeOverride} />
+      <ResultsTable
+        result={result}
+        constraints={constraints}
+        onGradeOverride={setGradeOverride}
+      />
     </div>
   )
 }

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -9,13 +9,16 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { evaluateConstraints } from "@/lib/gradeConstraints"
 import type {
   GradeCalculationResult,
+  GradeConstraintData,
   GradeItemResult,
 } from "@/types/grade.types"
 
 interface ResultsTableProps {
   result: GradeCalculationResult
+  constraints?: GradeConstraintData[]
   onGradeOverride: (params: {
     studentId: string
     targetType: "grade_item" | "overall"
@@ -282,9 +285,25 @@ function EditableGradeLabel({
  * 生徒ごとの各評価項目パーセンテージ・成績ラベル・総合成績を表示する。
  * 各列ヘッダーをクリックしてソート可能。
  */
-export function ResultsTable({ result, onGradeOverride }: ResultsTableProps) {
+export function ResultsTable({
+  result,
+  constraints = [],
+  onGradeOverride,
+}: ResultsTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>("registrationOrder")
   const [sortAsc, setSortAsc] = useState(true)
+
+  // 制約ルール違反を評価（studentId → 違反一覧）
+  const violationsByStudent = useMemo(
+    () => evaluateConstraints(result, constraints).violations,
+    [result, constraints]
+  )
+
+  // 凡例に表示する有効ルール
+  const activeConstraints = useMemo(
+    () => constraints.filter((c) => c.enabled),
+    [constraints]
+  )
 
   // 各列に対応するboundaryLabels（minPercentage降順）を算出
   const boundaryLabelsMap = useMemo(() => {
@@ -347,97 +366,154 @@ export function ResultsTable({ result, onGradeOverride }: ResultsTableProps) {
   )
 
   return (
-    <div className="mt-6 overflow-x-auto rounded-lg border">
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50">
-          <tr>
-            <SortHeader label="順序" sortId="registrationOrder" />
-            <SortHeader label="番号" sortId="attendanceNumber" />
-            <th className="px-2 py-2 text-left font-medium">氏名</th>
-            {result.gradeItems.map((gradeItem) => (
-              <SortHeader
-                key={gradeItem.id}
-                label={gradeItem.name}
-                sortId={gradeItem.id}
-              />
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {sortedStudents.map((student) => (
-            <tr key={student.studentId} className="border-t">
-              <td className="text-muted-foreground px-2 py-1.5 text-center">
-                {result.students.indexOf(student) + 1}
-              </td>
-              <td className="px-2 py-1.5 text-center">
-                {student.attendanceNumber ?? "-"}
-              </td>
-              <td className="px-2 py-1.5">
-                {student.lastName} {student.firstName}
-              </td>
-              {result.gradeItems.map((gradeItem) => {
-                const itemResult = student.gradeItemResults.find(
-                  (r) => r.gradeItemId === gradeItem.id
-                )
-
-                // 除外表示
-                if (itemResult?.isExcluded) {
-                  return (
-                    <td key={gradeItem.id} className="px-2 py-1.5 text-center">
-                      <span className="text-muted-foreground text-xs italic">
-                        除外
-                      </span>
-                    </td>
-                  )
-                }
-
-                const hasEstimated = itemResult?.sourceScores.some(
-                  (s) => s.isEstimated
-                )
-                return (
-                  <td key={gradeItem.id} className="px-2 py-1.5 text-center">
-                    <div className="flex items-center justify-center gap-1.5">
-                      {itemResult ? (
-                        <GradeItemBreakdownPopover
-                          itemResult={itemResult}
-                          hasEstimated={!!hasEstimated}
-                        />
-                      ) : (
-                        <span className="w-12 text-right text-xs tabular-nums">
-                          -
-                        </span>
-                      )}
-                      <EditableGradeLabel
-                        gradeLabel={itemResult?.gradeLabel ?? null}
-                        originalLabel={itemResult?.originalGradeLabel ?? null}
-                        overrideLabel={itemResult?.overrideGradeLabel ?? null}
-                        boundaryLabels={boundaryLabelsMap[gradeItem.id] ?? []}
-                        onCommit={(newLabel) =>
-                          onGradeOverride({
-                            studentId: student.studentId,
-                            targetType: "grade_item",
-                            gradeItemId: gradeItem.id,
-                            overrideLabel: newLabel,
-                          })
-                        }
-                      />
-                    </div>
-                  </td>
-                )
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {result.students.some((s) =>
-        s.gradeItemResults.some((gi) =>
-          gi.sourceScores.some((ss) => ss.isEstimated)
-        )
-      ) && (
-        <div className="border-t px-3 py-1.5">
-          <span className="text-xs text-amber-600">* 欠測推定を含む</span>
-        </div>
+    <>
+      {activeConstraints.length > 0 && (
+        <ConstraintLegend constraints={activeConstraints} />
       )}
+      <div className="mt-6 overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <SortHeader label="順序" sortId="registrationOrder" />
+              <SortHeader label="番号" sortId="attendanceNumber" />
+              <th className="px-2 py-2 text-left font-medium">氏名</th>
+              {result.gradeItems.map((gradeItem) => (
+                <SortHeader
+                  key={gradeItem.id}
+                  label={gradeItem.name}
+                  sortId={gradeItem.id}
+                />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedStudents.map((student) => {
+              const violations =
+                violationsByStudent.get(student.studentId) ?? []
+              const rowColor = violations[0]?.color
+              const rowTitle =
+                violations.length > 0
+                  ? violations
+                      .map((v) =>
+                        v.message ? `${v.name}: ${v.message}` : v.name
+                      )
+                      .join("\n")
+                  : undefined
+              return (
+                <tr
+                  key={student.studentId}
+                  className="border-t"
+                  style={rowColor ? { backgroundColor: rowColor } : undefined}
+                  title={rowTitle}
+                >
+                  <td className="text-muted-foreground px-2 py-1.5 text-center">
+                    {result.students.indexOf(student) + 1}
+                  </td>
+                  <td className="px-2 py-1.5 text-center">
+                    {student.attendanceNumber ?? "-"}
+                  </td>
+                  <td className="px-2 py-1.5">
+                    {student.lastName} {student.firstName}
+                  </td>
+                  {result.gradeItems.map((gradeItem) => {
+                    const itemResult = student.gradeItemResults.find(
+                      (r) => r.gradeItemId === gradeItem.id
+                    )
+
+                    // 除外表示
+                    if (itemResult?.isExcluded) {
+                      return (
+                        <td
+                          key={gradeItem.id}
+                          className="px-2 py-1.5 text-center"
+                        >
+                          <span className="text-muted-foreground text-xs italic">
+                            除外
+                          </span>
+                        </td>
+                      )
+                    }
+
+                    const hasEstimated = itemResult?.sourceScores.some(
+                      (s) => s.isEstimated
+                    )
+                    return (
+                      <td
+                        key={gradeItem.id}
+                        className="px-2 py-1.5 text-center"
+                      >
+                        <div className="flex items-center justify-center gap-1.5">
+                          {itemResult ? (
+                            <GradeItemBreakdownPopover
+                              itemResult={itemResult}
+                              hasEstimated={!!hasEstimated}
+                            />
+                          ) : (
+                            <span className="w-12 text-right text-xs tabular-nums">
+                              -
+                            </span>
+                          )}
+                          <EditableGradeLabel
+                            gradeLabel={itemResult?.gradeLabel ?? null}
+                            originalLabel={
+                              itemResult?.originalGradeLabel ?? null
+                            }
+                            overrideLabel={
+                              itemResult?.overrideGradeLabel ?? null
+                            }
+                            boundaryLabels={
+                              boundaryLabelsMap[gradeItem.id] ?? []
+                            }
+                            onCommit={(newLabel) =>
+                              onGradeOverride({
+                                studentId: student.studentId,
+                                targetType: "grade_item",
+                                gradeItemId: gradeItem.id,
+                                overrideLabel: newLabel,
+                              })
+                            }
+                          />
+                        </div>
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+        {result.students.some((s) =>
+          s.gradeItemResults.some((gi) =>
+            gi.sourceScores.some((ss) => ss.isEstimated)
+          )
+        ) && (
+          <div className="border-t px-3 py-1.5">
+            <span className="text-xs text-amber-600">* 欠測推定を含む</span>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+/** 制約ルールの色凡例 */
+function ConstraintLegend({
+  constraints,
+}: {
+  constraints: GradeConstraintData[]
+}) {
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+      <span className="text-muted-foreground">制約ルール:</span>
+      {constraints.map((c) => (
+        <span key={c.id} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-3 w-3 rounded border"
+            style={{ backgroundColor: c.color }}
+          />
+          {c.name}
+        </span>
+      ))}
     </div>
   )
 }

--- a/src/hooks/grades/useGradeConstraints.ts
+++ b/src/hooks/grades/useGradeConstraints.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from "react"
+
+import type {
+  GradeConstraintData,
+  GradeConstraintInput,
+} from "@/types/grade.types"
+
+/** 観点間の制約ルールの取得・作成・更新・削除・並べ替えを管理するフック */
+export function useGradeConstraints(gradeId: string) {
+  const [constraints, setConstraints] = useState<GradeConstraintData[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadData = useCallback(async () => {
+    try {
+      const result = await window.electronAPI.grade.getGradeConstraints(gradeId)
+      if (result.success && result.constraints) {
+        setConstraints(result.constraints)
+      }
+    } catch (error) {
+      console.error("Error loading grade constraints:", error)
+    } finally {
+      setLoading(false)
+    }
+  }, [gradeId])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const createConstraint = useCallback(
+    async (constraint: GradeConstraintInput) => {
+      const result = await window.electronAPI.grade.createGradeConstraint({
+        gradeId,
+        constraint,
+      })
+      if (result.success) await loadData()
+      return result
+    },
+    [gradeId, loadData]
+  )
+
+  const updateConstraint = useCallback(
+    async (id: string, constraint: Partial<GradeConstraintInput>) => {
+      const result = await window.electronAPI.grade.updateGradeConstraint({
+        id,
+        constraint,
+      })
+      if (result.success) await loadData()
+      return result
+    },
+    [loadData]
+  )
+
+  const deleteConstraint = useCallback(
+    async (id: string) => {
+      const result = await window.electronAPI.grade.deleteGradeConstraint(id)
+      if (result.success) await loadData()
+      return result
+    },
+    [loadData]
+  )
+
+  return {
+    constraints,
+    loading,
+    createConstraint,
+    updateConstraint,
+    deleteConstraint,
+    reload: loadData,
+  }
+}

--- a/src/lib/gradeConstraints.ts
+++ b/src/lib/gradeConstraints.ts
@@ -1,0 +1,344 @@
+/**
+ * 観点間の制約ルール評価
+ *
+ * 成績算出結果（GradeCalculationResult）に対して、Grade個別に定義された制約ルールを
+ * 適用し、各生徒がどのルールに違反しているかを算出する。DB・算出ロジックには非干渉の
+ * 純粋関数。結果表（06-results）の行着色と、境界設定（05-boundaries）のライブプレビュー
+ * の両方で使用する。
+ */
+
+import { Parser, type Value } from "expr-eval"
+
+import type {
+  ConsistencyConfig,
+  ConstraintViolation,
+  GradeCalculationResult,
+  GradeConstraintData,
+  MutualExclusionConfig,
+  StudentGradeResult,
+} from "@/types/grade.types"
+
+/** 整合ルールの既定設定（Excel流: A=5, B=3, C=1 の平均、許容±1）。target は項目選択時に設定 */
+export const DEFAULT_CONSISTENCY_CONFIG: ConsistencyConfig = {
+  labelValues: { A: 5, B: 3, C: 1 },
+  aggregate: "average",
+  tolerance: 1,
+  target: "",
+}
+
+/** 混在禁止ルールの既定設定（A・C混在禁止） */
+export const DEFAULT_MUTUAL_EXCLUSION_CONFIG: MutualExclusionConfig = {
+  labels: ["A", "C"],
+}
+
+/** 制約ルールの既定色（薄い赤） */
+export const DEFAULT_CONSTRAINT_COLOR = "#fecaca"
+
+export interface ConstraintEvaluation {
+  /** studentId → 違反ルール一覧 */
+  violations: Map<string, ConstraintViolation[]>
+  /** constraintId → 該当生徒数（プレビュー用） */
+  counts: Map<string, number>
+  /** constraintId → エラーメッセージ（式のパース失敗等） */
+  errors: Map<string, string>
+}
+
+// 式評価器（安全: eval不使用）。代入・条件演算子は無効化する。
+const parser = new Parser({
+  operators: {
+    assignment: false,
+    conditional: false,
+    logical: true,
+    comparison: true,
+    concatenate: false,
+    in: false,
+    factorial: false,
+  },
+})
+
+interface ViewpointLabel {
+  name: string
+  label: string
+}
+
+/**
+ * 各 GradeItem の境界ラベルを昇順（弱→強）に並べ、項目名で引けるようにする。
+ * ラベルが数値でも labelValues にも無い場合の順位換算に使う。
+ */
+function buildOrderedLabelsMap(
+  result: GradeCalculationResult
+): Map<string, string[]> {
+  const idToName = new Map(result.gradeItems.map((gi) => [gi.id, gi.name]))
+  const byName = new Map<string, string[]>()
+  for (const bs of result.boundarySets) {
+    if (bs.targetType !== "grade_item" || !bs.gradeItemId) continue
+    const name = idToName.get(bs.gradeItemId)
+    if (!name) continue
+    // minPercentage 昇順 = 弱い評価が先頭
+    const ordered = [...bs.boundaries]
+      .sort((a, b) => a.minPercentage - b.minPercentage)
+      .map((b) => b.label)
+    byName.set(name, ordered)
+  }
+  return byName
+}
+
+/**
+ * ラベルを数値へ換算する。
+ * 1. labelValues に定義があればそれを使う
+ * 2. ラベル自体が数値ならその数値
+ * 3. 順序リスト（弱→強）内の順位（1始まり）
+ * いずれも該当しなければ null。
+ */
+function labelToValue(
+  label: string | null,
+  labelValues: Record<string, number> | undefined,
+  ordered: string[] | undefined
+): number | null {
+  if (label === null) return null
+  if (labelValues && label in labelValues) return labelValues[label]
+  const asNumber = Number(label)
+  if (label.trim() !== "" && !Number.isNaN(asNumber)) return asNumber
+  if (ordered) {
+    const idx = ordered.indexOf(label)
+    if (idx >= 0) return idx + 1
+  }
+  return null
+}
+
+/** 生徒の観点ラベル一覧（除外・未算出は含めない） */
+function collectViewpointLabels(student: StudentGradeResult): ViewpointLabel[] {
+  return student.gradeItemResults
+    .filter((r) => !r.isExcluded)
+    .map((r) => ({ name: r.gradeItemName, label: r.gradeLabel }))
+    .filter((v): v is ViewpointLabel => v.label !== null)
+}
+
+function evalConsistency(
+  config: ConsistencyConfig,
+  viewpoints: ViewpointLabel[],
+  ordered: Map<string, string[]>
+): boolean {
+  // 「評定」を担う GradeItem を比較先にし、指定の観点（未指定なら残り全部）を集計対象にする
+  const targetItem = viewpoints.find((v) => v.name === config.target)
+  if (!targetItem) return false
+  const targetVal = labelToValue(
+    targetItem.label,
+    config.labelValues,
+    ordered.get(config.target)
+  )
+  if (targetVal === null) return false
+
+  const selected = config.viewpointItems ?? []
+  const aggregationViewpoints =
+    selected.length > 0
+      ? viewpoints.filter((v) => selected.includes(v.name))
+      : viewpoints.filter((v) => v.name !== config.target)
+  if (aggregationViewpoints.length === 0) return false
+
+  const values = aggregationViewpoints
+    .map((v) => labelToValue(v.label, config.labelValues, ordered.get(v.name)))
+    .filter((v): v is number => v !== null)
+  if (values.length === 0) return false
+
+  const sum = values.reduce((acc, v) => acc + v, 0)
+  const aggregate = config.aggregate === "sum" ? sum : sum / values.length
+
+  return Math.abs(targetVal - aggregate) > config.tolerance
+}
+
+function evalMutualExclusion(
+  config: MutualExclusionConfig,
+  viewpoints: ViewpointLabel[]
+): boolean {
+  const present = new Set(
+    viewpoints
+      .map((v) => v.label)
+      .filter((label) => config.labels.includes(label))
+  )
+  return present.size >= 2
+}
+
+/**
+ * 式評価用スコープを構築。関数名は英語（label/item/has/count/sum/mean/min/max）。
+ * 観点名・ラベルは文字列引数（ダブルクォート）で渡す。
+ * 集計関数は引数に項目名を並べるとその項目だけ、無引数なら全項目を対象にする。
+ */
+function buildExpressionScope(
+  viewpoints: ViewpointLabel[],
+  ordered: Map<string, string[]>,
+  allItemNames: Set<string>
+): Record<string, Value> {
+  // 各項目の数値（ラベル値: 数値ラベルはそのまま、A/B/C等は弱→強の順位）
+  const itemValue = (vp: ViewpointLabel) =>
+    labelToValue(vp.label, undefined, ordered.get(vp.name))
+
+  // 存在しない項目名の参照はタイプミスとみなしエラーにする（無言失火を防ぐ）。
+  // 実在する項目だが当該生徒が除外されている場合は throw せず未定義扱い。
+  const requireKnownItem = (name: string) => {
+    if (!allItemNames.has(name)) {
+      throw new Error(`項目「${name}」は存在しません`)
+    }
+  }
+
+  // 対象項目を名前で絞る（名前無し=全項目）
+  const selected = (names: Value[]) => {
+    if (names.length === 0) return viewpoints
+    const wanted = names.map(String)
+    wanted.forEach(requireKnownItem)
+    return viewpoints.filter((v) => wanted.includes(v.name))
+  }
+  const numericOf = (names: Value[]) =>
+    selected(names)
+      .map(itemValue)
+      .filter((v): v is number => v !== null)
+
+  return {
+    label: (name: Value) => {
+      requireKnownItem(String(name))
+      return viewpoints.find((v) => v.name === String(name))?.label ?? ""
+    },
+    item: (name: Value) => {
+      requireKnownItem(String(name))
+      const found = viewpoints.find((v) => v.name === String(name))
+      return found ? (itemValue(found) ?? NaN) : NaN
+    },
+    has: (labelValue: Value) =>
+      viewpoints.some((v) => v.label === String(labelValue)) ? 1 : 0,
+    count: (labelValue: Value) =>
+      viewpoints.filter((v) => v.label === String(labelValue)).length,
+    sum: (...names: Value[]) => numericOf(names).reduce((acc, v) => acc + v, 0),
+    mean: (...names: Value[]) => {
+      const vals = numericOf(names)
+      return vals.length
+        ? vals.reduce((acc, v) => acc + v, 0) / vals.length
+        : NaN
+    },
+    min: (...names: Value[]) => {
+      const vals = numericOf(names)
+      return vals.length ? Math.min(...vals) : NaN
+    },
+    max: (...names: Value[]) => {
+      const vals = numericOf(names)
+      return vals.length ? Math.max(...vals) : NaN
+    },
+  }
+}
+
+/** kind別の設定JSONを既定値にマージして復元する（不正JSONは既定値にフォールバック） */
+export function parseConfig<T>(raw: string, fallback: T): T {
+  try {
+    return { ...fallback, ...(JSON.parse(raw || "{}") as Partial<T>) }
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * 式を検証（構文チェック）。問題なければ null、あればエラーメッセージ。
+ */
+export function validateConstraintExpression(
+  expression: string
+): string | null {
+  if (!expression.trim()) return "式が空です"
+  try {
+    parser.parse(expression)
+    return null
+  } catch (error) {
+    return error instanceof Error ? error.message : "式の解析に失敗しました"
+  }
+}
+
+/**
+ * 全生徒 × 全ルールを評価する。
+ */
+export function evaluateConstraints(
+  result: GradeCalculationResult,
+  constraints: GradeConstraintData[]
+): ConstraintEvaluation {
+  const violations = new Map<string, ConstraintViolation[]>()
+  const counts = new Map<string, number>()
+  const errors = new Map<string, string>()
+
+  const ordered = buildOrderedLabelsMap(result)
+  const allItemNames = new Set(result.gradeItems.map((gi) => gi.name))
+  const active = constraints
+    .filter((c) => c.enabled)
+    .sort((a, b) => a.order - b.order)
+
+  // 事前検証（無言失火を防ぐためルール単位でエラーを記録）
+  //  - expression: 構文チェックしてコンパイル
+  //  - consistency: 比較先（評定）の項目が選択済みかつ実在するか
+  const compiled = new Map<string, ReturnType<typeof parser.parse> | null>()
+  for (const c of active) {
+    if (c.kind === "expression") {
+      try {
+        compiled.set(c.id, parser.parse(c.expression))
+      } catch (error) {
+        compiled.set(c.id, null)
+        errors.set(
+          c.id,
+          error instanceof Error ? error.message : "式の解析に失敗しました"
+        )
+      }
+    } else if (c.kind === "consistency") {
+      const cfg = parseConfig(c.config, DEFAULT_CONSISTENCY_CONFIG)
+      if (!cfg.target) {
+        errors.set(c.id, "評定（比較先の項目）が未選択です")
+      } else if (!allItemNames.has(cfg.target)) {
+        errors.set(c.id, `評定の項目「${cfg.target}」が見つかりません`)
+      }
+    }
+  }
+
+  for (const student of result.students) {
+    const viewpoints = collectViewpointLabels(student)
+
+    for (const c of active) {
+      if (errors.has(c.id)) continue // 検証エラー済みのルールは着色しない
+      let violated = false
+      try {
+        if (c.kind === "consistency") {
+          violated = evalConsistency(
+            parseConfig(c.config, DEFAULT_CONSISTENCY_CONFIG),
+            viewpoints,
+            ordered
+          )
+        } else if (c.kind === "mutual_exclusion") {
+          violated = evalMutualExclusion(
+            parseConfig(c.config, DEFAULT_MUTUAL_EXCLUSION_CONFIG),
+            viewpoints
+          )
+        } else if (c.kind === "expression") {
+          const expr = compiled.get(c.id)
+          if (!expr) continue // パースエラーは着色しない
+          const scope = buildExpressionScope(viewpoints, ordered, allItemNames)
+          violated = Boolean(expr.evaluate(scope))
+        }
+      } catch (error) {
+        // 評価時エラー（未定義観点名など）はルール単位で記録し着色しない
+        if (!errors.has(c.id)) {
+          errors.set(
+            c.id,
+            error instanceof Error ? error.message : "式の評価に失敗しました"
+          )
+        }
+        violated = false
+      }
+
+      if (violated) {
+        const list = violations.get(student.studentId) ?? []
+        list.push({
+          constraintId: c.id,
+          name: c.name,
+          color: c.color,
+          message: c.message,
+        })
+        violations.set(student.studentId, list)
+        counts.set(c.id, (counts.get(c.id) ?? 0) + 1)
+      }
+    }
+  }
+
+  return { violations, counts, errors }
+}

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -246,6 +246,30 @@ export interface GradeAPI {
       targetType: string
       gradeItemId: string | null
     }) => Promise<{ success: boolean; error?: string }>
+    getGradeConstraints: (gradeId: string) => Promise<{
+      success: boolean
+      constraints?: import("../grade.types").GradeConstraintData[]
+      error?: string
+    }>
+    createGradeConstraint: (data: {
+      gradeId: string
+      constraint: import("../grade.types").GradeConstraintInput
+    }) => Promise<{
+      success: boolean
+      constraint?: import("../grade.types").GradeConstraintData
+      error?: string
+    }>
+    updateGradeConstraint: (data: {
+      id: string
+      constraint: Partial<import("../grade.types").GradeConstraintInput>
+    }) => Promise<{
+      success: boolean
+      constraint?: import("../grade.types").GradeConstraintData
+      error?: string
+    }>
+    deleteGradeConstraint: (
+      id: string
+    ) => Promise<{ success: boolean; error?: string }>
     getGradeItemExclusions: (gradeId: string) => Promise<{
       success: boolean
       exclusions?: Array<{

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -184,3 +184,75 @@ export interface GradeCalculationResult {
     boundaries: { label: string; minPercentage: number }[]
   }[]
 }
+
+// ─────────────────────────────────────────────────────────────
+// 観点間の制約ルール（不適切な観点/評定の組合せを検知して着色）
+// ─────────────────────────────────────────────────────────────
+
+/** 制約ルールの種別 */
+export type GradeConstraintKind =
+  | "consistency" // 観点集計と評定の整合（Excel流: A=5,B=3,C=1の平均など）
+  | "mutual_exclusion" // 特定ラベルの混在禁止（A・C混在など）
+  | "expression" // 上級者向け自由記述式
+
+/** 整合ルールの設定 */
+export interface ConsistencyConfig {
+  /** ラベル→数値の対応（例 { A: 5, B: 3, C: 1 }） */
+  labelValues: Record<string, number>
+  /** 観点の集計方法 */
+  aggregate: "average" | "sum"
+  /** 許容する評定との差（これを超えたら違反） */
+  tolerance: number
+  /**
+   * 比較先の「評定」にあたる GradeItem 名（例「評定」）。
+   * その項目を評定とみなし、下の viewpointItems を集計して比較する。
+   */
+  target: string
+  /**
+   * 集計対象の観点 GradeItem 名の配列（例 知識・技能／思考・判断・表現／態度）。
+   * 空/未指定なら target 以外の全 GradeItem を対象にする。
+   */
+  viewpointItems?: string[]
+}
+
+/** 混在禁止ルールの設定 */
+export interface MutualExclusionConfig {
+  /** 同時に現れてはいけないラベル集合（例 ["A", "C"]） */
+  labels: string[]
+}
+
+/** DBに保存される制約ルール1件 */
+export interface GradeConstraintData {
+  id: string
+  gradeId: string
+  name: string
+  kind: GradeConstraintKind
+  /** kind別の設定JSON文字列（ConsistencyConfig / MutualExclusionConfig） */
+  config: string
+  /** kind="expression" 時の式 */
+  expression: string
+  color: string
+  message: string | null
+  enabled: boolean
+  order: number
+}
+
+/** 制約ルールの作成・更新入力 */
+export interface GradeConstraintInput {
+  name: string
+  kind: GradeConstraintKind
+  config: string
+  expression: string
+  color: string
+  message: string | null
+  enabled: boolean
+  order: number
+}
+
+/** 1生徒×1ルールの違反結果 */
+export interface ConstraintViolation {
+  constraintId: string
+  name: string
+  color: string
+  message: string | null
+}

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -76,6 +76,17 @@ export interface ArchiveGradeData {
     gradeItemName: string | null
     overrideLabel: string
   }[]
+  /** 観点間の制約ルール（後方互換: v1.7.0+。古いアーカイブではundefined） */
+  gradeConstraints?: {
+    name: string
+    kind: string
+    config: string
+    expression: string
+    color: string
+    message: string | null
+    enabled: boolean
+    order: number
+  }[]
 }
 
 export interface ArchiveGradeItem {
@@ -165,8 +176,7 @@ export interface ArchiveCourseworkItem {
 
 /** v1.4.0+: インポート時に資料ごとにユーザーが選ぶ取り込み方法 */
 export type CourseworkImportDecision =
-  | { action: "reuse"; existingId: string }
-  | { action: "new" }
+  { action: "reuse"; existingId: string } | { action: "new" }
 
 /** アーカイブ内の資料uuid → ユーザー決定 */
 export type CourseworkImportDecisions = Record<string, CourseworkImportDecision>
@@ -246,17 +256,21 @@ export interface GradeArchiveImportPreview {
  * - 1.5.0: courseworks.json を coursework-archive 形式（UUIDベース）で内包
  * - 1.6.0: GradeDataSource.maxScore 列を廃止（満点はライブ算出）。外部成績の構造は
  *   1.5.0 と同形のため専用 transformer は無し（ArchiveDataSource.maxScore は optional で旧読込互換）。
+ * - 1.7.0: 観点間の制約ルール（GradeConstraint）を追加。gradeConstraints は optional で
+ *   旧アーカイブ読込時は空配列扱い。構造は加算的なため専用 transformer は無し。
  *
  * 検出は manifest.version 文字列ではなくデータ形状で行う（旧アーカイブのバージョン
  * 表記が不正確でも確実に正規化するため。詳細は grade-transformers/index.ts）。
  */
-export type GradeArchiveVersion = "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.6.0"
+export type GradeArchiveVersion =
+  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.7.0"
 export const GRADE_SUPPORTED_VERSIONS: readonly GradeArchiveVersion[] = [
   "1.3.0",
   "1.4.0",
   "1.5.0",
   "1.6.0",
+  "1.7.0",
 ] as const
 
 export interface GradeTransformResult {


### PR DESCRIPTION
Closes #903

## 概要

成績結果（06-results）で、観点別評価と評定の組合せが校内ルールに合わない生徒の行を着色して知らせる機能を追加しました。ルールは 05-成績境界 に集約し、タブUIを縦並びに刷新した上で「観点間の制約ルール」エディタを新設しています。

## 変更点

- **ルール3種**（整合／混在禁止／上級:式）を Grade 個別に定義。式評価は expr-eval（eval不使用）
- **すべて GradeItem 同士の比較**に統一（総合 overall は廃止）
- **新テーブル `GradeConstraint`** ＋ 手書きマイグレーション（`20260701000000_add_grade_constraint`）
- **IPC/preload/型** を配線（get/create/update/delete）
- **`.grade` アーカイブ 1.7.0**（optional 追加・トランスフォーマー不要・旧版読込互換）
- **05-成績境界**: タブ廃止→縦並び＋制約ルールエディタ（ライブプレビュー付き）
- **06-結果**: 違反行の着色＋色凡例
- **無言失火の防止**: target 未選択・不明な項目名参照をエラーとして可視化
- `ConsistencyFields` / `MutualExclusionFields` をファイル分割

## テスト

- `__tests__/grades/gradeConstraints.test.ts`（評価ロジック単体・校内ルール検算・エラー化）
- `__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts`（制約ルールの往復・後方互換）
- 型チェック・ESLint・関連テスト（33件）すべてグリーン

## レビュー指摘の反映

high effort のコードレビューで挙がった指摘を反映済み（無言失火の可視化、`as` 除去、デッドコード削除、型/parse重複の解消、ファイル分割）。「undefined でフィールドを消す」等は Prisma 仕様（undefined=変更なし）により誤検知として却下。

🤖 Generated with [Claude Code](https://claude.com/claude-code)