### PR TITLE
feat(navigation): アプリシェルにブラウザ的な戻る/進むボタンを追加

### DIFF
--- a/electron-src/ipc-handlers/index.ts
+++ b/electron-src/ipc-handlers/index.ts
@@ -10,6 +10,7 @@ import { setupExamHandlers } from "./examHandlers"
 import { setupExportHandlers } from "./exportHandlers"
 import { setupGradeHandlers } from "./gradeHandlers"
 import { setupMiscHandlers } from "./miscHandlers"
+import { setupNavigationHandlers } from "./navigationHandlers"
 import { setupOmrConfigHandlers } from "./omrConfigHandlers"
 import { setupOMRHandlers } from "./omrHandlers"
 import { setupPdfToolsHandlers } from "./pdfToolsHandlers"
@@ -49,4 +50,5 @@ export function setupAllIPCHandlers(): void {
   registerStudentArchiveHandlers()
   setupSyncHandlers()
   setupAuditLogHandlers()
+  setupNavigationHandlers()
 }

--- a/electron-src/ipc-handlers/navigationHandlers.ts
+++ b/electron-src/ipc-handlers/navigationHandlers.ts
@@ -1,0 +1,40 @@
+import { ipcMain } from "electron"
+
+/** ナビゲーション履歴の1エントリ（URLと履歴内インデックス） */
+export interface NavigationHistoryEntry {
+  index: number
+  url: string
+}
+
+/** renderer のブラウザ的な戻る/進む UI に渡すナビゲーション状態 */
+export interface NavigationState {
+  canGoBack: boolean
+  canGoForward: boolean
+  activeIndex: number
+  entries: NavigationHistoryEntry[]
+}
+
+/**
+ * ブラウザ的な「戻る/進む」と履歴一覧を renderer へ提供する IPC ハンドラーを登録する。
+ * Chromium のセッション履歴（Next.js の pushState 遷移を含む）をそのまま利用するため、
+ * renderer 側で独自の履歴スタックを再実装する必要がない。
+ */
+export function setupNavigationHandlers(): void {
+  ipcMain.handle("navigation:get-state", (event): NavigationState => {
+    const history = event.sender.navigationHistory
+    const entries = history.getAllEntries().map((entry, index) => ({
+      index,
+      url: entry.url,
+    }))
+    return {
+      canGoBack: history.canGoBack(),
+      canGoForward: history.canGoForward(),
+      activeIndex: history.getActiveIndex(),
+      entries,
+    }
+  })
+
+  ipcMain.handle("navigation:go-to-index", (event, index: number) => {
+    event.sender.navigationHistory.goToIndex(index)
+  })
+}

--- a/electron-src/preload-apis/navigationApi.ts
+++ b/electron-src/preload-apis/navigationApi.ts
@@ -1,0 +1,12 @@
+import { ipcRenderer } from "electron"
+
+/** ブラウザ的な戻る/進む・履歴一覧を扱う IPC API */
+export function createNavigationApi() {
+  return {
+    navigation: {
+      getState: () => ipcRenderer.invoke("navigation:get-state"),
+      goToIndex: (index: number) =>
+        ipcRenderer.invoke("navigation:go-to-index", index),
+    },
+  }
+}

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -13,6 +13,7 @@ import { createExamClassroomApi } from "./preload-apis/examClassroomApi"
 import { createExportApi } from "./preload-apis/exportApi"
 import { createGradeApi } from "./preload-apis/gradeApi"
 import { createMiscApi } from "./preload-apis/miscApi"
+import { createNavigationApi } from "./preload-apis/navigationApi"
 import { createOmrApi } from "./preload-apis/omrApi"
 import { createPdfToolsApi } from "./preload-apis/pdfToolsApi"
 import { createScoringApi } from "./preload-apis/scoringApi"
@@ -53,6 +54,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   ...createOmrApi(),
   ...createAnswerSheetBuilderApi(),
   ...createMiscApi(),
+  ...createNavigationApi(),
   ...createSyncApi(),
   ...createAuditLogApi(),
 })

--- a/src/components/layout/HistoryNavButtons.tsx
+++ b/src/components/layout/HistoryNavButtons.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import {
+  ArrowLeft,
+  ArrowRight,
+  BarChart3,
+  Calculator,
+  ClipboardList,
+  FileEdit,
+  FileStack,
+  LogIn,
+  type LucideIcon,
+  PencilSparkles,
+  School,
+  Settings,
+  Tag,
+  Users,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
+import {
+  type NavigationMenuEntry,
+  useNavigationHistory,
+} from "@/hooks/useNavigationHistory"
+import { cn } from "@/lib/utils"
+
+// AppShell（Navigation.tsx）のセクションアイコンと対応させる
+const SECTION_ICONS: Record<string, LucideIcon> = {
+  exams: PencilSparkles,
+  "answer-sheet-builder": FileEdit,
+  coursework: ClipboardList,
+  grades: BarChart3,
+  "pdf-tools": FileStack,
+  students: Users,
+  classrooms: School,
+  "subtotal-groups": Calculator,
+  tags: Tag,
+  settings: Settings,
+  login: LogIn,
+}
+
+interface HistoryNavButtonProps {
+  direction: "back" | "forward"
+  disabled: boolean
+  entries: NavigationMenuEntry[]
+  onNavigate: () => void
+  onSelectIndex: (index: number) => void
+}
+
+function HistoryNavButton({
+  direction,
+  disabled,
+  entries,
+  onNavigate,
+  onSelectIndex,
+}: HistoryNavButtonProps) {
+  const activeIndex = entries.find((entry) => entry.isActive)?.index ?? -1
+  // 戻る＝現在より過去（index小）、進む＝現在より未来（index大）。いずれも現在地に近い順。
+  const menuEntries =
+    direction === "back"
+      ? entries.filter((entry) => entry.index < activeIndex)
+      : entries.filter((entry) => entry.index > activeIndex).reverse()
+
+  const label = direction === "back" ? "戻る" : "進む"
+  const Icon = direction === "back" ? ArrowLeft : ArrowRight
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          disabled={disabled}
+          aria-label={label}
+          title={`${label}（右クリックで履歴）`}
+          onClick={onNavigate}
+        >
+          <Icon className="h-4 w-4" />
+        </Button>
+      </ContextMenuTrigger>
+      {menuEntries.length > 0 && (
+        <ContextMenuContent className="max-h-80 w-96 max-w-[90vw] overflow-auto">
+          {menuEntries.map((entry) => {
+            const SectionIcon = SECTION_ICONS[entry.section]
+            return (
+              <ContextMenuItem
+                key={entry.index}
+                onSelect={() => onSelectIndex(entry.index)}
+              >
+                {SectionIcon && <SectionIcon />}
+                <span className="min-w-0 flex-1 truncate">{entry.label}</span>
+              </ContextMenuItem>
+            )
+          })}
+        </ContextMenuContent>
+      )}
+    </ContextMenu>
+  )
+}
+
+/** ヘッダーに置くブラウザ的な「戻る/進む」ボタン。左クリックで1手移動、右クリックで履歴一覧。 */
+export function HistoryNavButtons({ className }: { className?: string }) {
+  const { canGoBack, canGoForward, entries, goBack, goForward, goToIndex } =
+    useNavigationHistory()
+
+  return (
+    <div className={cn("flex items-center gap-0.5", className)}>
+      <HistoryNavButton
+        direction="back"
+        disabled={!canGoBack}
+        entries={entries}
+        onNavigate={goBack}
+        onSelectIndex={goToIndex}
+      />
+      <HistoryNavButton
+        direction="forward"
+        disabled={!canGoForward}
+        entries={entries}
+        onNavigate={goForward}
+        onSelectIndex={goToIndex}
+      />
+    </div>
+  )
+}

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -8,9 +8,9 @@ import {
   ClipboardList,
   FileEdit,
   FileStack,
-  Home,
   LogIn,
   LogOut,
+  PencilSparkles,
   School,
   Settings,
   Tag,
@@ -21,6 +21,7 @@ import { usePathname } from "next/navigation"
 import { Fragment } from "react"
 
 import { GuardedLink } from "@/components/common/GuardedLink"
+import { HistoryNavButtons } from "@/components/layout/HistoryNavButtons"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
@@ -42,7 +43,7 @@ interface NavItem {
 const navGroups: NavItem[][] = [
   [
     { href: "/answer-sheet-builder", label: "解答用紙作成", icon: FileEdit },
-    { href: "/exams", label: "試験一覧", icon: Home },
+    { href: "/exams", label: "試験一覧", icon: PencilSparkles },
     { href: "/coursework", label: "試験外成績資料", icon: ClipboardList },
     { href: "/grades", label: "成績算出", icon: BarChart3 },
   ],
@@ -79,13 +80,19 @@ export default function Navigation({
       <div
         className={cn(
           "flex h-16 items-center border-b px-2",
-          isSidebarMinimized ? "justify-center" : "justify-between px-6"
+          isSidebarMinimized ? "justify-center" : "justify-between px-4"
         )}
       >
         {!isSidebarMinimized && (
-          <GuardedLink href="/exams" className="text-lg font-semibold">
-            一括採点
-          </GuardedLink>
+          <div className="flex min-w-0 items-center gap-1">
+            <GuardedLink
+              href="/exams"
+              className="truncate text-lg font-semibold"
+            >
+              一括採点
+            </GuardedLink>
+            <HistoryNavButtons />
+          </div>
         )}
         <Button
           variant="ghost"

--- a/src/hooks/useNavigationHistory.ts
+++ b/src/hooks/useNavigationHistory.ts
@@ -1,0 +1,244 @@
+"use client"
+
+import { usePathname, useRouter } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+
+/** 履歴メニューに表示する1エントリ（ラベル解決済み） */
+export interface NavigationMenuEntry {
+  index: number
+  label: string
+  /** URL先頭セグメント（AppShellと同じセクションアイコンの選択に使う） */
+  section: string
+  isActive: boolean
+}
+
+/** 固有名を持つエンティティの種別（URLから判定） */
+type EntityKind = "exam" | "grade" | "coursework" | "asb"
+
+interface RouteLabel {
+  base: string
+  /** ワークフローのサブステップ名（例: 「4. 小計点」）。試験詳細ページ配下でのみ付く */
+  step?: string
+  entity?: { kind: EntityKind; id: string }
+}
+
+// 各ワークフローのステップフォルダ→表示名（対応する [id]/layout.tsx のステップ定義と揃える）
+const EXAM_STEP_LABELS: Record<string, string> = {
+  "01-upload": "1. 模範解答",
+  "02-template": "2. 採点領域",
+  "03-region-info": "3. 領域情報",
+  "04-question-group": "4. 小計点",
+  "05-students": "5. 受験生徒",
+  "06-student-answers": "6. 生徒答案",
+  "07-score-at-once": "7. 採点",
+  "08-export": "8. 結果",
+}
+
+const GRADE_STEP_LABELS: Record<string, string> = {
+  "01-setup": "1. 基本設定",
+  "02-students": "2. 生徒管理",
+  "03-data-sources": "3. データソース",
+  "04-manual-scores": "4. 外部成績",
+  "05-boundaries": "5. 成績境界",
+  "06-results": "6. 結果",
+  "07-export": "7. 出力",
+}
+
+const COURSEWORK_STEP_LABELS: Record<string, string> = {
+  "01-setup": "1. 基本設定",
+  "02-students": "2. 生徒管理",
+  "03-items": "3. 評価項目",
+  "04-scores": "4. 点数入力",
+  "05-results": "5. 結果",
+}
+
+/** pathname を「セクション名」と（あれば）ステップ名・固有名を引くためのエンティティ情報へ変換する */
+function routeToLabel(pathname: string): RouteLabel {
+  const segments = pathname.split("/").filter(Boolean)
+  const [first, second, third] = segments
+
+  switch (first) {
+    case undefined:
+    case "login":
+      return { base: "ログイン" }
+    case "dashboard":
+      return { base: "ダッシュボード" }
+    case "exams":
+      return second
+        ? {
+            base: "試験",
+            step: EXAM_STEP_LABELS[third],
+            entity: { kind: "exam", id: second },
+          }
+        : { base: "試験一覧" }
+    case "answer-sheet-builder":
+      return second
+        ? { base: "解答用紙作成", entity: { kind: "asb", id: second } }
+        : { base: "解答用紙作成" }
+    case "grades":
+      return second
+        ? {
+            base: "成績算出",
+            step: GRADE_STEP_LABELS[third],
+            entity: { kind: "grade", id: second },
+          }
+        : { base: "成績算出" }
+    case "coursework":
+      return second
+        ? {
+            base: "試験外成績資料",
+            step: COURSEWORK_STEP_LABELS[third],
+            entity: { kind: "coursework", id: second },
+          }
+        : { base: "試験外成績資料" }
+    case "students":
+      return { base: "生徒管理" }
+    case "classrooms":
+      return { base: "学級管理" }
+    case "subtotal-groups":
+      return { base: "小計点管理" }
+    case "tags":
+      return { base: "タグ管理" }
+    case "pdf-tools":
+      return { base: "PDF加工" }
+    case "settings":
+      return { base: "設定" }
+    default:
+      return { base: `/${segments.join("/")}` }
+  }
+}
+
+// 固有名はセッション中変化が稀なため、モジュールスコープでキャッシュする
+const entityNameCache = new Map<string, string>()
+
+async function resolveEntityName(
+  kind: EntityKind,
+  id: string
+): Promise<string | null> {
+  const cacheKey = `${kind}:${id}`
+  const cached = entityNameCache.get(cacheKey)
+  if (cached !== undefined) return cached
+
+  try {
+    let name: string | null = null
+    if (kind === "exam") {
+      const exam = await window.electronAPI.getExam(id)
+      name = exam?.examName ?? null
+    } else if (kind === "grade") {
+      const result = await window.electronAPI.grade.getById(id)
+      name = result.grade?.name ?? null
+    } else if (kind === "coursework") {
+      const result = await window.electronAPI.coursework.getById(id)
+      name = result.coursework?.name ?? null
+    } else if (kind === "asb") {
+      const result =
+        await window.electronAPI.answerSheetBuilder.loadDefinition(id)
+      name = result.data?.name ?? null
+    }
+    if (name) entityNameCache.set(cacheKey, name)
+    return name
+  } catch {
+    return null
+  }
+}
+
+/** URLから履歴メニュー用のラベルとセクションを組み立てる（固有名が引ければ「セクション｜固有名」） */
+async function buildEntry(
+  url: string
+): Promise<{ label: string; section: string }> {
+  let pathname: string
+  try {
+    pathname = new URL(url).pathname
+  } catch {
+    pathname = url
+  }
+
+  const section = pathname.split("/").filter(Boolean)[0] ?? "login"
+  const { base, step, entity } = routeToLabel(pathname)
+  if (!entity) return { label: base, section }
+
+  const name = await resolveEntityName(entity.kind, entity.id)
+  // 「セクション｜ステップ｜固有名」（ステップ・固有名は解決できたものだけ連結）
+  const label = [base, step, name].filter(Boolean).join("｜")
+  return { label, section }
+}
+
+export interface UseNavigationHistoryResult {
+  canGoBack: boolean
+  canGoForward: boolean
+  /** activeIndex を含む全履歴エントリ（新しい順に反転済み） */
+  entries: NavigationMenuEntry[]
+  goBack: () => void
+  goForward: () => void
+  goToIndex: (index: number) => void
+  refresh: () => void
+}
+
+/**
+ * Electron のセッション履歴を用いてブラウザ的な戻る/進む・履歴一覧を提供するフック。
+ * 履歴状態は遷移（pathname 変化）ごとに再取得し、各エントリのラベルを非同期解決する。
+ */
+export function useNavigationHistory(): UseNavigationHistoryResult {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+  const [entries, setEntries] = useState<NavigationMenuEntry[]>([])
+
+  const refresh = useCallback(() => {
+    let cancelled = false
+
+    const run = async () => {
+      const api = window.electronAPI?.navigation
+      if (!api) return
+
+      const state = await api.getState()
+      if (cancelled) return
+
+      setCanGoBack(state.canGoBack)
+      setCanGoForward(state.canGoForward)
+
+      const labeled = await Promise.all(
+        state.entries.map(async (entry) => {
+          const { label, section } = await buildEntry(entry.url)
+          return {
+            index: entry.index,
+            label,
+            section,
+            isActive: entry.index === state.activeIndex,
+          }
+        })
+      )
+      if (cancelled) return
+
+      // 新しい履歴を上に表示する（ブラウザの履歴メニューに倣う）
+      setEntries(labeled.reverse())
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // 遷移ごとに履歴状態を再取得する
+  useEffect(() => {
+    const cleanup = refresh()
+    return cleanup
+  }, [pathname, refresh])
+
+  const goToIndex = useCallback((index: number) => {
+    void window.electronAPI?.navigation?.goToIndex(index)
+  }, [])
+
+  return {
+    canGoBack,
+    canGoForward,
+    entries,
+    goBack: () => router.back(),
+    goForward: () => router.forward(),
+    goToIndex,
+    refresh,
+  }
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -23,6 +23,7 @@ import type { ExamClassroomAPI } from "./electron/examClassroomApi"
 import type { ExportAPI } from "./electron/exportApi"
 import type { GradeAPI } from "./electron/gradeApi"
 import type { MasterImageAPI } from "./electron/masterImageApi"
+import type { NavigationAPI } from "./electron/navigationApi"
 import type { OmrAPI } from "./electron/omrApi"
 import type { PdfToolsAPI } from "./electron/pdfToolsApi"
 import type { ScoringAPI } from "./electron/scoringApi"
@@ -94,6 +95,7 @@ export interface MyAPI
     OmrAPI,
     DataManagementAPI,
     SyncAPI,
+    NavigationAPI,
     AuditLogAPI {}
 
 // ---------------------------------------------------------------------------

--- a/src/types/electron/navigationApi.d.ts
+++ b/src/types/electron/navigationApi.d.ts
@@ -1,0 +1,24 @@
+/**
+ * ナビゲーション履歴関連API（ブラウザ的な戻る/進む・履歴一覧）
+ */
+
+/** ナビゲーション履歴の1エントリ（URLと履歴内インデックス） */
+export interface NavigationHistoryEntryData {
+  index: number
+  url: string
+}
+
+/** 戻る/進む UI に渡すナビゲーション状態 */
+export interface NavigationStateData {
+  canGoBack: boolean
+  canGoForward: boolean
+  activeIndex: number
+  entries: NavigationHistoryEntryData[]
+}
+
+export interface NavigationAPI {
+  navigation: {
+    getState: () => Promise<NavigationStateData>
+    goToIndex: (index: number) => Promise<void>
+  }
+}


### PR DESCRIPTION
Closes #983

## 概要

アプリシェル（サイドバー上部「一括採点」の右）にブラウザ的な戻る/進むボタンを追加します。

## 変更点

- **UI**: 戻る/進むボタン2つ。左クリックで1手移動、右クリックで履歴一覧。折りたたみ時は非表示
- **IPC（新規は履歴取得のみ）**: `navigation:get-state` / `navigation:go-to-index`。Electron の `navigationHistory`（Chromium セッション履歴＝Next の pushState 遷移も含む）を利用
- **履歴ラベル**: 「セクション｜ステップ｜固有名」。試験/成績算出/試験外成績資料のワークフローのステップ名に対応。固有名は既存 getter で解決。AppShell と同じセクションアイコン付き・幅拡大・長い名前は `…` 省略
- **アイコン**: 試験を `Home` → `PencilSparkles` に変更

## ファイル

新規:
- `electron-src/ipc-handlers/navigationHandlers.ts`
- `electron-src/preload-apis/navigationApi.ts`
- `src/types/electron/navigationApi.d.ts`
- `src/hooks/useNavigationHistory.ts`
- `src/components/layout/HistoryNavButtons.tsx`

変更:
- `electron-src/ipc-handlers/index.ts`
- `electron-src/preload.ts`
- `src/types/electron.d.ts`
- `src/components/layout/Navigation.tsx`

## 確認

- \`npm run typecheck\` 緑
- \`npm run lint\`（eslint + prettier --check）緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)