### PR TITLE
fix(03-data-sources): 一括更新のIPC reject時の無音失敗を修正

### DIFF
--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -132,7 +132,12 @@ export function useDataSources(gradeId: string) {
         }
       }[]
     ) => {
-      const results = await Promise.all(
+      // 個別更新IPC(grade:updateDataSource)は registerHandler 登録のため、
+      // backend例外時は reject する。allSettled で reject を吸収しないと
+      // 直後の loadData()/return に到達せず、呼び出し側の toast も再読込も
+      // 走らないまま無反応になる。allSettled なら reject も「失敗した1件」
+      // として畳み込め、下の「必ず再読込」の不変条件を守れる。
+      const results = await Promise.allSettled(
         updates.map((update) =>
           window.electronAPI.grade.updateDataSource(update.id, update.data)
         )
@@ -140,7 +145,12 @@ export function useDataSources(gradeId: string) {
       // 個別更新は独立にコミットされ、一部失敗でもDBは変わり得る。
       // UIを実DBへ追従させるため成否に関わらず必ず再読込する。
       await loadData()
-      return { success: results.every((result) => result.success) }
+      return {
+        success: results.every(
+          (settledResult) =>
+            settledResult.status === "fulfilled" && settledResult.value.success
+        ),
+      }
     },
     [loadData]
   )


### PR DESCRIPTION
## 概要

データソース一括更新 (`batchUpdateDataSources`) が `Promise.all` を使っていたため、個別更新IPCが1件でも reject すると全体が reject し、`loadData()` と `return` に到達せず、呼び出し側で toast も再読込もされないまま**無音失敗・UI無反応**になる不具合を修正する。

Closes #1001

## 変更点

- `src/hooks/grades/useDataSources.ts` の `batchUpdateDataSources` を `Promise.all` → `Promise.allSettled` に変更
- reject を「失敗した1件」として畳み込み、`loadData()` が常に実行されるように（フック自身が宣言する「成否に関わらず必ず再読込する」不変条件を遵守）
- 失敗時は `{ success: false }` を返し、呼び出し側 `handleBatchApply` の再適用フロー（選択保持＋`toast.error`）が正しく動く
- あわせて `.every` コールバックの要素名を命名規約に沿って `settledResult` に（`PromiseSettledResult` であることを明示）

## 背景

`grade:updateDataSource` は `registerHandler` 登録のため例外を再スローする（`registerSafeHandler` と異なり `{success:false}` に握り潰さない）。この前提で `Promise.all` は reject 伝播に脆弱だった。

## テスト

- `npm run lint` ✅
- `npm run typecheck`（該当ファイルのエラーなし）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)