### PR TITLE
fix(06-student-answers): DnD並べ替えが無効化(trash)ファイルを巻き込む問題を修正 (#964)

### DIFF
--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
@@ -179,25 +179,40 @@ export function useDragDropHandlers({
       // アップロードモード（方式A）: arrayMove で並べ替え、各位置の studentId/pageNumber は固定。
       // 新規ファイルの自動配置順を手で入れ替えるための経路（view の座標 move/swap とは別物）。
       if (activeContainer === overContainer && activeId !== overId) {
-        const newFiles = [...files]
-        const oldIndex = newFiles.findIndex((file) => file.id === activeId)
-        const newIndex = newFiles.findIndex((file) => file.id === overId)
+        // 同一コンテナ内のファイル（main=有効 / trash=無効）だけを並べ替え対象にする。
+        // 全 files を arrayMove すると、old〜new index 間に挟まった trash スロットへ
+        // 隣接スロットの studentId/pageNumber が誤って再代入される（#964）。
+        const containerFiles =
+          activeContainer === "main" ? getEnabledFiles() : getDisabledFiles()
+        const oldIndex = containerFiles.findIndex(
+          (file) => file.id === activeId
+        )
+        const newIndex = containerFiles.findIndex((file) => file.id === overId)
 
         if (oldIndex !== -1 && newIndex !== -1) {
-          // 1. fileIdのみを入れ替え、各位置のstudentIdとpageNumberは固定
-          const originalFiles = [...newFiles]
+          // fileId のみを入れ替え、各スロット（元の位置）の studentId/pageNumber は固定
           const reorderedFileIds = arrayMove(
-            newFiles.map((file) => file.id),
+            containerFiles.map((file) => file.id),
             oldIndex,
             newIndex
           )
 
-          // 2. 各位置に対して、新しいfileIdと元の論理位置を組み合わせ
-          const reorderedFiles = originalFiles.map((originalFile, index) => ({
-            ...files.find((file) => file.id === reorderedFileIds[index])!, // 新しいfileIdのファイルオブジェクト
-            studentId: originalFile.studentId, // 元の位置のstudentId
-            pageNumber: originalFile.pageNumber, // 元の位置のpageNumber
-          }))
+          // 各スロット id → 移動後の fileId のファイル（座標は元スロットのまま）
+          const remappedBySlotId = new Map(
+            containerFiles.map((slot, index) => [
+              slot.id,
+              {
+                ...files.find((file) => file.id === reorderedFileIds[index])!,
+                studentId: slot.studentId,
+                pageNumber: slot.pageNumber,
+              },
+            ])
+          )
+
+          // 元の files 並びを保ち、当該コンテナのスロットのみ差し替える（trash は据え置き）
+          const reorderedFiles = files.map(
+            (file) => remappedBySlotId.get(file.id) ?? file
+          )
 
           onFilesChange(reorderedFiles)
           toast.success("答案の配置を変更しました")


### PR DESCRIPTION
## 概要
生徒答案テーブルのアップロードモード（方式A）の DnD 並べ替えが、無効化（trash）ファイルを含む**全 `files` 配列**を `arrayMove` するスロット固定モデルだったため、無効ファイルを誤って巻き込む問題を修正します。

## 問題
`useDragDropHandlers.ts` の handleDragEnd（アップロードモード分岐）で、`const newFiles = [...files]` が有効/無効（trash）両方を含んでいた。main↔main のドラッグでも old〜new index 間に trash スロットが挟まると、その trash ファイルへ隣接スロットの `(studentId, pageNumber)` が再代入され、結果として**無効ファイルが誤って pendingChange 検出**されうる。

## 修正
同一コンテナ内のファイル（`main`=有効 / `trash`=無効）だけを `getEnabledFiles()` / `getDisabledFiles()` で絞って並べ替え対象にし、元の `files` 並びを保って当該コンテナのスロットのみ差し替える方式へ変更。trash を巻き込まなくなり、`trash↔trash` の並べ替えは従来どおり温存する。

view モード（方式B）は既に `applyCellMoveOrSwap(..., enabledFileIds)` で対処済みのため、本 PR は upload モード分岐のみを対象とする。

## 検証
- `npm run typecheck` 緑
- `npx eslint` / `prettier` 緑
- 既存 `dragDropUtils.test.ts` 通過

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)