### PR TITLE
fix(pdf-tools): パスワード保護PDFの書き出しエラーを解消

### DIFF
--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -105,6 +105,15 @@ app.on("ready", async () => {
       }
     })
 
+    // 前回セッションで残ったパスワード保護PDFの復号済み複製を掃除する
+    try {
+      const { cleanupDecryptedPdfCopies } =
+        await import("./lib/pdf-tools/decryptedPdfCopy")
+      cleanupDecryptedPdfCopies()
+    } catch (error) {
+      console.warn("Failed to clean up decrypted PDF copies:", error)
+    }
+
     // アプリケーションの初期化
     await initializeApp()
 

--- a/electron-src/ipc-handlers/pdfToolsHandlers.ts
+++ b/electron-src/ipc-handlers/pdfToolsHandlers.ts
@@ -8,6 +8,7 @@ import { PDFDocument } from "pdf-lib"
 
 import type { PdfToolsResult, RotationDegree } from "@/types/pdfTools.types"
 
+import { writeDecryptedPdfCopy } from "../lib/pdf-tools/decryptedPdfCopy"
 import { type MergePageInput, mergePdfs } from "../lib/pdf-tools/pdfMerger"
 import {
   type RotatePageInput,
@@ -70,6 +71,22 @@ export function setupPdfToolsHandlers(): void {
       outputDir: string
     }): Promise<PdfToolsResult> => {
       return await exportPagesToPng(options.imageBuffers, options.outputDir)
+    }
+  )
+
+  // パスワード保護PDFの復号済み複製を一時ファイルとして作成
+  // （pdf-lib は暗号化PDFを読めないため、復号済みページ画像から再構成する）
+  registerSafeHandler(
+    "pdf-tools:create-decrypted-copy",
+    async (options: {
+      pageImages: Uint8Array[]
+      pixelsPerPoint: number
+    }): Promise<{ success: boolean; path?: string; error?: string }> => {
+      const outputPath = await writeDecryptedPdfCopy(
+        options.pageImages,
+        options.pixelsPerPoint
+      )
+      return { success: true, path: outputPath }
     }
   )
 

--- a/electron-src/lib/pdf-tools/decryptedPdfCopy.ts
+++ b/electron-src/lib/pdf-tools/decryptedPdfCopy.ts
@@ -1,0 +1,61 @@
+/**
+ * パスワード保護PDFの復号済み複製の生成
+ *
+ * pdf-lib はパスワード付きPDFを読み込めないため、レンダラー側で pdf.js が
+ * パスワード復号してレンダリングしたページ画像から、保護なしのPDFを一時ファイル
+ * として再構成する。以後の結合・分割・回転はこの複製のパスに対して行う。
+ */
+import { randomUUID } from "crypto"
+import { app } from "electron"
+import * as fs from "fs"
+import * as path from "path"
+import { PDFDocument } from "pdf-lib"
+
+/** 復号済み複製を書き出す一時ディレクトリ */
+function decryptedCopyDir(): string {
+  return path.join(app.getPath("temp"), "score-at-once", "pdf-tools")
+}
+
+/**
+ * 復号済み複製の一時ディレクトリをまるごと削除する。
+ *
+ * 複製は取り込み後の書き出しまでパス参照され続けるため即時削除できない。
+ * 代わりにアプリ起動時に呼び、前回セッション（やクラッシュ）で残った複製を一括回収する。
+ * この時点では現セッションの複製はまだ存在しないため、使用中ファイルを消す心配がない。
+ */
+export function cleanupDecryptedPdfCopies(): void {
+  fs.rmSync(decryptedCopyDir(), { recursive: true, force: true })
+}
+
+/**
+ * 復号済みページ画像（PNG）から一時PDFを作成し、そのパスを返す。
+ *
+ * @param pageImages ページ順のPNG画像
+ * @param pixelsPerPoint 画像レンダリング倍率（1ポイントあたりのピクセル数）。
+ *   ページ寸法を元PDFと同じ物理サイズ（ポイント）に戻すために使う。
+ */
+export async function writeDecryptedPdfCopy(
+  pageImages: Uint8Array[],
+  pixelsPerPoint: number
+): Promise<string> {
+  const pdfDoc = await PDFDocument.create()
+
+  for (const pageImage of pageImages) {
+    const embeddedImage = await pdfDoc.embedPng(pageImage)
+    const pageWidth = embeddedImage.width / pixelsPerPoint
+    const pageHeight = embeddedImage.height / pixelsPerPoint
+    const page = pdfDoc.addPage([pageWidth, pageHeight])
+    page.drawImage(embeddedImage, {
+      x: 0,
+      y: 0,
+      width: pageWidth,
+      height: pageHeight,
+    })
+  }
+
+  const outputDir = decryptedCopyDir()
+  fs.mkdirSync(outputDir, { recursive: true })
+  const outputPath = path.join(outputDir, `decrypted-${randomUUID()}.pdf`)
+  fs.writeFileSync(outputPath, await pdfDoc.save())
+  return outputPath
+}

--- a/electron-src/preload-apis/pdfToolsApi.ts
+++ b/electron-src/preload-apis/pdfToolsApi.ts
@@ -38,6 +38,18 @@ export function createPdfToolsApi() {
         }>
         outputDir: string
       }) => ipcRenderer.invoke("pdf-tools:export-as-png", options),
+      createDecryptedCopy: (options: {
+        pageImages: Uint8Array[]
+        pixelsPerPoint: number
+      }) =>
+        ipcRenderer.invoke(
+          "pdf-tools:create-decrypted-copy",
+          options
+        ) as Promise<{
+          success: boolean
+          path?: string
+          error?: string
+        }>,
       selectSavePath: (options: {
         type: "pdf" | "directory"
         defaultName?: string

--- a/src/components/exams/01-upload/hooks/useMasterAnswers.ts
+++ b/src/components/exams/01-upload/hooks/useMasterAnswers.ts
@@ -96,12 +96,12 @@ export function useMasterAnswers(
 
           if (file.type === "application/pdf") {
             // Convert PDF to individual page images with password handling
-            const pdfImages = await convertPdfWithRetry(file)
-            if (pdfImages === null) {
+            const pdfConversion = await convertPdfWithRetry(file)
+            if (pdfConversion === null) {
               // ユーザーがパスワード入力をキャンセルした場合はアップロードを中断
               return
             }
-            allFilesData.push(...pdfImages)
+            allFilesData.push(...pdfConversion.images)
           } else {
             // Handle regular image files
             const imageData = await createUploadData(file)

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
@@ -80,8 +80,9 @@ export function useStudentAnswerUpload(
         try {
           if (file.type === "application/pdf") {
             // PDF処理 - 画像変換を実行（パスワードリトライ対応）
-            const pdfImages = await convertPdfWithRetry(file)
-            if (pdfImages) {
+            const pdfConversion = await convertPdfWithRetry(file)
+            if (pdfConversion) {
+              const pdfImages = pdfConversion.images
               for (let i = 0; i < pdfImages.length; i++) {
                 const image = pdfImages[i]
                 const blob = new Blob([image.buffer], { type: image.type })

--- a/src/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
+++ b/src/components/pdf-tools/import-panel/hooks/useImportedFiles.ts
@@ -1,7 +1,8 @@
 import { useCallback } from "react"
+import { toast } from "sonner"
 
 import { usePdfPasswordConversion } from "@/hooks/usePdfPasswordConversion"
-import type { ConvertedImage } from "@/lib/pdfConverter"
+import { type ConvertedImage, PDF_RENDER_SCALE } from "@/lib/pdfConverter"
 import type { ImportedFile } from "@/types/pdfTools.types"
 
 /** PDFファイルの読み込み・ページ情報取得・サムネイル生成を行うフック */
@@ -43,6 +44,43 @@ export function useImportedFiles() {
     []
   )
 
+  // 1ファイル分の共通処理: 画像変換し、パスワード保護PDFはパスを復号済み複製へ差し替える
+  const importFile = useCallback(
+    async (file: File, originalPath: string): Promise<ImportedFile | null> => {
+      // パスワード対応でPDFを画像変換（ページ数・サムネイルを一度に取得）
+      const conversion = await convertPdfWithRetry(file)
+      if (!conversion) {
+        // パスワード入力がキャンセルされた → このファイルはスキップ
+        return null
+      }
+
+      // 書き出し(pdf-lib)は暗号化PDFを読めないため、保護されていたPDFは
+      // 復号済みページ画像から再構成した一時PDFのパスに差し替える
+      let filePath = originalPath
+      if (conversion.passwordProtected) {
+        try {
+          filePath = await createDecryptedCopy(conversion.images)
+        } catch (error) {
+          // 複製の作成に失敗したら、無言で落とさずエラーを通知して当該ファイルを飛ばす
+          console.error(
+            `Failed to create decrypted copy for ${file.name}:`,
+            error
+          )
+          toast.error(
+            `「${file.name}」の復号済み複製の作成に失敗したため、取り込めませんでした`
+          )
+          return null
+        }
+        toast.info(
+          `「${file.name}」はパスワード保護されているため、画像化した複製を使用します`
+        )
+      }
+
+      return buildImportedFile(file.name, filePath, conversion.images)
+    },
+    [convertPdfWithRetry, buildImportedFile]
+  )
+
   // Fileオブジェクトから処理（ドラッグ&ドロップ用）
   const processFiles = useCallback(
     async (files: File[]): Promise<ImportedFile[]> => {
@@ -53,14 +91,10 @@ export function useImportedFiles() {
           // webUtils.getPathForFile でファイルパスを取得
           const filePath = window.electronAPI.pdfTools.getPathForFile(file)
 
-          // パスワード対応でPDFを画像変換（ページ数・サムネイルを一度に取得）
-          const images = await convertPdfWithRetry(file)
-          if (!images) {
-            // パスワード入力がキャンセルされた → このファイルはスキップ
-            continue
+          const importedFile = await importFile(file, filePath)
+          if (importedFile) {
+            processedFiles.push(importedFile)
           }
-
-          processedFiles.push(buildImportedFile(file.name, filePath, images))
         } catch (error) {
           console.error(`Error processing file ${file.name}:`, error)
         }
@@ -68,7 +102,7 @@ export function useImportedFiles() {
 
       return processedFiles
     },
-    [convertPdfWithRetry, buildImportedFile]
+    [importFile]
   )
 
   // ファイルパスから処理（Electronダイアログ用）
@@ -81,14 +115,10 @@ export function useImportedFiles() {
           // appimg:/// プロトコルでローカルファイルを読み込み、Fileオブジェクト化
           const file = await loadFileFromPath(filePath)
 
-          // パスワード対応でPDFを画像変換（ページ数・サムネイルを一度に取得）
-          const images = await convertPdfWithRetry(file)
-          if (!images) {
-            // パスワード入力がキャンセルされた → このファイルはスキップ
-            continue
+          const importedFile = await importFile(file, filePath)
+          if (importedFile) {
+            processedFiles.push(importedFile)
           }
-
-          processedFiles.push(buildImportedFile(file.name, filePath, images))
         } catch (error) {
           console.error(`Error processing file ${filePath}:`, error)
         }
@@ -96,7 +126,7 @@ export function useImportedFiles() {
 
       return processedFiles
     },
-    [convertPdfWithRetry, buildImportedFile]
+    [importFile]
   )
 
   return {
@@ -106,6 +136,18 @@ export function useImportedFiles() {
     handlePasswordSubmit,
     handlePasswordCancel,
   }
+}
+
+/** 復号済みページ画像から一時PDF（復号済み複製）を作成し、そのパスを返す */
+async function createDecryptedCopy(images: ConvertedImage[]): Promise<string> {
+  const result = await window.electronAPI.pdfTools.createDecryptedCopy({
+    pageImages: images.map((image) => new Uint8Array(image.buffer)),
+    pixelsPerPoint: PDF_RENDER_SCALE,
+  })
+  if (!result.success || !result.path) {
+    throw new Error(result.error || "復号済みPDFの作成に失敗しました")
+  }
+  return result.path
 }
 
 /** ローカルパスからFileオブジェクトを読み込む */

--- a/src/hooks/usePdfPasswordConversion.ts
+++ b/src/hooks/usePdfPasswordConversion.ts
@@ -19,6 +19,12 @@ const CLOSED_DIALOG: PdfPasswordDialogState = {
   isLoading: false,
 }
 
+/** 変換結果と、そのPDFがパスワード保護されていたかどうか */
+export interface PdfConversionOutcome {
+  images: ConvertedImage[]
+  passwordProtected: boolean
+}
+
 /**
  * パスワード保護PDFの変換を、パスワード入力ダイアログ付きで処理する共通フック。
  *
@@ -64,16 +70,17 @@ export function usePdfPasswordConversion() {
   /**
    * パスワード付きPDFを画像へ変換する（リトライ対応）。
    * @param file 変換対象のPDFファイル
-   * @returns 変換された画像配列。ユーザーがパスワード入力をキャンセルした場合は null。
+   * @returns 変換画像とパスワード保護有無。ユーザーがパスワード入力をキャンセルした場合は null。
    * @throws パスワード以外の理由で変換に失敗した場合
    */
   const convertPdfWithRetry = useCallback(
-    async (file: File): Promise<ConvertedImage[] | null> => {
+    async (file: File): Promise<PdfConversionOutcome | null> => {
       let hasError = false
 
       // まずパスワードなしで試行
       try {
-        return await convertPdfToImages(file)
+        const images = await convertPdfToImages(file)
+        return { images, passwordProtected: false }
       } catch (error) {
         if (
           !(error instanceof Error) ||
@@ -119,7 +126,7 @@ export function usePdfPasswordConversion() {
         try {
           const images = await convertPdfToImages(file, password)
           setPasswordDialog(CLOSED_DIALOG)
-          return images
+          return { images, passwordProtected: true }
         } catch (retryError) {
           if (
             retryError instanceof Error &&

--- a/src/lib/pdfConverter.ts
+++ b/src/lib/pdfConverter.ts
@@ -44,6 +44,12 @@ export interface ConvertedImage {
   buffer: ArrayBuffer
 }
 
+/**
+ * PDF→画像変換のレンダリング倍率（1ポイントあたりのピクセル数）。
+ * 変換画像からPDFページ寸法へ逆算する側（復号済み複製の生成等）と共有する。
+ */
+export const PDF_RENDER_SCALE = 2.0
+
 export interface PdfConversionError {
   type: "password-required" | "invalid-password" | "general-error"
   message: string
@@ -111,8 +117,7 @@ export async function convertPdfToImages(
 
     for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
       const page = await pdf.getPage(pageNum)
-      const scale = 2.0 // Higher scale for better quality
-      const viewport = page.getViewport({ scale })
+      const viewport = page.getViewport({ scale: PDF_RENDER_SCALE })
 
       const canvas = document.createElement("canvas")
       const context = canvas.getContext("2d")!

--- a/src/types/electron/pdfToolsApi.d.ts
+++ b/src/types/electron/pdfToolsApi.d.ts
@@ -33,6 +33,11 @@ export interface PdfToolsAPI {
       }>
       outputDir: string
     }) => Promise<{ success: boolean; outputPaths?: string[]; error?: string }>
+    /** パスワード保護PDFの復号済み複製（一時ファイル）を復号済みページ画像から作成 */
+    createDecryptedCopy: (options: {
+      pageImages: Uint8Array[]
+      pixelsPerPoint: number
+    }) => Promise<{ success: boolean; path?: string; error?: string }>
     selectSavePath: (options: {
       type: "pdf" | "directory"
       defaultName?: string


### PR DESCRIPTION
## 概要

PDF加工ページで、パスワード暗号化PDFを書き出そうとすると暗号化エラーで失敗する不具合を修正する。

Closes #975

## 原因

インポート時は pdf.js が復号してページ画像を生成するが、PDF書き出しは元ファイルのパスを pdf-lib で読み直す設計だった。pdf-lib は暗号化PDFを復号できないため、`PDFDocument.load()` が encrypted エラーで失敗していた（PNG書き出しは復号済み画像を使うため成功しており、PDF書き出しのみ失敗する非対称があった）。

## 対応

インポート時に、パスワード保護PDFを**復号済みページ画像から再構成した保護なしの一時PDF（復号済み複製）**へパスを差し替える。以後の結合・書き出しはこの複製を読むため、暗号化エラーが発生しない。

## 変更内容

- `src/lib/pdfConverter.ts`: レンダリング倍率を `PDF_RENDER_SCALE` として公開
- `src/hooks/usePdfPasswordConversion.ts`: `convertPdfWithRetry` の返り値に `passwordProtected` を追加（呼び出し3箇所を追従）
- `electron-src/lib/pdf-tools/decryptedPdfCopy.ts`（新規）: 復号済み複製の生成 + 起動時の一時ファイル一括クリーンアップ
- `electron-src/index.ts`: 起動時に前回セッションの復号済み複製を掃除
- `src/components/pdf-tools/import-panel/hooks/useImportedFiles.ts`: 保護PDFはパスを複製へ差し替え。複製作成失敗時はエラートーストで通知

## コードレビュー対応

高精度レビュー（workflow版 /code-review）で検出された、本変更に属する2件を修正済み:
- 復号済み複製の作成失敗時に無言でファイルが消える → エラートーストで通知しスキップ
- 復号済み複製の一時ファイルリーク → 起動時に一括クリーンアップ

## 確認

- `npm run typecheck` 通過
- `npm run lint`（対象ファイル）通過
- 復号済み複製が pdf-lib の結合経路（load → copyPages）を通ることをスクリプトで確認済み

## 留意点

復号済み複製は画像（scale 2.0 可逆PNG）から作るため、テキスト選択・ベクター情報は保持されない（pdf-lib 構成上の制約）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)