### PR TITLE
fix(grade): 試験外成績の配点超え・負値を成績算出にそのまま反映する

### DIFF
--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -919,7 +919,7 @@ describe("calculateGrades", () => {
     expect(ss.adjustmentReason).toBe("期限超過")
   })
 
-  it("加減点: letterモードの点数にも加算される（上限クランプ）", async () => {
+  it("加減点: letterモードの点数にも加算され、配点超えも反映される", async () => {
     const gp = buildGrade({
       gradeItems: [
         {
@@ -956,8 +956,49 @@ describe("calculateGrades", () => {
     const result = await calculateGrades("gp1")
     const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
 
-    // A(100) + 20 = 120 → clamp 100
-    expect(ss.rawScore).toBe(100)
+    // A(100) + 20 = 120。上限クランプを行わないため配点(100)超えがそのまま反映される
+    expect(ss.rawScore).toBe(120)
+    // 換算得点も weight(100) を超える（120/100*100 = 120）
+    expect(ss.weightedScore).toBe(120)
+  })
+
+  it("加減点: 減点で0未満になっても下限クランプせずそのまま反映される", async () => {
+    const gp = buildGrade({
+      gradeItems: [
+        {
+          id: "gi1",
+          name: "提出物",
+          order: 0,
+          dataSources: [
+            {
+              id: "ds1",
+              type: "manual",
+              name: "レポート",
+              maxScore: 100,
+              weight: 100,
+              examId: null,
+              subtotalId: null,
+              cropRegionId: null,
+              exam: null,
+              subtotal: null,
+              cropRegion: null,
+              inputMode: "numeric",
+              manualScores: [{ studentId: "s1", score: 10, adjustment: -30 }],
+              order: 0,
+            },
+          ],
+        },
+      ],
+    })
+    mockFindUnique.mockResolvedValue(gp)
+    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
+
+    const result = await calculateGrades("gp1")
+    const ss = result.result!.students[0].gradeItemResults[0].sourceScores[0]
+
+    // 10 - 30 = -20。下限クランプを行わないため負値もそのまま反映される
+    expect(ss.rawScore).toBe(-20)
+    expect(ss.weightedScore).toBe(-20)
   })
 
   it("コメントがsourceScoresに添付される", async () => {

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -610,7 +610,10 @@ function getCourseworkTotalRawScore(
  * coursework型データソース（試験外成績資料の評価項目）の実スコアを算出する。
  * - letterモード: 入力された評価記号を変換表で点数化
  * - numericモード: 入力された数値をそのまま使用
- * いずれも加点・減点(adjustment)を加算し、[0, maxScore]にクランプする。
+ * いずれも加点・減点(adjustment)を加算し、結果はクランプしない。
+ * 実際に入力された得点は配点超え（100%超）も負値（減点で0未満）もそのまま反映する。
+ * （推定で算出した代替スコアは別途 applyAdjustmentAndClamp で [0, 満点] に収める。
+ * 実入力と推定値で扱いを分け、推定値だけが配点を超えないようにするため。）
  * 満点は評価項目（CourseworkItem.maxScore）を live 参照する。
  */
 function getCourseworkRawScore(
@@ -649,8 +652,8 @@ function getCourseworkRawScore(
     cs.adjustment !== null && cs.adjustment !== undefined
       ? Number(cs.adjustment)
       : 0
-  const maxScore = Number(item.maxScore)
-  return clamp(base + adjustment, 0, maxScore)
+  // クランプしない。配点超え・負値のいずれも入力どおり成績算出に反映する。
+  return base + adjustment
 }
 
 /**


### PR DESCRIPTION
## 概要

Closes #909

試験外成績資料の `getCourseworkRawScore` の `[0, 満点]` クランプを撤廃し、加減点による配点超え（100%超）や減点による負値を成績算出へそのまま反映する。実入力のみクランプを外し、欠測補完の推定値は従来どおり `[0, 満点]` に収める。

## 変更点

| 対象 | 内容 |
|------|------|
| `getCourseworkRawScore` | `clamp(base+adjustment,0,max)` → `base+adjustment` |
| 適用範囲 | coursework / coursework_total 両型 |
| 推定経路 | クランプ維持（推定値のみ `[0,満点]`） |
| テスト | 配点超え反映・負値反映のケース追加/更新 |

## 調査結果（クランプ有無）

成績結果までの全経路を精査し、実入力スコアは **ソース換算得点 → 観点/総合の合計・パーセンテージ → 成績ラベル → 結果表示 → Excel/個人票出力** のいずれでもクランプされないことを確認。クランプは推定経路の3箇所（estimateByAverage / estimateByRegression / applyAdjustmentAndClamp）のみで、これは意図どおり維持。

## 検証

- `npm run typecheck`: パス
- `gradeCalculator.test.ts`: 30件パス（配点超え/負値の反映テスト含む）