### PR TITLE
chore: prettier フォーマットを一括適用

### DIFF
--- a/__tests__/audit/auditLog.test.ts
+++ b/__tests__/audit/auditLog.test.ts
@@ -111,8 +111,7 @@ describe("監査ログ recordAuditLog", () => {
     })
     const page = await getAuditLogs()
     const changes = page.entries[0].metadata?.changes as
-      | { before: unknown; after: unknown }[]
-      | undefined
+      { before: unknown; after: unknown }[] | undefined
     expect(changes?.[0].before).toBe("旧")
     expect(changes?.[0].after).toBe("新")
   })
@@ -146,8 +145,7 @@ describe("監査ログ 集約（coalesce）", () => {
     expect(page.total).toBe(1)
     expect(page.entries[0].occurrences).toBe(2)
     const changes = page.entries[0].metadata?.changes as
-      | { after: unknown }[]
-      | undefined
+      { after: unknown }[] | undefined
     expect(changes?.[0].after).toBe("B") // after は最新で上書き
   })
 

--- a/__tests__/screenshots/helpers/generate-images.ts
+++ b/__tests__/screenshots/helpers/generate-images.ts
@@ -76,21 +76,19 @@ function templateToDefinition(
           label: sq.label as string,
           branchQuestions: (
             (sq.branchQuestions as Array<Record<string, unknown>>) || []
-          ).map(
-            (bq): BranchQuestion => ({
-              id: bq.id as string,
-              label: bq.label as string,
-              heightMultiplier: bq.heightMultiplier as number,
-              points: bq.points as number,
-              textElements: [],
-              imageElements: [],
-              layoutWidth: (bq.layoutWidth as string) ?? undefined,
-              nextPlacement:
-                (bq.nextPlacement as BranchQuestion["nextPlacement"]) ??
-                undefined,
-              goUp: (bq.goUp as number) ?? undefined,
-            })
-          ),
+          ).map((bq): BranchQuestion => ({
+            id: bq.id as string,
+            label: bq.label as string,
+            heightMultiplier: bq.heightMultiplier as number,
+            points: bq.points as number,
+            textElements: [],
+            imageElements: [],
+            layoutWidth: (bq.layoutWidth as string) ?? undefined,
+            nextPlacement:
+              (bq.nextPlacement as BranchQuestion["nextPlacement"]) ??
+              undefined,
+            goUp: (bq.goUp as number) ?? undefined,
+          })),
           heightMultiplier: sq.heightMultiplier as number,
           points: sq.points as number,
           textElements: (

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -574,9 +574,8 @@ export function setupExportHandlers(): void {
         const margins = options.margins || {}
         // pageSizeがmmオブジェクトの場合はインチに変換
         let resolvedPageSize:
-          | "A4"
-          | "Letter"
-          | { width: number; height: number } = options.pageSize || "A4"
+          "A4" | "Letter" | { width: number; height: number } =
+          options.pageSize || "A4"
         if (
           typeof resolvedPageSize === "object" &&
           "width" in resolvedPageSize &&

--- a/electron-src/lib/export/excel/rowCreators.ts
+++ b/electron-src/lib/export/excel/rowCreators.ts
@@ -32,20 +32,16 @@ export async function createDataRows(
 ) {
   // 事前に順位を計算（総合点の降順でソート、null は最下位扱い）
   const scoringDataWithRank: ScoringDataWithRank[] = scoringData
-    .map(
-      (student, index): ScoringDataWithRank => ({
-        ...student,
-        originalIndex: index,
-        rank: 0, // 仮の値、後で正しい順位に更新
-      })
-    )
+    .map((student, index): ScoringDataWithRank => ({
+      ...student,
+      originalIndex: index,
+      rank: 0, // 仮の値、後で正しい順位に更新
+    }))
     .sort((a, b) => (b.totalScore ?? -1) - (a.totalScore ?? -1))
-    .map(
-      (student, rank): ScoringDataWithRank => ({
-        ...student,
-        rank: student.totalScore !== null ? rank + 1 : 0,
-      })
-    )
+    .map((student, rank): ScoringDataWithRank => ({
+      ...student,
+      rank: student.totalScore !== null ? rank + 1 : 0,
+    }))
     // 元の順序に戻す
     .sort((a, b) => a.originalIndex - b.originalIndex)
 

--- a/electron-src/lib/prisma/examStudent.ts
+++ b/electron-src/lib/prisma/examStudent.ts
@@ -58,9 +58,7 @@ export async function getStudentsForExam(examId: string) {
       return {
         ...studentRest,
         status: examStudent.status.toLowerCase() as
-          | "participating"
-          | "expected"
-          | "absent",
+          "participating" | "expected" | "absent",
         isInExam: true,
         customOrder: examStudent.customOrder,
         answerSheetCount: _count.studentAnswerImages,

--- a/electron-src/lib/prisma/schema/versionDetector.ts
+++ b/electron-src/lib/prisma/schema/versionDetector.ts
@@ -9,15 +9,7 @@ import { getTableColumns, tableExists } from "../databaseUtils"
  * S7=v0.7.x, S8=v0.8.x, S9=v0.9.x(現行)
  */
 export type SchemaVersion =
-  | "S3"
-  | "S4"
-  | "S5"
-  | "S6"
-  | "S7"
-  | "S8"
-  | "S9"
-  | "MIGRATED"
-  | "UNKNOWN"
+  "S3" | "S4" | "S5" | "S6" | "S7" | "S8" | "S9" | "MIGRATED" | "UNKNOWN"
 
 /** 既存DBのスキーマ状態を検出する */
 export const detectSchemaVersion = async (

--- a/electron-src/lib/shared/types/exportTypes.ts
+++ b/electron-src/lib/shared/types/exportTypes.ts
@@ -77,12 +77,7 @@ export interface ExportResult {
 
 // 問題分析関連の型定義
 export type DiscriminationLevel =
-  | "good"
-  | "acceptable"
-  | "marginal"
-  | "poor"
-  | "negative"
-  | "insufficient"
+  "good" | "acceptable" | "marginal" | "poor" | "negative" | "insufficient"
 
 export interface ItemAnalysisRow {
   questionId: string

--- a/src/app/exams/[examId]/02-template/page.tsx
+++ b/src/app/exams/[examId]/02-template/page.tsx
@@ -76,8 +76,7 @@ export default function TemplateStepPage() {
   const handleRegionsChange = useCallback(
     async (
       newRegions:
-        | CropRegionArea[]
-        | ((prev: CropRegionArea[]) => CropRegionArea[])
+        CropRegionArea[] | ((prev: CropRegionArea[]) => CropRegionArea[])
     ) => {
       const finalRegions =
         typeof newRegions === "function"

--- a/src/app/exams/[examId]/08-export/types.ts
+++ b/src/app/exams/[examId]/08-export/types.ts
@@ -60,11 +60,7 @@ export interface ExportOptions {
 
 // PDF出力フェーズの型
 export type ExportPhase =
-  | "initializing"
-  | "rendering"
-  | "embedding"
-  | "saving"
-  | "complete"
+  "initializing" | "rendering" | "embedding" | "saving" | "complete"
 
 // Canvas描画の詳細プログレス
 export interface RenderProgress {

--- a/src/components/common/BaseModal.tsx
+++ b/src/components/common/BaseModal.tsx
@@ -14,11 +14,7 @@ import {
 } from "@/components/ui/modal"
 
 export type ModalVariant =
-  | "default"
-  | "destructive"
-  | "success"
-  | "warning"
-  | "info"
+  "default" | "destructive" | "success" | "warning" | "info"
 
 interface BaseModalProps {
   open: boolean

--- a/src/components/coursework/02-students/CourseworkStudentsContainer.tsx
+++ b/src/components/coursework/02-students/CourseworkStudentsContainer.tsx
@@ -106,9 +106,10 @@ export function CourseworkStudentsContainer({
         const result =
           await window.electronAPI.coursework.getClasses(courseworkId)
         if (!result.success || !result.classes) return []
-        return result.classes.map(
-          (c): RosterClassOption => ({ id: c.classId, name: c.className })
-        )
+        return result.classes.map((c): RosterClassOption => ({
+          id: c.classId,
+          name: c.className,
+        }))
       },
       updateRowOrder: async (rowOrders) => {
         await window.electronAPI.coursework.updateStudentOrders(
@@ -135,14 +136,12 @@ export function CourseworkStudentsContainer({
           activeOnly
         )
         if (!result.success || !result.classes) return []
-        return result.classes.map(
-          (c): AddPanelClassItem => ({
-            id: c.id,
-            name: c.name,
-            studentCount: c.studentCount,
-            studentNames: [],
-          })
-        )
+        return result.classes.map((c): AddPanelClassItem => ({
+          id: c.id,
+          name: c.name,
+          studentCount: c.studentCount,
+          studentNames: [],
+        }))
       },
       fetchAvailableStudents: async (activeOnly) => {
         const result = await window.electronAPI.coursework.getAvailableStudents(
@@ -150,24 +149,22 @@ export function CourseworkStudentsContainer({
           activeOnly
         )
         if (!result.success || !result.students) return []
-        return result.students.map(
-          (s): AddPanelStudentItem => ({
-            id: s.id,
-            studentNumber: s.studentNumber,
-            lastName: s.lastName,
-            firstName: s.firstName,
-            lastNameKana: "",
-            firstNameKana: "",
-            memberships: s.className
-              ? [
-                  {
-                    attendanceNumber: null,
-                    class: { id: s.className, name: s.className },
-                  },
-                ]
-              : [],
-          })
-        )
+        return result.students.map((s): AddPanelStudentItem => ({
+          id: s.id,
+          studentNumber: s.studentNumber,
+          lastName: s.lastName,
+          firstName: s.firstName,
+          lastNameKana: "",
+          firstNameKana: "",
+          memberships: s.className
+            ? [
+                {
+                  attendanceNumber: null,
+                  class: { id: s.className, name: s.className },
+                },
+              ]
+            : [],
+        }))
       },
       addClasses: async (orderedClassIds, activeOnly) => {
         for (const classId of orderedClassIds) {

--- a/src/components/exams/05-students/components/ClassExamManager.tsx
+++ b/src/components/exams/05-students/components/ClassExamManager.tsx
@@ -95,15 +95,13 @@ export function ClassExamManager({
       emptyHint="「学級を追加」ボタンから学級を追加してください"
       fetchAvailableClasses={async () => {
         const classes = await window.electronAPI.examClass.getAvailable(examId)
-        return classes.map(
-          (c): AvailableClassOption => ({
-            id: c.id,
-            name: c.name,
-            classCode: c.classCode,
-            grade: c.grade,
-            studentCount: c.studentCount,
-          })
-        )
+        return classes.map((c): AvailableClassOption => ({
+          id: c.id,
+          name: c.name,
+          classCode: c.classCode,
+          grade: c.grade,
+          studentCount: c.studentCount,
+        }))
       }}
       onAddClasses={async (classIds) => {
         for (const classId of classIds) {

--- a/src/components/exams/05-students/components/exam-student-add-modal/components/ExamStudentAddModalContainer.tsx
+++ b/src/components/exams/05-students/components/exam-student-add-modal/components/ExamStudentAddModalContainer.tsx
@@ -39,14 +39,12 @@ export function ExamStudentAddModalContainer({
           activeOnly
         )
         if (!result.success || !result.classes) return []
-        return result.classes.map(
-          (c): AddPanelClassItem => ({
-            id: c.id,
-            name: c.name,
-            studentCount: c.studentCount,
-            studentNames: c.studentNames,
-          })
-        )
+        return result.classes.map((c): AddPanelClassItem => ({
+          id: c.id,
+          name: c.name,
+          studentCount: c.studentCount,
+          studentNames: c.studentNames,
+        }))
       },
       fetchAvailableStudents: async (activeOnly) => {
         const result = await window.electronAPI.getStudentsNotInExam(
@@ -54,20 +52,18 @@ export function ExamStudentAddModalContainer({
           activeOnly
         )
         if (!result.success || !result.students) return []
-        return result.students.map(
-          (s): AddPanelStudentItem => ({
-            id: s.id,
-            studentNumber: s.studentNumber,
-            lastName: s.lastName,
-            firstName: s.firstName,
-            lastNameKana: s.lastNameKana,
-            firstNameKana: s.firstNameKana,
-            memberships: s.memberships.map((m) => ({
-              attendanceNumber: m.attendanceNumber,
-              class: { id: m.class.id, name: m.class.name },
-            })),
-          })
-        )
+        return result.students.map((s): AddPanelStudentItem => ({
+          id: s.id,
+          studentNumber: s.studentNumber,
+          lastName: s.lastName,
+          firstName: s.firstName,
+          lastNameKana: s.lastNameKana,
+          firstNameKana: s.firstNameKana,
+          memberships: s.memberships.map((m) => ({
+            attendanceNumber: m.attendanceNumber,
+            class: { id: m.class.id, name: m.class.name },
+          })),
+        }))
       },
       addClasses: async (orderedClassIds, activeOnly) => {
         // 選択順に逐次追加（サーバが customOrder を末尾連番で付与）

--- a/src/components/exams/06-student-answers/student-answer-table/types/index.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/index.ts
@@ -23,11 +23,7 @@ export interface CellData {
   pageNumber?: number
   file?: UnifiedFile
   disabledReason?:
-    | "row"
-    | "column"
-    | "position"
-    | "existing_answer"
-    | "absent_student"
+    "row" | "column" | "position" | "existing_answer" | "absent_student"
 }
 
 // Component props interfaces
@@ -74,11 +70,7 @@ export interface EmptyTableCellProps {
   hasExistingAnswer?: boolean
   allowOverwrite?: boolean
   disabledReason?:
-    | "row"
-    | "column"
-    | "position"
-    | "existing_answer"
-    | "absent_student"
+    "row" | "column" | "position" | "existing_answer" | "absent_student"
   onTogglePosition?: () => void
   onUploadToCell?: () => void
   onToggleAnswerDisabled?: () => void

--- a/src/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/types/answerIndividualTypes.ts
@@ -8,12 +8,7 @@ import type {
 
 // 線種の型定義
 export type LineStyle =
-  | "solid"
-  | "wave"
-  | "zigzag"
-  | "double"
-  | "arrow"
-  | "both_arrow"
+  "solid" | "wave" | "zigzag" | "double" | "arrow" | "both_arrow"
 
 // アンカー方向（8方向 + center）
 export type AnchorDirection =
@@ -53,12 +48,7 @@ export interface DrawingElement {
 
 // 描画ツールの型定義
 export type DrawingTool =
-  | "hand"
-  | "text"
-  | "line"
-  | "rectangle"
-  | "ellipse"
-  | "select"
+  "hand" | "text" | "line" | "rectangle" | "ellipse" | "select"
 
 // 線の編集モード
 export type LineEditMode = "move" | "start" | "end" | null

--- a/src/components/exams/07-score-at-once/types/index.ts
+++ b/src/components/exams/07-score-at-once/types/index.ts
@@ -56,10 +56,7 @@ export type GradingMode = "grid" | "individual"
  * レイアウト方向
  */
 export type LayoutDirection =
-  | "right-down"
-  | "left-down"
-  | "down-right"
-  | "down-left"
+  "right-down" | "left-down" | "down-right" | "down-left"
 
 /**
  * クライアントサイド用のQuestionScore型
@@ -146,18 +143,13 @@ export type ScoringOperationMode = "keyboard" | "mouse"
  * - "partial_modal": クリックで部分点入力モーダルを開く
  */
 export type MouseBrushAction =
-  | Exclude<ScoringStatus, "unscored">
-  | "select"
-  | "partial_modal"
+  Exclude<ScoringStatus, "unscored"> | "select" | "partial_modal"
 
 /**
  * 模範解答表示モード
  */
 export type MasterAnswerDisplayMode =
-  | "off"
-  | "overlay"
-  | "split-horizontal"
-  | "split-vertical"
+  "off" | "overlay" | "split-horizontal" | "split-vertical"
 
 /**
  * 模範解答キー動作モード

--- a/src/components/exams/08-export/components/ExcelPreview.tsx
+++ b/src/components/exams/08-export/components/ExcelPreview.tsx
@@ -48,11 +48,7 @@ interface ExcelPreviewProps {
 }
 
 type SheetTab =
-  | "scores"
-  | "results"
-  | "item-analysis"
-  | "sp-table"
-  | "frequency"
+  "scores" | "results" | "item-analysis" | "sp-table" | "frequency"
 
 export function ExcelPreview({ data }: ExcelPreviewProps) {
   const [sheetTab, setSheetTab] = useState<SheetTab>("scores")

--- a/src/components/exams/08-export/components/ExportOptionsCard.tsx
+++ b/src/components/exams/08-export/components/ExportOptionsCard.tsx
@@ -17,9 +17,7 @@ import { Slider } from "@/components/ui/slider"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export type ExportTabType =
-  | "scored-answers"
-  | "grading-data"
-  | "individual-reports"
+  "scored-answers" | "grading-data" | "individual-reports"
 
 interface ExportOptionsCardProps {
   examId: string

--- a/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -273,12 +273,7 @@ export function PdfCanvasRenderer({
         endX: a.endX,
         endY: a.endY,
         lineStyle: a.lineStyle as
-          | "solid"
-          | "wave"
-          | "zigzag"
-          | "double"
-          | "arrow"
-          | "both_arrow",
+          "solid" | "wave" | "zigzag" | "double" | "arrow" | "both_arrow",
         text: a.text,
         fontSize: a.fontSize,
         textBoxWidth: 0,

--- a/src/components/exams/08-export/hooks/useExportPage.ts
+++ b/src/components/exams/08-export/hooks/useExportPage.ts
@@ -122,8 +122,7 @@ export function useExportPage() {
   const setScoringMarkConfig = useCallback(
     async (
       config:
-        | ScoringMarkConfig
-        | ((prev: ScoringMarkConfig) => ScoringMarkConfig)
+        ScoringMarkConfig | ((prev: ScoringMarkConfig) => ScoringMarkConfig)
     ) => {
       const newConfig =
         typeof config === "function" ? config(scoringMarkConfig) : config

--- a/src/components/grades/02-students/StudentsContainer.tsx
+++ b/src/components/grades/02-students/StudentsContainer.tsx
@@ -105,9 +105,10 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
       fetchClasses: async () => {
         const result = await window.electronAPI.grade.getClasses(gradeId)
         if (!result.success || !result.classes) return []
-        return result.classes.map(
-          (c): RosterClassOption => ({ id: c.classId, name: c.className })
-        )
+        return result.classes.map((c): RosterClassOption => ({
+          id: c.classId,
+          name: c.className,
+        }))
       },
       updateRowOrder: async (rowOrders) => {
         await window.electronAPI.grade.updateStudentOrders(gradeId, rowOrders)
@@ -128,14 +129,12 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
           activeOnly
         )
         if (!result.success || !result.classes) return []
-        return result.classes.map(
-          (c): AddPanelClassItem => ({
-            id: c.id,
-            name: c.name,
-            studentCount: c.studentCount,
-            studentNames: c.studentNames,
-          })
-        )
+        return result.classes.map((c): AddPanelClassItem => ({
+          id: c.id,
+          name: c.name,
+          studentCount: c.studentCount,
+          studentNames: c.studentNames,
+        }))
       },
       fetchAvailableStudents: async (activeOnly) => {
         const result = await window.electronAPI.grade.getAvailableStudents(
@@ -143,20 +142,18 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
           activeOnly
         )
         if (!result.success || !result.students) return []
-        return result.students.map(
-          (s): AddPanelStudentItem => ({
-            id: s.id,
-            studentNumber: s.studentNumber,
-            lastName: s.lastName,
-            firstName: s.firstName,
-            lastNameKana: s.lastNameKana,
-            firstNameKana: s.firstNameKana,
-            memberships: s.memberships.map((m) => ({
-              attendanceNumber: m.attendanceNumber,
-              class: { id: m.class.id, name: m.class.name },
-            })),
-          })
-        )
+        return result.students.map((s): AddPanelStudentItem => ({
+          id: s.id,
+          studentNumber: s.studentNumber,
+          lastName: s.lastName,
+          firstName: s.firstName,
+          lastNameKana: s.lastNameKana,
+          firstNameKana: s.firstNameKana,
+          memberships: s.memberships.map((m) => ({
+            attendanceNumber: m.attendanceNumber,
+            class: { id: m.class.id, name: m.class.name },
+          })),
+        }))
       },
       addClasses: async (orderedClassIds, activeOnly) => {
         for (const classId of orderedClassIds) {

--- a/src/components/grades/07-export/ExportContainer.tsx
+++ b/src/components/grades/07-export/ExportContainer.tsx
@@ -102,8 +102,7 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
   const setReportOptions = useCallback(
     (
       options:
-        | GradeReportOptions
-        | ((prev: GradeReportOptions) => GradeReportOptions)
+        GradeReportOptions | ((prev: GradeReportOptions) => GradeReportOptions)
     ) => {
       setReportOptionsState((prev) => {
         const newOptions =

--- a/src/components/help/page-specific/HelpContent07Scoring.tsx
+++ b/src/components/help/page-specific/HelpContent07Scoring.tsx
@@ -57,12 +57,7 @@ function getScrollParent(el: HTMLElement | null): HTMLElement | null {
 const MAX_SCORE = 10
 
 type DemoStatus =
-  | "unscored"
-  | "correct"
-  | "incorrect"
-  | "partial"
-  | "no_answer"
-  | "pending"
+  "unscored" | "correct" | "incorrect" | "partial" | "no_answer" | "pending"
 
 interface GuideKeys {
   correct: string
@@ -1639,12 +1634,7 @@ function IndividualScoringDemo({
 }
 
 type DrawToolKind =
-  | "line"
-  | "rectangle"
-  | "ellipse"
-  | "text"
-  | "select"
-  | "hand"
+  "line" | "rectangle" | "ellipse" | "text" | "select" | "hand"
 
 /** ツール説明アニメの答案下地（薄いプレースホルダ行） */
 function ToolBackdrop() {

--- a/src/types/answerSheetDefinition.types.ts
+++ b/src/types/answerSheetDefinition.types.ts
@@ -67,10 +67,7 @@ export interface BorderStyles {
 
 /** 文字数ガイドを表示するマスの隅 */
 export type ManuscriptGuidePosition =
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right"
+  "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
 /**
  * 原稿用紙の文字位置マーカー（先頭からN文字目に紐づく目印）。
@@ -277,10 +274,7 @@ export interface MultiColumnConfig {
 export type HeaderFieldType = "field" | "hfill" | "label"
 
 export type LinkedRegionType =
-  | "TOTAL_SCORE"
-  | "SUBTOTAL_SCORE"
-  | "STUDENT_NAME"
-  | "STUDENT_ID"
+  "TOTAL_SCORE" | "SUBTOTAL_SCORE" | "STUDENT_NAME" | "STUDENT_ID"
 
 export interface HeaderFieldDefinition {
   id: string

--- a/src/types/answerSheetLayout.types.ts
+++ b/src/types/answerSheetLayout.types.ts
@@ -174,10 +174,7 @@ export interface ComputedHeaderField {
   fontSize?: number
   /** 試験変換時に対応するCropRegionを自動生成する */
   linkedRegionType?:
-    | "TOTAL_SCORE"
-    | "SUBTOTAL_SCORE"
-    | "STUDENT_NAME"
-    | "STUDENT_ID"
+    "TOTAL_SCORE" | "SUBTOTAL_SCORE" | "STUDENT_NAME" | "STUDENT_ID"
 }
 
 export interface ComputedLayout {

--- a/src/types/courseworkArchive.types.ts
+++ b/src/types/courseworkArchive.types.ts
@@ -129,8 +129,7 @@ export interface CollectedCourseworkData {
 
 /** インポート時に資料ごとにユーザーが選ぶ取り込み方法 */
 export type CourseworkImportDecision =
-  | { action: "reuse"; existingId: string }
-  | { action: "new" }
+  { action: "reuse"; existingId: string } | { action: "new" }
 
 /** アーカイブ内の資料 uuid → ユーザー決定 */
 export type CourseworkImportDecisions = Record<string, CourseworkImportDecision>

--- a/src/types/drawingAnnotation.types.ts
+++ b/src/types/drawingAnnotation.types.ts
@@ -7,12 +7,7 @@
 export type DrawingType = "text" | "line" | "rectangle" | "ellipse"
 export type DrawingTool = "select" | "text" | "line" | "rectangle" | "ellipse"
 export type LineStyle =
-  | "solid"
-  | "wave"
-  | "zigzag"
-  | "double"
-  | "arrow"
-  | "both_arrow"
+  "solid" | "wave" | "zigzag" | "double" | "arrow" | "both_arrow"
 export type HorizontalAlign = "left" | "center" | "right"
 export type VerticalAlign = "top" | "center" | "bottom"
 export type AnchorDirection =

--- a/src/types/electron/auditLogApi.d.ts
+++ b/src/types/electron/auditLogApi.d.ts
@@ -6,20 +6,10 @@
  */
 
 export type AuditCategory =
-  | "exam"
-  | "grade"
-  | "answer_sheet"
-  | "student"
-  | "user"
-  | "system"
+  "exam" | "grade" | "answer_sheet" | "student" | "user" | "system"
 
 export type AuditVerb =
-  | "create"
-  | "update"
-  | "delete"
-  | "export"
-  | "import"
-  | "other"
+  "create" | "update" | "delete" | "export" | "import" | "other"
 
 /** before→after の単一フィールド差分 */
 export interface AuditChange {

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -215,10 +215,7 @@ export interface FileOverviewData {
  * - all_new: "全員を新しい生徒として追加する"
  */
 export type StudentMatchingStrategy =
-  | "by_student_number"
-  | "by_name"
-  | "individual"
-  | "all_new"
+  "by_student_number" | "by_name" | "individual" | "all_new"
 
 export type ClassMatchingStrategy = "by_name" | "individual" | "all_new"
 
@@ -1168,10 +1165,7 @@ export type UpdateDecisions = Record<string, FieldUpdateDecision>
  * - manual: "競合している採点を1つずつ確認する"
  */
 export type ScoringConflictResolutionStrategy =
-  | "import_wins"
-  | "existing_wins"
-  | "newer_wins"
-  | "manual"
+  "import_wins" | "existing_wins" | "newer_wins" | "manual"
 
 /**
  * 採点結果の競合（1件分）


### PR DESCRIPTION
現行の prettier 設定に未追従だった既存ファイル群（29ファイル）を整形。主に union 型の1行化などで、**ロジック変更はなく整形のみ**。

`npm run format` 実行時に毎回差分として現れていたノイズを解消する。