### PR TITLE
refactor(06-student-answers): 採点セルの同一性設計刷新とFK保存バグ修正

### DIFF
--- a/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
@@ -57,7 +57,6 @@ export function convertAnswerSheetsToFiles(
 
       // テーブルDnD統合用
       color: undefined,
-      position: undefined,
     }
   })
 }

--- a/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
@@ -13,7 +13,7 @@ import {
 import { TableCell } from "@/components/ui/table"
 
 export function EmptyTableCell({
-  student,
+  examStudent,
   pageNumber,
   isPositionDisabled,
   isPendingChange = false,
@@ -75,9 +75,10 @@ export function EmptyTableCell({
             ) : (
               <div className="text-xs text-gray-400">
                 {hasExistingAnswer ? "答案画像あり" : "空セル"}
-                {student && (
+                {examStudent && (
                   <div className="mt-1">
-                    {student.student.lastName} {student.student.firstName}
+                    {examStudent.student.lastName}{" "}
+                    {examStudent.student.firstName}
                   </div>
                 )}
                 {pageNumber && <div>P{pageNumber}</div>}

--- a/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
@@ -26,13 +26,13 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
-    togglePositionDisabled,
+    toggleCellDisabled,
     toggleFileDisabled,
     sortedStudents,
     getEnabledFiles,
     getFileColor,
     tableData,
-    positionsWithExistingAnswers,
+    cellsWithExistingAnswers,
     sensors,
     activeFile,
     handleDragStart,
@@ -113,7 +113,7 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
                 mode={mode}
                 previewMode={previewMode}
                 nameRegionAvailable={nameRegionAvailable}
-                positionsWithExistingAnswers={positionsWithExistingAnswers}
+                cellsWithExistingAnswers={cellsWithExistingAnswers}
                 allowOverwrite={allowOverwrite}
                 files={props.files}
                 affectedCells={affectedCells}
@@ -125,7 +125,7 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
                 drawNameRegionCanvas={drawNameRegionCanvas}
                 toggleRowDisabled={toggleRowDisabled}
                 toggleColDisabled={toggleColDisabled}
-                togglePositionDisabled={togglePositionDisabled}
+                toggleCellDisabled={toggleCellDisabled}
                 toggleFileDisabled={toggleFileDisabled}
                 onUploadModalOpen={handleUploadModalOpen}
                 onDeleteAnswerSheet={handleDeleteAnswerSheet}

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -3,8 +3,13 @@ import { rectSortingStrategy, SortableContext } from "@dnd-kit/sortable"
 import { EmptyTableCell } from "@/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell"
 import { FilePreviewCell } from "@/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell"
 import { SortableTableCell } from "@/components/exams/06-student-answers/student-answer-table/components/SortableTableCell"
-import type { PreviewMode } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  ExtendedDisabledState,
+  PreviewMode,
+} from "@/components/exams/06-student-answers/student-answer-table/types"
 import type { DisabledReason } from "@/components/exams/06-student-answers/student-answer-table/types/localTypes"
+import type { CellLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import { lookupHasCell } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
 import {
   Table,
@@ -19,24 +24,17 @@ interface TableContentProps {
   tableData: Array<
     Array<{
       type: "file" | "empty" | "disabled"
-      position: number
       file?: UnifiedFile
-      student?: ExamStudentWithMemberships
-      pageNumber?: number
+      disabledReason?: DisabledReason
     }>
   >
   sortedStudents: ExamStudentWithMemberships[]
   maxPages: number
-  disabledState: {
-    rows: Set<number>
-    cols: Set<number>
-    positions: Set<number>
-    files: Set<string>
-  }
+  disabledState: ExtendedDisabledState
   mode: "upload" | "view"
   previewMode: PreviewMode
   nameRegionAvailable: Record<number, boolean>
-  positionsWithExistingAnswers: Set<number>
+  cellsWithExistingAnswers: CellLookup
   allowOverwrite: boolean
   files: UnifiedFile[]
   affectedCells?: Set<string>
@@ -49,12 +47,11 @@ interface TableContentProps {
     file: UnifiedFile,
     pageNumber: number
   ) => Promise<string | null>
-  toggleRowDisabled: (index: number) => void
-  toggleColDisabled: (index: number) => void
-  togglePositionDisabled: (position: number) => void
+  toggleRowDisabled: (examStudentId: string) => void
+  toggleColDisabled: (pageNumber: number) => void
+  toggleCellDisabled: (studentId: string, pageNumber: number) => void
   toggleFileDisabled: (fileId: string) => void
   onUploadModalOpen: (
-    position: number,
     studentName: string | undefined,
     pageNumber: number | undefined
   ) => void
@@ -69,7 +66,7 @@ export function TableContent({
   mode,
   previewMode,
   nameRegionAvailable,
-  positionsWithExistingAnswers,
+  cellsWithExistingAnswers,
   allowOverwrite,
   files,
   affectedCells,
@@ -81,7 +78,7 @@ export function TableContent({
   drawNameRegionCanvas,
   toggleRowDisabled,
   toggleColDisabled,
-  togglePositionDisabled,
+  toggleCellDisabled,
   toggleFileDisabled,
   onUploadModalOpen,
   onDeleteAnswerSheet,
@@ -95,32 +92,30 @@ export function TableContent({
         <UITableHeader>
           <TableRow>
             {/* 生徒名列ヘッダー */}
-            <TableHead
-              className={`w-32 border text-center ${mode === "upload" ? "cursor-pointer" : ""}`}
-              onClick={
-                mode === "upload" ? () => toggleColDisabled(-1) : undefined
-              }
-            >
-              生徒名
-            </TableHead>
+            <TableHead className="w-32 border text-center">生徒名</TableHead>
             {/* ページ列ヘッダー */}
-            {Array.from({ length: maxPages }, (_, pageIndex) => (
-              <TableHead
-                key={pageIndex}
-                className={`w-32 border text-center ${
-                  mode === "upload" ? "cursor-pointer" : ""
-                } ${
-                  disabledState.cols.has(pageIndex) ? "bg-gray-200" : "bg-white"
-                }`}
-                onClick={
-                  mode === "upload"
-                    ? () => toggleColDisabled(pageIndex)
-                    : undefined
-                }
-              >
-                ページ {pageIndex + 1}
-              </TableHead>
-            ))}
+            {Array.from({ length: maxPages }, (_, pageIndex) => {
+              const pageNumber = pageIndex + 1
+              return (
+                <TableHead
+                  key={pageNumber}
+                  className={`w-32 border text-center ${
+                    mode === "upload" ? "cursor-pointer" : ""
+                  } ${
+                    disabledState.cols.includes(pageNumber)
+                      ? "bg-gray-200"
+                      : "bg-white"
+                  }`}
+                  onClick={
+                    mode === "upload"
+                      ? () => toggleColDisabled(pageNumber)
+                      : undefined
+                  }
+                >
+                  ページ {pageNumber}
+                </TableHead>
+              )
+            })}
           </TableRow>
         </UITableHeader>
         <TableBody>
@@ -131,13 +126,13 @@ export function TableContent({
                 className={`border text-center ${
                   mode === "upload" ? "cursor-pointer" : ""
                 } ${
-                  disabledState.rows.has(studentIndex)
+                  disabledState.rows.includes(sortedStudents[studentIndex].id)
                     ? "bg-gray-200"
                     : "bg-white"
                 }`}
                 onClick={
                   mode === "upload"
-                    ? () => toggleRowDisabled(studentIndex)
+                    ? () => toggleRowDisabled(sortedStudents[studentIndex].id)
                     : undefined
                 }
               >
@@ -154,22 +149,23 @@ export function TableContent({
 
               {/* ファイルセル */}
               {row.map((cellData, pageIndex) => {
+                // セル座標から生徒・ページを投射（セルは同一性を保持しない）
+                const examStudent = sortedStudents[studentIndex]
+                const pageNumber = pageIndex + 1
+
                 if (cellData.type === "disabled" || cellData.type === "empty") {
                   return (
                     <EmptyTableCellWithLogic
-                      key={cellData.position}
+                      key={pageNumber}
                       cellData={cellData}
-                      studentIndex={studentIndex}
-                      pageIndex={pageIndex}
-                      sortedStudents={sortedStudents}
-                      disabledState={disabledState}
+                      examStudent={examStudent}
+                      pageNumber={pageNumber}
                       mode={mode}
-                      positionsWithExistingAnswers={
-                        positionsWithExistingAnswers
-                      }
+                      cellsWithExistingAnswers={cellsWithExistingAnswers}
                       allowOverwrite={allowOverwrite}
                       files={files}
-                      togglePositionDisabled={togglePositionDisabled}
+                      disabledFiles={disabledState.files}
+                      toggleCellDisabled={toggleCellDisabled}
                       toggleFileDisabled={toggleFileDisabled}
                       onUploadModalOpen={onUploadModalOpen}
                     />
@@ -181,7 +177,11 @@ export function TableContent({
                 const isFileDisabled = disabledState.files.has(file.id)
                 const hasExistingAnswer =
                   mode === "upload" &&
-                  positionsWithExistingAnswers.has(cellData.position)
+                  lookupHasCell(
+                    cellsWithExistingAnswers,
+                    examStudent.studentId,
+                    pageNumber
+                  )
                 // 上書き無効時で既存答案がある場合はドラッグ無効
                 const isDragDisabledByOverwrite =
                   hasExistingAnswer && !allowOverwrite
@@ -190,13 +190,16 @@ export function TableContent({
                   <SortableTableCell
                     key={file.id}
                     id={file.id}
-                    position={cellData.position}
                     hasFile={true}
                     isPositionDisabled={isDragDisabledByOverwrite}
                     isFileDisabled={isFileDisabled}
                     onTogglePosition={
                       mode === "upload"
-                        ? () => togglePositionDisabled(cellData.position)
+                        ? () =>
+                            toggleCellDisabled(
+                              examStudent.studentId,
+                              pageNumber
+                            )
                         : () => {}
                     }
                     onToggleFileDisabled={
@@ -209,11 +212,11 @@ export function TableContent({
                     observerRef={observerRef}
                     mode={mode}
                     studentName={
-                      cellData.student
-                        ? `${cellData.student.student.lastName} ${cellData.student.student.firstName}`
+                      examStudent
+                        ? `${examStudent.student.lastName} ${examStudent.student.firstName}`
                         : undefined
                     }
-                    pageNumber={cellData.pageNumber ?? undefined}
+                    pageNumber={pageNumber}
                     hasScoreData={true}
                     onDeleteFileWithScoring={() => {
                       if (onDeleteAnswerSheet) {
@@ -223,12 +226,10 @@ export function TableContent({
                   >
                     <FilePreviewCell
                       file={file}
-                      pageNumber={cellData.pageNumber || 1}
+                      pageNumber={pageNumber}
                       previewMode={previewMode}
                       isFileDisabled={isFileDisabled}
-                      nameRegionAvailable={
-                        nameRegionAvailable[cellData.pageNumber || 1]
-                      }
+                      nameRegionAvailable={nameRegionAvailable[pageNumber]}
                       getFileColor={getFileColor}
                       drawNameRegionCanvas={drawNameRegionCanvas}
                       imageLoadState={imageLoadStates[file.id]}
@@ -248,32 +249,24 @@ export function TableContent({
   )
 }
 
-// 空セルのロジックを分離したコンポーネント
+// 空セル・無効セルの表示ロジック。無効理由は生成側で確定済みのものを
+// 受け取り（cellData.disabledReason）、ここでは再計算せず「流す」だけ。
 interface EmptyTableCellWithLogicProps {
   cellData: {
     type: "empty" | "disabled" | "file"
-    position: number
-    student?: ExamStudentWithMemberships
-    pageNumber?: number
     file?: UnifiedFile
+    disabledReason?: DisabledReason
   }
-  studentIndex: number
-  pageIndex: number
-  sortedStudents: ExamStudentWithMemberships[]
-  disabledState: {
-    rows: Set<number>
-    cols: Set<number>
-    positions: Set<number>
-    files: Set<string>
-  }
+  examStudent: ExamStudentWithMemberships
+  pageNumber: number
   mode: "upload" | "view"
-  positionsWithExistingAnswers: Set<number>
+  cellsWithExistingAnswers: CellLookup
   allowOverwrite: boolean
   files: UnifiedFile[]
-  togglePositionDisabled: (position: number) => void
+  disabledFiles: Set<string>
+  toggleCellDisabled: (studentId: string, pageNumber: number) => void
   toggleFileDisabled: (fileId: string) => void
   onUploadModalOpen: (
-    position: number,
     studentName: string | undefined,
     pageNumber: number | undefined
   ) => void
@@ -281,82 +274,48 @@ interface EmptyTableCellWithLogicProps {
 
 function EmptyTableCellWithLogic({
   cellData,
-  studentIndex,
-  pageIndex,
-  sortedStudents,
-  disabledState,
+  examStudent,
+  pageNumber,
   mode,
-  positionsWithExistingAnswers,
+  cellsWithExistingAnswers,
   allowOverwrite,
   files,
-  togglePositionDisabled,
+  disabledFiles,
+  toggleCellDisabled,
   toggleFileDisabled,
   onUploadModalOpen,
 }: EmptyTableCellWithLogicProps) {
-  // 既存答案があるかチェック（空セルまたは無効セル用）
+  // 既存答案があるか（オーバーレイ用）
   const hasExistingAnswerForEmpty =
     mode === "upload" &&
     (cellData.type === "empty" || cellData.type === "disabled") &&
-    positionsWithExistingAnswers.has(cellData.position)
+    lookupHasCell(cellsWithExistingAnswers, examStudent.studentId, pageNumber)
 
-  // そのセルに新しく追加しようとしている画像ファイルがあるかチェック
+  // そのセルに新しく追加しようとしている画像ファイルがあるか
   const newFileInCell = files.find(
     (file) =>
-      file.studentId === cellData.student?.id &&
-      file.pageNumber === cellData.pageNumber &&
-      !disabledState.files.has(file.id)
+      file.studentId === examStudent.studentId &&
+      file.pageNumber === pageNumber &&
+      !disabledFiles.has(file.id)
   )
   const hasNewFileToUpload = !!newFileInCell
 
-  // 無効化の理由を判定
-  let disabledReason: DisabledReason = undefined
-  if (cellData.type === "disabled") {
-    const student = sortedStudents[studentIndex]
-
-    if (disabledState.rows.has(studentIndex)) {
-      // 行無効の場合、欠席生徒かどうかをチェック
-      if (student?.status === "absent") {
-        disabledReason = "absent_student"
-      } else {
-        disabledReason = "row"
-      }
-    } else if (disabledState.cols.has(pageIndex)) {
-      disabledReason = "column"
-    } else if (disabledState.positions.has(cellData.position)) {
-      disabledReason = "position"
-    } else if (
-      mode === "upload" &&
-      !allowOverwrite &&
-      positionsWithExistingAnswers.has(cellData.position)
-    ) {
-      disabledReason = "existing_answer"
-    } else {
-      // 他の理由で無効化されている場合はundefinedのまま
-      disabledReason = undefined
-    }
-  }
+  const studentName = `${examStudent.student.lastName} ${examStudent.student.firstName}`
 
   return (
     <EmptyTableCell
-      position={cellData.position}
-      student={cellData.student || null}
-      pageNumber={cellData.pageNumber || null}
+      examStudent={examStudent}
+      pageNumber={pageNumber}
       isPositionDisabled={cellData.type === "disabled"}
       isPendingChange={false}
       mode={mode}
       hasExistingAnswer={hasExistingAnswerForEmpty}
       allowOverwrite={allowOverwrite}
-      disabledReason={disabledReason}
-      onTogglePosition={() => togglePositionDisabled(cellData.position)}
-      onUploadToCell={() => {
-        onUploadModalOpen(
-          cellData.position,
-          cellData.student
-            ? `${cellData.student.student.lastName} ${cellData.student.student.firstName}`
-            : undefined,
-          cellData.pageNumber ?? undefined
-        )
-      }}
+      disabledReason={cellData.disabledReason}
+      onTogglePosition={() =>
+        toggleCellDisabled(examStudent.studentId, pageNumber)
+      }
+      onUploadToCell={() => onUploadModalOpen(studentName, pageNumber)}
       onToggleAnswerDisabled={() => {
         if (newFileInCell) {
           toggleFileDisabled(newFileInCell.id)

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
@@ -1,103 +1,112 @@
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import { manualDisabledReason } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
-/** 答案テーブルの行・列・セル単位の無効化状態と上書きモードを管理するフック */
+/**
+ * 答案テーブルの行・列・セル単位の無効化状態と上書きモードを管理するフック。
+ * 同一性でキーする: 行 = examStudentId[]、列 = pageNumber[]、
+ * セル = {studentId, pageNumber}[]（いずれも少数なので配列）、
+ * files = Set<fileId>（アップロードで多数になりうるので O(1)）。
+ */
 export function useDisabledState() {
   const [disabledState, setDisabledState] = useState<ExtendedDisabledState>({
-    rows: new Set(),
-    cols: new Set(),
-    positions: new Set(),
+    rows: [],
+    cols: [],
+    cells: [],
     files: new Set(),
   })
 
   // 既存答案上書きモードの状態管理
   const [allowOverwrite, setAllowOverwrite] = useState(false)
 
-  const toggleRowDisabled = useCallback((rowIndex: number) => {
-    setDisabledState((prev) => {
-      const newRows = new Set(prev.rows)
-      if (newRows.has(rowIndex)) {
-        newRows.delete(rowIndex)
-      } else {
-        newRows.add(rowIndex)
-      }
-      return { ...prev, rows: newRows }
-    })
+  const toggleRowDisabled = useCallback((examStudentId: string) => {
+    setDisabledState((prev) => ({
+      ...prev,
+      rows: prev.rows.includes(examStudentId)
+        ? prev.rows.filter(
+            (rowExamStudentId) => rowExamStudentId !== examStudentId
+          )
+        : [...prev.rows, examStudentId],
+    }))
   }, [])
 
-  const toggleColDisabled = useCallback((colIndex: number) => {
-    setDisabledState((prev) => {
-      const newCols = new Set(prev.cols)
-      if (newCols.has(colIndex)) {
-        newCols.delete(colIndex)
-      } else {
-        newCols.add(colIndex)
-      }
-      return { ...prev, cols: newCols }
-    })
+  const toggleColDisabled = useCallback((pageNumber: number) => {
+    setDisabledState((prev) => ({
+      ...prev,
+      cols: prev.cols.includes(pageNumber)
+        ? prev.cols.filter((colPageNumber) => colPageNumber !== pageNumber)
+        : [...prev.cols, pageNumber],
+    }))
   }, [])
 
-  const togglePositionDisabled = useCallback((position: number) => {
-    setDisabledState((prev) => {
-      const newPositions = new Set(prev.positions)
-      if (newPositions.has(position)) {
-        newPositions.delete(position)
-      } else {
-        newPositions.add(position)
-      }
-      return { ...prev, positions: newPositions }
-    })
-  }, [])
+  const toggleCellDisabled = useCallback(
+    (studentId: string, pageNumber: number) => {
+      setDisabledState((prev) => {
+        const alreadyDisabled = prev.cells.some(
+          (cell) =>
+            cell.studentId === studentId && cell.pageNumber === pageNumber
+        )
+        return {
+          ...prev,
+          cells: alreadyDisabled
+            ? prev.cells.filter(
+                (cell) =>
+                  !(
+                    cell.studentId === studentId &&
+                    cell.pageNumber === pageNumber
+                  )
+              )
+            : [...prev.cells, { studentId, pageNumber }],
+        }
+      })
+    },
+    []
+  )
 
   const toggleFileDisabled = useCallback((fileId: string) => {
     setDisabledState((prev) => {
-      const newFiles = new Set(prev.files)
-      if (newFiles.has(fileId)) {
-        newFiles.delete(fileId)
+      const nextFiles = new Set(prev.files)
+      if (nextFiles.has(fileId)) {
+        nextFiles.delete(fileId)
       } else {
-        newFiles.add(fileId)
+        nextFiles.add(fileId)
       }
-      return { ...prev, files: newFiles }
+      return { ...prev, files: nextFiles }
     })
   }, [])
 
-  const isPositionDisabled = useCallback(
-    (studentIndex: number, pageIndex: number) => {
-      const position = studentIndex * 100 + pageIndex // Simple position calculation
+  const isCellDisabled = useCallback(
+    (examStudent: ExamStudentWithMemberships, pageNumber: number) => {
       return (
-        disabledState.rows.has(studentIndex) ||
-        disabledState.cols.has(pageIndex) ||
-        disabledState.positions.has(position)
+        manualDisabledReason(disabledState, examStudent, pageNumber) !==
+        undefined
       )
     },
     [disabledState]
   )
 
-  // 初期化関数（現在は何もしない）
+  // 欠席生徒を初期状態で行無効にする。初回ロード時のみ適用し、以降は
+  // students の参照変化で再適用しない（教員が手動で有効化した行を握り潰さないため）。
+  const didInitAbsentRef = useRef(false)
   const initializeStudentsWithoutAnswers = useCallback(
     (students: ExamStudentWithMemberships[]) => {
-      // 欠席生徒を初期状態で行無効にする（ユーザーが手動で有効化可能）
-      const sortedStudents = [...students].sort((studentA, studentB) => {
-        const studentAOrder = studentA.customOrder ?? Number.MAX_SAFE_INTEGER
-        const studentBOrder = studentB.customOrder ?? Number.MAX_SAFE_INTEGER
-        return studentAOrder - studentBOrder
-      })
+      if (didInitAbsentRef.current || students.length === 0) return
+      didInitAbsentRef.current = true
 
-      const absentStudentRows = new Set<number>()
-      sortedStudents.forEach((student, index) => {
-        if (student.status === "absent") {
-          absentStudentRows.add(index)
-        }
-      })
+      const absentExamStudentIds = students
+        .filter((examStudent) => examStudent.status === "absent")
+        .map((examStudent) => examStudent.id)
 
-      // 欠席生徒がいる場合のみ状態を更新
-      if (absentStudentRows.size > 0) {
-        setDisabledState((prev) => ({
-          ...prev,
-          rows: new Set([...prev.rows, ...absentStudentRows]),
-        }))
+      if (absentExamStudentIds.length > 0) {
+        setDisabledState((prev) => {
+          const merged = [...prev.rows]
+          for (const examStudentId of absentExamStudentIds) {
+            if (!merged.includes(examStudentId)) merged.push(examStudentId)
+          }
+          return { ...prev, rows: merged }
+        })
       }
     },
     []
@@ -107,9 +116,9 @@ export function useDisabledState() {
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
-    togglePositionDisabled,
+    toggleCellDisabled,
     toggleFileDisabled,
-    isPositionDisabled,
+    isCellDisabled,
     initializeStudentsWithoutAnswers,
     allowOverwrite,
     setAllowOverwrite,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
@@ -57,11 +57,12 @@ export function useMarkerCorrection({
     const targetMap = new Map<string, number>()
     if (markerCorrectionEnabled) {
       for (const row of tableData) {
-        for (const cell of row) {
-          if (cell.file && cell.pageNumber) {
-            targetMap.set(cell.file.id, cell.pageNumber)
+        // マスターページ番号はセルの列位置から投射（pageIndex + 1）
+        row.forEach((cell, pageIndex) => {
+          if (cell.file) {
+            targetMap.set(cell.file.id, pageIndex + 1)
           }
-        }
+        })
       }
     }
 

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -49,9 +49,9 @@ export function useStudentAnswerTableLogic({
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
-    togglePositionDisabled,
+    toggleCellDisabled,
     toggleFileDisabled,
-    isPositionDisabled,
+    isCellDisabled,
     initializeStudentsWithoutAnswers,
     allowOverwrite,
     setAllowOverwrite,
@@ -63,14 +63,14 @@ export function useStudentAnswerTableLogic({
     getDisabledFiles,
     getFileColor,
     tableData,
-    positionsWithExistingAnswers,
+    cellsWithExistingAnswers,
   } = useTableData({
     files,
     students,
     modelAnswerCount,
     fileOrder,
     disabledState,
-    isPositionDisabled,
+    isCellDisabled,
     mode,
     existingStudentAnswers,
     allowOverwrite,
@@ -168,23 +168,20 @@ export function useStudentAnswerTableLogic({
   const handleUpload = () => {
     const uploadData: UploadData[] = []
 
-    // 動的テーブルデータから配置済みファイルのアップロードデータを生成
-    tableData.forEach((row) => {
-      row.forEach((cell) => {
-        if (
-          cell.type === "file" &&
-          cell.file &&
-          cell.student &&
-          cell.pageNumber
-        ) {
+    // 動的テーブルデータから配置済みファイルのアップロードデータを生成。
+    // 生徒とページはセル座標 [studentIndex][pageIndex] から投射する。
+    tableData.forEach((row, studentIndex) => {
+      row.forEach((cell, pageIndex) => {
+        if (cell.type === "file" && cell.file) {
+          const examStudent = sortedStudents[studentIndex]
           uploadData.push({
             name: cell.file.name,
             fileName: cell.file.name,
             originalFileName: cell.file.originalFileName,
             type: cell.file.type,
             buffer: cell.file.buffer,
-            studentId: cell.student.id,
-            pageNumber: cell.pageNumber,
+            studentId: examStudent.studentId,
+            pageNumber: pageIndex + 1,
             overwrite: allowOverwrite,
             correctWithMarkers: false, // クライアント側で補正済み
             correctionStatus: cell.file.correctionStatus,
@@ -197,13 +194,11 @@ export function useStudentAnswerTableLogic({
   }
 
   const handleUploadModalOpen = (
-    position: number,
     studentName: string | undefined,
     pageNumber: number | undefined
   ) => {
     setUploadModalState({
       isOpen: true,
-      position,
       studentName,
       pageNumber,
     })
@@ -216,7 +211,7 @@ export function useStudentAnswerTableLogic({
   const handleUploadToCell = (file: File, pageNumber?: number) => {
     // TODO: 指定されたセル位置にファイルをアップロード
     console.log(
-      `Uploading to position ${uploadModalState.position}:`,
+      `Uploading to ${uploadModalState.studentName ?? "?"} p${uploadModalState.pageNumber ?? "?"}:`,
       file.name,
       pageNumber
     )
@@ -239,13 +234,13 @@ export function useStudentAnswerTableLogic({
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
-    togglePositionDisabled,
+    toggleCellDisabled,
     toggleFileDisabled,
     sortedStudents,
     getEnabledFiles,
     getFileColor,
     tableData,
-    positionsWithExistingAnswers,
+    cellsWithExistingAnswers,
     sensors,
     activeFile,
     handleDragStart,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -3,11 +3,12 @@ import { useCallback, useMemo } from "react"
 import { useTableDataGeneration } from "@/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration"
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
 import {
-  calculateDynamicDisabledPositions,
-  calculatePositionsWithExistingAnswers,
+  calculateCellsWithExistingAnswers,
+  calculateDynamicDisabledCells,
   getDisabledFiles,
   getEnabledFiles,
   getFileColor,
+  lookupHasCell,
   sortStudentsByCustomOrder,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
@@ -22,7 +23,10 @@ interface UseTableDataParams {
   modelAnswerCount: number
   fileOrder: PlacementStrategy
   disabledState: ExtendedDisabledState
-  isPositionDisabled: (studentIndex: number, pageIndex: number) => boolean
+  isCellDisabled: (
+    examStudent: ExamStudentWithMemberships,
+    pageNumber: number
+  ) => boolean
   mode?: "upload" | "view"
   existingStudentAnswers?: Array<{
     id: string
@@ -41,7 +45,7 @@ export function useTableData({
   modelAnswerCount,
   fileOrder,
   disabledState,
-  isPositionDisabled,
+  isCellDisabled,
   mode,
   existingStudentAnswers,
   allowOverwrite = false,
@@ -51,9 +55,9 @@ export function useTableData({
     return sortStudentsByCustomOrder(students)
   }, [students])
 
-  // 動的無効化位置の計算
-  const dynamicDisabledPositions = useMemo(() => {
-    return calculateDynamicDisabledPositions(
+  // 動的無効化セルの計算
+  const dynamicDisabledCells = useMemo(() => {
+    return calculateDynamicDisabledCells(
       files,
       sortedStudents,
       modelAnswerCount,
@@ -62,23 +66,25 @@ export function useTableData({
     )
   }, [files, sortedStudents, modelAnswerCount, disabledState, mode])
 
-  // 拡張されたisPositionDisabled関数
-  const enhancedIsPositionDisabled = useCallback(
-    (studentIndex: number, pageIndex: number) => {
-      const position = studentIndex * modelAnswerCount + pageIndex
-
+  // 手動無効化 + 動的無効化を合わせたセル無効判定
+  const enhancedIsCellDisabled = useCallback(
+    (examStudent: ExamStudentWithMemberships, pageNumber: number) => {
       // 元の無効化チェック
-      if (isPositionDisabled(studentIndex, pageIndex)) return true
+      if (isCellDisabled(examStudent, pageNumber)) return true
 
       // 動的無効化チェック
-      return dynamicDisabledPositions.has(position)
+      return lookupHasCell(
+        dynamicDisabledCells,
+        examStudent.studentId,
+        pageNumber
+      )
     },
-    [isPositionDisabled, modelAnswerCount, dynamicDisabledPositions]
+    [isCellDisabled, dynamicDisabledCells]
   )
 
-  // 既存答案がある位置の計算（警告オーバーレイ用）
-  const positionsWithExistingAnswers = useMemo(() => {
-    return calculatePositionsWithExistingAnswers(
+  // 既存答案があるセルの計算（警告オーバーレイ用）
+  const cellsWithExistingAnswers = useMemo(() => {
+    return calculateCellsWithExistingAnswers(
       files,
       sortedStudents,
       modelAnswerCount,
@@ -117,7 +123,7 @@ export function useTableData({
     fileOrder,
     disabledState,
     mode,
-    enhancedIsPositionDisabled,
+    enhancedIsCellDisabled,
     allowOverwrite,
     existingStudentAnswers,
   })
@@ -128,6 +134,6 @@ export function useTableData({
     getDisabledFiles: getDisabledFilesCallback,
     getFileColor: getFileColorCallback,
     tableData,
-    positionsWithExistingAnswers,
+    cellsWithExistingAnswers,
   }
 }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -4,7 +4,10 @@ import type {
   CellData,
   ExtendedDisabledState,
 } from "@/components/exams/06-student-answers/student-answer-table/types"
-import { getEnabledFiles } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import {
+  getEnabledFiles,
+  manualDisabledReason,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
   PlacementStrategy,
   UnifiedFile,
@@ -18,9 +21,9 @@ interface UseTableDataGenerationParams {
   fileOrder: PlacementStrategy
   disabledState: ExtendedDisabledState
   mode?: "upload" | "view"
-  enhancedIsPositionDisabled: (
-    studentIndex: number,
-    pageIndex: number
+  enhancedIsCellDisabled: (
+    examStudent: ExamStudentWithMemberships,
+    pageNumber: number
   ) => boolean
   allowOverwrite?: boolean
   existingStudentAnswers?: Array<{
@@ -40,7 +43,7 @@ export function useTableDataGeneration({
   fileOrder,
   disabledState,
   mode,
-  enhancedIsPositionDisabled,
+  enhancedIsCellDisabled,
   allowOverwrite = false,
   existingStudentAnswers = [],
 }: UseTableDataGenerationParams) {
@@ -60,8 +63,9 @@ export function useTableDataGeneration({
         studentIndex < sortedStudents.length;
         studentIndex++
       ) {
+        const examStudent = sortedStudents[studentIndex]
         for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          if (!enhancedIsPositionDisabled(studentIndex, pageIndex)) {
+          if (!enhancedIsCellDisabled(examStudent, pageIndex + 1)) {
             validPositions.push({ studentIndex, pageIndex })
           }
         }
@@ -102,41 +106,24 @@ export function useTableDataGeneration({
         studentIndex < sortedStudents.length;
         studentIndex++
       ) {
-        const student = sortedStudents[studentIndex]
+        const examStudent = sortedStudents[studentIndex]
         const row: CellData[] = []
 
         for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          const position = studentIndex * modelAnswerCount + pageIndex
-          const isDisabled = enhancedIsPositionDisabled(studentIndex, pageIndex)
+          const isDisabled = enhancedIsCellDisabled(examStudent, pageIndex + 1)
 
           if (isDisabled) {
-            // 無効セル（手動無効化 + 動的無効化）
-            row.push({
-              type: "disabled",
-              position,
-              student,
-              pageNumber: pageIndex + 1,
-            })
+            // 無効セル（手動無効化 + 動的無効化）。確認モードは表示上「答案なし」
+            row.push({ type: "disabled" })
           } else {
             // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
             const key = `${studentIndex}-${pageIndex}`
             const file = filePositionMap.get(key)
 
             if (file) {
-              row.push({
-                type: "file",
-                position,
-                student,
-                pageNumber: pageIndex + 1,
-                file,
-              })
+              row.push({ type: "file", file })
             } else {
-              row.push({
-                type: "empty",
-                position,
-                student,
-                pageNumber: pageIndex + 1,
-              })
+              row.push({ type: "empty" })
             }
           }
         }
@@ -171,17 +158,17 @@ export function useTableDataGeneration({
         studentIndex < sortedStudents.length;
         studentIndex++
       ) {
+        const examStudent = sortedStudents[studentIndex]
         for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          const position = studentIndex * modelAnswerCount + pageIndex
-          const positionKey = `${studentIndex}-${pageIndex}`
+          const pageNumber = pageIndex + 1
+          const placementKey = `${studentIndex}-${pageIndex}`
 
           const isManuallyDisabled =
-            disabledState.rows.has(studentIndex) ||
-            disabledState.cols.has(pageIndex) ||
-            disabledState.positions.has(position)
+            manualDisabledReason(disabledState, examStudent, pageNumber) !==
+            undefined
 
           // 既存答案がある場合は上書き設定をチェック
-          const hasExistingAnswer = existingAnswerPositions.has(positionKey)
+          const hasExistingAnswer = existingAnswerPositions.has(placementKey)
           const shouldSkipExisting = hasExistingAnswer && !allowOverwrite
 
           if (!isManuallyDisabled && !shouldSkipExisting) {
@@ -235,27 +222,22 @@ export function useTableDataGeneration({
         studentIndex < sortedStudents.length;
         studentIndex++
       ) {
-        const student = sortedStudents[studentIndex]
+        const examStudent = sortedStudents[studentIndex]
         const row: CellData[] = []
 
         for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          const position = studentIndex * modelAnswerCount + pageIndex
           const pageNumber = pageIndex + 1
 
-          // 位置無効化チェック（手動無効化のみ）
-          const isManuallyDisabled =
-            disabledState.rows.has(studentIndex) ||
-            disabledState.cols.has(pageIndex) ||
-            disabledState.positions.has(position)
+          // 手動無効化の判定と理由を1回の評価で確定（ちゃんとやる側）
+          const manualReason = manualDisabledReason(
+            disabledState,
+            examStudent,
+            pageNumber
+          )
 
-          if (isManuallyDisabled) {
-            // 手動無効化セル
-            row.push({
-              type: "disabled",
-              position,
-              student,
-              pageNumber,
-            })
+          if (manualReason) {
+            // 手動無効化セル（無効理由も権威的にここで確定）
+            row.push({ type: "disabled", disabledReason: manualReason })
           } else {
             // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
             const key = `${studentIndex}-${pageIndex}`
@@ -267,30 +249,13 @@ export function useTableDataGeneration({
 
             if (file) {
               // ファイルあり（自動配置されたファイル）
-              row.push({
-                type: "file",
-                position,
-                student,
-                pageNumber,
-                file: file,
-              })
+              row.push({ type: "file", file })
             } else if (shouldShowAsDisabled) {
               // 既存答案があり上書き無効の場合は無効セルとして表示
-              row.push({
-                type: "disabled",
-                position,
-                student,
-                pageNumber,
-                disabledReason: "existing_answer",
-              })
+              row.push({ type: "disabled", disabledReason: "existing_answer" })
             } else {
               // ファイルなし（空セル）
-              row.push({
-                type: "empty",
-                position,
-                student,
-                pageNumber,
-              })
+              row.push({ type: "empty" })
             }
           }
         }
@@ -307,7 +272,7 @@ export function useTableDataGeneration({
     fileOrder,
     disabledState,
     mode,
-    enhancedIsPositionDisabled,
+    enhancedIsCellDisabled,
     allowOverwrite,
     existingStudentAnswers,
   ])

--- a/src/components/exams/06-student-answers/student-answer-table/types/index.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/index.ts
@@ -7,20 +7,29 @@ import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 // Preview mode for different display options
 export type PreviewMode = "full" | "name-only"
 
-// Extended disabled state for table management
-export interface ExtendedDisabledState {
-  rows: Set<number>
-  cols: Set<number>
-  positions: Set<number>
-  files: Set<string>
+// セル同一性 = (studentId, pageNumber)。Set の合成文字列キーをやめ、
+// 型付きレコードで持つ（DnD の FileState と同じ identity 照合の流儀）。
+export interface DisabledCell {
+  studentId: string
+  pageNumber: number
 }
 
-// Cell data structure for table rendering
+// Extended disabled state for table management.
+// index やフラット position ではなく、安定した同一性でキーする
+// （並べ替え・フィルタ・生徒追加でズレないため）。Set は使わず配列で持つ。
+export interface ExtendedDisabledState {
+  rows: string[] // examStudentId（ExamStudent.id）— 無効行は少数なので配列
+  cols: number[] // pageNumber（1始まりの序数）— 無効列は少数なので配列
+  cells: DisabledCell[] // (studentId, pageNumber) — 個別無効セルは少数なので配列
+  files: Set<string> // fileId — アップロードで多数になりうるので Set（O(1)）
+}
+
+// Cell data structure for table rendering.
+// セルは「そのマスに置かれた物（file）と無効理由」だけを持つ。
+// 生徒・ページ・position はグリッド座標 [studentIndex][pageIndex] と
+// sortedStudents から投射する（セルにエンティティを複製させない）。
 export interface CellData {
   type: "file" | "empty" | "disabled"
-  position: number
-  student?: ExamStudentWithMemberships
-  pageNumber?: number
   file?: UnifiedFile
   disabledReason?:
     "row" | "column" | "position" | "existing_answer" | "absent_student"
@@ -43,7 +52,6 @@ export interface FilePreviewCellProps {
 
 export interface SortableTableCellProps {
   id: string
-  position: number
   hasFile: boolean
   isPositionDisabled: boolean
   isFileDisabled: boolean
@@ -61,8 +69,7 @@ export interface SortableTableCellProps {
 }
 
 export interface EmptyTableCellProps {
-  position: number
-  student: ExamStudentWithMemberships | null
+  examStudent: ExamStudentWithMemberships | null
   pageNumber: number | null
   isPositionDisabled: boolean
   isPendingChange?: boolean

--- a/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
@@ -14,7 +14,6 @@ import type { FileState } from "./dragDropTypes"
 
 export interface UploadModalState {
   isOpen: boolean
-  position?: number
   studentName?: string
   pageNumber?: number
 }

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -1,6 +1,73 @@
-import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  DisabledCell,
+  ExtendedDisabledState,
+} from "@/components/exams/06-student-answers/student-answer-table/types"
+import type { DisabledReason } from "@/components/exams/06-student-answers/student-answer-table/types/localTypes"
 import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
+
+/**
+ * セルレコード配列に (studentId, pageNumber) が含まれるかを判定する。
+ * 文字列合成キーを使わず identity のフィールド比較で照合する（DnD の FileState と同流儀）。
+ * ユーザートグル由来の小さな配列（disabledState.cells）専用。
+ */
+export function hasCell(
+  cells: DisabledCell[],
+  studentId: string,
+  pageNumber: number
+): boolean {
+  return cells.some(
+    (cell) => cell.studentId === studentId && cell.pageNumber === pageNumber
+  )
+}
+
+/**
+ * (studentId, pageNumber) の集合を O(1) 照合するルックアップ。
+ * 文字列合成キー（`${a}:${b}`）を使わず studentId → pageNumber集合 の入れ子で持つ。
+ * グリッド全体分に膨らみうる派生集合（既存答案・動的無効）向け。
+ */
+export type CellLookup = Map<string, Set<number>>
+
+export function addCellToLookup(
+  lookup: CellLookup,
+  studentId: string,
+  pageNumber: number
+): void {
+  const pages = lookup.get(studentId)
+  if (pages) {
+    pages.add(pageNumber)
+  } else {
+    lookup.set(studentId, new Set([pageNumber]))
+  }
+}
+
+export function lookupHasCell(
+  lookup: CellLookup,
+  studentId: string,
+  pageNumber: number
+): boolean {
+  return lookup.get(studentId)?.has(pageNumber) ?? false
+}
+
+/**
+ * 手動無効化（行・列・個別セル）の理由を返す唯一の場所。無効でなければ undefined。
+ * 「無効か」の真偽と「なぜ無効か」を1回の評価で確定する（判定の二重走査を避ける）。
+ * 既存答案(existing_answer)・確認モードの動的無効はここでは扱わない（呼び出し側の責務）。
+ */
+export function manualDisabledReason(
+  disabledState: ExtendedDisabledState,
+  examStudent: ExamStudentWithMemberships,
+  pageNumber: number
+): DisabledReason {
+  if (disabledState.rows.includes(examStudent.id)) {
+    return examStudent.status === "absent" ? "absent_student" : "row"
+  }
+  if (disabledState.cols.includes(pageNumber)) return "column"
+  if (hasCell(disabledState.cells, examStudent.studentId, pageNumber)) {
+    return "position"
+  }
+  return undefined
+}
 
 /** 生徒をcustomOrder昇順にソートした新しい配列を返す */
 export function sortStudentsByCustomOrder(
@@ -13,49 +80,38 @@ export function sortStudentsByCustomOrder(
   })
 }
 
-/** 確認モードで答案が存在しないテーブル位置を無効化するSetを返す */
-export function calculateDynamicDisabledPositions(
+/** 確認モードで答案が存在しないセル（無効化対象）を O(1) 照合ルックアップで返す */
+export function calculateDynamicDisabledCells(
   files: UnifiedFile[],
   sortedStudents: ExamStudentWithMemberships[],
   masterImageCount: number,
   disabledState: ExtendedDisabledState,
   mode?: "upload" | "view"
-): Set<number> {
-  const dynamicDisabled = new Set<number>()
+): CellLookup {
+  const dynamicDisabled: CellLookup = new Map()
 
-  // 確認モードでは答案がない位置のみ無効化
+  // 確認モードでは答案がないセルのみ無効化
   if (mode === "view") {
-    for (
-      let studentIndex = 0;
-      studentIndex < sortedStudents.length;
-      studentIndex++
-    ) {
-      const student = sortedStudents[studentIndex]
-
+    for (const examStudent of sortedStudents) {
       for (let pageIndex = 0; pageIndex < masterImageCount; pageIndex++) {
         const pageNumber = pageIndex + 1
-        const position = studentIndex * masterImageCount + pageIndex
 
-        // 手動無効化済みの位置はスキップ
-        if (
-          disabledState.rows.has(studentIndex) ||
-          disabledState.cols.has(pageIndex) ||
-          disabledState.positions.has(position)
-        ) {
+        // 手動無効化済みのセルはスキップ
+        if (manualDisabledReason(disabledState, examStudent, pageNumber)) {
           continue
         }
 
-        // その位置に対応する答案があるかチェック
-        const hasAnswerForPosition = files.some(
+        // そのセルに対応する答案があるかチェック
+        const hasAnswerForCell = files.some(
           (file) =>
-            file.studentId === student.studentId &&
+            file.studentId === examStudent.studentId &&
             file.pageNumber === pageNumber &&
             !disabledState.files.has(file.id)
         )
 
         // 答案がない場合は動的無効化
-        if (!hasAnswerForPosition) {
-          dynamicDisabled.add(position)
+        if (!hasAnswerForCell) {
+          addCellToLookup(dynamicDisabled, examStudent.studentId, pageNumber)
         }
       }
     }
@@ -65,8 +121,8 @@ export function calculateDynamicDisabledPositions(
   return dynamicDisabled
 }
 
-/** 既存の答案が割り当てられているテーブル位置のSetを返す（警告オーバーレイ用） */
-export function calculatePositionsWithExistingAnswers(
+/** 既存の答案が割り当てられているセルを O(1) 照合ルックアップで返す（警告オーバーレイ用） */
+export function calculateCellsWithExistingAnswers(
   files: UnifiedFile[],
   sortedStudents: ExamStudentWithMemberships[],
   masterImageCount: number,
@@ -77,48 +133,40 @@ export function calculatePositionsWithExistingAnswers(
     studentId: string | null
     pageNumber: number
   }>
-): Set<number> {
-  const positions = new Set<number>()
+): CellLookup {
+  const cells: CellLookup = new Map()
 
-  // sortedStudentsを使用してテーブル表示順序と一致させる
-  for (
-    let studentIndex = 0;
-    studentIndex < sortedStudents.length;
-    studentIndex++
-  ) {
-    const student = sortedStudents[studentIndex]
-
+  for (const examStudent of sortedStudents) {
     for (let pageIndex = 0; pageIndex < masterImageCount; pageIndex++) {
       const pageNumber = pageIndex + 1
-      const position = studentIndex * masterImageCount + pageIndex
 
-      // その位置に対応する答案があるかチェック
-      let hasAnswerForPosition = false
+      // そのセルに対応する答案があるかチェック
+      let hasAnswerForCell = false
 
       if (mode === "upload" && existingAnswerSheets) {
         // アップロードモード: existingAnswerSheets から判定
-        hasAnswerForPosition = existingAnswerSheets.some(
+        hasAnswerForCell = existingAnswerSheets.some(
           (sheet) =>
-            sheet.studentId === student.studentId &&
+            sheet.studentId === examStudent.studentId &&
             sheet.pageNumber === pageNumber
         )
       } else {
         // 確認モード: files から判定
-        hasAnswerForPosition = files.some(
+        hasAnswerForCell = files.some(
           (file) =>
-            file.studentId === student.studentId &&
+            file.studentId === examStudent.studentId &&
             file.pageNumber === pageNumber &&
             !disabledState.files.has(file.id)
         )
       }
 
-      if (hasAnswerForPosition) {
-        positions.add(position)
+      if (hasAnswerForCell) {
+        addCellToLookup(cells, examStudent.studentId, pageNumber)
       }
     }
   }
 
-  return positions
+  return cells
 }
 
 /** 無効化されていないファイルのみをフィルタリングして返す */

--- a/src/components/exams/06-student-answers/types.ts
+++ b/src/components/exams/06-student-answers/types.ts
@@ -29,7 +29,6 @@ export interface UnifiedFile {
 
   // テーブルDnD統合用
   color?: string // 表示色（テスト・デバッグ用）
-  position?: number // table内の位置（studentIndex * maxPages + pageNumber - 1）
   imagePath?: string | null // 既存画像ファイルのパス（遅延読み込み用）
   correctionStatus?: "corrected" | "skipped" | "not_requested" // マーカー補正結果
   correctedForPage?: number // 補正時に対応付けたマスターページ番号


### PR DESCRIPTION
## 概要
`06-student-answers` 答案配置テーブルのセル状態設計を、位置インデックス依存から**安定同一性**（examStudentId × studentId × pageNumber）ベースへ全面刷新し、発端となった FK 保存バグを修正した。

Closes #966

## 主な変更
- **FK 修正**: アップロード `studentId` を `examStudent.studentId`（Student.id）へ。`studentAnswerImage.create()` の外部キー制約違反を解消。
- **セル投射化**: `CellData` を `{type, file?, disabledReason?}` に縮約。生徒/ページ/position は座標から投射。フラット position を全廃。
- **無効化状態の同一性化**: 合成文字列キー Set → `rows=examStudentId[]` / `cols=pageNumber[]` / `cells={studentId,pageNumber}[]` / `files=Set<fileId>`。×100 の乗数不一致も除去。
- **無効理由の権威化**: `manualDisabledReason` に集約（判定＋理由を1回で確定）。描画側は流すだけ。
- **性能**: 派生ルックアップを `Map<studentId, Set<pageNumber>>` で O(1) 化（大規模ロスタの O(n²) 退行回避）。
- **欠席自動無効**: 初回のみ適用に限定し手動再有効化の握り潰しを修正。

## 検証
- typecheck / eslint / prettier グリーン。
- 並行監査3件 + high-effort code-review の指摘を全反映（correctness 1 + perf 3 + cleanup 3）。

## 補足
関連する既知負債は #961–#965 に分離記録。DB スキーマは現行のまま（ExamStudent×ExamPage 多対多昇格は #962 で別途検討）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
