### PR TITLE
feat(03-data-sources): データソースDnD並べ替え＋欠測一括設定に推定ソース選択

### DIFF
--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -34,7 +34,6 @@ import {
   updateGradeConstraint,
 } from "../lib/prisma/gradeConstraint"
 import {
-  batchUpdateAbsentPolicy,
   calculateSourceMaxScore,
   createDataSource,
   deleteDataSource,
@@ -293,23 +292,6 @@ export function setupGradeHandlers(): void {
     "grade:reorderDataSources",
     async (items: { id: string; order: number }[]) => {
       return reorderDataSources(items)
-    }
-  )
-
-  registerHandler(
-    "grade:batchUpdateAbsentPolicy",
-    async (
-      dataSourceIds: string[],
-      policy: {
-        absentMethod: string
-        absentRatio: number
-        absentOffset: number
-        treatExpectedAsMissing?: boolean
-        estimationMode?: string
-        estimationSourceIds?: string[]
-      }
-    ) => {
-      return batchUpdateAbsentPolicy(dataSourceIds, policy)
     }
   )
 

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -422,55 +422,6 @@ export async function reorderDataSources(
 }
 
 /**
- * 複数DataSourceの欠席ポリシーを一括更新
- */
-export async function batchUpdateAbsentPolicy(
-  dataSourceIds: string[],
-  policy: {
-    absentMethod: string
-    absentRatio: number
-    absentOffset: number
-    treatExpectedAsMissing?: boolean
-    estimationMode?: string
-    estimationSourceIds?: string[]
-  }
-) {
-  try {
-    const updateData: Record<string, unknown> = {
-      absentMethod: policy.absentMethod,
-      absentRatio: policy.absentRatio,
-      absentOffset: policy.absentOffset,
-    }
-    if (policy.treatExpectedAsMissing !== undefined) {
-      updateData.treatExpectedAsMissing = policy.treatExpectedAsMissing
-    }
-    if (policy.estimationMode !== undefined) {
-      updateData.estimationMode = policy.estimationMode
-    }
-    if (policy.estimationSourceIds !== undefined) {
-      updateData.estimationSourceIds = JSON.stringify(
-        policy.estimationSourceIds
-      )
-    }
-    await prisma.$transaction(
-      dataSourceIds.map((id) =>
-        prisma.gradeDataSource.update({
-          where: { id },
-          data: updateData,
-        })
-      )
-    )
-    return { success: true }
-  } catch (error) {
-    console.error("Error batch updating absent policy:", error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    }
-  }
-}
-
-/**
  * 全試験試験候補を取得（SubtotalGroupフィルタなし）
  */
 export async function getExamCandidates() {

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -118,22 +118,6 @@ export function createGradeApi() {
         ipcRenderer.invoke("grade:deleteDataSource", id),
       reorderDataSources: (items: { id: string; order: number }[]) =>
         ipcRenderer.invoke("grade:reorderDataSources", items),
-      batchUpdateAbsentPolicy: (
-        dataSourceIds: string[],
-        policy: {
-          absentMethod: string
-          absentRatio: number
-          absentOffset: number
-          treatExpectedAsMissing?: boolean
-          estimationMode?: string
-          estimationSourceIds?: string[]
-        }
-      ) =>
-        ipcRenderer.invoke(
-          "grade:batchUpdateAbsentPolicy",
-          dataSourceIds,
-          policy
-        ),
       getBoundarySets: (gradeId: string) =>
         ipcRenderer.invoke("grade:getBoundarySets", gradeId),
       upsertBoundarySet: (data: {

--- a/src/components/grades/03-data-sources/DataSourceRow.tsx
+++ b/src/components/grades/03-data-sources/DataSourceRow.tsx
@@ -3,8 +3,10 @@
 import { Check, Pencil, Trash2, X } from "lucide-react"
 import { useState } from "react"
 
+import { DragHandle, useSortableRow } from "@/components/common/sortable-table"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import type { GradeDataSourceWithRelations } from "@/types/grade.types"
 
@@ -22,6 +24,12 @@ interface DataSourceRowProps {
   dataSource: GradeDataSourceWithRelations
   /** 同じGrade内の全DataSource（推定ソース選択用） */
   allDataSources: GradeDataSourceWithRelations[]
+  /** 欠測一括設定モード中はチェックボックスを表示する */
+  batchMode: boolean
+  /** 一括設定の選択状態 */
+  selected: boolean
+  /** チェックボックスの選択トグル */
+  onToggleSelect: (id: string) => void
   onUpdate: (
     id: string,
     data: {
@@ -41,9 +49,13 @@ interface DataSourceRowProps {
 export function DataSourceRow({
   dataSource,
   allDataSources,
+  batchMode,
+  selected,
+  onToggleSelect,
   onUpdate,
   onDelete,
 }: DataSourceRowProps) {
+  const { setNodeRef, style, dragHandleProps } = useSortableRow(dataSource.id)
   const [editing, setEditing] = useState(false)
   const [name, setName] = useState(dataSource.name)
   const [weight, setWeight] = useState(String(dataSource.weight))
@@ -66,8 +78,18 @@ export function DataSourceRow({
 
   if (editing) {
     return (
-      <div className="space-y-2 rounded border p-2">
+      <div
+        ref={setNodeRef}
+        style={style}
+        className="space-y-2 rounded border p-2"
+      >
         <div className="flex items-center gap-2">
+          {batchMode && (
+            <Checkbox
+              checked={selected}
+              onCheckedChange={() => onToggleSelect(dataSource.id)}
+            />
+          )}
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -124,8 +146,19 @@ export function DataSourceRow({
   })()
 
   return (
-    <div className="flex items-center justify-between rounded border p-2">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="bg-background flex items-center justify-between rounded border p-2"
+    >
       <div className="flex items-center gap-3">
+        <DragHandle dragHandleProps={dragHandleProps} />
+        {batchMode && (
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(dataSource.id)}
+          />
+        )}
         <Badge variant={isCoursework ? "secondary" : "default"}>
           {typeLabel}
         </Badge>

--- a/src/components/grades/03-data-sources/DataSourcesContainer.tsx
+++ b/src/components/grades/03-data-sources/DataSourcesContainer.tsx
@@ -1,13 +1,19 @@
 "use client"
 
+import type { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
 import { Pencil, Plus, Settings, Trash2, Users } from "lucide-react"
 import Link from "next/link"
 import { useCallback, useState } from "react"
+import { toast } from "sonner"
 
+import { SortableTableProvider } from "@/components/common/sortable-table"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
   Select,
   SelectContent,
@@ -18,6 +24,8 @@ import {
 import { useDataSources } from "@/hooks/grades/useDataSources"
 import type {
   AbsentMethod,
+  EstimationMode,
+  GradeDataSourceWithRelations,
   GradeItemWithDataSources,
 } from "@/types/grade.types"
 
@@ -38,8 +46,9 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     deleteGradeItem,
     createDataSource,
     updateDataSource,
-    batchUpdateAbsentPolicy,
+    batchUpdateDataSources,
     deleteDataSource,
+    reorderDataSources,
     reload,
   } = useDataSources(gradeId)
 
@@ -77,6 +86,28 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     setExclusionModalOpen(true)
   }, [loadStudentsAndClassrooms])
 
+  const handleDataSourceDragEnd = useCallback(
+    (dataSources: GradeDataSourceWithRelations[]) => (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = dataSources.findIndex(
+        (dataSource) => dataSource.id === active.id
+      )
+      const newIndex = dataSources.findIndex(
+        (dataSource) => dataSource.id === over.id
+      )
+      if (oldIndex === -1 || newIndex === -1) return
+      const reordered = arrayMove(dataSources, oldIndex, newIndex)
+      void reorderDataSources(
+        reordered.map((dataSource, index) => ({
+          id: dataSource.id,
+          order: index,
+        }))
+      )
+    },
+    [reorderDataSources]
+  )
+
   // 一括欠測設定
   const [batchMode, setBatchMode] = useState(false)
   const [selectedDataSourceIds, setSelectedDataSourceIds] = useState<
@@ -85,6 +116,11 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
   const [batchMethod, setBatchMethod] = useState<AbsentMethod>("zero")
   const [batchRatio, setBatchRatio] = useState("1")
   const [batchOffset, setBatchOffset] = useState("0")
+  const [batchEstimationMode, setBatchEstimationMode] =
+    useState<EstimationMode>("all")
+  const [batchEstimationSourceIds, setBatchEstimationSourceIds] = useState<
+    string[]
+  >([])
 
   if (loading || !exam) {
     return (
@@ -121,13 +157,43 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     })
   }
 
+  const usesEstimationSources =
+    batchMethod === "average" || batchMethod === "regression"
+
+  const toggleBatchEstimationSourceId = (id: string) => {
+    setBatchEstimationSourceIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((sourceId) => sourceId !== id)
+        : [...prev, id]
+    )
+  }
+
   const handleBatchApply = async () => {
     if (selectedDataSourceIds.size === 0) return
-    await batchUpdateAbsentPolicy([...selectedDataSourceIds], {
-      absentMethod: batchMethod,
-      absentRatio: Number(batchRatio),
-      absentOffset: Number(batchOffset),
-    })
+    // 推定に使うソースは平均比率法・重回帰法のときのみ適用。ソースは自由に
+    // 選べるが、各ターゲットは自分自身を推定ソースにできない（個別行popoverの
+    // 自ソース除外と同じ規則）。そこでターゲットごとに自idだけを除いた列を
+    // 組み立て、普遍的な個別更新をターゲット分だけ回す。
+    const updates = [...selectedDataSourceIds].map((targetId) => ({
+      id: targetId,
+      data: {
+        absentMethod: batchMethod,
+        absentRatio: Number(batchRatio),
+        absentOffset: Number(batchOffset),
+        ...(usesEstimationSources && {
+          estimationMode: batchEstimationMode,
+          estimationSourceIds: batchEstimationSourceIds.filter(
+            (sourceId) => sourceId !== targetId
+          ),
+        }),
+      },
+    }))
+    const result = await batchUpdateDataSources(updates)
+    if (!result.success) {
+      // 一部だけ適用済みの可能性がある。パネルと選択は保持し再適用できるようにする。
+      toast.error("一部のデータソースに一括設定を適用できませんでした")
+      return
+    }
     setBatchMode(false)
     setSelectedDataSourceIds(new Set())
   }
@@ -239,6 +305,64 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
               適用
             </Button>
           </div>
+
+          {/* 推定に使用するソース（平均比率法・重回帰法のみ） */}
+          {usesEstimationSources && (
+            <div className="mt-3 space-y-2 border-t border-amber-200 pt-3">
+              <Label className="text-xs">推定に使用するソース</Label>
+              <RadioGroup
+                value={batchEstimationMode}
+                onValueChange={(value) =>
+                  setBatchEstimationMode(value as EstimationMode)
+                }
+                className="flex gap-4"
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="all" id="batch-mode-all" />
+                  <Label
+                    htmlFor="batch-mode-all"
+                    className="text-xs font-normal"
+                  >
+                    自ソース以外の全て
+                  </Label>
+                </div>
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="selected" id="batch-mode-selected" />
+                  <Label
+                    htmlFor="batch-mode-selected"
+                    className="text-xs font-normal"
+                  >
+                    選択
+                  </Label>
+                </div>
+              </RadioGroup>
+
+              {batchEstimationMode === "selected" && (
+                <div className="max-h-36 space-y-1 overflow-y-auto rounded border bg-white p-2">
+                  {/* ソースは自由に選択可。各ターゲットの自ソース除外は適用時に行う */}
+                  {allDataSources.map((candidateSource) => (
+                    <div
+                      key={candidateSource.id}
+                      className="flex items-center gap-2"
+                    >
+                      <Checkbox
+                        checked={batchEstimationSourceIds.includes(
+                          candidateSource.id
+                        )}
+                        onCheckedChange={() =>
+                          toggleBatchEstimationSourceId(candidateSource.id)
+                        }
+                        className="h-3.5 w-3.5"
+                      />
+                      <span className="truncate text-xs">
+                        {candidateSource.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -298,27 +422,25 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
 
           {/* DataSource リスト */}
           {gradeItem.dataSources.length > 0 && (
-            <div className="mb-3 space-y-2">
-              {gradeItem.dataSources.map((dataSource) => (
-                <div key={dataSource.id} className="flex items-start gap-2">
-                  {batchMode && (
-                    <Checkbox
-                      checked={selectedDataSourceIds.has(dataSource.id)}
-                      onCheckedChange={() => toggleDsSelection(dataSource.id)}
-                      className="mt-3"
-                    />
-                  )}
-                  <div className="flex-1">
-                    <DataSourceRow
-                      dataSource={dataSource}
-                      allDataSources={allDataSources}
-                      onUpdate={updateDataSource}
-                      onDelete={deleteDataSource}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
+            <SortableTableProvider
+              items={gradeItem.dataSources.map((dataSource) => dataSource.id)}
+              onDragEnd={handleDataSourceDragEnd(gradeItem.dataSources)}
+            >
+              <div className="mb-3 space-y-2">
+                {gradeItem.dataSources.map((dataSource) => (
+                  <DataSourceRow
+                    key={dataSource.id}
+                    dataSource={dataSource}
+                    allDataSources={allDataSources}
+                    batchMode={batchMode}
+                    selected={selectedDataSourceIds.has(dataSource.id)}
+                    onToggleSelect={toggleDsSelection}
+                    onUpdate={updateDataSource}
+                    onDelete={deleteDataSource}
+                  />
+                ))}
+              </div>
+            </SortableTableProvider>
           )}
 
           {/* インラインデータソース追加 */}

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from "react"
 
-import type { GradeWithRelations } from "@/types/grade.types"
+import type {
+  AbsentMethod,
+  EstimationMode,
+  GradeWithRelations,
+} from "@/types/grade.types"
 
 /** 成績評定項目とデータソースのCRUD操作を管理するフック */
 export function useDataSources(gradeId: string) {
@@ -106,19 +110,44 @@ export function useDataSources(gradeId: string) {
     [loadData]
   )
 
-  const batchUpdateAbsentPolicy = useCallback(
+  // 一括更新は専用IPCを持たず、普遍的な個別更新IPCをターゲット分だけ回す。
+  // 自ソース除外などターゲットごとの差分は呼び出し側で組み立て済みの前提。
+  //
+  // 【設計判断】$transaction による原子性(all-or-nothing)は意図的に持たない。
+  // 「一括適用」は同じ操作を各対象へ繰り返すだけの作業であり、部分適用が残っても
+  // 意味が通り、再度「適用」を押せば回復できる（呼び出し側は失敗時に選択を保持し
+  // 再適用可能にしている）。原子性のためだけに専用の一括IPC/トランザクションを
+  // backendへ復活させないこと（普遍的な個別更新IPCのみを保つのが本設計の狙い）。
+  const batchUpdateDataSources = useCallback(
     async (
-      dataSourceIds: string[],
-      policy: {
-        absentMethod: string
-        absentRatio: number
-        absentOffset: number
-      }
+      updates: {
+        id: string
+        data: {
+          absentMethod?: AbsentMethod
+          absentRatio?: number
+          absentOffset?: number
+          treatExpectedAsMissing?: boolean
+          estimationMode?: EstimationMode
+          estimationSourceIds?: string[]
+        }
+      }[]
     ) => {
-      const result = await window.electronAPI.grade.batchUpdateAbsentPolicy(
-        dataSourceIds,
-        policy
+      const results = await Promise.all(
+        updates.map((update) =>
+          window.electronAPI.grade.updateDataSource(update.id, update.data)
+        )
       )
+      // 個別更新は独立にコミットされ、一部失敗でもDBは変わり得る。
+      // UIを実DBへ追従させるため成否に関わらず必ず再読込する。
+      await loadData()
+      return { success: results.every((result) => result.success) }
+    },
+    [loadData]
+  )
+
+  const deleteDataSource = useCallback(
+    async (id: string) => {
+      const result = await window.electronAPI.grade.deleteDataSource(id)
       if (result.success) {
         await loadData()
       }
@@ -127,9 +156,9 @@ export function useDataSources(gradeId: string) {
     [loadData]
   )
 
-  const deleteDataSource = useCallback(
-    async (id: string) => {
-      const result = await window.electronAPI.grade.deleteDataSource(id)
+  const reorderDataSources = useCallback(
+    async (items: { id: string; order: number }[]) => {
+      const result = await window.electronAPI.grade.reorderDataSources(items)
       if (result.success) {
         await loadData()
       }
@@ -146,8 +175,9 @@ export function useDataSources(gradeId: string) {
     deleteGradeItem,
     createDataSource,
     updateDataSource,
-    batchUpdateAbsentPolicy,
+    batchUpdateDataSources,
     deleteDataSource,
+    reorderDataSources,
     reload: loadData,
   }
 }

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -210,17 +210,6 @@ export interface GradeAPI {
     reorderDataSources: (
       items: { id: string; order: number }[]
     ) => Promise<{ success: boolean; error?: string }>
-    batchUpdateAbsentPolicy: (
-      dataSourceIds: string[],
-      policy: {
-        absentMethod: string
-        absentRatio: number
-        absentOffset: number
-        treatExpectedAsMissing?: boolean
-        estimationMode?: string
-        estimationSourceIds?: string[]
-      }
-    ) => Promise<{ success: boolean; error?: string }>
     getBoundarySets: (gradeId: string) => Promise<{
       success: boolean
       boundarySets?: import("../grade.types").GradeBoundarySetWithItemAndBoundaries[]


### PR DESCRIPTION
Closes #993

## 概要
成績データソースまわりの機能追加と設計是正。

### 1. DnD 並べ替え
共通 `sortable-table` を利用し 05-boundaries と同 UI で実装。未接続だった `reorderDataSources` を配線。並べ替えは GradeItem 単位（`order` は gradeItem 内スコープ）。

### 2. 欠測一括設定に推定ソース選択
平均比率法・重回帰法のとき「推定に使用するソース」（全て / 選択）を表示。個別行 popover と同挙動。

### 3. 一括更新の設計是正
- 専用 `batchUpdateAbsentPolicy` IPC を撤去（prisma / ipc / preload / 型）
- renderer が普遍的な個別更新 IPC `updateDataSource` をターゲット分だけ逐次実行
- 「自ソース除外」は renderer で per-target 構築（各ターゲットが自 id のみ除外）
- **原子性は意図的に持たない**設計判断をコメントで明示

## code-review（high）指摘対応
- 部分失敗時も必ず再読込
- 失敗を toast 通知＋パネル/選択保持で再適用可能に
- 編集中も選択チェックボックス表示（回帰修正）
- 一括更新シグネチャを精密型（AbsentMethod / EstimationMode）へ

## テスト
- 自分の担当7ファイルの `tsc` / `eslint` / `prettier` はクリーン
- 注: `gradeCalculator.ts` 系の型エラーは別セッションの並行リファクタ由来で本PR対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)