### PR TITLE
refactor(naming): 変数名・型名の包括的監査に基づく実体名化と重複解消

### DIFF
--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -279,25 +279,30 @@ export function setupExportHandlers(): void {
             : null,
       }))
 
-      const scoringData = result.scoringData?.map((sd) => ({
-        studentId: sd.studentId,
-        studentName: sd.studentName,
-        studentNumber: sd.studentNumber,
-        grade: sd.grade,
-        className: sd.className,
+      const scoringData = result.scoringData?.map((studentScoring) => ({
+        studentId: studentScoring.studentId,
+        studentName: studentScoring.studentName,
+        studentNumber: studentScoring.studentNumber,
+        grade: studentScoring.grade,
+        className: studentScoring.className,
         attendanceNumber:
-          sd.attendanceNumber != null ? Number(sd.attendanceNumber) : null,
-        status: sd.status,
-        scores: sd.scores.map((score) => ({
+          studentScoring.attendanceNumber != null
+            ? Number(studentScoring.attendanceNumber)
+            : null,
+        status: studentScoring.status,
+        scores: studentScoring.scores.map((score) => ({
           questionId: score.questionId,
           questionLabel: score.questionLabel,
           score: score.score != null ? Number(score.score) : null,
           maxScore: Number(score.maxScore),
           status: score.status,
         })),
-        totalScore: sd.totalScore != null ? Number(sd.totalScore) : null,
-        totalMaxScore: Number(sd.totalMaxScore),
-        subtotalScores: sd.subtotalScores.map((subtotalScore) => ({
+        totalScore:
+          studentScoring.totalScore != null
+            ? Number(studentScoring.totalScore)
+            : null,
+        totalMaxScore: Number(studentScoring.totalMaxScore),
+        subtotalScores: studentScoring.subtotalScores.map((subtotalScore) => ({
           subtotalId: subtotalScore.subtotalId,
           subtotalLabel: subtotalScore.subtotalLabel,
           score:

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -254,18 +254,18 @@ export async function convertToExam(
 
       // CropRegion作成（ヘッダーフィールドのlinkedRegionType）
       const linkedFields = pageLayout.headerFields.filter(
-        (hf) => hf.linkedRegionType
+        (headerField) => headerField.linkedRegionType
       )
-      for (const hf of linkedFields) {
-        const normalizedX = hf.x / multiPageLayout.pageWidthMm
-        const normalizedY = hf.y / multiPageLayout.pageHeightMm
-        const normalizedW = hf.width / multiPageLayout.pageWidthMm
-        const normalizedH = hf.height / multiPageLayout.pageHeightMm
+      for (const headerField of linkedFields) {
+        const normalizedX = headerField.x / multiPageLayout.pageWidthMm
+        const normalizedY = headerField.y / multiPageLayout.pageHeightMm
+        const normalizedW = headerField.width / multiPageLayout.pageWidthMm
+        const normalizedH = headerField.height / multiPageLayout.pageHeightMm
         await prisma.cropRegion.create({
           data: {
             examPageId: examPage.id,
-            label: hf.label,
-            type: hf.linkedRegionType!,
+            label: headerField.label,
+            type: headerField.linkedRegionType!,
             x: normalizedX,
             y: normalizedY,
             width: normalizedW,

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -20,6 +20,7 @@ import {
 import {
   ScoreDetail,
   ScoringData,
+  SubtotalGroupData,
   SubtotalScore,
 } from "../../shared/types/exportTypes"
 
@@ -27,17 +28,6 @@ import {
 export interface SubtotalColumn {
   subtotalId: string
   label: string
-}
-
-/** SubtotalGroup情報（Excel出力用） */
-interface SubtotalGroupData {
-  groupId: string
-  groupName: string
-  subtotals: Array<{
-    id: string
-    name: string
-    order: number
-  }>
 }
 
 /**

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -18,7 +18,10 @@ import {
   calculateSubtotalScoreBySubtotalId,
   type QuestionScoreData,
 } from "../../shared/calculations/subtotalCalculator"
-import type { SubtotalScore } from "../../shared/types/exportTypes"
+import type {
+  SubtotalGroupData,
+  SubtotalScore,
+} from "../../shared/types/exportTypes"
 import { fetchExportData } from "../excel/dataFetcher"
 import { generateLearningAdvice } from "./adviceGenerator"
 import {
@@ -228,16 +231,6 @@ export async function fetchIndividualReportData(
 /**
  * SubtotalGroupとSubtotalの情報を取得
  */
-interface SubtotalGroupData {
-  groupId: string
-  groupName: string
-  subtotals: Array<{
-    id: string
-    name: string
-    order: number
-  }>
-}
-
 async function getSubtotalGroupsWithSubtotals(
   examId: string
 ): Promise<SubtotalGroupData[]> {

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -467,64 +467,81 @@ export async function createImportedData(
       }
 
       // 12.10. CompoundAnswerを作成 (v1.11.0+)
-      for (const ca of data.examData.compoundAnswers || []) {
-        const newExamPageId = remapId(ca.examPageId, mappings.examPage)
+      for (const compoundAnswer of data.examData.compoundAnswers || []) {
+        const newExamPageId = remapId(
+          compoundAnswer.examPageId,
+          mappings.examPage
+        )
         if (newExamPageId) {
           await tx.compoundAnswer.create({
             data: {
-              id: remapIdRequired(ca.id, mappings.compoundAnswer),
+              id: remapIdRequired(compoundAnswer.id, mappings.compoundAnswer),
               examPageId: newExamPageId,
-              label: ca.label,
-              answerFormat: ca.answerFormat,
-              correctAnswer: ca.correctAnswer,
-              points: ca.points,
-              orderIndex: ca.orderIndex,
-              alternativeAnswers: ca.alternativeAnswers,
-              requireReduced: ca.requireReduced,
+              label: compoundAnswer.label,
+              answerFormat: compoundAnswer.answerFormat,
+              correctAnswer: compoundAnswer.correctAnswer,
+              points: compoundAnswer.points,
+              orderIndex: compoundAnswer.orderIndex,
+              alternativeAnswers: compoundAnswer.alternativeAnswers,
+              requireReduced: compoundAnswer.requireReduced,
             },
           })
         }
       }
 
       // 12.11. CompoundAnswerMemberを作成 (v1.11.0+)
-      for (const cam of data.examData.compoundAnswerMembers || []) {
+      for (const compoundAnswerMember of data.examData.compoundAnswerMembers ||
+        []) {
         const newCompoundAnswerId = remapId(
-          cam.compoundAnswerId,
+          compoundAnswerMember.compoundAnswerId,
           mappings.compoundAnswer
         )
-        const newCropRegionId = remapId(cam.cropRegionId, mappings.cropRegion)
+        const newCropRegionId = remapId(
+          compoundAnswerMember.cropRegionId,
+          mappings.cropRegion
+        )
         if (newCompoundAnswerId && newCropRegionId) {
           await tx.compoundAnswerMember.create({
             data: {
-              id: remapIdRequired(cam.id, mappings.compoundAnswerMember),
+              id: remapIdRequired(
+                compoundAnswerMember.id,
+                mappings.compoundAnswerMember
+              ),
               compoundAnswerId: newCompoundAnswerId,
               cropRegionId: newCropRegionId,
-              order: cam.order,
-              roleLabel: cam.roleLabel,
-              separator: cam.separator,
+              order: compoundAnswerMember.order,
+              roleLabel: compoundAnswerMember.roleLabel,
+              separator: compoundAnswerMember.separator,
             },
           })
         }
       }
 
       // 12.12. CompoundAnswerScoreを作成 (v1.11.0+)
-      for (const cas of data.examData.compoundAnswerScores || []) {
+      for (const compoundAnswerScore of data.examData.compoundAnswerScores ||
+        []) {
         const newCompoundAnswerId = remapId(
-          cas.compoundAnswerId,
+          compoundAnswerScore.compoundAnswerId,
           mappings.compoundAnswer
         )
-        const newStudentId = remapId(cas.studentId, mappings.student)
+        const newStudentId = remapId(
+          compoundAnswerScore.studentId,
+          mappings.student
+        )
         if (newCompoundAnswerId && newStudentId) {
           await tx.compoundAnswerScore.create({
             data: {
-              id: remapIdRequired(cas.id, mappings.compoundAnswerScore),
+              id: remapIdRequired(
+                compoundAnswerScore.id,
+                mappings.compoundAnswerScore
+              ),
               compoundAnswerId: newCompoundAnswerId,
               studentId: newStudentId,
               userId: currentUserId,
-              recognizedAnswer: cas.recognizedAnswer,
-              status: cas.status,
-              partialScore: cas.partialScore
-                ? parseFloat(cas.partialScore)
+              recognizedAnswer: compoundAnswerScore.recognizedAnswer,
+              status: compoundAnswerScore.status,
+              partialScore: compoundAnswerScore.partialScore
+                ? parseFloat(compoundAnswerScore.partialScore)
                 : null,
             },
           })
@@ -532,16 +549,22 @@ export async function createImportedData(
       }
 
       // 13. CropSubtotalを作成
-      for (const cs of data.subtotalsData.cropSubtotals) {
-        const newCropRegionId = remapId(cs.cropRegionId, mappings.cropRegion)
-        const newSubtotalId = remapId(cs.subtotalId, mappings.subtotal)
+      for (const cropSubtotal of data.subtotalsData.cropSubtotals) {
+        const newCropRegionId = remapId(
+          cropSubtotal.cropRegionId,
+          mappings.cropRegion
+        )
+        const newSubtotalId = remapId(
+          cropSubtotal.subtotalId,
+          mappings.subtotal
+        )
         if (newCropRegionId && newSubtotalId) {
           await tx.cropSubtotal.create({
             data: {
-              id: remapIdRequired(cs.id, mappings.cropSubtotal),
+              id: remapIdRequired(cropSubtotal.id, mappings.cropSubtotal),
               cropRegionId: newCropRegionId,
               subtotalId: newSubtotalId,
-              assignmentType: cs.assignmentType,
+              assignmentType: cropSubtotal.assignmentType,
             },
           })
         }
@@ -576,23 +599,28 @@ export async function createImportedData(
 
       // 14.5. ScoreDecisionを作成 (v1.13.0+)
       // decidedByUserIdは現在のログインユーザーで上書き
-      for (const sd of data.scoresData.scoreDecisions || []) {
-        const newCropRegionId = remapId(sd.cropRegionId, mappings.cropRegion)
-        const newStudentId = remapId(sd.studentId, mappings.student)
+      for (const scoreDecision of data.scoresData.scoreDecisions || []) {
+        const newCropRegionId = remapId(
+          scoreDecision.cropRegionId,
+          mappings.cropRegion
+        )
+        const newStudentId = remapId(scoreDecision.studentId, mappings.student)
 
         if (newCropRegionId && newStudentId) {
           await tx.scoreDecision.create({
             data: {
-              id: remapIdRequired(sd.id, mappings.scoreDecision),
+              id: remapIdRequired(scoreDecision.id, mappings.scoreDecision),
               cropRegionId: newCropRegionId,
               studentId: newStudentId,
-              verdict: sd.verdict,
-              score: sd.score ? parseFloat(sd.score) : null,
-              comment: sd.comment,
+              verdict: scoreDecision.verdict,
+              score: scoreDecision.score
+                ? parseFloat(scoreDecision.score)
+                : null,
+              comment: scoreDecision.comment,
               decidedByUserId: currentUserId,
-              decidedAt: new Date(sd.decidedAt),
+              decidedAt: new Date(scoreDecision.decidedAt),
               sourceQuestionScoreId: remapId(
-                sd.sourceQuestionScoreId,
+                scoreDecision.sourceQuestionScoreId,
                 mappings.questionScore
               ),
             },
@@ -602,20 +630,22 @@ export async function createImportedData(
 
       // 14.6. ReturnSnapshot（返却版スナップショット）を作成 (v1.14.0+)
       // capturedByUserId は現在のログインユーザーで上書き
-      for (const rs of data.scoresData.returnSnapshots || []) {
-        const newExamId = remapId(rs.examId, mappings.exam)
-        const newStudentId = remapId(rs.studentId, mappings.student)
+      for (const returnSnapshot of data.scoresData.returnSnapshots || []) {
+        const newExamId = remapId(returnSnapshot.examId, mappings.exam)
+        const newStudentId = remapId(returnSnapshot.studentId, mappings.student)
 
         if (newExamId && newStudentId) {
           await tx.returnSnapshot.create({
             data: {
-              id: remapIdRequired(rs.id, mappings.returnSnapshot),
+              id: remapIdRequired(returnSnapshot.id, mappings.returnSnapshot),
               examId: newExamId,
               studentId: newStudentId,
-              scoresJson: rs.scoresJson,
-              totalScore: rs.totalScore ? parseFloat(rs.totalScore) : null,
+              scoresJson: returnSnapshot.scoresJson,
+              totalScore: returnSnapshot.totalScore
+                ? parseFloat(returnSnapshot.totalScore)
+                : null,
               capturedByUserId: currentUserId,
-              capturedAt: new Date(rs.capturedAt),
+              capturedAt: new Date(returnSnapshot.capturedAt),
             },
           })
         }
@@ -623,37 +653,40 @@ export async function createImportedData(
 
       // 15. DrawingAnnotationを作成
       // v0.3.0以降: userIdを現在のログインユーザーで上書き
-      for (const da of data.scoresData.drawingAnnotations) {
+      for (const drawingAnnotation of data.scoresData.drawingAnnotations) {
         const newQuestionScoreId = remapId(
-          da.questionScoreId,
+          drawingAnnotation.questionScoreId,
           mappings.questionScore
         )
 
         if (newQuestionScoreId) {
           await tx.drawingAnnotation.create({
             data: {
-              id: remapIdRequired(da.id, mappings.drawingAnnotation),
+              id: remapIdRequired(
+                drawingAnnotation.id,
+                mappings.drawingAnnotation
+              ),
               questionScoreId: newQuestionScoreId,
-              type: da.type,
-              x: da.x,
-              y: da.y,
-              color: da.color,
-              strokeWidth: da.strokeWidth,
-              width: da.width,
-              height: da.height,
-              endX: da.endX,
-              endY: da.endY,
-              lineStyle: da.lineStyle,
-              text: da.text,
-              fontSize: da.fontSize,
-              textBoxWidth: da.textBoxWidth,
-              textBoxHeight: da.textBoxHeight,
-              horizontalAlign: da.horizontalAlign,
-              verticalAlign: da.verticalAlign,
-              anchorDirection: da.anchorDirection,
-              displayX: da.displayX,
-              displayY: da.displayY,
-              isFavorite: da.isFavorite,
+              type: drawingAnnotation.type,
+              x: drawingAnnotation.x,
+              y: drawingAnnotation.y,
+              color: drawingAnnotation.color,
+              strokeWidth: drawingAnnotation.strokeWidth,
+              width: drawingAnnotation.width,
+              height: drawingAnnotation.height,
+              endX: drawingAnnotation.endX,
+              endY: drawingAnnotation.endY,
+              lineStyle: drawingAnnotation.lineStyle,
+              text: drawingAnnotation.text,
+              fontSize: drawingAnnotation.fontSize,
+              textBoxWidth: drawingAnnotation.textBoxWidth,
+              textBoxHeight: drawingAnnotation.textBoxHeight,
+              horizontalAlign: drawingAnnotation.horizontalAlign,
+              verticalAlign: drawingAnnotation.verticalAlign,
+              anchorDirection: drawingAnnotation.anchorDirection,
+              displayX: drawingAnnotation.displayX,
+              displayY: drawingAnnotation.displayY,
+              isFavorite: drawingAnnotation.isFavorite,
               userId: currentUserId,
             },
           })

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -31,10 +31,10 @@ function getMathJaxSource(): string {
 export function resolveMathJaxSrc(html: string): string {
   if (!html.includes("__MATHJAX_SRC__")) return html
   try {
-    const src = getMathJaxSource()
+    const source = getMathJaxSource()
     return html.replace(
       '<script src="__MATHJAX_SRC__"></script>',
-      `<script>${src}</script>`
+      `<script>${source}</script>`
     )
   } catch (err) {
     console.error("Failed to load MathJax source:", err)

--- a/electron-src/lib/prisma/asbDefinitionConverters.ts
+++ b/electron-src/lib/prisma/asbDefinitionConverters.ts
@@ -107,87 +107,97 @@ export type FlatGlobalSettings = {
 }
 
 /** GlobalSettings をDBフラットカラム形式に変換する */
-export function flattenGlobalSettings(s: GlobalSettings): FlatGlobalSettings {
+export function flattenGlobalSettings(
+  settings: GlobalSettings
+): FlatGlobalSettings {
   return {
-    paperSize: s.paperSize,
-    orientation: s.orientation,
-    verticalLayout: s.verticalLayout ?? false,
-    baseRowHeight: s.baseRowHeight,
-    numberDisplayMode: s.numberDisplayMode,
-    marginTop: s.margins.top,
-    marginBottom: s.margins.bottom,
-    marginLeft: s.margins.left,
-    marginRight: s.margins.right,
-    colWidthMajorNumber: s.columnWidths.majorNumber,
-    colWidthSubNumber: s.columnWidths.subNumber,
-    colWidthBranchNumber: s.columnWidths.branchNumber,
-    majorQuestionSpacing: s.spacing.majorQuestionSpacing,
-    headerHeight: s.spacing.headerHeight,
-    borderOuterBorder: s.borderConfig.outerBorder,
-    borderMajorDivider: s.borderConfig.majorDivider,
-    borderSubDivider: s.borderConfig.subDivider,
-    borderBranchDivider: s.borderConfig.branchDivider,
-    borderMajorNumberDivider: s.borderConfig.majorNumberDivider,
-    borderSubNumberDivider: s.borderConfig.subNumberDivider,
-    borderBranchNumberDivider: s.borderConfig.branchNumberDivider,
-    borderOuterBorderWidth: s.borderConfig.outerBorderWidth ?? null,
-    borderMajorDividerWidth: s.borderConfig.majorDividerWidth ?? null,
-    borderSubDividerWidth: s.borderConfig.subDividerWidth ?? null,
-    borderBranchDividerWidth: s.borderConfig.branchDividerWidth ?? null,
+    paperSize: settings.paperSize,
+    orientation: settings.orientation,
+    verticalLayout: settings.verticalLayout ?? false,
+    baseRowHeight: settings.baseRowHeight,
+    numberDisplayMode: settings.numberDisplayMode,
+    marginTop: settings.margins.top,
+    marginBottom: settings.margins.bottom,
+    marginLeft: settings.margins.left,
+    marginRight: settings.margins.right,
+    colWidthMajorNumber: settings.columnWidths.majorNumber,
+    colWidthSubNumber: settings.columnWidths.subNumber,
+    colWidthBranchNumber: settings.columnWidths.branchNumber,
+    majorQuestionSpacing: settings.spacing.majorQuestionSpacing,
+    headerHeight: settings.spacing.headerHeight,
+    borderOuterBorder: settings.borderConfig.outerBorder,
+    borderMajorDivider: settings.borderConfig.majorDivider,
+    borderSubDivider: settings.borderConfig.subDivider,
+    borderBranchDivider: settings.borderConfig.branchDivider,
+    borderMajorNumberDivider: settings.borderConfig.majorNumberDivider,
+    borderSubNumberDivider: settings.borderConfig.subNumberDivider,
+    borderBranchNumberDivider: settings.borderConfig.branchNumberDivider,
+    borderOuterBorderWidth: settings.borderConfig.outerBorderWidth ?? null,
+    borderMajorDividerWidth: settings.borderConfig.majorDividerWidth ?? null,
+    borderSubDividerWidth: settings.borderConfig.subDividerWidth ?? null,
+    borderBranchDividerWidth: settings.borderConfig.branchDividerWidth ?? null,
     borderMajorNumberDividerWidth:
-      s.borderConfig.majorNumberDividerWidth ?? null,
-    borderSubNumberDividerWidth: s.borderConfig.subNumberDividerWidth ?? null,
+      settings.borderConfig.majorNumberDividerWidth ?? null,
+    borderSubNumberDividerWidth:
+      settings.borderConfig.subNumberDividerWidth ?? null,
     borderBranchNumberDividerWidth:
-      s.borderConfig.branchNumberDividerWidth ?? null,
+      settings.borderConfig.branchNumberDividerWidth ?? null,
     borderManuscriptCharDivider:
-      s.borderConfig.manuscriptCharDivider ?? "dashed",
+      settings.borderConfig.manuscriptCharDivider ?? "dashed",
     borderManuscriptLineDivider:
-      s.borderConfig.manuscriptLineDivider ?? "solid",
+      settings.borderConfig.manuscriptLineDivider ?? "solid",
     borderManuscriptCharDividerWidth:
-      s.borderConfig.manuscriptCharDividerWidth ?? null,
+      settings.borderConfig.manuscriptCharDividerWidth ?? null,
     borderManuscriptLineDividerWidth:
-      s.borderConfig.manuscriptLineDividerWidth ?? null,
-    borderOuterBorderDashRatio: s.borderConfig.outerBorderDashRatio ?? null,
-    borderOuterBorderGapRatio: s.borderConfig.outerBorderGapRatio ?? null,
-    borderMajorDividerDashRatio: s.borderConfig.majorDividerDashRatio ?? null,
-    borderMajorDividerGapRatio: s.borderConfig.majorDividerGapRatio ?? null,
-    borderSubDividerDashRatio: s.borderConfig.subDividerDashRatio ?? null,
-    borderSubDividerGapRatio: s.borderConfig.subDividerGapRatio ?? null,
-    borderBranchDividerDashRatio: s.borderConfig.branchDividerDashRatio ?? null,
-    borderBranchDividerGapRatio: s.borderConfig.branchDividerGapRatio ?? null,
+      settings.borderConfig.manuscriptLineDividerWidth ?? null,
+    borderOuterBorderDashRatio:
+      settings.borderConfig.outerBorderDashRatio ?? null,
+    borderOuterBorderGapRatio:
+      settings.borderConfig.outerBorderGapRatio ?? null,
+    borderMajorDividerDashRatio:
+      settings.borderConfig.majorDividerDashRatio ?? null,
+    borderMajorDividerGapRatio:
+      settings.borderConfig.majorDividerGapRatio ?? null,
+    borderSubDividerDashRatio:
+      settings.borderConfig.subDividerDashRatio ?? null,
+    borderSubDividerGapRatio: settings.borderConfig.subDividerGapRatio ?? null,
+    borderBranchDividerDashRatio:
+      settings.borderConfig.branchDividerDashRatio ?? null,
+    borderBranchDividerGapRatio:
+      settings.borderConfig.branchDividerGapRatio ?? null,
     borderMajorNumberDividerDashRatio:
-      s.borderConfig.majorNumberDividerDashRatio ?? null,
+      settings.borderConfig.majorNumberDividerDashRatio ?? null,
     borderMajorNumberDividerGapRatio:
-      s.borderConfig.majorNumberDividerGapRatio ?? null,
+      settings.borderConfig.majorNumberDividerGapRatio ?? null,
     borderSubNumberDividerDashRatio:
-      s.borderConfig.subNumberDividerDashRatio ?? null,
+      settings.borderConfig.subNumberDividerDashRatio ?? null,
     borderSubNumberDividerGapRatio:
-      s.borderConfig.subNumberDividerGapRatio ?? null,
+      settings.borderConfig.subNumberDividerGapRatio ?? null,
     borderBranchNumberDividerDashRatio:
-      s.borderConfig.branchNumberDividerDashRatio ?? null,
+      settings.borderConfig.branchNumberDividerDashRatio ?? null,
     borderBranchNumberDividerGapRatio:
-      s.borderConfig.branchNumberDividerGapRatio ?? null,
+      settings.borderConfig.branchNumberDividerGapRatio ?? null,
     borderManuscriptCharDividerDashRatio:
-      s.borderConfig.manuscriptCharDividerDashRatio ?? null,
+      settings.borderConfig.manuscriptCharDividerDashRatio ?? null,
     borderManuscriptCharDividerGapRatio:
-      s.borderConfig.manuscriptCharDividerGapRatio ?? null,
+      settings.borderConfig.manuscriptCharDividerGapRatio ?? null,
     borderManuscriptLineDividerDashRatio:
-      s.borderConfig.manuscriptLineDividerDashRatio ?? null,
+      settings.borderConfig.manuscriptLineDividerDashRatio ?? null,
     borderManuscriptLineDividerGapRatio:
-      s.borderConfig.manuscriptLineDividerGapRatio ?? null,
-    omrMarkersEnabled: s.omrMarkers.enabled,
-    omrMarkersSizeMm: s.omrMarkers.sizeMm,
-    omrMarkersOffsetMm: s.omrMarkers.offsetMm,
-    fontFamily: s.fonts.family,
-    fontDefaultSize: s.fonts.defaultSize,
-    fontMajorNumberSize: s.fonts.majorNumberSize,
-    fontSubNumberSize: s.fonts.subNumberSize,
-    fontBranchNumberSize: s.fonts.branchNumberSize,
-    multiColumnEnabled: s.multiColumn.enabled,
-    multiColumnCount: s.multiColumn.columnCount,
-    multiColumnGapMm: s.multiColumn.columnGapMm,
-    multiColumnDividerLine: s.multiColumn.dividerLine,
-    multiColumnDividerLineWidth: s.multiColumn.dividerLineWidth,
+      settings.borderConfig.manuscriptLineDividerGapRatio ?? null,
+    omrMarkersEnabled: settings.omrMarkers.enabled,
+    omrMarkersSizeMm: settings.omrMarkers.sizeMm,
+    omrMarkersOffsetMm: settings.omrMarkers.offsetMm,
+    fontFamily: settings.fonts.family,
+    fontDefaultSize: settings.fonts.defaultSize,
+    fontMajorNumberSize: settings.fonts.majorNumberSize,
+    fontSubNumberSize: settings.fonts.subNumberSize,
+    fontBranchNumberSize: settings.fonts.branchNumberSize,
+    multiColumnEnabled: settings.multiColumn.enabled,
+    multiColumnCount: settings.multiColumn.columnCount,
+    multiColumnGapMm: settings.multiColumn.columnGapMm,
+    multiColumnDividerLine: settings.multiColumn.dividerLine,
+    multiColumnDividerLineWidth: settings.multiColumn.dividerLineWidth,
   }
 }
 

--- a/electron-src/lib/shared/calculations/itemAnalysis.ts
+++ b/electron-src/lib/shared/calculations/itemAnalysis.ts
@@ -136,8 +136,8 @@ export function computeItemAnalysis(
   ): number | null => {
     if (maxScore <= 0) return null
     const rates: number[] = []
-    for (const i of idxs) {
-      const score = completeMaps[i].get(questionId)?.score
+    for (const completeMapIndex of idxs) {
+      const score = completeMaps[completeMapIndex].get(questionId)?.score
       if (score == null) continue
       rates.push(score / maxScore)
     }

--- a/electron-src/lib/shared/types/exportTypes.ts
+++ b/electron-src/lib/shared/types/exportTypes.ts
@@ -38,6 +38,17 @@ export interface SubtotalScore {
   hasQuestionAssignments: boolean
 }
 
+/** SubtotalGroupとその小計項目の情報（Excel・個人成績表出力で共通） */
+export interface SubtotalGroupData {
+  groupId: string
+  groupName: string
+  subtotals: Array<{
+    id: string
+    name: string
+    order: number
+  }>
+}
+
 export interface ScoreDetail {
   questionId: string
   questionLabel: string

--- a/electron-src/lib/shared/utilities/excelUtilities.ts
+++ b/electron-src/lib/shared/utilities/excelUtilities.ts
@@ -7,10 +7,10 @@ import * as ExcelJS from "exceljs"
  */
 export function getExcelColumnLetter(colIndex: number): string {
   let result = ""
-  let num = colIndex - 1
-  while (num >= 0) {
-    result = String.fromCharCode(65 + (num % 26)) + result
-    num = Math.floor(num / 26) - 1
+  let columnValue = colIndex - 1
+  while (columnValue >= 0) {
+    result = String.fromCharCode(65 + (columnValue % 26)) + result
+    columnValue = Math.floor(columnValue / 26) - 1
   }
   return result
 }

--- a/electron-src/lib/sync/syncConfig.ts
+++ b/electron-src/lib/sync/syncConfig.ts
@@ -78,9 +78,9 @@ export function loadSyncConfig(): SyncAppConfig {
 
 export function saveSyncConfig(config: SyncAppConfig): void {
   const configPath = getConfigPath()
-  const dir = path.dirname(configPath)
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true })
+  const directory = path.dirname(configPath)
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true })
   }
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8")
 }

--- a/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
@@ -66,25 +66,25 @@ export function AnswerSheetDefinitionList() {
   )
 
   const sorted = [...definitions].sort((definitionA, definitionB) => {
-    const dir = sortDir === "asc" ? 1 : -1
+    const direction = sortDir === "asc" ? 1 : -1
     switch (sortKey) {
       case "name":
-        return dir * definitionA.name.localeCompare(definitionB.name)
+        return direction * definitionA.name.localeCompare(definitionB.name)
       case "updatedAt":
         return (
-          dir *
+          direction *
           (definitionA.updatedAt ?? "").localeCompare(
             definitionB.updatedAt ?? ""
           )
         )
       case "questionCount":
         return (
-          dir *
+          direction *
           ((definitionA.questionCount ?? 0) - (definitionB.questionCount ?? 0))
         )
       case "totalPoints":
         return (
-          dir *
+          direction *
           ((definitionA.totalPoints ?? 0) - (definitionB.totalPoints ?? 0))
         )
       default:

--- a/src/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
+++ b/src/components/answer-sheet-builder/components/form/OMRCellConfigForm.tsx
@@ -189,7 +189,7 @@ export function OMRCellConfigForm({
         <div className="border-muted ml-2 space-y-1.5 border-l-2 pl-3">
           {/* 認識タイプ */}
           <div className="flex items-center gap-1.5">
-            <Label className="text-muted-foreground min-w-[3rem] text-xs">
+            <Label className="text-muted-foreground min-w-12 text-xs">
               種類
             </Label>
             <Select value={config.type} onValueChange={handleTypeChange}>
@@ -262,9 +262,7 @@ function ChoiceConfigFields({
     <>
       {/* ラベルプリセット */}
       <div className="flex items-center gap-1.5">
-        <Label className="text-muted-foreground min-w-[3rem] text-xs">
-          ラベル
-        </Label>
+        <Label className="text-muted-foreground min-w-12 text-xs">ラベル</Label>
         <Select
           value={currentPresetValue}
           onValueChange={(preset) => {
@@ -309,17 +307,15 @@ function ChoiceConfigFields({
       {/* カスタムラベル入力 */}
       {isCustom && (
         <div className="flex items-center gap-1.5">
-          <Label className="text-muted-foreground min-w-[3rem] text-xs">
-            入力
-          </Label>
+          <Label className="text-muted-foreground min-w-12 text-xs">入力</Label>
           <Input
             className="h-7 w-44 text-xs"
             value={customInput}
             placeholder="例: +,-,±"
             onChange={(e) => {
-              const val = e.target.value
-              setCustomInput(val)
-              const labels = val
+              const value = e.target.value
+              setCustomInput(value)
+              const labels = value
                 .split(",")
                 .map((label) => label.trim())
                 .filter((label) => label.length > 0)
@@ -341,7 +337,7 @@ function ChoiceConfigFields({
       {/* 選択肢数（プリセット時のみ調整可能） */}
       {!isCustom && (
         <div className="flex items-center gap-1.5">
-          <Label className="text-muted-foreground min-w-[3rem] text-xs">
+          <Label className="text-muted-foreground min-w-12 text-xs">
             選択肢数
           </Label>
           <input
@@ -371,9 +367,7 @@ function ChoiceConfigFields({
 
       {/* 配置方向 */}
       <div className="flex items-center gap-1.5">
-        <Label className="text-muted-foreground min-w-[3rem] text-xs">
-          配置
-        </Label>
+        <Label className="text-muted-foreground min-w-12 text-xs">配置</Label>
         <Select
           value={config.layout}
           onValueChange={(v: "horizontal" | "vertical") =>
@@ -392,7 +386,7 @@ function ChoiceConfigFields({
 
       {/* 正解選択 */}
       <div className="flex items-start gap-1.5">
-        <Label className="text-muted-foreground mt-1 min-w-[3rem] text-xs">
+        <Label className="text-muted-foreground mt-1 min-w-12 text-xs">
           正解
         </Label>
         <div className="flex flex-wrap gap-1">
@@ -402,7 +396,7 @@ function ChoiceConfigFields({
               <button
                 key={idx}
                 type="button"
-                className={`h-6 min-w-[1.5rem] rounded border px-1 text-xs ${
+                className={`h-6 min-w-6 rounded border px-1 text-xs ${
                   isSelected
                     ? "border-primary bg-primary/10 text-primary"
                     : "border-muted text-muted-foreground hover:border-primary/50"
@@ -434,9 +428,7 @@ function DigitConfigFields({
   return (
     <>
       <div className="flex items-center gap-1.5">
-        <Label className="text-muted-foreground min-w-[3rem] text-xs">
-          桁数
-        </Label>
+        <Label className="text-muted-foreground min-w-12 text-xs">桁数</Label>
         <input
           type="number"
           className="border-input h-7 w-14 [appearance:textfield] rounded border px-1.5 text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
@@ -452,9 +444,7 @@ function DigitConfigFields({
         />
       </div>
       <div className="flex items-center gap-1.5">
-        <Label className="text-muted-foreground min-w-[3rem] text-xs">
-          正解
-        </Label>
+        <Label className="text-muted-foreground min-w-12 text-xs">正解</Label>
         <input
           className="border-input h-7 w-20 rounded border px-1.5 text-center text-xs"
           value={config.correctAnswer ?? ""}

--- a/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
+++ b/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
@@ -142,14 +142,14 @@ function MathSpan({
   const ref = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    const el = ref.current
-    if (!el || !window.MathJax?.tex2svg) return
+    const element = ref.current
+    if (!element || !window.MathJax?.tex2svg) return
     try {
       const container = window.MathJax.tex2svg(tex, {
         display: displayMath ?? false,
       })
-      el.innerHTML = ""
-      el.appendChild(container)
+      element.innerHTML = ""
+      element.appendChild(container)
     } catch {
       // フォールバック: そのまま表示
     }

--- a/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
+++ b/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
@@ -133,8 +133,12 @@ export function CourseworkScoresContainer({
                 const trimmed = value.trim()
                 if (trimmed === "") return true
                 if (isLetter) return validLabelSet.has(trimmed)
-                const num = Number(trimmed)
-                return !isNaN(num) && num >= 0 && num <= item.maxScore
+                const parsedValue = Number(trimmed)
+                return (
+                  !isNaN(parsedValue) &&
+                  parsedValue >= 0 &&
+                  parsedValue <= item.maxScore
+                )
               },
             },
           },
@@ -149,8 +153,8 @@ export function CourseworkScoresContainer({
               validate: (value: string) => {
                 const trimmed = value.trim()
                 if (trimmed === "") return true
-                const num = Number(trimmed)
-                return !isNaN(num) && isFinite(num)
+                const parsedValue = Number(trimmed)
+                return !isNaN(parsedValue) && isFinite(parsedValue)
               },
             },
           },
@@ -218,9 +222,13 @@ export function CourseworkScoresContainer({
               if (trimmed === "") {
                 pushPatch(item, studentId, { score: null })
               } else {
-                const num = Number(trimmed)
-                if (!isNaN(num) && num >= 0 && num <= item.maxScore) {
-                  pushPatch(item, studentId, { score: num })
+                const parsedValue = Number(trimmed)
+                if (
+                  !isNaN(parsedValue) &&
+                  parsedValue >= 0 &&
+                  parsedValue <= item.maxScore
+                ) {
+                  pushPatch(item, studentId, { score: parsedValue })
                 }
                 // 範囲外・無効値は無視
               }
@@ -234,9 +242,9 @@ export function CourseworkScoresContainer({
             if (trimmed === "") {
               pushPatch(item, studentId, { adjustment: null })
             } else {
-              const num = Number(trimmed)
-              if (!isNaN(num) && isFinite(num)) {
-                pushPatch(item, studentId, { adjustment: num })
+              const parsedValue = Number(trimmed)
+              if (!isNaN(parsedValue) && isFinite(parsedValue)) {
+                pushPatch(item, studentId, { adjustment: parsedValue })
               }
               // 無効値は無視
             }

--- a/src/components/exams/06-student-answers/types.ts
+++ b/src/components/exams/06-student-answers/types.ts
@@ -171,21 +171,6 @@ export interface DragData {
 // ============================================================================
 
 /**
- * 一時的な変換ファイル（中間データ）
- */
-export interface ConvertedFileTemp {
-  id: string
-  name: string
-  type: string
-  size: number
-  buffer: ArrayBuffer
-  preview: string
-  originalFileName: string
-  pageNumber: number
-  pageLabel?: string
-}
-
-/**
  * ファイル処理の進捗状態
  */
 export interface FileProcessingProgress {

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -185,23 +185,23 @@ export function ScoringContentArea({
   // 非表示に戻す際は対称的な補正で元の中心へ復帰する。
   useEffect(() => {
     if (gradingMode !== "individual") return
-    const el = answerScrollRef.current
-    if (!el) return
+    const element = answerScrollRef.current
+    if (!element) return
 
-    let prevW = el.clientWidth
-    let prevH = el.clientHeight
+    let prevW = element.clientWidth
+    let prevH = element.clientHeight
 
     const observer = new ResizeObserver(() => {
-      const newW = el.clientWidth
-      const newH = el.clientHeight
+      const newW = element.clientWidth
+      const newH = element.clientHeight
       if (newW === prevW && newH === prevH) return
       // 旧サイズで中心にあったコンテンツ点を、新サイズでも中心に保つ
-      el.scrollLeft += (prevW - newW) / 2
-      el.scrollTop += (prevH - newH) / 2
+      element.scrollLeft += (prevW - newW) / 2
+      element.scrollTop += (prevH - newH) / 2
       prevW = newW
       prevH = newH
     })
-    observer.observe(el)
+    observer.observe(element)
     return () => observer.disconnect()
   }, [gradingMode])
 

--- a/src/components/exams/08-export/components/IndividualReportSettings.tsx
+++ b/src/components/exams/08-export/components/IndividualReportSettings.tsx
@@ -486,18 +486,18 @@ export function IndividualReportSettings({
                     placeholder="なし"
                     value={options.adviceOptions.reviewRateMin ?? ""}
                     onChange={(e) => {
-                      const val = e.target.value
-                      if (val === "") {
+                      const inputValue = e.target.value
+                      if (inputValue === "") {
                         updateOption("adviceOptions", {
                           ...options.adviceOptions,
                           reviewRateMin: null,
                         })
                       } else {
-                        const num = Number(val)
-                        if (!isNaN(num)) {
+                        const parsedValue = Number(inputValue)
+                        if (!isNaN(parsedValue)) {
                           updateOption("adviceOptions", {
                             ...options.adviceOptions,
-                            reviewRateMin: num,
+                            reviewRateMin: parsedValue,
                           })
                         }
                       }
@@ -510,18 +510,18 @@ export function IndividualReportSettings({
                     placeholder="なし"
                     value={options.adviceOptions.reviewRateMax ?? ""}
                     onChange={(e) => {
-                      const val = e.target.value
-                      if (val === "") {
+                      const inputValue = e.target.value
+                      if (inputValue === "") {
                         updateOption("adviceOptions", {
                           ...options.adviceOptions,
                           reviewRateMax: null,
                         })
                       } else {
-                        const num = Number(val)
-                        if (!isNaN(num)) {
+                        const parsedValue = Number(inputValue)
+                        if (!isNaN(parsedValue)) {
                           updateOption("adviceOptions", {
                             ...options.adviceOptions,
-                            reviewRateMax: num,
+                            reviewRateMax: parsedValue,
                           })
                         }
                       }
@@ -537,18 +537,18 @@ export function IndividualReportSettings({
                     placeholder="全て"
                     value={options.adviceOptions.reviewQuestionCount ?? ""}
                     onChange={(e) => {
-                      const val = e.target.value
-                      if (val === "") {
+                      const inputValue = e.target.value
+                      if (inputValue === "") {
                         updateOption("adviceOptions", {
                           ...options.adviceOptions,
                           reviewQuestionCount: null,
                         })
                       } else {
-                        const num = Number(val)
-                        if (!isNaN(num)) {
+                        const parsedValue = Number(inputValue)
+                        if (!isNaN(parsedValue)) {
                           updateOption("adviceOptions", {
                             ...options.adviceOptions,
-                            reviewQuestionCount: num,
+                            reviewQuestionCount: parsedValue,
                           })
                         }
                       }

--- a/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
+++ b/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
@@ -103,8 +103,8 @@ export function ConstraintRulesEditor({
   // プレビュー用に成績算出結果を取得
   const loadCalc = useCallback(async () => {
     try {
-      const res = await window.electronAPI.grade.calculateGrades(gradeId)
-      if (res.success && res.result) setCalcResult(res.result)
+      const result = await window.electronAPI.grade.calculateGrades(gradeId)
+      if (result.success && result.result) setCalcResult(result.result)
     } catch (error) {
       console.error("Error calculating grades for preview:", error)
     }

--- a/src/components/grades/07-export/ExcelExportTab.tsx
+++ b/src/components/grades/07-export/ExcelExportTab.tsx
@@ -19,11 +19,11 @@ export function ExcelExportTab({
   const handleExportExcel = async () => {
     setExporting(true)
     try {
-      const res = await window.electronAPI.grade.exportExcel(gradeId, {
+      const result = await window.electronAPI.grade.exportExcel(gradeId, {
         studentIds: selectedStudentIds,
       })
-      if (!res.success) {
-        console.error("Export failed:", res.error)
+      if (!result.success) {
+        console.error("Export failed:", result.error)
       }
     } catch (err) {
       console.error("Export error:", err)

--- a/src/components/grades/07-export/ExportContainer.tsx
+++ b/src/components/grades/07-export/ExportContainer.tsx
@@ -161,8 +161,9 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
       if (searchTerm) {
         const term = searchTerm.toLowerCase()
         const name = `${student.lastName} ${student.firstName}`.toLowerCase()
-        const num = student.studentNumber?.toLowerCase() ?? ""
-        if (!name.includes(term) && !num.includes(term)) return false
+        const studentNumberLower = student.studentNumber?.toLowerCase() ?? ""
+        if (!name.includes(term) && !studentNumberLower.includes(term))
+          return false
       }
       return true
     })

--- a/src/components/help/page-specific/HelpContent07Scoring.tsx
+++ b/src/components/help/page-specific/HelpContent07Scoring.tsx
@@ -212,12 +212,12 @@ const HELP07_KEYFRAMES = `
 /** 一覧表示の説明アニメ：答案が並び、順に印がついていく */
 function GridStyleAnimation() {
   const colors = useScoringStatusColors()
-  const sel = useSelectionBorder()
+  const selectionBorder = useSelectionBorder()
   const marks = [true, false, true, true, false, true]
   return (
     <div
       className="grid grid-cols-3 gap-1.5"
-      style={{ "--help07-sel": sel } as CSSProperties}
+      style={{ "--help07-sel": selectionBorder } as CSSProperties}
     >
       {marks.map((isCorrect, i) => (
         <div
@@ -582,19 +582,19 @@ function ScoringGridDemo({
     selectedRef.current = n
     setSelected(n)
   }
-  const setPartialSynced = (p: PartialInput) => {
-    partialRef.current = p
-    setPartial(p)
+  const setPartialSynced = (partialInput: PartialInput) => {
+    partialRef.current = partialInput
+    setPartial(partialInput)
   }
 
   const applyStatus = useCallback((status: DemoStatus, score?: number) => {
-    const sel = selectedRef.current
+    const selectedIndex = selectedRef.current
     const updated = cellsRef.current.map((cell, i) =>
-      i === sel ? { ...cell, status, score } : cell
+      i === selectedIndex ? { ...cell, status, score } : cell
     )
     setCellsSynced(updated)
     const after = updated.findIndex(
-      (cell, i) => i > sel && cell.status === "unscored"
+      (cell, i) => i > selectedIndex && cell.status === "unscored"
     )
     const wrap =
       after === -1
@@ -611,8 +611,8 @@ function ScoringGridDemo({
     if (items.length === 0) return 1
     const top0 = items[0].offsetTop
     let cols = 0
-    for (const it of items) {
-      if (it.offsetTop === top0) cols++
+    for (const child of items) {
+      if (child.offsetTop === top0) cols++
       else break
     }
     return Math.max(1, cols)
@@ -677,9 +677,9 @@ function ScoringGridDemo({
       setPartialSynced({ active: false, value: "" })
       return
     }
-    const num = Math.min(MAX_SCORE, Math.max(0, Number(value)))
+    const clampedScore = Math.min(MAX_SCORE, Math.max(0, Number(value)))
     setPartialSynced({ active: false, value: "" })
-    applyStatus("partial", num)
+    applyStatus("partial", clampedScore)
   }, [applyStatus])
 
   const confirmPending = useCallback(() => {
@@ -1380,20 +1380,20 @@ function IndividualScoringDemo({
     selectedRef.current = n
     setSelected(n)
   }
-  const setPartialSynced = (p: PartialInput) => {
-    partialRef.current = p
-    setPartial(p)
+  const setPartialSynced = (partialInput: PartialInput) => {
+    partialRef.current = partialInput
+    setPartial(partialInput)
   }
 
   const applyStatus = useCallback((status: DemoStatus, score?: number) => {
-    const sel = selectedRef.current
+    const selectedIndex = selectedRef.current
     const updated = cellsRef.current.map((cell, i) =>
-      i === sel ? { ...cell, status, score } : cell
+      i === selectedIndex ? { ...cell, status, score } : cell
     )
     setCellsSynced(updated)
     // 採点したら次の未採点の生徒へ自動で進む
     const after = updated.findIndex(
-      (cell, i) => i > sel && cell.status === "unscored"
+      (cell, i) => i > selectedIndex && cell.status === "unscored"
     )
     const wrap =
       after === -1
@@ -1441,9 +1441,9 @@ function IndividualScoringDemo({
       setPartialSynced({ active: false, value: "" })
       return
     }
-    const num = Math.min(MAX_SCORE, Math.max(0, Number(value)))
+    const clampedScore = Math.min(MAX_SCORE, Math.max(0, Number(value)))
     setPartialSynced({ active: false, value: "" })
-    applyStatus("partial", num)
+    applyStatus("partial", clampedScore)
   }, [applyStatus])
 
   const confirmPending = useCallback(() => {
@@ -1850,7 +1850,7 @@ function DisplayModeMini({
 }) {
   if (mode === "overlay") {
     return (
-      <div className="relative flex aspect-[4/3] w-full items-center justify-center overflow-hidden rounded border border-gray-300 bg-white">
+      <div className="relative flex aspect-4/3 w-full items-center justify-center overflow-hidden rounded border border-gray-300 bg-white">
         <span className="text-2xl font-bold text-blue-900/70">答</span>
         <span
           className="absolute inset-0 flex items-center justify-center bg-rose-500/10 text-2xl font-bold text-rose-500/60"

--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -295,11 +295,11 @@ export function TagsPageContainer() {
       }
       await loadTags()
     } catch (error) {
-      const msg =
+      const message =
         error instanceof Error && error.message.includes("Unique")
           ? "同じ名前のタグが既に存在します"
           : "タグの保存に失敗しました"
-      toast.error(msg)
+      toast.error(message)
       throw error // モーダルを閉じない
     }
   }

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -85,28 +85,28 @@ export interface ExamListItem {
 export function isValidExam(data: unknown): data is ExamWithDetails {
   if (typeof data !== "object" || data === null) return false
 
-  const obj = data as Record<string, unknown>
+  const record = data as Record<string, unknown>
 
   // DateはIPC経由でDateオブジェクトとして渡される
-  const isValidDate = (val: unknown): boolean =>
-    val instanceof Date || typeof val === "string"
+  const isValidDate = (value: unknown): boolean =>
+    value instanceof Date || typeof value === "string"
 
   return (
-    typeof obj.id === "string" &&
-    typeof obj.examName === "string" &&
-    (obj.examDate === null || isValidDate(obj.examDate)) &&
-    (obj.description === undefined ||
-      obj.description === null ||
-      typeof obj.description === "string") &&
-    isValidDate(obj.createdAt) &&
-    isValidDate(obj.updatedAt) &&
-    (obj.examPages === undefined || Array.isArray(obj.examPages)) &&
-    (obj.cropRegions === undefined || Array.isArray(obj.cropRegions)) &&
-    (obj.examStudents === undefined || Array.isArray(obj.examStudents)) &&
-    (obj.userExams === undefined || Array.isArray(obj.userExams)) &&
-    (obj.examSubtotalGroups === undefined ||
-      Array.isArray(obj.examSubtotalGroups)) &&
-    (obj.answerImages === undefined || Array.isArray(obj.answerImages))
+    typeof record.id === "string" &&
+    typeof record.examName === "string" &&
+    (record.examDate === null || isValidDate(record.examDate)) &&
+    (record.description === undefined ||
+      record.description === null ||
+      typeof record.description === "string") &&
+    isValidDate(record.createdAt) &&
+    isValidDate(record.updatedAt) &&
+    (record.examPages === undefined || Array.isArray(record.examPages)) &&
+    (record.cropRegions === undefined || Array.isArray(record.cropRegions)) &&
+    (record.examStudents === undefined || Array.isArray(record.examStudents)) &&
+    (record.userExams === undefined || Array.isArray(record.userExams)) &&
+    (record.examSubtotalGroups === undefined ||
+      Array.isArray(record.examSubtotalGroups)) &&
+    (record.answerImages === undefined || Array.isArray(record.answerImages))
   )
 }
 


### PR DESCRIPTION
## 概要

変数名・型名の包括的監査（#921）に基づく是正。略語・濁った局所変数を実体名へ統一し、型名の明確な重複・デッドコードを解消する。

Closes #921

## 変更点（24ファイル）

### 変数名 — 実体名化
- `dataCreator.ts`: import 7ループの `ca/cam/cas/cs/sd/rs/da` → `compoundAnswer`〜`drawingAnnotation`
- `examConverter`(hf→headerField)・`exportHandlers`(sd→studentScoring)・`asbDefinitionConverters`(s→settings)・`itemAnalysis`(i→completeMapIndex)
- 非幾何の濁り変数: res→result, msg→message, sel→selectedIndex/selectionBorder, el→element, dir→direction/directory, src→source, num→parsedValue 他, val→value/inputValue, obj→record

### 型名 — 明確な2件
- `SubtotalGroupData` の export用2重複を `shared/types/exportTypes.ts` へ統合
- デッドコード `ConvertedFileTemp` を削除

### 方針
- Canvas/幾何イディオム（ctx/img/idx/pos/len）は慣例維持
- シリアライズ型（QuestionScoreData 等）は規約の優先度3/4として正当なため現状維持

## 検証

- typecheck・lint 通過
- テスト 902 passed（既知 #917 のみ失敗・無関係）
- code-review(high) で検出した `src→source` の文字列リテラル波及バグ（MathJax非インライン化）を修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)