### PR TITLE
refactor(db): 物理テーブル名を Classroom 系へ統一・teacherStat→teacherStatistics 改名

### DIFF
--- a/__tests__/calculations/classAverageRows.test.ts
+++ b/__tests__/calculations/classAverageRows.test.ts
@@ -3,7 +3,7 @@
  *
  * appendClassAverageRows が
  * - 全体平均行（受験者＝合計点 non-null）
- * - teacherStat 学級ごとの学級平均行（母集団=学級全体、重複カウント）
+ * - teacherStatistics 学級ごとの学級平均行（母集団=学級全体、重複カウント）
  * を正しい列に出すことを検証する。
  */
 import * as ExcelJS from "exceljs"
@@ -13,18 +13,18 @@ import { appendClassAverageRows } from "@/electron-src/lib/export/excel/averageR
 import type { ScoringData } from "@/electron-src/lib/shared/types/exportTypes"
 import type { ExamClassroomWithMembers } from "@/types/prismaExtensions"
 
-/** ExamClassroomWithMembers の最小モック（テストで使う teacherStat / class.name / memberships のみ） */
+/** ExamClassroomWithMembers の最小モック（テストで使う teacherStatistics / class.name / memberships のみ） */
 function makeClass(
   name: string,
   studentIds: string[],
-  teacherStat = true
+  teacherStatistics = true
 ): ExamClassroomWithMembers {
   return {
     id: `ec-${name}`,
     examId: "e1",
     classroomId: `c-${name}`,
     administered: true,
-    teacherStat,
+    teacherStatistics,
     studentReport: true,
     order: 0,
     classroom: {
@@ -70,7 +70,7 @@ const NAME_COL = 7
 const TOTAL_COL = 8
 
 describe("appendClassAverageRows", () => {
-  it("全体平均と teacherStat 学級平均を正しい列・値で出す", () => {
+  it("全体平均と teacherStatistics 学級平均を正しい列・値で出す", () => {
     const workbook = new ExcelJS.Workbook()
     const worksheet = workbook.addWorksheet("点数一覧")
     worksheet.addRow([

--- a/__tests__/exam/integration/examStudentClass.test.ts
+++ b/__tests__/exam/integration/examStudentClass.test.ts
@@ -311,10 +311,10 @@ describe("Exam 在籍フィルタ", () => {
       expect(idsOf(classBMembers)).toEqual([active.id])
       // left はどの学級の集計にも含まれない
       expect(members.flatMap(idsOf)).not.toContain(left.id)
-      // 生徒ごと追加した学級は teacherStat / studentReport が true
-      expect(classAMembers.teacherStat).toBe(true)
+      // 生徒ごと追加した学級は teacherStatistics / studentReport が true
+      expect(classAMembers.teacherStatistics).toBe(true)
       expect(classAMembers.studentReport).toBe(true)
-      expect(classBMembers.teacherStat).toBe(true)
+      expect(classBMembers.teacherStatistics).toBe(true)
     })
   })
 })

--- a/__tests__/helpers/testExamBuilder.ts
+++ b/__tests__/helpers/testExamBuilder.ts
@@ -260,7 +260,7 @@ export async function createFullTestExam(
       examId: exam.id,
       classroomId: classroom.id,
       administered: true,
-      teacherStat: true,
+      teacherStatistics: true,
       studentReport: true,
       order: 0,
     },

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -125,18 +125,22 @@ describe("DateTime正規化マイグレーション", () => {
       null: 1,
     })
 
-    // 本番と同じ経路: Prismaクエリ (driver adapter が Date を ISO text で渡す)
+    // 本番と同じ経路を模す: driver adapter が Date を ISO text で渡すため、
+    // $queryRawUnsafe に Date をバインドして integer(endDate) と比較する。
+    // テーブルは normalize migration と同じ旧物理名 StudentClassMembership で作成しており、
+    // 新物理名へマップされる Prisma クライアントでは参照できないため生SQLを用いる。
     const refDate = new Date(REFERENCE)
-    const filter = {
-      OR: [{ endDate: null }, { endDate: { gte: refDate } }],
+    const countActiveSince = async (): Promise<number> => {
+      const rows = await prisma.$queryRawUnsafe<{ n: number | bigint }[]>(
+        `SELECT COUNT(*) AS n FROM "StudentClassMembership" WHERE "endDate" IS NULL OR "endDate" >= ?`,
+        refDate
+      )
+      return Number(rows[0].n)
     }
 
     // 【バグ再現】integer(endDate) >= text(基準日) は SQLite型優先順位で常にfalse。
     // 在籍中の未来終了(m_future)が除外され、null(m_active)の1件しか拾えない
-    const before = await prisma.studentClassroomMembership.count({
-      where: filter,
-    })
-    expect(before).toBe(1)
+    expect(await countActiveSince()).toBe(1)
 
     // 正規化マイグレーション適用
     await applyMigrationFor(["StudentClassMembership"])
@@ -149,10 +153,7 @@ describe("DateTime正規化マイグレーション", () => {
 
     // 【修正確認】未来終了(m_future) + 在籍中(m_active) の2件が正しく拾える。
     // 過去終了(m_past)は基準日時点で在籍していないため除外されるのが正しい
-    const after = await prisma.studentClassroomMembership.count({
-      where: filter,
-    })
-    expect(after).toBe(2)
+    expect(await countActiveSince()).toBe(2)
   })
 
   it("変換形式が driver adapter と同一 (YYYY-MM-DDTHH:MM:SS.mmm+00:00)", async () => {
@@ -198,7 +199,7 @@ describe("DateTime正規化マイグレーション", () => {
     "AsbCharGuide",
     "AuditLog",
     "Coursework",
-    "CourseworkClass",
+    "CourseworkClassroom", // 旧 CourseworkClass（20260704010000 でリネーム）
     "CourseworkItem",
     "CourseworkLetterScale",
     "CourseworkScore",
@@ -206,6 +207,17 @@ describe("DateTime正規化マイグレーション", () => {
     "CourseworkTag",
     "GradeConstraint",
     "ReturnSnapshot",
+  ])
+
+  // 20260704010000_rename_class_tables_to_classroom で物理名をリネームしたテーブル。
+  // normalize migration (20260613144726) は旧物理名（classes / StudentClassMembership /
+  // ExamClass / GradeClass）でこれらを既に正規化済みで、RENAME TO は ISO text データを
+  // 保持するため再正規化は不要。歴史migrationは編集禁止のため現物理名を網羅チェックから除外する。
+  const RENAMED_AFTER_NORMALIZATION = new Set([
+    "Classroom",
+    "StudentClassroomMembership",
+    "ExamClassroom",
+    "GradeClassroom",
   ])
 
   it("網羅性: migration.sql が schema.prisma の全 DateTime カラムをカバーする", () => {
@@ -221,7 +233,11 @@ describe("DateTime正規化マイグレーション", () => {
       const body = modelMatch[2]
       const mapMatch = body.match(/@@map\("([^"]+)"\)/)
       const table = mapMatch ? mapMatch[1] : modelMatch[1]
-      if (POST_MIGRATION_TABLES.has(table)) continue
+      if (
+        POST_MIGRATION_TABLES.has(table) ||
+        RENAMED_AFTER_NORMALIZATION.has(table)
+      )
+        continue
       for (const line of body.split("\n")) {
         const parts = line.trim().split(/\s+/)
         if (parts.length >= 2 && parts[1].startsWith("DateTime")) {

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -422,7 +422,7 @@ export async function seedExamWithScoring(
         examId,
         classroomId,
         administered: true,
-        teacherStat: true,
+        teacherStatistics: true,
         studentReport: true,
       },
     })
@@ -729,7 +729,7 @@ export async function seedSimpleExam(
       examId,
       classroomId: classAId,
       administered: true,
-      teacherStat: true,
+      teacherStatistics: true,
       studentReport: true,
     },
   })

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -560,7 +560,7 @@ export async function collectExamData(
             examId: examClass.examId,
             classroomId: examClass.classroomId,
             administered: examClass.administered,
-            teacherStat: examClass.teacherStat,
+            teacherStatistics: examClass.teacherStatistics,
             studentReport: examClass.studentReport,
             order: examClass.order,
             createdAt: examClass.createdAt.toISOString(),

--- a/electron-src/lib/export/excel/averageRows.ts
+++ b/electron-src/lib/export/excel/averageRows.ts
@@ -67,17 +67,17 @@ function buildAverageRow(
  * 学級平均行を点数一覧シートへ追加する（Phase 4・主成果）
  *
  * - 1行目: 全体平均（受験者＝合計点 non-null）
- * - 以降: teacherStat=true の登録学級ごとの学級平均
+ * - 以降: teacherStatistics=true の登録学級ごとの学級平均
  *   母集団は「学級全体」（受験日所属者・getClassMembersForExam）。生徒選択チェックとは無関係。
  *   1人の生徒は所属する全学級の平均に重複カウントされる。
  *
  * @param allScoringData 全受験生徒の採点データ（選択生徒ではなく試験全体）
- * @param teacherStatClasses teacherStat=true の登録学級（受験日所属生徒つき）
+ * @param teacherStatisticsClasses teacherStatistics=true の登録学級（受験日所属生徒つき）
  */
 export function appendClassAverageRows(
   worksheet: ExcelJS.Worksheet,
   allScoringData: ScoringData[],
-  teacherStatClasses: ExamClassroomWithMembers[],
+  teacherStatisticsClasses: ExamClassroomWithMembers[],
   subtotalColumns: SubtotalColumn[],
   questionRegions: CropRegion[]
 ): void {
@@ -97,11 +97,11 @@ export function appendClassAverageRows(
   )
   overallRow.eachCell((cell) => applyCellStyle(cell, "total"))
 
-  // 学級ごとの平均（teacherStat=true）
+  // 学級ごとの平均（teacherStatistics=true）
   const byId = new Map(
     allScoringData.map((scoringData) => [scoringData.studentId, scoringData])
   )
-  for (const examClass of teacherStatClasses) {
+  for (const examClass of teacherStatisticsClasses) {
     const members = examClass.classroom.memberships
       .map((membership) => byId.get(membership.studentId))
       .filter(

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -72,10 +72,10 @@ export async function exportGradingDataExcel(
       }
     }
 
-    // teacherStat=true の登録学級（受験日所属生徒つき）= 学級平均行の対象
-    const teacherStatClasses = (await getClassMembersForExam(examId)).filter(
-      (examClass) => examClass.teacherStat
-    )
+    // teacherStatistics=true の登録学級（受験日所属生徒つき）= 学級平均行の対象
+    const teacherStatisticsClasses = (
+      await getClassMembersForExam(examId)
+    ).filter((examClass) => examClass.teacherStatistics)
 
     // Excelワークブック作成
     const workbook = new ExcelJS.Workbook()
@@ -87,7 +87,7 @@ export async function exportGradingDataExcel(
       dataResult.subtotalColumns,
       scoringData,
       allScoringData,
-      teacherStatClasses
+      teacherStatisticsClasses
     )
 
     // 正誤一覧シート作成

--- a/electron-src/lib/export/excel/sheetCreators.ts
+++ b/electron-src/lib/export/excel/sheetCreators.ts
@@ -26,8 +26,8 @@ export async function createScoreSheet(
   scoringData: ScoringData[],
   /** 学級平均行の母集団（試験全体の採点データ。選択生徒ではない） */
   allScoringData: ScoringData[] = [],
-  /** teacherStat=true の登録学級（受験日所属生徒つき） */
-  teacherStatClasses: ExamClassroomWithMembers[] = []
+  /** teacherStatistics=true の登録学級（受験日所属生徒つき） */
+  teacherStatisticsClasses: ExamClassroomWithMembers[] = []
 ): Promise<ExcelJS.Worksheet> {
   const worksheet = workbook.addWorksheet("点数一覧")
 
@@ -41,7 +41,7 @@ export async function createScoreSheet(
   appendClassAverageRows(
     worksheet,
     allScoringData,
-    teacherStatClasses,
+    teacherStatisticsClasses,
     subtotalColumns,
     questionRegions
   )

--- a/electron-src/lib/import/examClassFlags.ts
+++ b/electron-src/lib/import/examClassFlags.ts
@@ -1,20 +1,25 @@
 /**
- * アーカイブの ExamClass 出力フラグ（teacherStat/studentReport）を解決する。
+ * アーカイブの ExamClassroom 出力フラグ（teacherStatistics/studentReport）を解決する。
  *
- * v1.15.0+ は明示フィールドを持つ。旧アーカイブには無いので旧フラグから補完する：
- * 教員集計 = 旧 statistics、生徒表示 = 再採番(administered)。
+ * v1.16.0+ は teacherStatistics を持つ。旧アーカイブには無いので旧フラグから補完する：
+ * v1.15.0 は teacherStat、〜v1.14.0 は 教員集計=旧 statistics、生徒表示=再採番(administered)。
  *
  * import の2経路（exam-archive/dataCreator・merge/idIntegrationImporter）で共有し、
  * 補完規則の重複・ドリフトを防ぐ。
  */
 export function resolveExamClassOutputFlags(examClass: {
+  teacherStatistics?: boolean | null
   teacherStat?: boolean | null
   studentReport?: boolean | null
   statistics?: boolean | null
   administered?: boolean | null
-}): { teacherStat: boolean; studentReport: boolean } {
+}): { teacherStatistics: boolean; studentReport: boolean } {
   return {
-    teacherStat: examClass.teacherStat ?? examClass.statistics ?? false,
+    teacherStatistics:
+      examClass.teacherStatistics ??
+      examClass.teacherStat ??
+      examClass.statistics ??
+      false,
     studentReport: examClass.studentReport ?? examClass.administered ?? false,
   }
 }

--- a/electron-src/lib/import/transformers/types.ts
+++ b/electron-src/lib/import/transformers/types.ts
@@ -41,6 +41,7 @@ import type {
  * - 1.13.0: v0.12.x (ScoreDecision 追加 — OWNERによる確定スコア。QuestionScoreのstatus proposed/final廃止)
  * - 1.14.0: v0.13.x (ReturnSnapshot 追加 — 答案返却版スナップショット。返却後の採点修正差分検出用)
  * - 1.15.0: v0.14.x (ExamClass に teacherStat/studentReport、ExamSubtotalGroup に selectedForTable/selectedForBoxPlot 追加 — 学級統計再設計。statistics 廃止)
+ * - 1.16.0: v0.14.x (物理テーブル名を Classroom 系へ統一、ExamClassroom.teacherStat → teacherStatistics リネーム。読込は旧 teacherStat/statistics を補完)
  */
 export type ArchiveVersion =
   | "1.0.0"
@@ -59,9 +60,10 @@ export type ArchiveVersion =
   | "1.13.0"
   | "1.14.0"
   | "1.15.0"
+  | "1.16.0"
 
 /** 現在の最新バージョン */
-export const CURRENT_VERSION: ArchiveVersion = "1.15.0"
+export const CURRENT_VERSION: ArchiveVersion = "1.16.0"
 
 /** サポートされている全バージョン（古い順） */
 export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
@@ -81,6 +83,7 @@ export const SUPPORTED_VERSIONS: readonly ArchiveVersion[] = [
   "1.13.0",
   "1.14.0",
   "1.15.0",
+  "1.16.0",
 ] as const
 
 // =============================================================================

--- a/electron-src/lib/prisma/class.ts
+++ b/electron-src/lib/prisma/class.ts
@@ -59,7 +59,7 @@ export const createClass = async (
 
     await recordAuditLog({
       action: "class.create",
-      entityType: "Class",
+      entityType: "Classroom",
       entityId: created.id,
       target: created.name,
     })
@@ -101,7 +101,7 @@ export const updateClass = async (
 
     await recordAuditLog({
       action: "class.update",
-      entityType: "Class",
+      entityType: "Classroom",
       entityId: updated.id,
       target: updated.name,
       changes: diffFields(
@@ -151,7 +151,7 @@ export const deleteClass = async (
 
     await recordAuditLog({
       action: "class.delete",
-      entityType: "Class",
+      entityType: "Classroom",
       entityId: classroomId,
       target: deleted.name,
     })

--- a/electron-src/lib/prisma/coursework.ts
+++ b/electron-src/lib/prisma/coursework.ts
@@ -752,7 +752,7 @@ const courseworkRosterAdapter: RosterAdapter = {
   scope: (targetId) => resolveCourseworkScope(targetId),
   audit: {
     studentEntity: "CourseworkStudent",
-    classEntity: "CourseworkClass",
+    classEntity: "CourseworkClassroom",
     addAction: "coursework.student.add",
     removeAction: "coursework.student.remove",
     reorderAction: "coursework.student.reorder",

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -39,14 +39,14 @@ export interface AddExamClassOptions {
   examId: string
   classroomId: string
   administered?: boolean
-  teacherStat?: boolean
+  teacherStatistics?: boolean
   studentReport?: boolean
 }
 
 export interface UpdateExamClassOptions {
   id: string
   administered?: boolean
-  teacherStat?: boolean
+  teacherStatistics?: boolean
   studentReport?: boolean
   order?: number
 }
@@ -139,7 +139,7 @@ export const addExamClass = async (
     examId,
     classroomId,
     administered = false,
-    teacherStat = false,
+    teacherStatistics = false,
     studentReport = false,
   } = options
 
@@ -156,7 +156,7 @@ export const addExamClass = async (
         examId,
         classroomId,
         administered,
-        teacherStat,
+        teacherStatistics,
         studentReport,
         order: nextOrder,
       },
@@ -191,14 +191,14 @@ export const addExamClass = async (
 export const updateExamClass = async (
   options: UpdateExamClassOptions
 ): Promise<ExamClassWithDetails> => {
-  const { id, administered, teacherStat, studentReport, order } = options
+  const { id, administered, teacherStatistics, studentReport, order } = options
 
   try {
     return await prisma.examClassroom.update({
       where: { id },
       data: {
         ...(administered !== undefined && { administered }),
-        ...(teacherStat !== undefined && { teacherStat }),
+        ...(teacherStatistics !== undefined && { teacherStatistics }),
         ...(studentReport !== undefined && { studentReport }),
         ...(order !== undefined && { order }),
       },
@@ -393,11 +393,11 @@ export const addStudentsFromClass = async (
         examId,
         classroomId,
         administered: true,
-        teacherStat: true, // 生徒ごと追加した学級は教員集計の対象
+        teacherStatistics: true, // 生徒ごと追加した学級は教員集計の対象
         studentReport: true, // administered なので生徒表示の対象
         order: nextOrder,
       },
-      // 再追加では構造（administered）のみ再宣言し、出力フラグ（teacherStat/studentReport）は
+      // 再追加では構造（administered）のみ再宣言し、出力フラグ（teacherStatistics/studentReport）は
       // 08 画面で設定したユーザーの選択を尊重して触らない
       update: {
         administered: true,
@@ -603,7 +603,7 @@ export const getStudentClassInfo = async (
  * （用途2/3の学級平均は「学級全体」を母集団とするため、order優先の単一化はしない）。
  *
  * order 昇順の全登録学級を返し、消費側が用途別にフィルタする
- * （Excel は teacherStat、個人成績表は studentReport）。所属生徒IDは
+ * （Excel は teacherStatistics、個人成績表は studentReport）。所属生徒IDは
  * `ec.classroom.memberships.map((m) => m.studentId)` で取得する。
  */
 export const getClassMembersForExam = async (

--- a/electron-src/lib/prisma/gradeStudent.ts
+++ b/electron-src/lib/prisma/gradeStudent.ts
@@ -243,7 +243,7 @@ const gradeRosterAdapter: RosterAdapter = {
   scope: (targetId) => resolveGradeScope(targetId),
   audit: {
     studentEntity: "GradeStudent",
-    classEntity: "GradeClass",
+    classEntity: "GradeClassroom",
     addAction: "grade.student.add",
     removeAction: "grade.student.remove",
     reorderAction: "grade.student.reorder",

--- a/electron-src/lib/prisma/studentClassMembership.ts
+++ b/electron-src/lib/prisma/studentClassMembership.ts
@@ -90,7 +90,7 @@ export const deleteStudentClassMembership = async (
 
     await recordAuditLog({
       action: "class.membership.remove",
-      entityType: "StudentClassMembership",
+      entityType: "StudentClassroomMembership",
       entityId: id,
       scopeId: before?.classroomId ?? null,
       scopeLabel: before?.classroom.name ?? null,
@@ -207,7 +207,7 @@ export const addStudentToClass = async (
 
     await recordAuditLog({
       action: "class.membership.add",
-      entityType: "StudentClassMembership",
+      entityType: "StudentClassroomMembership",
       entityId: result.id,
       scopeId: classroomId,
       scopeLabel: result.classroom?.name ?? null,

--- a/electron-src/preload-apis/examClassApi.ts
+++ b/electron-src/preload-apis/examClassApi.ts
@@ -15,13 +15,13 @@ export function createExamClassApi() {
         examId: string
         classroomId: string
         administered?: boolean
-        teacherStat?: boolean
+        teacherStatistics?: boolean
         studentReport?: boolean
       }) => ipcRenderer.invoke("exam-class:add", options),
       update: (options: {
         id: string
         administered?: boolean
-        teacherStat?: boolean
+        teacherStatistics?: boolean
         studentReport?: boolean
         order?: number
       }) => ipcRenderer.invoke("exam-class:update", options),

--- a/prisma/migrations/20260704010000_rename_class_tables_to_classroom/migration.sql
+++ b/prisma/migrations/20260704010000_rename_class_tables_to_classroom/migration.sql
@@ -1,0 +1,87 @@
+-- 学級(Classroom)関連テーブルの物理名を @@map 旧「Class」名からモデル名へ統一。
+-- モデル/カラム名は既に Classroom 系（20260702010000 で列 classId→classroomId 済み）だが、
+-- 物理テーブル名だけ classes / *Class の旧名が @@map で残っていた。これを解消する。
+-- 併せて ExamClassroom.teacherStat を teacherStatistics へリネーム（略語解消）。
+--
+-- 【重要】RENAME TO が他テーブルの inbound FK 参照（子テーブルの REFERENCES "classes" 等）を
+-- 書き換えるのは foreign_keys=ON のときのみ。migrationDeployer は FK 既定 OFF で適用するため、
+-- OFF のままだと子テーブル（StudentClassroomMembership / ExamClassroom / GradeClassroom /
+-- CourseworkClassroom）が消えた旧名を参照する dangling FK になる。よってリネーム前に明示的に
+-- ON にする（bridgeMigrations.ts:750-751 と同方針）。deployer はトランザクション非使用のため
+-- PRAGMA が有効。末尾で deployer 既定の OFF に戻す。
+-- インデックス名は RENAME TO で旧プレフィックスのまま残るため、DROP/CREATE で新名に揃える。
+
+PRAGMA foreign_keys = ON;
+
+-- ============================================================================
+-- 1. テーブル物理名のリネーム
+-- ============================================================================
+ALTER TABLE "classes" RENAME TO "Classroom";
+ALTER TABLE "StudentClassMembership" RENAME TO "StudentClassroomMembership";
+ALTER TABLE "ExamClass" RENAME TO "ExamClassroom";
+ALTER TABLE "GradeClass" RENAME TO "GradeClassroom";
+ALTER TABLE "CourseworkClass" RENAME TO "CourseworkClassroom";
+
+-- ============================================================================
+-- 2. インデックス名を新テーブル名プレフィックスへ揃える
+--    （RENAME TO はインデックスを引き継ぐが名称は旧プレフィックスのまま残るため）
+-- ============================================================================
+
+-- Classroom（旧 classes）: name UNIQUE
+DROP INDEX IF EXISTS "classes_name_key";
+CREATE UNIQUE INDEX "Classroom_name_key" ON "Classroom"("name");
+
+-- StudentClassroomMembership（旧 StudentClassMembership）
+DROP INDEX IF EXISTS "StudentClassMembership_studentId_idx";
+DROP INDEX IF EXISTS "StudentClassMembership_classroomId_idx";
+DROP INDEX IF EXISTS "StudentClassMembership_classroomId_attendanceNumber_idx";
+DROP INDEX IF EXISTS "StudentClassMembership_startDate_endDate_idx";
+CREATE INDEX "StudentClassroomMembership_studentId_idx" ON "StudentClassroomMembership"("studentId");
+CREATE INDEX "StudentClassroomMembership_classroomId_idx" ON "StudentClassroomMembership"("classroomId");
+CREATE INDEX "StudentClassroomMembership_classroomId_attendanceNumber_idx" ON "StudentClassroomMembership"("classroomId", "attendanceNumber");
+CREATE INDEX "StudentClassroomMembership_startDate_endDate_idx" ON "StudentClassroomMembership"("startDate", "endDate");
+
+-- ExamClassroom（旧 ExamClass）
+DROP INDEX IF EXISTS "ExamClass_examId_classroomId_key";
+DROP INDEX IF EXISTS "ExamClass_examId_idx";
+DROP INDEX IF EXISTS "ExamClass_classroomId_idx";
+CREATE UNIQUE INDEX "ExamClassroom_examId_classroomId_key" ON "ExamClassroom"("examId", "classroomId");
+CREATE INDEX "ExamClassroom_examId_idx" ON "ExamClassroom"("examId");
+CREATE INDEX "ExamClassroom_classroomId_idx" ON "ExamClassroom"("classroomId");
+
+-- GradeClassroom（旧 GradeClass）
+DROP INDEX IF EXISTS "GradeClass_gradeId_classroomId_key";
+DROP INDEX IF EXISTS "GradeClass_gradeId_idx";
+DROP INDEX IF EXISTS "GradeClass_classroomId_idx";
+CREATE UNIQUE INDEX "GradeClassroom_gradeId_classroomId_key" ON "GradeClassroom"("gradeId", "classroomId");
+CREATE INDEX "GradeClassroom_gradeId_idx" ON "GradeClassroom"("gradeId");
+CREATE INDEX "GradeClassroom_classroomId_idx" ON "GradeClassroom"("classroomId");
+
+-- CourseworkClassroom（旧 CourseworkClass）
+DROP INDEX IF EXISTS "CourseworkClass_courseworkId_classroomId_key";
+DROP INDEX IF EXISTS "CourseworkClass_courseworkId_idx";
+DROP INDEX IF EXISTS "CourseworkClass_classroomId_idx";
+CREATE UNIQUE INDEX "CourseworkClassroom_courseworkId_classroomId_key" ON "CourseworkClassroom"("courseworkId", "classroomId");
+CREATE INDEX "CourseworkClassroom_courseworkId_idx" ON "CourseworkClassroom"("courseworkId");
+CREATE INDEX "CourseworkClassroom_classroomId_idx" ON "CourseworkClassroom"("classroomId");
+
+-- ============================================================================
+-- 3. ExamClassroom.teacherStat → teacherStatistics（略語解消）
+-- ============================================================================
+ALTER TABLE "ExamClassroom" RENAME COLUMN "teacherStat" TO "teacherStatistics";
+
+-- ============================================================================
+-- 4. tombstone の防御的整合（DeletedRecord.tableName は物理名を直接 DELETE に展開する）。
+--    現状 Class 系の tombstone は記録されないが（DrawingAnnotation のみ）、
+--    他バージョン由来で旧名が存在した場合に備え deletedAt を温存したまま新名へ書き換える。
+-- ============================================================================
+UPDATE "DeletedRecord" SET "tableName" = 'Classroom' WHERE "tableName" = 'classes';
+UPDATE "DeletedRecord" SET "tableName" = 'StudentClassroomMembership' WHERE "tableName" = 'StudentClassMembership';
+UPDATE "DeletedRecord" SET "tableName" = 'ExamClassroom' WHERE "tableName" = 'ExamClass';
+UPDATE "DeletedRecord" SET "tableName" = 'GradeClassroom' WHERE "tableName" = 'GradeClass';
+UPDATE "DeletedRecord" SET "tableName" = 'CourseworkClassroom' WHERE "tableName" = 'CourseworkClass';
+
+-- ============================================================================
+-- 5. FK enforcement を deployer 既定（OFF）へ戻す
+-- ============================================================================
+PRAGMA foreign_keys = OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,8 +40,6 @@ model Classroom {
   examClassrooms       ExamClassroom[]
   gradeClassrooms      GradeClassroom[]
   courseworkClassrooms CourseworkClassroom[]
-
-  @@map("classes")
 }
 
 model Student {
@@ -85,7 +83,6 @@ model StudentClassroomMembership {
   @@index([classroomId])
   @@index([classroomId, attendanceNumber])
   @@index([startDate, endDate])
-  @@map("StudentClassMembership")
 }
 
 model Exam {
@@ -396,15 +393,15 @@ model AuditLog {
 }
 
 model ExamClassroom {
-  id            String   @id @default(uuid())
-  examId        String
-  classroomId   String
-  administered  Boolean  @default(false) // 学級・出席番号表示（再採番）の対象
-  teacherStat   Boolean  @default(false) // 教員集計対象（Excel学級平均行）
-  studentReport Boolean  @default(false) // 生徒表示対象（個人成績表の学級比較）
-  order         Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id                String   @id @default(uuid())
+  examId            String
+  classroomId       String
+  administered      Boolean  @default(false) // 学級・出席番号表示（再採番）の対象
+  teacherStatistics Boolean  @default(false) // 教員集計対象（Excel学級平均行）
+  studentReport     Boolean  @default(false) // 生徒表示対象（個人成績表の学級比較）
+  order             Int      @default(0) // 複数クラス時の優先順位（小さいほど優先）
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
   exam      Exam      @relation(fields: [examId], references: [id], onDelete: Cascade)
   classroom Classroom @relation(fields: [classroomId], references: [id], onDelete: Cascade)
@@ -412,7 +409,6 @@ model ExamClassroom {
   @@unique([examId, classroomId])
   @@index([examId])
   @@index([classroomId])
-  @@map("ExamClass")
 }
 
 model Tag {
@@ -722,7 +718,6 @@ model GradeClassroom {
   @@unique([gradeId, classroomId])
   @@index([gradeId])
   @@index([classroomId])
-  @@map("GradeClass")
 }
 
 /// 成績算出プロジェクトの対象生徒
@@ -901,7 +896,6 @@ model CourseworkClassroom {
   @@unique([courseworkId, classroomId])
   @@index([courseworkId])
   @@index([classroomId])
-  @@map("CourseworkClass")
 }
 
 /// 試験外成績資料の対象生徒（名簿）。点数が項目ごとに複数つくため名簿は独立テーブル。

--- a/src/app/exams/[examId]/05-students/page.tsx
+++ b/src/app/exams/[examId]/05-students/page.tsx
@@ -92,7 +92,7 @@ export default function StudentsPage() {
             <TabsTrigger value="students" className="px-4">
               受験生徒一覧
             </TabsTrigger>
-            <TabsTrigger value="classes" className="px-4">
+            <TabsTrigger value="classrooms" className="px-4">
               学級の関連付け
             </TabsTrigger>
           </TabsList>
@@ -153,7 +153,7 @@ export default function StudentsPage() {
         </TabsContent>
 
         {/* 受験学級タブ */}
-        <TabsContent value="classes" className="flex-1 overflow-auto pb-6">
+        <TabsContent value="classrooms" className="flex-1 overflow-auto pb-6">
           <ClassExamManager
             examId={examId}
             examClassrooms={examClassrooms}

--- a/src/components/common/student-add-panel/components/StudentAddPanel.tsx
+++ b/src/components/common/student-add-panel/components/StudentAddPanel.tsx
@@ -135,12 +135,12 @@ export function StudentAddPanel({
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className={tabsClass}>
       <TabsList className="grid w-full grid-cols-2">
-        <TabsTrigger value="classes">学級で追加</TabsTrigger>
+        <TabsTrigger value="classrooms">学級で追加</TabsTrigger>
         <TabsTrigger value="individuals">個別で追加</TabsTrigger>
       </TabsList>
 
       {/* 学級で追加 */}
-      <TabsContent value="classes" className={tabsContentClass}>
+      <TabsContent value="classrooms" className={tabsContentClass}>
         <label className="flex w-fit cursor-pointer items-center gap-2 text-sm">
           <Switch
             checked={classActiveOnly}

--- a/src/components/common/student-add-panel/hooks/useStudentAddPanel.ts
+++ b/src/components/common/student-add-panel/hooks/useStudentAddPanel.ts
@@ -100,7 +100,7 @@ export function useStudentAddPanel({
   classActiveOnlyDefault,
   studentActiveOnlyDefault,
 }: UseStudentAddPanelParams) {
-  const [activeTab, setActiveTab] = useState("classes")
+  const [activeTab, setActiveTab] = useState("classrooms")
   const [classes, setClasses] = useState<SelectableClass[]>([])
   const [students, setStudents] = useState<SelectableStudent[]>([])
   const [searchTerm, setSearchTerm] = useState("")

--- a/src/components/exams/05-students/components/ClassExamManager.tsx
+++ b/src/components/exams/05-students/components/ClassExamManager.tsx
@@ -120,7 +120,7 @@ export function ClassExamManager({
             examId,
             classroomId,
             administered: true,
-            teacherStat: true,
+            teacherStatistics: true,
             studentReport: true,
           })
         }

--- a/src/components/exams/05-students/components/exam-students-page/components/ClassStatisticsCards.tsx
+++ b/src/components/exams/05-students/components/exam-students-page/components/ClassStatisticsCards.tsx
@@ -13,8 +13,8 @@ export function ClassStatisticsCards({
   const administeredClasses = examClassrooms.filter(
     (examClass) => examClass.administered
   ).length
-  const teacherStatClasses = examClassrooms.filter(
-    (examClass) => examClass.teacherStat
+  const teacherStatisticsClasses = examClassrooms.filter(
+    (examClass) => examClass.teacherStatistics
   ).length
 
   return (
@@ -36,7 +36,7 @@ export function ClassStatisticsCards({
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-gray-600">教員集計</span>
         <span className="rounded-md border border-blue-200 bg-blue-100 px-3 text-lg font-bold text-blue-700">
-          {teacherStatClasses}
+          {teacherStatisticsClasses}
         </span>
       </div>
     </div>

--- a/src/components/exams/05-students/hooks/useExamClasses.ts
+++ b/src/components/exams/05-students/hooks/useExamClasses.ts
@@ -25,7 +25,7 @@ interface UseExamClassesReturn {
     examClassId: string,
     options: {
       administered?: boolean
-      teacherStat?: boolean
+      teacherStatistics?: boolean
       studentReport?: boolean
     }
   ) => Promise<ExamClassWithDetails | null>
@@ -82,7 +82,7 @@ export function useExamClasses({
       examClassId: string,
       options: {
         administered?: boolean
-        teacherStat?: boolean
+        teacherStatistics?: boolean
         studentReport?: boolean
       }
     ): Promise<ExamClassWithDetails | null> => {

--- a/src/components/exams/08-export/components/StatClassSelector.tsx
+++ b/src/components/exams/08-export/components/StatClassSelector.tsx
@@ -21,7 +21,7 @@ interface StatClassSelectorProps {
 /**
  * 統計対象学級の選択（Phase 3）
  *
- * 試験に登録された学級ごとに「教員集計(teacherStat)」「生徒表示(studentReport)」を切り替える。
+ * 試験に登録された学級ごとに「教員集計(teacherStatistics)」「生徒表示(studentReport)」を切り替える。
  * - 教員集計: Excel の学級平均行に出す学級
  * - 生徒表示: 個人成績表の学級比較に出す学級（生徒に渡るので慎重に）
  * どちらも複数選択可（1人の生徒が複数学級の平均に数えられる）。受験生徒画面(05)の再採番とは別軸。
@@ -50,7 +50,7 @@ export function StatClassSelector({ examId }: StatClassSelectorProps) {
   const updateFlag = useCallback(
     async (
       examClassId: string,
-      patch: { teacherStat?: boolean; studentReport?: boolean }
+      patch: { teacherStatistics?: boolean; studentReport?: boolean }
     ) => {
       // 楽観的更新
       setClasses((prev) =>
@@ -137,10 +137,10 @@ export function StatClassSelector({ examId }: StatClassSelectorProps) {
                 </TableCell>
                 <TableCell className="text-center">
                   <Checkbox
-                    checked={examClass.teacherStat}
+                    checked={examClass.teacherStatistics}
                     onCheckedChange={(checked) =>
                       updateFlag(examClass.id, {
-                        teacherStat: checked === true,
+                        teacherStatistics: checked === true,
                       })
                     }
                   />

--- a/src/types/electron/examClassApi.d.ts
+++ b/src/types/electron/examClassApi.d.ts
@@ -10,7 +10,7 @@ export interface ExamClassWithDetails {
   examId: string
   classroomId: string
   administered: boolean
-  teacherStat: boolean
+  teacherStatistics: boolean
   studentReport: boolean
   order: number
   createdAt: Date
@@ -27,7 +27,7 @@ export interface ExamClassWithClass {
   examId: string
   classroomId: string
   administered: boolean
-  teacherStat: boolean
+  teacherStatistics: boolean
   studentReport: boolean
   order: number
   createdAt: Date
@@ -85,7 +85,7 @@ export interface ExamClassAPI {
       examId: string
       classroomId: string
       administered?: boolean
-      teacherStat?: boolean
+      teacherStatistics?: boolean
       studentReport?: boolean
     }) => Promise<ExamClassWithDetails>
 
@@ -95,7 +95,7 @@ export interface ExamClassAPI {
     update: (options: {
       id: string
       administered?: boolean
-      teacherStat?: boolean
+      teacherStatistics?: boolean
       studentReport?: boolean
       order?: number
     }) => Promise<ExamClassWithDetails>

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -767,8 +767,10 @@ export interface ArchiveExamData {
     administered: boolean
     /** 〜v1.14.0 の旧フラグ（v1.15.0 で teacherStat へ移行）。旧アーカイブ読込時のみ存在 */
     statistics?: boolean
-    /** v1.15.0+ 教員集計対象 */
+    /** v1.15.0 の旧フラグ（v1.16.0 で teacherStatistics へリネーム）。旧アーカイブ読込時のみ存在 */
     teacherStat?: boolean
+    /** v1.16.0+ 教員集計対象 */
+    teacherStatistics?: boolean
     /** v1.15.0+ 生徒表示対象 */
     studentReport?: boolean
     order: number


### PR DESCRIPTION
## 概要

`@@map` で旧「Class」名のまま残っていた物理テーブル名5つを Classroom 系モデル名へ統一し、`ExamClassroom.teacherStat` を `teacherStatistics` へ改名（略語解消）。

Closes #919

## 変更の柱

| 分類 | 内容 |
| --- | --- |
| schema + migration | `@@map` 5つ削除・列改名。migration 20260704010000 で RENAME TO ×5・インデックス改名・列改名・DeletedRecord 防御UPDATE。**FK dangling 対策で `PRAGMA foreign_keys=ON`〜`OFF` で囲む** |
| teacherStatistics | コード/DTO/UI/Excel出力/アーカイブへ反映。境界 examClassFlags は `teacherStatistics ?? teacherStat ?? statistics` で後方互換 |
| アーカイブ v1.16.0 | `teacherStatistics` 追加（`teacherStat`/`statistics` は legacy 保持）、旧 .score 読込互換 |
| 命名の取りこぼし | 監査ログ entityType 旧Class名4箇所→モデル名、Tabs `value="classes"`→`"classrooms"` |

## FK dangling 対策（レビュー指摘反映）

SQLite の `ALTER TABLE RENAME TO` は `foreign_keys=ON` のときのみ子テーブルの inbound FK 参照を更新する。migrationDeployer は FK 既定 OFF・非トランザクションのため、OFF のままだと子4テーブルが消えた旧名を参照する dangling FK になる。code-review（high）でこの欠陥を検出→ migration を `PRAGMA foreign_keys=ON` で囲んで修正。replay で子テーブルが `Classroom` を正しく参照することを実証済み。

## 検証

- `npm run typecheck` / `npm run lint`: GREEN
- fresh-install migration replay: 全 migration 昇順適用・FK dangling ゼロ・整合 OK
- テスト: 既知 #917 以外は全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
