### PR TITLE
feat(06-results): 欠測推定の計算式をネストpopoverで表示

### DIFF
--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -1186,6 +1186,7 @@ describe("estimateAbsentScore", () => {
     const result = estimateAbsentScore("zero", "s1", "ds1", 100, rawScoreMap, [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 100,
         absentMethod: "zero",
         absentRatio: 1,
@@ -1193,7 +1194,8 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ])
-    expect(result).toBe(0)
+    expect(result?.value).toBe(0)
+    expect(result?.effectiveMethod).toBe("zero")
   })
 
   it("method='average' → 他DataSourceの比率から推定", () => {
@@ -1212,6 +1214,7 @@ describe("estimateAbsentScore", () => {
     const allDataSources = [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 200,
         absentMethod: "average" as const,
         absentRatio: 1,
@@ -1220,6 +1223,7 @@ describe("estimateAbsentScore", () => {
       },
       {
         id: "ds2",
+        name: "ds2",
         maxScore: 100,
         absentMethod: "null" as const,
         absentRatio: 1,
@@ -1228,6 +1232,7 @@ describe("estimateAbsentScore", () => {
       },
       {
         id: "ds3",
+        name: "ds3",
         maxScore: 50,
         absentMethod: "null" as const,
         absentRatio: 1,
@@ -1243,7 +1248,10 @@ describe("estimateAbsentScore", () => {
       rawScoreMap,
       allDataSources
     )
-    expect(result).toBeCloseTo(140)
+    expect(result?.value).toBeCloseTo(140)
+    expect(result?.effectiveMethod).toBe("average")
+    expect(result?.averageRatio).toBeCloseTo(0.7)
+    expect(result?.averageSources).toHaveLength(2)
   })
 
   it("method='average' → 他DataSourceがない場合はnull", () => {
@@ -1252,6 +1260,7 @@ describe("estimateAbsentScore", () => {
     const allDataSources = [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 100,
         absentMethod: "average" as const,
         absentRatio: 1,
@@ -1308,6 +1317,7 @@ describe("estimateAbsentScore", () => {
     const allDataSources = [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 100,
         absentMethod: "regression" as const,
         absentRatio: 1,
@@ -1316,6 +1326,7 @@ describe("estimateAbsentScore", () => {
       },
       {
         id: "ds2",
+        name: "ds2",
         maxScore: 100,
         absentMethod: "null" as const,
         absentRatio: 1,
@@ -1333,8 +1344,14 @@ describe("estimateAbsentScore", () => {
     )
     // 結果はOLS回帰の予測値で、0-100の範囲内であること
     expect(result).not.toBeNull()
-    expect(result!).toBeGreaterThanOrEqual(0)
-    expect(result!).toBeLessThanOrEqual(100)
+    expect(result!.value).toBeGreaterThanOrEqual(0)
+    expect(result!.value).toBeLessThanOrEqual(100)
+    expect(result!.effectiveMethod).toBe("regression")
+    expect(result!.intercept).not.toBeUndefined()
+    // 説明変数は ds2 の1つ
+    expect(result!.regressionTerms).toHaveLength(1)
+    expect(result!.regressionTerms![0].name).toBe("ds2")
+    expect(result!.regressionTerms![0].value).toBe(60)
   })
 
   it("method='regression' → サンプル不足は平均比率法にフォールバック", () => {
@@ -1358,6 +1375,7 @@ describe("estimateAbsentScore", () => {
     const allDataSources = [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 100,
         absentMethod: "regression" as const,
         absentRatio: 1,
@@ -1366,6 +1384,7 @@ describe("estimateAbsentScore", () => {
       },
       {
         id: "ds2",
+        name: "ds2",
         maxScore: 100,
         absentMethod: "null" as const,
         absentRatio: 1,
@@ -1382,7 +1401,9 @@ describe("estimateAbsentScore", () => {
       allDataSources
     )
     // averageフォールバック: s1のds2比率=60/100=0.6 → 0.6*100=60
-    expect(result).toBeCloseTo(60)
+    expect(result?.value).toBeCloseTo(60)
+    expect(result?.effectiveMethod).toBe("average")
+    expect(result?.fallbackReason).toBe("insufficient_samples")
   })
 
   it("method='regression' → 説明変数なしはnull", () => {
@@ -1393,6 +1414,7 @@ describe("estimateAbsentScore", () => {
     const allDataSources = [
       {
         id: "ds1",
+        name: "ds1",
         maxScore: 100,
         absentMethod: "regression" as const,
         absentRatio: 1,

--- a/electron-src/lib/shared/calculations/absentEstimation.ts
+++ b/electron-src/lib/shared/calculations/absentEstimation.ts
@@ -6,8 +6,34 @@
  * - regression: OLS重回帰による予測（サンプル不足・特異行列時は average にフォールバック）
  */
 
-import type { AbsentMethod } from "../../../../src/types/grade.types"
+import type {
+  AbsentMethod,
+  EstimationFallbackReason,
+  EstimationRegressionTerm,
+  EstimationSourceContribution,
+} from "../../../../src/types/grade.types"
 import type { DataSourceInfo } from "./gradeCalculatorTypes"
+
+/**
+ * 欠測推定の生の結果（乗率・加減点の適用前）。
+ * gradeCalculator が乗率・加減点を適用して最終的な EstimationDetail を組み立てる。
+ */
+export interface AbsentEstimation {
+  /** 推定素点（内部クランプ済み、乗率・加減点適用前） */
+  value: number
+  /** 実際に使われた推定方法（regressionがaverageにフォールバックした場合は"average"） */
+  effectiveMethod: AbsentMethod
+  /** 平均比率法（フォールバック含む）で使用したソース内訳 */
+  averageSources?: EstimationSourceContribution[]
+  /** 平均比率法の平均比率 */
+  averageRatio?: number
+  /** 重回帰法の切片（β0） */
+  intercept?: number
+  /** 重回帰法の各説明変数の項 */
+  regressionTerms?: EstimationRegressionTerm[]
+  /** 重回帰法がaverageにフォールバックした理由 */
+  fallbackReason?: EstimationFallbackReason
+}
 
 /**
  * 欠測時の代替スコアを推定
@@ -19,9 +45,9 @@ export function estimateAbsentScore(
   maxScore: number,
   rawScoreMap: Map<string, Map<string, number | null>>,
   allDataSources: DataSourceInfo[]
-): number | null {
+): AbsentEstimation | null {
   if (method === "zero") {
-    return 0
+    return { value: 0, effectiveMethod: "zero" }
   }
   if (method === "average") {
     return estimateByAverage(
@@ -54,25 +80,37 @@ function estimateByAverage(
   maxScore: number,
   rawScoreMap: Map<string, Map<string, number | null>>,
   allDataSources: DataSourceInfo[]
-): number | null {
+): AbsentEstimation | null {
   const studentScores = rawScoreMap.get(studentId)
   if (!studentScores) return null
 
+  const averageSources: EstimationSourceContribution[] = []
   let ratioSum = 0
-  let ratioCount = 0
 
   for (const dataSource of allDataSources) {
     if (dataSource.id === dataSourceId) continue
     if (dataSource.maxScore <= 0) continue
     const score = studentScores.get(dataSource.id)
     if (score === null || score === undefined) continue
-    ratioSum += score / dataSource.maxScore
-    ratioCount++
+    const ratio = score / dataSource.maxScore
+    averageSources.push({
+      id: dataSource.id,
+      name: dataSource.name,
+      score,
+      maxScore: dataSource.maxScore,
+      ratio,
+    })
+    ratioSum += ratio
   }
 
-  if (ratioCount === 0) return null
-  const avgRatio = ratioSum / ratioCount
-  return clamp(avgRatio * maxScore, 0, maxScore)
+  if (averageSources.length === 0) return null
+  const averageRatio = ratioSum / averageSources.length
+  return {
+    value: clamp(averageRatio * maxScore, 0, maxScore),
+    effectiveMethod: "average",
+    averageSources,
+    averageRatio,
+  }
 }
 
 /**
@@ -87,7 +125,12 @@ function estimateByRegression(
   maxScore: number,
   rawScoreMap: Map<string, Map<string, number | null>>,
   allDataSources: DataSourceInfo[]
-): number | null {
+): AbsentEstimation | null {
+  // predictor ID → 表示名（説明変数の項名に使う）
+  const nameByDataSourceId = new Map(
+    allDataSources.map((dataSource) => [dataSource.id, dataSource.name])
+  )
+
   // 他DataSourceのID一覧（predictor変数）
   const predictorDsIds = allDataSources
     .filter(
@@ -138,12 +181,13 @@ function estimateByRegression(
   const minSamples = availablePredictors.length + 2
   if (X.length < minSamples) {
     // サンプル不足の場合、平均比率法にフォールバック
-    return estimateByAverage(
+    return fallbackToAverage(
       studentId,
       dataSourceId,
       maxScore,
       rawScoreMap,
-      allDataSources
+      allDataSources,
+      "insufficient_samples"
     )
   }
 
@@ -152,12 +196,13 @@ function estimateByRegression(
   const beta = solveOLS(X, Y, p)
   if (!beta) {
     // 特異行列の場合、平均比率法にフォールバック
-    return estimateByAverage(
+    return fallbackToAverage(
       studentId,
       dataSourceId,
       maxScore,
       rawScoreMap,
-      allDataSources
+      allDataSources,
+      "singular_matrix"
     )
   }
 
@@ -172,7 +217,45 @@ function estimateByRegression(
     predicted += beta[j] * xTarget[j]
   }
 
-  return clamp(predicted, 0, maxScore)
+  // 説明変数の項（beta[0]=切片、beta[j+1]=predictor jの係数）
+  const regressionTerms: EstimationRegressionTerm[] = availablePredictors.map(
+    (predId, index) => ({
+      id: predId,
+      name: nameByDataSourceId.get(predId) ?? predId,
+      value: targetStudentScores.get(predId)!,
+      coefficient: beta[index + 1],
+    })
+  )
+
+  return {
+    value: clamp(predicted, 0, maxScore),
+    effectiveMethod: "regression",
+    intercept: beta[0],
+    regressionTerms,
+  }
+}
+
+/**
+ * 重回帰法がサンプル不足/特異行列で平均比率法に落ちた場合の共通処理。
+ * averageの推定結果にフォールバック理由を付与して返す。
+ */
+function fallbackToAverage(
+  studentId: string,
+  dataSourceId: string,
+  maxScore: number,
+  rawScoreMap: Map<string, Map<string, number | null>>,
+  allDataSources: DataSourceInfo[],
+  reason: EstimationFallbackReason
+): AbsentEstimation | null {
+  const fallback = estimateByAverage(
+    studentId,
+    dataSourceId,
+    maxScore,
+    rawScoreMap,
+    allDataSources
+  )
+  if (fallback === null) return null
+  return { ...fallback, fallbackReason: reason }
 }
 
 /**
@@ -249,6 +332,19 @@ function solveOLS(X: number[][], Y: number[], p: number): number[] | null {
 }
 
 /**
+ * 乗率・加減点を適用した生の値（クランプ前）: estimated × ratio + offset。
+ * applyAdjustmentAndClamp と結果画面の内訳表示が同じ式を共有するための単一実装
+ * （表示側で式を再導出しないための SSOT）。
+ */
+export function adjustEstimate(
+  estimated: number,
+  ratio: number,
+  offset: number
+): number {
+  return estimated * ratio + offset
+}
+
+/**
  * 調整(ratio/offset)を適用し、[0, maxScore]にクランプ
  */
 export function applyAdjustmentAndClamp(
@@ -257,8 +353,11 @@ export function applyAdjustmentAndClamp(
   offset: number,
   maxScore: number
 ): number {
-  const adjusted = estimated * ratio + offset
-  return Math.round(clamp(adjusted, 0, maxScore) * 100) / 100
+  return (
+    Math.round(
+      clamp(adjustEstimate(estimated, ratio, offset), 0, maxScore) * 100
+    ) / 100
+  )
 }
 
 /**

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -6,6 +6,7 @@
 
 import type {
   AbsentMethod,
+  EstimationDetail,
   GradeCalculationResult,
   GradeItemResult,
   SourceScoreResult,
@@ -18,6 +19,7 @@ import {
 import prisma from "../../prisma/client"
 import { computeLiveMaxScore } from "../../prisma/gradeDataSource"
 import {
+  adjustEstimate,
   applyAdjustmentAndClamp,
   estimateAbsentScore,
 } from "./absentEstimation"
@@ -228,6 +230,7 @@ export async function calculateGrades(gradeId: string): Promise<{
         }
         return {
           id: dataSource.id,
+          name: dataSource.name,
           maxScore: liveMaxScoreMap.get(dataSource.id) ?? 0,
           absentMethod: (dataSource.absentMethod ?? "null") as AbsentMethod,
           absentRatio: Number(dataSource.absentRatio ?? 1),
@@ -316,6 +319,7 @@ export async function calculateGrades(gradeId: string): Promise<{
           const studentScores = rawScoreMap.get(student.id)
           let rawScore = studentScores?.get(dataSource.id) ?? null
           let isEstimated = false
+          let estimationDetail: EstimationDetail | null = null
 
           // rawScoreがnullかつ推定設定がある場合、代替スコアを算出
           if (rawScore === null && absentMethod !== "null") {
@@ -327,7 +331,7 @@ export async function calculateGrades(gradeId: string): Promise<{
                   )
                 : dataSourceInfos
 
-            const estimated = estimateAbsentScore(
+            const estimation = estimateAbsentScore(
               absentMethod,
               student.id,
               dataSource.id,
@@ -335,15 +339,35 @@ export async function calculateGrades(gradeId: string): Promise<{
               rawScoreMap,
               sourcesToUse
             )
-            if (estimated !== null) {
+            if (estimation !== null) {
               // 調整 + クランプ
               rawScore = applyAdjustmentAndClamp(
-                estimated,
+                estimation.value,
                 absentRatio,
                 absentOffset,
                 maxScore
               )
               isEstimated = true
+              // 結果画面のpopoverで「どう推定したか」を表示するための内訳。
+              // adjustedScore は applyAdjustmentAndClamp と同じ adjustEstimate を共有し、
+              // 表示側で式を再導出しない（SSOT）。
+              estimationDetail = {
+                effectiveMethod: estimation.effectiveMethod,
+                baseEstimate: estimation.value,
+                ratio: absentRatio,
+                offset: absentOffset,
+                adjustedScore: adjustEstimate(
+                  estimation.value,
+                  absentRatio,
+                  absentOffset
+                ),
+                finalScore: rawScore,
+                averageSources: estimation.averageSources,
+                averageRatio: estimation.averageRatio,
+                intercept: estimation.intercept,
+                regressionTerms: estimation.regressionTerms,
+                fallbackReason: estimation.fallbackReason,
+              }
             }
           }
 
@@ -369,6 +393,7 @@ export async function calculateGrades(gradeId: string): Promise<{
             weight,
             weightedScore,
             isEstimated,
+            estimation: estimationDetail,
             letterValue: courseworkScore?.letterValue ?? null,
             adjustment:
               courseworkScore?.adjustment !== null &&

--- a/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
@@ -19,6 +19,7 @@ export interface ExamDataCache {
  */
 export interface DataSourceInfo {
   id: string
+  name: string
   maxScore: number
   absentMethod: AbsentMethod
   absentRatio: number

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -14,6 +14,7 @@ import type {
   GradeCalculationResult,
   GradeConstraintData,
   GradeItemResult,
+  SourceScoreResult,
 } from "@/types/grade.types"
 
 interface ResultsTableProps {
@@ -32,6 +33,175 @@ type SortKey = "registrationOrder" | "attendanceNumber" | string
 // ---------------------------------------------------------------------------
 // ScoreBreakdownPopover – %クリックで算出根拠を表示
 // ---------------------------------------------------------------------------
+
+const ABSENT_METHOD_LABELS: Record<string, string> = {
+  zero: "0点",
+  average: "平均比率法",
+  regression: "重回帰法",
+}
+
+const FALLBACK_REASON_LABELS: Record<string, string> = {
+  insufficient_samples: "サンプル不足",
+  singular_matrix: "多重共線性（特異行列）",
+}
+
+/** 数値を小数digits桁で表示（末尾の余分な0は残す＝式の桁を揃える） */
+function fmt(value: number, digits = 2): string {
+  return value.toFixed(digits)
+}
+
+/** クランプ判定の許容誤差（丸め・浮動小数のブレを吸収） */
+const CLAMP_EPSILON = 0.005
+
+/**
+ * クランプ前の値 rawValue が最終値 finalValue と乖離＝[0, maxScore]にクランプされた場合の
+ * 注記文字列を返す（乖離がなければ空文字）。内訳表示の各所で共有する。
+ */
+function clampNote(
+  rawValue: number,
+  finalValue: number,
+  maxScore: number
+): string {
+  return Math.abs(rawValue - finalValue) > CLAMP_EPSILON
+    ? `（0〜${fmt(maxScore)}にクランプ）`
+    : ""
+}
+
+/**
+ * 欠測推定の内訳（どの方法・どの式で推定したか）を表示するブロック。
+ * average は使用ソースの比率と平均、regression は切片+係数の線形式まで見せる。
+ */
+function EstimationExplain({
+  sourceScore,
+}: {
+  sourceScore: SourceScoreResult
+}) {
+  const estimation = sourceScore.estimation
+  if (!estimation) return null
+
+  const methodLabel =
+    ABSENT_METHOD_LABELS[estimation.effectiveMethod] ??
+    estimation.effectiveMethod
+  const targetMaxScore = sourceScore.maxScore
+  const hasAdjustment = estimation.ratio !== 1 || estimation.offset !== 0
+  // クランプ前の値。乗率・加減点があれば adjustedScore（backendが adjustEstimate で算出）、
+  // なければ推定素点そのもの。これと finalScore の乖離でクランプ有無を判定する。
+  const preClampScore = hasAdjustment
+    ? estimation.adjustedScore
+    : estimation.baseEstimate
+
+  return (
+    <div className="rounded-md bg-amber-50 p-2.5 text-[10px] leading-relaxed text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+      <p className="font-semibold">
+        {sourceScore.dataSourceName}（欠測推定: {methodLabel}）
+      </p>
+
+      {estimation.fallbackReason && (
+        <p className="text-amber-700 dark:text-amber-300">
+          ※ 重回帰法は
+          {FALLBACK_REASON_LABELS[estimation.fallbackReason] ??
+            estimation.fallbackReason}
+          のため平均比率法にフォールバック
+        </p>
+      )}
+
+      {/* zero法 */}
+      {estimation.effectiveMethod === "zero" && <p>欠測 → 0点</p>}
+
+      {/* average法（フォールバック含む） */}
+      {estimation.averageSources && estimation.averageRatio !== undefined && (
+        <div className="mt-0.5">
+          {estimation.averageSources.map((source) => (
+            <p key={source.id} className="tabular-nums">
+              {source.name}: {fmt(source.score)} / {fmt(source.maxScore)} ={" "}
+              {fmt(source.ratio, 3)}
+            </p>
+          ))}
+          <p className="tabular-nums">
+            平均比率 = {fmt(estimation.averageRatio, 3)}
+          </p>
+          <p className="tabular-nums">
+            推定素点 = {fmt(estimation.averageRatio, 3)} × {fmt(targetMaxScore)}{" "}
+            = {fmt(estimation.baseEstimate)}
+            {clampNote(
+              estimation.averageRatio * targetMaxScore,
+              estimation.baseEstimate,
+              targetMaxScore
+            )}
+          </p>
+        </div>
+      )}
+
+      {/* regression法 */}
+      {estimation.effectiveMethod === "regression" &&
+        estimation.intercept !== undefined &&
+        estimation.regressionTerms && (
+          <RegressionFormula
+            intercept={estimation.intercept}
+            terms={estimation.regressionTerms}
+            baseEstimate={estimation.baseEstimate}
+            maxScore={targetMaxScore}
+          />
+        )}
+
+      {/* 乗率・加減点 */}
+      {hasAdjustment && (
+        <p className="tabular-nums">
+          乗率×加減点 = {fmt(estimation.baseEstimate)} × {estimation.ratio}{" "}
+          {estimation.offset >= 0 ? "+" : "−"}{" "}
+          {fmt(Math.abs(estimation.offset))} = {fmt(estimation.adjustedScore)}
+        </p>
+      )}
+
+      <p className="font-medium tabular-nums">
+        最終 = {fmt(estimation.finalScore)}
+        {clampNote(preClampScore, estimation.finalScore, targetMaxScore)}
+      </p>
+    </div>
+  )
+}
+
+/** 重回帰の線形式: β0 + β1×x1 + ... = 予測値（クランプ注記付き） */
+function RegressionFormula({
+  intercept,
+  terms,
+  baseEstimate,
+  maxScore,
+}: {
+  intercept: number
+  terms: { id: string; name: string; value: number; coefficient: number }[]
+  baseEstimate: number
+  maxScore: number
+}) {
+  const rawSum =
+    intercept +
+    terms.reduce((sum, term) => sum + term.coefficient * term.value, 0)
+
+  const expr = terms.reduce((acc, term) => {
+    const sign = term.coefficient >= 0 ? "+" : "−"
+    return `${acc} ${sign} ${fmt(Math.abs(term.coefficient), 3)}×${fmt(term.value)}`
+  }, fmt(intercept))
+
+  return (
+    <div className="mt-0.5">
+      <p className="break-all tabular-nums">
+        予測 = {expr} = {fmt(rawSum)}
+      </p>
+      {terms.map((term) => (
+        <p
+          key={term.id}
+          className="text-amber-700 tabular-nums dark:text-amber-300"
+        >
+          {term.name}: 係数 {fmt(term.coefficient, 3)} × 素点 {fmt(term.value)}
+        </p>
+      ))}
+      <p className="tabular-nums">
+        推定素点 = {fmt(baseEstimate)}
+        {clampNote(rawSum, baseEstimate, maxScore)}
+      </p>
+    </div>
+  )
+}
 
 /** GradeItem列の%ポップオーバー: データソース別の内訳 */
 function GradeItemBreakdownPopover({
@@ -71,7 +241,7 @@ function GradeItemBreakdownPopover({
           {pctText}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-3" align="start">
+      <PopoverContent className="w-80 p-3" align="start">
         <p className="mb-1 text-xs font-semibold">{itemResult.gradeItemName}</p>
         <p className="text-muted-foreground mb-2 text-[10px]">
           換算 = (素点 ÷ 満点) × 換算満点 ※欠点は除外
@@ -95,9 +265,24 @@ function GradeItemBreakdownPopover({
                   className={`border-b last:border-0 ${isMissing ? "text-muted-foreground line-through" : ""}`}
                 >
                   <td className="py-1 pr-1">
-                    {sourceScore.dataSourceName}
-                    {sourceScore.isEstimated && (
-                      <span className="ml-0.5 text-amber-600">*</span>
+                    {sourceScore.isEstimated && sourceScore.estimation ? (
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            className="cursor-pointer text-left text-amber-600 hover:underline"
+                            title="クリックで推定の計算式を表示"
+                          >
+                            {sourceScore.dataSourceName}
+                            <span className="ml-0.5">*</span>
+                          </button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-80 p-0" align="start">
+                          <EstimationExplain sourceScore={sourceScore} />
+                        </PopoverContent>
+                      </Popover>
+                    ) : (
+                      sourceScore.dataSourceName
                     )}
                   </td>
                   <td className="py-1 text-right tabular-nums">

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -205,6 +205,8 @@ export interface SourceScoreResult {
   weight: number
   weightedScore: number | null
   isEstimated: boolean
+  /** 欠測推定の内訳（isEstimated=true のときのみ。どの方法・式で推定したか） */
+  estimation: EstimationDetail | null
   /** 文字モード時に入力された評価記号（manual型のみ） */
   letterValue: string | null
   /** 適用された加点・減点（manual型のみ。0なら調整なし） */
@@ -213,6 +215,61 @@ export interface SourceScoreResult {
   adjustmentReason: string | null
   /** コメント（manual型のみ。成績通知書に表示） */
   comment: string | null
+}
+
+/** 平均比率法で使用した1ソースの寄与（score/maxScore = ratio） */
+export interface EstimationSourceContribution {
+  /** 元ソースの GradeDataSource.id（表示名は衝突しうるため React key はこれを使う） */
+  id: string
+  name: string
+  score: number
+  maxScore: number
+  ratio: number
+}
+
+/** 重回帰法の1説明変数の項（coefficient × value） */
+export interface EstimationRegressionTerm {
+  /** 説明変数となった GradeDataSource.id（React key 用） */
+  id: string
+  name: string
+  value: number
+  coefficient: number
+}
+
+/** 重回帰法がフォールバックした理由 */
+export type EstimationFallbackReason =
+  "insufficient_samples" | "singular_matrix"
+
+/**
+ * 欠測推定の内訳。
+ * 「どの方法で・どのソースから・どんな式で推定したか」を結果画面のpopoverに表示するために持つ。
+ */
+export interface EstimationDetail {
+  /**
+   * 実際に使われた推定方法（regressionがサンプル不足/特異行列でaverageに落ちた場合は"average"）。
+   * 設定された方法との差異は fallbackReason で表す。
+   */
+  effectiveMethod: AbsentMethod
+  /** 推定素点（乗率・加減点の適用前、内部クランプ済み） */
+  baseEstimate: number
+  /** 乗率 */
+  ratio: number
+  /** 加減点 */
+  offset: number
+  /** 乗率・加減点を適用した値（クランプ前）。= baseEstimate × ratio + offset */
+  adjustedScore: number
+  /** 最終スコア（= clamp(adjustedScore)。SourceScoreResult.rawScoreと同値） */
+  finalScore: number
+  /** 平均比率法（重回帰のフォールバック含む）で使用したソース内訳 */
+  averageSources?: EstimationSourceContribution[]
+  /** 平均比率法の平均比率 */
+  averageRatio?: number
+  /** 重回帰法の切片（β0） */
+  intercept?: number
+  /** 重回帰法の各説明変数の項 */
+  regressionTerms?: EstimationRegressionTerm[]
+  /** 重回帰法がaverageにフォールバックした理由（あれば） */
+  fallbackReason?: EstimationFallbackReason
 }
 
 /** 成績算出結果全体 */


### PR DESCRIPTION
## 概要

成績算出結果（06-results）の内訳popover内で、欠測推定されたデータソース名（`*` 付き）をクリックすると、**ネストしたpopover**で「どう推定したか」の計算式を表示する。

Closes #997

## 変更点

### 表示（renderer）
- `ResultsTable.tsx` に `EstimationExplain` / `RegressionFormula` を追加
- 推定ソース名をネストpopoverのトリガー化（クリックで式を表示）
- 平均比率法の内訳、重回帰の係数式（β0 + Σ βi·xi）、乗率・加減点、クランプ注記、フォールバック理由を表示

### 算出（main）
- `EstimationDetail` 型を追加し `SourceScoreResult.estimation` として付与
- `estimateAbsentScore` が値だけでなく推定内訳（使用ソース・平均比率・回帰係数・フォールバック理由）を返すよう変更
- 乗率・加減点は `applyAdjustmentAndClamp` と共有する `adjustEstimate` で算出（表示側で式を再導出しない SSOT）
- `DataSourceInfo.name` を追加（式にソース名を出すため）

## コードレビュー対応

high レベルの multi-agent レビューで挙がった cleanup 指摘を反映済み:
- 死にフィールド `EstimationDetail.method` を削除（`effectiveMethod` + `fallbackReason` で表現）
- クランプ注記の epsilon を `CLAMP_EPSILON` + `clampNote()` に集約（4箇所の重複解消）
- `nameByDsId` → `nameByDataSourceId`（命名規約: 略語禁止）
- 調整値を backend の `adjustedScore` から受け取り表示層の再導出を削減

## 検証
- typecheck（Next.js + electron-src）通過
- eslint / prettier クリーン
- grade テスト 90 件パス

## 対象外（別セッションの変更）
`useDataSources.ts` の batch 更新に関するレビュー指摘（未処理reject・アトミック性）は本セッションの変更対象外のため含めていない。