### PR TITLE
refactor(06): baseline/占有信号を id 射影から実体渡しへ是正

### DIFF
--- a/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -28,16 +28,9 @@ export function StudentAnswerUpload({
     [examPages]
   )
 
-  // view 方式B の差分基準（DB baseline）／upload の占有信号。いずれも id で同定。
-  const existingAnswers = useMemo(
-    () =>
-      placedAnswers.map((answer) => ({
-        id: answer.id,
-        studentId: answer.studentId,
-        examPageId: answer.examPageId,
-      })),
-    [placedAnswers]
-  )
+  // view 方式B の差分基準（DB baseline）／upload の占有信号は、DB答案の実体
+  // （placedAnswers = PlacedAnswerImage[]）をそのまま渡す（id 3つ組へ射影しない）。
+  // 受け手は AnswerImageIdentity 契約で id を読むだけ。
 
   const {
     isUploading,
@@ -95,7 +88,7 @@ export function StudentAnswerUpload({
         onReloadData={onUploadComplete}
         affectedCells={affectedCells}
         onUpdatePendingChanges={onUpdatePendingChanges}
-        existingAnswers={existingAnswers}
+        existingAnswers={placedAnswers}
         correctionStatusMap={correctionStatusMap}
       />
     )
@@ -125,7 +118,7 @@ export function StudentAnswerUpload({
           onFilesChange={setFiles}
           onUpload={handleUpload}
           onReloadData={onUploadComplete}
-          existingAnswers={existingAnswers}
+          existingAnswers={placedAnswers}
           markerCorrectionEnabled={markerCorrectionEnabled}
           markerCorrectionAvailable={markerCorrectionAvailable}
           markerDiagnostics={markerDiagnostics}

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
@@ -6,10 +6,7 @@ import { useDragDrop } from "@/components/exams/06-student-answers/student-answe
 import { useNameRegion } from "@/components/exams/06-student-answers/student-answer-table/hooks/useNameRegion"
 import { useTableData } from "@/components/exams/06-student-answers/student-answer-table/hooks/useTableData"
 import type { PreviewMode } from "@/components/exams/06-student-answers/student-answer-table/types"
-import type {
-  AnswerCellBaseline,
-  FileState,
-} from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
+import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import type {
   AnswerImageIdentity,
   ExamPageColumn,
@@ -38,7 +35,7 @@ export interface UseAnswerTableCoreParams<TItem extends AnswerImageIdentity> {
       toState: FileState
     }>
   ) => void
-  existingAnswers?: AnswerCellBaseline[]
+  existingAnswers?: AnswerImageIdentity[]
 }
 
 export function useAnswerTableCore<TItem extends AnswerImageIdentity>({

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
@@ -3,10 +3,7 @@ import { arrayMove } from "@dnd-kit/sortable"
 import { useCallback } from "react"
 import { toast } from "sonner"
 
-import type {
-  AnswerCellBaseline,
-  FileState,
-} from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
+import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import {
   applyCellMoveOrSwap,
   decodeCellDroppableId,
@@ -36,7 +33,7 @@ interface UseDragDropHandlersParams<TItem extends AnswerImageIdentity> {
       toState: FileState
     }>
   ) => void
-  existingAnswers?: AnswerCellBaseline[]
+  existingAnswers?: AnswerImageIdentity[]
   setActiveFile: (file: TItem | null) => void
 }
 

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -28,11 +28,7 @@ interface UseTableDataParams<TItem extends AnswerImageIdentity> {
     examPageId: string
   ) => boolean
   mode?: "upload" | "view"
-  existingAnswers?: Array<{
-    id: string
-    studentId: string | null
-    examPageId: string | null
-  }>
+  existingAnswers?: AnswerImageIdentity[]
   allowOverwrite?: boolean
 }
 

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -28,11 +28,7 @@ interface UseTableDataGenerationParams<TItem extends AnswerImageIdentity> {
     examPageId: string
   ) => boolean
   allowOverwrite?: boolean
-  existingAnswers?: Array<{
-    id: string
-    studentId: string | null
-    examPageId: string | null
-  }>
+  existingAnswers?: AnswerImageIdentity[]
 }
 
 /**

--- a/src/components/exams/06-student-answers/student-answer-table/types/dragDropTypes.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/dragDropTypes.ts
@@ -12,16 +12,10 @@ import type {
 } from "@/components/exams/06-student-answers/types"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
-// ファイル状態管理用の型定義。座標は id（examPageId）で持つ（pageNumber 序数は key 不可）。
+// ファイル状態管理用の型定義。DnD の移動 from/to はセル座標（移動先は空マス＝実体が
+// 無いこともある）なので、実体ではなく id（studentId, examPageId）で持つ。
 export interface FileState {
   fileId: string
-  studentId: string | null
-  examPageId: string | null
-}
-
-// view 方式B の差分基準（DB 上の答案座標）。id で同定する。
-export interface AnswerCellBaseline {
-  id: string
   studentId: string | null
   examPageId: string | null
 }
@@ -46,8 +40,9 @@ export interface UseDragDropParams<
       toState: FileState
     }>
   ) => void
-  // view 方式B の差分基準（DB 上の答案座標）。可変 ref ではなくこれと突き合わせる。
-  existingAnswers?: AnswerCellBaseline[]
+  // view 方式B の差分基準（DB 上の答案 = PlacedAnswerImage 実体をそのまま渡す）。
+  // 可変 ref ではなくこれと突き合わせる。読み取り契約は AnswerImageIdentity。
+  existingAnswers?: AnswerImageIdentity[]
 }
 
 // ドラッグ&ドロップフックの戻り値型

--- a/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types/localTypes.ts
@@ -1,4 +1,5 @@
 import type {
+  AnswerImageIdentity,
   ExamPageColumn,
   PlacementStrategy,
   UnsavedAnswerImage,
@@ -9,7 +10,7 @@ import type {
   PlacedAnswerImage,
 } from "@/types/prismaExtensions"
 
-import type { AnswerCellBaseline, FileState } from "./dragDropTypes"
+import type { FileState } from "./dragDropTypes"
 
 // ============================================================================
 // answer-table コンポーネントの型定義
@@ -22,8 +23,9 @@ export interface AnswerTableBaseProps {
   examPages: ExamPageColumn[]
   imageLoadStates?: Record<string, "pending" | "loading" | "loaded" | "error">
   onReloadData?: () => void
-  // upload: 既存答案の占有信号 / view: DnD 差分の DB baseline（いずれも id で同定）
-  existingAnswers?: AnswerCellBaseline[]
+  // 既存答案（PlacedAnswerImage 実体をそのまま渡す）。upload では占有信号、view では
+  // DnD 差分の DB baseline として使う。読み取り契約は AnswerImageIdentity（id で同定）。
+  existingAnswers?: AnswerImageIdentity[]
 }
 
 /** アップロード（新規追加）モードのテーブル。ファイルは未保存の UnsavedAnswerImage。 */

--- a/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
@@ -1,7 +1,4 @@
-import type {
-  AnswerCellBaseline,
-  FileState,
-} from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
+import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types/dragDropTypes"
 import type { AnswerImageIdentity } from "@/components/exams/06-student-answers/types"
 
 /**
@@ -111,7 +108,7 @@ export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
  */
 export function diffFilesAgainstBaseline<T extends AnswerImageIdentity>(
   files: T[],
-  baseline: AnswerCellBaseline[]
+  baseline: AnswerImageIdentity[]
 ): Array<{ fileId: string; fromState: FileState; toState: FileState }> {
   const baselineById = new Map(baseline.map((cell) => [cell.id, cell]))
   const changedFiles: Array<{

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -131,11 +131,7 @@ export function calculateCellsWithExistingAnswers<
   examPages: ExamPageColumn[],
   disabledState: ExtendedDisabledState,
   mode?: "upload" | "view",
-  existingAnswers?: Array<{
-    id: string
-    studentId: string | null
-    examPageId: string | null
-  }>
+  existingAnswers?: AnswerImageIdentity[]
 ): CellLookup {
   const cells: CellLookup = new Map()
 


### PR DESCRIPTION
Closes #987

## 概要

「id ではなく実体を持つ」原則に沿い、DB baseline / 占有信号として `PlacedAnswerImage` 実体を `{ id, studentId, examPageId }` へ射影していた残課題を是正しました。

## 変更

- `StudentAnswerUpload`: `existingAnswers` の `.map` 射影 memo を撤去し、`placedAnswers`（実体）を直渡し。
- 重複型 `AnswerCellBaseline`（`AnswerImageIdentity` と構造同一）を廃止し一本化。
- `diffFilesAgainstBaseline` / `calculateCellsWithExistingAnswers` / 各フックの `existingAnswers` を `AnswerImageIdentity[]` 契約へ統一。

## 据え置き（正当な id 保持）

- `FileState`（移動 from/to）は移動先が空マス＝実体不在の座標記述のため id のまま。
- IPC 境界・dnd-kit droppable・React key は id が正しい。

## 検証

- `npm run typecheck` グリーン / `npm run lint` クリーン / DnD テスト green / 挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByFRmpGMXS4QoyFqF86jmb
