### PR TITLE
fix(editable-table): 貼り付け時に空白行を保持し行ズレを解消

### DIFF
--- a/src/components/common/EditableTable.tsx
+++ b/src/components/common/EditableTable.tsx
@@ -101,8 +101,7 @@ function EditableCell<T>({
   }
 
   const meta = column.columnDef.meta as
-    | { placeholder?: string; validate?: (value: string) => boolean }
-    | undefined
+    { placeholder?: string; validate?: (value: string) => boolean } | undefined
 
   // 非空かつ検証NGのセルは赤背景で警告（保存されない入力を可視化）
   const strValue = String(value ?? "")
@@ -316,7 +315,11 @@ export function EditableTable<T extends object>({
     e.preventDefault()
 
     const paste = e.clipboardData.getData("text")
-    const rows = paste.split("\n").filter((row) => row.trim() !== "")
+    // CRLF/CR を LF に正規化してから分割（末尾セルに \r が混入するのを防ぐ）
+    const rows = paste.replace(/\r\n?/g, "\n").split("\n")
+    // 末尾の終端改行による空行のみ除去。途中の空行は行対応を保つため残す
+    // （空行を除去すると空白セルの分だけ以降の行が上に詰まりズレる）
+    while (rows.length > 0 && rows[rows.length - 1].trim() === "") rows.pop()
 
     if (rows.length === 0) return
 


### PR DESCRIPTION
## 概要

スプレッドシートからの貼り付けで途中の空白行が除去され、以降の行が上に詰まって別の生徒に値が入る不具合を修正します。

Closes #905

## 原因

`src/components/common/EditableTable.tsx` の `handlePaste` が、行分割後に
`filter((row) => row.trim() !== "")` で全ての空白行を除去していた。
readOnly列を持つマージ経路では既存行と `startRowIndex + ri` で対応付けるため、空白行の脱落がそのまま行ズレになる。

## 変更内容

- 空白行を無条件除去する filter を廃止
- 末尾の終端改行による空行のみ除去（`while ... pop()`）。途中の空白行は行対応維持のため保持
- CRLF/CR を LF に正規化し、末尾セルへの `\r` 混入も解消

```js
const rows = paste.replace(/\r\n?/g, "\n").split("\n")
while (rows.length > 0 && rows[rows.length - 1].trim() === "") rows.pop()
```

## 影響範囲

`EditableTable` を通る全貼り付け経路に適用:
- 試験外成績の点数入力（マージ経路・報告バグ本体）
- 生徒インポート / 学級生徒インポート（全置換経路）

## テスト

- `npx eslint` / `prettier --check` 対象ファイルクリーン
- 変更は貼り付けハンドラの行分割ロジックのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)