### PR TITLE
feat(06-student-answers): 確認モードのDnDを方式B化＋レビュー修正

### DIFF
--- a/__tests__/renderer/utils/dragDropUtils.test.ts
+++ b/__tests__/renderer/utils/dragDropUtils.test.ts
@@ -1,0 +1,184 @@
+/**
+ * 06-student-answers テーブル DnD（方式B）の純粋ロジック検証。
+ *
+ * セル座標 droppable の codec と、view モードの move/swap（applyCellMoveOrSwap）を
+ * ブラウザ非依存で検証する。実際のドラッグ操作（dnd-kit の衝突判定・描画）は
+ * ここでは扱わず、`npm run dev` での手動確認に委ねる。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  applyCellMoveOrSwap,
+  decodeCellDroppableId,
+  diffFilesAgainstBaseline,
+  encodeCellDroppableId,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils"
+import type { UnifiedFile } from "@/components/exams/06-student-answers/types"
+
+function makeFile(
+  id: string,
+  studentId: string | undefined,
+  pageNumber: number
+): UnifiedFile {
+  return {
+    id,
+    name: `answer-${id}`,
+    type: "image/png",
+    pageNumber,
+    isSelected: false,
+    originalFileName: `answer-${id}.png`,
+    studentId,
+  }
+}
+
+const STUDENT_A = "11111111-1111-4111-8111-111111111111"
+const STUDENT_B = "22222222-2222-4222-8222-222222222222"
+
+describe("encodeCellDroppableId / decodeCellDroppableId", () => {
+  it("エンコードとデコードが往復で一致する", () => {
+    const encoded = encodeCellDroppableId(STUDENT_A, 3)
+    expect(encoded).toBe(`cell:${STUDENT_A}:3`)
+    expect(decodeCellDroppableId(encoded)).toEqual({
+      studentId: STUDENT_A,
+      pageNumber: 3,
+    })
+  })
+
+  it("cell: 接頭辞でない ID（ファイルID）は null を返す", () => {
+    expect(decodeCellDroppableId(STUDENT_A)).toBeNull()
+    expect(decodeCellDroppableId("trash-area")).toBeNull()
+  })
+
+  it("ページ番号が整数でなければ null を返す", () => {
+    expect(decodeCellDroppableId(`cell:${STUDENT_A}:abc`)).toBeNull()
+    expect(decodeCellDroppableId(`cell:${STUDENT_A}:`)).toBeNull()
+  })
+})
+
+describe("applyCellMoveOrSwap", () => {
+  it("空セルへの移動: ドラッグした答案の座標だけが更新される", () => {
+    const files = [makeFile("f1", STUDENT_A, 1)]
+    const result = applyCellMoveOrSwap(files, "f1", {
+      studentId: STUDENT_B,
+      pageNumber: 2,
+    })
+
+    expect(result).not.toBe(files)
+    expect(result.find((file) => file.id === "f1")).toMatchObject({
+      studentId: STUDENT_B,
+      pageNumber: 2,
+    })
+  })
+
+  it("占有セルへの移動: 2つの答案の座標が入れ替わる（同一ページの生徒付け替え）", () => {
+    const files = [makeFile("f1", STUDENT_A, 1), makeFile("f2", STUDENT_B, 1)]
+    // f1 を studentB, page1（f2 の居場所）へ → swap
+    const result = applyCellMoveOrSwap(files, "f1", {
+      studentId: STUDENT_B,
+      pageNumber: 1,
+    })
+
+    expect(result.find((file) => file.id === "f1")).toMatchObject({
+      studentId: STUDENT_B,
+      pageNumber: 1,
+    })
+    expect(result.find((file) => file.id === "f2")).toMatchObject({
+      studentId: STUDENT_A,
+      pageNumber: 1,
+    })
+  })
+
+  it("対角の入れ替え: (A,p1) と (B,p2) がページを跨いで座標入れ替えになる", () => {
+    const files = [makeFile("f1", STUDENT_A, 1), makeFile("f2", STUDENT_B, 2)]
+    const result = applyCellMoveOrSwap(files, "f1", {
+      studentId: STUDENT_B,
+      pageNumber: 2,
+    })
+
+    expect(result.find((file) => file.id === "f1")).toMatchObject({
+      studentId: STUDENT_B,
+      pageNumber: 2,
+    })
+    expect(result.find((file) => file.id === "f2")).toMatchObject({
+      studentId: STUDENT_A,
+      pageNumber: 1,
+    })
+  })
+
+  it("同一セルへのドロップは変更なし（同じ配列参照を返す）", () => {
+    const files = [makeFile("f1", STUDENT_A, 1)]
+    const result = applyCellMoveOrSwap(files, "f1", {
+      studentId: STUDENT_A,
+      pageNumber: 1,
+    })
+    expect(result).toBe(files)
+  })
+
+  it("存在しない activeFileId は変更なし", () => {
+    const files = [makeFile("f1", STUDENT_A, 1)]
+    const result = applyCellMoveOrSwap(files, "missing", {
+      studentId: STUDENT_B,
+      pageNumber: 2,
+    })
+    expect(result).toBe(files)
+  })
+
+  it("occupantEligibleIds に含まれない占有ファイルは swap 対象にしない（隠れ答案の巻き込み防止）", () => {
+    // f2 は移動先座標に居るが「表に見えていない」→ swap せず、移動先に移すだけ
+    const files = [makeFile("f1", STUDENT_A, 1), makeFile("f2", STUDENT_B, 1)]
+    const result = applyCellMoveOrSwap(
+      files,
+      "f1",
+      { studentId: STUDENT_B, pageNumber: 1 },
+      new Set(["f1"]) // f2 は対象外
+    )
+    expect(result.find((file) => file.id === "f1")).toMatchObject({
+      studentId: STUDENT_B,
+      pageNumber: 1,
+    })
+    // f2 は動かない（隠れて座標を書き換えられない）
+    expect(result.find((file) => file.id === "f2")).toMatchObject({
+      studentId: STUDENT_B,
+      pageNumber: 1,
+    })
+  })
+})
+
+describe("diffFilesAgainstBaseline", () => {
+  const baseline = [
+    { id: "f1", studentId: STUDENT_A, pageNumber: 1 },
+    { id: "f2", studentId: STUDENT_B, pageNumber: 1 },
+  ]
+
+  it("DB 基準から座標が変わったファイルだけを from(DB)/to(現在) で返す", () => {
+    // f1 を studentB へ移動済みの working copy
+    const files = [makeFile("f1", STUDENT_B, 2), makeFile("f2", STUDENT_B, 1)]
+    const diff = diffFilesAgainstBaseline(files, baseline)
+
+    expect(diff).toHaveLength(1)
+    expect(diff[0]).toMatchObject({
+      fileId: "f1",
+      fromState: { studentId: STUDENT_A, pageNumber: 1 },
+      toState: { studentId: STUDENT_B, pageNumber: 2 },
+    })
+  })
+
+  it("複数回ドラッグ相当（2件移動済み）でも累積差分を全件返す（[3] の回帰防止）", () => {
+    // f1→(B,2), f2→(A,2) の 2 件を移動した状態
+    const files = [makeFile("f1", STUDENT_B, 2), makeFile("f2", STUDENT_A, 2)]
+    const diff = diffFilesAgainstBaseline(files, baseline)
+
+    expect(diff.map((change) => change.fileId).sort()).toEqual(["f1", "f2"])
+  })
+
+  it("DB と同じ配置に戻れば差分は空（stateless なので元に戻すと消える）", () => {
+    const files = [makeFile("f1", STUDENT_A, 1), makeFile("f2", STUDENT_B, 1)]
+    expect(diffFilesAgainstBaseline(files, baseline)).toHaveLength(0)
+  })
+
+  it("baseline に無い id（新規・除籍等）は差分対象外", () => {
+    const files = [makeFile("unknown", STUDENT_A, 3)]
+    expect(diffFilesAgainstBaseline(files, baseline)).toHaveLength(0)
+  })
+})

--- a/docs/06-student-answers-cell-architecture-plan.md
+++ b/docs/06-student-answers-cell-architecture-plan.md
@@ -21,10 +21,27 @@
   - テスト `__tests__/exam/integration/studentAnswerPlacementApply.test.ts`（**7件パス**）。
   - **コードレビュー(high)反映済み**: (F1/F2) carry で**移動先セルの残存採点（moving 集合外）を stale として掃除**（QuestionScore 二重計上・ScoreDecision unique 違反を修正）。(F3) `finalStudentId=null` は**拒否**（削除は deleteStudentAnswer 専用・ファイル/監査漏れ回避）。(F4) 移動先が batch 外答案で**占有時は明示エラー**（上書きしない）。残: F5=トランザクション内の逐次クエリ（性能・非破損、未対応）。
 - **Phase 3a**: view 適用を新 API へ配線（`handleApplyChanges`）。`ConfirmChangesModal` をハイブリッド（追従/破棄グルーピング・破棄は行ごとチェック必須＋2段階確認）へ全面改修。`ScoringDataOption` 撤去、`PlacementScorePolicy` 導入。
+  - **Phase 0〜3a は main にマージ済み**（`34f9c54b` / PR #972 / Issue #971）。
+- **Phase 3b**: view の DnD を **method B（グリッドドロップ+swap）** へ。**（実装完了・型/lint/テストグリーン。DnD の実挙動のみ要手動確認）**
+  - view の `tableData` 配置を**配列順 → ファイル自身の座標 (studentId, pageNumber) 基準**へ（`useTableDataGeneration` の view 分岐）。これで DnD は座標更新だけで完結し、`arrayMove`/`buildDnDArray` の脆い index 依存が view から外れた。
+  - 空セルを `useDroppable`（`EmptyTableCell`、view のみ・id=`cell:${studentId}:${pageNumber}`）。占有セルは `useSortable`（file）が droppable を兼ねる。`handleDragEnd` を view 分岐化し、over が空セル(cell:)でもファイル(fileId)でも対象セル座標を求め、`applyCellMoveOrSwap` で **空=移動 / 占有=座標swap**。採点の追従/破棄は従来通り確認モーダル(`PlacementScorePolicy`)で解決。
+  - 並び順トグルは view で**非表示**（`TableHeader`）。view の答案は実セルに固定表示するため再配置が無意味なため（ユーザー承認済み）。
+  - upload=method A 経路は**不変**（`EmptyTableCell` の droppable は upload では `disabled`、`handleDragEnd` の arrayMove 分岐は upload 専用に整理・dead な view 分岐を除去）。
+  - 純粋ロジックのテスト `__tests__/renderer/utils/dragDropUtils.test.ts`（**13件パス**）：codec 往復/不正入力、move/swap/対角swap/同一セル no-op/未知ID/occupant フィルタ/baseline 差分。
+  - **要手動検証（`npm run dev`）**: グリッド上のドラッグ描画（view で `rectSortingStrategy` の「隙間を空ける」アニメが残るため swap 時の見た目は手動確認で微調整）。
+
+- **Phase 3b コードレビュー(high)反映済み**（重大6・cleanup2 のうち下記を修正）:
+  - **[3]/[7] 累積差分の取りこぼし（最重大）**: `initialFileStatesRef` は `useDragDropState` effect が files 変化のたび post-move にリセットするため、可変 ref 依存の差分は 2 回目のドラッグで 1 回目を落とす（親は `setPendingChanges` 全置換）。→ **可変 ref を撤去し、毎回 DB baseline（`existingStudentAnswers`）と現在配置を突き合わせる stateless 差分 `diffFilesAgainstBaseline`** に変更。反映後再読込でも常に正しい。記録できない場合（baseline/コールバック欠如）は見た目も動かさない。
+  - **[1] 欠席生徒へのドロップ**: `EmptyTableCell` の droppable を `status==="absent"` で `disabled`。
+  - **[2] 隠れ答案の巻き込み swap**: `applyCellMoveOrSwap` の occupant 判定を `getEnabledFiles` の id 集合に限定（view は trash 無しだが防御）。
+  - **[6] O(files×students)**: view 配置生成で `studentId→行index` の Map を1回構築。
+  - **[8] 誤解を招く toast**: `newFiles===files` でアクティブ答案が存在する同一セル時のみ「元の位置に戻されました」。
+  - **未対応=[4]/[5]（要相談）**: baseline に居るが「除籍で studentId が現ロスターに無い／ページ数削減で範囲外」の答案は座標配置できず**表から不可視**になる。旧 index 方式は別生徒のマスへ誤配置して見せていた（データ整合的には旧方式も難あり）。恒久対応は「未配置/孤立答案」枠の新設＝別スコープ。
 
 ### 残り（次の作業）
 
-- **Phase 3b**: view の DnD を **method B（グリッドドロップ+swap）** へ。各マス `useDroppable`・各答案 `useDraggable`・空=移動/埋=swap。pendingChange 生成は現状 method A のまま（apply/modal は DnD 非依存で流用可）。
+- **[4]/[5] 孤立答案の扱い**（除籍・ページ範囲外で不可視）: **対応要否を含め次セッションで判断**。旧 index 方式は誤帰属で見せていたため単純な「戻し」は不可。要対応なら「未配置/孤立答案」専用枠を新設（別 issue 候補）。
+
 - **Phase 3c**: セルの掴む/落とす部分（`SortableTableCell`）を**スロット化**して表本体を DnD 非依存に。upload=method A を注入。ここで `UnifiedFile` を `PendingImage`/`AnswerItem` へ**3分割**（単一 `files` state が両モード兼用のため Phase 3 と不可分）。
 - **Phase 6 相当**: 旧 `batch.ts`/`placement.ts`/`swap`（**FK強制下で壊れる temp studentId 方式**）の撤去、デッドコード整理（#965）、§6 手動検証（**DnD 挙動は要実機確認**）。
 
@@ -32,8 +49,9 @@
 
 - **FK は実行時強制**。既存 `batchUpdateStudentAnswerPlacements`/`swap*`/`updateStudentAnswerPlacement` は偽 studentId の一時ID方式で**FK違反で壊れる**（旧挙動破綻の一因）。新 `applyStudentAnswerPlacements` は基本 Prisma で回避済み。3b/3c で旧関数を撤去。
 - **sqlite-nas-sync 安全性を実コードで確認**: 二次 `@@unique` は `conflict.ts` ケース2 で LWW 収束（全表汎用）。delete→**同一id**再作成は `sync.ts` の tombstone-ignore（現存すれば再作成とみなす）で安全。→ 新コードは id 保持で delete+再作成している。
-- **並行セッション**が `electron-src/lib/import/*`（transformers WIP）を編集中。型チェックの `transformWarnings`/`EXAM_CURRENT_VERSION` エラーは無関係。自分のファイルのみ扱う。
-- 未コミット。git-workflow は未実行（自分のファイルのみ add する）。
+- **並行セッション**が `electron-src/lib/import/*`（transformers WIP）を編集中。自分のファイルのみ扱う（その import 変更は `94d8cd72` で main 済み）。
+- **view 配置は座標基準（3b で確定）**: `useTableDataGeneration` の view 分岐は `file.studentId`/`pageNumber` でマスへ配置する。`calculateDynamicDisabledCells`（答案なし=無効）も座標一致判定なので整合。view には手動無効（行/列/セル）UI が無く `disabledState` は空のまま＝無効セルは常に「答案なし」＝ドロップ可。
+- Phase 0〜3a は `34f9c54b` で main 済み。**Phase 3b は未コミット**（本セッションの変更・git-workflow 未実行、自分のファイルのみ add する）。
 
 ### 主要な触点ファイル
 

--- a/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import { useDroppable } from "@dnd-kit/core"
 import { Ban, FileX, Upload, X } from "lucide-react"
 
 import type { EmptyTableCellProps } from "@/components/exams/06-student-answers/student-answer-table/types"
+import { encodeCellDroppableId } from "@/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -56,10 +58,27 @@ export function EmptyTableCell({
   // 右クリックメニューを表示するかの判定（uploadモードでは無効セルでもメニュー表示）
   const shouldShowContextMenu = mode === "upload"
 
+  // 確認モード（方式B）: 空セルも答案のドロップ先にする。
+  // セル座標を droppable ID にして handleDragEnd で (studentId, pageNumber) を復号する。
+  // upload では disabled にして方式A（ファイル間の並べ替え）に影響させない。
+  // 欠席生徒のマスは「答案なし」表示だが、欠席者に答案を割り当てないようドロップ不可にする。
+  const isAbsentStudent = examStudent?.status === "absent"
+  const { setNodeRef, isOver } = useDroppable({
+    id: encodeCellDroppableId(
+      examStudent?.studentId ?? "none",
+      pageNumber ?? 0
+    ),
+    disabled: mode !== "view" || !examStudent || isAbsentStudent,
+  })
+  const isDropTarget = mode === "view" && isOver
+
   return (
     <TableCell
-      className={`relative h-32 w-32 border p-1 ${
+      ref={setNodeRef}
+      className={`relative h-32 w-32 border p-1 transition-colors ${
         isPositionDisabled ? "bg-gray-100" : "bg-white"
+      } ${
+        isDropTarget ? "bg-blue-100 outline outline-2 outline-blue-500" : ""
       }`}
     >
       <ContextMenu>

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableHeader.tsx
@@ -56,11 +56,13 @@ export function TableHeader({
         </CardTitle>
 
         <div className="flex flex-wrap items-center gap-4">
-          {/* 配置戦略選択 */}
-          <PlacementStrategySelector
-            fileOrder={fileOrder}
-            onFileOrderChange={onFileOrderChange}
-          />
+          {/* 配置戦略選択（新規配置＝アップロード専用。確認モードでは答案は実セルに固定表示するため非表示） */}
+          {mode === "upload" && (
+            <PlacementStrategySelector
+              fileOrder={fileOrder}
+              onFileOrderChange={onFileOrderChange}
+            />
+          )}
 
           {/* プレビューモード切り替え */}
           <PreviewModeToggle

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDrop.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDrop.ts
@@ -21,6 +21,7 @@ export function useDragDrop({
   fileOrder,
   onReloadData,
   onUpdatePendingChanges,
+  existingStudentAnswers,
 }: UseDragDropParams): UseDragDropReturn {
   // 状態管理
   const { activeFile, setActiveFile, fileStatesRef, initialFileStatesRef } =
@@ -45,6 +46,7 @@ export function useDragDrop({
     fileOrder,
     onReloadData,
     onUpdatePendingChanges,
+    existingStudentAnswers,
     setActiveFile,
     fileStatesRef,
     initialFileStatesRef,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
@@ -5,8 +5,9 @@ import { toast } from "sonner"
 
 import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import {
-  compareFileStates,
-  updateFileStatesFromDnDArray,
+  applyCellMoveOrSwap,
+  decodeCellDroppableId,
+  diffFilesAgainstBaseline,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils"
 import type {
   PlacementStrategy,
@@ -31,6 +32,11 @@ interface UseDragDropHandlersParams {
       toState: FileState
     }>
   ) => void
+  existingStudentAnswers?: Array<{
+    id: string
+    studentId: string | null
+    pageNumber: number
+  }>
   setActiveFile: (file: UnifiedFile | null) => void
   fileStatesRef: React.MutableRefObject<FileState[]>
   initialFileStatesRef: React.MutableRefObject<FileState[]>
@@ -44,13 +50,10 @@ export function useDragDropHandlers({
   onFilesChange,
   getEnabledFiles,
   getDisabledFiles,
-  students,
-  modelAnswerCount,
   mode,
   onUpdatePendingChanges,
+  existingStudentAnswers,
   setActiveFile,
-  fileStatesRef,
-  initialFileStatesRef,
 }: UseDragDropHandlersParams) {
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
@@ -84,6 +87,73 @@ export function useDragDropHandlers({
       const activeId = active.id.toString()
       const overId = over.id.toString()
 
+      // 確認モード（方式B）: 対象セル座標へ move、占有セルなら swap。
+      // over は空セルの droppable（cell:...）か、占有セルのファイル（fileId）。
+      // どちらでも対象セルの (studentId, pageNumber) を求め、座標だけ更新する。
+      if (mode === "view") {
+        // 差分は DB baseline（existingStudentAnswers）と突き合わせて毎回算出する。
+        // これが無いと配置変更を pending として記録できない＝黙って取りこぼすので、
+        // 記録できない場合は見た目も動かさない（onFilesChange を呼ばない）。
+        if (!existingStudentAnswers || !onUpdatePendingChanges) {
+          setActiveFile(null)
+          return
+        }
+
+        const target =
+          decodeCellDroppableId(overId) ??
+          (() => {
+            const overFile = files.find((file) => file.id === overId)
+            return overFile?.studentId
+              ? {
+                  studentId: overFile.studentId,
+                  pageNumber: overFile.pageNumber,
+                }
+              : null
+          })()
+
+        if (!target) {
+          setActiveFile(null)
+          return
+        }
+
+        // 占有判定は「表に見えている答案」だけに限定する（trash 等の隠れ答案を巻き込まない）
+        const enabledFileIds = new Set(getEnabledFiles().map((file) => file.id))
+        const newFiles = applyCellMoveOrSwap(
+          files,
+          activeId,
+          target,
+          enabledFileIds
+        )
+        if (newFiles === files) {
+          // 実質変更なし（同一セルへのドロップのみ通知。対象/アクティブ不明時は無言）
+          if (files.some((file) => file.id === activeId)) {
+            toast.info("元の位置に戻されました")
+          }
+          setActiveFile(null)
+          return
+        }
+
+        onFilesChange(newFiles)
+
+        // 可変 ref ではなく DB baseline との差分（累積・全置換で安全）
+        const changedFiles = diffFilesAgainstBaseline(
+          newFiles,
+          existingStudentAnswers
+        )
+        onUpdatePendingChanges(changedFiles)
+
+        if (changedFiles.length > 0) {
+          toast.success(`${changedFiles.length}件の答案配置を変更しました`, {
+            description: "「変更を反映」ボタンで確定してください",
+          })
+        } else {
+          toast.info("元の位置に戻されました")
+        }
+
+        setActiveFile(null)
+        return
+      }
+
       if (activeId === overId) {
         setActiveFile(null)
         return
@@ -106,8 +176,9 @@ export function useDragDropHandlers({
       const activeContainer = findContainer(activeId)
       const overContainer = findContainer(overId)
 
+      // アップロードモード（方式A）: arrayMove で並べ替え、各位置の studentId/pageNumber は固定。
+      // 新規ファイルの自動配置順を手で入れ替えるための経路（view の座標 move/swap とは別物）。
       if (activeContainer === overContainer && activeId !== overId) {
-        // 新規追加・確認モード共通: arrayMoveによる順延ロジック
         const newFiles = [...files]
         const oldIndex = newFiles.findIndex((file) => file.id === activeId)
         const newIndex = newFiles.findIndex((file) => file.id === overId)
@@ -129,46 +200,7 @@ export function useDragDropHandlers({
           }))
 
           onFilesChange(reorderedFiles)
-
-          // 3. DnD操作時: 配列変更 + 3つ組同期更新（ファイル実データをそのまま使用）
-          if (mode === "view") {
-            const newFileStates = updateFileStatesFromDnDArray(reorderedFiles)
-            fileStatesRef.current = newFileStates
-          }
-
-          // 確認モードでは一括でPendingChangeを更新
-          if (
-            mode === "view" &&
-            students &&
-            modelAnswerCount &&
-            onUpdatePendingChanges &&
-            initialFileStatesRef.current.length > 0
-          ) {
-            // 現在のファイル状態と初期状態を比較
-            const currentFileStates = fileStatesRef.current
-            const changedFiles = compareFileStates(
-              initialFileStatesRef.current,
-              currentFileStates
-            )
-
-            // 変更されたファイル情報を一括で親に渡す
-            onUpdatePendingChanges(changedFiles)
-
-            // ドラッグ操作完了のtoast表示
-            if (changedFiles.length > 0) {
-              toast.success(
-                `${changedFiles.length}件の答案配置を変更しました`,
-                {
-                  description: "「変更を反映」ボタンで確定してください",
-                }
-              )
-            } else {
-              toast.info("元の位置に戻されました")
-            }
-          } else if (mode === "upload") {
-            // upload モードでのドラッグ操作完了のtoast
-            toast.success("答案の配置を変更しました")
-          }
+          toast.success("答案の配置を変更しました")
         }
       }
 
@@ -180,12 +212,9 @@ export function useDragDropHandlers({
       getEnabledFiles,
       getDisabledFiles,
       mode,
-      students,
-      modelAnswerCount,
       onUpdatePendingChanges,
+      existingStudentAnswers,
       setActiveFile,
-      fileStatesRef,
-      initialFileStatesRef,
     ]
   )
 

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useStudentAnswerTableLogic.ts
@@ -87,6 +87,7 @@ export function useStudentAnswerTableLogic({
     fileOrder,
     onReloadData,
     onUpdatePendingChanges,
+    existingStudentAnswers,
   })
 
   // ============================================================================

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -53,52 +53,24 @@ export function useTableDataGeneration({
     const data: CellData[][] = []
 
     if (mode === "view") {
-      // 確認モード: ファイル配列の順序に基づく配置戦略適用（動的無効化対応）
-
-      // 有効セル（無効でないセル）の位置を事前に計算（動的無効化考慮）
-      const validPositions: Array<{ studentIndex: number; pageIndex: number }> =
-        []
-      for (
-        let studentIndex = 0;
-        studentIndex < sortedStudents.length;
-        studentIndex++
-      ) {
-        const examStudent = sortedStudents[studentIndex]
-        for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          if (!enhancedIsCellDisabled(examStudent, pageIndex + 1)) {
-            validPositions.push({ studentIndex, pageIndex })
-          }
-        }
-      }
-
-      // 配置戦略に基づいて有効セルをソート
-      if (fileOrder === "page-first") {
-        // ページ順: ページ番号を優先してソート
-        validPositions.sort((positionA, positionB) => {
-          if (positionA.pageIndex !== positionB.pageIndex) {
-            return positionA.pageIndex - positionB.pageIndex
-          }
-          return positionA.studentIndex - positionB.studentIndex
-        })
-      } else {
-        // 生徒順: 生徒番号を優先してソート（デフォルトで既にこの順序）
-        validPositions.sort((positionA, positionB) => {
-          if (positionA.studentIndex !== positionB.studentIndex) {
-            return positionA.studentIndex - positionB.studentIndex
-          }
-          return positionA.pageIndex - positionB.pageIndex
-        })
-      }
-
-      // ファイルと有効セルをマッピング（ファイル配列の順序で）
-      const filePositionMap = new Map<string, UnifiedFile>()
-      validPositions.forEach((position, fileIndex) => {
-        const file = enabledFiles[fileIndex]
-        if (file) {
-          const key = `${position.studentIndex}-${position.pageIndex}`
-          filePositionMap.set(key, file)
-        }
+      // 確認モード（方式B）: 各答案を自身の実セル座標 (studentId, pageNumber) に配置する。
+      // 配列順ではなく座標基準にすることで、DnD の move/swap が座標更新だけで完結し、
+      // 任意マスへの移動・占有マスとの入れ替えが素直に描画へ反映される。
+      // studentId → 行インデックスを1回だけ引けるようにする（O(files×students) を避ける）
+      const studentIndexById = new Map<string, number>()
+      sortedStudents.forEach((examStudent, studentIndex) => {
+        studentIndexById.set(examStudent.studentId, studentIndex)
       })
+
+      const fileByCell = new Map<string, UnifiedFile>()
+      for (const file of enabledFiles) {
+        if (!file.studentId) continue
+        const studentIndex = studentIndexById.get(file.studentId)
+        if (studentIndex === undefined) continue
+        const pageIndex = file.pageNumber - 1
+        if (pageIndex < 0 || pageIndex >= modelAnswerCount) continue
+        fileByCell.set(`${studentIndex}-${pageIndex}`, file)
+      }
 
       // テーブルデータを生成
       for (
@@ -110,21 +82,16 @@ export function useTableDataGeneration({
         const row: CellData[] = []
 
         for (let pageIndex = 0; pageIndex < modelAnswerCount; pageIndex++) {
-          const isDisabled = enhancedIsCellDisabled(examStudent, pageIndex + 1)
+          const file = fileByCell.get(`${studentIndex}-${pageIndex}`)
 
-          if (isDisabled) {
-            // 無効セル（手動無効化 + 動的無効化）。確認モードは表示上「答案なし」
+          if (file) {
+            // 答案が居るセルは常にファイルセル（動的無効化は答案なしセルにのみ効く）
+            row.push({ type: "file", file })
+          } else if (enhancedIsCellDisabled(examStudent, pageIndex + 1)) {
+            // 答案なしセル。確認モードは表示上「答案なし」
             row.push({ type: "disabled" })
           } else {
-            // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
-            const key = `${studentIndex}-${pageIndex}`
-            const file = filePositionMap.get(key)
-
-            if (file) {
-              row.push({ type: "file", file })
-            } else {
-              row.push({ type: "empty" })
-            }
+            row.push({ type: "empty" })
           }
         }
 

--- a/src/components/exams/06-student-answers/student-answer-table/types/dragDropTypes.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/dragDropTypes.ts
@@ -36,6 +36,12 @@ export interface UseDragDropParams {
       toState: FileState
     }>
   ) => void
+  // view 方式B の差分基準（DB 上の答案座標）。可変 ref ではなくこれと突き合わせる。
+  existingStudentAnswers?: Array<{
+    id: string
+    studentId: string | null
+    pageNumber: number
+  }>
 }
 
 // ドラッグ&ドロップフックの戻り値型

--- a/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
@@ -75,6 +75,148 @@ export function buildDnDArrayFromFileStates(
   return orderedFiles
 }
 
+/**
+ * view 方式B のセル droppable ID を (studentId, pageNumber) から生成する。
+ * studentId は uuid（コロンを含まない）前提。ファイルID（uuid）と衝突しないよう
+ * `cell:` 接頭辞で名前空間を分ける。
+ */
+export function encodeCellDroppableId(
+  studentId: string,
+  pageNumber: number
+): string {
+  return `cell:${studentId}:${pageNumber}`
+}
+
+/** セル droppable ID を (studentId, pageNumber) に復号する。cell: 接頭辞でなければ null */
+export function decodeCellDroppableId(
+  droppableId: string
+): { studentId: string; pageNumber: number } | null {
+  const prefix = "cell:"
+  if (!droppableId.startsWith(prefix)) return null
+  const rest = droppableId.slice(prefix.length)
+  const lastColon = rest.lastIndexOf(":")
+  if (lastColon <= 0) return null
+  const studentId = rest.slice(0, lastColon)
+  const pageText = rest.slice(lastColon + 1)
+  const pageNumber = Number(pageText)
+  // ページ番号は1始まり。空文字（Number("")→0）や小数・非数は不正。
+  if (!studentId || pageText === "" || !Number.isInteger(pageNumber)) {
+    return null
+  }
+  if (pageNumber < 1) return null
+  return { studentId, pageNumber }
+}
+
+/**
+ * view 方式B: ドラッグした答案を対象セル (studentId, pageNumber) へ配置する。
+ * 対象セルに別の答案が既にある場合は 2 セルの座標を入れ替える（swap）。
+ * 採点データの追従/破棄は後段の確認モーダル（PlacementScorePolicy）で解決するため、
+ * ここでは座標だけを更新する（新しい配列を返す。変更が無ければ元の配列を返す）。
+ */
+export function applyCellMoveOrSwap(
+  files: UnifiedFile[],
+  activeFileId: string,
+  target: { studentId: string; pageNumber: number },
+  // 占有判定を「表に見えている答案」に限定するための任意フィルタ。
+  // trash 等で非表示の答案を隠れて swap しないため（view は無効ファイル無しだが防御的に受ける）。
+  occupantEligibleIds?: Set<string>
+): UnifiedFile[] {
+  const activeFile = files.find((file) => file.id === activeFileId)
+  if (!activeFile) return files
+
+  const sourceStudentId = activeFile.studentId
+  const sourcePageNumber = activeFile.pageNumber
+
+  // 同一セルへのドロップは変更なし
+  if (
+    sourceStudentId === target.studentId &&
+    sourcePageNumber === target.pageNumber
+  ) {
+    return files
+  }
+
+  const occupant = files.find(
+    (file) =>
+      file.id !== activeFileId &&
+      file.studentId === target.studentId &&
+      file.pageNumber === target.pageNumber &&
+      (occupantEligibleIds ? occupantEligibleIds.has(file.id) : true)
+  )
+
+  return files.map((file) => {
+    if (file.id === activeFileId) {
+      return {
+        ...file,
+        studentId: target.studentId,
+        pageNumber: target.pageNumber,
+      }
+    }
+    if (occupant && file.id === occupant.id) {
+      // 空セルへの移動なら occupant は無く、この分岐は通らない。
+      // 占有セルなら元の答案を移動元へ入れ替える。
+      return {
+        ...file,
+        studentId: sourceStudentId,
+        pageNumber: sourcePageNumber,
+      }
+    }
+    return file
+  })
+}
+
+/** DB 上の答案の基準座標（(studentId, pageNumber)）。view 方式B の差分基準。 */
+export interface AnswerCellBaseline {
+  id: string
+  studentId: string | null
+  pageNumber: number
+}
+
+/**
+ * view 方式B: 現在のファイル配置（working copy）を DB baseline と突き合わせ、
+ * 座標が変わったファイルだけを PendingChange 生成用の差分（fromState=DB / toState=現在）で返す。
+ *
+ * 可変 ref（initialFileStatesRef）に依存せず毎回 DB 真実から算出するため、
+ * 複数回ドラッグ・反映後の再読込でも累積差分が常に正しい（親は全置換して安全）。
+ * baseline に無い id（新規・除籍等）は対象外。
+ */
+export function diffFilesAgainstBaseline(
+  files: UnifiedFile[],
+  baseline: AnswerCellBaseline[]
+): Array<{ fileId: string; fromState: FileState; toState: FileState }> {
+  const baselineById = new Map(baseline.map((cell) => [cell.id, cell]))
+  const changedFiles: Array<{
+    fileId: string
+    fromState: FileState
+    toState: FileState
+  }> = []
+
+  for (const file of files) {
+    const base = baselineById.get(file.id)
+    if (!base) continue
+    const currentStudentId = file.studentId ?? null
+    if (
+      base.studentId !== currentStudentId ||
+      base.pageNumber !== file.pageNumber
+    ) {
+      changedFiles.push({
+        fileId: file.id,
+        fromState: {
+          fileId: file.id,
+          studentId: base.studentId,
+          pageNumber: base.pageNumber,
+        },
+        toState: {
+          fileId: file.id,
+          studentId: currentStudentId,
+          pageNumber: file.pageNumber,
+        },
+      })
+    }
+  }
+
+  return changedFiles
+}
+
 /** DnD後のファイル配列からFileState（ファイルID・生徒ID・ページ番号の組）を再生成する */
 export function updateFileStatesFromDnDArray(
   dndArray: UnifiedFile[]


### PR DESCRIPTION
Closes #973

## 概要

生徒答案の確認モード(view)のDnDを「並べ替えリスト(方式A)」から「任意マスへ移動・占有マスは座標swap(方式B)」へ変更する。アップロードモードの方式A経路は不変。

## 変更点

- view の配置を配列順→座標 `(studentId, pageNumber)` 基準へ（`useTableDataGeneration`）
- 空セルを `useDroppable` 化し、`handleDragEnd` を view 分岐化（`applyCellMoveOrSwap`: 空=移動 / 占有=swap）
- 並び順トグルは view で非表示
- 採点の追従/破棄は確認モーダル（`PlacementScorePolicy`）で解決

## コードレビュー(high)反映

- **[最重大]** 可変 ref 依存で2回目のドラッグが1回目を落とす件を、DB baseline との stateless 差分 `diffFilesAgainstBaseline` へ置換
- 欠席生徒へのドロップ不可・隠れ答案の巻き込み防止・O(files×students) 解消・toast 条件修正

## テスト

- `__tests__/renderer/utils/dragDropUtils.test.ts`（13件）／型・lint・prettier グリーン
- **DnD 実挙動は要手動確認（`npm run dev`）**

## 残課題（次セッション）

- [4]/[5] 孤立答案の不可視化（対応要否含め判断）／ Phase 3c ／ Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)