### PR TITLE
fix(help): Tailwind v4 の aspect 比率クラスを新記法へ移行

### DIFF
--- a/src/components/help/page-specific/HelpContent07Scoring.tsx
+++ b/src/components/help/page-specific/HelpContent07Scoring.tsx
@@ -1863,7 +1863,7 @@ function DisplayModeMini({
   }
   if (mode === "split-h") {
     return (
-      <div className="relative aspect-[4/3] w-full overflow-hidden rounded border border-gray-300 bg-white">
+      <div className="relative aspect-4/3 w-full overflow-hidden rounded border border-gray-300 bg-white">
         {/* 答案用紙：中央から左半分の中央へ寄る */}
         <div
           className="absolute inset-y-0 left-0 flex w-full items-center justify-center text-2xl font-bold text-blue-900/70"
@@ -1882,7 +1882,7 @@ function DisplayModeMini({
     )
   }
   return (
-    <div className="relative aspect-[4/3] w-full overflow-hidden rounded border border-gray-300 bg-white">
+    <div className="relative aspect-4/3 w-full overflow-hidden rounded border border-gray-300 bg-white">
       {/* 答案用紙：中央から上半分の中央へ寄る */}
       <div
         className="absolute inset-x-0 top-0 flex h-full items-center justify-center text-2xl font-bold text-blue-900/70"


### PR DESCRIPTION
## 概要

`HelpContent07Scoring.tsx` の `aspect-[4/3]` を Tailwind v4 の `aspect-4/3` 記法へ更新。

Closes #923

## 変更点

- `DisplayModeMini`（split-h / split-v）の `aspect-[4/3]` → `aspect-4/3`（2箇所）

## 検証

- lint（eslint + prettier）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)