### PR TITLE
refactor(08-export): ExportMainView を出力ロジックのフック/純関数へ分割

### DIFF
--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -1,12 +1,7 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { toast } from "sonner"
+import { useMemo, useState } from "react"
 
-import type {
-  RenderedPageData,
-  RenderProgress,
-} from "@/app/exams/[examId]/08-export/types"
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 import {
   ExportOptionsCard,
@@ -14,19 +9,16 @@ import {
 } from "@/components/exams/08-export/components/ExportOptionsCard"
 import ExportProgressModal from "@/components/exams/08-export/components/ExportProgressModal"
 import ExportWarningModal from "@/components/exams/08-export/components/ExportWarningModal"
-import { generatePrintHtml } from "@/components/exams/08-export/components/individual-report/generatePrintHtml"
-import {
-  PdfCanvasRenderer,
-  type PdfExportPageData,
-} from "@/components/exams/08-export/components/PdfCanvasRenderer"
+import { PdfCanvasRenderer } from "@/components/exams/08-export/components/PdfCanvasRenderer"
 import { ReturnDiffPanel } from "@/components/exams/08-export/components/ReturnDiffPanel"
 import { StudentSelectionCard } from "@/components/exams/08-export/components/StudentSelectionCard"
+import { useDataFileExports } from "@/components/exams/08-export/hooks/useDataFileExports"
 import { useExcelPreview } from "@/components/exams/08-export/hooks/useExcelPreview"
 import { useExportPage } from "@/components/exams/08-export/hooks/useExportPage"
 import { useIndividualReportPreview } from "@/components/exams/08-export/hooks/useIndividualReportPreview"
+import { useScoredAnswerPdfExport } from "@/components/exams/08-export/hooks/useScoredAnswerPdfExport"
 import { useScoredAnswerPreview } from "@/components/exams/08-export/hooks/useScoredAnswerPreview"
-import { loadStudentExportPlacements } from "@/components/exams/08-export/utils/loadStudentExportPlacements"
-import type { ScoringMarkConfigForPdf } from "@/components/exams/08-export/utils/pdfCanvasRenderer"
+import { buildScoringMarkConfigForPdf } from "@/components/exams/08-export/utils/buildScoringMarkConfigForPdf"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import PageHeader from "@/components/layout/PageHeader"
 
@@ -43,25 +35,6 @@ export default function ExportMainView() {
   const [pendingExportType, setPendingExportType] = useState<
     "scored-answers" | "grading-data" | "individual-reports" | null
   >(null)
-
-  // Canvas描画用の状態
-  const [pdfExportPages, setPdfExportPages] = useState<PdfExportPageData[]>([])
-  const [startCanvasRendering, setStartCanvasRendering] = useState(false)
-
-  // 保存先選択のPromiseを保持（並行処理用）
-  const savePathPromiseRef = useRef<Promise<{
-    success: boolean
-    filePath?: string
-    canceled?: boolean
-  }> | null>(null)
-
-  // ストリーミングセッション用の状態
-  const streamingSessionIdRef = useRef<string | null>(null)
-  const [embeddedPagesCount, setEmbeddedPagesCount] = useState(0)
-  const [totalPagesCount, setTotalPagesCount] = useState(0)
-  const [canvasRenderingComplete, setCanvasRenderingComplete] = useState(false)
-  const savePathResultRef = useRef<{ filePath: string } | null>(null)
-  const isExportCancelledRef = useRef(false)
 
   const {
     exam,
@@ -138,86 +111,13 @@ export default function ExportMainView() {
       }))
   }, [students, selectedStudents])
 
-  /**
-   * scoringMarkConfigをScoringMarkConfigForPdf形式に変換
-   */
-  const getScoringMarkConfigForPdf =
-    useCallback((): ScoringMarkConfigForPdf => {
-      // 部分点設定を取得（partialScoreが存在する場合はそれを使用、なければ旧式設定からフォールバック）
-      const partialScore = scoringMarkConfig.partialScore
-      const partialScoreConfig =
-        partialScore && partialScore.size !== undefined
-          ? partialScore
-          : {
-              position: scoringMarkConfig.scorePosition || "middle-center",
-              size: scoringMarkConfig.scoreSize || 14,
-              offsetX: scoringMarkConfig.scoreOffsetX || 0,
-              offsetY: scoringMarkConfig.scoreOffsetY || 0,
-              color: "#ef4444",
-              opacity: 100,
-            }
-
-      // 小計点設定を取得（subtotalScore → summaryScore → デフォルトの順でフォールバック）
-      const subtotalScoreConfig = scoringMarkConfig.subtotalScore ??
-        scoringMarkConfig.summaryScore ?? {
-          position: "middle-center",
-          size: 18,
-          offsetX: 0,
-          offsetY: 0,
-          color: "#2563eb",
-          opacity: 100,
-        }
-
-      // 合計点設定を取得（totalScore → summaryScore → デフォルトの順でフォールバック）
-      const totalScoreConfig = scoringMarkConfig.totalScore ??
-        scoringMarkConfig.summaryScore ?? {
-          position: "middle-center",
-          size: 18,
-          offsetX: 0,
-          offsetY: 0,
-          color: "#2563eb",
-          opacity: 100,
-        }
-
-      return {
-        markPosition: scoringMarkConfig.markPosition,
-        markSize: scoringMarkConfig.markSize,
-        markColor: scoringMarkConfig.markColor ?? "#ef4444",
-        markOpacity: scoringMarkConfig.markOpacity ?? 100,
-        showPartialScore: true,
-        partialScorePosition: partialScoreConfig.position || "middle-center",
-        partialScoreSize: partialScoreConfig.size || 14,
-        partialScoreOffsetX: partialScoreConfig.offsetX || 0,
-        partialScoreOffsetY: partialScoreConfig.offsetY || 0,
-        partialScoreColor: partialScoreConfig.color ?? "#ef4444",
-        partialScoreOpacity: partialScoreConfig.opacity ?? 100,
-        // 小計点用設定
-        subtotalScorePosition: subtotalScoreConfig.position || "middle-center",
-        subtotalScoreSize: subtotalScoreConfig.size || 18,
-        subtotalScoreOffsetX: subtotalScoreConfig.offsetX || 0,
-        subtotalScoreOffsetY: subtotalScoreConfig.offsetY || 0,
-        subtotalScoreColor: subtotalScoreConfig.color ?? "#2563eb",
-        subtotalScoreOpacity: subtotalScoreConfig.opacity ?? 100,
-        // 合計点用設定
-        totalScorePosition: totalScoreConfig.position || "middle-center",
-        totalScoreSize: totalScoreConfig.size || 18,
-        totalScoreOffsetX: totalScoreConfig.offsetX || 0,
-        totalScoreOffsetY: totalScoreConfig.offsetY || 0,
-        totalScoreColor: totalScoreConfig.color ?? "#2563eb",
-        totalScoreOpacity: totalScoreConfig.opacity ?? 100,
-        // ステータスごとの表示設定
-        showMarkForStatus: scoringMarkConfig.showMarkForStatus,
-        showScoreForStatus: scoringMarkConfig.showScoreForStatus,
-      }
-    }, [scoringMarkConfig])
-
   // プレビュー用にmemoized configを用意（毎レンダーで新オブジェクト生成→無限ループ防止）
   const scoringMarkConfigForPdf = useMemo(
-    () => getScoringMarkConfigForPdf(),
-    [getScoringMarkConfigForPdf]
+    () => buildScoringMarkConfigForPdf(scoringMarkConfig),
+    [scoringMarkConfig]
   )
 
-  // 採点済み答案プレビュー（getScoringMarkConfigForPdfの後に配置）
+  // 採点済み答案プレビュー（scoringMarkConfigForPdfの後に配置）
   const {
     previewImageUrls: scoredAnswerPreviewUrls,
     isLoading: isScoredAnswerPreviewLoading,
@@ -232,10 +132,41 @@ export default function ExportMainView() {
       !!exam?.id && selectedStudents.size > 0 && exportTab === "scored-answers",
   })
 
-  /**
-   * Canvas描画ベースのPDF出力（ストリーミング処理フロー）
-   * 1. データ取得 → 2. ストリーミングセッション作成 & 保存先選択 → 3. Canvas描画（完了次第PDF埋め込み） → 4. PDF保存
-   */
+  // 採点済み答案の Canvas 描画ベース PDF 出力（ストリーミング処理）
+  const {
+    executeExportScoredAnswers,
+    pdfExportPages,
+    startCanvasRendering,
+    handleCanvasProgress,
+    handlePageComplete,
+    handleCanvasComplete,
+    handleCanvasError,
+    embeddedPagesCount,
+    totalPagesCount,
+    canvasRenderingComplete,
+  } = useScoredAnswerPdfExport({
+    exam,
+    selectedStudents,
+    exportOptions,
+    setIsExporting,
+    setShowProgressModal,
+    setExportProgress,
+    setExportStatus,
+    setCurrentStep,
+  })
+
+  // Canvas 描画を伴わないファイル出力（採点データExcel・R データ・個人成績表印刷）
+  const {
+    executeExportGradingData,
+    handleExportRData,
+    executeExportIndividualReports,
+  } = useDataFileExports({
+    exam,
+    selectedStudents,
+    individualReportOptions,
+    setIsExporting,
+  })
+
   /**
    * 採点データバリデーションを実行し、警告があればモーダルを表示する
    * @returns true: バリデーション通過（警告なし）、false: 警告あり（モーダル表示）
@@ -269,7 +200,15 @@ export default function ExportMainView() {
     return true
   }
 
-  const handleExportScoredAnswers = async () => {
+  /**
+   * 出力前の共通フロー（生徒選択チェック → 出力中ガード → バリデーション →
+   * 出力実行）をまとめる。バリデーションで警告が出た場合は validateBeforeExport が
+   * 警告モーダルを表示し、続行時は handleContinueExport から execute が呼ばれる。
+   */
+  const runValidatedExport = async (
+    exportType: "scored-answers" | "grading-data" | "individual-reports",
+    execute: () => Promise<void>
+  ): Promise<void> => {
     if (selectedStudents.size === 0) {
       alert("出力する生徒を選択してください")
       return
@@ -280,11 +219,10 @@ export default function ExportMainView() {
     }
 
     try {
-      // バリデーション実行
-      const isValid = await validateBeforeExport("scored-answers")
+      const isValid = await validateBeforeExport(exportType)
       if (!isValid) return
 
-      await executeExportScoredAnswers()
+      await execute()
     } catch (error) {
       console.error("Export error:", error)
       alert(
@@ -293,415 +231,14 @@ export default function ExportMainView() {
     }
   }
 
-  const executeExportScoredAnswers = async () => {
-    if (!exam) return
-    try {
-      // 処理開始
-      setIsExporting(true)
-      setShowProgressModal(true)
-      setExportProgress(0)
-      setExportStatus("processing")
-      setCurrentStep("データを取得中...")
-      setEmbeddedPagesCount(0)
-      setTotalPagesCount(0)
-      setCanvasRenderingComplete(false)
-      savePathResultRef.current = null
-      isExportCancelledRef.current = false
+  const handleExportScoredAnswers = () =>
+    runValidatedExport("scored-answers", executeExportScoredAnswers)
 
-      const selectedStudentIds = Array.from(selectedStudents)
+  const handleExportGradingData = () =>
+    runValidatedExport("grading-data", executeExportGradingData)
 
-      // 1. データ取得
-      const dataResult = await window.electronAPI.export.getPdfExportData({
-        examId: exam.id,
-        selectedStudentIds,
-      })
-
-      if (!dataResult.success || !dataResult.pages) {
-        throw new Error(dataResult.error || "データ取得に失敗しました")
-      }
-
-      if (dataResult.pages.length === 0) {
-        throw new Error("出力対象のページがありません")
-      }
-
-      setTotalPagesCount(dataResult.pages.length)
-      setExportProgress(5)
-
-      // 2. ストリーミングセッション作成（空ページを事前に作成）
-      setCurrentStep("PDFセッションを作成中...")
-      const sessionResult =
-        await window.electronAPI.export.createPdfStreamingSession({
-          totalPages: dataResult.pages.length,
-          pdfOrientation: exportOptions.pdfOrientation,
-        })
-
-      if (!sessionResult.success || !sessionResult.sessionId) {
-        throw new Error(
-          sessionResult.error || "PDFセッションの作成に失敗しました"
-        )
-      }
-
-      streamingSessionIdRef.current = sessionResult.sessionId
-
-      // 3. 保存先選択を並行で開始
-      setCurrentStep("保存先を選択してください...")
-      const savePathPromise = window.electronAPI.export.selectPdfSavePath({
-        examName: exam?.examName,
-      })
-      savePathPromiseRef.current = savePathPromise
-
-      // キャンセル監視：Canvas描画完了前にキャンセルされたら即座に中断
-      savePathPromise.then((result) => {
-        if (!result.success || result.canceled || !result.filePath) {
-          // キャンセルフラグを立てる
-          isExportCancelledRef.current = true
-          // キャンセルされた場合、Canvas描画中なら中断
-          setStartCanvasRendering(false)
-          setPdfExportPages([])
-          setShowProgressModal(false)
-          setIsExporting(false)
-          setEmbeddedPagesCount(0)
-          setTotalPagesCount(0)
-          setCanvasRenderingComplete(false)
-          savePathPromiseRef.current = null
-          savePathResultRef.current = null
-          // セッションのクリーンアップ
-          if (streamingSessionIdRef.current) {
-            window.electronAPI.export.cancelStreamingSession(
-              streamingSessionIdRef.current
-            )
-            streamingSessionIdRef.current = null
-          }
-        }
-      })
-
-      // 4. Canvas描画を開始（onPageCompleteでPDFに逐次埋め込み）
-      setPdfExportPages(dataResult.pages)
-      setStartCanvasRendering(true)
-
-      // handlePageComplete と handleCanvasComplete がストリーミング処理を実行
-    } catch (error) {
-      console.error("Export error:", error)
-      setExportStatus("error")
-      setCurrentStep(
-        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
-      )
-      setIsExporting(false)
-      setStartCanvasRendering(false)
-      setPdfExportPages([])
-      setEmbeddedPagesCount(0)
-      setTotalPagesCount(0)
-      setCanvasRenderingComplete(false)
-      savePathPromiseRef.current = null
-      savePathResultRef.current = null
-      // セッションのクリーンアップ
-      if (streamingSessionIdRef.current) {
-        window.electronAPI.export.cancelStreamingSession(
-          streamingSessionIdRef.current
-        )
-        streamingSessionIdRef.current = null
-      }
-    }
-  }
-
-  /**
-   * Canvas描画進捗コールバック（並列処理対応）
-   */
-  const handleCanvasProgress = useCallback(
-    (progress: RenderProgress) => {
-      if (progress.phase === "preload") {
-        setExportProgress(5)
-        setCurrentStep("採点マーク画像を読み込み中...")
-      } else if (progress.phase === "rendering") {
-        // 10-90%をCanvas描画+PDF埋め込みに割り当て
-        // Canvas描画進捗とPDF埋め込み進捗を合成
-        const canvasWeight = 0.7 // Canvas描画に70%
-        const embedWeight = 0.3 // PDF埋め込みに30%
-        const canvasProgress = progress.completed / progress.total
-        const embedProgress = embeddedPagesCount / (totalPagesCount || 1)
-        const combinedProgress =
-          10 +
-          Math.round(
-            (canvasProgress * canvasWeight + embedProgress * embedWeight) * 80
-          )
-        setExportProgress(combinedProgress)
-        const parallelStr =
-          progress.inProgress > 0 ? ` (${progress.inProgress}並列)` : ""
-        setCurrentStep(
-          `Canvas: ${progress.completed}/${progress.total}ページ${parallelStr} | PDF: ${embeddedPagesCount}/${totalPagesCount}ページ埋め込み済み`
-        )
-      } else if (progress.phase === "complete") {
-        setExportProgress(90)
-        setCurrentStep("Canvas描画完了、PDF保存中...")
-      }
-    },
-    [setExportProgress, setCurrentStep, embeddedPagesCount, totalPagesCount]
-  )
-
-  /**
-   * 1ページ完了時のコールバック（ストリーミング埋め込み）
-   */
-  const handlePageComplete = useCallback(async (pageData: RenderedPageData) => {
-    // キャンセル済みなら何もしない
-    if (isExportCancelledRef.current) {
-      return
-    }
-
-    if (!streamingSessionIdRef.current) {
-      console.error("Streaming session not found")
-      return
-    }
-
-    try {
-      const result = await window.electronAPI.export.addPageToStreamingSession({
-        sessionId: streamingSessionIdRef.current,
-        pageIndex: pageData.pageIndex,
-        imageData: pageData.imageData,
-      })
-
-      if (result.success) {
-        setEmbeddedPagesCount((prev) => prev + 1)
-      } else {
-        console.error(
-          `Failed to embed page ${pageData.pageIndex}:`,
-          result.error
-        )
-      }
-    } catch (error) {
-      console.error(`Error embedding page ${pageData.pageIndex}:`, error)
-    }
-  }, [])
-
-  /**
-   * Canvas描画完了コールバック
-   * 保存先選択を待ち、埋め込み完了フラグを立てる
-   */
-  const handleCanvasComplete = useCallback(
-    async (
-      _renderedPages: Array<{
-        studentId: string
-        pageNumber: number
-        imageData: ArrayBuffer
-      }>
-    ) => {
-      // キャンセル済みなら何もしない
-      if (isExportCancelledRef.current) {
-        return
-      }
-
-      setStartCanvasRendering(false)
-      setPdfExportPages([])
-
-      // ストリーミングセッションがない場合はエラー
-      if (!streamingSessionIdRef.current) {
-        setExportStatus("error")
-        setCurrentStep("PDFセッションが見つかりません")
-        setIsExporting(false)
-        savePathPromiseRef.current = null
-        return
-      }
-
-      // 保存先選択の完了を待つ
-      if (!savePathPromiseRef.current) {
-        setExportStatus("error")
-        setCurrentStep("保存先選択が開始されていません")
-        setIsExporting(false)
-        // セッションのクリーンアップ
-        window.electronAPI.export.cancelStreamingSession(
-          streamingSessionIdRef.current
-        )
-        streamingSessionIdRef.current = null
-        return
-      }
-
-      setCurrentStep("保存先の選択を待っています...")
-      const savePathResult = await savePathPromiseRef.current
-      savePathPromiseRef.current = null
-
-      if (
-        !savePathResult.success ||
-        savePathResult.canceled ||
-        !savePathResult.filePath
-      ) {
-        // キャンセルされた場合 - 全状態をリセット
-        setShowProgressModal(false)
-        setIsExporting(false)
-        setEmbeddedPagesCount(0)
-        setTotalPagesCount(0)
-        setCanvasRenderingComplete(false)
-        savePathResultRef.current = null
-        // セッションのクリーンアップ
-        window.electronAPI.export.cancelStreamingSession(
-          streamingSessionIdRef.current
-        )
-        streamingSessionIdRef.current = null
-        return
-      }
-
-      // 保存先を保持し、Canvas描画完了フラグを立てる
-      // PDF埋め込み完了を待ってからuseEffectでPDF保存を実行
-      savePathResultRef.current = { filePath: savePathResult.filePath }
-      setCanvasRenderingComplete(true)
-    },
-    [setExportStatus, setCurrentStep, setIsExporting, setShowProgressModal]
-  )
-
-  /**
-   * Canvas描画エラーコールバック
-   */
-  const handleCanvasError = useCallback(
-    (error: Error) => {
-      console.error("Canvas rendering error:", error)
-      setStartCanvasRendering(false)
-      setPdfExportPages([])
-      setExportStatus("error")
-      setCurrentStep(`Canvas描画エラー: ${error.message}`)
-      setIsExporting(false)
-      setEmbeddedPagesCount(0)
-      setTotalPagesCount(0)
-      setCanvasRenderingComplete(false)
-      savePathPromiseRef.current = null
-      savePathResultRef.current = null
-      // セッションのクリーンアップ
-      if (streamingSessionIdRef.current) {
-        window.electronAPI.export.cancelStreamingSession(
-          streamingSessionIdRef.current
-        )
-        streamingSessionIdRef.current = null
-      }
-    },
-    [setExportStatus, setCurrentStep, setIsExporting]
-  )
-
-  /**
-   * Canvas描画完了 + PDF埋め込み完了時にPDF保存を実行
-   */
-  useEffect(() => {
-    const finalizePdf = async () => {
-      if (!canvasRenderingComplete) return
-      if (embeddedPagesCount < totalPagesCount) return
-      if (!streamingSessionIdRef.current) return
-      if (!savePathResultRef.current) return
-
-      try {
-        setExportProgress(95)
-        setCurrentStep("PDFを保存中...")
-
-        const result = await window.electronAPI.export.finalizeStreamingSession(
-          {
-            sessionId: streamingSessionIdRef.current,
-            outputPath: savePathResultRef.current.filePath,
-          }
-        )
-
-        streamingSessionIdRef.current = null
-        savePathResultRef.current = null
-        setCanvasRenderingComplete(false)
-
-        if (result.success) {
-          setExportProgress(100)
-          setExportStatus("completed")
-          setCurrentStep("完了しました")
-        } else {
-          setExportStatus("error")
-          setCurrentStep(`エラー: ${result.error}`)
-        }
-      } catch (error) {
-        console.error("PDF finalization error:", error)
-        setExportStatus("error")
-        setCurrentStep("PDF保存中にエラーが発生しました")
-        if (streamingSessionIdRef.current) {
-          window.electronAPI.export.cancelStreamingSession(
-            streamingSessionIdRef.current
-          )
-          streamingSessionIdRef.current = null
-        }
-      } finally {
-        setIsExporting(false)
-      }
-    }
-
-    finalizePdf()
-  }, [
-    canvasRenderingComplete,
-    embeddedPagesCount,
-    totalPagesCount,
-    setExportProgress,
-    setCurrentStep,
-    setExportStatus,
-    setIsExporting,
-  ])
-
-  const handleExportGradingData = async () => {
-    if (selectedStudents.size === 0) {
-      alert("出力する生徒を選択してください")
-      return
-    }
-
-    try {
-      // バリデーション実行
-      const isValid = await validateBeforeExport("grading-data")
-      if (!isValid) return
-
-      await executeExportGradingData()
-    } catch (error) {
-      console.error("Export error:", error)
-      alert("出力中にエラーが発生しました")
-    }
-  }
-
-  const executeExportGradingData = async () => {
-    if (!exam) return
-    setIsExporting(true)
-
-    try {
-      const selectedStudentIds = Array.from(selectedStudents)
-      const studentPlacements = await loadStudentExportPlacements(exam.id)
-
-      const result = await window.electronAPI.exportGradingDataExcel({
-        examId: exam.id,
-        selectedStudentIds,
-        forceExport: true,
-        studentPlacements,
-      })
-
-      if (result.success) {
-        alert(
-          `採点データExcelの出力が完了しました。\n保存先: ${result.outputPath}`
-        )
-      } else {
-        alert(`出力に失敗しました: ${result.error}`)
-      }
-    } catch (error) {
-      console.error("Export error:", error)
-      alert("出力中にエラーが発生しました")
-    } finally {
-      setIsExporting(false)
-    }
-  }
-
-  const handleExportRData = async (format: "csv" | "json") => {
-    if (!exam) return
-    setIsExporting(true)
-    try {
-      const selectedStudentIds = Array.from(selectedStudents)
-      const result = await window.electronAPI.exportRData({
-        examId: exam.id,
-        selectedStudentIds,
-        format,
-      })
-      if (result.success) {
-        toast.success(`分析用データを出力しました: ${result.outputPath}`)
-      } else if (result.error !== "出力がキャンセルされました") {
-        toast.error(`出力に失敗しました: ${result.error ?? ""}`)
-      }
-    } catch (error) {
-      console.error("R data export error:", error)
-      toast.error("出力中にエラーが発生しました")
-    } finally {
-      setIsExporting(false)
-    }
-  }
+  const handleExportIndividualReports = () =>
+    runValidatedExport("individual-reports", executeExportIndividualReports)
 
   const handleContinueExport = async () => {
     setShowWarningModal(false)
@@ -714,76 +251,6 @@ export default function ExportMainView() {
       await executeExportScoredAnswers()
     } else if (exportType === "individual-reports") {
       await executeExportIndividualReports()
-    }
-  }
-
-  const handleExportIndividualReports = async () => {
-    if (selectedStudents.size === 0) {
-      alert("出力する生徒を選択してください")
-      return
-    }
-
-    if (isExporting) {
-      return
-    }
-
-    try {
-      // バリデーション実行
-      const isValid = await validateBeforeExport("individual-reports")
-      if (!isValid) return
-
-      await executeExportIndividualReports()
-    } catch (error) {
-      console.error("Individual report export error:", error)
-      alert(
-        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
-      )
-    }
-  }
-
-  const executeExportIndividualReports = async () => {
-    if (!exam) return
-    setIsExporting(true)
-
-    try {
-      const selectedStudentIds = Array.from(selectedStudents)
-      const studentPlacements = await loadStudentExportPlacements(exam.id)
-
-      // 1. データ取得（統計・アドバイス含む）
-      const dataResult =
-        await window.electronAPI.export.getIndividualReportData({
-          examId: exam.id,
-          selectedStudentIds,
-          options: individualReportOptions,
-          studentPlacements,
-        })
-
-      if (!dataResult.success || !dataResult.reports) {
-        throw new Error(dataResult.error || "データ取得に失敗しました")
-      }
-
-      // 2. HTMLを生成（プレビューと同じ構造）
-      const html = generatePrintHtml(
-        dataResult.reports,
-        individualReportOptions
-      )
-
-      // 3. 印刷ダイアログを開く
-      const result = await window.electronAPI.export.openPrintDialog({
-        html,
-        title: `個人成績表 - ${exam?.examName || ""}`,
-      })
-
-      if (!result.success) {
-        throw new Error(result.error || "印刷ダイアログを開けませんでした")
-      }
-    } catch (error) {
-      console.error("Individual report export error:", error)
-      alert(
-        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
-      )
-    } finally {
-      setIsExporting(false)
     }
   }
 
@@ -891,7 +358,7 @@ export default function ExportMainView() {
         {/* Canvas描画コンポーネント（非表示） */}
         <PdfCanvasRenderer
           pages={pdfExportPages}
-          scoringMarkConfig={getScoringMarkConfigForPdf()}
+          scoringMarkConfig={scoringMarkConfigForPdf}
           startRendering={startCanvasRendering}
           poolSize={exportOptions.parallelCount}
           onProgress={handleCanvasProgress}

--- a/src/components/exams/08-export/hooks/useDataFileExports.ts
+++ b/src/components/exams/08-export/hooks/useDataFileExports.ts
@@ -1,0 +1,134 @@
+"use client"
+
+import type { Exam } from "@prisma/client"
+import type { Dispatch, SetStateAction } from "react"
+import { toast } from "sonner"
+
+import { generatePrintHtml } from "@/components/exams/08-export/components/individual-report/generatePrintHtml"
+import { loadStudentExportPlacements } from "@/components/exams/08-export/utils/loadStudentExportPlacements"
+import type { IndividualReportOptions } from "@/electron-src/lib/export/individual-report/types"
+
+interface UseDataFileExportsParams {
+  exam: Exam | null
+  selectedStudents: Set<string>
+  individualReportOptions: IndividualReportOptions
+  setIsExporting: Dispatch<SetStateAction<boolean>>
+}
+
+/**
+ * Canvas 描画を伴わないファイル出力（採点データ Excel・分析用 R データ・個人成績表の印刷）を
+ * 管理するフック。バリデーションや警告モーダルの制御は呼び出し側（ExportMainView）が担い、
+ * 本フックはバリデーション通過後に実行される出力処理（execute 系）と、バリデーション不要の
+ * R データ出力を提供する。
+ */
+export function useDataFileExports({
+  exam,
+  selectedStudents,
+  individualReportOptions,
+  setIsExporting,
+}: UseDataFileExportsParams) {
+  const executeExportGradingData = async () => {
+    if (!exam) return
+    setIsExporting(true)
+
+    try {
+      const selectedStudentIds = Array.from(selectedStudents)
+      const studentPlacements = await loadStudentExportPlacements(exam.id)
+
+      const result = await window.electronAPI.exportGradingDataExcel({
+        examId: exam.id,
+        selectedStudentIds,
+        forceExport: true,
+        studentPlacements,
+      })
+
+      if (result.success) {
+        alert(
+          `採点データExcelの出力が完了しました。\n保存先: ${result.outputPath}`
+        )
+      } else {
+        alert(`出力に失敗しました: ${result.error}`)
+      }
+    } catch (error) {
+      console.error("Export error:", error)
+      alert("出力中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const handleExportRData = async (format: "csv" | "json") => {
+    if (!exam) return
+    setIsExporting(true)
+    try {
+      const selectedStudentIds = Array.from(selectedStudents)
+      const result = await window.electronAPI.exportRData({
+        examId: exam.id,
+        selectedStudentIds,
+        format,
+      })
+      if (result.success) {
+        toast.success(`分析用データを出力しました: ${result.outputPath}`)
+      } else if (result.error !== "出力がキャンセルされました") {
+        toast.error(`出力に失敗しました: ${result.error ?? ""}`)
+      }
+    } catch (error) {
+      console.error("R data export error:", error)
+      toast.error("出力中にエラーが発生しました")
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const executeExportIndividualReports = async () => {
+    if (!exam) return
+    setIsExporting(true)
+
+    try {
+      const selectedStudentIds = Array.from(selectedStudents)
+      const studentPlacements = await loadStudentExportPlacements(exam.id)
+
+      // 1. データ取得（統計・アドバイス含む）
+      const dataResult =
+        await window.electronAPI.export.getIndividualReportData({
+          examId: exam.id,
+          selectedStudentIds,
+          options: individualReportOptions,
+          studentPlacements,
+        })
+
+      if (!dataResult.success || !dataResult.reports) {
+        throw new Error(dataResult.error || "データ取得に失敗しました")
+      }
+
+      // 2. HTMLを生成（プレビューと同じ構造）
+      const html = generatePrintHtml(
+        dataResult.reports,
+        individualReportOptions
+      )
+
+      // 3. 印刷ダイアログを開く
+      const result = await window.electronAPI.export.openPrintDialog({
+        html,
+        title: `個人成績表 - ${exam?.examName || ""}`,
+      })
+
+      if (!result.success) {
+        throw new Error(result.error || "印刷ダイアログを開けませんでした")
+      }
+    } catch (error) {
+      console.error("Individual report export error:", error)
+      alert(
+        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
+      )
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return {
+    executeExportGradingData,
+    handleExportRData,
+    executeExportIndividualReports,
+  }
+}

--- a/src/components/exams/08-export/hooks/useScoredAnswerPdfExport.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPdfExport.ts
@@ -1,0 +1,423 @@
+"use client"
+
+import type { Exam } from "@prisma/client"
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import type {
+  ExportOptions,
+  RenderedPageData,
+  RenderProgress,
+} from "@/app/exams/[examId]/08-export/types"
+import type { PdfExportPageData } from "@/components/exams/08-export/components/PdfCanvasRenderer"
+
+interface UseScoredAnswerPdfExportParams {
+  exam: Exam | null
+  selectedStudents: Set<string>
+  exportOptions: ExportOptions
+  setIsExporting: Dispatch<SetStateAction<boolean>>
+  setShowProgressModal: Dispatch<SetStateAction<boolean>>
+  setExportProgress: Dispatch<SetStateAction<number>>
+  setExportStatus: Dispatch<
+    SetStateAction<"processing" | "completed" | "error">
+  >
+  setCurrentStep: Dispatch<SetStateAction<string>>
+}
+
+/**
+ * 採点済み答案の Canvas 描画ベース PDF 出力（ストリーミング処理フロー）を管理するフック。
+ * 1. データ取得 → 2. ストリーミングセッション作成 & 保存先選択 → 3. Canvas描画（完了次第PDF埋め込み） → 4. PDF保存
+ *
+ * プログレスモーダルの状態（進捗・ステップ・出力中フラグ）は useExportPage が保持する共有状態を
+ * 受け取って更新する。Canvas描画・PDF埋め込みに固有の状態（ページ・セッション・埋め込み数など）は
+ * 本フック内に閉じる。
+ */
+export function useScoredAnswerPdfExport({
+  exam,
+  selectedStudents,
+  exportOptions,
+  setIsExporting,
+  setShowProgressModal,
+  setExportProgress,
+  setExportStatus,
+  setCurrentStep,
+}: UseScoredAnswerPdfExportParams) {
+  // Canvas描画用の状態
+  const [pdfExportPages, setPdfExportPages] = useState<PdfExportPageData[]>([])
+  const [startCanvasRendering, setStartCanvasRendering] = useState(false)
+
+  // 保存先選択のPromiseを保持（並行処理用）
+  const savePathPromiseRef = useRef<Promise<{
+    success: boolean
+    filePath?: string
+    canceled?: boolean
+  }> | null>(null)
+
+  // ストリーミングセッション用の状態
+  const streamingSessionIdRef = useRef<string | null>(null)
+  const [embeddedPagesCount, setEmbeddedPagesCount] = useState(0)
+  const [totalPagesCount, setTotalPagesCount] = useState(0)
+  const [canvasRenderingComplete, setCanvasRenderingComplete] = useState(false)
+  const savePathResultRef = useRef<{ filePath: string } | null>(null)
+  const isExportCancelledRef = useRef(false)
+
+  const executeExportScoredAnswers = async () => {
+    if (!exam) return
+    try {
+      // 処理開始
+      setIsExporting(true)
+      setShowProgressModal(true)
+      setExportProgress(0)
+      setExportStatus("processing")
+      setCurrentStep("データを取得中...")
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathResultRef.current = null
+      isExportCancelledRef.current = false
+
+      const selectedStudentIds = Array.from(selectedStudents)
+
+      // 1. データ取得
+      const dataResult = await window.electronAPI.export.getPdfExportData({
+        examId: exam.id,
+        selectedStudentIds,
+      })
+
+      if (!dataResult.success || !dataResult.pages) {
+        throw new Error(dataResult.error || "データ取得に失敗しました")
+      }
+
+      if (dataResult.pages.length === 0) {
+        throw new Error("出力対象のページがありません")
+      }
+
+      setTotalPagesCount(dataResult.pages.length)
+      setExportProgress(5)
+
+      // 2. ストリーミングセッション作成（空ページを事前に作成）
+      setCurrentStep("PDFセッションを作成中...")
+      const sessionResult =
+        await window.electronAPI.export.createPdfStreamingSession({
+          totalPages: dataResult.pages.length,
+          pdfOrientation: exportOptions.pdfOrientation,
+        })
+
+      if (!sessionResult.success || !sessionResult.sessionId) {
+        throw new Error(
+          sessionResult.error || "PDFセッションの作成に失敗しました"
+        )
+      }
+
+      streamingSessionIdRef.current = sessionResult.sessionId
+
+      // 3. 保存先選択を並行で開始
+      setCurrentStep("保存先を選択してください...")
+      const savePathPromise = window.electronAPI.export.selectPdfSavePath({
+        examName: exam?.examName,
+      })
+      savePathPromiseRef.current = savePathPromise
+
+      // キャンセル監視：Canvas描画完了前にキャンセルされたら即座に中断
+      savePathPromise.then((result) => {
+        if (!result.success || result.canceled || !result.filePath) {
+          // キャンセルフラグを立てる
+          isExportCancelledRef.current = true
+          // キャンセルされた場合、Canvas描画中なら中断
+          setStartCanvasRendering(false)
+          setPdfExportPages([])
+          setShowProgressModal(false)
+          setIsExporting(false)
+          setEmbeddedPagesCount(0)
+          setTotalPagesCount(0)
+          setCanvasRenderingComplete(false)
+          savePathPromiseRef.current = null
+          savePathResultRef.current = null
+          // セッションのクリーンアップ
+          if (streamingSessionIdRef.current) {
+            window.electronAPI.export.cancelStreamingSession(
+              streamingSessionIdRef.current
+            )
+            streamingSessionIdRef.current = null
+          }
+        }
+      })
+
+      // 4. Canvas描画を開始（onPageCompleteでPDFに逐次埋め込み）
+      setPdfExportPages(dataResult.pages)
+      setStartCanvasRendering(true)
+
+      // handlePageComplete と handleCanvasComplete がストリーミング処理を実行
+    } catch (error) {
+      console.error("Export error:", error)
+      setExportStatus("error")
+      setCurrentStep(
+        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`
+      )
+      setIsExporting(false)
+      setStartCanvasRendering(false)
+      setPdfExportPages([])
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathPromiseRef.current = null
+      savePathResultRef.current = null
+      // セッションのクリーンアップ
+      if (streamingSessionIdRef.current) {
+        window.electronAPI.export.cancelStreamingSession(
+          streamingSessionIdRef.current
+        )
+        streamingSessionIdRef.current = null
+      }
+    }
+  }
+
+  /**
+   * Canvas描画進捗コールバック（並列処理対応）
+   */
+  const handleCanvasProgress = useCallback(
+    (progress: RenderProgress) => {
+      if (progress.phase === "preload") {
+        setExportProgress(5)
+        setCurrentStep("採点マーク画像を読み込み中...")
+      } else if (progress.phase === "rendering") {
+        // 10-90%をCanvas描画+PDF埋め込みに割り当て
+        // Canvas描画進捗とPDF埋め込み進捗を合成
+        const canvasWeight = 0.7 // Canvas描画に70%
+        const embedWeight = 0.3 // PDF埋め込みに30%
+        const canvasProgress = progress.completed / progress.total
+        const embedProgress = embeddedPagesCount / (totalPagesCount || 1)
+        const combinedProgress =
+          10 +
+          Math.round(
+            (canvasProgress * canvasWeight + embedProgress * embedWeight) * 80
+          )
+        setExportProgress(combinedProgress)
+        const parallelStr =
+          progress.inProgress > 0 ? ` (${progress.inProgress}並列)` : ""
+        setCurrentStep(
+          `Canvas: ${progress.completed}/${progress.total}ページ${parallelStr} | PDF: ${embeddedPagesCount}/${totalPagesCount}ページ埋め込み済み`
+        )
+      } else if (progress.phase === "complete") {
+        setExportProgress(90)
+        setCurrentStep("Canvas描画完了、PDF保存中...")
+      }
+    },
+    [setExportProgress, setCurrentStep, embeddedPagesCount, totalPagesCount]
+  )
+
+  /**
+   * 1ページ完了時のコールバック（ストリーミング埋め込み）
+   */
+  const handlePageComplete = useCallback(async (pageData: RenderedPageData) => {
+    // キャンセル済みなら何もしない
+    if (isExportCancelledRef.current) {
+      return
+    }
+
+    if (!streamingSessionIdRef.current) {
+      console.error("Streaming session not found")
+      return
+    }
+
+    try {
+      const result = await window.electronAPI.export.addPageToStreamingSession({
+        sessionId: streamingSessionIdRef.current,
+        pageIndex: pageData.pageIndex,
+        imageData: pageData.imageData,
+      })
+
+      if (result.success) {
+        setEmbeddedPagesCount((prev) => prev + 1)
+      } else {
+        console.error(
+          `Failed to embed page ${pageData.pageIndex}:`,
+          result.error
+        )
+      }
+    } catch (error) {
+      console.error(`Error embedding page ${pageData.pageIndex}:`, error)
+    }
+  }, [])
+
+  /**
+   * Canvas描画完了コールバック
+   * 保存先選択を待ち、埋め込み完了フラグを立てる
+   */
+  const handleCanvasComplete = useCallback(
+    async (
+      _renderedPages: Array<{
+        studentId: string
+        pageNumber: number
+        imageData: ArrayBuffer
+      }>
+    ) => {
+      // キャンセル済みなら何もしない
+      if (isExportCancelledRef.current) {
+        return
+      }
+
+      setStartCanvasRendering(false)
+      setPdfExportPages([])
+
+      // ストリーミングセッションがない場合はエラー
+      if (!streamingSessionIdRef.current) {
+        setExportStatus("error")
+        setCurrentStep("PDFセッションが見つかりません")
+        setIsExporting(false)
+        savePathPromiseRef.current = null
+        return
+      }
+
+      // 保存先選択の完了を待つ
+      if (!savePathPromiseRef.current) {
+        setExportStatus("error")
+        setCurrentStep("保存先選択が開始されていません")
+        setIsExporting(false)
+        // セッションのクリーンアップ
+        window.electronAPI.export.cancelStreamingSession(
+          streamingSessionIdRef.current
+        )
+        streamingSessionIdRef.current = null
+        return
+      }
+
+      setCurrentStep("保存先の選択を待っています...")
+      const savePathResult = await savePathPromiseRef.current
+      savePathPromiseRef.current = null
+
+      if (
+        !savePathResult.success ||
+        savePathResult.canceled ||
+        !savePathResult.filePath
+      ) {
+        // キャンセルされた場合 - 全状態をリセット
+        setShowProgressModal(false)
+        setIsExporting(false)
+        setEmbeddedPagesCount(0)
+        setTotalPagesCount(0)
+        setCanvasRenderingComplete(false)
+        savePathResultRef.current = null
+        // セッションのクリーンアップ
+        window.electronAPI.export.cancelStreamingSession(
+          streamingSessionIdRef.current
+        )
+        streamingSessionIdRef.current = null
+        return
+      }
+
+      // 保存先を保持し、Canvas描画完了フラグを立てる
+      // PDF埋め込み完了を待ってからuseEffectでPDF保存を実行
+      savePathResultRef.current = { filePath: savePathResult.filePath }
+      setCanvasRenderingComplete(true)
+    },
+    [setExportStatus, setCurrentStep, setIsExporting, setShowProgressModal]
+  )
+
+  /**
+   * Canvas描画エラーコールバック
+   */
+  const handleCanvasError = useCallback(
+    (error: Error) => {
+      console.error("Canvas rendering error:", error)
+      setStartCanvasRendering(false)
+      setPdfExportPages([])
+      setExportStatus("error")
+      setCurrentStep(`Canvas描画エラー: ${error.message}`)
+      setIsExporting(false)
+      setEmbeddedPagesCount(0)
+      setTotalPagesCount(0)
+      setCanvasRenderingComplete(false)
+      savePathPromiseRef.current = null
+      savePathResultRef.current = null
+      // セッションのクリーンアップ
+      if (streamingSessionIdRef.current) {
+        window.electronAPI.export.cancelStreamingSession(
+          streamingSessionIdRef.current
+        )
+        streamingSessionIdRef.current = null
+      }
+    },
+    [setExportStatus, setCurrentStep, setIsExporting]
+  )
+
+  /**
+   * Canvas描画完了 + PDF埋め込み完了時にPDF保存を実行
+   */
+  useEffect(() => {
+    const finalizePdf = async () => {
+      if (!canvasRenderingComplete) return
+      if (embeddedPagesCount < totalPagesCount) return
+      if (!streamingSessionIdRef.current) return
+      if (!savePathResultRef.current) return
+
+      try {
+        setExportProgress(95)
+        setCurrentStep("PDFを保存中...")
+
+        const result = await window.electronAPI.export.finalizeStreamingSession(
+          {
+            sessionId: streamingSessionIdRef.current,
+            outputPath: savePathResultRef.current.filePath,
+          }
+        )
+
+        streamingSessionIdRef.current = null
+        savePathResultRef.current = null
+        setCanvasRenderingComplete(false)
+
+        if (result.success) {
+          setExportProgress(100)
+          setExportStatus("completed")
+          setCurrentStep("完了しました")
+        } else {
+          setExportStatus("error")
+          setCurrentStep(`エラー: ${result.error}`)
+        }
+      } catch (error) {
+        console.error("PDF finalization error:", error)
+        setExportStatus("error")
+        setCurrentStep("PDF保存中にエラーが発生しました")
+        if (streamingSessionIdRef.current) {
+          window.electronAPI.export.cancelStreamingSession(
+            streamingSessionIdRef.current
+          )
+          streamingSessionIdRef.current = null
+        }
+      } finally {
+        setIsExporting(false)
+      }
+    }
+
+    finalizePdf()
+  }, [
+    canvasRenderingComplete,
+    embeddedPagesCount,
+    totalPagesCount,
+    setExportProgress,
+    setCurrentStep,
+    setExportStatus,
+    setIsExporting,
+  ])
+
+  return {
+    executeExportScoredAnswers,
+    // PdfCanvasRenderer 用
+    pdfExportPages,
+    startCanvasRendering,
+    handleCanvasProgress,
+    handlePageComplete,
+    handleCanvasComplete,
+    handleCanvasError,
+    // ExportProgressModal 用
+    embeddedPagesCount,
+    totalPagesCount,
+    canvasRenderingComplete,
+  }
+}

--- a/src/components/exams/08-export/utils/buildScoringMarkConfigForPdf.ts
+++ b/src/components/exams/08-export/utils/buildScoringMarkConfigForPdf.ts
@@ -1,0 +1,79 @@
+import type { ScoringMarkConfig } from "@/components/exams/08-export/components/ScoringMarkSettings"
+import type { ScoringMarkConfigForPdf } from "@/components/exams/08-export/utils/pdfCanvasRenderer"
+
+/**
+ * 採点マーク設定（画面編集用の ScoringMarkConfig）を、Canvas/PDF 描画用の
+ * ScoringMarkConfigForPdf 形式へ変換する。部分点・小計点・合計点の各設定は
+ * 新形式（partialScore/subtotalScore/totalScore）を優先し、無ければ旧形式
+ * （summaryScore・scorePosition 等）からフォールバックする。
+ */
+export function buildScoringMarkConfigForPdf(
+  scoringMarkConfig: ScoringMarkConfig
+): ScoringMarkConfigForPdf {
+  // 部分点設定を取得（partialScoreが存在する場合はそれを使用、なければ旧式設定からフォールバック）
+  const partialScore = scoringMarkConfig.partialScore
+  const partialScoreConfig =
+    partialScore && partialScore.size !== undefined
+      ? partialScore
+      : {
+          position: scoringMarkConfig.scorePosition || "middle-center",
+          size: scoringMarkConfig.scoreSize || 14,
+          offsetX: scoringMarkConfig.scoreOffsetX || 0,
+          offsetY: scoringMarkConfig.scoreOffsetY || 0,
+          color: "#ef4444",
+          opacity: 100,
+        }
+
+  // 小計点設定を取得（subtotalScore → summaryScore → デフォルトの順でフォールバック）
+  const subtotalScoreConfig = scoringMarkConfig.subtotalScore ??
+    scoringMarkConfig.summaryScore ?? {
+      position: "middle-center",
+      size: 18,
+      offsetX: 0,
+      offsetY: 0,
+      color: "#2563eb",
+      opacity: 100,
+    }
+
+  // 合計点設定を取得（totalScore → summaryScore → デフォルトの順でフォールバック）
+  const totalScoreConfig = scoringMarkConfig.totalScore ??
+    scoringMarkConfig.summaryScore ?? {
+      position: "middle-center",
+      size: 18,
+      offsetX: 0,
+      offsetY: 0,
+      color: "#2563eb",
+      opacity: 100,
+    }
+
+  return {
+    markPosition: scoringMarkConfig.markPosition,
+    markSize: scoringMarkConfig.markSize,
+    markColor: scoringMarkConfig.markColor ?? "#ef4444",
+    markOpacity: scoringMarkConfig.markOpacity ?? 100,
+    showPartialScore: true,
+    partialScorePosition: partialScoreConfig.position || "middle-center",
+    partialScoreSize: partialScoreConfig.size || 14,
+    partialScoreOffsetX: partialScoreConfig.offsetX || 0,
+    partialScoreOffsetY: partialScoreConfig.offsetY || 0,
+    partialScoreColor: partialScoreConfig.color ?? "#ef4444",
+    partialScoreOpacity: partialScoreConfig.opacity ?? 100,
+    // 小計点用設定
+    subtotalScorePosition: subtotalScoreConfig.position || "middle-center",
+    subtotalScoreSize: subtotalScoreConfig.size || 18,
+    subtotalScoreOffsetX: subtotalScoreConfig.offsetX || 0,
+    subtotalScoreOffsetY: subtotalScoreConfig.offsetY || 0,
+    subtotalScoreColor: subtotalScoreConfig.color ?? "#2563eb",
+    subtotalScoreOpacity: subtotalScoreConfig.opacity ?? 100,
+    // 合計点用設定
+    totalScorePosition: totalScoreConfig.position || "middle-center",
+    totalScoreSize: totalScoreConfig.size || 18,
+    totalScoreOffsetX: totalScoreConfig.offsetX || 0,
+    totalScoreOffsetY: totalScoreConfig.offsetY || 0,
+    totalScoreColor: totalScoreConfig.color ?? "#2563eb",
+    totalScoreOpacity: totalScoreConfig.opacity ?? 100,
+    // ステータスごとの表示設定
+    showMarkForStatus: scoringMarkConfig.showMarkForStatus,
+    showScoreForStatus: scoringMarkConfig.showScoreForStatus,
+  }
+}


### PR DESCRIPTION
## 概要

Closes #995

905行の `ExportMainView.tsx` から出力オーケストレーションを責務別に切り出し、コンポーネントを状態配線＋JSX 中心へ縮小（**905→370行**）。ロジックは挙動保存で移設。

## 変更内容

| ファイル | 役割 |
|---|---|
| `hooks/useScoredAnswerPdfExport.ts`（新・423行） | 採点済み答案の Canvas→PDF ストリーミング出力の状態機械（state/ref・4コールバック・finalize effect・execute） |
| `hooks/useDataFileExports.ts`（新・134行） | 非Canvas系出力（採点データExcel・R分析データ・個人成績表印刷） |
| `utils/buildScoringMarkConfigForPdf.ts`（新・79行） | `ScoringMarkConfig` → `ScoringMarkConfigForPdf` の純変換 |
| `ExportMainView.tsx`（370行） | 状態配線・バリデーション・警告モーダル制御・JSX。3つの export ハンドラの定型を `runValidatedExport` に集約 |

## 挙動について

- 逐語移設で挙動保存。唯一の意図的デルタは、`PdfCanvasRenderer` へ渡す config を毎レンダー生成の関数呼び出しから memoized 値へ変更（描画トリガは `startRendering` を ref 経由で読むため挙動同一・再生成減）。
- `runValidatedExport` 集約に伴い、`grading-data` に欠落していた `isExporting` ガードを付与し、catch のエラー表示を全経路で統一（二重出力の潜在リスクと非対称の解消）。

## 型規約

新規ドメイン型を作らず既存型のみ使用。フック引数はファイル内 interface、返り値は推論。セッターは React 標準 `Dispatch<SetStateAction<...>>`。`any`/`as` の追加なし。

## 検証

- `npm run typecheck`（Next.js + electron-src 両方）通過
- eslint / prettier クリーン（対象4ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)