### PR TITLE
feat(grade): 試験外成績資料を資料全体単位でデータソース追加できる機能を追加

### DIFF
--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -38,6 +38,13 @@ const mockCourseworkItemFindUnique = vi.fn(
         : null
     )
 )
+// computeLiveMaxScore は coursework_total 型の満点を courseworkId で全項目を
+// findMany して合算する。courseworkId → 各項目の {maxScore} を登録し、モックが返す。
+const courseworkTotalItems = new Map<string, { maxScore: unknown }[]>()
+const mockCourseworkItemFindMany = vi.fn(
+  ({ where: { courseworkId } }: { where: { courseworkId: string } }) =>
+    Promise.resolve(courseworkTotalItems.get(courseworkId) ?? [])
+)
 vi.mock("@/electron-src/lib/prisma/client", () => ({
   default: {
     grade: {
@@ -56,6 +63,8 @@ vi.mock("@/electron-src/lib/prisma/client", () => ({
     courseworkItem: {
       findUnique: (...args: [{ where: { id: string } }]) =>
         mockCourseworkItemFindUnique(...args),
+      findMany: (...args: [{ where: { courseworkId: string } }]) =>
+        mockCourseworkItemFindMany(...args),
     },
   },
 }))
@@ -1029,6 +1038,84 @@ describe("calculateGrades", () => {
     const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
     expect(ss.rawScore).toBe(75)
     expect(ss.isEstimated).toBe(false)
+  })
+
+  it("coursework_total: 資料の全評価項目のスコア・満点を合算する", async () => {
+    // 資料 cw1 は2項目（満点 50 + 30 = 80）。生徒 s1 は 40 + 30 = 70 点。
+    courseworkTotalItems.clear()
+    courseworkTotalItems.set("cw1", [{ maxScore: 50 }, { maxScore: 30 }])
+
+    const gp = {
+      id: "gp1",
+      name: "PJ",
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "資料",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "coursework_total",
+              name: "資料合計",
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              courseworkItemId: null,
+              courseworkId: "cw1",
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              courseworkItem: null,
+              coursework: {
+                items: [
+                  {
+                    maxScore: 50,
+                    inputMode: "numeric",
+                    scores: [{ studentId: "s1", score: 40 }],
+                    letterScales: [],
+                  },
+                  {
+                    maxScore: 30,
+                    inputMode: "numeric",
+                    scores: [{ studentId: "s1", score: 30 }],
+                    letterScales: [],
+                  },
+                ],
+              },
+              weight: 100,
+              order: 0,
+              absentMethod: "null",
+              absentRatio: 1,
+              absentOffset: 0,
+              treatExpectedAsMissing: false,
+              estimationMode: "all",
+              estimationSourceIds: "[]",
+            },
+          ],
+        },
+      ],
+      boundarySets: [],
+      gradeClasses: [],
+    }
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([
+      buildStudent({ id: "s1" }),
+      buildStudent({ id: "s2", studentNumber: "S002" }),
+    ])
+
+    const result = await calculateGrades("gp1")
+
+    // s1: 合算 70点 / 満点 80点 → 換算 70/80*100 = 87.5
+    const s1 = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+    expect(s1.rawScore).toBe(70)
+    expect(s1.maxScore).toBe(80)
+    expect(s1.weightedScore).toBe(87.5)
+
+    // s2: 全項目未入力 → rawScore は null（absentMethod="null" のため推定なし）
+    const s2Item = result.result!.students[1].gradeItemResults[0]
+    expect(s2Item.sourceScores[0].rawScore).toBeNull()
+    expect(s2Item.isAllMissing).toBe(true)
   })
 })
 

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -247,6 +247,7 @@ export function setupGradeHandlers(): void {
       subtotalId?: string
       cropRegionId?: string
       courseworkItemId?: string
+      courseworkId?: string
       name: string
       weight: number
       absentMethod?: string

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -44,6 +44,7 @@ export async function collectGradeArchiveData(
               subtotal: true,
               cropRegion: true,
               courseworkItem: { include: { coursework: true } },
+              coursework: { select: { id: true, name: true } },
             },
             orderBy: { order: "asc" },
           },
@@ -120,16 +121,22 @@ export async function collectGradeArchiveData(
         }
         return []
       })(),
+      // coursework: 評価項目参照（courseworkId は親資料 / courseworkItemId は項目）
+      // coursework_total: 資料全体参照（courseworkId のみ・項目参照は null）
       courseworkId:
         ds.type === "coursework"
           ? (ds.courseworkItem?.coursework?.id ?? null)
-          : null,
+          : ds.type === "coursework_total"
+            ? (ds.coursework?.id ?? null)
+            : null,
       courseworkItemId:
         ds.type === "coursework" ? (ds.courseworkItem?.id ?? null) : null,
       courseworkName:
         ds.type === "coursework"
           ? (ds.courseworkItem?.coursework?.name ?? null)
-          : null,
+          : ds.type === "coursework_total"
+            ? (ds.coursework?.name ?? null)
+            : null,
       courseworkItemName:
         ds.type === "coursework" ? (ds.courseworkItem?.name ?? null) : null,
     })),

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -269,6 +269,31 @@ export async function importGradeArchive(
               }
             }
 
+            // Coursework（資料全体）解決（uuid一次・名前二次）。
+            //   exam/subtotal/cropRegion と同じく import 時に直接照合する。
+            let courseworkId: string | null = null
+            if (dsData.type === "coursework_total") {
+              if (dsData.courseworkId) {
+                const byId = await tx.coursework.findUnique({
+                  where: { id: dsData.courseworkId },
+                  select: { id: true },
+                })
+                courseworkId = byId?.id ?? null
+              }
+              if (!courseworkId && dsData.courseworkName) {
+                const byName = await tx.coursework.findFirst({
+                  where: { name: dsData.courseworkName },
+                  select: { id: true },
+                })
+                courseworkId = byName?.id ?? null
+              }
+              if (!courseworkId) {
+                warnings.push(
+                  `成績項目「${giData.name}」のデータソース「${dsData.name}」: 参照先の試験外成績資料が見つかりませんでした`
+                )
+              }
+            }
+
             let examId: string | null = null
             if (
               dsData.examName &&
@@ -319,6 +344,7 @@ export async function importGradeArchive(
                 subtotalId,
                 cropRegionId,
                 courseworkItemId,
+                courseworkId,
                 name: dsData.name,
                 // v1.6.0: GradeDataSource.maxScore 列は廃止。満点はライブ算出するため挿入しない。
                 weight: dsData.weight,

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -40,6 +40,7 @@ export async function getDataSourcesByGradeItemId(gradeItemId: string) {
             _count: { select: { scores: true, gradeDataSources: true } },
           },
         },
+        coursework: { select: { id: true, name: true } },
       },
       orderBy: { order: "asc" },
     })
@@ -58,11 +59,12 @@ export async function getDataSourcesByGradeItemId(gradeItemId: string) {
  */
 export async function createDataSource(data: {
   gradeItemId: string
-  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework"
+  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"
   examId?: string
   subtotalId?: string
   cropRegionId?: string
   courseworkItemId?: string
+  courseworkId?: string
   name: string
   weight: number
   absentMethod?: string
@@ -88,6 +90,7 @@ export async function createDataSource(data: {
         subtotalId: data.subtotalId,
         cropRegionId: data.cropRegionId,
         courseworkItemId: data.courseworkItemId,
+        courseworkId: data.courseworkId,
         name: data.name,
         weight: data.weight,
         order: nextOrder,
@@ -121,6 +124,7 @@ export async function createDataSource(data: {
             _count: { select: { scores: true, gradeDataSources: true } },
           },
         },
+        coursework: { select: { id: true, name: true } },
       },
     })
 
@@ -183,6 +187,7 @@ export async function updateDataSource(
             _count: { select: { scores: true, gradeDataSources: true } },
           },
         },
+        coursework: { select: { id: true, name: true } },
       },
     })
 
@@ -413,6 +418,16 @@ export async function computeLiveMaxScore(
     return Number(item?.maxScore ?? 0)
   }
 
+  // coursework_total: 資料全体（全評価項目）の満点合計
+  if (ds.type === "coursework_total") {
+    if (!ds.courseworkId) return 0
+    const items = await prisma.courseworkItem.findMany({
+      where: { courseworkId: ds.courseworkId },
+      select: { maxScore: true },
+    })
+    return items.reduce((sum, item) => sum + Number(item.maxScore), 0)
+  }
+
   // crop_region: 設問の配点
   if (ds.type === "crop_region") {
     if (!ds.cropRegionId) return 0
@@ -462,6 +477,7 @@ export async function calculateSourceMaxScore(data: {
   subtotalId?: string
   cropRegionId?: string
   courseworkItemId?: string
+  courseworkId?: string
 }): Promise<{ success: boolean; maxScore?: number; error?: string }> {
   try {
     return { success: true, maxScore: await computeLiveMaxScore(data) }

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -65,6 +65,16 @@ export async function calculateGrades(gradeId: string): Promise<{
                     letterScales: { orderBy: { order: "asc" } },
                   },
                 },
+                coursework: {
+                  include: {
+                    items: {
+                      include: {
+                        scores: true,
+                        letterScales: { orderBy: { order: "asc" } },
+                      },
+                    },
+                  },
+                },
               },
               orderBy: { order: "asc" },
             },
@@ -519,6 +529,19 @@ async function getRawScore(
       }[]
       letterScales: { label: string; score: unknown }[]
     } | null
+    coursework?: {
+      items: {
+        maxScore: unknown
+        inputMode: string
+        scores: {
+          studentId: string
+          score: unknown
+          letterValue?: string | null
+          adjustment?: unknown
+        }[]
+        letterScales: { label: string; score: unknown }[]
+      }[]
+    } | null
   },
   examDataCache: Map<string, ExamDataCache>
 ): Promise<number | null> {
@@ -546,8 +569,41 @@ async function getRawScore(
     )
   } else if (ds.type === "coursework" && ds.courseworkItem) {
     return getCourseworkRawScore(studentId, ds.courseworkItem)
+  } else if (ds.type === "coursework_total" && ds.coursework) {
+    return getCourseworkTotalRawScore(studentId, ds.coursework.items)
   }
   return null
+}
+
+/**
+ * coursework_total型データソース（試験外成績資料の全評価項目合計）の実スコアを算出する。
+ * 各評価項目のスコアを getCourseworkRawScore で求めて合算する。
+ * exam_total と同様、採点済み項目のみを合算し、全項目が未入力なら null を返す。
+ */
+function getCourseworkTotalRawScore(
+  studentId: string,
+  items: {
+    maxScore: unknown
+    inputMode: string
+    scores: {
+      studentId: string
+      score: unknown
+      letterValue?: string | null
+      adjustment?: unknown
+    }[]
+    letterScales: { label: string; score: unknown }[]
+  }[]
+): number | null {
+  let total = 0
+  let hasScored = false
+  for (const item of items) {
+    const score = getCourseworkRawScore(studentId, item)
+    if (score !== null) {
+      hasScored = true
+      total += score
+    }
+  }
+  return hasScored ? total : null
 }
 
 /**

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -82,6 +82,7 @@ export function createGradeApi() {
         subtotalId?: string
         cropRegionId?: string
         courseworkItemId?: string
+        courseworkId?: string
         name: string
         weight: number
         absentMethod?: string

--- a/prisma/migrations/20260702000000_add_coursework_id_to_grade_data_source/migration.sql
+++ b/prisma/migrations/20260702000000_add_coursework_id_to_grade_data_source/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: GradeDataSource に試験外成績資料（Coursework）全体への参照を追加
+-- （courseworkItemId は評価項目単位、courseworkId は資料全体を参照する coursework_total 型用）
+ALTER TABLE "GradeDataSource" ADD COLUMN "courseworkId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "GradeDataSource_courseworkId_idx" ON "GradeDataSource"("courseworkId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -740,16 +740,18 @@ model GradeStudent {
   @@index([gradeId, customOrder])
 }
 
-/// 成績データソース（5種: exam_total / subtotal / crop_region / coursework）
+/// 成績データソース（6種: exam_total / subtotal / crop_region / coursework / coursework_total）
 /// coursework型は CourseworkItem（試験外成績資料の評価項目）を参照する
+/// coursework_total型は Coursework（試験外成績資料）全体を参照し、全評価項目のスコアを合算する
 model GradeDataSource {
   id                     String   @id @default(uuid())
   gradeItemId            String
-  type                   String // "exam_total" | "subtotal" | "crop_region" | "coursework"
+  type                   String // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"
   examId                 String?
   subtotalId             String?
   cropRegionId           String?
   courseworkItemId       String?
+  courseworkId           String?
   name                   String
   weight                 Decimal
   order                  Int      @default(0)
@@ -767,12 +769,14 @@ model GradeDataSource {
   subtotal       Subtotal?       @relation(fields: [subtotalId], references: [id], onDelete: Cascade)
   cropRegion     CropRegion?     @relation(fields: [cropRegionId], references: [id], onDelete: Cascade)
   courseworkItem CourseworkItem? @relation(fields: [courseworkItemId], references: [id], onDelete: SetNull)
+  coursework     Coursework?     @relation(fields: [courseworkId], references: [id], onDelete: SetNull)
 
   @@index([gradeItemId])
   @@index([examId])
   @@index([subtotalId])
   @@index([cropRegionId])
   @@index([courseworkItemId])
+  @@index([courseworkId])
 }
 
 /// 評価項目ごとの対象生徒除外設定
@@ -872,10 +876,11 @@ model Coursework {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
-  classes  CourseworkClass[]
-  students CourseworkStudent[]
-  tags     CourseworkTag[]
-  items    CourseworkItem[]
+  classes          CourseworkClass[]
+  students         CourseworkStudent[]
+  tags             CourseworkTag[]
+  items            CourseworkItem[]
+  gradeDataSources GradeDataSource[]
 }
 
 /// 試験外成績資料の対象学級

--- a/src/components/grades/03-data-sources/AddDataSourceInline.tsx
+++ b/src/components/grades/03-data-sources/AddDataSourceInline.tsx
@@ -15,6 +15,9 @@ import {
 
 type DataSourceType = "exam_total" | "subtotal" | "crop_region" | "coursework"
 
+/** 資料の評価項目セレクトで「資料全体（全項目合計）」を表すセンチネル値 */
+const COURSEWORK_WHOLE = "__whole__"
+
 interface AddDataSourceInlineProps {
   gradeItemId: string
   onCreate: (data: {
@@ -24,6 +27,7 @@ interface AddDataSourceInlineProps {
     subtotalId?: string
     cropRegionId?: string
     courseworkItemId?: string
+    courseworkId?: string
     name: string
     weight: number
   }) => Promise<{ success: boolean }>
@@ -171,14 +175,24 @@ export function AddDataSourceInline({
     autoSeedWeight()
   }, [autoSeedWeight])
 
-  // coursework型: 評価項目選択時に換算満点・名前を補完
+  // coursework型: 評価項目（または資料全体）選択時に換算満点・名前を補完
   useEffect(() => {
     if (type !== "coursework") return
     const coursework = courseworks.find((c) => c.id === selectedCourseworkId)
-    const item = coursework?.items.find(
-      (i) => i.id === selectedCourseworkItemId
-    )
-    if (coursework && item) {
+    if (!coursework) return
+    if (selectedCourseworkItemId === COURSEWORK_WHOLE) {
+      // 資料全体: 換算満点の初期値は全評価項目の満点合計、名前は「資料名(合計)」
+      // maxScore は IPC 経由で文字列化され得る（Prisma Decimal）ため必ず数値化して加算する
+      const totalMax = coursework.items.reduce(
+        (sum, i) => sum + Number(i.maxScore),
+        0
+      )
+      setWeight((prev) => (prev ? prev : String(totalMax)))
+      setName(`${coursework.name}(合計)`)
+      return
+    }
+    const item = coursework.items.find((i) => i.id === selectedCourseworkItemId)
+    if (item) {
       setWeight((prev) => (prev ? prev : String(item.maxScore)))
       setName(`${coursework.name}(${item.name})`)
     }
@@ -220,9 +234,12 @@ export function AddDataSourceInline({
     if (!name.trim() || !weight) return
     setAdding(true)
     try {
+      // 資料全体が選ばれた場合は coursework_total 型（資料IDを参照）へ切り替える
+      const isWhole =
+        type === "coursework" && selectedCourseworkItemId === COURSEWORK_WHOLE
       const data: Parameters<typeof onCreate>[0] = {
         gradeItemId,
-        type,
+        type: isWhole ? "coursework_total" : type,
         name: name.trim(),
         weight: Number(weight),
       }
@@ -236,7 +253,11 @@ export function AddDataSourceInline({
         data.cropRegionId = selectedCropRegionId || undefined
       }
       if (type === "coursework") {
-        data.courseworkItemId = selectedCourseworkItemId || undefined
+        if (isWhole) {
+          data.courseworkId = selectedCourseworkId || undefined
+        } else {
+          data.courseworkItemId = selectedCourseworkItemId || undefined
+        }
       }
       const result = await onCreate(data)
       if (result.success) {
@@ -414,7 +435,7 @@ export function AddDataSourceInline({
                 ))}
               </SelectContent>
             </Select>
-            {selectedCourseworkItems.length > 0 && (
+            {selectedCourseworkId && (
               <Select
                 value={selectedCourseworkItemId}
                 onValueChange={setSelectedCourseworkItemId}
@@ -423,6 +444,7 @@ export function AddDataSourceInline({
                   <SelectValue placeholder="評価項目" />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value={COURSEWORK_WHOLE}>（資料全体）</SelectItem>
                   {selectedCourseworkItems.map((i) => (
                     <SelectItem key={i.id} value={i.id}>
                       {i.name}

--- a/src/components/grades/03-data-sources/DataSourceRow.tsx
+++ b/src/components/grades/03-data-sources/DataSourceRow.tsx
@@ -15,6 +15,7 @@ const TYPE_LABELS: Record<string, string> = {
   subtotal: "小計",
   crop_region: "設問",
   coursework: "資料",
+  coursework_total: "資料合計",
 }
 
 interface DataSourceRowProps {
@@ -47,7 +48,8 @@ export function DataSourceRow({
   const [name, setName] = useState(dataSource.name)
   const [weight, setWeight] = useState(String(dataSource.weight))
 
-  const isCoursework = dataSource.type === "coursework"
+  const isCoursework =
+    dataSource.type === "coursework" || dataSource.type === "coursework_total"
   // 満点は元データ（設問配点 / 評価項目満点）からライブ算出した値をバックエンドが
   // 全型で dataSource.maxScore に載せて返す。ここでは表示のみで編集不可。
   const displayMaxScore = dataSource.maxScore
@@ -114,6 +116,9 @@ export function DataSourceRow({
     }
     if (dataSource.courseworkItem) {
       return `${dataSource.courseworkItem.coursework.name} > ${dataSource.courseworkItem.name}`
+    }
+    if (dataSource.coursework) {
+      return `${dataSource.coursework.name} > 全項目`
     }
     return null
   })()

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -70,6 +70,7 @@ export function useDataSources(gradeId: string) {
       subtotalId?: string
       cropRegionId?: string
       courseworkItemId?: string
+      courseworkId?: string
       name: string
       weight: number
     }) => {

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -168,6 +168,7 @@ export interface GradeAPI {
       subtotalId?: string
       cropRegionId?: string
       courseworkItemId?: string
+      courseworkId?: string
       name: string
       weight: number
       absentMethod?: string

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -45,11 +45,12 @@ export type EstimationMode = "all" | "selected"
 export interface GradeDataSourceWithDetails {
   id: string
   gradeItemId: string
-  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework"
+  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"
   examId: string | null
   subtotalId: string | null
   cropRegionId: string | null
   courseworkItemId: string | null
+  courseworkId: string | null
   name: string
   maxScore: number
   weight: number
@@ -75,6 +76,8 @@ export interface GradeDataSourceWithDetails {
         coursework: { id: string; name: string }
       })
     | null
+  /** coursework_total型が参照する資料（全評価項目を合算する対象） */
+  coursework: { id: string; name: string } | null
 }
 
 export type { InputMode }

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -96,7 +96,7 @@ export interface ArchiveGradeItem {
 }
 
 export interface ArchiveDataSource {
-  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework"（旧: "manual"）
+  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"（旧: "manual"）
   name: string
   /**
    * @deprecated v1.6.0 で GradeDataSource.maxScore 列が廃止された（満点は元データから
@@ -119,11 +119,11 @@ export interface ArchiveDataSource {
   treatExpectedAsMissing?: boolean
   estimationMode?: string
   estimationSourceIds?: string[]
-  /** v1.4.0+: type==="coursework" の参照先資料uuid（照合の一次キー） */
+  /** v1.4.0+: type==="coursework"（項目参照）/ v1.8.0+: type==="coursework_total"（資料全体）の参照先資料uuid（照合の一次キー） */
   courseworkId?: string | null
   /** v1.4.0+: type==="coursework" の参照先評価項目uuid（照合の一次キー） */
   courseworkItemId?: string | null
-  /** v1.4.0+: type==="coursework" の参照先資料名（uuid不一致時の二次フォールバック） */
+  /** v1.4.0+: type==="coursework"（項目参照）/ v1.8.0+: type==="coursework_total"（資料全体）の参照先資料名（uuid不一致時の二次フォールバック） */
   courseworkName?: string | null
   /** v1.4.0+: type==="coursework" の参照先評価項目名（名前フォールバック） */
   courseworkItemName?: string | null
@@ -258,19 +258,24 @@ export interface GradeArchiveImportPreview {
  *   1.5.0 と同形のため専用 transformer は無し（ArchiveDataSource.maxScore は optional で旧読込互換）。
  * - 1.7.0: 観点間の制約ルール（GradeConstraint）を追加。gradeConstraints は optional で
  *   旧アーカイブ読込時は空配列扱い。構造は加算的なため専用 transformer は無し。
+ * - 1.8.0: 資料全体を参照する coursework_total 型 DataSource を追加。参照先資料は
+ *   既存の ArchiveDataSource.courseworkId / courseworkName（optional）で表現するため
+ *   新規フィールドは無く、旧アーカイブには coursework_total が存在しないだけなので
+ *   専用 transformer は無し（加算的変更）。
  *
  * 検出は manifest.version 文字列ではなくデータ形状で行う（旧アーカイブのバージョン
  * 表記が不正確でも確実に正規化するため。詳細は grade-transformers/index.ts）。
  */
 export type GradeArchiveVersion =
-  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.7.0"
+  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0" | "1.8.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.8.0"
 export const GRADE_SUPPORTED_VERSIONS: readonly GradeArchiveVersion[] = [
   "1.3.0",
   "1.4.0",
   "1.5.0",
   "1.6.0",
   "1.7.0",
+  "1.8.0",
 ] as const
 
 export interface GradeTransformResult {

--- a/src/types/prismaExtensions.ts
+++ b/src/types/prismaExtensions.ts
@@ -306,6 +306,10 @@ export type GradeDataSourceMaxScoreRef = Pick<GradeDataSource, "type"> &
   Partial<
     Pick<
       GradeDataSource,
-      "examId" | "subtotalId" | "cropRegionId" | "courseworkItemId"
+      | "examId"
+      | "subtotalId"
+      | "cropRegionId"
+      | "courseworkItemId"
+      | "courseworkId"
     >
   >


### PR DESCRIPTION
## 概要

Closes #907

成績算出のデータソースに **`coursework_total`（資料全体）** 型を新設し、試験外成績資料（Coursework）を評価項目単位だけでなく**資料全体（全評価項目の合算）**として追加できるようにした。試験の `exam_total` と同じ挙動。

## 変更点

| 領域 | 内容 |
|------|------|
| スキーマ | `GradeDataSource.courseworkId` + `Coursework` 逆リレーション追加。手書きマイグレーション `20260702000000` |
| 満点算出 | `computeLiveMaxScore` に全項目満点合計ケース追加（ライブ算出） |
| スコア算出 | `gradeCalculator` に `getCourseworkTotalRawScore`（採点済み項目のみ合算・全未入力は欠測） |
| UI | 資料選択後の項目セレクトに「（資料全体）」追加。換算満点初期値=全項目満点合計 |
| アーカイブ | export/import を `coursework_total` 対応、版数 1.7.0→1.8.0（既存 `courseworkId` 流用でトランスフォーマー不要） |
| 型/IPC | grade.types / prismaExtensions / preload / handler / hook / gradeApi.d.ts |
| テスト | 合算・欠測のユニットテスト追加 |

## 補足修正

換算満点初期値が Prisma Decimal の文字列化により文字列連結で不正値（例 `04124`）になる不具合を修正（`Number()` 化して加算）。

## 検証

- `npm run typecheck`: パス
- 変更ファイルの eslint / prettier: パス
- `gradeCalculator.test.ts`（+専用テスト）/ `gradeArchiveRoundTrip.test.ts` / grade・coursework・import-export: パス

## 注意

本ブランチは本セッションで実装した coursework_total 機能のファイルのみを対象にステージ・コミットしている（同一作業ツリーで並行している他セッションの変更は含まない）。