### PR TITLE
chore(naming): Classroom リネーム一連(#915-#944)のコメント/docs/識別子の陳腐化を適正化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,8 @@ npx prisma studio
 ├── /src/app                     # Next.js App Router
 │   ├── /answer-sheet-builder    # 答案用紙ビルダー
 │   │   └── /[definitionId]      # 個別定義
-│   ├── /classes                 # 学級管理
-│   │   └── /[classId]           # 個別学級管理
+│   ├── /classrooms              # 学級管理
+│   │   └── /[classroomId]       # 個別学級管理
 │   ├── /dashboard               # ダッシュボード
 │   ├── /exams                   # 試験管理
 │   │   └── /[examId]            # 個別試験（8段階ワークフロー）
@@ -114,7 +114,7 @@ npx prisma studio
 ├── /src/components              # Reactコンポーネント
 │   ├── /answer-sheet-builder    # 答案用紙ビルダー
 │   ├── /auth                    # 認証コンポーネント
-│   ├── /class                   # 学級管理コンポーネント
+│   ├── /classroom               # 学級管理コンポーネント
 │   ├── /common                  # 共通コンポーネント
 │   ├── /drawing                 # 描画・アノテーション
 │   ├── /exams                   # 試験関連（8段階ワークフロー対応）

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -15,7 +15,7 @@ import { resolve } from "path"
 import { describe, expect, it } from "vitest"
 
 import {
-  CLASS_CASCADE_MOVERS,
+  CLASSROOM_CASCADE_MOVERS,
   STUDENT_CASCADE_MOVERS,
   SUBTOTAL_GROUP_CASCADE_MOVERS,
 } from "../../../electron-src/lib/import/merge/idChangeExecutor"
@@ -56,7 +56,7 @@ function cascadeChildrenFromSchema(target: string): string[] {
 describe("ID変更時のカスケード網羅性（schema.prisma駆動）", () => {
   const cases = [
     { target: "Student", movers: STUDENT_CASCADE_MOVERS },
-    { target: "Classroom", movers: CLASS_CASCADE_MOVERS },
+    { target: "Classroom", movers: CLASSROOM_CASCADE_MOVERS },
     { target: "SubtotalGroup", movers: SUBTOTAL_GROUP_CASCADE_MOVERS },
   ]
 

--- a/docs/import-export-architecture.md
+++ b/docs/import-export-architecture.md
@@ -107,7 +107,7 @@ interface ArchiveManifest {
 | `examStudents`               | 試験-生徒紐づけ                                         |
 | `userExams`                  | 空配列 (v0.3.0+、インポート時に現在のユーザーで再作成)  |
 | `examSubtotalGroups`         | 試験-小計グループ紐づけ                                 |
-| `examClasses`                | 試験-学級紐づけ                                         |
+| `examClassrooms`             | 試験-学級紐づけ                                         |
 | `examMarkingFormats`         | 採点マーク設定 (v1.4.0+)                                |
 | `examExportSettings`         | エクスポート設定 (v1.4.0+)                              |
 | `cropRegionMarkingOverrides` | 領域別マーク上書き設定 (v1.4.0+)                        |
@@ -138,7 +138,7 @@ flowchart TD
 | 1    | Prisma `exam.findUnique` + includes    | examPages, cropRegions, questionScores, drawingAnnotations を一括取得 |
 | 2    | 関連する生徒IDを収集                   | examStudents, studentAnswerImages, questionScores から                |
 | 3    | 生徒データを取得                       | `student.findMany`                                                    |
-| 4    | 学級と所属を取得                       | StudentClassMembership 経由                                           |
+| 4    | 学級と所属を取得                       | StudentClassroomMembership 経由                                       |
 | 5    | 現在ユーザーのみ取得                   | **パスワード除外** (`select` で passcode を除外)                      |
 | 6    | (欠番)                                 | -                                                                     |
 | 7    | 小計グループ・小計を取得               | examSubtotalGroups 経由                                               |
@@ -190,7 +190,7 @@ flowchart TD
 
     subgraph "Stage 1: 単一トランザクション"
         I --> J[processStudentIdIntegration]
-        J --> K[processClassIdIntegration]
+        J --> K[processClassroomIdIntegration]
         K --> L[processSubtotalGroupIdIntegration]
         L --> M[processSubtotals]
         M --> N[processExam]
@@ -225,7 +225,7 @@ flowchart TD
 | 順序 | 関数                                | 処理内容                                       |
 | ---- | ----------------------------------- | ---------------------------------------------- |
 | 1    | `processStudentIdIntegration`       | 生徒のID照合 + 新規作成/既存紐づけ             |
-| 2    | `processClassIdIntegration`         | 学級のID照合 + 新規作成/既存紐づけ             |
+| 2    | `processClassroomIdIntegration`     | 学級のID照合 + 新規作成/既存紐づけ             |
 | 3    | `processSubtotalGroupIdIntegration` | 小計グループのID照合 + 新規作成/既存紐づけ     |
 | 4    | `processSubtotals`                  | 小計のマージ (名前+グループで重複チェック)     |
 | 5    | `processExam`                       | 試験作成 or 既存マージ判定                     |
@@ -317,7 +317,7 @@ flowchart TD
 | カテゴリ                     | UUID照合 | 二次照合キー                      |
 | ---------------------------- | -------- | --------------------------------- |
 | 生徒 (Student)               | id       | studentNumber, lastName+firstName |
-| 学級 (Class)                 | id       | name, classCode                   |
+| 学級 (Classroom)             | id       | name, classroomCode               |
 | 小計グループ (SubtotalGroup) | id       | name                              |
 | ユーザー (User)              | id       | username                          |
 | 試験 (Exam)                  | id       | (なし - ID一致のみ)               |
@@ -453,7 +453,7 @@ flowchart TD
         DB_QS[QuestionScore]
         DB_DA[DrawingAnnotation]
         DB_S[Student]
-        DB_C[Class]
+        DB_C[Classroom]
         DB_U[User]
         DB_SG[SubtotalGroup]
         DB_MI[MasterImage]
@@ -569,7 +569,7 @@ flowchart TD
 | ---------------------------------------------------------------- | ----------------------------------------------------------- |
 | `electron-src/lib/import/merge/matcher.ts`                       | 全カテゴリのマッチング統合、事前照合 (`performPreMatching`) |
 | `electron-src/lib/import/merge/matchers/studentMatcher.ts`       | 生徒のマッチング (UUID、学籍番号、氏名)                     |
-| `electron-src/lib/import/merge/matchers/classMatcher.ts`         | 学級のマッチング (UUID、名前、classCode)                    |
+| `electron-src/lib/import/merge/matchers/classroomMatcher.ts`     | 学級のマッチング (UUID、名前、classroomCode)                |
 | `electron-src/lib/import/merge/matchers/subtotalGroupMatcher.ts` | 小計グループのマッチング (UUID、名前)                       |
 | `electron-src/lib/import/merge/matchers/userMatcher.ts`          | ユーザーのマッチング (UUID、username)                       |
 | `electron-src/lib/import/merge/matchers/types.ts`                | マッチャー共通型定義                                        |

--- a/docs/import-export-tests.md
+++ b/docs/import-export-tests.md
@@ -37,7 +37,7 @@ __tests__/
 │   │   ├── idIntegrationImporter.test.ts # ID統合インポート全体
 │   │   ├── subtotalGroupProcessor.test.ts # 小計グループ処理
 │   │   ├── studentProcessor.test.ts     # 生徒処理
-│   │   ├── classProcessor.test.ts       # 学級処理
+│   │   ├── classroomProcessor.test.ts   # 学級処理
 │   │   ├── idChangeExecutor.test.ts     # ID変更の実行
 │   │   └── scoringConflictDetector.test.ts # 採点競合の検出
 │   └── scenarios/                   # シナリオテスト
@@ -69,9 +69,9 @@ __tests__/
 
 DBに完全な試験データを一式作成するヘルパー。
 
-| 関数                                  | 説明                                                                                                 |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `createFullTestExam(prisma, options)` | User, Exam, Pages, CropRegions, Students, Class, QuestionScores 等を一括作成し、全エンティティを返す |
+| 関数                                  | 説明                                                                                                     |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `createFullTestExam(prisma, options)` | User, Exam, Pages, CropRegions, Students, Classroom, QuestionScores 等を一括作成し、全エンティティを返す |
 
 オプションで `pageCount`, `studentCount`, `includeV140Data`, `includeScores` などを制御可能。
 
@@ -256,7 +256,7 @@ DBから試験データを収集する `collectExamData` 関数を検証。
 | DC-9  | v1.4.0データが収集される                       | ExamMarkingFormat等の収集  |
 | DC-10 | Subject/SubjectSubtotalGroupデータが収集される | 教科データの収集           |
 | DC-11 | 画像パスが相対パスで取得される                 | パス形式の確認             |
-| DC-12 | Classがメンバーシップ経由で収集される          | 学級の間接収集             |
+| DC-12 | Classroomがメンバーシップ経由で収集される      | 学級の間接収集             |
 
 ### archiveRoundTrip.test.ts（11テスト）
 
@@ -346,7 +346,7 @@ DBから試験データを収集する `collectExamData` 関数を検証。
 | インポートデータの方が新しい場合にフィールドが更新される         | フィールド更新（use_newer/新しい） |
 | インポートデータの方が古い場合はフィールドが更新されない         | フィールド更新（use_newer/古い）   |
 
-### classProcessor.test.ts（9テスト）
+### classroomProcessor.test.ts（9テスト）
 
 学級レコードのID統合処理を検証。
 
@@ -441,7 +441,7 @@ Stage 2のID変更処理（レコード再作成 + FK更新 + 旧レコード削
 | B3     | ExamExportSettingsがインポートで処理されることを確認              | パス |
 | B3     | CropRegionMarkingOverrideがインポートで処理されることを確認       | パス |
 | B3     | Subject/SubjectSubtotalGroupがインポートで処理されることを確認    | パス |
-| B3     | ExamClassがインポートで処理されることを確認                       | パス |
+| B3     | ExamClassroomがインポートで処理されることを確認                   | パス |
 | B4     | ID変更時のUNIQUE制約がtemp-value方式で回避される                  | todo |
 | B5     | create_new決定では学籍番号にサフィックスを付与して新規作成する    | パス |
 | B6     | 既存ページはcounts.unchanged.pages++でカウントされる              | パス |

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -232,7 +232,7 @@ export function setupMiscHandlers(): void {
     }
   )
 
-  // Class handlers
+  // Classroom handlers
   registerHandler("fetch-classrooms", async () => {
     return await fetchClassrooms()
   })

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -62,7 +62,7 @@ export function setupStudentHandlers(): void {
     return await deleteStudent(id)
   })
 
-  // Student Class Membership handlers
+  // Student Classroom Membership handlers
   registerHandler(
     "create-student-class-membership",
     async (membershipData: Prisma.StudentClassroomMembershipCreateInput) => {

--- a/electron-src/lib/import/coursework-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/coursework-archive/archiveExtractor.ts
@@ -61,7 +61,7 @@ export async function extractCourseworkArchive(archivePath: string): Promise<{
       return { success: false, error: "マニフェストファイルが見つかりません" }
     }
 
-    // 学級リネーム前の旧キー（classroomId/classes）は読取り時に現行キーへ正規化
+    // 学級リネーム前の旧キー（classId/classes/className/classCode）は読取り時に現行キー（classroom*）へ正規化
     const courseworks = normalizeLegacyClassroomKeys(
       readJsonFile<ArchiveCourseworkRef[]>(tempDir, "courseworks.json") ?? []
     )

--- a/electron-src/lib/import/exam-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/exam-archive/archiveExtractor.ts
@@ -96,7 +96,7 @@ export async function extractArchive(archivePath: string): Promise<{
 
     // 各JSONファイルを読み込み
     // v1.5.0+: exam.json, v1.4.0以前: project.json にフォールバック
-    // 学級リネーム前の旧キー（classroomId/classes）は読取り時に現行キーへ正規化
+    // 学級リネーム前の旧キー（classId/classes/className/classCode）は読取り時に現行キー（classroom*）へ正規化
     const legacyNormalizedExamData = normalizeLegacyClassroomKeys(
       readJsonFile<ArchiveExamData>(tempDir, "exam.json") ??
         readJsonFile<ArchiveExamData>(tempDir, "project.json")

--- a/electron-src/lib/import/exam-archive/idRemapper.ts
+++ b/electron-src/lib/import/exam-archive/idRemapper.ts
@@ -34,7 +34,7 @@ export interface IdMappings {
   examClassroom: Record<string, string>
   /** Student ID: 旧ID -> 新ID */
   student: Record<string, string>
-  /** Class ID: 旧ID -> 新ID */
+  /** Classroom ID: 旧ID -> 新ID */
   classroom: Record<string, string>
   /** StudentClassroomMembership ID: 旧ID -> 新ID */
   membership: Record<string, string>

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -45,7 +45,7 @@ export async function extractGradeArchive(
     }
 
     const manifest: GradeArchiveManifest = JSON.parse(manifestJson)
-    // 学級リネーム前の旧キー（className/classes/classroomId）は読取り時に現行キーへ正規化
+    // 学級リネーム前の旧キー（classId/classes/className/classCode）は読取り時に現行キー（classroom*）へ正規化
     const gradeData: ArchiveGradeData = normalizeLegacyClassroomKeys(
       JSON.parse(files["grade-exam.json"] ?? "{}")
     )

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -25,7 +25,7 @@ export async function previewGradeArchiveImport(
   const { gradeData } = data
   const courseworkArchive = data.courseworkArchive
 
-  // Class照合（複数学級対応）
+  // Classroom照合（複数学級対応）
   const classroomMatches = await Promise.all(
     gradeData.classroomRefs.map(async (ref) => {
       const existing = await prisma.classroom.findUnique({
@@ -35,7 +35,7 @@ export async function previewGradeArchiveImport(
     })
   )
 
-  // ExamExam照合
+  // Exam照合
   const examMatches = await Promise.all(
     gradeData.examRefs.map(async (ref) => {
       const exams = await prisma.exam.findMany({
@@ -164,7 +164,7 @@ export async function importGradeArchive(
           })
         }
 
-        // 2. Class照合→GradeClassroom作成
+        // 2. Classroom照合→GradeClassroom作成
         for (let i = 0; i < gradeData.classroomRefs.length; i++) {
           const ref = gradeData.classroomRefs[i]
           const classroom = await tx.classroom.findUnique({

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -2,18 +2,18 @@
  * ID変更処理
  *
  * 「書き出したPCに合わせる」を選んだ場合、既存IDを.scoreのIDに変更する。
- * 旧レコードを削除して新IDで作り直す方式のため、対象（Student/Class/SubtotalGroup）に
+ * 旧レコードを削除して新IDで作り直す方式のため、対象（Student/Classroom/SubtotalGroup）に
  * onDelete:Cascade で紐づく子テーブルは、旧レコード削除の前に必ず新IDへ移し替える
  * 必要がある。移し替え漏れがあると旧レコード削除時にサイレントにカスケード削除される。
  *
  * 【規約 / convention-as-code】
  * 対象への onDelete:Cascade 子テーブルを schema.prisma に追加したら、必ず対応する
- * CascadeMover を下記レジストリ（STUDENT/CLASS/SUBTOTAL_GROUP_CASCADE_MOVERS）へ
+ * CascadeMover を下記レジストリ（STUDENT/CLASSROOM/SUBTOTAL_GROUP_CASCADE_MOVERS）へ
  * 追加すること。レジストリと schema のカスケード子が一致しているかは
  * __tests__/import-export/unit/cascadeCoverage.test.ts が schema.prisma を解析して
  * 自動検証する（追加忘れはテストが赤くなって検出される）。
  *
- * UNIQUE制約のあるフィールド（Student.studentNumber, Class.name）は temp-value方式で回避:
+ * UNIQUE制約のあるフィールド（Student.studentNumber, Classroom.name）は temp-value方式で回避:
  * 既存レコードのUNIQUEフィールドを一時値に変更してから新レコードを作成し、旧を削除する。
  */
 
@@ -204,9 +204,9 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
 ]
 
 /**
- * Class に onDelete:Cascade で紐づく子テーブル全件。
+ * Classroom に onDelete:Cascade で紐づく子テーブル全件。
  */
-export const CLASS_CASCADE_MOVERS: CascadeMover[] = [
+export const CLASSROOM_CASCADE_MOVERS: CascadeMover[] = [
   {
     model: "StudentClassroomMembership",
     move: (tx, from, to) =>
@@ -382,7 +382,7 @@ async function changeStudentId(
 
 /**
  * 学級IDの変更（temp-value方式 + カスケード子の移し替え）
- * 移し替え対象は CLASS_CASCADE_MOVERS を参照（schema と一致をテストで強制）。
+ * 移し替え対象は CLASSROOM_CASCADE_MOVERS を参照（schema と一致をテストで強制）。
  */
 async function changeClassroomId(
   tx: PrismaTransaction,
@@ -417,7 +417,7 @@ async function changeClassroomId(
 
   // 3. カスケード子を全件移し替え（旧学級削除前に必須）
   await moveCascadeChildren(
-    CLASS_CASCADE_MOVERS,
+    CLASSROOM_CASCADE_MOVERS,
     tx,
     target.existingId,
     target.newId

--- a/electron-src/preload-apis/studentApi.ts
+++ b/electron-src/preload-apis/studentApi.ts
@@ -25,7 +25,7 @@ export function createStudentApi() {
         error?: string
       }>,
 
-    // Class related
+    // Classroom related
     fetchClassrooms: () => ipcRenderer.invoke("fetch-classrooms"),
     createClassroom: (classroomData: Prisma.ClassroomCreateInput) =>
       ipcRenderer.invoke("create-class", classroomData),
@@ -44,7 +44,7 @@ export function createStudentApi() {
         error?: string
       }>,
 
-    // Student Class Membership related
+    // Student Classroom Membership related
     createStudentClassroomMembership: (
       membershipData: Prisma.StudentClassroomMembershipCreateInput
     ) => ipcRenderer.invoke("create-student-class-membership", membershipData),

--- a/src/components/common/classroom-roster/types.ts
+++ b/src/components/common/classroom-roster/types.ts
@@ -12,7 +12,7 @@ import type { ReactNode } from "react"
 export interface ClassroomRosterEntry {
   /** リンクのID（examClassroomId / gradeClassroom.id / courseworkClassroom.id） */
   id: string
-  /** 学級ID（Class.id） */
+  /** 学級ID（Classroom.id） */
   classroomId: string
   /** 学級名 */
   name: string

--- a/src/types/electron/classroomStudentApi.d.ts
+++ b/src/types/electron/classroomStudentApi.d.ts
@@ -41,7 +41,7 @@ interface ClassroomStudentExamResult {
  * 学級・生徒・所属関連API
  */
 export interface ClassroomStudentAPI {
-  // Class related
+  // Classroom related
   fetchClassrooms: () => Promise<ClassroomWithMemberships[]>
   getClassroomsNotInExam: (
     examId: string,
@@ -99,7 +99,7 @@ export interface ClassroomStudentAPI {
     error?: string
   }>
 
-  // Student Class Membership related
+  // Student Classroom Membership related
   createStudentClassroomMembership: (
     membershipData: Prisma.StudentClassroomMembershipCreateInput
   ) => Promise<StudentClassroomMembershipWithDetails>


### PR DESCRIPTION
Closes #945

## 概要

Class→Classroom リネーム一連（#915-#944）のマージ後に残っていた**コメント・ドキュメント・改名漏れ識別子**を適正化し、あわせて **transformer / migration が保全されていることを確認**した。

## 変更点

- **コメント17件**の stale な実体参照を訂正（`Class`→`Classroom`、`Class照合`→`Classroom照合`、二重適用 `ExamExam照合`→`Exam照合`、extractor の旧キー説明を `classId` 系へ修正）
- **改名漏れ識別子** `CLASS_CASCADE_MOVERS` → `CLASSROOM_CASCADE_MOVERS`（全参照・テスト更新）
- **CLAUDE.md** のルート/コンポーネントディレクトリを実体（`classrooms/[classroomId]`・`classroom`）に追従
- **docs/import-export-architecture.md** の壊れた参照修正（改名済みファイルパス `classroomMatcher.ts`・シンボル `processClassroomIdIntegration`・`examClassrooms`・現行スキーマ表 `Classroom/classroomCode`・mermaid ノード）
- **docs/import-export-tests.md** の改名済みテスト参照（`classroomProcessor.test.ts` 等）

## transformer / migration の保全確認（結論: 保全済み）

- `prisma/migrations/` は series で**新規5件追加のみ・既存改変ゼロ**。
- transformer が `classroomName`/`classrooms` を参照するのは正しい（読取り境界の `normalizeLegacyClassroomKeys` が transformer チェーンより先に走る `extract+normalize → transform` の順のため）。

## 保全（改名してはいけない landmine）

- 物理/歴史スキーマ旧名（`ProjectClass`/`ExamClass`/`GradeClass`/`StudentClassMembership`/`classId`/`classCode`）
- アーカイブ形状型名（`ArchiveCwClass`/`ArchiveClassesData`）・物理JSONキー・旧互換 `teacherStat`
- version履歴表・schema-history・設計スナップショット `class-statistics-redesign.md`（歴史記録）

## 検証

- typecheck 0 / lint clean / 関連テスト58件パス / code-review（高精度・4 finder + 検証パス）指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHRv6MXsoNSc3ULxjw6oR9
