### PR TITLE
fix(pdf-tools): owner-password暗号化PDFの書き出しを可能にする

### DIFF
--- a/electron-src/ipc-handlers/pdfToolsHandlers.ts
+++ b/electron-src/ipc-handlers/pdfToolsHandlers.ts
@@ -135,7 +135,10 @@ export function setupPdfToolsHandlers(): void {
       }
 
       const fileBuffer = fs.readFileSync(filePath)
-      const pdfDoc = await PDFDocument.load(fileBuffer)
+      // owner-password のみの暗号化PDFでもページ数を取得できるよう ignoreEncryption を付ける
+      const pdfDoc = await PDFDocument.load(fileBuffer, {
+        ignoreEncryption: true,
+      })
       const pageCount = pdfDoc.getPageCount()
       const name = path.basename(filePath)
 

--- a/electron-src/lib/pdf-tools/pdfMerger.ts
+++ b/electron-src/lib/pdf-tools/pdfMerger.ts
@@ -66,7 +66,12 @@ export async function mergePdfs(
           continue
         }
         const fileBuffer = fs.readFileSync(resolvedPath)
-        sourcePdf = await PDFDocument.load(fileBuffer)
+        // owner-password のみの暗号化PDF（印刷/コピー制限）はユーザーパスワード無しで
+        // 内容を読めるため、ignoreEncryption で pdf-lib の EncryptedPDFError を回避する。
+        // ユーザーパスワード付きPDFはインポート時に復号済み複製へ差し替え済み。
+        sourcePdf = await PDFDocument.load(fileBuffer, {
+          ignoreEncryption: true,
+        })
         pdfCache.set(resolvedPath, sourcePdf)
       }
 

--- a/electron-src/lib/pdf-tools/pdfRotator.ts
+++ b/electron-src/lib/pdf-tools/pdfRotator.ts
@@ -27,7 +27,10 @@ export async function rotatePdfPages(
 ): Promise<RotateResult> {
   try {
     const fileBuffer = fs.readFileSync(filePath)
-    const pdf = await PDFDocument.load(fileBuffer)
+    // owner-password のみの暗号化PDF（印刷/コピー制限）はユーザーパスワード無しで
+    // 内容を読めるため、ignoreEncryption で pdf-lib の EncryptedPDFError を回避する。
+    // ユーザーパスワード付きPDFはインポート時に復号済み複製へ差し替え済み。
+    const pdf = await PDFDocument.load(fileBuffer, { ignoreEncryption: true })
 
     for (const { pageNumber, rotation } of rotations) {
       const pageIndex = pageNumber - 1

--- a/electron-src/lib/pdf-tools/pdfSplitter.ts
+++ b/electron-src/lib/pdf-tools/pdfSplitter.ts
@@ -22,7 +22,12 @@ export async function splitPdf(
 ): Promise<SplitResult> {
   try {
     const fileBuffer = fs.readFileSync(filePath)
-    const sourcePdf = await PDFDocument.load(fileBuffer)
+    // owner-password のみの暗号化PDF（印刷/コピー制限）はユーザーパスワード無しで
+    // 内容を読めるため、ignoreEncryption で pdf-lib の EncryptedPDFError を回避する。
+    // ユーザーパスワード付きPDFはインポート時に復号済み複製へ差し替え済み。
+    const sourcePdf = await PDFDocument.load(fileBuffer, {
+      ignoreEncryption: true,
+    })
     const pageCount = sourcePdf.getPageCount()
 
     // 出力ディレクトリを作成


### PR DESCRIPTION
## 概要

#976 でユーザーパスワード付きPDFの書き出しを修正したが、**owner-password のみで暗号化されたPDF（閲覧はパスワード不要、印刷/コピー制限のみ）** の書き出しが依然失敗する不具合を修正する。

Closes #977

## 原因

owner-password のみのPDFは pdf.js が無警告で開くため `convertPdfWithRetry` の `passwordProtected` が `false` となり、復号済み複製の経路を通らず元の暗号化パスがそのまま書き出しへ渡る。pdf-lib は既定で暗号化PDFを拒否するため、`PDFDocument.load` が `EncryptedPDFError` を投げていた。

（別セッションの code-review で検出された指摘への対応）

## 対応

owner-password PDFはユーザーパスワードが空で内容を読めるため、pdf-lib の `PDFDocument.load` 全4箇所に `{ ignoreEncryption: true }` を付与して直接処理し、保護なしで出力する。ベクター情報も保持される。ユーザーパスワード付きPDFは #976 の復号済み複製経路が引き続き担う。

## 変更内容

- `pdfMerger.ts` / `pdfSplitter.ts` / `pdfRotator.ts` / `pdfToolsHandlers.ts`（get-pdf-info）の `PDFDocument.load` に `{ ignoreEncryption: true }` を付与

## 確認

- `tsc -p electron-src`（electron側型チェック）通過
- 対象ファイルの eslint / prettier 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)