### PR TITLE
feat(grades): 成績算出のコピー（複製）機能を追加

### DIFF
--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -15,6 +15,7 @@ import {
 import {
   createGrade,
   deleteGrade,
+  duplicateGrade,
   getAllGrades,
   getGradeById,
   getGradeExportSettings,
@@ -115,6 +116,10 @@ export function setupGradeHandlers(): void {
 
   registerHandler("grade:delete", async (id: string) => {
     return deleteGrade(id)
+  })
+
+  registerHandler("grade:duplicate", async (id: string) => {
+    return duplicateGrade(id)
   })
 
   registerSafeHandler("grade:getExportSettings", async (gradeId: string) => {

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -274,6 +274,11 @@ export const AUDIT_ACTIONS = {
     verb: "delete",
     label: "成績「{target}」を削除しました",
   },
+  "grade.duplicate": {
+    category: "grade",
+    verb: "create",
+    label: "成績「{target}」を複製しました",
+  },
   "grade.export": {
     category: "grade",
     verb: "export",

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -7,6 +7,7 @@ import prisma from "./client"
 import {
   gradeItemWithDataSourcesInclude,
   hydrateGrade,
+  parseEstimationSourceIds,
 } from "./gradeDataSource"
 import { serializePrisma } from "./serializePrisma"
 
@@ -231,6 +232,286 @@ export async function deleteGrade(id: string) {
     return { success: true }
   } catch (error) {
     console.error("Error deleting grade exam:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/**
+ * 既存の成績名から重複しない「（コピー）」名を採番する。
+ * `${base} (コピー)`、以降 `${base} (コピー 2)`, `(コピー 3)` … と空きを探す。
+ */
+function buildCopyName(base: string, existingNames: Set<string>): string {
+  const first = `${base} (コピー)`
+  if (!existingNames.has(first)) return first
+  let n = 2
+  while (existingNames.has(`${base} (コピー ${n})`)) n++
+  return `${base} (コピー ${n})`
+}
+
+/**
+ * 成績算出試験をツリーごと複製する。
+ *
+ * Grade を頂点に、GradeItem / GradeDataSource / GradeBoundarySet+GradeBoundary /
+ * GradeOverride / GradeItemExclusion / GradeClassroom / GradeStudent /
+ * GradeConstraint / GradeExportSettings をすべて新IDで再作成する。
+ *
+ * 外部参照（examId・studentId・classroomId・cropRegionId・courseworkId 等）は
+ * 同一DB内でそのまま流用する（アーカイブ取込と違い名前照合は不要）。
+ * Grade 内部を参照するフィールドは新IDへ再リンクする:
+ *   - GradeItem を指す子（DataSource / BoundarySet / Override / Exclusion）→ 旧→新 gradeItemId
+ *   - GradeDataSource.estimationSourceIds（同一Grade内の他DataSource ID群）→ 旧→新 dataSourceId
+ *
+ * ⚠️ Grade に子テーブル／内部参照フィールドを追加した場合は、ここと
+ *    import/grade-archive の dataCreator（アーカイブ取込側）の両方を更新すること。
+ *
+ * 複製元の読み取りと全 create は単一トランザクション内で行い、共有DB上の並行編集に
+ * 対する一貫性を確保する。行数が多い独立テーブルは createMany でまとめて挿入する。
+ */
+export async function duplicateGrade(id: string) {
+  try {
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const source = await tx.grade.findUnique({
+          where: { id },
+          include: {
+            gradeClassrooms: { orderBy: { order: "asc" } },
+            gradeStudents: true,
+            gradeItems: {
+              include: { dataSources: { orderBy: { order: "asc" } } },
+              orderBy: { order: "asc" },
+            },
+            boundarySets: {
+              include: { boundaries: { orderBy: { order: "asc" } } },
+            },
+            gradeOverrides: true,
+            gradeItemExclusions: true,
+            gradeConstraints: { orderBy: { order: "asc" } },
+            exportSettings: true,
+          },
+        })
+        if (!source) return null
+
+        // 重複しないコピー名（Grade.name にDB制約は無く、UX目的の best-effort）
+        const allGrades = await tx.grade.findMany({ select: { name: true } })
+        const copyName = buildCopyName(
+          source.name,
+          new Set(allGrades.map((grade) => grade.name))
+        )
+
+        // 旧gradeItemId → 新gradeItemId。非nullなのに解決できなければ複製元が壊れて
+        // いるため throw してロールバックする（矛盾した行を作らない）。
+        const itemIdMap = new Map<string, string>()
+        const remapItemId = (oldId: string | null): string | null => {
+          if (!oldId) return null
+          const newId = itemIdMap.get(oldId)
+          if (!newId) {
+            throw new Error(`GradeItem ${oldId} の複製先が見つかりません`)
+          }
+          return newId
+        }
+
+        // 1. Grade 本体
+        const grade = await tx.grade.create({
+          data: {
+            name: copyName,
+            description: source.description,
+            referenceDate: source.referenceDate,
+          },
+        })
+
+        // 2. エクスポート設定（1:1）
+        if (source.exportSettings) {
+          await tx.gradeExportSettings.create({
+            data: {
+              gradeId: grade.id,
+              settingsJson: source.exportSettings.settingsJson,
+            },
+          })
+        }
+
+        // 3. 対象学級（独立行）
+        if (source.gradeClassrooms.length > 0) {
+          await tx.gradeClassroom.createMany({
+            data: source.gradeClassrooms.map((gradeClassroom) => ({
+              gradeId: grade.id,
+              classroomId: gradeClassroom.classroomId,
+              order: gradeClassroom.order,
+            })),
+          })
+        }
+
+        // 4. 対象生徒（独立行）
+        if (source.gradeStudents.length > 0) {
+          await tx.gradeStudent.createMany({
+            data: source.gradeStudents.map((gradeStudent) => ({
+              gradeId: grade.id,
+              studentId: gradeStudent.studentId,
+              customOrder: gradeStudent.customOrder,
+            })),
+          })
+        }
+
+        // 5. 評価項目 + データソース。
+        //    新IDを後続の再リンクに使うため個別 create し、旧→新の
+        //    gradeItemId / dataSourceId マップを両方構築する。
+        //    estimationSourceIds は同一Grade内の他DataSource IDを指し前方参照が
+        //    あり得るため、この時点では元値のままコピーし、全DataSource作成後（5.5）
+        //    に新IDへ remap する。
+        const dataSourceIdMap = new Map<string, string>()
+        const dataSourcesToRelink: {
+          newId: string
+          oldEstimationSourceIds: string[]
+        }[] = []
+        for (const gradeItem of source.gradeItems) {
+          const newItem = await tx.gradeItem.create({
+            data: {
+              gradeId: grade.id,
+              name: gradeItem.name,
+              order: gradeItem.order,
+            },
+          })
+          itemIdMap.set(gradeItem.id, newItem.id)
+
+          for (const dataSource of gradeItem.dataSources) {
+            const newDataSource = await tx.gradeDataSource.create({
+              data: {
+                gradeItemId: newItem.id,
+                type: dataSource.type,
+                examId: dataSource.examId,
+                subtotalId: dataSource.subtotalId,
+                cropRegionId: dataSource.cropRegionId,
+                courseworkItemId: dataSource.courseworkItemId,
+                courseworkId: dataSource.courseworkId,
+                name: dataSource.name,
+                weight: dataSource.weight,
+                order: dataSource.order,
+                absentMethod: dataSource.absentMethod,
+                absentRatio: dataSource.absentRatio,
+                absentOffset: dataSource.absentOffset,
+                treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
+                estimationMode: dataSource.estimationMode,
+                estimationSourceIds: dataSource.estimationSourceIds,
+              },
+            })
+            dataSourceIdMap.set(dataSource.id, newDataSource.id)
+            const oldEstimationSourceIds = parseEstimationSourceIds(
+              dataSource.estimationSourceIds
+            )
+            if (oldEstimationSourceIds.length > 0) {
+              dataSourcesToRelink.push({
+                newId: newDataSource.id,
+                oldEstimationSourceIds,
+              })
+            }
+          }
+        }
+
+        // 5.5. estimationSourceIds を新DataSource IDへ remap
+        //   （元Grade内に見つからないID＝不整合は落とす）。
+        for (const relink of dataSourcesToRelink) {
+          const remapped = relink.oldEstimationSourceIds
+            .map((oldSourceId) => dataSourceIdMap.get(oldSourceId))
+            .filter((newSourceId): newSourceId is string => !!newSourceId)
+          await tx.gradeDataSource.update({
+            where: { id: relink.newId },
+            data: { estimationSourceIds: JSON.stringify(remapped) },
+          })
+        }
+
+        // 6. 評定境界セット + 境界（gradeItemId を再リンク）
+        for (const boundarySet of source.boundarySets) {
+          const newBoundarySet = await tx.gradeBoundarySet.create({
+            data: {
+              gradeId: grade.id,
+              targetType: boundarySet.targetType,
+              gradeItemId: remapItemId(boundarySet.gradeItemId),
+            },
+          })
+          if (boundarySet.boundaries.length > 0) {
+            await tx.gradeBoundary.createMany({
+              data: boundarySet.boundaries.map((boundary) => ({
+                gradeBoundarySetId: newBoundarySet.id,
+                label: boundary.label,
+                minPercentage: boundary.minPercentage,
+                order: boundary.order,
+              })),
+            })
+          }
+        }
+
+        // 7. 評定の手動上書き（gradeItemId を再リンク／独立行）
+        if (source.gradeOverrides.length > 0) {
+          await tx.gradeOverride.createMany({
+            data: source.gradeOverrides.map((gradeOverride) => ({
+              gradeId: grade.id,
+              studentId: gradeOverride.studentId,
+              targetType: gradeOverride.targetType,
+              gradeItemId: remapItemId(gradeOverride.gradeItemId),
+              overrideLabel: gradeOverride.overrideLabel,
+            })),
+          })
+        }
+
+        // 8. 評価項目ごとの生徒除外（gradeItemId 必須のため remap 結果を非nullで使う／独立行）
+        if (source.gradeItemExclusions.length > 0) {
+          await tx.gradeItemExclusion.createMany({
+            data: source.gradeItemExclusions.map((exclusion) => {
+              const newItemId = itemIdMap.get(exclusion.gradeItemId)
+              if (!newItemId) {
+                throw new Error(
+                  `GradeItem ${exclusion.gradeItemId} の複製先が見つかりません`
+                )
+              }
+              return {
+                gradeId: grade.id,
+                studentId: exclusion.studentId,
+                gradeItemId: newItemId,
+              }
+            }),
+          })
+        }
+
+        // 9. 観点間の制約ルール（式・configは観点名参照のためID再マップ不要／独立行）
+        if (source.gradeConstraints.length > 0) {
+          await tx.gradeConstraint.createMany({
+            data: source.gradeConstraints.map((gradeConstraint) => ({
+              gradeId: grade.id,
+              name: gradeConstraint.name,
+              kind: gradeConstraint.kind,
+              config: gradeConstraint.config,
+              expression: gradeConstraint.expression,
+              color: gradeConstraint.color,
+              message: gradeConstraint.message,
+              enabled: gradeConstraint.enabled,
+              order: gradeConstraint.order,
+            })),
+          })
+        }
+
+        return { gradeId: grade.id, name: copyName }
+      },
+      { timeout: 30000 }
+    )
+
+    if (!result) {
+      return { success: false, error: "Grade exam not found" }
+    }
+
+    await recordAuditLog({
+      action: "grade.duplicate",
+      entityType: "Grade",
+      entityId: result.gradeId,
+      scopeId: result.gradeId,
+      scopeLabel: result.name,
+      target: result.name,
+    })
+
+    return getGradeById(result.gradeId)
+  } catch (error) {
+    console.error("Error duplicating grade exam:", error)
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -76,7 +76,7 @@ export const gradeItemWithDataSourcesInclude = {
 } satisfies Prisma.GradeItemInclude
 
 /** estimationSourceIds（JSON文字列 or 既に配列）を string[] へ正規化する。 */
-function parseEstimationSourceIds(value: unknown): string[] {
+export function parseEstimationSourceIds(value: unknown): string[] {
   if (Array.isArray(value)) return value as string[]
   if (typeof value === "string") {
     try {

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -21,6 +21,7 @@ export function createGradeApi() {
         }
       ) => ipcRenderer.invoke("grade:update", id, data),
       delete: (id: string) => ipcRenderer.invoke("grade:delete", id),
+      duplicate: (id: string) => ipcRenderer.invoke("grade:duplicate", id),
       // 生徒・学級管理
       getStudents: (gradeId: string) =>
         ipcRenderer.invoke("grade:getStudents", gradeId),

--- a/src/components/grades/list/GradeListContainer.tsx
+++ b/src/components/grades/list/GradeListContainer.tsx
@@ -3,6 +3,7 @@
 import {
   BarChart3,
   ClipboardEdit,
+  Copy,
   Eye,
   FolderInput,
   FolderOutput,
@@ -101,6 +102,21 @@ export function GradeListContainer() {
       }
     } catch (error) {
       console.error("Error deleting grade exam:", error)
+    }
+  }
+
+  const handleDuplicate = async (id: string) => {
+    try {
+      const result = await window.electronAPI.grade.duplicate(id)
+      if (result.success && result.grade) {
+        await loadGrades()
+        toast.success(`「${result.grade.name}」を複製しました`)
+      } else if (!result.success) {
+        toast.error("複製に失敗しました", { description: result.error })
+      }
+    } catch (error) {
+      console.error("Error duplicating grade exam:", error)
+      toast.error("複製に失敗しました")
     }
   }
 
@@ -275,6 +291,12 @@ export function GradeListContainer() {
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => handleDuplicate(grade.id)}
+                            >
+                              <Copy className="mr-2 h-4 w-4" />
+                              複製
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() =>
                                 window.electronAPI.grade.exportArchive(grade.id)

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -35,6 +35,11 @@ export interface GradeAPI {
       error?: string
     }>
     delete: (id: string) => Promise<{ success: boolean; error?: string }>
+    duplicate: (id: string) => Promise<{
+      success: boolean
+      grade?: import("../grade.types").GradeWithRelations
+      error?: string
+    }>
     // 生徒・学級管理
     getStudents: (gradeId: string) => Promise<{
       success: boolean


### PR DESCRIPTION
## 概要

成績算出（Grade）に**コピー（複製）機能**を追加しました。既存の成績構成をテンプレートとして再利用できます。

Closes #981

## 変更点

- 成績一覧（`/grades`）の各行「⋯」メニューに **「複製」** を追加。
- `duplicateGrade(id)`（`electron-src/lib/prisma/grade.ts`）を新設し、Grade をツリーごと新IDで複製:
  - `GradeItem` / `GradeDataSource` / `GradeBoundarySet`+`GradeBoundary` / `GradeOverride` / `GradeItemExclusion` / `GradeClassroom` / `GradeStudent` / `GradeConstraint` / `GradeExportSettings` を全て再作成。
  - 外部参照は同一DB内でそのまま流用。`GradeItem` を指す子は 旧→新 `gradeItemId` マップで再リンク。
  - `estimationSourceIds`（同一Grade内の他DataSource ID群）は 旧→新 `dataSourceId` マップで remap（前方参照に対応する2パス方式）。
  - 名前は `〇〇 (コピー)` / `(コピー 2)` … で自動採番。
- IPC (`grade:duplicate`) / preload API (`grade.duplicate`) / 型定義 / 監査アクション (`grade.duplicate`) を追加。

## 堅牢性（コードレビュー指摘の反映）

- `estimationSourceIds` のダングリング参照を dataSourceId remap で解消。
- 複製元読み取り＋全 create を単一トランザクションに集約（TOCTOU 回避）。
- 独立行は `createMany` バッチ挿入＋`timeout` 明示（大規模Grade のタイムアウト回避）。
- `gradeItemId` 解決不能な不整合は `throw` してロールバック。

## テスト

- `npm run typecheck`（Next.js + electron-src 両方）通過。
- 変更ファイルに対する ESLint / Prettier 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
