### PR TITLE
feat(06-student-answers): 答案配置の採点安全化と型分離

### DIFF
--- a/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
+++ b/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
@@ -1,0 +1,333 @@
+/**
+ * applyStudentAnswerPlacements（view 方式B: 2軸移動 + carry/discard）の採点安全性テスト
+ *
+ * 検証対象（docs/06-student-answers-cell-architecture-plan.md §3-4）:
+ * - 2軸移動: examPageId が実際に更新される（旧 batchUpdate は finalPageNumber を無視していた）
+ * - carry（同一ページ）: 採点が studentId 付け替えで追従し、DrawingAnnotation が温存される
+ * - discard: 影響採点（両スコア表）が削除され、注釈は tombstone される
+ * - ガード: carry かつページ変化はエラー（DBは不変）
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { applyStudentAnswerPlacements } from "@/electron-src/lib/prisma/studentAnswer/placementApply"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 単純な構成（2生徒 × 2ページ × 1設問/ページ、全マス答案あり）で試験を作る */
+async function buildSimpleExam() {
+  const exam = await createFullTestExam(testPrisma, {
+    studentCount: 2,
+    pageCount: 2,
+    cropRegionsPerPage: 1,
+    includeScores: true,
+    includeStudentAnswerImages: true,
+  })
+
+  const [studentA, studentB] = exam.students
+  const page1 = exam.pages.find((page) => page.pageNumber === 1)!
+  const page2 = exam.pages.find((page) => page.pageNumber === 2)!
+  const region1 = exam.cropRegions.find(
+    (region) => region.examPageId === page1.id
+  )!
+  const region2 = exam.cropRegions.find(
+    (region) => region.examPageId === page2.id
+  )!
+
+  const image = (pageId: string, studentId: string) =>
+    exam.studentAnswerImages.find(
+      (answerImage) =>
+        answerImage.examPageId === pageId && answerImage.studentId === studentId
+    )!
+  const score = (cropRegionId: string, studentId: string) =>
+    exam.questionScores.find(
+      (questionScore) =>
+        questionScore.cropRegionId === cropRegionId &&
+        questionScore.studentId === studentId
+    )!
+
+  return {
+    exam,
+    studentA,
+    studentB,
+    page1,
+    page2,
+    region1,
+    region2,
+    image,
+    score,
+  }
+}
+
+describe("applyStudentAnswerPlacements", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("① 同一ページの生徒swap: carry で採点が追従し DrawingAnnotation が温存される", async () => {
+    const { studentA, studentB, page1, region1, image, score } =
+      await buildSimpleExam()
+
+    const scoreA = score(region1.id, studentA.id)
+    const scoreB = score(region1.id, studentB.id)
+
+    // scoreA（studentA の r1 採点）に注釈を付ける
+    const annotation = await testPrisma.drawingAnnotation.create({
+      data: {
+        id: crypto.randomUUID(),
+        questionScoreId: scoreA.id,
+        type: "circle",
+        x: 5,
+        y: 5,
+        userId: (await testPrisma.user.findFirstOrThrow()).id,
+      },
+    })
+
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: image(page1.id, studentA.id).id,
+        finalStudentId: studentB.id,
+        finalPageNumber: 1,
+        scorePolicy: "carry",
+      },
+      {
+        fileId: image(page1.id, studentB.id).id,
+        finalStudentId: studentA.id,
+        finalPageNumber: 1,
+        scorePolicy: "carry",
+      },
+    ])
+    expect(result.success).toBe(true)
+
+    // 画像の studentId が入れ替わり、ページは p1 のまま
+    const imgAfterA = await testPrisma.studentAnswerImage.findUniqueOrThrow({
+      where: { id: image(page1.id, studentA.id).id },
+    })
+    expect(imgAfterA.studentId).toBe(studentB.id)
+    expect(imgAfterA.examPageId).toBe(page1.id)
+
+    // 採点が studentId 付け替えで追従（行=id は保持）
+    const scoreAAfter = await testPrisma.questionScore.findUniqueOrThrow({
+      where: { id: scoreA.id },
+    })
+    const scoreBAfter = await testPrisma.questionScore.findUniqueOrThrow({
+      where: { id: scoreB.id },
+    })
+    expect(scoreAAfter.studentId).toBe(studentB.id)
+    expect(scoreBAfter.studentId).toBe(studentA.id)
+
+    // DrawingAnnotation は同じ questionScore に紐付いたまま温存
+    const annotationAfter = await testPrisma.drawingAnnotation.findUnique({
+      where: { id: annotation.id },
+    })
+    expect(annotationAfter).not.toBeNull()
+    expect(annotationAfter!.questionScoreId).toBe(scoreA.id)
+  })
+
+  it("① 同一ページ discard: 影響採点が削除され注釈も消える", async () => {
+    const { studentA, studentB, page1, region1, image, score } =
+      await buildSimpleExam()
+
+    const scoreA = score(region1.id, studentA.id)
+    await testPrisma.drawingAnnotation.create({
+      data: {
+        id: crypto.randomUUID(),
+        questionScoreId: scoreA.id,
+        type: "circle",
+        x: 1,
+        y: 1,
+        userId: (await testPrisma.user.findFirstOrThrow()).id,
+      },
+    })
+
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: image(page1.id, studentA.id).id,
+        finalStudentId: studentB.id,
+        finalPageNumber: 1,
+        scorePolicy: "discard",
+      },
+      {
+        fileId: image(page1.id, studentB.id).id,
+        finalStudentId: studentA.id,
+        finalPageNumber: 1,
+        scorePolicy: "discard",
+      },
+    ])
+    expect(result.success).toBe(true)
+
+    // r1 の採点（A・B とも）は削除
+    const remaining = await testPrisma.questionScore.findMany({
+      where: { cropRegionId: region1.id },
+    })
+    expect(remaining).toHaveLength(0)
+
+    // 注釈も cascade 削除
+    const annotations = await testPrisma.drawingAnnotation.findMany({
+      where: { questionScoreId: scoreA.id },
+    })
+    expect(annotations).toHaveLength(0)
+  })
+
+  it("② ページ跨ぎ移動(discard): examPageId が更新され、移動元ページの採点が破棄される", async () => {
+    const { studentA, page1, page2, region1, region2, image, score } =
+      await buildSimpleExam()
+
+    const imgP1A = image(page1.id, studentA.id)
+    const imgP2A = image(page2.id, studentA.id)
+
+    // A の p1画像 と p2画像 を入れ替え（両方ページが変わる→discard）
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: imgP1A.id,
+        finalStudentId: studentA.id,
+        finalPageNumber: 2,
+        scorePolicy: "discard",
+      },
+      {
+        fileId: imgP2A.id,
+        finalStudentId: studentA.id,
+        finalPageNumber: 1,
+        scorePolicy: "discard",
+      },
+    ])
+    expect(result.success).toBe(true)
+
+    // examPageId が実際に更新される（旧 batchUpdate は無視していた核心バグの修正）
+    const imgP1AAfter = await testPrisma.studentAnswerImage.findUniqueOrThrow({
+      where: { id: imgP1A.id },
+    })
+    const imgP2AAfter = await testPrisma.studentAnswerImage.findUniqueOrThrow({
+      where: { id: imgP2A.id },
+    })
+    expect(imgP1AAfter.examPageId).toBe(page2.id)
+    expect(imgP2AAfter.examPageId).toBe(page1.id)
+
+    // A の r1・r2 採点は破棄
+    expect(
+      await testPrisma.questionScore.findUnique({
+        where: { id: score(region1.id, studentA.id).id },
+      })
+    ).toBeNull()
+    expect(
+      await testPrisma.questionScore.findUnique({
+        where: { id: score(region2.id, studentA.id).id },
+      })
+    ).toBeNull()
+  })
+
+  it("carry かつページ変化はエラー（DBは不変）", async () => {
+    const { studentA, page1, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, studentA.id)
+
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: imgP1A.id,
+        finalStudentId: studentA.id,
+        finalPageNumber: 2, // ページ変化
+        scorePolicy: "carry", // 追従は不可
+      },
+    ])
+    expect(result.success).toBe(false)
+
+    // ロールバックで examPageId は元のまま
+    const imgAfter = await testPrisma.studentAnswerImage.findUniqueOrThrow({
+      where: { id: imgP1A.id },
+    })
+    expect(imgAfter.examPageId).toBe(page1.id)
+  })
+
+  it("carry: 移動先生徒の孤立採点は掃除され二重計上しない", async () => {
+    const { studentA, studentB, page1, region1, image } =
+      await buildSimpleExam()
+
+    // B の p1 画像を削除（採点は孤立して残る = deleteStudentAnswer 相当）。
+    // これで移動先 (p1,B) は空マスになり、B は r1 に孤立採点だけを持つ。
+    await testPrisma.studentAnswerImage.delete({
+      where: { id: image(page1.id, studentB.id).id },
+    })
+
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: image(page1.id, studentA.id).id,
+        finalStudentId: studentB.id,
+        finalPageNumber: 1,
+        scorePolicy: "carry",
+      },
+    ])
+    expect(result.success).toBe(true)
+
+    // r1 の採点は1件のみ（B の孤立採点は掃除、A の採点が B へ追従）
+    const r1Scores = await testPrisma.questionScore.findMany({
+      where: { cropRegionId: region1.id },
+    })
+    expect(r1Scores).toHaveLength(1)
+    expect(r1Scores[0].studentId).toBe(studentB.id)
+  })
+
+  it("finalStudentId=null（削除）は拒否され、画像は残る", async () => {
+    const { studentA, page1, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, studentA.id)
+
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: imgP1A.id,
+        finalStudentId: null,
+        finalPageNumber: 1,
+        scorePolicy: "discard",
+      },
+    ])
+    expect(result.success).toBe(false)
+    expect(
+      await testPrisma.studentAnswerImage.findUnique({
+        where: { id: imgP1A.id },
+      })
+    ).not.toBeNull()
+  })
+
+  it("移動先が batch 外の答案で占有されていればエラー（上書きしない）", async () => {
+    const { studentA, studentB, page1, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, studentA.id)
+
+    // A の p1 を、占有済みの (p1,B) へ単独移動（入れ替えでない）→ 拒否
+    const result = await applyStudentAnswerPlacements([
+      {
+        fileId: imgP1A.id,
+        finalStudentId: studentB.id,
+        finalPageNumber: 1,
+        scorePolicy: "discard",
+      },
+    ])
+    expect(result.success).toBe(false)
+
+    // A は動いていない
+    const imgAfter = await testPrisma.studentAnswerImage.findUniqueOrThrow({
+      where: { id: imgP1A.id },
+    })
+    expect(imgAfter.studentId).toBe(studentA.id)
+    expect(imgAfter.examPageId).toBe(page1.id)
+  })
+})

--- a/docs/06-student-answers-cell-architecture-plan.md
+++ b/docs/06-student-answers-cell-architecture-plan.md
@@ -1,0 +1,510 @@
+# 06-student-answers セル配置アーキテクチャ再設計 実装計画
+
+> この文書は単独で読めるように書いてある（会話のコンテキストが失われても実装を継続できる）。
+> 対象は `src/components/exams/06-student-answers/` と `src/app/exams/[examId]/06-student-answers/`。
+> 作成: 2026-07-09。前提コミット: `5c8554b5`（同一性設計刷新・Set/位置キー撤廃・FK保存バグ修正が main にマージ済み）。
+
+---
+
+## 実装ステータス（2026-07-11 時点・コンパクト後の再開用サマリ）
+
+> このセクションだけ読めば現在地が分かるように書く。詳細は各 Phase 節。
+
+### 完了（すべて 06 配下で型/lint/format グリーン。※型チェックの2件のエラーは**別の並行セッションの import-export WIP 由来**で無関係・触らない）
+
+- **Phase 1**: `ProcessedStudentAnswer` 中間層撤去（Prisma型 `StudentAnswerImageWithExamPageAndStudent` を素通し）。**0埋め廃止**（`UnifiedFile.buffer`/`size` を任意化・偽 `ArrayBuffer(0)` 撤去）。
+- **Phase 2（大部分）**: 共通描画型 **`AnswerItem`** を `types.ts` に導入し描画層（`FilePreviewCell`/`TableDragOverlay`/`getFileColor`/`drawNameRegionCanvas`/`loadStudentAnswerImage`）を decouple。`SortableContext` を `TableContent` から `StudentAnswerTable` へ引き上げ。
+- **Phase 0（バックエンド・テスト付き）**: 新規 `electron-src/lib/prisma/studentAnswer/placementApply.ts` の `applyStudentAnswerPlacements(moves)`。
+  - moves: `{ fileId, finalStudentId, finalPageNumber, scorePolicy:"carry"|"discard" }[]`。
+  - 2軸移動（examPageId 更新）／carry=**QuestionScore を id 指定 updateMany で付け替え（DrawingAnnotation 温存）**＋ScoreDecision は id 保持で delete→再作成／discard=tombstone→両スコア表削除／画像は id 保持で delete→再作成。
+  - **基本 Prisma のみ**（一時ID退避・`defer_foreign_keys` 不使用）。IPC: `apply-answer-sheet-placements`。
+  - テスト `__tests__/exam/integration/studentAnswerPlacementApply.test.ts`（**7件パス**）。
+  - **コードレビュー(high)反映済み**: (F1/F2) carry で**移動先セルの残存採点（moving 集合外）を stale として掃除**（QuestionScore 二重計上・ScoreDecision unique 違反を修正）。(F3) `finalStudentId=null` は**拒否**（削除は deleteStudentAnswer 専用・ファイル/監査漏れ回避）。(F4) 移動先が batch 外答案で**占有時は明示エラー**（上書きしない）。残: F5=トランザクション内の逐次クエリ（性能・非破損、未対応）。
+- **Phase 3a**: view 適用を新 API へ配線（`handleApplyChanges`）。`ConfirmChangesModal` をハイブリッド（追従/破棄グルーピング・破棄は行ごとチェック必須＋2段階確認）へ全面改修。`ScoringDataOption` 撤去、`PlacementScorePolicy` 導入。
+
+### 残り（次の作業）
+
+- **Phase 3b**: view の DnD を **method B（グリッドドロップ+swap）** へ。各マス `useDroppable`・各答案 `useDraggable`・空=移動/埋=swap。pendingChange 生成は現状 method A のまま（apply/modal は DnD 非依存で流用可）。
+- **Phase 3c**: セルの掴む/落とす部分（`SortableTableCell`）を**スロット化**して表本体を DnD 非依存に。upload=method A を注入。ここで `UnifiedFile` を `PendingImage`/`AnswerItem` へ**3分割**（単一 `files` state が両モード兼用のため Phase 3 と不可分）。
+- **Phase 6 相当**: 旧 `batch.ts`/`placement.ts`/`swap`（**FK強制下で壊れる temp studentId 方式**）の撤去、デッドコード整理（#965）、§6 手動検証（**DnD 挙動は要実機確認**）。
+
+### 重要な発見・地雷（再開時に忘れない）
+
+- **FK は実行時強制**。既存 `batchUpdateStudentAnswerPlacements`/`swap*`/`updateStudentAnswerPlacement` は偽 studentId の一時ID方式で**FK違反で壊れる**（旧挙動破綻の一因）。新 `applyStudentAnswerPlacements` は基本 Prisma で回避済み。3b/3c で旧関数を撤去。
+- **sqlite-nas-sync 安全性を実コードで確認**: 二次 `@@unique` は `conflict.ts` ケース2 で LWW 収束（全表汎用）。delete→**同一id**再作成は `sync.ts` の tombstone-ignore（現存すれば再作成とみなす）で安全。→ 新コードは id 保持で delete+再作成している。
+- **並行セッション**が `electron-src/lib/import/*`（transformers WIP）を編集中。型チェックの `transformWarnings`/`EXAM_CURRENT_VERSION` エラーは無関係。自分のファイルのみ扱う。
+- 未コミット。git-workflow は未実行（自分のファイルのみ add する）。
+
+### 主要な触点ファイル
+
+- 型: `src/components/exams/06-student-answers/types.ts`（`AnswerItem`/`PlacementScorePolicy`/`UnifiedFile`）
+- 表: `student-answer-table/components/{TableContent,StudentAnswerTable,SortableTableCell,ConfirmChangesModal}.tsx`
+- DnD: `student-answer-table/hooks/{useDragDrop,useDragDropHandlers,useDragDropState}.ts` + `utils/dragDropUtils.ts`
+- 配線: `src/app/exams/[examId]/06-student-answers/{hooks,components}/index.tsx`
+- バックエンド: `electron-src/lib/prisma/studentAnswer/placementApply.ts`（+ `index.ts`/`studentAnswer.ts` の export、`ipc-handlers/miscHandlers.ts`、`preload-apis/answerSheetApi.ts`、`src/types/electron/studentAnswerApi.d.ts`）
+
+---
+
+## 0. 背景（なぜこの計画があるか）
+
+発端は「生徒答案アップロードで `prisma.studentAnswerImage.create()` が **Foreign key constraint violated**」。
+原因は配置テーブルが `cell.student.id`（＝`ExamStudent.id`）を `StudentAnswerImage.studentId`（FK→`Student.id`）に渡していたこと。
+すでに修正済み（`examStudent.studentId` を渡す）。その調査から派生した設計の腐りを、本計画で構造的に解消する。
+
+前提コミットで**完了済み**:
+
+- `CellData` を `{ type, file?, disabledReason? }` に縮約。生徒/ページ/position は座標 `[studentIndex][pageIndex]` から投射。
+- 無効化状態を同一性化（`rows=examStudentId[]` / `cols=pageNumber[]` / `cells={studentId,pageNumber}[]` / `files=Set<fileId>`）。合成文字列キー・×100 の乗数不一致を除去。
+- 無効理由を生成側 `manualDisabledReason` で権威的に確定（描画は流すだけ）。
+- 派生ルックアップを `Map<studentId, Set<pageNumber>>` に（※後述の通り本計画で見直す）。
+
+**本計画で扱う残課題**:
+
+1. `UnifiedFile` が「未保存ファイル」と「DB答案」を1型に融合し、view で偽 buffer（`ArrayBuffer(0)`/`size:0`）を詰めている（＝issue #963）。
+2. DnD が upload/view とも「並べ替えリスト方式」で、view の疎な修正に合わず trash 巻き込み等の歪みを生む（＝issue #964）。
+3. 無効状態の「由来」（導出/ユーザー操作/スイッチ）が混ざっていて、欠席の自動無効がユーザーの手動有効化を握り潰す潜在バグの温床。
+4. 前提コミットで入れた `Set`/`Map` は**未計測の早すぎる最適化**の疑い（会話で合意）。素直な形に戻し、必要が測定で示されたときだけ局所導入する。
+
+---
+
+## 1. 確定した設計判断（この通りに実装する）
+
+以下はすべて合意済み。実装中に迷ったらここに従う。
+
+### 1-1. モードは2つ・非同居
+
+- タブ「新規追加」= `mode="upload"`、タブ「配置済み答案の確認」= `mode="view"`（`src/app/exams/[examId]/06-student-answers/components/index.tsx`）。
+- **upload**: 未保存ファイル（ドロップ→変換した画像）だけを配置・描画する。既存DB答案は「そのマスは埋まっている＝無効」の**占有信号としてのみ**使い、ファイルとしては描画しない。
+- **view**: DB答案だけを描画する。
+- 両者が同じファイル配列に**混ざることはない**。
+
+### 1-2. 一時画像と DB 答案は別のデータ構造（結合しない・0埋め廃止）
+
+- 未保存（`PendingImage`）と DB答案（`ExistingAnswer`）は**別型**。無理に揃えない。
+- 共有するのは「表と DnD が読む最小のセル要素」だけ。各モードは自分のソースをその最小形へ**変換して流し込む**（変換関数を各モードに置く。特別な "アダプター層" という抽象は作らない）。
+- **偽 buffer（0埋め）は全廃**。DnD・表・描画に画像のバイト列（`buffer`）は不要。必要なのは `id / studentId / pageNumber / preview`。
+
+**命名について（`UnifiedFile` は廃止）**:
+
+- `UnifiedFile` は false merge（偽の統合）の名前。非同居の「未保存」と「DB答案」を1型に併合したせいで 0埋めが要っただけで、「統一」という名は実態に嘘をついている（名前が「どう作ったか」を語り「何であるか」を語っていない＝命名の悪臭）。
+- 解体先は `PendingImage` / `ExistingAnswer` / `AnswerItem`。
+- 共通型も **"Unified" と呼ばない**。`AnswerItem` は「エンティティの併合」ではなく「そのマスに置かれた要素の最小共通ビュー（投射）」。実体で名付ける（`AnswerItem` / `PlacedAnswer` / `CellItem` 等、実装時に確定）。
+
+### 1-3. 共通化の境界：「表の描画」は共通、「DnD の振る舞い」は別々
+
+- **共通**: グリッドのレイアウト（行=生徒 × 列=ページ、ヘッダ、無効表示）＋セルの中身の描画（プレビュー / 空 / 無効理由）。DnD を知らない。
+- **別々（モード別に注入）**: どのマスが掴める/落とせるか、ドラッグ完了で何が起きるか。共通の表コンポーネントに両方の DnD を埋め込まない（肥大化＝元の木阿弥）。表本体は DnD 非依存にし、DnD ラッパーを外から被せる（props / ラッパー / スロット）。
+
+### 1-4. DnD はモード別 2 系統
+
+| モード | 方式                                                                                  | 理由                                                      |
+| ------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| upload | **並べ替えリスト**（`SortableContext` + フラット `AnswerItem[]` + `arrayMove`）       | 束の画像を一括で並べて割り当てる UX。フラットリストが必要 |
+| view   | **グリッドドロップ + swap**（各マス=ドロップ受け皿、各答案=掴む対象、**リスト不要**） | 誤配置の疎な修正。1個をピンポイントで移す                 |
+
+- view の衝突ポリシー（移動先マスの扱い）:
+  - 空マスへドロップ → **移動**（元マスが空になる）。
+  - 既に答案があるマスへドロップ → **swap（交換）**。**上書き・消去はしない**（両方とも本物の生徒答案なので損失禁止）。
+  - swap は無損失・可逆なので**確認モーダル不要**。
+- 移動先は**別ページ列を含む任意のマス**（生徒軸・ページ軸の両方を跨ぐ）。→ DB は `examPageId` と `studentId` の**両方**を更新する必要がある（後述 §3-3 と Phase 0）。
+- これにより #964（trash 巻き込み）と position 計算の歪みは view から構造的に消える。
+
+> **view は配置戦略を持たない（R4 確定）**: view はマス目に真の DB 座標で描画するため、page-first/student-first の並べ替え対象そのものが無い。**配置戦略セレクタは upload 専用**。§1-5 のリセット＋確認は upload のみに適用する。
+
+### 1-5. 配置戦略（page-first / student-first）の切り替え
+
+- 切り替え時、リストは**完全再構築**する。
+- **両モードとも、手動配置の有無に関わらずリセットし、確認モーダルを出す**（「並べ替えをやり直すと手動の配置は破棄されます。よろしいですか？」）。
+- view の手動ドラッグは未コミットの DB 修正（pendingChange）なので、破棄は特に明示的に確認する。
+
+### 1-6. 無効の「由来」は 3 種類（分けて持つ）
+
+1. **導出（保存しない・データから毎回わかる）**
+   - 欠席: `ExamStudent.status === "absent"`。
+   - 既存答案占有: DB に答案がある `(studentId, pageNumber)` かつ `!allowOverwrite`（**upload モードのみ**）。
+2. **ユーザー操作の状態（保存する）**
+   - 行（生徒）無効・列（ページ）無効・個別セル無効。
+3. **スイッチ**
+   - `allowOverwrite`（「既存答案占有」による無効を解除する）。
+
+規則:
+
+- **欠席は導出**。`disabledState` に保存しない。行の既定値として与える。
+- **ユーザーの行明示（有効化/無効化）が欠席の既定に勝つ**。→ 欠席者を手動で有効化したら、`students` 再取得でも消えない（現状の `didInitAbsentRef` 応急処置を、由来分離で根本解消する）。
+- 無効理由（`row`/`column`/`position`/`absent_student`/`existing_answer`）は**生成側で権威的に確定**し、描画側は再計算せず流すだけ。
+
+### 1-7. Set/Map は「早すぎる最適化」を避ける
+
+- 前提コミットで入れた `disabledState.files: Set` と `CellLookup=Map<studentId,Set<pageNumber>>` は**未計測**。
+- 方針: **状態の芯はシンプル（配列、またはプロパティ）に戻す。** 速度対策が要るとしても、それは描画/DnD の直前で**局所的に**作るもので、真実の源に埋め込まない。
+- **ファイルの無効はプロパティ化**（`pending.disabled`）を第一候補にする。別リスト（`disabledState.files`）参照の O(n) 突き合わせ自体が消え、Set の是非が問題にならなくなる。
+- どうしても局所 Set/Map を使う場合も、**エンコード合成文字列キー（`` `${a}:${b}` ``）は使わない**（過去の ×100 バグの温床）。`Map<studentId, Set<pageNumber>>` のような型付き入れ子にする。
+
+---
+
+## 2. 現状の構造（調査結果）
+
+### 2-1. ファイル構成（全 5,350 行）
+
+```
+student-answer-management/
+  components/  FileUploadZone / GridHeader / StudentAnswerUpload
+  hooks/       useStudentAnswerUpload           # ドロップ→変換→アップロード
+  utils/       convertStudentAnswersToFiles      # DB答案→UnifiedFile（★0埋め）
+               reorderFilesByStrategy            # 戦略切替の再配置 / DB→順序付き配列
+  types/       index.ts (ProcessedStudentAnswer) # ★Prisma手写しの中間層
+student-answer-table/
+  components/  TableContent / StudentAnswerTable / EmptyTableCell / SortableTableCell
+               FilePreviewCell / TableHeader / TableDragOverlay / PlacementStrategySelector
+               OverwriteToggle / MarkerCorrectionToggle / PreviewModeToggle
+               UploadModalWrapper / UploadToCellModal / DeleteConfirmationModal
+               ConfirmChangesModal
+  hooks/       useStudentAnswerTableLogic        # 統合ロジック
+               useTableData / useTableDataGeneration   # 配置（流し込み）
+               useDisabledState                  # 無効状態
+               useDragDrop / useDragDropState / useDragDropHandlers  # DnD（現状リスト方式・両モード共通）
+               useMarkerCorrection / useNameRegion
+  types/       index.ts (CellData, ExtendedDisabledState, DisabledCell, *Props)
+               localTypes.ts (StudentAnswerTableProps, UploadModalState, DisabledReason)
+               dragDropTypes.ts (FileState)
+  utils/       tableDataUtils / dragDropUtils
+types.ts       UnifiedFile / UploadData / PendingChange / PlacementStrategy / ScoringDataOption
+app/.../06-student-answers/
+  hooks/index.tsx       # データ取得（students / studentAnswers / modelAnswerCount）＋pendingChanges適用
+  components/index.tsx  # 2タブ（upload / view）でStudentAnswerUploadを描画
+  page.tsx
+```
+
+### 2-2. 現状の型（要点）
+
+```ts
+// types.ts — 融合型（★問題の中心）
+interface UnifiedFile {
+  id: string; name; type; size: number
+  buffer: ArrayBuffer          // ★未保存は本物、DB由来は new ArrayBuffer(0)（偽）
+  preview?: string
+  studentId?: string           // 配置済みの生徒
+  pageNumber: number           // マス列（序数）
+  isSelected: boolean; originalFileName; pageLabel?
+  color?; imagePath?: string | null   // DB由来の遅延読込パス
+  correctionStatus?; correctedForPage?; correctionError?
+}
+
+// table/types/index.ts
+interface CellData { type: "file"|"empty"|"disabled"; file?: UnifiedFile; disabledReason? }
+interface DisabledCell { studentId: string; pageNumber: number }
+interface ExtendedDisabledState {
+  rows: string[]; cols: number[]; cells: DisabledCell[]; files: Set<string>   // ★filesのSetは要見直し
+}
+
+// table/types/dragDropTypes.ts
+interface FileState { fileId: string; studentId: string | null; pageNumber: number }
+
+// management/types/index.ts — ★Prisma手写しの中間層
+interface ProcessedStudentAnswer {
+  id; studentId: string|null; pageNumber: number   // ★examPageIdをドロップ
+  originalImagePath: string|null; isAbsent: boolean
+  student: {...}|null; examId: string; status: "ready"
+}
+```
+
+### 2-3. 現状のデータフロー
+
+- **upload**: `useStudentAnswerUpload.convertFiles`（raw File→`UnifiedFile`、本物 buffer、`pageNumber`=PDF内ページ、`studentId` なし）→ `files`。
+  `handleUpload(uploadData)` が `window.electronAPI.uploadStudentAnswers(examId, uploadData)` へ post。
+  `uploadData` の `studentId`/`pageNumber` は**セル座標**から（`sortedStudents[studentIndex].studentId` / `pageIndex+1`）。既存答案は `existingStudentAnswers`（占有信号）として別経路。
+- **view**: `buildOrderedFileArrayFromStudentAnswers`（`ProcessedStudentAnswer[]`→`convertAnswerSheetsToFiles`＝**0埋め**→順序付き `UnifiedFile[]`）→ `files`。
+  DnD で並べ替え → `pendingChange` → `ConfirmChangesModal` → `onApplyChanges`（DB 適用）。
+- **DnD（両モード共通・現状）**: `SortableContext` + `useSortable({id})` + `handleDragEnd` の `arrayMove`。`FileState{fileId,studentId,pageNumber}` で位置をアンカー。view は `compareFileStates` で pendingChange を生成。
+
+### 2-4. DB 層（変更しない前提の境界）
+
+- `getStudentAnswersByExamId(examId)`: **Prisma 型そのまま返す**（`StudentAnswerImage` + `student` + `examPage`）。`@@unique([examPageId, studentId])`。
+- `uploadStudentAnswers(examId, filesData[{ studentId, pageNumber, imagePath..., overwrite, correctionStatus }])`: `pageNumber` で `ExamPage` を find/create し `StudentAnswerImage` を作成。`studentId` は **Student.id**。
+- `deleteStudentAnswer(answerSheetId)`。
+- 06 hook が Prisma→`ProcessedStudentAnswer` 変換（`examPageId` を落として `pageNumber` のみ）と `modelAnswerCount = Math.max(pageNumber)` を作っている（`ExamPage.id` を捨てている）。
+
+---
+
+## 3. 目標アーキテクチャ
+
+```
+【ソース：別々】  PendingImage[]                 ExistingAnswer[]（Prisma土台）
+                      │ toItem（upload側）           │ toItem（view側）
+                      ▼                              ▼
+【共通の要素形】               AnswerItem { id, studentId, pageNumber, preview }
+                      │                              │
+【DnD：別々】     並べ替えリスト(方式A)          グリッドドロップ+swap(方式B)
+                   SortableContext+arrayMove       droppableマス+draggable答案（listなし）
+                      │                              │
+                      └──────────────┬───────────────┘
+【表：共通】            グリッド描画（行=生徒 × 列=ページ、セル= item / empty / disabled+reason）
+                       ※ DnD の振る舞いは外から注入（表本体はDnD非依存）
+【無効状態：共通の解決器】
+   由来: 導出(欠席/既存答案占有) + ユーザートグル(行/列/セル) + スイッチ(overwrite)
+   → 生成側で「このマスは無効か+理由」を権威的に確定 → 描画は流すだけ
+```
+
+### 3-1. 目標の型（草案）
+
+```ts
+// 共通: 表とDnDが読む「セルに載る要素」の描画ビュー。
+// R2: FilePreviewCell が消費する項目まで含める（4フィールドでは不足）。
+//   FilePreviewCell は preview / imagePath(遅延) / name / correctionStatus /
+//   correctionError / getFileColor(item) / drawNameRegionCanvas(item) を読む。
+interface AnswerItem {
+  id: string // dnd-kit の識別子（fileId / answerSheetId）
+  studentId: string // どの生徒のマスか（= Student.id）
+  pageNumber: number // どのページのマスか（当面は序数。将来 examPageId へ #961）
+  name: string // 表示・alt 用
+  preview: string | null // 未保存は blob URL、DB答案は null（imagePath から遅延読込）
+  imagePath?: string | null // DB答案の遅延読込パス（未保存は無い）
+  // R5: 補正バッジは upload→view を correctionStatusMap 経由で運ぶ。
+  //     ExistingAnswer(Prisma) は補正フィールドを持たないので item に載せる。
+  correctionStatus?: "corrected" | "skipped" | "not_requested"
+  correctionError?: string
+}
+
+// 未保存（DBに縛られない自由な形）
+interface PendingImage {
+  id: string
+  buffer: ArrayBuffer // 本物
+  preview: string
+  originalFileName: string
+  sourcePageNumber: number // 元PDF内のページ（配置前の素性）
+  studentId?: string // 配置で決まる
+  pageNumber?: number // 配置で決まる（マス列）
+  disabled?: boolean // ゴミ箱＝プロパティ（別Setを廃止）
+  correctionStatus?: "corrected" | "skipped" | "not_requested"
+  correctedForPage?: number
+  correctionError?: string
+}
+
+// DB答案（Prisma型を土台。手写し中間層 ProcessedStudentAnswer を廃止）
+type ExistingAnswer = Prisma.StudentAnswerImageGetPayload<{
+  include: { student: true; examPage: true }
+}>
+// studentId, examPageId, examPage.pageNumber, imagePath, student.* を持つ
+```
+
+### 3-2. 無効状態（由来別）
+
+```ts
+// 保存するのはユーザー操作＋スイッチだけ
+interface DisabledUserState {
+  rows: string[] // examStudentId（ユーザーが明示的に無効化した行）
+  rowsEnabled: string[] // examStudentId（欠席の既定を上書きして有効化した行）
+  cols: number[] // pageNumber
+  cells: { studentId; pageNumber }[]
+  allowOverwrite: boolean // スイッチ
+}
+// 導出（保存しない）: 欠席(status) / 既存答案占有(DB, uploadのみ)
+
+// 権威的な解決（生成側・描画は流すだけ）
+function resolveDisabled(examStudent, pageNumber, ctx): DisabledReason
+// 優先順位の考え方:
+//   行override(rows/rowsEnabled) > 欠席既定 > 列 > セル > 既存答案占有(!overwrite)
+//   （厳密な優先順位は実装時に確定。ユーザー明示が欠席既定に勝つことは必須）
+```
+
+> 注: `rows`/`rowsEnabled` の二本立ては一案。`Map<examStudentId, boolean>`（明示オーバーライド）でも良い。要は「欠席=導出の既定、ユーザー明示=勝つ上書き」を表現できれば形は問わない。実装時に決める。
+
+### 3-3. DB 配置APIの制約（調査で確定・Phase 3 の前提）
+
+view の方式B（任意マスへ移動＋swap）は、既存のDB配置APIでは**成立しない**。両関数とも `studentId` しか更新せず、`examPageId`（ページ軸）を一切動かさない：
+
+| 関数（`electron-src/lib/prisma/studentAnswer/batch.ts`） | 更新する                        | 更新しない                                           |
+| -------------------------------------------------------- | ------------------------------- | ---------------------------------------------------- |
+| `batchUpdateStudentAnswerPlacements`（:100-124）         | `studentId` のみ（2段階一時ID） | `examPageId`（`finalPageNumber` は受け取るが未使用） |
+| `swapStudentAnswerPlacementsWithScoring`（:230-250）     | `studentId` のみ（3段階一時ID） | `examPageId`                                         |
+
+`StudentAnswerImage` は `@@unique([examPageId, studentId])`、`studentId`→`Student.id`（`schema.prisma:151-164`）。答案は `(studentId, examPage.pageNumber)` に居るので、別ページ列へのドロップ＝`examPageId` の付け替えが必須だが、現状は沈黙で無視される（＝現 view の cross-page ドラッグは先在の no-op バグ）。
+
+**帰結**: 計画 §5「DB契約を変えない」は view については撤回し、**Phase 0 でDB配置APIを2軸（examPageId + studentId）対応へ拡張**し、さらに**採点安全な適用ロジックへ作り直す**。
+
+- 移動: `finalPageNumber` を `examId` で `ExamPage` に解決し `examPageId` を更新。studentId と併せて更新。
+- swap: 2答案が `(examPageId, studentId)` ペアを交換。`@@unique` を跨ぐため一時退避を2軸に拡張。
+
+### 3-4. 採点安全モデル（配置移動とスコアの整合・確定仕様）
+
+**現状の危険（調査で確定）**:
+
+- スコアはページに縛られる: `QuestionScore` は `(cropRegionId, studentId)`、`CropRegion` は `examPageId` に属す（`schema.prisma:166-179, 253-266`）。→ **別ページへスコアは追従できない**。
+- **返却成績 `ScoreDecision`（OWNER確定値, `schema.prisma:271-`）を配置移動系は一切触っていない。** `batchUpdate`/`swap` は `QuestionScore` のみ。→ 画像の生徒だけ付け替わり確定成績が元生徒に残る＝**他人の成績を返却する穴**。
+- 現行 with-scoring は `QuestionScore` を**同一 studentId のまま**削除→再作成する churn（`batch.ts:129-135`）で、実際には移していない。専用 `swapStudentAnswerPlacements*` は IPC 配線済みだが 06 UI からは未使用。
+
+**安全 invariant（北極星）**:
+
+> あるスコア（`QuestionScore` も `ScoreDecision` も）が `(生徒X, ページPの枠R)` に付くなら、スロット `(X, P)` の画像は「Xが実際に解いてそのスコアが付いた答案」でなければならない。
+
+これを壊す移動は必ず **追従**（同一ページのみ可・スコアの studentId 付け替え）／**破棄**（削除→要再採点）のいずれかで解消する。**古いスコアを黙って残す経路は廃止**（invariant違反の唯一の危険パス）。
+
+**移動分類と選択肢（確定）** — 移動を `(生徒_from, ページ_from) → (生徒_to, ページ_to)`：
+
+| 種別                    | 条件                 | スコア追従             | 選択肢（据え置きは廃止）             | 既定     | 確認                |
+| ----------------------- | -------------------- | ---------------------- | ------------------------------------ | -------- | ------------------- |
+| ①生徒付け替え           | ページ同一・生徒違い | 可（同ページ枠を付替） | **入れ替え**（採点も追従）/ **破棄** | 入れ替え | 破棄選択時のみ2段階 |
+| ②ページ違い（同一生徒） | 生徒同一・ページ違い | 不可                   | **破棄して移動**                     | 破棄     | **2段階**           |
+| ③対角（両方違い）       | 生徒もページも違い   | 不可                   | **破棄して入れ替え**                 | 破棄     | **2段階**           |
+
+規則:
+
+- **選択肢は「入れ替え（追従）」か「破棄」の二択のみ。** 据え置き（画像のみ移動・採点そのまま）は完全廃止。
+- **追従（入れ替え）は①のみ提示可**。しかも**そのページの枠のスコアだけ**を付け替える（全スコアchurn廃止）。
+- **②③はページが変わるので追従不可 → 破棄一択**。破棄時は **モーダルで2回確認**。①でも**破棄を選んだら2回確認**。
+- **全ケースで `QuestionScore` と `ScoreDecision` を同時に処理**（追従 or 破棄）。破棄は tombstone/監査を残す。`DrawingAnnotation` は既存 tombstone 機構。
+
+---
+
+## 4. 実装ステップ（順序・各段階で型チェック）
+
+各フェーズ末で `npm run typecheck` / eslint / prettier をグリーンに保つ。DnD は挙動確認が必要（§6）。
+
+### Phase 0 — DB 配置APIの2軸拡張＋採点安全な適用への作り直し（view 方式B の前提・§3-3/§3-4）
+
+**進捗（2026-07-10）— ✅ バックエンド実装＋テスト完了**:
+
+- 新規 `electron-src/lib/prisma/studentAnswer/placementApply.ts` に `applyStudentAnswerPlacements(moves)` を実装（既存 `batch.ts` は Phase 3 で置換するまで温存）。
+  - moves: `{ fileId, finalStudentId, finalPageNumber, scorePolicy: "carry"|"discard" }[]`。
+  - **2軸移動**: `finalPageNumber`→`ExamPage` 解決で `examPageId` も更新（旧 batchUpdate が無視していた核心バグを解消）。
+  - **carry**（ページscoped）:
+    - `QuestionScore` は unique が無いので **id 指定の `updateMany` で studentId 付け替え**（id 保持 → `DrawingAnnotation` 温存。swap も id 指定で途中衝突なし）。
+    - `ScoreDecision`（unique あり・子なし）は **delete → 最終位置へ再作成**。
+  - **discard**: `DrawingAnnotation` を tombstone → `QuestionScore`＋`ScoreDecision` 削除。
+  - **画像**: unique の 2-cycle 回避に **delete → 同一 id で再作成**（id・imagePath・createdAt 保持、ファイル実体は不触）。
+  - **ガード**: carry×ページ変化はエラー。
+  - **基本 Prisma のみ（findMany/updateMany/deleteMany/createMany）。一時ID退避も `defer_foreign_keys` も使わない。** ⚠️ 既存 `batch.ts`/`swap`/`placement.ts` は偽 studentId の一時ID方式で、FK 強制下では壊れる（旧 batchUpdate 破綻の一因）。Phase 3 置換時に撤去。
+  - **削除・再作成は id を保持**（画像・ScoreDecision とも）。sqlite-nas-sync 的に安全: 二次 UNIQUE は `conflict.ts` ケース2 で LWW 収束（全表汎用・`StudentAnswerImage` の unique も対象）、delete→同一id再作成は `sync.ts` の「現存すれば tombstone 無視（再作成とみなし存続）」で余計な削除伝播を回避。
+- IPC 配線: `apply-answer-sheet-placements`（`preload-apis/answerSheetApi.ts` / `ipc-handlers/miscHandlers.ts` / `src/types/electron/studentAnswerApi.d.ts`）。
+- テスト `__tests__/exam/integration/studentAnswerPlacementApply.test.ts`（4件パス）: ①carry追従＋注釈温存 / ①discard削除 / ②ページ跨ぎで examPageId 更新＋破棄 / carryガード。
+- 型/lint/format グリーン（自分の範囲）。
+
+> データ書き込み経路の変更（採点データ破棄を含む）。実行前に必ず許可を取る（DBファイル・破壊的操作の事前許可ルール）。
+
+1. **2軸移動**: `batchUpdateStudentAnswerPlacements`（`batch.ts`）を `examPageId` も更新するよう拡張。`finalPageNumber` を `examId` で `ExamPage.findFirst` 解決（模範解答ページは既存前提・無ければエラー）。`@@unique([examPageId, studentId])` 回避の一時ID方式を `(examPageId, studentId)` の2軸へ拡張。swap も 2 答案の `(examPageId, studentId)` ペア交換に拡張。
+2. **スコア処理を分類駆動に**（§3-4 の①②③）。適用時に各移動を分類し:
+   - ①入れ替え（追従）: **そのページの枠**の `QuestionScore` と `ScoreDecision` を studentId 付け替え（全スコアchurn廃止）。
+   - ②③破棄: 影響スロットの `QuestionScore` と `ScoreDecision` を削除（tombstone/監査記録）。要再採点。
+3. **両スコア表を必ず処理**: 現状無視されている `ScoreDecision`（返却成績）を追従/破棄の対象に含める。`DrawingAnnotation` は既存 tombstone 機構を流用。
+4. **ガード**: ②③（ページ変化）では「追従（入れ替え）」を受け付けない（破棄のみ）。据え置き（採点そのまま）経路はAPIレベルで廃止。
+5. 適用の引数を「分類＋スコア処理方針（carry/discard）」を運べる形へ拡張（`{fileId, finalStudentId, finalPageNumber, scorePolicy}` 等）。IPC 契約（`preload-apis/answerSheetApi.ts` / `ipc-handlers/miscHandlers.ts`）を合わせて更新。
+6. **確認UX**（`ConfirmChangesModal` 改修・ハイブリッド方式に確定）:
+   - 「変更を反映」押下 → 一覧モーダル。変更1件ごとに「誰の採点がどうなるか（追従/破棄）」を明示。
+   - **破棄を伴う項目（②③、および①で破棄を選んだもの）は行ごとにチェック必須**。全チェックが揃うまで「反映」ボタンは無効。追従のみの①はチェック不要で流す。
+   - 全チェック後「反映」→ **最終確認1回（2段階目）**「破棄を伴います。よろしいですか？」→ 実行。
+   - 既定は安全側（①=入れ替え、②③=破棄）。据え置き（採点そのまま）は選択肢に無い。
+   - **UX品質要件（多数変更でも分かりやすく）**:
+     - 変更を**追従／破棄でグルーピング**し、破棄グループを目立たせる（色・アイコン）。件数バッジ（例「破棄 2件」）を先頭に。
+     - リストは**スクロール領域を固定高**にし（ヘッダ／件数サマリ／フッタ「反映」ボタンはスクロール外に常時可視＝sticky）、長大でもボタンを見失わない。
+     - 未チェックの破棄項目が残るとき、反映ボタン近傍に**残数（例「未了解 1件」）**を出し、クリックで最初の未チェック行へスクロール。
+     - 各行は移動を「A・P1 → B・P1」の**視覚的な向き**で示し、swap は双方向矢印＋「入れ替え」バッジ。破棄行は赤系、追従行は青系で即判別。
+     - 生徒名は氏名で表示（IDを見せない）。長名は省略せずtooltip等で確認可能に。
+
+### Phase 1 — 型の分離（0埋め廃止の土台）
+
+**進捗（2026-07-10）**:
+
+- ✅ **1a 完了**: `ProcessedStudentAnswer` 手写し中間層を撤去。DB答案は Prisma 型 `StudentAnswerImageWithExamPageAndStudent`（=`ExistingAnswer`、`prismaExtensions.ts:201`）を素通し。06 hook の Prisma→Processed 変換を削除、`usePendingChanges` は `examPage.pageNumber` を直接読む。テーブル境界（`StudentAnswerUpload`）でだけ占有信号 `{id, studentId, pageNumber}` へ射影。型チェック/lint グリーン。
+- ✅ **1b 0埋め廃止 完了**: `UnifiedFile.buffer`/`size` を任意化し、`convertAnswerSheetsToFiles` の偽 `new ArrayBuffer(0)`/`size:0` を撤廃。消費側を guard（`handleUpload` は buffer 有りのみ、`useMarkerCorrection` は Task にバッファ保持、TableHeader の size 表示を条件化）。型チェック/lint グリーン。
+- ⏳ **残り（Phase 2/3 と同時に land）**: `UnifiedFile` 名の解体（→ `PendingImage`/`AnswerItem`）と 3 型への完全分割。**理由**: 現状 `useStudentAnswerUpload` の単一 `files` state が upload/view 両モードを兼ね、DnD・マーカー補正・handleUpload が同一リストの buffer に依存する。ここで無理に型を割ると使い捨ての buffer 保全ハック（merge-by-id）が要る。DnD をモード別に割る Phase 2/3 でリスト自体が分かれるので、そこで `PendingImage[]`（upload源）/`AnswerItem[]`（共通描画）へ自然に分割する。
+
+1. ~~`PendingImage` / `AnswerItem` を新設~~ → Phase 2/3 で実施（上記理由）。`ExistingAnswer`＝既存 `StudentAnswerImageWithExamPageAndStudent` を採用済み。
+2. `convertFiles`（`useStudentAnswerUpload`）を `PendingImage[]` 生成に変更 → Phase 3。
+3. ✅ view 側の 0埋め・中間層は撤去済み（`convertAnswerSheetsToFiles` は buffer/size を作らない）。`ExistingAnswer[]` を直接持ち回り済み。
+4. ✅ `UploadData` は現行維持。upload 保存経路は据え置き。
+
+### Phase 2 — 共通表コンポーネントの切り出し（DnD 非依存）
+
+> R3: 現状 `DndContext` は `StudentAnswerTable.tsx:78`、`SortableContext` は `TableContent.tsx:87`、セルは `SortableTableCell`（内部 `useSortable`）と、DnD が共通描画に**埋め込まれている**。共通化の境界を `DndContext` より下に引き直すのが本フェーズの主眼。
+
+**進捗（2026-07-10）**:
+
+- ✅ `SortableContext` を `TableContent` から除去し `StudentAnswerTable`（`DndContext` の下）へ引き上げ。表本体は `@dnd-kit/sortable` を import しなくなった。
+- ✅ **共通描画型 `AnswerItem` を導入**（`types.ts`）。「未保存/DB答案の両ソースを射影した表示専用の投射」で、`UnifiedFile` はその上位型。描画層（`FilePreviewCell`/`TableDragOverlay`/`getFileColor`/`drawNameRegionCanvas`/`loadStudentAnswerImage`）を `AnswerItem` へ寄せ、表示を `UnifiedFile` から decouple。upload の buffer 等はパイプライン側 `UnifiedFile` に残置（Phase 3 の DnD 分割時に `PendingImage` へ）。型/lint グリーン（06配下）。
+- ⏳ 残り: セルの掴む/落とす部分（`SortableTableCell`）のスロット化。view の droppable セルを作る Phase 3 と同時に実施（片方だけ作っても意味が薄いため）。
+
+> 注: 型チェックの2件のエラー（`transformWarnings`/`EXAM_CURRENT_VERSION`）は**並行セッションの import-export WIP 由来**で本作業とは無関係（06配下はエラーゼロ）。
+
+1. `TableContent` から「グリッド描画（行×列・ヘッダ・セル= item/empty/disabled+reason）」だけを取り出した**共通表**にする。入力は `AnswerItem` の配置結果＋解決済み無効状態。**`SortableContext` を TableContent から除去**する。
+2. セルの DnD ラッパー（掴める/落とせる）は**スロット/ラッパー props**（例: `renderCell` / `CellWrapper`）で外から差し込む。表本体は `SortableContext` も `useSortable` も `useDroppable` も知らない。upload は sortable セル、view は droppable セルを注入する。
+3. `FilePreviewCell` / `EmptyTableCell` はプレビュー描画の共通部品として維持（アクションは props で注入）。`FilePreviewCell` の入力を `UnifiedFile` から `AnswerItem`（§3-1）へ差し替え。
+
+### Phase 3 — DnD 2 系統
+
+**進捗（2026-07-10）— 3a 完了（apply/modal 配線）**:
+
+- ✅ view 適用を新 `applyStudentAnswerPlacements` API へ接続（`app/.../hooks/index.tsx` `handleApplyChanges`）。pendingChange ごとに ページ変化を判定し `scorePolicy`（carry/discard）を確定して move を構築。旧 `batchUpdateStudentAnswerPlacements`＋`ScoringDataOption` は撤去。
+- ✅ `ConfirmChangesModal` をハイブリッド方式へ全面改修: 追従/破棄グルーピング（色）・件数サマリ・同一ページは carry/discard トグル・破棄項目は行ごと Checkbox 必須（未了解数表示）・破棄ありは2段階目「破棄して反映」。追従のみは直接反映。固定高スクロール＋フッタ常時可視。
+- ✅ `PlacementScorePolicy` 型を 06 に導入。型/lint/format グリーン（06配下）。
+- ⏳ 残り（3b/3c）: DnD を method B（view=グリッドドロップ+swap）へ、セルスロット化、upload=method A。**現状 DnD は method A のまま**で、pendingChange は method A が生成（apply/modal は DnD 非依存なので流用可）。**要手動確認**（DnD 挙動）。
+
+1. **upload = 並べ替えリスト（方式A）**: 現行 `useDragDrop*` を `AnswerItem[]` の上に載せ替え。`SortableContext` + `arrayMove` を維持。配置戦略の自動整列＋手動並べ替え。
+2. **view = グリッドドロップ + swap（方式B）を新規実装**:
+   - 各マス（生徒×ページ）を `useDroppable`、各答案を `useDraggable`。
+   - drop ハンドラ: 空マス→移動 / 既存あり→**swap**。上書き禁止。
+   - これを `pendingChange`（fromState/toState）に変換 → `ConfirmChangesModal` → `onApplyChanges`（DB適用）。
+   - `SortableContext`/フラットリスト/`arrayMove` は view では使わない。
+3. `TableDragOverlay` はドラッグ中プレビュー用に両系統から流用（preview だけ見る）。
+
+### Phase 4 — 無効状態を由来別に再構成
+
+1. `useDisabledState` を「ユーザー操作＋スイッチのみ保存」に。欠席は保存せず導出。行はユーザー明示が欠席既定に勝つ形へ（`didInitAbsentRef` の応急処置を撤去）。
+2. `manualDisabledReason` を「導出（欠席/既存答案占有）＋ユーザートグル（行/列/セル）」を優先順位付きで解決する権威関数に拡張。描画は結果を流すだけ。
+3. 前提コミットの `disabledState.files: Set` と `CellLookup=Map` を**見直す**:
+   - ファイル無効は `PendingImage.disabled` プロパティへ（別リスト参照＝O(n)突き合わせを消す）。
+   - 既存答案占有/動的無効は、素直に導出（必要が測定で示された時だけ局所 `Map<studentId,Set<pageNumber>>`）。**エンコード文字列キー禁止**。
+
+### Phase 5 — 配置戦略切り替え（両モード・リセット＋確認）
+
+1. `PlacementStrategySelector` の変更ハンドラで、**確認モーダル**を挟む（手動配置の有無に関わらず）。
+2. 確定で完全リセット（自動整列し直す）。view は未コミット pendingChange 破棄を明示。
+
+### Phase 6 — 配線・掃除・検証
+
+1. `useStudentAnswerTableLogic` / `StudentAnswerUpload` / 06 hook の配線を新型・新DnDに合わせる。
+2. デッド/未完コード整理（#965: `observerRef` 遅延読込は未実装＝削除 or 実装、`handleUploadToCell` TODO スタブ）。
+3. §6 の検証を全部通す。
+
+---
+
+## 5. 壊してはいけないもの（回帰厳禁）
+
+- **DB 保存**: `uploadStudentAnswers` の `studentId` は **Student.id**（`examStudent.studentId`）。`ExamStudent.id` を渡さない（元バグ）。
+- **アップロードの (studentId, pageNumber) はセル座標由来**（ファイルの素性ではなくマスが決める）。
+- **view の修正フロー**: DnD → pendingChange → `ConfirmChangesModal` → DB 適用（`onApplyChanges`）。答案の削除経路（`deleteStudentAnswer`）。
+  - ※ 適用先の `batchUpdate*` は Phase 0 で2軸対応へ拡張する（従来の studentId 単軸挙動は同一ページ内移動として維持）。upload の保存契約（`uploadStudentAnswers`）は不変。
+- **マーカー補正**: upload 専用。`imagePath` を持つ既存ファイルはスキップ。`markerAvailablePages` に基づく補正/復元。
+- **プレビューの遅延読込**（DB答案）と **blob URL の解放**（未保存、`useStudentAnswerUpload` の revoke）。
+- **欠席の既定無効**は維持しつつ、**手動有効化が再取得で消えない**こと（由来分離で保証）。
+
+---
+
+## 6. 検証（実機・DB書き込みを伴うので都度許可）
+
+1. **upload**: PDF/画像ドロップ→変換→グリッド自動整列→手動並べ替え→アップロード→`StudentAnswerImage` が正しい `(studentId, examPage)` で作成される（FK違反ゼロ）。
+2. **占有無効**: 既にアップロード済みのマスが upload タブで無効表示。`allowOverwrite` ON で解除。
+3. **view グリッドドロップ**: 誤配置答案を別マスへドロップ→空=移動/埋=swap→pendingChange→確認→DB反映。上書き消去が起きないこと。
+4. **戦略切替**: 手動配置あり時に確認モーダル→リセット。両モード。
+5. **欠席**: 欠席者の行が既定無効→手動有効化→再取得で維持される。
+6. **マーカー補正・遅延プレビュー・blob解放**が従来通り。
+7. `npm run typecheck` / `npm run lint` グリーン。
+
+---
+
+## 7. 本計画のスコープ外（別 issue）
+
+- **#961**: 列軸を `pageNumber`（序数）→ `ExamPage.id`（真の同一性）へ。供給層＋`FileState`＋`UploadData`＋DnD を横断。本計画は `pageNumber` のまま進め、`AnswerItem.pageNumber` を将来 `examPageId` に差し替えられる形にしておく。
+- **#962**: `StudentAnswerImage` を `Student×ExamPage` から `ExamStudent×ExamPage` の多対多へ（採点層全体が Student キーのため単独判断・要設計）。
+- **#963**: UnifiedFile 判別union化 → **本計画の中核で解消**（型分離・0埋め廃止）。
+- **#964**: DnD trash 巻き込み → **本計画の view 方式B化で構造的に解消**。
+- **#965**: デッド/未完コード整理 → Phase 6 で随時。
+
+---
+
+## 8. 用語
+
+- **AnswerItem**: 表と DnD が読む、セルに載る最小の要素（id/studentId/pageNumber/preview）。
+- **PendingImage**: アップロード前の未保存画像（本物 buffer を持つ・DB に無い）。
+- **ExistingAnswer**: DB の `StudentAnswerImage`（Prisma 型そのもの）。
+- **占有無効 (existing_answer)**: upload で、そのマスに既にDB答案がある → `!allowOverwrite` なら無効。
+- **swap**: view のドロップで、移動先が埋まっている時に 2 マスを交換（上書きしない）。

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -16,12 +16,14 @@ import {
   uploadMasterAnswers,
 } from "../lib/prisma/masterAnswer"
 import {
+  applyStudentAnswerPlacements,
   associateStudentAnswerWithStudent,
   batchUpdateStudentAnswerPlacements,
   deleteStudentAnswer,
   getStudentAnswerById,
   getStudentAnswersByExamId,
   setStudentAnswerAbsent,
+  type StudentAnswerPlacementMove,
   swapStudentAnswerPlacements,
   swapStudentAnswerPlacementsWithScoring,
   updateStudentAnswerPlacement,
@@ -224,6 +226,18 @@ export function setupMiscHandlers(): void {
         moves,
         withScoring
       )
+      if (!result.success) {
+        const errorMessage = "error" in result ? result.error : "Unknown error"
+        throw new Error(errorMessage)
+      }
+      return result
+    }
+  )
+
+  registerHandler(
+    "apply-answer-sheet-placements",
+    async (moves: StudentAnswerPlacementMove[]) => {
+      const result = await applyStudentAnswerPlacements(moves)
       if (!result.success) {
         const errorMessage = "error" in result ? result.error : "Unknown error"
         throw new Error(errorMessage)

--- a/electron-src/lib/prisma/studentAnswer.ts
+++ b/electron-src/lib/prisma/studentAnswer.ts
@@ -9,14 +9,18 @@
 
 // 全ての関数を再エクスポート
 export {
+  // 採点安全な配置適用（view 方式B）
+  applyStudentAnswerPlacements,
   associateStudentAnswerWithStudent,
   // 一括操作
   batchUpdateStudentAnswerPlacements,
   deleteStudentAnswer,
   getStudentAnswerById,
   getStudentAnswersByExamId,
+  type PlacementScorePolicy,
   // ステータス管理
   setStudentAnswerAbsent,
+  type StudentAnswerPlacementMove,
   swapStudentAnswerPlacements,
   swapStudentAnswerPlacementsWithScoring,
   // 配置管理

--- a/electron-src/lib/prisma/studentAnswer/index.ts
+++ b/electron-src/lib/prisma/studentAnswer/index.ts
@@ -29,3 +29,10 @@ export {
   batchUpdateStudentAnswerPlacements,
   swapStudentAnswerPlacementsWithScoring,
 } from "./batch"
+
+// 採点安全な配置適用（view 方式B: 2軸移動 + carry/discard）
+export {
+  applyStudentAnswerPlacements,
+  type PlacementScorePolicy,
+  type StudentAnswerPlacementMove,
+} from "./placementApply"

--- a/electron-src/lib/prisma/studentAnswer/placementApply.ts
+++ b/electron-src/lib/prisma/studentAnswer/placementApply.ts
@@ -1,0 +1,317 @@
+/**
+ * 答案配置の採点安全な一括適用（view の方式B: 任意マスへ移動・衝突swap）
+ *
+ * 設計（docs/06-student-answers-cell-architecture-plan.md §3-3/§3-4）:
+ * - 2軸移動: studentId だけでなく examPageId も更新する（finalPageNumber を ExamPage に解決）。
+ * - 採点はページ scoped: 移動元ページの CropRegion × 現生徒の QuestionScore/ScoreDecision のみ対象。
+ * - carry（追従・同一ページのみ）:
+ *   - QuestionScore は unique が無いので **id 指定の updateMany で studentId 付け替え**（id 保持 →
+ *     子の DrawingAnnotation を温存。swap も id 指定なので途中衝突なし）。
+ *   - ScoreDecision は `@@unique([cropRegionId, studentId])` があるため **delete → 最終位置へ再作成**。
+ * - discard: DrawingAnnotation を tombstone してから両スコア表を削除。
+ * - **移動先セルの残存採点を掃除**: 移動先 (finalStudentId, 移動先ページの CropRegion) に既存の
+ *   採点があり、それが「移動してくる採点（moving 集合）」でない場合は stale として削除する
+ *   （さもないと carry で QuestionScore が二重計上、ScoreDecision は unique 違反になる）。
+ * - 画像は `@@unique([examPageId, studentId])` の 2-cycle を避けるため **delete → 同一 id で再作成**。
+ * - ガード: carry かつページ変化はエラー。finalStudentId=null（削除）は不可（削除は別操作）。
+ *   移動先が batch 外の答案で占有されている場合もエラー（上書きはしない）。
+ *
+ * いずれも基本的な Prisma 操作のみ（findMany/updateMany/deleteMany/createMany）。
+ */
+import type { Prisma } from "@prisma/client"
+
+import prisma from "../client"
+import { recordDrawingAnnotationDeletionsForQuestionScores } from "../deletedRecord"
+
+export type PlacementScorePolicy = "carry" | "discard"
+
+export interface StudentAnswerPlacementMove {
+  fileId: string
+  finalStudentId: string | null // null は不可（本APIは削除を扱わない）
+  finalPageNumber: number
+  scorePolicy: PlacementScorePolicy
+}
+
+/**
+ * 複数の答案配置を採点安全に一括適用する。
+ * @param moves スロット置換を表す移動の配列（swap は両方を含む／空マスへは移動）
+ */
+export async function applyStudentAnswerPlacements(
+  moves: StudentAnswerPlacementMove[]
+) {
+  if (moves.length === 0) return { success: true }
+
+  // 本APIは配置の移動/入れ替え専用。削除は deleteStudentAnswer（ファイル削除・監査込み）を使う。
+  const nullMove = moves.find((move) => move.finalStudentId === null)
+  if (nullMove) {
+    return {
+      success: false,
+      error:
+        "配置適用では画像の削除はできません（削除は別操作を使用してください）",
+    }
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // 1. 現在の配置を取得（再作成のため imagePath/createdAt も保持）
+      const currentAnswers = await Promise.all(
+        moves.map((move) =>
+          tx.studentAnswerImage.findUnique({
+            where: { id: move.fileId },
+            select: {
+              id: true,
+              studentId: true,
+              examPageId: true,
+              imagePath: true,
+              createdAt: true,
+              examPage: { select: { examId: true } },
+            },
+          })
+        )
+      )
+      const missingIndex = currentAnswers.findIndex(
+        (currentAnswer) => !currentAnswer
+      )
+      if (missingIndex !== -1) {
+        throw new Error(`答案が見つかりません: ${moves[missingIndex].fileId}`)
+      }
+
+      // 2. ターゲット examPageId 解決 + carry ガード
+      type PlacementPlan = {
+        move: StudentAnswerPlacementMove
+        current: NonNullable<(typeof currentAnswers)[number]>
+        finalStudentId: string
+        targetExamPageId: string
+      }
+      const plans: PlacementPlan[] = []
+      for (let index = 0; index < moves.length; index++) {
+        const move = moves[index]
+        const current = currentAnswers[index]!
+        const finalStudentId = move.finalStudentId! // null は上で除外済み
+
+        const targetPage = await tx.examPage.findFirst({
+          where: {
+            examId: current.examPage.examId,
+            pageNumber: move.finalPageNumber,
+          },
+          select: { id: true },
+        })
+        if (!targetPage) {
+          throw new Error(`ページ${move.finalPageNumber}が見つかりません`)
+        }
+
+        const pageChanged = current.examPageId !== targetPage.id
+        if (move.scorePolicy === "carry" && pageChanged) {
+          throw new Error(
+            "ページを跨ぐ移動では採点情報の追従はできません（破棄を選択してください）"
+          )
+        }
+
+        plans.push({
+          move,
+          current,
+          finalStudentId,
+          targetExamPageId: targetPage.id,
+        })
+      }
+
+      // 移動先が batch 外の答案で占有されていないか（上書きは不可、入れ替えのみ）
+      const batchFileIds = plans.map((plan) => plan.move.fileId)
+      for (const plan of plans) {
+        const occupant = await tx.studentAnswerImage.findFirst({
+          where: {
+            examPageId: plan.targetExamPageId,
+            studentId: plan.finalStudentId,
+            id: { notIn: batchFileIds },
+          },
+          select: { id: true },
+        })
+        if (occupant) {
+          throw new Error(
+            "移動先に別の答案があります（入れ替えでのみ移動できます）"
+          )
+        }
+      }
+
+      // 3. 移動する採点（source）の収集。moving 集合も作る（移動先掃除で使う）。
+      const questionScoreIdsToDelete: string[] = [] // discard source + stale destination
+      const scoreDecisionIdsToDelete: string[] = [] // discard/carry source + stale destination
+      const questionScoreCarryUpdates: Array<{
+        ids: string[]
+        finalStudentId: string
+      }> = []
+      const scoreDecisionsToRecreate: Prisma.ScoreDecisionCreateManyInput[] = []
+      const movingQuestionScoreIds = new Set<string>()
+      const movingScoreDecisionIds = new Set<string>()
+      // 移動先掃除のための (finalStudentId, 移動先ページの cropRegionIds)
+      const destinationScopes: Array<{
+        finalStudentId: string
+        cropRegionIds: string[]
+      }> = []
+
+      const cropRegionIdsByPage = new Map<string, string[]>()
+      const getCropRegionIds = async (examPageId: string) => {
+        const cached = cropRegionIdsByPage.get(examPageId)
+        if (cached) return cached
+        const cropRegions = await tx.cropRegion.findMany({
+          where: { examPageId },
+          select: { id: true },
+        })
+        const ids = cropRegions.map((cropRegion) => cropRegion.id)
+        cropRegionIdsByPage.set(examPageId, ids)
+        return ids
+      }
+
+      for (const plan of plans) {
+        const sourceCropRegionIds = await getCropRegionIds(
+          plan.current.examPageId
+        )
+        const targetCropRegionIds = await getCropRegionIds(
+          plan.targetExamPageId
+        )
+        destinationScopes.push({
+          finalStudentId: plan.finalStudentId,
+          cropRegionIds: targetCropRegionIds,
+        })
+
+        if (sourceCropRegionIds.length === 0) continue
+
+        const questionScores = await tx.questionScore.findMany({
+          where: {
+            studentId: plan.current.studentId,
+            cropRegionId: { in: sourceCropRegionIds },
+          },
+          select: { id: true },
+        })
+        const scoreDecisions = await tx.scoreDecision.findMany({
+          where: {
+            studentId: plan.current.studentId,
+            cropRegionId: { in: sourceCropRegionIds },
+          },
+        })
+        questionScores.forEach((questionScore) =>
+          movingQuestionScoreIds.add(questionScore.id)
+        )
+        scoreDecisions.forEach((scoreDecision) =>
+          movingScoreDecisionIds.add(scoreDecision.id)
+        )
+
+        if (plan.move.scorePolicy === "discard") {
+          questionScoreIdsToDelete.push(
+            ...questionScores.map((questionScore) => questionScore.id)
+          )
+          scoreDecisionIdsToDelete.push(
+            ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
+          )
+        } else {
+          // carry: QuestionScore は id 指定で studentId 付け替え（注釈を温存）
+          if (questionScores.length > 0) {
+            questionScoreCarryUpdates.push({
+              ids: questionScores.map((questionScore) => questionScore.id),
+              finalStudentId: plan.finalStudentId,
+            })
+          }
+          // ScoreDecision は unique 回避のため delete → id 保持で最終位置へ再作成
+          scoreDecisionIdsToDelete.push(
+            ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
+          )
+          scoreDecisionsToRecreate.push(
+            ...scoreDecisions.map((scoreDecision) => ({
+              id: scoreDecision.id,
+              cropRegionId: scoreDecision.cropRegionId,
+              studentId: plan.finalStudentId,
+              verdict: scoreDecision.verdict,
+              score: scoreDecision.score,
+              comment: scoreDecision.comment,
+              decidedByUserId: scoreDecision.decidedByUserId,
+              decidedAt: scoreDecision.decidedAt,
+              createdAt: scoreDecision.createdAt,
+              sourceQuestionScoreId: scoreDecision.sourceQuestionScoreId,
+            }))
+          )
+        }
+      }
+
+      // 3b. 移動先セルの残存採点（moving でないもの）を stale として掃除する。
+      for (const scope of destinationScopes) {
+        if (scope.cropRegionIds.length === 0) continue
+        const staleQuestionScores = await tx.questionScore.findMany({
+          where: {
+            studentId: scope.finalStudentId,
+            cropRegionId: { in: scope.cropRegionIds },
+          },
+          select: { id: true },
+        })
+        const staleScoreDecisions = await tx.scoreDecision.findMany({
+          where: {
+            studentId: scope.finalStudentId,
+            cropRegionId: { in: scope.cropRegionIds },
+          },
+          select: { id: true },
+        })
+        for (const questionScore of staleQuestionScores) {
+          if (!movingQuestionScoreIds.has(questionScore.id)) {
+            questionScoreIdsToDelete.push(questionScore.id)
+          }
+        }
+        for (const scoreDecision of staleScoreDecisions) {
+          if (!movingScoreDecisionIds.has(scoreDecision.id)) {
+            scoreDecisionIdsToDelete.push(scoreDecision.id)
+          }
+        }
+      }
+
+      // 4. QuestionScore: DrawingAnnotation を tombstone してから削除
+      if (questionScoreIdsToDelete.length > 0) {
+        await recordDrawingAnnotationDeletionsForQuestionScores(
+          questionScoreIdsToDelete,
+          { tx }
+        )
+        await tx.questionScore.deleteMany({
+          where: { id: { in: questionScoreIdsToDelete } },
+        })
+      }
+
+      // 5. carry の QuestionScore: id 指定で studentId 付け替え（行=注釈を保持）
+      for (const carryUpdate of questionScoreCarryUpdates) {
+        await tx.questionScore.updateMany({
+          where: { id: { in: carryUpdate.ids } },
+          data: { studentId: carryUpdate.finalStudentId },
+        })
+      }
+
+      // 6. ScoreDecision: 対象を削除 → carry 分を最終位置へ再作成（unique 回避）
+      if (scoreDecisionIdsToDelete.length > 0) {
+        await tx.scoreDecision.deleteMany({
+          where: { id: { in: scoreDecisionIdsToDelete } },
+        })
+      }
+      if (scoreDecisionsToRecreate.length > 0) {
+        await tx.scoreDecision.createMany({ data: scoreDecisionsToRecreate })
+      }
+
+      // 7. 画像移動: delete → 同一 id で再作成（2-cycle 回避、id/imagePath/createdAt 保持）
+      await tx.studentAnswerImage.deleteMany({
+        where: { id: { in: batchFileIds } },
+      })
+      await tx.studentAnswerImage.createMany({
+        data: plans.map((plan) => ({
+          id: plan.move.fileId,
+          examPageId: plan.targetExamPageId,
+          studentId: plan.finalStudentId,
+          imagePath: plan.current.imagePath,
+          createdAt: plan.current.createdAt,
+        })),
+      })
+    })
+
+    return { success: true }
+  } catch (error) {
+    console.error("Error applying student answer placements:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "答案配置の適用に失敗しました",
+    }
+  }
+}

--- a/electron-src/preload-apis/answerSheetApi.ts
+++ b/electron-src/preload-apis/answerSheetApi.ts
@@ -75,5 +75,13 @@ export function createAnswerSheetApi() {
         moves,
         withScoring
       ),
+    applyStudentAnswerPlacements: (
+      moves: Array<{
+        fileId: string
+        finalStudentId: string | null
+        finalPageNumber: number
+        scorePolicy: "carry" | "discard"
+      }>
+    ) => ipcRenderer.invoke("apply-answer-sheet-placements", moves),
   }
 }

--- a/src/app/exams/[examId]/06-student-answers/components/index.tsx
+++ b/src/app/exams/[examId]/06-student-answers/components/index.tsx
@@ -6,15 +6,17 @@ import { Eye, Grid3X3 } from "lucide-react"
 
 import ProtectedRoute from "@/components/auth/ProtectedRoute"
 import { StudentAnswerUpload } from "@/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload"
-import type { ProcessedStudentAnswer } from "@/components/exams/06-student-answers/student-answer-management/types"
 import { ConfirmChangesModal } from "@/components/exams/06-student-answers/student-answer-table/components/ConfirmChangesModal"
 import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import type {
   PendingChange,
-  ScoringDataOption,
+  PlacementScorePolicy,
 } from "@/components/exams/06-student-answers/types"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
+import type {
+  ExamStudentWithMemberships,
+  StudentAnswerImageWithExamPageAndStudent,
+} from "@/types/prismaExtensions"
 
 // Types
 export type StudentAnswerTab = "new-grid" | "current"
@@ -69,7 +71,7 @@ interface StudentAnswersTabContentProps {
   examId: string
   students: ExamStudentWithMemberships[]
   modelAnswerCount: number
-  studentAnswers: ProcessedStudentAnswer[]
+  studentAnswers: StudentAnswerImageWithExamPageAndStudent[]
   pendingChanges: PendingChange[]
   affectedCells: Set<string>
   onUploadComplete: () => void
@@ -83,7 +85,9 @@ interface StudentAnswersTabContentProps {
   ) => void
   isConfirmModalOpen: boolean
   onCloseConfirmModal: () => void
-  onApplyChanges: (option: ScoringDataOption) => Promise<void>
+  onApplyChanges: (
+    policies: Record<string, PlacementScorePolicy>
+  ) => Promise<void>
   onResetChanges: () => Promise<void>
   onUploadFileCountChange?: (count: number) => void
   correctionStatusMap?: Map<string, "corrected" | "skipped">

--- a/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
+++ b/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
@@ -5,19 +5,21 @@
 import { useCallback, useRef, useState } from "react"
 import { toast } from "sonner"
 
-import type { ProcessedStudentAnswer } from "@/components/exams/06-student-answers/student-answer-management/types"
 import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import type {
   PendingChange,
-  ScoringDataOption,
+  PlacementScorePolicy,
 } from "@/components/exams/06-student-answers/types"
 import type { ExamPageWithContent } from "@/electron-src/lib/prisma/examPage"
-import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
+import type {
+  ExamStudentWithMemberships,
+  StudentAnswerImageWithExamPageAndStudent,
+} from "@/types/prismaExtensions"
 
 export function useStudentAnswersData(examId: string) {
   const [students, setStudents] = useState<ExamStudentWithMemberships[]>([])
   const [studentAnswers, setStudentAnswers] = useState<
-    ProcessedStudentAnswer[]
+    StudentAnswerImageWithExamPageAndStudent[]
   >([])
   const [modelAnswerCount, setModelAnswerCount] = useState<number>(0)
   const [isLoading, setIsLoading] = useState(true)
@@ -57,29 +59,8 @@ export function useStudentAnswersData(examId: string) {
         studentAnswersResult.success &&
         studentAnswersResult.studentAnswerImages
       ) {
-        // Convert Prisma型をProcessedStudentAnswer型に変換
-        const processedAnswers: ProcessedStudentAnswer[] =
-          studentAnswersResult.studentAnswerImages.map((img) => ({
-            id: img.id,
-            studentId: img.studentId,
-            pageNumber: img.examPage.pageNumber,
-            originalImagePath: img.imagePath,
-            isAbsent:
-              img.student?.examStudents?.[0]?.status === "absent" || false,
-            student: img.student
-              ? {
-                  id: img.student.id,
-                  lastName: img.student.lastName,
-                  firstName: img.student.firstName,
-                  lastNameKana: img.student.lastNameKana,
-                  firstNameKana: img.student.firstNameKana,
-                  studentNumber: img.student.studentNumber,
-                }
-              : null,
-            examId: img.examPage.examId,
-            status: "ready" as const,
-          }))
-        setStudentAnswers(processedAnswers)
+        // Prisma 型（examPage/student 込み）をそのまま保持する。手写しの中間層は置かない。
+        setStudentAnswers(studentAnswersResult.studentAnswerImages)
       }
 
       // Load model answer count
@@ -120,7 +101,7 @@ export function useStudentAnswersData(examId: string) {
 export function usePendingChanges(
   onDataReload: () => Promise<void>,
   students?: ExamStudentWithMemberships[],
-  studentAnswers?: ProcessedStudentAnswer[]
+  studentAnswers?: StudentAnswerImageWithExamPageAndStudent[]
 ) {
   const [pendingChanges, setPendingChanges] = useState<PendingChange[]>([])
   const [affectedCells, setAffectedCells] = useState<Set<string>>(new Set())
@@ -155,7 +136,7 @@ export function usePendingChanges(
           const targetFile = studentAnswers?.find(
             (sheet) =>
               sheet.studentId === toState.studentId &&
-              sheet.pageNumber === toState.pageNumber &&
+              sheet.examPage.pageNumber === toState.pageNumber &&
               sheet.id !== fileId // 移動されたファイル自体は除外
           )
 
@@ -166,7 +147,7 @@ export function usePendingChanges(
               ? {
                   id: targetFile.id,
                   studentId: targetFile.studentId,
-                  pageNumber: targetFile.pageNumber,
+                  pageNumber: targetFile.examPage.pageNumber,
                 }
               : null,
             totalStudentAnswers: studentAnswers?.length || 0,
@@ -204,58 +185,43 @@ export function usePendingChanges(
   )
 
   const handleApplyChanges = useCallback(
-    async (option: ScoringDataOption) => {
+    async (policies: Record<string, PlacementScorePolicy>) => {
       try {
-        // 全ての変更を一方向移動として収集
-        const allMoves: Array<{
-          fileId: string
-          finalStudentId: string | null
-          finalPageNumber: number
-        }> = []
-
-        for (const change of pendingChanges) {
-          // 移動されるファイルの最終位置
-          allMoves.push({
+        // 各変更を最終位置＋採点方針(carry/discard)付きの move へ。
+        // ページ変化の move は carry を受け付けない（バックエンドでもガード）。
+        const moves = pendingChanges.map((change) => {
+          const pageChanged =
+            change.fromPosition.pageNumber !== change.toPosition.pageNumber
+          const requested = policies[change.id] ?? "carry"
+          const scorePolicy: PlacementScorePolicy = pageChanged
+            ? "discard"
+            : requested
+          return {
             fileId: change.movedFileId,
             finalStudentId: change.toPosition.studentId,
             finalPageNumber: change.toPosition.pageNumber,
-          })
-        }
-
-        console.log("🔄 Batch moves to apply:", {
-          totalMoves: allMoves.length,
-          moves: allMoves.map((move) => ({
-            fileId: move.fileId.substring(0, 8) + "...",
-            to: `${move.finalStudentId?.substring(0, 8) || "null"}...page${move.finalPageNumber}`,
-          })),
+            scorePolicy,
+          }
         })
 
-        // 一括移動処理：トランザクション内で全ての移動を同時実行
-        console.log("📝 Calling batch placement update...")
         const result =
-          await window.electronAPI.batchUpdateStudentAnswerPlacements(
-            allMoves,
-            option === "with-scoring"
-          )
-
-        console.log("✅ Batch placement update result:", result)
+          await window.electronAPI.applyStudentAnswerPlacements(moves)
 
         if (!result || !result.success) {
-          throw new Error(result?.error || "一括配置変更に失敗しました")
+          throw new Error(result?.error || "配置変更の適用に失敗しました")
         }
 
-        console.log("🔄 Clearing pending changes and reloading data...")
         setPendingChanges([])
         setAffectedCells(new Set())
-
-        console.log("🔄 Calling onDataReload...")
         await onDataReload()
-        console.log("✅ Data reload completed")
 
-        const optionText =
-          option === "with-scoring" ? "採点情報込み" : "答案画像のみ"
+        const discardCount = moves.filter(
+          (move) => move.scorePolicy === "discard"
+        ).length
         toast.success(
-          `${pendingChanges.length}件の変更を適用しました（${optionText}）`
+          discardCount > 0
+            ? `${moves.length}件を反映しました（採点破棄 ${discardCount}件）`
+            : `${moves.length}件を反映しました`
         )
       } catch (error) {
         console.error("変更の適用に失敗しました:", error)

--- a/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 
 import { FileUploadZone } from "@/components/exams/06-student-answers/student-answer-management/components/FileUploadZone"
 import { useStudentAnswerUpload } from "@/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload"
@@ -29,6 +29,18 @@ export function StudentAnswerUpload({
 }: StudentAnswerUploadProps) {
   const finalModelAnswerCount = modelAnswerCount
   const finalExistingAnswers = existingStudentAnswers
+
+  // 表・DnD が占有信号として読む最小形（{id, studentId, pageNumber}）に射影する。
+  // DB答案は Prisma 型のまま持ち回り、テーブル境界でだけ座標へ落とす。
+  const existingAnswerOccupancy = useMemo(
+    () =>
+      finalExistingAnswers?.map((answerSheet) => ({
+        id: answerSheet.id,
+        studentId: answerSheet.studentId,
+        pageNumber: answerSheet.examPage.pageNumber,
+      })),
+    [finalExistingAnswers]
+  )
   const {
     // State
     isUploading,
@@ -145,7 +157,7 @@ export function StudentAnswerUpload({
         pendingChanges={pendingChanges}
         affectedCells={affectedCells}
         onUpdatePendingChanges={onUpdatePendingChanges}
-        existingStudentAnswers={finalExistingAnswers}
+        existingStudentAnswers={existingAnswerOccupancy}
       />
     )
   }
@@ -176,7 +188,7 @@ export function StudentAnswerUpload({
           observerRef={observerRef}
           mode={mode}
           onReloadData={onUploadComplete}
-          existingStudentAnswers={finalExistingAnswers}
+          existingStudentAnswers={existingAnswerOccupancy}
           markerCorrectionEnabled={markerCorrectionEnabled}
           markerCorrectionAvailable={markerCorrectionAvailable}
           markerDiagnostics={markerDiagnostics}

--- a/src/components/exams/06-student-answers/student-answer-management/types/index.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/types/index.ts
@@ -1,25 +1,9 @@
 import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import type { PendingChange } from "@/components/exams/06-student-answers/types"
-import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
-
-// Processed student answer format for component compatibility
-export interface ProcessedStudentAnswer {
-  id: string
-  studentId: string | null
-  pageNumber: number
-  originalImagePath: string | null
-  isAbsent: boolean
-  student: {
-    id: string
-    lastName: string
-    firstName: string
-    lastNameKana: string
-    firstNameKana: string
-    studentNumber: string
-  } | null
-  examId: string
-  status: "ready"
-}
+import type {
+  ExamStudentWithMemberships,
+  StudentAnswerImageWithExamPageAndStudent,
+} from "@/types/prismaExtensions"
 
 // Local component-specific types
 export interface StudentAnswerUploadProps {
@@ -27,7 +11,8 @@ export interface StudentAnswerUploadProps {
   students: ExamStudentWithMemberships[]
   modelAnswerCount: number
   onUploadComplete?: () => void
-  existingStudentAnswers?: ProcessedStudentAnswer[]
+  // DB答案は Prisma 型（examPage/student 込み）をそのまま持ち回る。手写し中間層は置かない。
+  existingStudentAnswers?: StudentAnswerImageWithExamPageAndStudent[]
   mode?: "upload" | "view"
 
   // 変更状態管理用（確認モードのみ）

--- a/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/utils/convertStudentAnswersToFiles.ts
@@ -1,50 +1,22 @@
-import type { ProcessedStudentAnswer } from "@/components/exams/06-student-answers/student-answer-management/types"
-import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+import type {
+  AnswerItem,
+  UnifiedFile,
+} from "@/components/exams/06-student-answers/types"
+import type { StudentAnswerImageWithExamPageAndStudent } from "@/types/prismaExtensions"
 
-// For backward compatibility, support both processed and raw formats
-type AnswerSheetInput =
-  | ProcessedStudentAnswer
-  | {
-      // Raw Prisma format
-      id: string
-      studentId: string | null
-      imagePath: string
-      student: {
-        id: string
-        lastName: string
-        firstName: string
-        lastNameKana: string
-        firstNameKana: string
-        studentId: string
-      } | null
-      examPage: {
-        pageNumber: number
-      }
-    }
-
-/** DB取得済みの答案データをテーブル表示用のUnifiedFile配列に変換する */
+/** DB取得済みの答案データ（Prisma型）をテーブル表示用のUnifiedFile配列に変換する */
 export function convertAnswerSheetsToFiles(
-  answerSheets: AnswerSheetInput[]
+  answerSheets: StudentAnswerImageWithExamPageAndStudent[]
 ): UnifiedFile[] {
   return answerSheets.map((answerSheet) => {
-    // Handle both processed format (originalImagePath) and raw format (imagePath)
-    const imagePath =
-      "originalImagePath" in answerSheet
-        ? answerSheet.originalImagePath
-        : answerSheet.imagePath
-
-    // Handle both processed format (pageNumber) and raw format (examPage.pageNumber)
-    const pageNumber =
-      "pageNumber" in answerSheet
-        ? answerSheet.pageNumber
-        : answerSheet.examPage.pageNumber
+    const imagePath = answerSheet.imagePath
+    const pageNumber = answerSheet.examPage.pageNumber
 
     return {
       id: answerSheet.id,
       name: `${answerSheet.studentId || "unknown"}_page${pageNumber}`,
       type: imagePath?.split(".").pop() || "image",
-      size: 0, // 既存ファイルのサイズは取得不可
-      buffer: new ArrayBuffer(0), // 既存ファイルのバッファは遅延読み込み
+      // DB答案は size/buffer を持たない（遅延読込。偽の 0埋めはしない）。
       preview: undefined, // 遅延読み込みでBase64データを設定
       studentId: answerSheet.studentId || undefined,
       pageNumber: pageNumber || 1,
@@ -61,9 +33,9 @@ export function convertAnswerSheetsToFiles(
   })
 }
 
-/** UnifiedFileから答案画像をBase64データURLとして読み込む（遅延読み込み対応） */
+/** 答案画像をBase64データURLとして読み込む（遅延読み込み対応） */
 export async function loadStudentAnswerImage(
-  file: UnifiedFile
+  file: AnswerItem
 ): Promise<string> {
   // 新規ファイル（メモリ内）の場合はpreviewを返す
   if (file.preview && !file.imagePath) {

--- a/src/components/exams/06-student-answers/student-answer-management/utils/reorderFilesByStrategy.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/utils/reorderFilesByStrategy.ts
@@ -2,9 +2,11 @@ import type {
   PlacementStrategy,
   UnifiedFile,
 } from "@/components/exams/06-student-answers/types"
-import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
+import type {
+  ExamStudentWithMemberships,
+  StudentAnswerImageWithExamPageAndStudent,
+} from "@/types/prismaExtensions"
 
-import type { ProcessedStudentAnswer } from "../types"
 import { convertAnswerSheetsToFiles } from "./convertStudentAnswersToFiles"
 
 /** 配置戦略（ページ順/生徒順）に基づいてファイル配列を再配置する */
@@ -81,7 +83,7 @@ export function reorderFilesByStrategy(
 
 /** 既存の答案データを配置戦略に基づく統一ファイル配列に変換する */
 export function buildOrderedFileArrayFromStudentAnswers(
-  studentAnswers: ProcessedStudentAnswer[],
+  studentAnswers: StudentAnswerImageWithExamPageAndStudent[],
   students: ExamStudentWithMemberships[],
   modelAnswerCount: number,
   fileOrder: PlacementStrategy

--- a/src/components/exams/06-student-answers/student-answer-table/components/ConfirmChangesModal.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/ConfirmChangesModal.tsx
@@ -1,13 +1,19 @@
 "use client"
 
-import { AlertTriangle, FileEdit, Loader2 } from "lucide-react"
-import { useState } from "react"
+import {
+  AlertTriangle,
+  ArrowLeftRight,
+  ArrowRight,
+  Loader2,
+} from "lucide-react"
+import { useMemo, useState } from "react"
 
 import type {
   PendingChange,
-  ScoringDataOption,
+  PlacementScorePolicy,
 } from "@/components/exams/06-student-answers/types"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -16,17 +22,26 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Switch } from "@/components/ui/switch"
 
 interface ConfirmChangesModalProps {
   isOpen: boolean
   onClose: () => void
   pendingChanges: PendingChange[]
-  onConfirm: (option: ScoringDataOption) => Promise<void>
+  onConfirm: (policies: Record<string, PlacementScorePolicy>) => Promise<void>
   onReset?: () => Promise<void>
 }
 
+/** ページが変わる移動か（＝採点は追従不可・破棄一択） */
+function isPageChange(change: PendingChange): boolean {
+  return change.fromPosition.pageNumber !== change.toPosition.pageNumber
+}
+
+/**
+ * 変更適用の確認モーダル（ハイブリッド方式）。
+ * - 追従(carry)のみの①は摩擦なく流す。
+ * - 破棄を伴う項目（②③のページ変化・①の破棄選択）は行ごとにチェック必須＋最終確認1回。
+ */
 export function ConfirmChangesModal({
   isOpen,
   onClose,
@@ -34,14 +49,62 @@ export function ConfirmChangesModal({
   onConfirm,
   onReset,
 }: ConfirmChangesModalProps) {
-  const [selectedOption, setSelectedOption] =
-    useState<ScoringDataOption>("with-scoring")
+  // 同一ページ変更の方針（既定 carry）。ページ変化は常に discard で state に持たない。
+  const [samePagePolicies, setSamePagePolicies] = useState<
+    Record<string, PlacementScorePolicy>
+  >({})
+  const [ackedDiscards, setAckedDiscards] = useState<Set<string>>(new Set())
+  const [phase, setPhase] = useState<"list" | "confirm">("list")
   const [isApplying, setIsApplying] = useState(false)
 
-  const handleConfirm = async () => {
+  const effectivePolicy = (change: PendingChange): PlacementScorePolicy =>
+    isPageChange(change) ? "discard" : (samePagePolicies[change.id] ?? "carry")
+
+  const discardChanges = useMemo(
+    () =>
+      pendingChanges.filter((change) => effectivePolicy(change) === "discard"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pendingChanges, samePagePolicies]
+  )
+  const carryCount = pendingChanges.length - discardChanges.length
+  const unackedCount = discardChanges.filter(
+    (change) => !ackedDiscards.has(change.id)
+  ).length
+  const allAcked = unackedCount === 0
+
+  const buildPolicies = (): Record<string, PlacementScorePolicy> => {
+    const policies: Record<string, PlacementScorePolicy> = {}
+    for (const change of pendingChanges) {
+      policies[change.id] = effectivePolicy(change)
+    }
+    return policies
+  }
+
+  const resetLocalState = () => {
+    setSamePagePolicies({})
+    setAckedDiscards(new Set())
+    setPhase("list")
+  }
+
+  const handleClose = () => {
+    resetLocalState()
+    onClose()
+  }
+
+  const handleProceed = () => {
+    // 破棄があれば2段階目の最終確認へ。追従のみなら直接適用。
+    if (discardChanges.length > 0) {
+      setPhase("confirm")
+    } else {
+      void applyNow()
+    }
+  }
+
+  const applyNow = async () => {
     setIsApplying(true)
     try {
-      await onConfirm(selectedOption)
+      await onConfirm(buildPolicies())
+      resetLocalState()
       onClose()
     } catch (error) {
       console.error("変更の適用に失敗しました:", error)
@@ -50,199 +113,190 @@ export function ConfirmChangesModal({
     }
   }
 
-  const handleCancel = () => {
-    onClose()
-  }
-
-  const handleReset = async () => {
-    if (onReset) {
-      await onReset()
+  const setPolicy = (changeId: string, policy: PlacementScorePolicy) => {
+    setSamePagePolicies((prev) => ({ ...prev, [changeId]: policy }))
+    // discard→carry に戻したら ack もクリア
+    if (policy === "carry") {
+      setAckedDiscards((prev) => {
+        const next = new Set(prev)
+        next.delete(changeId)
+        return next
+      })
     }
   }
 
+  const toggleAck = (changeId: string) => {
+    setAckedDiscards((prev) => {
+      const next = new Set(prev)
+      if (next.has(changeId)) next.delete(changeId)
+      else next.add(changeId)
+      return next
+    })
+  }
+
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-h-[85vh] max-w-4xl overflow-y-auto">
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <FileEdit className="h-5 w-5" />
-            {pendingChanges.length}件の変更を適用
+            {pendingChanges.length}件の配置変更を反映
           </DialogTitle>
           <DialogDescription>
-            以下の答案配置変更をデータベースに反映します。処理方法を選択してください。
+            追従 {carryCount}件 / 破棄 {discardChanges.length}件
+            {discardChanges.length > 0 &&
+              "（破棄は対象生徒の再採点が必要です）"}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6">
-          {/* 変更リスト */}
-          <div className="space-y-3">
-            <h4 className="text-sm font-medium text-gray-700">変更内容:</h4>
-            <div className="max-h-40 space-y-2 overflow-y-auto">
-              {pendingChanges.map((change, index) => (
-                <div
-                  key={change.id}
-                  className="flex items-center gap-4 rounded-lg border bg-gray-50 p-3"
-                >
-                  <span className="min-w-7.5 font-mono text-sm text-gray-500">
+        {/* 変更リスト（固定高スクロール。フッタは常時可視） */}
+        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
+          {pendingChanges.map((change, index) => {
+            const pageChange = isPageChange(change)
+            const policy = effectivePolicy(change)
+            const isSwap = change.targetFileId !== null
+            const needsAck = policy === "discard"
+            const acked = ackedDiscards.has(change.id)
+
+            return (
+              <div
+                key={change.id}
+                className={`rounded-lg border p-3 ${
+                  policy === "discard"
+                    ? "border-red-200 bg-red-50"
+                    : "border-blue-200 bg-blue-50"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="min-w-6 font-mono text-xs text-gray-500">
                     #{index + 1}
                   </span>
-                  <div className="flex-1 text-sm">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium">
-                        {change.fromPosition.studentName || "未割当"}
-                        <span className="ml-1 text-gray-500">
-                          P{change.fromPosition.pageNumber}
-                        </span>
+                  <div className="flex flex-1 items-center gap-2 text-sm">
+                    <span className="font-medium">
+                      {change.fromPosition.studentName || "未割当"}
+                      <span className="ml-1 text-gray-500">
+                        P{change.fromPosition.pageNumber}
                       </span>
-                      <span className="text-gray-400">→</span>
-                      <span className="font-medium">
-                        {change.toPosition.studentName || "未割当"}
-                        <span className="ml-1 text-gray-500">
-                          P{change.toPosition.pageNumber}
-                        </span>
+                    </span>
+                    {isSwap ? (
+                      <ArrowLeftRight className="h-4 w-4 text-gray-400" />
+                    ) : (
+                      <ArrowRight className="h-4 w-4 text-gray-400" />
+                    )}
+                    <span className="font-medium">
+                      {change.toPosition.studentName || "未割当"}
+                      <span className="ml-1 text-gray-500">
+                        P{change.toPosition.pageNumber}
                       </span>
-                      {change.targetFileId && (
-                        <span className="rounded bg-blue-50 px-2 py-1 text-xs text-blue-600">
-                          入れ替え
-                        </span>
-                      )}
-                    </div>
+                    </span>
+                    {isSwap && (
+                      <span className="rounded bg-white px-1.5 py-0.5 text-xs text-gray-600">
+                        入れ替え
+                      </span>
+                    )}
                   </div>
-                </div>
-              ))}
-            </div>
-          </div>
 
-          {/* 処理オプション選択 */}
-          <div className="border-t pt-4">
-            <Label className="mb-4 block text-base font-semibold">
-              採点データの処理方法
-            </Label>
-            <RadioGroup
-              value={selectedOption}
-              onValueChange={(value) =>
-                setSelectedOption(value as ScoringDataOption)
-              }
-              className="space-y-4"
-            >
-              {/* 推奨オプション: 採点情報も一緒に入れ替え */}
-              <div className="rounded-lg border-2 border-blue-200 bg-blue-50 p-4">
-                <div className="flex items-start space-x-3">
-                  <RadioGroupItem
-                    value="with-scoring"
-                    id="with-scoring"
-                    className="mt-1 shrink-0"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <Label
-                      htmlFor="with-scoring"
-                      className="block cursor-pointer"
-                    >
-                      <div className="flex flex-wrap items-center gap-2 font-medium text-blue-800">
-                        採点情報も一緒に入れ替え
-                        <span className="shrink-0 rounded-full bg-blue-600 px-2 py-1 text-xs text-white">
-                          推奨
-                        </span>
-                      </div>
-                      <div className="mt-2 text-sm text-blue-700">
-                        答案画像と採点結果を正しく対応させます。論理的に一貫した処理です。
-                      </div>
-                    </Label>
-                  </div>
+                  {/* 同一ページのみ carry/discard を選べる */}
+                  {!pageChange ? (
+                    <label className="flex shrink-0 items-center gap-2 text-xs text-gray-700">
+                      採点を移す
+                      <Switch
+                        checked={policy === "carry"}
+                        onCheckedChange={(checked) =>
+                          setPolicy(change.id, checked ? "carry" : "discard")
+                        }
+                      />
+                    </label>
+                  ) : (
+                    <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-red-600">
+                      <AlertTriangle className="h-3.5 w-3.5" />
+                      ページ変更→破棄
+                    </span>
+                  )}
                 </div>
-              </div>
 
-              {/* 答案画像のみ入れ替え（警告付き） */}
-              <div className="rounded-lg border-2 border-orange-200 bg-orange-50 p-4">
-                <div className="flex items-start space-x-3">
-                  <RadioGroupItem
-                    value="image-only"
-                    id="image-only"
-                    className="mt-1 shrink-0"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <Label
-                      htmlFor="image-only"
-                      className="block cursor-pointer"
-                    >
-                      <div className="flex flex-wrap items-center gap-2 font-medium text-orange-800">
-                        <AlertTriangle className="h-4 w-4 shrink-0" />
-                        答案画像のみ入れ替え
-                      </div>
-                      <div className="mt-2 text-sm text-orange-700">
-                        採点情報は元の位置に残します。
-                      </div>
-                      <div className="mt-2 flex items-center gap-1 text-sm font-medium text-red-600">
-                        <AlertTriangle className="h-3 w-3 shrink-0" />
-                        注意: 答案と評価結果の不整合が発生します
-                      </div>
-                    </Label>
-                  </div>
-                </div>
+                {/* 破棄項目は了解チェック必須 */}
+                {needsAck && (
+                  <label className="mt-2 flex items-center gap-2 text-xs font-medium text-red-700">
+                    <Checkbox
+                      checked={acked}
+                      onCheckedChange={() => toggleAck(change.id)}
+                    />
+                    {change.toPosition.studentName || "対象生徒"}
+                    の採点を破棄することを了解
+                  </label>
+                )}
               </div>
-            </RadioGroup>
-
-            {/* 警告メッセージ（答案のみ選択時） */}
-            {selectedOption === "image-only" && (
-              <div className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4">
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-red-500" />
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-3 font-medium text-red-800">
-                      ⚠️ データ整合性への影響
-                    </div>
-                    <ul className="space-y-2 text-sm text-red-700">
-                      <li>• 生徒Aの答案に生徒Bの採点結果が紐づきます</li>
-                      <li>• 採点結果と実際の答案内容が一致しなくなります</li>
-                      <li>
-                        • 成績データの信頼性に問題が生じる可能性があります
-                      </li>
-                    </ul>
-                    <div className="mt-4 rounded border border-red-300 bg-red-100 p-3">
-                      <div className="text-sm font-medium text-red-800">
-                        推奨: 「採点情報も一緒に入れ替え」を選択してください
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
+            )
+          })}
         </div>
 
-        <DialogFooter className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={handleCancel}
-            disabled={isApplying}
-          >
-            キャンセル
-          </Button>
-          {onReset && (
-            <Button
-              variant="outline"
-              onClick={handleReset}
-              disabled={isApplying}
-              className="border-red-300 text-red-600 hover:bg-red-50"
-            >
-              リセット
-            </Button>
-          )}
-          <Button
-            onClick={handleConfirm}
-            disabled={isApplying}
-            className={
-              selectedOption === "with-scoring"
-                ? "bg-blue-600 hover:bg-blue-700"
-                : "bg-orange-600 hover:bg-orange-700"
-            }
-          >
-            {isApplying && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {selectedOption === "with-scoring"
-              ? "採点情報込みで"
-              : "答案画像のみ"}
-            {pendingChanges.length}件を適用
-          </Button>
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs">
+            {phase === "confirm" ? (
+              <span className="font-medium text-red-700">
+                破棄を伴います。よろしいですか？（{discardChanges.length}
+                件を破棄）
+              </span>
+            ) : (
+              !allAcked && (
+                <span className="text-red-600">
+                  未了解 {unackedCount}件（破棄項目を全てチェックしてください）
+                </span>
+              )
+            )}
+          </div>
+          <div className="flex gap-2">
+            {phase === "confirm" ? (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => setPhase("list")}
+                  disabled={isApplying}
+                >
+                  戻る
+                </Button>
+                <Button
+                  onClick={applyNow}
+                  disabled={isApplying}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  {isApplying && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  破棄して反映
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleClose}
+                  disabled={isApplying}
+                >
+                  キャンセル
+                </Button>
+                {onReset && (
+                  <Button
+                    variant="outline"
+                    onClick={onReset}
+                    disabled={isApplying}
+                    className="border-red-300 text-red-600 hover:bg-red-50"
+                  >
+                    リセット
+                  </Button>
+                )}
+                <Button
+                  onClick={handleProceed}
+                  disabled={isApplying || !allAcked}
+                >
+                  {isApplying && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  反映
+                </Button>
+              </>
+            )}
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/StudentAnswerTable.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { closestCenter, DndContext } from "@dnd-kit/core"
+import { rectSortingStrategy, SortableContext } from "@dnd-kit/sortable"
 import { FileImage } from "lucide-react"
 
 import { TableContent } from "@/components/exams/06-student-answers/student-answer-table/components/TableContent"
@@ -105,31 +106,36 @@ export function StudentAnswerTable(props: StudentAnswerTableProps) {
 
           <CardContent className="p-4">
             <div className="min-h-96">
-              <TableContent
-                tableData={tableData}
-                sortedStudents={sortedStudents}
-                maxPages={maxPages}
-                disabledState={disabledState}
-                mode={mode}
-                previewMode={previewMode}
-                nameRegionAvailable={nameRegionAvailable}
-                cellsWithExistingAnswers={cellsWithExistingAnswers}
-                allowOverwrite={allowOverwrite}
-                files={props.files}
-                affectedCells={affectedCells}
-                imageLoadStates={imageLoadStates}
-                observerRef={observerRef}
-                correctingFileIds={correctingFileIds}
-                getEnabledFiles={getEnabledFiles}
-                getFileColor={getFileColor}
-                drawNameRegionCanvas={drawNameRegionCanvas}
-                toggleRowDisabled={toggleRowDisabled}
-                toggleColDisabled={toggleColDisabled}
-                toggleCellDisabled={toggleCellDisabled}
-                toggleFileDisabled={toggleFileDisabled}
-                onUploadModalOpen={handleUploadModalOpen}
-                onDeleteAnswerSheet={handleDeleteAnswerSheet}
-              />
+              {/* DnD 文脈（並べ替え）は表の外側で与える。表本体は DnD 非依存。 */}
+              <SortableContext
+                items={getEnabledFiles().map((file) => file.id)}
+                strategy={rectSortingStrategy}
+              >
+                <TableContent
+                  tableData={tableData}
+                  sortedStudents={sortedStudents}
+                  maxPages={maxPages}
+                  disabledState={disabledState}
+                  mode={mode}
+                  previewMode={previewMode}
+                  nameRegionAvailable={nameRegionAvailable}
+                  cellsWithExistingAnswers={cellsWithExistingAnswers}
+                  allowOverwrite={allowOverwrite}
+                  files={props.files}
+                  affectedCells={affectedCells}
+                  imageLoadStates={imageLoadStates}
+                  observerRef={observerRef}
+                  correctingFileIds={correctingFileIds}
+                  getFileColor={getFileColor}
+                  drawNameRegionCanvas={drawNameRegionCanvas}
+                  toggleRowDisabled={toggleRowDisabled}
+                  toggleColDisabled={toggleColDisabled}
+                  toggleCellDisabled={toggleCellDisabled}
+                  toggleFileDisabled={toggleFileDisabled}
+                  onUploadModalOpen={handleUploadModalOpen}
+                  onDeleteAnswerSheet={handleDeleteAnswerSheet}
+                />
+              </SortableContext>
             </div>
           </CardContent>
         </Card>

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -1,5 +1,3 @@
-import { rectSortingStrategy, SortableContext } from "@dnd-kit/sortable"
-
 import { EmptyTableCell } from "@/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell"
 import { FilePreviewCell } from "@/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell"
 import { SortableTableCell } from "@/components/exams/06-student-answers/student-answer-table/components/SortableTableCell"
@@ -10,7 +8,10 @@ import type {
 import type { DisabledReason } from "@/components/exams/06-student-answers/student-answer-table/types/localTypes"
 import type { CellLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import { lookupHasCell } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
-import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+import type {
+  AnswerItem,
+  UnifiedFile,
+} from "@/components/exams/06-student-answers/types"
 import {
   Table,
   TableBody,
@@ -41,10 +42,9 @@ interface TableContentProps {
   imageLoadStates?: Record<string, "pending" | "loading" | "loaded" | "error">
   observerRef?: React.RefObject<IntersectionObserver | null>
   correctingFileIds?: Set<string>
-  getEnabledFiles: () => UnifiedFile[]
-  getFileColor: (file: UnifiedFile) => string
+  getFileColor: (file: AnswerItem) => string
   drawNameRegionCanvas: (
-    file: UnifiedFile,
+    file: AnswerItem,
     pageNumber: number
   ) => Promise<string | null>
   toggleRowDisabled: (examStudentId: string) => void
@@ -73,7 +73,6 @@ export function TableContent({
   imageLoadStates = {},
   observerRef,
   correctingFileIds,
-  getEnabledFiles,
   getFileColor,
   drawNameRegionCanvas,
   toggleRowDisabled,
@@ -84,168 +83,160 @@ export function TableContent({
   onDeleteAnswerSheet,
 }: TableContentProps) {
   return (
-    <SortableContext
-      items={getEnabledFiles().map((file) => file.id)}
-      strategy={rectSortingStrategy}
-    >
-      <Table>
-        <UITableHeader>
-          <TableRow>
-            {/* 生徒名列ヘッダー */}
-            <TableHead className="w-32 border text-center">生徒名</TableHead>
-            {/* ページ列ヘッダー */}
-            {Array.from({ length: maxPages }, (_, pageIndex) => {
-              const pageNumber = pageIndex + 1
-              return (
-                <TableHead
-                  key={pageNumber}
-                  className={`w-32 border text-center ${
-                    mode === "upload" ? "cursor-pointer" : ""
-                  } ${
-                    disabledState.cols.includes(pageNumber)
-                      ? "bg-gray-200"
-                      : "bg-white"
-                  }`}
-                  onClick={
-                    mode === "upload"
-                      ? () => toggleColDisabled(pageNumber)
-                      : undefined
-                  }
-                >
-                  ページ {pageNumber}
-                </TableHead>
-              )
-            })}
-          </TableRow>
-        </UITableHeader>
-        <TableBody>
-          {tableData.map((row, studentIndex) => (
-            <TableRow key={sortedStudents[studentIndex].studentId}>
-              {/* 生徒名セル */}
+    <Table>
+      <UITableHeader>
+        <TableRow>
+          {/* 生徒名列ヘッダー */}
+          <TableHead className="w-32 border text-center">生徒名</TableHead>
+          {/* ページ列ヘッダー */}
+          {Array.from({ length: maxPages }, (_, pageIndex) => {
+            const pageNumber = pageIndex + 1
+            return (
               <TableHead
-                className={`border text-center ${
+                key={pageNumber}
+                className={`w-32 border text-center ${
                   mode === "upload" ? "cursor-pointer" : ""
                 } ${
-                  disabledState.rows.includes(sortedStudents[studentIndex].id)
+                  disabledState.cols.includes(pageNumber)
                     ? "bg-gray-200"
                     : "bg-white"
                 }`}
                 onClick={
                   mode === "upload"
-                    ? () => toggleRowDisabled(sortedStudents[studentIndex].id)
+                    ? () => toggleColDisabled(pageNumber)
                     : undefined
                 }
               >
-                <div className="px-2 py-1">
-                  <div className="text-sm font-medium">
-                    {sortedStudents[studentIndex].student.lastName}{" "}
-                    {sortedStudents[studentIndex].student.firstName}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {sortedStudents[studentIndex].student.studentNumber}
-                  </div>
-                </div>
+                ページ {pageNumber}
               </TableHead>
+            )
+          })}
+        </TableRow>
+      </UITableHeader>
+      <TableBody>
+        {tableData.map((row, studentIndex) => (
+          <TableRow key={sortedStudents[studentIndex].studentId}>
+            {/* 生徒名セル */}
+            <TableHead
+              className={`border text-center ${
+                mode === "upload" ? "cursor-pointer" : ""
+              } ${
+                disabledState.rows.includes(sortedStudents[studentIndex].id)
+                  ? "bg-gray-200"
+                  : "bg-white"
+              }`}
+              onClick={
+                mode === "upload"
+                  ? () => toggleRowDisabled(sortedStudents[studentIndex].id)
+                  : undefined
+              }
+            >
+              <div className="px-2 py-1">
+                <div className="text-sm font-medium">
+                  {sortedStudents[studentIndex].student.lastName}{" "}
+                  {sortedStudents[studentIndex].student.firstName}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {sortedStudents[studentIndex].student.studentNumber}
+                </div>
+              </div>
+            </TableHead>
 
-              {/* ファイルセル */}
-              {row.map((cellData, pageIndex) => {
-                // セル座標から生徒・ページを投射（セルは同一性を保持しない）
-                const examStudent = sortedStudents[studentIndex]
-                const pageNumber = pageIndex + 1
+            {/* ファイルセル */}
+            {row.map((cellData, pageIndex) => {
+              // セル座標から生徒・ページを投射（セルは同一性を保持しない）
+              const examStudent = sortedStudents[studentIndex]
+              const pageNumber = pageIndex + 1
 
-                if (cellData.type === "disabled" || cellData.type === "empty") {
-                  return (
-                    <EmptyTableCellWithLogic
-                      key={pageNumber}
-                      cellData={cellData}
-                      examStudent={examStudent}
-                      pageNumber={pageNumber}
-                      mode={mode}
-                      cellsWithExistingAnswers={cellsWithExistingAnswers}
-                      allowOverwrite={allowOverwrite}
-                      files={files}
-                      disabledFiles={disabledState.files}
-                      toggleCellDisabled={toggleCellDisabled}
-                      toggleFileDisabled={toggleFileDisabled}
-                      onUploadModalOpen={onUploadModalOpen}
-                    />
-                  )
-                }
-
-                // ファイルセル
-                const file = cellData.file!
-                const isFileDisabled = disabledState.files.has(file.id)
-                const hasExistingAnswer =
-                  mode === "upload" &&
-                  lookupHasCell(
-                    cellsWithExistingAnswers,
-                    examStudent.studentId,
-                    pageNumber
-                  )
-                // 上書き無効時で既存答案がある場合はドラッグ無効
-                const isDragDisabledByOverwrite =
-                  hasExistingAnswer && !allowOverwrite
-
+              if (cellData.type === "disabled" || cellData.type === "empty") {
                 return (
-                  <SortableTableCell
-                    key={file.id}
-                    id={file.id}
-                    hasFile={true}
-                    isPositionDisabled={isDragDisabledByOverwrite}
-                    isFileDisabled={isFileDisabled}
-                    onTogglePosition={
-                      mode === "upload"
-                        ? () =>
-                            toggleCellDisabled(
-                              examStudent.studentId,
-                              pageNumber
-                            )
-                        : () => {}
-                    }
-                    onToggleFileDisabled={
-                      mode === "upload"
-                        ? () => toggleFileDisabled(file.id)
-                        : () => {}
-                    }
-                    onUploadToCell={() => {}}
-                    fileId={file.id}
-                    observerRef={observerRef}
-                    mode={mode}
-                    studentName={
-                      examStudent
-                        ? `${examStudent.student.lastName} ${examStudent.student.firstName}`
-                        : undefined
-                    }
+                  <EmptyTableCellWithLogic
+                    key={pageNumber}
+                    cellData={cellData}
+                    examStudent={examStudent}
                     pageNumber={pageNumber}
-                    hasScoreData={true}
-                    onDeleteFileWithScoring={() => {
-                      if (onDeleteAnswerSheet) {
-                        onDeleteAnswerSheet(file.id)
-                      }
-                    }}
-                  >
-                    <FilePreviewCell
-                      file={file}
-                      pageNumber={pageNumber}
-                      previewMode={previewMode}
-                      isFileDisabled={isFileDisabled}
-                      nameRegionAvailable={nameRegionAvailable[pageNumber]}
-                      getFileColor={getFileColor}
-                      drawNameRegionCanvas={drawNameRegionCanvas}
-                      imageLoadState={imageLoadStates[file.id]}
-                      isPendingChange={affectedCells?.has(file.id) || false}
-                      hasExistingAnswer={hasExistingAnswer}
-                      allowOverwrite={allowOverwrite}
-                      isCorrecting={correctingFileIds?.has(file.id) || false}
-                    />
-                  </SortableTableCell>
+                    mode={mode}
+                    cellsWithExistingAnswers={cellsWithExistingAnswers}
+                    allowOverwrite={allowOverwrite}
+                    files={files}
+                    disabledFiles={disabledState.files}
+                    toggleCellDisabled={toggleCellDisabled}
+                    toggleFileDisabled={toggleFileDisabled}
+                    onUploadModalOpen={onUploadModalOpen}
+                  />
                 )
-              })}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </SortableContext>
+              }
+
+              // ファイルセル
+              const file = cellData.file!
+              const isFileDisabled = disabledState.files.has(file.id)
+              const hasExistingAnswer =
+                mode === "upload" &&
+                lookupHasCell(
+                  cellsWithExistingAnswers,
+                  examStudent.studentId,
+                  pageNumber
+                )
+              // 上書き無効時で既存答案がある場合はドラッグ無効
+              const isDragDisabledByOverwrite =
+                hasExistingAnswer && !allowOverwrite
+
+              return (
+                <SortableTableCell
+                  key={file.id}
+                  id={file.id}
+                  hasFile={true}
+                  isPositionDisabled={isDragDisabledByOverwrite}
+                  isFileDisabled={isFileDisabled}
+                  onTogglePosition={
+                    mode === "upload"
+                      ? () =>
+                          toggleCellDisabled(examStudent.studentId, pageNumber)
+                      : () => {}
+                  }
+                  onToggleFileDisabled={
+                    mode === "upload"
+                      ? () => toggleFileDisabled(file.id)
+                      : () => {}
+                  }
+                  onUploadToCell={() => {}}
+                  fileId={file.id}
+                  observerRef={observerRef}
+                  mode={mode}
+                  studentName={
+                    examStudent
+                      ? `${examStudent.student.lastName} ${examStudent.student.firstName}`
+                      : undefined
+                  }
+                  pageNumber={pageNumber}
+                  hasScoreData={true}
+                  onDeleteFileWithScoring={() => {
+                    if (onDeleteAnswerSheet) {
+                      onDeleteAnswerSheet(file.id)
+                    }
+                  }}
+                >
+                  <FilePreviewCell
+                    file={file}
+                    pageNumber={pageNumber}
+                    previewMode={previewMode}
+                    isFileDisabled={isFileDisabled}
+                    nameRegionAvailable={nameRegionAvailable[pageNumber]}
+                    getFileColor={getFileColor}
+                    drawNameRegionCanvas={drawNameRegionCanvas}
+                    imageLoadState={imageLoadStates[file.id]}
+                    isPendingChange={affectedCells?.has(file.id) || false}
+                    hasExistingAnswer={hasExistingAnswer}
+                    allowOverwrite={allowOverwrite}
+                    isCorrecting={correctingFileIds?.has(file.id) || false}
+                  />
+                </SortableTableCell>
+              )
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   )
 }
 

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableDragOverlay.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableDragOverlay.tsx
@@ -2,14 +2,14 @@ import { DragOverlay } from "@dnd-kit/core"
 
 import { FilePreviewCell } from "@/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell"
 import type { PreviewMode } from "@/components/exams/06-student-answers/student-answer-table/types"
-import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+import type { AnswerItem } from "@/components/exams/06-student-answers/types"
 
 interface TableDragOverlayProps {
-  activeFile: UnifiedFile | null
+  activeFile: AnswerItem | null
   previewMode: PreviewMode
-  getFileColor: (file: UnifiedFile) => string
+  getFileColor: (file: AnswerItem) => string
   drawNameRegionCanvas: (
-    file: UnifiedFile,
+    file: AnswerItem,
     pageNumber: number
   ) => Promise<string | null>
 }

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
@@ -139,9 +139,11 @@ export function TableHeader({
                           <p className="truncate text-sm font-medium">
                             {file.name.split(" - ページ")[0] || file.name}
                           </p>
-                          <p className="text-xs text-gray-500">
-                            {(file.size / 1024).toFixed(1)}KB
-                          </p>
+                          {file.size !== undefined && (
+                            <p className="text-xs text-gray-500">
+                              {(file.size / 1024).toFixed(1)}KB
+                            </p>
+                          )}
                         </div>
                         <Button
                           variant="ghost"

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
@@ -67,11 +67,16 @@ export function useMarkerCorrection({
     }
 
     // 処理が必要なファイルを抽出
-    type Task = { file: UnifiedFile; target: number | undefined }
+    type Task = {
+      file: UnifiedFile
+      buffer: ArrayBuffer
+      target: number | undefined
+    }
     const tasks: Task[] = []
     for (const file of files) {
-      // DB読み込み済みの既存答案（imagePathあり、buffer空）は対象外
-      if (file.imagePath) continue
+      // DB読み込み済みの既存答案（imagePathあり）や buffer 無しは対象外
+      if (file.imagePath || !file.buffer) continue
+      const buffer = file.buffer
       const rawTarget = targetMap.get(file.id)
       // マスターが存在しないページは対象外（undefined扱いで復元）
       const target =
@@ -84,10 +89,10 @@ export function useMarkerCorrection({
           file.correctedForPage !== undefined ||
           file.correctionStatus !== undefined
         ) {
-          tasks.push({ file, target: undefined })
+          tasks.push({ file, buffer, target: undefined })
         }
       } else if (file.correctedForPage !== target) {
-        tasks.push({ file, target })
+        tasks.push({ file, buffer, target })
       }
     }
 
@@ -109,10 +114,10 @@ export function useMarkerCorrection({
 
     const processTasks = async () => {
       const processed = await Promise.all(
-        tasks.map(async ({ file, target }) => {
+        tasks.map(async ({ file, buffer, target }) => {
           // 元バッファを初回のみ記憶
           if (!originalBuffersRef.current.has(file.id)) {
-            originalBuffersRef.current.set(file.id, file.buffer)
+            originalBuffersRef.current.set(file.id, buffer)
           }
           const origBuffer = originalBuffersRef.current.get(file.id)!
 

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react"
 
-import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+import type { AnswerItem } from "@/components/exams/06-student-answers/types"
 
 /** 答案画像から氏名欄領域をクリッピングして表示するためのフック */
 export function useNameRegion(examId: string) {
@@ -34,7 +34,7 @@ export function useNameRegion(examId: string) {
 
   // 氏名欄クリッピング用のcanvas描画
   const drawNameRegionCanvas = useCallback(
-    async (file: UnifiedFile, pageNumber: number) => {
+    async (file: AnswerItem, pageNumber: number) => {
       const canvas = canvasRef.current
       if (!canvas) {
         return null

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -172,7 +172,8 @@ export function useStudentAnswerTableLogic({
     // 生徒とページはセル座標 [studentIndex][pageIndex] から投射する。
     tableData.forEach((row, studentIndex) => {
       row.forEach((cell, pageIndex) => {
-        if (cell.type === "file" && cell.file) {
+        // 未保存画像のみ本物の buffer を持つ（DB答案は buffer なし＝アップロード対象外）。
+        if (cell.type === "file" && cell.file && cell.file.buffer) {
           const examStudent = sortedStudents[studentIndex]
           uploadData.push({
             name: cell.file.name,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -12,6 +12,7 @@ import {
   sortStudentsByCustomOrder,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
+  AnswerItem,
   PlacementStrategy,
   UnifiedFile,
 } from "@/components/exams/06-student-answers/types"
@@ -111,7 +112,7 @@ export function useTableData({
   }, [files, disabledState])
 
   // ファイルカラーの取得
-  const getFileColorCallback = useCallback((file: UnifiedFile) => {
+  const getFileColorCallback = useCallback((file: AnswerItem) => {
     return getFileColor(file)
   }, [])
 

--- a/src/components/exams/06-student-answers/student-answer-table/types/index.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AnswerItem,
   PlacementStrategy,
   UnifiedFile,
 } from "@/components/exams/06-student-answers/types"
@@ -37,14 +38,14 @@ export interface CellData {
 
 // Component props interfaces
 export interface FilePreviewCellProps {
-  file: UnifiedFile
+  file: AnswerItem
   pageNumber: number
   previewMode: PreviewMode
   isFileDisabled: boolean
   nameRegionAvailable: boolean
-  getFileColor: (file: UnifiedFile) => string
+  getFileColor: (file: AnswerItem) => string
   drawNameRegionCanvas: (
-    file: UnifiedFile,
+    file: AnswerItem,
     pageNumber: number
   ) => Promise<string | null>
   imageLoadState?: "pending" | "loading" | "loaded" | "error"

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -3,7 +3,10 @@ import type {
   ExtendedDisabledState,
 } from "@/components/exams/06-student-answers/student-answer-table/types"
 import type { DisabledReason } from "@/components/exams/06-student-answers/student-answer-table/types/localTypes"
-import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+import type {
+  AnswerItem,
+  UnifiedFile,
+} from "@/components/exams/06-student-answers/types"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
 /**
@@ -186,7 +189,7 @@ export function getDisabledFiles(
 }
 
 /** ファイルIDのハッシュからTailwind背景色クラスを決定する */
-export function getFileColor(file: UnifiedFile): string {
+export function getFileColor(file: AnswerItem): string {
   const colors = [
     "bg-red-200",
     "bg-blue-200",

--- a/src/components/exams/06-student-answers/types.ts
+++ b/src/components/exams/06-student-answers/types.ts
@@ -11,6 +11,24 @@
 // ============================================================================
 
 /**
+ * セルに載る要素の「描画ビュー」（表・DnD・プレビューが読む最小共通形）。
+ * 未保存画像（PendingImage 相当）と DB答案（ExistingAnswer 相当）の**両ソースを射影**した
+ * 表示専用の投射であって、エンティティの併合ではない（"Unified" とは呼ばない）。
+ * `UnifiedFile` はこれを満たす上位型（buffer 等の upload 専用フィールドを追加で持つ）。
+ */
+export interface AnswerItem {
+  id: string
+  studentId?: string // 配置済みの生徒ID（= Student.id）
+  pageNumber: number // マス列（1始まりの序数）
+  name: string // 表示・alt 用
+  preview?: string // 未保存は blob URL、DB答案は遅延読込前は無し
+  imagePath?: string | null // DB答案の遅延読込パス
+  correctionStatus?: "corrected" | "skipped" | "not_requested"
+  correctionError?: string
+  color?: string
+}
+
+/**
  * 統一されたファイル型定義
  * ConvertedFile + TestFileの統合版
  */
@@ -18,8 +36,10 @@ export interface UnifiedFile {
   id: string
   name: string
   type: string
-  size: number
-  buffer: ArrayBuffer
+  // 未保存（ドロップ変換）の画像だけが本物の buffer/size を持つ。
+  // DB答案（imagePath で遅延読込）は持たない（偽の 0埋めはしない）。
+  size?: number
+  buffer?: ArrayBuffer
   preview?: string
   studentId?: string // 配置済みの場合の生徒ID
   pageNumber: number // ページ番号（1から開始）
@@ -94,8 +114,9 @@ export interface PendingChange {
 }
 
 /**
- * 採点データ処理オプション
+ * 移動1件ごとの採点データ処理方針（view 方式B）。
+ * - carry: 採点も追従（同一ページの生徒付け替えのみ可）
+ * - discard: 採点を破棄（要再採点。ページ跨ぎは常にこれ）
+ * バックエンド `applyStudentAnswerPlacements` の scorePolicy と一致させる。
  */
-export type ScoringDataOption =
-  | "image-only" // 答案画像のみ入れ替え
-  | "with-scoring" // 採点情報も一緒に入れ替え
+export type PlacementScorePolicy = "carry" | "discard"

--- a/src/types/electron/studentAnswerApi.d.ts
+++ b/src/types/electron/studentAnswerApi.d.ts
@@ -97,6 +97,17 @@ export interface StudentAnswerAPI {
     success: boolean
     error?: string
   }>
+  applyStudentAnswerPlacements: (
+    moves: Array<{
+      fileId: string
+      finalStudentId: string | null
+      finalPageNumber: number
+      scorePolicy: "carry" | "discard"
+    }>
+  ) => Promise<{
+    success: boolean
+    error?: string
+  }>
   getImageData: (relativePath: string) => Promise<{
     success: boolean
     data?: string


### PR DESCRIPTION
Closes #971

## 概要
view の答案配置（移動・入れ替え）を**採点安全**に適用する新 API と、その確認 UX・型分離をまとめて実装。

## 主な変更
### 採点安全な配置適用（Phase 0）
- `applyStudentAnswerPlacements`（`electron-src/lib/prisma/studentAnswer/placementApply.ts`）
  - 2軸移動（`examPageId` も更新）／carry=注釈温存の studentId 付け替え／discard=tombstone後に両スコア表削除
  - 移動先セルの残存採点を掃除（二重計上・`ScoreDecision` unique 違反を防止）
  - null 削除拒否・占有マス上書きは明示エラー・基本 Prisma のみ
- テスト7件

### view 適用・確認モーダル（Phase 3a）
- `handleApplyChanges` を新 API へ配線、`ConfirmChangesModal` をハイブリッド確認へ全面改修

### 型分離・0埋め廃止（Phase 1/2）
- `ProcessedStudentAnswer` 撤去・`UnifiedFile.buffer/size` 任意化・`AnswerItem` 導入・`SortableContext` 分離

## コードレビュー(high)反映
F1/F2/F3/F4 を修正済み（F5=性能は今後）。

## 確認
- 06配下: 型/lint/format グリーン
- 新規テスト 7件パス（`studentAnswerPlacementApply.test.ts`）
- DnD の method B 化（3b/3c）と実機での DnD 挙動確認は別作業

🤖 Generated with [Claude Code](https://claude.com/claude-code)