### PR TITLE
fix(export): 採点マークのサイズ上限クランプを撤廃し設定値を直接反映

### DIFF
--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -347,12 +347,7 @@ export function useCanvasDrawing({
             : null
 
           if (markImage) {
-            const configMarkSize = scoringMarkConfig?.markSize ?? 50
-            const markSize = Math.min(
-              configMarkSize,
-              regionWidth * 0.8,
-              regionHeight * 0.8
-            )
+            const markSize = scoringMarkConfig?.markSize ?? 50
 
             const markPos = scoringMarkConfig
               ? calculateMarkPosition(

--- a/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
+++ b/src/components/exams/08-export/utils/pdfCanvasRenderer.ts
@@ -669,11 +669,7 @@ function drawScoringMark(
   const regionWidth = region.width * imageWidth
   const regionHeight = region.height * imageHeight
 
-  const markSize = Math.min(
-    config.markSize,
-    regionWidth * 0.8,
-    regionHeight * 0.8
-  )
+  const markSize = config.markSize
   const { x, y } = calculateMarkPosition(
     regionX,
     regionY,


### PR DESCRIPTION
## 概要

採点マークのサイズが100超で解答用紙に反映されない問題を修正。解答領域サイズによる上限クランプを撤廃し、設定値（`config.markSize`）を描画サイズへ直接反映するようにした。

Closes #932

## 背景

ユーザー問い合わせより。採点マークのサイズをUI上で最大200まで設定できるが、100前後を超えると解答用紙に反映されず、印刷時に○×が小さく潰れて判別できなかった。

## 原因

`markSize`（スキャン画像の実解像度基準の絶対px値）を、解答領域の幅・高さの80%で `Math.min` クランプしていた。横長で高さの低い解答欄では `regionHeight * 0.8` が実効上限となり、設定値を上げても頭打ちになっていた。

## 変更内容

PDF/印刷出力（`pdfCanvasRenderer.ts`）と一括採点プレビュー（`useCanvasDrawing.ts`）の両経路でクランプを撤廃し、`config.markSize` を描画サイズへ直接使用。

```diff
-  const markSize = Math.min(
-    config.markSize,
-    regionWidth * 0.8,
-    regionHeight * 0.8,
-  )
+  const markSize = config.markSize
```

## 影響

- 解答欄より大きいサイズを設定するとマークが欄からはみ出して描画される（意図した挙動。隣接欄と重なる可能性あり）。
- `regionWidth`/`regionHeight` はマーク位置計算・枠描画で引き続き使用。

## 確認

- `npm run typecheck` パス
- 対象2ファイルの eslint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)