### PR TITLE
refactor(export): 採番学級の解決を renderer 主導へ（単一ソース化）

### DIFF
--- a/__tests__/exam/integration/examStudentClass.test.ts
+++ b/__tests__/exam/integration/examStudentClass.test.ts
@@ -19,14 +19,15 @@ vi.mock("../../../electron-src/lib/prisma/client", async () => {
 
 import {
   addStudentsFromClass,
+  getAdministeredClasses,
   getClassMembersForExam,
-  getStudentClassInfoForExam,
 } from "@/electron-src/lib/prisma/examClass"
 import {
   getClassesNotInExam,
   getStudentsForExam,
   getStudentsNotInExam,
 } from "@/electron-src/lib/prisma/examStudent"
+import { resolveExamClassroomPlacement } from "@/lib/examClassroomPlacement"
 
 import {
   cleanupTestDatabase,
@@ -243,20 +244,23 @@ describe("Exam 在籍フィルタ", () => {
     })
   })
 
-  // P3修正: 在籍解決（採番・表示）も受験日基準で判定する
-  describe("getStudentClassInfoForExam（受験日スナップショット）", () => {
+  // P3修正: 在籍解決（採番・表示）も受験日基準で判定する。
+  // 採番学級の解決は renderer 側 resolveExamClassroomPlacement が担い、
+  // 受験日スナップショット絞り込みは main の getAdministeredClasses が行う。
+  describe("採番学級の解決（getAdministeredClasses + resolveExamClassroomPlacement）", () => {
     it("受験日時点で在籍する生徒のみ学級情報を解決する", async () => {
       const { exam, classA, active, left } = await createTestData()
       // administered=true の ExamClass を作る（両方を受験者に追加）
       await addStudentsFromClass(exam.id, classA.id, false)
 
-      const info = await getStudentClassInfoForExam(exam.id)
+      const administeredClasses = await getAdministeredClasses(exam.id)
+      const placement = resolveExamClassroomPlacement(administeredClasses)
 
       // 受験日(2024-04-10)に在籍中の active のみ解決。転出済み left は除外
-      expect(Object.keys(info)).toEqual([active.id])
-      expect(info[active.id].classroom?.name).toBe("3年A組")
-      expect(info[active.id].attendanceNumber).toBe(1)
-      expect(info[left.id]).toBeUndefined()
+      expect(Object.keys(placement)).toEqual([active.id])
+      expect(placement[active.id].classroom?.name).toBe("3年A組")
+      expect(placement[active.id].attendanceNumber).toBe(1)
+      expect(placement[left.id]).toBeUndefined()
     })
   })
 

--- a/__tests__/exam/unit/examClassroomPlacement.test.ts
+++ b/__tests__/exam/unit/examClassroomPlacement.test.ts
@@ -1,0 +1,88 @@
+/**
+ * resolveExamClassroomPlacement（renderer 側の採番学級リゾルバ）の単体テスト
+ *
+ * 受験日スナップショット絞り込みは main の getAdministeredClasses が担うため、ここでは
+ * 純関数としての「order 昇順の first-match-wins」と lean な出力を検証する
+ * （受験日絞り込みとの結合は examStudentClass.test.ts の統合テストで担保）。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { resolveExamClassroomPlacement } from "@/lib/examClassroomPlacement"
+import type { ExamClassWithClass } from "@/types/electron/examClassApi"
+
+/** テスト用の administered ExamClassroom を最小構成で組み立てる */
+function buildExamClass(
+  order: number,
+  classroom: { id: string; name: string; grade: number | null },
+  members: Array<{ studentId: string; attendanceNumber: number | null }>
+): ExamClassWithClass {
+  return {
+    id: `ec-${classroom.id}`,
+    examId: "exam-1",
+    classroomId: classroom.id,
+    administered: true,
+    teacherStatistics: true,
+    studentReport: true,
+    order,
+    createdAt: new Date("2024-04-01"),
+    updatedAt: new Date("2024-04-01"),
+    classroom: {
+      id: classroom.id,
+      name: classroom.name,
+      grade: classroom.grade,
+      classCode: null,
+      createdAt: new Date("2024-04-01"),
+      updatedAt: new Date("2024-04-01"),
+      memberships: members.map((member) => ({
+        id: `m-${classroom.id}-${member.studentId}`,
+        studentId: member.studentId,
+        classroomId: classroom.id,
+        attendanceNumber: member.attendanceNumber,
+        startDate: new Date("2024-04-01"),
+        endDate: null,
+        createdAt: new Date("2024-04-01"),
+        updatedAt: new Date("2024-04-01"),
+        // resolver は student を参照しないため最小限で補う
+        student: { id: member.studentId } as unknown,
+      })),
+    },
+    // ExamClassWithClass は exam を含まないためこのままでよい
+  } as unknown as ExamClassWithClass
+}
+
+describe("resolveExamClassroomPlacement", () => {
+  it("生徒が複数の administered 学級に所属する場合、order 昇順で最初の学級を採番学級にする", () => {
+    // 意図的に配列順は order 昇順にしない（リゾルバが order で並べ直すことを検証）
+    const administeredClasses = [
+      buildExamClass(1, { id: "clubB", name: "バスケ部", grade: 3 }, [
+        { studentId: "s1", attendanceNumber: 7 },
+      ]),
+      buildExamClass(0, { id: "classA", name: "3年A組", grade: 3 }, [
+        { studentId: "s1", attendanceNumber: 1 },
+        { studentId: "s2", attendanceNumber: 2 },
+      ]),
+    ]
+
+    const placement = resolveExamClassroomPlacement(administeredClasses)
+
+    // s1 は order=0 の classA が採番学級（clubB ではない）
+    expect(placement["s1"].classroom?.name).toBe("3年A組")
+    expect(placement["s1"].attendanceNumber).toBe(1)
+    expect(placement["s1"].order).toBe(0)
+
+    // s2 は classA のみ
+    expect(placement["s2"].classroom?.name).toBe("3年A組")
+    expect(placement["s2"].attendanceNumber).toBe(2)
+
+    // 採番学級に memberships は同梱しない（Classroom スカラーのみ）
+    expect(
+      (placement["s1"].classroom as unknown as { memberships?: unknown })
+        .memberships
+    ).toBeUndefined()
+  })
+
+  it("administered 学級が空なら空のマップを返す", () => {
+    expect(resolveExamClassroomPlacement([])).toEqual({})
+  })
+})

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -175,6 +175,36 @@ cropRegions.filter((cr) => cr.points > 0)
 
 **外部ライブラリ規約のコールバックは `value` を使う**: `onValueChange={(value) => …}`（shadcn/Radix の多数派に従う。1文字 `v` は避けて `value` と綴る）。**実体名化する対象**: 実体要素の `s`/`c`/`m`/`cr`/`sg` → `student`/`classroom`/`membership`/`cropRegion`/`subtotalGroup`。
 
+#### id ではなく実体を持つ原則（`xxxIds` の扱い）
+
+**id を保持してよいのは、id そのものが目的の場合に限る。** 次の 4 用途のみ正当:
+
+1. **選択・所属の判定** — UI の選択状態（`selectedStudentIds`）。意味論が「集合・重複なし・所属判定」なら `string[]` より `Set<string>` を優先する。
+2. **並べ替えの順序** — reorder ペイロード（`orderedIds`）。順序そのものが payload。
+3. **関連付けの設定** — `setExamTags(examId, tagIds)` のような関連の張り替え。
+4. **IPC／シリアライズ境界の通過** — レンダラ→main へ id を渡し、DB を持つ main 側で取得する（実体を境界越しに運ばない）。
+
+**downstream で実体のフィールドが要るなら、最初から実体を持つ。** 判定テスト:
+
+> `.find((x) => x.id === id)` や id 指定 fetch で、前段が既に持っていた（or 持つべき）実体を作り直していないか？
+
+作り直しているなら、その前段が実体を保持すべきだったサイン。特に **実体を `.map((e) => e.id)` で id 配列に潰した直後に DB／API を叩いて同じ実体を取り直す**のは冗長往復で禁止。
+
+```typescript
+// ❌ 実体を id に潰し、あとで DB/API から取り直す（冗長往復）
+const studentIds = students.map((student) => student.id)
+const reloaded = await api.getStudentsByIds(studentIds) // students は既に手元にある
+
+// ❌ id 配列を .find のループで実体へ引き直す（O(n·m) の再構築）
+const rows = visibleIds.map((id) => allRows.find((row) => row.id === id))
+
+// ✅ 実体をそのまま持つ／どうしても id state なら Map で一括引き（順序保持・O(n)）
+const rowById = new Map(allRows.map((row) => [row.id, row]))
+const rows = visibleIds.map((id) => rowById.get(id)).filter(Boolean)
+```
+
+**例外**: 外部ライブラリが id 文字列を渡してくる場合（dnd-kit の `active.id: string` から行を引く等）は規約に従い `.find` で可。
+
 ---
 
 ## 不要なコードの削除
@@ -311,6 +341,33 @@ interface StudentData {
   // ...Prisma型と同じフィールドを再定義
 }
 ```
+
+### 独自型を制限する目的（なぜ上位を優先するか）
+
+独自型の制限が守っているのは **DB への書き込み整合性** である。独自型で DB と異なる「特殊なデータ構造」をコンポーネント／IPC 間で運ぶと、それを DB に書き戻す（永続化する）ときに破綻する。逆に言えば、**DB に永続化しない経路は型制限の対象外**：
+
+- **ファイル書き出し（Excel / PDF 等）**: DB に反映しない read-out。フックで得たデータを出力に必要な形へ整えて main 側へ渡してよい。ただし「好きな型」ではなく **必要な型**（変な型の乱立を防ぐ）。
+- **フィルタ機能・DB 非保存の UI / DnD 状態**: 同様に carve-out（上記 a と同義）。ただし DB をミラーした view-model をこの名目で温存しない（それは下記のフックで解く）。
+
+### DB 由来データを計算した値の扱い
+
+DB で管理されるデータを **計算した値** を使いたい場合：
+
+1. **原則そのコンポーネント内で計算する**。renderer にデータが揃っていれば再フェッチにはならない（禁止なのは「データ不足で再クエリ／再フェッチ」する方）。main 側で特殊な計算をして専用 IPC を生やさない。
+2. 計算ロジックが長く別ファイルに出したい → **型を宣言せず引数で渡す**か **フックを定義**する。
+3. **複数箇所で同じ計算値を使う → 共通フックを作って共有する**。フックの返り値「全体」に名前は付けない（推論／`ReturnType`）。名前を付けるのは複数箇所で共有する“データの形”のみ。
+4. 新機能開発時は既存フックのロジックが適切か検証し、既存を変更するか新規に作るかを吟味する。
+
+> 独自型を不必要に宣言すると、その裏に **重複ロジック・デッドコード・再クエリ・変更未追従** が生まれる。シンプルにデータを渡し、共通のデータ構造（Prisma 拡張型）を使うのが大規模コードベースの原則。
+
+### Decimal 型・リテラル型の「適切な対応」（型注入）
+
+Prisma 型のうち renderer で扱いにくい一部（Decimal、SQLite に enum が無いための `String` 列）は、**独自型を作らず「型注入」で上書き**する。共通形は `Omit<PrismaModel, "field"> & { field: 補正型 }` ＋ **境界で1回だけ変換**。
+
+- **Decimal → number**: 型は `types/prismaExtensions.ts` に集約（例 `SerializedQuestionScore = Omit<QuestionScore, "partialScore"> & { partialScore: number | null }`）。実行時は境界で `decimal.toNumber()`。理由: Prisma の Decimal（decimal.js）は IPC で壊れ renderer で扱いにくい。
+- **string → literal union**: SSOT を 1 ファイルに（`ScoringStatus` / `ExamStudentStatus` が前例）。`const XS = [...] as const` → `type X = (typeof XS)[number]`（1 配列から union 導出）＋型ガード `isX` ＋境界コンバータ `toX(s): X`（想定外は安全な既定へ）。型は `Omit<PrismaModel, "status"> & { status: X }`、実行時は境界で `toX(row.status)`。union をあちこち手書きしない。
+
+`Omit` は「上書き（Decimal / union）・機密除去（`password` 等）」に使う。禁止するのは「表示のために小さくする縮小 `Pick`」の独自 view の方。
 
 ### 禁止事項
 
@@ -683,3 +740,4 @@ export async function exportToExcel(
 | 2025-01-12 | 命名規則・不要コード削除のセクションを追加                       |
 | 2025-01-12 | ESLint設定との整合性確認・修正、Tailwind CSSマイグレーション追加 |
 | 2026-07-04 | 命名規則に「実体名の原則・高階関数優先・慣例例外 A/B」を追加     |
+| 2026-07-05 | 命名規則に「id ではなく実体を持つ原則（`xxxIds` の扱い）」を追加 |

--- a/docs/type-cleanup-backlog.md
+++ b/docs/type-cleanup-backlog.md
@@ -15,25 +15,12 @@
 - **Task 1（PR #935 merge 済み）**: placement を renderer 側解決へ。専用 IPC（`getStudentClassInfo` map / `getStudentClassInfoSingle` single）と main `getStudentClassInfo`（単一）・未使用 `ExamClassroomPlacementMap` を撤去。新設 `src/lib/examClassroomPlacement.ts` の `resolveExamClassroomPlacement(administeredClasses)` が既存 `getAdministered`（DB 構造 IPC）から採番を計算。併せて受験生徒型を nested `ExamStudentWithDetails` へ集約・08 選択を `useStudentSelection` へ・06 並び替えを customOrder のみへ・`ExamClassroomPlacement` に `Classroom` 同梱。
 - **Task 2（実装済み・未コミット・緑）**: 06 のフラット `UnifiedStudent` を撤廃し `ExamStudentWithDetails`（nested）を持ち回る（16 ファイル、`.id`→`.studentId` / 氏名→`.student.X`）。**副産物の大発見**: `student-answer-management` に放棄された「管理グリッド」実装が丸ごとデッド（現行は `student-answer-table` パス）。`StudentGridRow`/`StudentCell`/`AnswerCell`/`useStudentAnswerUploadMain`/`useStudentManagement`/`useFileProcessing` ＋ 専用型（`StudentGridRowProps` 他・`StudentWithAnswers`・`hooks/types.ts` 丸ごと・06 root の未使用 `TableCell`/`TableData`）を削除。classroom バッジは唯一 dead な `StudentCell` のみが消費していたため、**06 は placement 自体が不要**になり loadData から撤去（placement は 05 のみ利用）。
 
----
-
-## 残タスク（この設計で確定）
-
-### 3. export（Excel/PDF）を renderer 主導に
-
-- 型制限の対象外。renderer が採番を含む**必要な**データを export IPC に渡し、`dataFetcher` の `getStudentClassInfoForExam` 呼び出し（main 側採番解決）を撤去。
-- 「好きな型」ではなく必要な型（乱立防止）。
-- 完了時: main `getStudentClassInfoForExam` を撤去 → 境界型 `ExamClassroomPlacement` は renderer 専用になるので `src/lib/examClassroomPlacement.ts` へ移す。併せて `resolveExamClassroomPlacement` の単体テストを追加（現状は main の `getStudentClassInfoForExam` テストがロジックを担保）。
-
-### 4. coding-style.md へ規約差分を追記（並行セッション完了後）
-
-- 追記内容: 目的＝DB書き込み保護 / 書き出しは対象外＋必要な型 / 計算はコンポーネント・フック / Decimal・union の型注入。
-- **`docs/coding-style.md` は現在並行セッションが編集中**のため、そのセッション完了を待って反映。
+- **Task 3（実装済み・未コミット・緑）**: export（Excel/プレビュー/個人成績表）の採番学級解決を renderer 主導へ。renderer が `resolveExamClassroomPlacement` で解決し、書き出しに**必要な情報だけ**（学級名/学年/出席番号＝lean な `StudentExportPlacement`）を各 export IPC へ渡す。共通ヘルパ `loadStudentExportPlacements`。main `getStudentClassInfoForExam` を撤去し `fetchExportData(examId, ids, studentPlacements?)` へ（未指定は `memberships[0]` フォールバック）。placement 不要な validate/R/PDF は未渡し。境界型 `ExamClassroomPlacement` を `src/lib/examClassroomPlacement.ts` へ移設（main 完全脱依存）。`resolveExamClassroomPlacement` の単体テスト（order 昇順 first-match）＋統合テストを新経路（getAdministeredClasses + resolver）へ更新。
+- **Task 4（実装済み・未コミット）**: `docs/coding-style.md` §型管理の方針へ規約差分を追記（目的＝DB書き込み保護 / 書き出しは対象外＋必要な型 / 計算はコンポーネント・フック / Decimal・union の型注入）。
 
 ---
 
-## 進め方メモ
+## 全タスク完了
 
-- 残るは 3（export 付け替え）→ 4（coding-style.md 追記）。各段で typecheck ゲート。
-- 並行セッション所有ファイル（`coding-style.md` / `identifier-vs-entity-audit.md` / `type-convention-audit.md`）は触らない。
-- Task 1 は PR #935 で merge 済み。Task 2 は未コミット（緑）。
+- Task 1（PR #935 merge 済み）、Task 2（PR #937 merge 済み）、Task 3・Task 4 実装済み・緑。
+- 並行セッション所有ファイル（`identifier-vs-entity-audit.md` / `type-convention-audit.md`）は触らない。`coding-style.md` は OWNER 指示により Task 4 を追記（並行セッションの co-pending 変更が同居）。

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -24,6 +24,7 @@ import {
   captureReturnSnapshot,
   getReturnDiff,
 } from "../lib/prisma/returnSnapshot"
+import type { StudentExportPlacement } from "../lib/shared/types/exportTypes"
 import {
   buildConflictIdentifiers,
   validateScoringData,
@@ -245,6 +246,7 @@ export function setupExportHandlers(): void {
       examId: string
       selectedStudentIds: string[]
       outputPath?: string
+      studentPlacements?: Record<string, StudentExportPlacement>
     }) => {
       return await exportGradingDataExcel(options)
     }
@@ -258,10 +260,15 @@ export function setupExportHandlers(): void {
   // Excelプレビュー用データ取得
   registerSafeHandler(
     "export:getExcelPreviewData",
-    async (options: { examId: string; selectedStudentIds: string[] }) => {
+    async (options: {
+      examId: string
+      selectedStudentIds: string[]
+      studentPlacements?: Record<string, StudentExportPlacement>
+    }) => {
       const result = await fetchExportData(
         options.examId,
-        options.selectedStudentIds
+        options.selectedStudentIds,
+        options.studentPlacements
       )
       if (!result.success) {
         return { success: false, error: result.error }

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -5,7 +5,6 @@ import type { ScoringStatus } from "@/types/scoringStatus.types"
 
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
 import { getExamById } from "../../prisma/exam"
-import { getStudentClassInfoForExam } from "../../prisma/examClass"
 import { getStudentsForExam } from "../../prisma/examStudent"
 import { getQuestionScoresForExam } from "../../prisma/questionScore"
 import { getScoreDecisionsForExam } from "../../prisma/scoreDecision"
@@ -23,6 +22,7 @@ import {
 import {
   ScoreDetail,
   ScoringData,
+  StudentExportPlacement,
   SubtotalGroupData,
   SubtotalScore,
 } from "../../shared/types/exportTypes"
@@ -58,7 +58,8 @@ export interface ExportDataResult {
  */
 export async function fetchExportData(
   examId: string,
-  selectedStudentIds: string[]
+  selectedStudentIds: string[],
+  studentPlacements?: Record<string, StudentExportPlacement>
 ): Promise<ExportDataResult> {
   try {
     // 基本データの取得
@@ -71,10 +72,6 @@ export async function fetchExportData(
     if (!studentsResult.success) {
       return { success: false, error: "生徒データの取得に失敗しました" }
     }
-
-    // 表示用の学級・出席番号は受験日スナップショット＋order解決で決定（P1修正）。
-    // memberships[0]（startDate降順の先頭＝偶然の値）には依存しない。
-    const classInfoMap = await getStudentClassInfoForExam(examId)
 
     const cropRegions = await getCropRegionsByExamId(examId)
     const questionScoresResult = await getQuestionScoresForExam(examId)
@@ -98,7 +95,7 @@ export async function fetchExportData(
     // Excel 出力層は内部で flat な Student 射影（student.id = 生徒ID）を消費するため、
     // IPC/renderer 契約の nested な ExamStudentWithDetails をここで境界フラット化する。
     // customOrder / status は ExamStudent 実列を平坦に畳み、表示学級（grade/className/
-    // attendanceNumber）は受験日スナップショット解決を優先して付与する。
+    // attendanceNumber）は renderer が採番解決して渡した studentPlacements を優先する。
     const selectedStudents = (studentsResult.students || [])
       .filter(
         (examStudent) =>
@@ -108,15 +105,15 @@ export async function fetchExportData(
       .map((examStudent) => {
         const student = examStudent.student
 
-        // 受験日スナップショット＋order優先で解決した学級情報を使う（P1修正）
-        const resolved = classInfoMap[examStudent.studentId]
+        // renderer が採番解決して渡した表示学級情報を優先（採番学級の SSOT は renderer）
+        const resolved = studentPlacements?.[examStudent.studentId]
 
-        // 解決不能時（administered学級に未所属等）は memberships[0] へフォールバック
+        // 未指定（administered学級に未所属等）は memberships[0] へフォールバック
         const fallbackMembership = student.memberships?.[0]
         const fallbackClass = fallbackMembership?.classroom
 
-        const grade = resolved?.classroom?.grade ?? fallbackClass?.grade ?? null
-        const className = resolved?.classroom?.name ?? fallbackClass?.name
+        const grade = resolved?.grade ?? fallbackClass?.grade ?? null
+        const className = resolved?.className ?? fallbackClass?.name
         const attendanceNumber =
           resolved?.attendanceNumber ?? fallbackMembership?.attendanceNumber
 

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -30,7 +30,12 @@ export async function exportGradingDataExcel(
 
     // 学級平均行の母集団は「試験全体」（生徒選択に無関係）なので、全受験生徒データを
     // 1回だけ取得し、選択生徒分は in-memory で絞る（部分出力時の二重フェッチを回避）。
-    const dataResult = await fetchExportData(examId, [])
+    // 採番学級は renderer が解決して渡す studentPlacements を使う。
+    const dataResult = await fetchExportData(
+      examId,
+      [],
+      options.studentPlacements
+    )
     if (!dataResult.success) {
       return { success: false, error: dataResult.error }
     }

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -48,11 +48,16 @@ import type {
 export async function fetchIndividualReportData(
   options: GetIndividualReportDataOptions
 ): Promise<GetIndividualReportDataResult> {
-  const { examId, selectedStudentIds, options: reportOptions } = options
+  const {
+    examId,
+    selectedStudentIds,
+    options: reportOptions,
+    studentPlacements,
+  } = options
 
   try {
-    // 全生徒のデータを取得（平均計算等に必要）
-    const allDataResult = await fetchExportData(examId, [])
+    // 全生徒のデータを取得（平均計算等に必要）。採番学級は renderer が解決して渡す。
+    const allDataResult = await fetchExportData(examId, [], studentPlacements)
     if (!allDataResult.success || !allDataResult.exam) {
       return {
         success: false,
@@ -61,7 +66,11 @@ export async function fetchIndividualReportData(
     }
 
     // 選択された生徒のデータを取得
-    const selectedDataResult = await fetchExportData(examId, selectedStudentIds)
+    const selectedDataResult = await fetchExportData(
+      examId,
+      selectedStudentIds,
+      studentPlacements
+    )
     if (!selectedDataResult.success || !selectedDataResult.scoringData) {
       return {
         success: false,

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -7,7 +7,10 @@ import type { SubtotalGroup } from "@prisma/client"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 
 import type { BoxPlotData } from "../../shared/calculations/numericStats"
-import type { ScoringData } from "../../shared/types/exportTypes"
+import type {
+  ScoringData,
+  StudentExportPlacement,
+} from "../../shared/types/exportTypes"
 
 // ================== 表示モード関連 ==================
 
@@ -271,6 +274,8 @@ export interface GetIndividualReportDataOptions {
   examId: string
   selectedStudentIds: string[]
   options: IndividualReportOptions
+  /** renderer が採番解決して渡す表示学級情報（studentId キー） */
+  studentPlacements?: Record<string, StudentExportPlacement>
 }
 
 /** 個人成績表データ取得結果 */

--- a/electron-src/lib/prisma/examClass.ts
+++ b/electron-src/lib/prisma/examClass.ts
@@ -1,6 +1,5 @@
 import { ExamClassroom, Prisma } from "@prisma/client"
 
-import type { ExamClassroomPlacement } from "@/types/electron/examClassApi"
 import type { ExamClassroomWithMembers } from "@/types/prismaExtensions"
 
 import { recordAuditLog } from "./auditLog"
@@ -464,78 +463,12 @@ export const addStudentsFromClass = async (
 }
 
 /**
- * 試験内の全生徒の学級・出席番号情報を取得
- *
- * ロジック:
- * 1. ExamClassroom (administered=true) を order 順で取得
- * 2. 各クラスの StudentClassroomMembership を取得
- * 3. 生徒ごとに、最初にマッチするクラスの情報を返す
- *
- * @returns Map<studentId, ExamClassroomPlacement>
- */
-export const getStudentClassInfoForExam = async (
-  examId: string
-): Promise<Record<string, ExamClassroomPlacement>> => {
-  try {
-    // 受験日時点で在籍する所属のみを解決対象とする（受験日スナップショット）
-    const referenceDate = await getExamReferenceDate(examId)
-
-    // 1. administered=true の ExamClassroom を order 順で取得
-    const examClassrooms = await prisma.examClassroom.findMany({
-      where: {
-        examId,
-        administered: true,
-      },
-      include: {
-        classroom: {
-          include: {
-            memberships: {
-              where: membershipFilterAt(referenceDate),
-              include: {
-                student: true,
-              },
-            },
-          },
-        },
-      },
-      orderBy: { order: "asc" },
-    })
-
-    // 2. 生徒ごとの学級情報をマップに格納（order順で最初にマッチしたものを使用）
-    const result: Record<string, ExamClassroomPlacement> = {}
-
-    for (const examClass of examClassrooms) {
-      // 解決用に include した memberships は出力に含めず、Classroom スカラーをそのまま同梱する
-      const { memberships: _memberships, ...classroom } = examClass.classroom
-
-      for (const membership of examClass.classroom.memberships) {
-        // 既に情報がある生徒はスキップ（order優先順位を尊重）
-        if (result[membership.studentId]) {
-          continue
-        }
-
-        result[membership.studentId] = {
-          classroom,
-          attendanceNumber: membership.attendanceNumber,
-          order: examClass.order,
-        }
-      }
-    }
-
-    return result
-  } catch (error) {
-    console.error(`Failed to get student class info for exam ${examId}:`, error)
-    throw error
-  }
-}
-
-/**
  * 登録学級ごとの所属生徒（集計エンジン・Phase 1）
  *
  * 試験に登録された各 ExamClassroom について、**受験日時点で在籍する**生徒（class.memberships）を
  * 含む Prisma payload（{@link ExamClassroomWithMembers}）をそのまま返す。memberships は受験日
- * スナップショットで where 絞り込み・出席番号→学籍番号順にソート済み。採番
- * （getStudentClassInfoForExam）と異なり**1人の生徒は所属する全学級に重複カウント**される
+ * スナップショットで where 絞り込み・出席番号→学籍番号順にソート済み。採番学級の解決
+ * （renderer 側 `resolveExamClassroomPlacement`）と異なり**1人の生徒は所属する全学級に重複カウント**される
  * （用途2/3の学級平均は「学級全体」を母集団とするため、order優先の単一化はしない）。
  *
  * order 昇順の全登録学級を返し、消費側が用途別にフィルタする

--- a/electron-src/lib/shared/types/exportTypes.ts
+++ b/electron-src/lib/shared/types/exportTypes.ts
@@ -3,11 +3,26 @@
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 import type { ScoringStatus } from "@/types/scoringStatus.types"
 
+/**
+ * 出力に必要な生徒ごとの表示学級情報（採番学級の解決結果）。
+ *
+ * 採番学級の解決は renderer 側（`resolveExamClassroomPlacement`）で行い、書き出しに
+ * 必要な値だけをこの lean な形で main へ渡す（export は型制限の対象外・DB へ書き戻さない）。
+ * 未指定の生徒は fetchExportData 側で `student.memberships[0]` にフォールバックする。
+ */
+export interface StudentExportPlacement {
+  grade: number | null
+  className: string | null
+  attendanceNumber: number | null
+}
+
 export interface ExportGradingDataOptions {
   examId: string
   selectedStudentIds: string[]
   outputPath?: string
   forceExport?: boolean // 警告を無視して強制実行
+  /** renderer が採番解決して渡す表示学級情報（studentId キー）。Excel 出力で使用 */
+  studentPlacements?: Record<string, StudentExportPlacement>
 }
 
 export interface ScoringData {

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -53,6 +53,10 @@ export function createExportApi() {
         examId: string
         selectedStudentIds: string[]
         options: import("../lib/export/individual-report").IndividualReportOptions
+        studentPlacements?: Record<
+          string,
+          import("../lib/shared/types/exportTypes").StudentExportPlacement
+        >
       }) => ipcRenderer.invoke("export:getIndividualReportData", options),
       getSubtotalGroupsForReport: (examId: string) =>
         ipcRenderer.invoke("export:getSubtotalGroupsForReport", examId),
@@ -85,6 +89,10 @@ export function createExportApi() {
       getExcelPreviewData: (options: {
         examId: string
         selectedStudentIds: string[]
+        studentPlacements?: Record<
+          string,
+          import("../lib/shared/types/exportTypes").StudentExportPlacement
+        >
       }) => ipcRenderer.invoke("export:getExcelPreviewData", options),
       // 印刷ダイアログを開く
       openPrintDialog: (options: {
@@ -108,6 +116,10 @@ export function createExportApi() {
       examId: string
       selectedStudentIds: string[]
       outputPath?: string
+      studentPlacements?: Record<
+        string,
+        import("../lib/shared/types/exportTypes").StudentExportPlacement
+      >
     }) => ipcRenderer.invoke("export-grading-data-excel", options),
 
     // R / exametrika 向けデータ出力（#834）

--- a/src/components/exams/05-students/components/StudentRemovalConfirmModal.tsx
+++ b/src/components/exams/05-students/components/StudentRemovalConfirmModal.tsx
@@ -12,7 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import type { ExamClassroomPlacement } from "@/types/electron/examClassApi"
+import type { ExamClassroomPlacement } from "@/lib/examClassroomPlacement"
 import type { ExamStudentWithDetails } from "@/types/prismaExtensions"
 
 interface StudentRemovalConfirmModalProps {

--- a/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
+++ b/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
@@ -3,8 +3,10 @@
 import { useCallback, useEffect, useState } from "react"
 
 import type { RosterClassOption } from "@/components/common/roster-table"
-import { resolveExamClassroomPlacement } from "@/lib/examClassroomPlacement"
-import type { ExamClassroomPlacement } from "@/types/electron/examClassApi"
+import {
+  type ExamClassroomPlacement,
+  resolveExamClassroomPlacement,
+} from "@/lib/examClassroomPlacement"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 import type { ExamStudentWithDetails } from "@/types/prismaExtensions"
 

--- a/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
+++ b/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
@@ -38,7 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Table, TableBody } from "@/components/ui/table"
-import type { ExamClassroomPlacement } from "@/types/electron/examClassApi"
+import type { ExamClassroomPlacement } from "@/lib/examClassroomPlacement"
 import type { ExamStudentWithDetails } from "@/types/prismaExtensions"
 
 /** 受験生徒（ExamStudent）と表示学級情報を共通の RosterRow へ変換 */

--- a/src/components/exams/05-students/components/sortable-student-table/types/studentTableTypes.ts
+++ b/src/components/exams/05-students/components/sortable-student-table/types/studentTableTypes.ts
@@ -1,5 +1,5 @@
 import type { RosterClassOption } from "@/components/common/roster-table"
-import type { ExamClassroomPlacement } from "@/types/electron/examClassApi"
+import type { ExamClassroomPlacement } from "@/lib/examClassroomPlacement"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 import type { ExamStudentWithDetails } from "@/types/prismaExtensions"
 

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -25,6 +25,7 @@ import { useExcelPreview } from "@/components/exams/08-export/hooks/useExcelPrev
 import { useExportPage } from "@/components/exams/08-export/hooks/useExportPage"
 import { useIndividualReportPreview } from "@/components/exams/08-export/hooks/useIndividualReportPreview"
 import { useScoredAnswerPreview } from "@/components/exams/08-export/hooks/useScoredAnswerPreview"
+import { loadStudentExportPlacements } from "@/components/exams/08-export/utils/loadStudentExportPlacements"
 import type { ScoringMarkConfigForPdf } from "@/components/exams/08-export/utils/pdfCanvasRenderer"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
@@ -655,11 +656,13 @@ export default function ExportMainView() {
 
     try {
       const selectedStudentIds = Array.from(selectedStudents)
+      const studentPlacements = await loadStudentExportPlacements(exam.id)
 
       const result = await window.electronAPI.exportGradingDataExcel({
         examId: exam.id,
         selectedStudentIds,
         forceExport: true,
+        studentPlacements,
       })
 
       if (result.success) {
@@ -744,6 +747,7 @@ export default function ExportMainView() {
 
     try {
       const selectedStudentIds = Array.from(selectedStudents)
+      const studentPlacements = await loadStudentExportPlacements(exam.id)
 
       // 1. データ取得（統計・アドバイス含む）
       const dataResult =
@@ -751,6 +755,7 @@ export default function ExportMainView() {
           examId: exam.id,
           selectedStudentIds,
           options: individualReportOptions,
+          studentPlacements,
         })
 
       if (!dataResult.success || !dataResult.reports) {

--- a/src/components/exams/08-export/hooks/useExcelPreview.ts
+++ b/src/components/exams/08-export/hooks/useExcelPreview.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react"
 
+import { loadStudentExportPlacements } from "@/components/exams/08-export/utils/loadStudentExportPlacements"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 import type { ScoringStatus } from "@/types/scoringStatus.types"
 
@@ -83,9 +84,11 @@ export function useExcelPreview({
       setError(null)
 
       try {
+        const studentPlacements = await loadStudentExportPlacements(examId)
         const result = await window.electronAPI.export.getExcelPreviewData({
           examId,
           selectedStudentIds,
+          studentPlacements,
         })
 
         if (!result.success || !result.scoringData) {

--- a/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
+++ b/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import type { IndividualReportOptions } from "@/app/exams/[examId]/08-export/types"
+import { loadStudentExportPlacements } from "@/components/exams/08-export/utils/loadStudentExportPlacements"
 import type { IndividualReportData } from "@/electron-src/lib/export/individual-report/types"
 
 interface UseIndividualReportPreviewOptions {
@@ -66,10 +67,12 @@ export function useIndividualReportPreview({
     setError(null)
 
     try {
+      const studentPlacements = await loadStudentExportPlacements(examId)
       const result = await window.electronAPI.export.getIndividualReportData({
         examId,
         selectedStudentIds: [previewStudentId],
         options: optionsRef.current,
+        studentPlacements,
       })
 
       if (result.success && result.reports && result.reports.length > 0) {

--- a/src/components/exams/08-export/utils/loadStudentExportPlacements.ts
+++ b/src/components/exams/08-export/utils/loadStudentExportPlacements.ts
@@ -1,0 +1,28 @@
+import type { StudentExportPlacement } from "@/electron-src/lib/shared/types/exportTypes"
+import { resolveExamClassroomPlacement } from "@/lib/examClassroomPlacement"
+
+/**
+ * 書き出し（Excel / 個人成績表）に必要な採番学級情報を renderer 側で解決して返す。
+ *
+ * 採番学級の解決は renderer が単一ソースで担い（`resolveExamClassroomPlacement`）、
+ * main へは書き出しに必要な値だけ（学級名・学年・出席番号）を lean な形で渡す。
+ * main 側は placement を解決せず、渡された値をそのまま出力に使う（export は型制限の対象外）。
+ */
+export async function loadStudentExportPlacements(
+  examId: string
+): Promise<Record<string, StudentExportPlacement>> {
+  const administeredClasses =
+    await window.electronAPI.examClassroom.getAdministered(examId)
+  const placementByStudent = resolveExamClassroomPlacement(administeredClasses)
+
+  return Object.fromEntries(
+    Object.entries(placementByStudent).map(([studentId, placement]) => [
+      studentId,
+      {
+        grade: placement.classroom?.grade ?? null,
+        className: placement.classroom?.name ?? null,
+        attendanceNumber: placement.attendanceNumber,
+      },
+    ])
+  )
+}

--- a/src/lib/examClassroomPlacement.ts
+++ b/src/lib/examClassroomPlacement.ts
@@ -1,7 +1,20 @@
-import type {
-  ExamClassroomPlacement,
-  ExamClassWithClass,
-} from "@/types/electron/examClassApi"
+import type { Classroom } from "@prisma/client"
+
+import type { ExamClassWithClass } from "@/types/electron/examClassApi"
+
+/**
+ * 採番学級の解決結果（studentId → 表示学級・出席番号・学級順）。
+ *
+ * renderer 側で administered 学級から解決する computed な形。採番学級（Prisma `Classroom`）を
+ * 同梱し、05 の表示・並び替えや 08 の書き出し placement 生成で共有する。
+ */
+export interface ExamClassroomPlacement {
+  /** 採番順を決める administered 学級（Prisma Classroom を同梱。未所属なら null） */
+  classroom: Classroom | null
+  attendanceNumber: number | null
+  /** ExamClassroom の並び順 */
+  order: number | null
+}
 
 /**
  * administered 学級（`examClassroom.getAdministered` の戻り値＝DB 構造そのまま）から、

--- a/src/types/electron/examClassApi.d.ts
+++ b/src/types/electron/examClassApi.d.ts
@@ -47,17 +47,6 @@ export interface AvailableClass {
 }
 
 /**
- * 生徒の学級・出席番号情報（ExamClassroom経由で取得）
- */
-export interface ExamClassroomPlacement {
-  /** 採番順を決める administered 学級（Prisma Classroom をそのまま同梱。未所属なら null） */
-  classroom: Classroom | null
-  attendanceNumber: number | null
-  /** ExamClassroom の並び順 */
-  order: number | null
-}
-
-/**
  * ExamClassroom関連API
  */
 export interface ExamClassAPI {

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -8,6 +8,7 @@ import type {
   CaptureReturnSnapshotResult,
   ReturnDiffResult,
 } from "@/electron-src/lib/prisma/returnSnapshot"
+import type { StudentExportPlacement } from "@/electron-src/lib/shared/types/exportTypes"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 import type { ScoringStatus } from "@/types/scoringStatus.types"
 
@@ -193,6 +194,7 @@ export interface ExportAPI {
       examId: string
       selectedStudentIds: string[]
       options: IndividualReportOptions
+      studentPlacements?: Record<string, StudentExportPlacement>
     }) => Promise<GetIndividualReportDataResult>
 
     // 個人成績表用小計点グループ一覧取得
@@ -250,6 +252,7 @@ export interface ExportAPI {
     getExcelPreviewData: (options: {
       examId: string
       selectedStudentIds: string[]
+      studentPlacements?: Record<string, StudentExportPlacement>
     }) => Promise<{
       success: boolean
       questionRegions?: Array<{
@@ -316,6 +319,7 @@ export interface ExportAPI {
     selectedStudentIds: string[]
     outputPath?: string
     forceExport?: boolean
+    studentPlacements?: Record<string, StudentExportPlacement>
   }) => Promise<{
     success: boolean
     outputPath?: string


### PR DESCRIPTION
## 概要

export（Excel/個別レポート）の採番学級解決を renderer 主導の単一ソースへ移す。renderer が `resolveExamClassroomPlacement` で解決し、書き出しに必要な情報だけ（`StudentExportPlacement`）を main へ渡す。main の `getStudentClassInfoForExam` を撤去。

Closes #938

## 変更点

- renderer 共通ヘルパ `loadStudentExportPlacements` を新設し、placement を実消費する4経路（Excel出力・Excelプレビュー・個別レポート出力/プレビュー）へ配線。
- `fetchExportData(examId, ids, studentPlacements?)` へ変更（未指定は `memberships[0]` フォールバック）。placement 不要な validate/R/PDF は未渡し。
- 境界型 `ExamClassroomPlacement` を `src/lib/examClassroomPlacement.ts` へ移設（05 の import 更新）。
- resolver 単体テスト追加・統合テスト更新。
- `docs/coding-style.md` §型管理の方針へ規約差分を追記（co-pending の並行セッション変更が同居）。

## 検証

- `npm run typecheck` / `npm run lint` 緑
- `npx vitest run` は既知の無関係 grade テスト1件を除き緑
- コードレビュー(high)で検出したプレビュー経路の placement 渡し漏れを修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)