### PR TITLE
一覧フィルタ機能の3画面追加と解答用紙タグ機能の新設

### DIFF
--- a/docs/list-filter-detail-refactor-plan.md
+++ b/docs/list-filter-detail-refactor-plan.md
@@ -1,0 +1,281 @@
+# 一覧フィルタ＋詳細画面リファクタ 実装計画
+
+当初の依頼「試験一覧と同様のフィルタ機能を、解答用紙作成・試験外成績資料・成績算出にも実装する」から派生した一連の改修計画。フィルタ機能一式は実装済み。本書は**残りの大物（破壊的なルーティング再編を含む）**の実装計画を、次セッションでそのまま着手できる粒度で記録する。
+
+作成日: 2026-07-13
+
+---
+
+## 0. 完了済み（実装・型チェック通過・整形済み）
+
+### フィルタ機能（3画面共通）
+
+| 画面           | 検索 | タグ | 学級 | 日付範囲 | 一括タグ付与 |
+| -------------- | ---- | ---- | ---- | -------- | ------------ |
+| 解答用紙作成   | ✅   | ✅   | —    | 更新日   | ✅           |
+| 試験外成績資料 | ✅   | ✅   | ✅   | 実施日   | ✅           |
+| 成績算出       | ✅   | —    | ✅   | 基準日   | —            |
+
+### 新設した共通部品
+
+- `src/hooks/useListFilter.ts` — 汎用フィルタ適用hook。`ListFilterAccessors<T>`（`searchTexts`/`tagIds?`/`classroomIds?`/`date?`）を注入。返り値に `filteredItems` と各state/トグル。**accessors はモジュールレベル定数で渡し参照を安定させる**（依存配列に入るため）。
+- `src/components/common/ListFilterBar.tsx` — presentational。検索Input・タグ/学級のPopoverチェックボックス（`MultiSelectFilter`）・日付範囲Popover（`DateRangeFilter`）・件数表示。`tagFilter`/`classroomFilter`/`dateRangeFilter` は optional、`leading` に画面固有要素を差し込む。exported型: `FilterOption`, `MultiSelectFilterConfig`, `DateRangeFilterConfig`。
+- `src/components/common/BulkTagAssignButton.tsx` — 選択中アイテムへタグ一括付与するPopover。props: `selectedCount`/`allTags`/`onAssign`。
+
+### 解答用紙のタグ機能（新規スキーマ）
+
+- `prisma/schema.prisma`: `AsbDefinitionTag` 中間テーブル追加、`Tag.asbDefinitionTags` / `AsbDefinition.tags` 逆リレーション。
+- `prisma/migrations/20260713000000_add_asb_definition_tag/migration.sql`（手書き。**MIGRATION_CHECKSUMS には足さない** — `deployPendingMigrations` が起動時 replay する。CourseworkTag を雛形にした CREATE TABLE + 3 INDEX）。
+- `electron-src/lib/prisma/asbDefinitionTag.ts`（`examTag.ts` 雛形。get/create/delete/`setAsbDefinitionTags`）。
+- `electron-src/ipc-handlers/tagHandlers.ts`: `asbDefinitionTag:getByDefinitionId|create|delete|setDefinitionTags` 追加。
+- `electron-src/preload-apis/tagApi.ts`: `asbDefinitionTagGetByDefinitionId|Create|Delete|SetDefinitionTags` 追加。
+- `src/types/electron/tagApi.d.ts`: `AsbDefinitionTagWithTag` 型＋メソッド型追加。
+- `electron-src/lib/prisma/asbDefinition.ts` `listAsbDefinitions`: `select` に `tags`、返り値に `tags` 追加。
+- `src/types/answerSheetBuilder.types.ts` `ASBDefinitionListItem`: `tags?: { id; name; color: string | null }[]` 追加。
+
+### coursework 一覧取得の拡張
+
+- `electron-src/lib/prisma/coursework.ts` `getCourseworks`: `include` に `tags`・`classrooms` 追加。
+- `src/types/coursework.types.ts` `CourseworkSummary`: `tags`・`classrooms` を include 形状に拡張。
+
+### その他
+
+- 解答用紙一覧の削除確認をネイティブ `confirm()` → `AlertDialog` モーダル化（`AnswerSheetDefinitionList.tsx`。destructiveパターンは `ClassroomRemovalDialog.tsx` を踏襲）。
+- 成績算出一覧「次のステップ」ボタンの CSS はみ出し修正（`GradeListContainer.tsx`。アイコンに `shrink-0`、テキストに `min-w-0 truncate`）。
+
+---
+
+## 1. 解答用紙 detail / 1.作成 / 2.書き出し 3ページ分離
+
+### 目的
+
+現状 `/answer-sheet-builder/[definitionId]` がエディタ直行。試験(exam)のワークフロー流儀に揃え、**3ページ構成**（概要 / 1.作成 / 2.書き出し）に分離する。detail は「段階」ではなく概要ページ。
+
+### 新しいルーティング
+
+```
+src/app/answer-sheet-builder/[definitionId]/
+├── layout.tsx        # 新規: パンくずタブ（概要 / 1. 作成 / 2. 書き出し）
+├── page.tsx          # 概要(detail)に書き換え
+├── 01-edit/page.tsx  # 新規: 現エディタ（AnswerSheetBuilderMainView）を移設
+└── 02-export/page.tsx # 新規: 書き出しページ
+```
+
+### 実装ステップ
+
+1. **`[definitionId]/layout.tsx`（新規）** — `exams/[examId]/layout.tsx` を雛形に。
+   - `useParams` で `definitionId`、`usePathname` で現在地判定。
+   - `loadDefinition(definitionId)` で name 取得（`window.electronAPI.answerSheetBuilder.loadDefinition`）。
+   - タブ: `[{ label: "概要", path: "" }, { label: "1. 作成", path: "/01-edit" }, { label: "2. 書き出し", path: "/02-export" }]`。base = `/answer-sheet-builder/${definitionId}`。**現在地判定は `pathname === base + step.path`（exact。exams の `includes` は概要=空pathで誤判定するため不可）**。
+   - パンくず: `解答用紙作成(href) > {name}`。右に「一覧へ戻る」。
+   - `GuardedLink`（`@/components/common/GuardedLink`）＋ `Breadcrumb`系（`@/components/ui/breadcrumb`）＋ `cn`（`@/lib/utils`）。
+   - `<main className="min-h-0 flex-1 overflow-auto">{children}</main>`。
+
+2. **`01-edit/page.tsx`（新規）** — 現 `[definitionId]/page.tsx` の内容をそのまま移設:
+
+   ```tsx
+   "use client"
+   import { useParams } from "next/navigation"
+   import { AnswerSheetBuilderMainView } from "@/components/answer-sheet-builder/AnswerSheetBuilderMainView"
+   export default function Page() {
+     const params = useParams<{ definitionId: string }>()
+     return <AnswerSheetBuilderMainView definitionId={params.definitionId} />
+   }
+   ```
+
+3. **`02-export/page.tsx`（新規）** ＋ **`AnswerSheetExportView`（新規コンポーネント）**
+   - `ExportDialog.tsx`（`src/components/answer-sheet-builder/components/export/ExportDialog.tsx`）の中身（PDF/PNG/印刷ボタン＋DPI入力）を Dialog ラッパーを外してページ化。
+   - `loadDefinition(definitionId)` で `AnswerSheetDefinition` 取得 → `useAnswerSheetExport()`（`exportPdf`/`exportPng`/`printSheet`/`isExporting`）を使用。
+   - 配置は機能内: `src/components/answer-sheet-builder/AnswerSheetExportView.tsx`。
+
+4. **`[definitionId]/page.tsx` を detail に書き換え** ＋ **`AnswerSheetDefinitionDetail`（新規コンポーネント）**
+   - `src/components/answer-sheet-builder/AnswerSheetDefinitionDetail.tsx`。
+   - `loadDefinition` でメタ取得。設問数・配点は `AnswerSheetBuilderMainView.tsx` 120-140行の算出ロジック、または `listAsbDefinitions` の集計を流用。
+   - 表示: 名前 / 用紙サイズ・向き / 設問数 / 合計配点 / レンダーモード / 更新日時。
+   - **個別タグ設定UI**: `EditExamWindow.tsx`（`src/components/exams/forms/EditExamWindow.tsx` 173-236行）を雛形に。Input＋サジェスト（`tagGetAll` フィルタ）＋追加ボタン＋Enter、確定タグは `Badge`＋`X`削除。
+     - 現タグ取得: `window.electronAPI.asbDefinitionTagGetByDefinitionId(definitionId)`。
+     - 反映: `window.electronAPI.asbDefinitionTagSetDefinitionTags(definitionId, tagIds)`（detail なので即時保存が自然）。tag名→id は `tagFindOrCreate`。
+   - 「1. 作成へ」「2. 書き出しへ」の導線ボタン。
+
+5. **`AnswerSheetBuilderMainView.tsx` の書き出し機能を分離**
+   - 出力ボタン（203-211行 `setExportDialogOpen(true)`）を `router.push(\`/answer-sheet-builder/${definition.id}/02-export\`)` に変更（`useRouter` は既にimport済み・45行）。
+   - `ExportDialog` マウント（364-368行）と `exportDialogOpen` state・`ExportDialog` import を削除。
+   - **変換ダイアログ（`ExamIntegrationDialog`）は残す**。
+
+6. **一覧 `AnswerSheetDefinitionList.tsx` の遷移先調整**
+   - 行クリック `handleEdit` → 概要(detail) `/answer-sheet-builder/${id}`。
+   - DropdownMenu「編集」→ `/answer-sheet-builder/${id}/01-edit`。
+   - `handleCreate`（新規作成後）→ `/answer-sheet-builder/${id}/01-edit`（作成直後は編集したい）。
+
+### 注意
+
+- URL 変更（`[definitionId]` = エディタ → 概要）は上記遷移箇所すべてに波及。取りこぼしに注意。
+- エディタは自動保存なので `GuardedLink` の未保存ガードは実質不要だが、一貫性のため使ってよい。
+
+---
+
+## 2. .asb archive のタグ対応（version 1.2.0）
+
+### 設計方針（coursework-archive 流を採用）
+
+exam-archive は subtotalGroup 経由でタグ収集するが .asb には subtotalGroup が無い。**coursework-archive の「Tag本体セクション + tagId参照」＋ `resolveTags`（UUID一次照合 → name upsert）** が最良の雛形。schema は実装済み（`AsbDefinitionTag`）なので **export/import ロジックの追加のみ**。
+
+### 変更ファイル
+
+1. **`src/types/asbArchive.types.ts`**
+   - `AsbArchiveVersion` に `"1.2.0"` 追加、`ASB_CURRENT_VERSION = "1.2.0"`、`ASB_SUPPORTED_VERSIONS` に追加。
+   - 型追加:
+     ```ts
+     export interface ArchiveAsbTag {
+       id: string
+       name: string
+       order: number
+       color: string | null
+     }
+     export interface AsbArchiveData {
+       manifest: AsbArchiveManifest
+       definition: AnswerSheetDefinition
+       tagsData?: ArchiveAsbTag[] // v1.2.0+
+       asbDefinitionTags?: { tagId: string }[] // v1.2.0+ 定義への参照
+     }
+     ```
+
+2. **`electron-src/lib/import/asb-transformers/V1_1_0_to_V1_2_0.ts`（新規）**
+   - `V1_0_0_to_V1_1_0.ts` を雛形に。`fromVersion="1.1.0"`/`toVersion="1.2.0"`。
+   - `transform`: `tagsData`/`asbDefinitionTags` を `?? []` で補完し冪等に、`manifest.version = "1.2.0"`、`warnings: []`。
+   - `asb-transformers/index.ts` の `ASB_TRANSFORMERS` 配列に `new V1_1_0_to_V1_2_0_Transformer()` を追加＋import。
+
+3. **Export `electron-src/lib/export/asb-archive/dataCollector.ts`**
+   - `collectAsbData` を prisma アクセス可能に（`asbDefinitionId` と prisma を渡し非同期化）。
+
+   ```ts
+   const asbDefinitionTags = await prisma.asbDefinitionTag.findMany({
+     where: { asbDefinitionId: definition.id },
+     include: { tag: true },
+   })
+   const tagsData: ArchiveAsbTag[] = asbDefinitionTags.map(
+     (asbDefinitionTag) => ({
+       id: asbDefinitionTag.tag.id,
+       name: asbDefinitionTag.tag.name,
+       order: asbDefinitionTag.tag.order,
+       color: asbDefinitionTag.tag.color,
+     })
+   )
+   const asbDefinitionTagRefs = asbDefinitionTags.map((asbDefinitionTag) => ({
+     tagId: asbDefinitionTag.tagId,
+   }))
+   ```
+   - `archiveCreator.ts` の `createManifest`/ZIP書き込みで `tagsData`/`asbDefinitionTags` をアーカイブに含める。
+
+4. **Import `electron-src/lib/import/asb-archive/dataCreator.ts`**
+   - coursework の `resolveTags`（`electron-src/lib/import/coursework-archive/idRemapper.ts` 162-185行）を移植:
+     ```ts
+     const tagMap = new Map<string, string>()
+     for (const archiveTag of tagsData ?? []) {
+       const byId = await tx.tag.findUnique({ where: { id: archiveTag.id } })
+       if (byId) {
+         tagMap.set(archiveTag.id, byId.id)
+         continue
+       }
+       const tag = await tx.tag.upsert({
+         where: { name: archiveTag.name },
+         create: {
+           name: archiveTag.name,
+           order: archiveTag.order,
+           color: archiveTag.color,
+         },
+         update: {},
+       })
+       tagMap.set(archiveTag.id, tag.id)
+     }
+     for (const ref of asbDefinitionTags ?? []) {
+       const realTagId = tagMap.get(ref.tagId)
+       if (!realTagId) continue
+       const existing = await tx.asbDefinitionTag.findUnique({
+         where: {
+           asbDefinitionId_tagId: {
+             asbDefinitionId: newDefinitionId,
+             tagId: realTagId,
+           },
+         },
+       })
+       if (!existing) {
+         await tx.asbDefinitionTag.create({
+           data: { asbDefinitionId: newDefinitionId, tagId: realTagId },
+         })
+       }
+     }
+     ```
+   - **`name @unique` の環境またぎ衝突は必ず `upsert({ where: { name } })` で吸収**（tagId 直挿入は禁止）。
+   - **トランザクション境界**: 現状 `dataCreator` は `saveAsbDefinition` 経由で保存。タグ解決・`AsbDefinitionTag` 挿入を定義保存と同一トランザクションに載せられるか要確認（`dataCreator.ts` と `saveAsbDefinition` 全文を確認して組み込み先を決める）。
+
+5. **テスト新設**: `__tests__/import-export/` に ASB transformer チェーン＋round-trip テスト（exam版 `examTransformerChain.test.ts` / `charGuideRoundTrip.test.ts` を参考）。旧 1.1.0 形状フィクスチャで `tagsData` 未定義→no-op を検証。
+
+### 参照
+
+- `src/types/examArchive.types.ts` `ArchiveTagsData`（1073-1098）
+- `electron-src/lib/import/coursework-archive/idRemapper.ts` `resolveTags`（162-185）← 最良の雛形
+- `electron-src/lib/import/exam-archive/dataCreator.ts`（152-238）
+
+---
+
+## 3. coursework / grade の 01-setup を detail編集モーダル化
+
+### 目的
+
+試験外成績資料(coursework)・成績算出(grade)の「01-setup（基本設定）」段階を廃止し、試験(exam)流儀の **detail画面＋編集モーダル** に揃える。ワークフロー/パンくず再編を含む。
+
+### 未調査（着手前に調べる）
+
+- coursework: `src/app/coursework/[courseworkId]/` のルーティング・layout・01-setup が持つ設定項目（name/description/date/学級/タグ）と、その保存API。detail画面の有無。
+- grade: `src/app/grades/[gradeId]/` 同様。01-setup の設定項目（name/description/referenceDate/学級）と保存API。
+- 試験(exam)の detail＋編集モーダルの実装（`src/components/exams/detail/`、`EditExamWindow.tsx`）を雛形として確認。
+
+### 想定ステップ（調査後に確定）
+
+1. 各 `[id]/layout.tsx` のワークフローステップ配列から `01-setup` を除去し、以降を繰り上げ。
+2. detail画面（`[id]/page.tsx` 相当）に基本設定の表示＋「編集」ボタン→編集モーダル（`EditExamWindow` 相当）を新設。
+3. 01-setup ページ・コンポーネントを削除（re-export は残さず import 元を全更新 — CLAUDE.md 方針）。
+4. 新規作成後の遷移先（現状 `/coursework/${id}/01-setup` / `/grades/${id}/01-setup`）を detail へ変更。`CourseworkListContainer`/`GradeListContainer` の `handleCreated`・import後遷移も更新。
+5. パンくず・「次のステップ」導線の整合。
+
+### 注意
+
+- 新規作成直後は設定が空。detail で編集モーダルを自動で開く等の UX 配慮を検討。
+- grade/coursework の学級管理は `ClassRosterManager`（共通化済み、`project_class_statistics_phase5_blocked` 参照）。基本設定と学級管理の切り分けに注意。
+
+---
+
+## 4. 最終検証（Phase 8）
+
+- `npm run typecheck`（Next.js + electron-src 両方）
+- `npm run lint`（eslint + prettier --check）。**format は自分の変更ファイルのみ `prettier --write`**（並行セッション注意。`useDataSources.ts` 等の既存未ステージ変更には触れない）。
+- `npx vitest run __tests__/import-export/`（archive 変更時）＋関連テスト。
+- 動作確認: 各一覧のフィルタ・一括タグ付与・削除モーダル、解答用紙の detail/edit/export 遷移、.asb round-trip でタグ往復。
+
+---
+
+## 進め方の推奨
+
+破壊的なルーティング変更（1・3）は取りこぼしが出やすいので、**1つのPhaseごとに typecheck を通してからコミット**する。順序は 1（解答用紙分離）→ 2（archive）→ 3（coursework/grade setup）→ 4（検証）。2 は 1 と独立なので順不同可。
+
+---
+
+## code-review（high effort, 2026-07-13）の指摘
+
+**correctness はこのセッションで修正済み**:
+
+- 日付フィルタの UTC/ローカル日ズレ → `useListFilter` でローカル日（`getFullYear/getMonth/getDate`）比較に。
+- ASB: 削除後も id が選択に残り FK 失敗を握りつぶし誤 success → `confirmDelete` で `selectedIds` から削除 id を除去。
+- coursework: `setCourseworkTags` 全置換による stale タグ消失＋`{success:false}` 無視 → 個別追加 API `addCourseworkTag`（`courseworkTag.upsert`、冪等）を新設し、一括付与を `coursework.addTag` へ。失敗は throw して error トースト。
+- フィルタ0件で「該当なし」が出ない（3画面）→ 各 TableBody に条件付き「条件に一致する〜がありません」行。ASB は空状態ガードを `definitions.length===0` に変更。
+- loadTags の空 catch → `console.error` でログ。
+- 命名: `useListFilter` の `item` → `listItem`（濁り名の是正）。
+
+**cleanup（本リファクタ内で解消・計画送り）**:
+
+- **ExamList を useListFilter/ListFilterBar に移行**（現状インライン重複）。試験一覧の挙動を壊さないよう単体検証しながら。
+- **行選択の共通化**: `selectedIds`/`toggleSelect`/`toggleSelectAll`/`allSelected` が coursework/ASB で重複 → `useRowSelection<T>` hook 化。
+- **一括タグ付与の共通化**: coursework(addTag)と ASB(asbDefinitionTagCreate)で意味論が揃ったので共通ヘルパーに。
+- **option 集約の共通化**: grade/coursework の学級 `nameById` 集約が重複。
+- **`.asb` archive のタグ未対応（correctness）は §2 で対応**。

--- a/electron-src/ipc-handlers/courseworkHandlers.ts
+++ b/electron-src/ipc-handlers/courseworkHandlers.ts
@@ -16,6 +16,7 @@ import {
   previewCourseworkImport,
 } from "../lib/import/coursework-archive"
 import {
+  addCourseworkTag,
   addStudentsFromClassroomToCoursework,
   addStudentsToCoursework,
   batchUpsertCourseworkScores,
@@ -237,6 +238,13 @@ export function setupCourseworkHandlers(): void {
     "coursework:setTags",
     async (courseworkId: string, tagIds: string[]) => {
       return setCourseworkTags(courseworkId, tagIds)
+    }
+  )
+
+  registerHandler(
+    "coursework:addTag",
+    async (courseworkId: string, tagId: string) => {
+      return addCourseworkTag(courseworkId, tagId)
     }
   )
 

--- a/electron-src/ipc-handlers/tagHandlers.ts
+++ b/electron-src/ipc-handlers/tagHandlers.ts
@@ -3,6 +3,12 @@
  */
 
 import {
+  createAsbDefinitionTag,
+  deleteAsbDefinitionTag,
+  getAsbDefinitionTags,
+  setAsbDefinitionTags,
+} from "../lib/prisma/asbDefinitionTag"
+import {
   createExamTag,
   deleteExamTag,
   getExamTags,
@@ -97,6 +103,32 @@ export function setupTagHandlers(): void {
     "examTag:setExamTags",
     async (examId: string, tagIds: string[]) => {
       return setExamTags(examId, tagIds)
+    }
+  )
+
+  // AsbDefinitionTag CRUD
+  registerHandler(
+    "asbDefinitionTag:getByDefinitionId",
+    async (asbDefinitionId: string) => {
+      return getAsbDefinitionTags(asbDefinitionId)
+    }
+  )
+
+  registerHandler(
+    "asbDefinitionTag:create",
+    async (data: { asbDefinitionId: string; tagId: string }) => {
+      return createAsbDefinitionTag(data)
+    }
+  )
+
+  registerHandler("asbDefinitionTag:delete", async (id: string) => {
+    return deleteAsbDefinitionTag(id)
+  })
+
+  registerHandler(
+    "asbDefinitionTag:setDefinitionTags",
+    async (asbDefinitionId: string, tagIds: string[]) => {
+      return setAsbDefinitionTags(asbDefinitionId, tagIds)
     }
   )
 }

--- a/electron-src/lib/prisma/asbDefinition.ts
+++ b/electron-src/lib/prisma/asbDefinition.ts
@@ -121,6 +121,11 @@ export async function listAsbDefinitions(
       orientation: true,
       updatedAt: true,
       createdAt: true,
+      tags: {
+        select: {
+          tag: true,
+        },
+      },
       majorQuestions: {
         select: {
           subQuestions: {
@@ -169,6 +174,7 @@ export async function listAsbDefinitions(
       orientation: row.orientation,
       questionCount,
       totalPoints,
+      tags: row.tags.map((asbDefinitionTag) => asbDefinitionTag.tag),
       updatedAt: row.updatedAt.toISOString(),
       createdAt: row.createdAt.toISOString(),
     }

--- a/electron-src/lib/prisma/asbDefinitionTag.ts
+++ b/electron-src/lib/prisma/asbDefinitionTag.ts
@@ -1,0 +1,58 @@
+/**
+ * AsbDefinitionTag（解答用紙定義-タグ関連）のPrisma操作関数
+ */
+
+import prisma from "./client"
+
+/**
+ * 解答用紙定義に紐づくタグを取得
+ */
+export async function getAsbDefinitionTags(asbDefinitionId: string) {
+  return prisma.asbDefinitionTag.findMany({
+    where: { asbDefinitionId },
+    include: {
+      tag: true,
+    },
+  })
+}
+
+/**
+ * 解答用紙定義-タグ関連を作成
+ */
+export async function createAsbDefinitionTag(data: {
+  asbDefinitionId: string
+  tagId: string
+}) {
+  return prisma.asbDefinitionTag.create({
+    data,
+  })
+}
+
+/**
+ * 解答用紙定義-タグ関連を削除
+ */
+export async function deleteAsbDefinitionTag(id: string) {
+  return prisma.asbDefinitionTag.delete({
+    where: { id },
+  })
+}
+
+/**
+ * 解答用紙定義のタグを一括設定（既存を全削除して再作成）
+ */
+export async function setAsbDefinitionTags(
+  asbDefinitionId: string,
+  tagIds: string[]
+) {
+  return prisma.$transaction(async (tx) => {
+    await tx.asbDefinitionTag.deleteMany({ where: { asbDefinitionId } })
+    if (tagIds.length === 0) return []
+    await tx.asbDefinitionTag.createMany({
+      data: tagIds.map((tagId) => ({ asbDefinitionId, tagId })),
+    })
+    return tx.asbDefinitionTag.findMany({
+      where: { asbDefinitionId },
+      include: { tag: true },
+    })
+  })
+}

--- a/electron-src/lib/prisma/coursework.ts
+++ b/electron-src/lib/prisma/coursework.ts
@@ -45,6 +45,13 @@ export async function getCourseworks() {
     const courseworks = await prisma.coursework.findMany({
       include: {
         _count: { select: { items: true, students: true } },
+        tags: {
+          include: { tag: { select: { id: true, name: true, color: true } } },
+        },
+        classrooms: {
+          include: { classroom: { select: { id: true, name: true } } },
+          orderBy: { order: "asc" },
+        },
       },
       orderBy: [{ date: "desc" }, { createdAt: "desc" }],
     })
@@ -891,6 +898,24 @@ export async function setCourseworkTags(
     return { success: true }
   } catch (error) {
     console.error("Error setting coursework tags:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
+
+/** 資料にタグを1件追加（既存タグは保持・冪等）。一括付与での既存タグ消失を避ける */
+export async function addCourseworkTag(courseworkId: string, tagId: string) {
+  try {
+    await prisma.courseworkTag.upsert({
+      where: { courseworkId_tagId: { courseworkId, tagId } },
+      update: {},
+      create: { courseworkId, tagId },
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Error adding coursework tag:", error)
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",

--- a/electron-src/preload-apis/courseworkApi.ts
+++ b/electron-src/preload-apis/courseworkApi.ts
@@ -135,6 +135,8 @@ export function createCourseworkApi() {
       // タグ
       setTags: (courseworkId: string, tagIds: string[]) =>
         ipcRenderer.invoke("coursework:setTags", courseworkId, tagIds),
+      addTag: (courseworkId: string, tagId: string) =>
+        ipcRenderer.invoke("coursework:addTag", courseworkId, tagId),
 
       // アーカイブ（.coursework のエクスポート／インポート）
       exportArchive: (courseworkId: string) =>

--- a/electron-src/preload-apis/tagApi.ts
+++ b/electron-src/preload-apis/tagApi.ts
@@ -33,5 +33,24 @@ export function createTagApi() {
     examTagDelete: (id: string) => ipcRenderer.invoke("examTag:delete", id),
     examTagSetExamTags: (examId: string, tagIds: string[]) =>
       ipcRenderer.invoke("examTag:setExamTags", examId, tagIds),
+
+    // AsbDefinitionTag（解答用紙定義-タグ関連）
+    asbDefinitionTagGetByDefinitionId: (asbDefinitionId: string) =>
+      ipcRenderer.invoke("asbDefinitionTag:getByDefinitionId", asbDefinitionId),
+    asbDefinitionTagCreate: (data: {
+      asbDefinitionId: string
+      tagId: string
+    }) => ipcRenderer.invoke("asbDefinitionTag:create", data),
+    asbDefinitionTagDelete: (id: string) =>
+      ipcRenderer.invoke("asbDefinitionTag:delete", id),
+    asbDefinitionTagSetDefinitionTags: (
+      asbDefinitionId: string,
+      tagIds: string[]
+    ) =>
+      ipcRenderer.invoke(
+        "asbDefinitionTag:setDefinitionTags",
+        asbDefinitionId,
+        tagIds
+      ),
   }
 }

--- a/prisma/migrations/20260713000000_add_asb_definition_tag/migration.sql
+++ b/prisma/migrations/20260713000000_add_asb_definition_tag/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable: 解答用紙定義のタグ（既存 Tag と多対多）
+CREATE TABLE "AsbDefinitionTag" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "asbDefinitionId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AsbDefinitionTag_asbDefinitionId_fkey" FOREIGN KEY ("asbDefinitionId") REFERENCES "AsbDefinition" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "AsbDefinitionTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- CreateIndex
+CREATE INDEX "AsbDefinitionTag_asbDefinitionId_idx" ON "AsbDefinitionTag"("asbDefinitionId");
+
+-- CreateIndex
+CREATE INDEX "AsbDefinitionTag_tagId_idx" ON "AsbDefinitionTag"("tagId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AsbDefinitionTag_asbDefinitionId_tagId_key" ON "AsbDefinitionTag"("asbDefinitionId", "tagId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -422,6 +422,7 @@ model Tag {
   tagSubtotalGroups TagSubtotalGroup[]
   examTags          ExamTag[]
   courseworkTags    CourseworkTag[]
+  asbDefinitionTags AsbDefinitionTag[]
 }
 
 model TagSubtotalGroup {
@@ -451,6 +452,22 @@ model ExamTag {
 
   @@unique([examId, tagId])
   @@index([examId])
+  @@index([tagId])
+}
+
+/// 解答用紙定義のタグ（既存 Tag と多対多）
+model AsbDefinitionTag {
+  id              String   @id @default(uuid())
+  asbDefinitionId String
+  tagId           String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  asbDefinition AsbDefinition @relation(fields: [asbDefinitionId], references: [id], onDelete: Cascade)
+  tag           Tag           @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([asbDefinitionId, tagId])
+  @@index([asbDefinitionId])
   @@index([tagId])
 }
 
@@ -1082,6 +1099,7 @@ model AsbDefinition {
 
   majorQuestions AsbMajorQuestion[]
   headerFields   AsbHeaderField[]
+  tags           AsbDefinitionTag[]
 
   @@index([userId])
 }

--- a/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
@@ -10,10 +10,24 @@ import {
   Trash2,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 
+import { BulkTagAssignButton } from "@/components/common/BulkTagAssignButton"
+import { ListFilterBar } from "@/components/common/ListFilterBar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,11 +44,23 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { useAuth } from "@/contexts/AuthContext"
+import { type ListFilterAccessors, useListFilter } from "@/hooks/useListFilter"
+import type { ASBDefinitionListItem } from "@/types/answerSheetBuilder.types"
 
 import { useAnswerSheetDefinitions } from "./hooks/useAnswerSheetDefinitions"
 
 type SortKey = "name" | "updatedAt" | "questionCount" | "totalPoints"
 type SortDir = "asc" | "desc"
+
+/** 解答用紙一覧のフィルタ対象値（名前・タグ名／タグ／更新日） */
+const ASB_FILTER_ACCESSORS: ListFilterAccessors<ASBDefinitionListItem> = {
+  searchTexts: (definition) => [
+    definition.name,
+    ...(definition.tags ?? []).map((tag) => tag.name),
+  ],
+  tagIds: (definition) => (definition.tags ?? []).map((tag) => tag.id),
+  date: (definition) => definition.updatedAt ?? null,
+}
 
 /**
  * 解答用紙定義の一覧表示・作成・複製・削除を行うコンポーネント。
@@ -52,6 +78,36 @@ export function AnswerSheetDefinitionList() {
 
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt")
   const [sortDir, setSortDir] = useState<SortDir>("desc")
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
+  const [deleteTarget, setDeleteTarget] = useState<{
+    id: string
+    name: string
+  } | null>(null)
+
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        setAllTags(await window.electronAPI.tagGetAll())
+      } catch (error) {
+        console.error("Error loading tags:", error)
+      }
+    }
+    void loadTags()
+  }, [])
+
+  const {
+    filteredItems: filteredDefinitions,
+    searchTerm,
+    setSearchTerm,
+    filterTagIds,
+    toggleTagId,
+    clearTagIds,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+  } = useListFilter(definitions, ASB_FILTER_ACCESSORS)
 
   const toggleSort = useCallback(
     (key: SortKey) => {
@@ -65,7 +121,7 @@ export function AnswerSheetDefinitionList() {
     [sortKey]
   )
 
-  const sorted = [...definitions].sort((definitionA, definitionB) => {
+  const sorted = [...filteredDefinitions].sort((definitionA, definitionB) => {
     const direction = sortDir === "asc" ? 1 : -1
     switch (sortKey) {
       case "name":
@@ -92,6 +148,64 @@ export function AnswerSheetDefinitionList() {
     }
   })
 
+  const toggleSelect = useCallback((definitionId: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(definitionId)
+      } else {
+        next.delete(definitionId)
+      }
+      return next
+    })
+  }, [])
+
+  const allSelected =
+    sorted.length > 0 &&
+    sorted.every((definition) => selectedIds.has(definition.id))
+
+  const toggleSelectAll = useCallback(
+    (checked: boolean) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        for (const definition of sorted) {
+          if (checked) {
+            next.add(definition.id)
+          } else {
+            next.delete(definition.id)
+          }
+        }
+        return next
+      })
+    },
+    [sorted]
+  )
+
+  const handleBulkAddTag = async (tagName: string) => {
+    try {
+      const tag = await window.electronAPI.tagFindOrCreate(tagName)
+      for (const definitionId of selectedIds) {
+        try {
+          await window.electronAPI.asbDefinitionTagCreate({
+            asbDefinitionId: definitionId,
+            tagId: tag.id,
+          })
+        } catch {
+          // 既に紐づいている場合は unique 制約で失敗するが無視
+        }
+      }
+      toast.success("タグを追加しました", {
+        description: `${selectedIds.size}件の解答用紙に「${tagName}」を追加`,
+      })
+      setSelectedIds(new Set())
+      setAllTags(await window.electronAPI.tagGetAll())
+      await loadDefinitions()
+    } catch (error) {
+      console.error("Error bulk adding tag:", error)
+      toast.error("タグの追加に失敗しました")
+    }
+  }
+
   const handleCreate = useCallback(async () => {
     if (!user?.id) return
     const api = window.electronAPI?.answerSheetBuilder
@@ -115,13 +229,17 @@ export function AnswerSheetDefinitionList() {
     [router]
   )
 
-  const handleDelete = useCallback(
-    async (id: string, name: string) => {
-      if (!confirm(`「${name}」を削除しますか？`)) return
-      await deleteDefinition(id)
-    },
-    [deleteDefinition]
-  )
+  const confirmDelete = async () => {
+    if (!deleteTarget) return
+    await deleteDefinition(deleteTarget.id)
+    // 削除した定義の id を選択から除く（stale id への一括タグ付与を防ぐ）
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      next.delete(deleteTarget.id)
+      return next
+    })
+    setDeleteTarget(null)
+  }
 
   const handleExport = useCallback(async (definitionId: string) => {
     const api = window.electronAPI?.answerSheetBuilder
@@ -207,11 +325,45 @@ export function AnswerSheetDefinitionList() {
             <FolderInput className="mr-2 h-4 w-4" />
             .asb 読み込み
           </Button>
+          {selectedIds.size > 0 && (
+            <>
+              <span className="text-muted-foreground text-sm">
+                {selectedIds.size}件選択中
+              </span>
+              <BulkTagAssignButton
+                selectedCount={selectedIds.size}
+                allTags={allTags}
+                onAssign={handleBulkAddTag}
+              />
+            </>
+          )}
         </div>
+        {definitions.length > 0 && (
+          <ListFilterBar
+            searchTerm={searchTerm}
+            onSearchTermChange={setSearchTerm}
+            searchPlaceholder="名前・タグで検索"
+            totalCount={definitions.length}
+            filteredCount={filteredDefinitions.length}
+            tagFilter={{
+              options: allTags,
+              selectedIds: filterTagIds,
+              onToggle: toggleTagId,
+              onClear: clearTagIds,
+            }}
+            dateRangeFilter={{
+              label: "更新日",
+              from: dateFrom,
+              to: dateTo,
+              onFromChange: setDateFrom,
+              onToChange: setDateTo,
+            }}
+          />
+        )}
       </div>
 
       <div className="min-h-0 flex-1 p-4">
-        {sorted.length === 0 ? (
+        {definitions.length === 0 ? (
           <div className="flex h-48 flex-col items-center justify-center rounded-lg border-2 border-dashed">
             <p className="text-muted-foreground mb-2">
               解答用紙定義がありません
@@ -226,6 +378,15 @@ export function AnswerSheetDefinitionList() {
             <Table wrapperClassName="h-full">
               <TableHeader className="bg-card sticky top-0 z-10">
                 <TableRow className="hover:bg-transparent">
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={allSelected}
+                      onCheckedChange={(checked) =>
+                        toggleSelectAll(checked === true)
+                      }
+                      aria-label="全選択"
+                    />
+                  </TableHead>
                   <TableHead
                     className="cursor-pointer select-none"
                     onClick={() => toggleSort("name")}
@@ -255,14 +416,46 @@ export function AnswerSheetDefinitionList() {
                 </TableRow>
               </TableHeader>
               <TableBody>
+                {sorted.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="text-muted-foreground py-8 text-center"
+                    >
+                      条件に一致する解答用紙がありません
+                    </TableCell>
+                  </TableRow>
+                )}
                 {sorted.map((definition) => (
                   <TableRow
                     key={definition.id}
                     className="group cursor-pointer"
                     onClick={() => handleEdit(definition.id)}
                   >
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <Checkbox
+                        checked={selectedIds.has(definition.id)}
+                        onCheckedChange={(checked) =>
+                          toggleSelect(definition.id, checked === true)
+                        }
+                        aria-label={`${definition.name} を選択`}
+                      />
+                    </TableCell>
                     <TableCell className="font-medium">
                       {definition.name}
+                      {definition.tags && definition.tags.length > 0 && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {definition.tags.map((tag) => (
+                            <Badge
+                              key={tag.id}
+                              variant="secondary"
+                              className="text-xs"
+                            >
+                              {tag.name}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
                       {definition.paperSize ?? "-"}{" "}
@@ -317,7 +510,10 @@ export function AnswerSheetDefinitionList() {
                           <DropdownMenuItem
                             className="text-destructive"
                             onClick={() =>
-                              handleDelete(definition.id, definition.name)
+                              setDeleteTarget({
+                                id: definition.id,
+                                name: definition.name,
+                              })
                             }
                           >
                             <Trash2 className="mr-2 h-4 w-4" />
@@ -333,6 +529,32 @@ export function AnswerSheetDefinitionList() {
           </div>
         )}
       </div>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>解答用紙を削除しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              「{deleteTarget?.name}」を削除します。この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(e) => {
+                e.preventDefault()
+                void confirmDelete()
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/components/common/BulkTagAssignButton.tsx
+++ b/src/components/common/BulkTagAssignButton.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { Tag } from "lucide-react"
+import { useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+interface BulkTagAssignButtonProps {
+  /** 選択中の件数（0 のときは呼び出し側で非表示にする想定） */
+  selectedCount: number
+  /** 既存タグの候補一覧 */
+  allTags: { id: string; name: string }[]
+  /** タグ名を受け取り、選択中アイテムへ付与する（新規作成含む） */
+  onAssign: (tagName: string) => Promise<void>
+}
+
+/**
+ * 選択中アイテムへタグを一括付与するボタン＋Popover。
+ * タグ名の直接入力（Enter で新規作成込み）と既存タグからの選択に対応する。
+ */
+export function BulkTagAssignButton({
+  selectedCount,
+  allTags,
+  onAssign,
+}: BulkTagAssignButtonProps) {
+  const [open, setOpen] = useState(false)
+  const [tagInput, setTagInput] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleAssign = async (tagName: string) => {
+    if (!tagName.trim()) return
+    await onAssign(tagName.trim())
+    setTagInput("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="rounded-lg">
+          <Tag className="mr-2 h-4 w-4" />
+          タグを一括追加
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-3" align="start">
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-xs">
+            選択中の{selectedCount}件にタグを追加
+          </p>
+          <Input
+            ref={inputRef}
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                e.preventDefault()
+                void handleAssign(tagInput)
+              }
+            }}
+            placeholder="タグ名を入力してEnter"
+            className="h-8 text-sm"
+            autoFocus
+          />
+          {allTags.length > 0 && (
+            <div className="max-h-28 overflow-y-auto">
+              {allTags
+                .filter(
+                  (tag) =>
+                    !tagInput.trim() ||
+                    tag.name
+                      .toLowerCase()
+                      .includes(tagInput.trim().toLowerCase())
+                )
+                .map((tag) => (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    className="hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm"
+                    onClick={() => void handleAssign(tag.name)}
+                  >
+                    <Tag className="h-3 w-3 opacity-50" />
+                    {tag.name}
+                  </button>
+                ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/common/ListFilterBar.tsx
+++ b/src/components/common/ListFilterBar.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import type { LucideIcon } from "lucide-react"
+import { Calendar, School, Search, Tag, X as XIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+/** 複数選択フィルタ（タグ・学級）の選択肢1件 */
+export interface FilterOption {
+  id: string
+  name: string
+}
+
+/** タグ・学級など複数選択フィルタの設定 */
+export interface MultiSelectFilterConfig {
+  options: FilterOption[]
+  selectedIds: Set<string>
+  onToggle: (id: string, checked: boolean) => void
+  onClear: () => void
+}
+
+/** 日付範囲フィルタの設定（値は YYYY-MM-DD、空文字は未指定） */
+export interface DateRangeFilterConfig {
+  label: string
+  from: string
+  to: string
+  onFromChange: (value: string) => void
+  onToChange: (value: string) => void
+}
+
+interface ListFilterBarProps {
+  searchTerm: string
+  onSearchTermChange: (value: string) => void
+  searchPlaceholder: string
+  totalCount: number
+  filteredCount: number
+  tagFilter?: MultiSelectFilterConfig
+  classroomFilter?: MultiSelectFilterConfig
+  dateRangeFilter?: DateRangeFilterConfig
+  /** 左側に差し込む画面固有の要素（一括タグ付与ボタン等） */
+  leading?: ReactNode
+}
+
+/** 一覧共通のフィルタバー（検索・タグ・学級・日付範囲・件数表示） */
+export function ListFilterBar({
+  searchTerm,
+  onSearchTermChange,
+  searchPlaceholder,
+  totalCount,
+  filteredCount,
+  tagFilter,
+  classroomFilter,
+  dateRangeFilter,
+  leading,
+}: ListFilterBarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {leading}
+      <div className="ml-auto flex flex-wrap items-center gap-2">
+        <div className="relative">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+          <Input
+            value={searchTerm}
+            onChange={(e) => onSearchTermChange(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="h-8 w-48 pl-8 text-sm"
+          />
+        </div>
+        {tagFilter && (
+          <MultiSelectFilter label="タグ" icon={Tag} config={tagFilter} />
+        )}
+        {classroomFilter && (
+          <MultiSelectFilter
+            label="学級"
+            icon={School}
+            config={classroomFilter}
+          />
+        )}
+        {dateRangeFilter && <DateRangeFilter config={dateRangeFilter} />}
+        <span className="text-muted-foreground text-xs">
+          {filteredCount === totalCount
+            ? `${totalCount}件`
+            : `${filteredCount} / ${totalCount}件`}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function MultiSelectFilter({
+  label,
+  icon: Icon,
+  config,
+}: {
+  label: string
+  icon: LucideIcon
+  config: MultiSelectFilterConfig
+}) {
+  const { options, selectedIds, onToggle, onClear } = config
+  if (options.length === 0) return null
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={selectedIds.size > 0 ? "border-primary text-primary" : ""}
+        >
+          <Icon className="mr-1.5 h-3.5 w-3.5" />
+          {label}
+          {selectedIds.size > 0 && (
+            <Badge
+              variant="secondary"
+              className="ml-1.5 h-5 min-w-5 px-1 text-xs"
+            >
+              {selectedIds.size}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-2" align="start">
+        <div className="max-h-48 space-y-1 overflow-y-auto">
+          {options.map((option) => (
+            <label
+              key={option.id}
+              className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm"
+            >
+              <Checkbox
+                checked={selectedIds.has(option.id)}
+                onCheckedChange={(checked) =>
+                  onToggle(option.id, checked === true)
+                }
+              />
+              {option.name}
+            </label>
+          ))}
+        </div>
+        {selectedIds.size > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-1 w-full text-xs"
+            onClick={onClear}
+          >
+            <XIcon className="mr-1 h-3 w-3" />
+            フィルタをクリア
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function DateRangeFilter({ config }: { config: DateRangeFilterConfig }) {
+  const { label, from, to, onFromChange, onToChange } = config
+  const active = from !== "" || to !== ""
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={active ? "border-primary text-primary" : ""}
+        >
+          <Calendar className="mr-1.5 h-3.5 w-3.5" />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 space-y-2 p-3" align="start">
+        <div className="space-y-1">
+          <span className="text-muted-foreground text-xs">開始</span>
+          <Input
+            type="date"
+            value={from}
+            onChange={(e) => onFromChange(e.target.value)}
+            className="h-8 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <span className="text-muted-foreground text-xs">終了</span>
+          <Input
+            type="date"
+            value={to}
+            onChange={(e) => onToChange(e.target.value)}
+            className="h-8 text-sm"
+          />
+        </div>
+        {active && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full text-xs"
+            onClick={() => {
+              onFromChange("")
+              onToChange("")
+            }}
+          >
+            <XIcon className="mr-1 h-3 w-3" />
+            クリア
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/coursework/list/CourseworkListContainer.tsx
+++ b/src/components/coursework/list/CourseworkListContainer.tsx
@@ -9,10 +9,14 @@ import {
   Trash2,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
+import { BulkTagAssignButton } from "@/components/common/BulkTagAssignButton"
+import { ListFilterBar } from "@/components/common/ListFilterBar"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +31,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { type ListFilterAccessors, useListFilter } from "@/hooks/useListFilter"
 import type { CourseworkSummary } from "@/types/coursework.types"
 import type {
   CourseworkArchiveImportPreview,
@@ -35,6 +40,25 @@ import type {
 
 import { CourseworkCreateDialog } from "./CourseworkCreateDialog"
 import { CourseworkImportDialog } from "./CourseworkImportDialog"
+
+/** 試験外成績資料一覧のフィルタ対象値（名前・説明・タグ名・学級名／タグ／学級／実施日） */
+const COURSEWORK_FILTER_ACCESSORS: ListFilterAccessors<CourseworkSummary> = {
+  searchTexts: (coursework) => [
+    coursework.name,
+    coursework.description,
+    ...coursework.tags.map((courseworkTag) => courseworkTag.tag.name),
+    ...coursework.classrooms.map(
+      (courseworkClassroom) => courseworkClassroom.classroom.name
+    ),
+  ],
+  tagIds: (coursework) =>
+    coursework.tags.map((courseworkTag) => courseworkTag.tag.id),
+  classroomIds: (coursework) =>
+    coursework.classrooms.map(
+      (courseworkClassroom) => courseworkClassroom.classroomId
+    ),
+  date: (coursework) => coursework.date,
+}
 
 /**
  * 試験外成績資料（Coursework）の一覧コンテナ
@@ -54,6 +78,8 @@ export function CourseworkListContainer() {
     null
   )
   const [importing, setImporting] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
 
   const loadCourseworks = useCallback(async () => {
     try {
@@ -71,6 +97,17 @@ export function CourseworkListContainer() {
   useEffect(() => {
     loadCourseworks()
   }, [loadCourseworks])
+
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        setAllTags(await window.electronAPI.tagGetAll())
+      } catch (error) {
+        console.error("Error loading tags:", error)
+      }
+    }
+    void loadTags()
+  }, [])
 
   const handleCreated = (id: string) => {
     setShowCreateDialog(false)
@@ -175,6 +212,97 @@ export function CourseworkListContainer() {
     setImportArchivePath(null)
   }
 
+  const toggleSelect = useCallback((courseworkId: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(courseworkId)
+      } else {
+        next.delete(courseworkId)
+      }
+      return next
+    })
+  }, [])
+
+  // 選択中の各資料へ、既存タグを保持したままタグを追加する
+  const handleBulkAddTag = async (tagName: string) => {
+    try {
+      const tag = await window.electronAPI.tagFindOrCreate(tagName)
+      const targetCourseworks = courseworks.filter((coursework) =>
+        selectedIds.has(coursework.id)
+      )
+      for (const coursework of targetCourseworks) {
+        // 既存タグを保持したまま1件追加（全置換 setTags による stale 消失を回避）
+        const result = await window.electronAPI.coursework.addTag(
+          coursework.id,
+          tag.id
+        )
+        if (!result.success) {
+          throw new Error(result.error ?? "タグの追加に失敗しました")
+        }
+      }
+      toast.success("タグを追加しました", {
+        description: `${targetCourseworks.length}件の資料に「${tagName}」を追加`,
+      })
+      setSelectedIds(new Set())
+      setAllTags(await window.electronAPI.tagGetAll())
+      await loadCourseworks()
+    } catch (error) {
+      console.error("Error bulk adding tag:", error)
+      toast.error("タグの追加に失敗しました")
+    }
+  }
+
+  const classroomOptions = useMemo(() => {
+    const nameById = new Map<string, string>()
+    for (const coursework of courseworks) {
+      for (const courseworkClassroom of coursework.classrooms) {
+        nameById.set(
+          courseworkClassroom.classroom.id,
+          courseworkClassroom.classroom.name
+        )
+      }
+    }
+    return [...nameById.entries()].map(([id, name]) => ({ id, name }))
+  }, [courseworks])
+
+  const {
+    filteredItems: filteredCourseworks,
+    searchTerm,
+    setSearchTerm,
+    filterTagIds,
+    toggleTagId,
+    clearTagIds,
+    filterClassroomIds,
+    toggleClassroomId,
+    clearClassroomIds,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+  } = useListFilter(courseworks, COURSEWORK_FILTER_ACCESSORS)
+
+  const allSelected =
+    filteredCourseworks.length > 0 &&
+    filteredCourseworks.every((coursework) => selectedIds.has(coursework.id))
+
+  const toggleSelectAll = useCallback(
+    (checked: boolean) => {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        for (const coursework of filteredCourseworks) {
+          if (checked) {
+            next.add(coursework.id)
+          } else {
+            next.delete(coursework.id)
+          }
+        }
+        return next
+      })
+    },
+    [filteredCourseworks]
+  )
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -203,7 +331,47 @@ export function CourseworkListContainer() {
             <FolderInput className="mr-2 h-4 w-4" />
             .coursework 読み込み
           </Button>
+          {selectedIds.size > 0 && (
+            <>
+              <span className="text-muted-foreground text-sm">
+                {selectedIds.size}件選択中
+              </span>
+              <BulkTagAssignButton
+                selectedCount={selectedIds.size}
+                allTags={allTags}
+                onAssign={handleBulkAddTag}
+              />
+            </>
+          )}
         </div>
+        {courseworks.length > 0 && (
+          <ListFilterBar
+            searchTerm={searchTerm}
+            onSearchTermChange={setSearchTerm}
+            searchPlaceholder="資料名・タグ・学級で検索"
+            totalCount={courseworks.length}
+            filteredCount={filteredCourseworks.length}
+            tagFilter={{
+              options: allTags,
+              selectedIds: filterTagIds,
+              onToggle: toggleTagId,
+              onClear: clearTagIds,
+            }}
+            classroomFilter={{
+              options: classroomOptions,
+              selectedIds: filterClassroomIds,
+              onToggle: toggleClassroomId,
+              onClear: clearClassroomIds,
+            }}
+            dateRangeFilter={{
+              label: "実施日",
+              from: dateFrom,
+              to: dateTo,
+              onFromChange: setDateFrom,
+              onToChange: setDateTo,
+            }}
+          />
+        )}
       </div>
 
       <div className="min-h-0 flex-1 p-4">
@@ -222,6 +390,15 @@ export function CourseworkListContainer() {
             <Table wrapperClassName="h-full">
               <TableHeader className="bg-card sticky top-0 z-10">
                 <TableRow className="hover:bg-transparent">
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={allSelected}
+                      onCheckedChange={(checked) =>
+                        toggleSelectAll(checked === true)
+                      }
+                      aria-label="全選択"
+                    />
+                  </TableHead>
                   <TableHead>資料名</TableHead>
                   <TableHead className="w-40 text-center">実施日</TableHead>
                   <TableHead className="w-40 text-center">編集</TableHead>
@@ -229,8 +406,27 @@ export function CourseworkListContainer() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {courseworks.map((coursework) => (
+                {filteredCourseworks.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={5}
+                      className="text-muted-foreground py-8 text-center"
+                    >
+                      条件に一致する資料がありません
+                    </TableCell>
+                  </TableRow>
+                )}
+                {filteredCourseworks.map((coursework) => (
                   <TableRow key={coursework.id} className="group">
+                    <TableCell>
+                      <Checkbox
+                        checked={selectedIds.has(coursework.id)}
+                        onCheckedChange={(checked) =>
+                          toggleSelect(coursework.id, checked === true)
+                        }
+                        aria-label={`${coursework.name} を選択`}
+                      />
+                    </TableCell>
                     <TableCell>
                       <div>
                         <div className="font-medium">{coursework.name}</div>
@@ -240,6 +436,19 @@ export function CourseworkListContainer() {
                           生徒: {coursework._count.students}名 / 評価項目:{" "}
                           {coursework._count.items}
                         </div>
+                        {coursework.tags.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {coursework.tags.map((courseworkTag) => (
+                              <Badge
+                                key={courseworkTag.tag.id}
+                                variant="secondary"
+                                className="text-xs"
+                              >
+                                {courseworkTag.tag.name}
+                              </Badge>
+                            ))}
+                          </div>
+                        )}
                       </div>
                     </TableCell>
 

--- a/src/components/grades/list/GradeListContainer.tsx
+++ b/src/components/grades/list/GradeListContainer.tsx
@@ -15,9 +15,10 @@ import {
   Users,
 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
+import { ListFilterBar } from "@/components/common/ListFilterBar"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -33,6 +34,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { type ListFilterAccessors, useListFilter } from "@/hooks/useListFilter"
 import { getGradeStatus } from "@/lib/gradeStatus"
 import type { CourseworkImportDecision } from "@/types/courseworkArchive.types"
 import type { GradeWithRelations } from "@/types/grade.types"
@@ -53,6 +55,20 @@ const STEP_ICONS: Record<
   4: ClipboardEdit,
   5: Sliders,
   6: BarChart3,
+}
+
+/** 成績算出一覧のフィルタ対象値（名前・説明・学級名／学級／基準日） */
+const GRADE_FILTER_ACCESSORS: ListFilterAccessors<GradeWithRelations> = {
+  searchTexts: (grade) => [
+    grade.name,
+    grade.description,
+    ...grade.gradeClassrooms.map(
+      (gradeClassroom) => gradeClassroom.classroom.name
+    ),
+  ],
+  classroomIds: (grade) =>
+    grade.gradeClassrooms.map((gradeClassroom) => gradeClassroom.classroomId),
+  date: (grade) => grade.referenceDate,
 }
 
 /**
@@ -176,6 +192,30 @@ export function GradeListContainer() {
     setImportArchiveData(null)
   }
 
+  // 一覧に出現する学級を集約してフィルタ選択肢にする
+  const classroomOptions = useMemo(() => {
+    const nameById = new Map<string, string>()
+    for (const grade of grades) {
+      for (const gradeClassroom of grade.gradeClassrooms) {
+        nameById.set(gradeClassroom.classroom.id, gradeClassroom.classroom.name)
+      }
+    }
+    return [...nameById.entries()].map(([id, name]) => ({ id, name }))
+  }, [grades])
+
+  const {
+    filteredItems: filteredGrades,
+    searchTerm,
+    setSearchTerm,
+    filterClassroomIds,
+    toggleClassroomId,
+    clearClassroomIds,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+  } = useListFilter(grades, GRADE_FILTER_ACCESSORS)
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -205,6 +245,28 @@ export function GradeListContainer() {
             .grade 読み込み
           </Button>
         </div>
+        {grades.length > 0 && (
+          <ListFilterBar
+            searchTerm={searchTerm}
+            onSearchTermChange={setSearchTerm}
+            searchPlaceholder="試験名・学級で検索"
+            totalCount={grades.length}
+            filteredCount={filteredGrades.length}
+            classroomFilter={{
+              options: classroomOptions,
+              selectedIds: filterClassroomIds,
+              onToggle: toggleClassroomId,
+              onClear: clearClassroomIds,
+            }}
+            dateRangeFilter={{
+              label: "基準日",
+              from: dateFrom,
+              to: dateTo,
+              onFromChange: setDateFrom,
+              onToChange: setDateTo,
+            }}
+          />
+        )}
       </div>
 
       <div className="min-h-0 flex-1 p-4">
@@ -232,7 +294,17 @@ export function GradeListContainer() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {grades.map((grade) => {
+                {filteredGrades.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="text-muted-foreground py-8 text-center"
+                    >
+                      条件に一致する試験がありません
+                    </TableCell>
+                  </TableRow>
+                )}
+                {filteredGrades.map((grade) => {
                   const status = getGradeStatus(grade)
                   const StepIcon = STEP_ICONS[status.step] ?? BarChart3
 
@@ -274,8 +346,10 @@ export function GradeListContainer() {
                           onClick={() => router.push(status.url)}
                           className="w-48 justify-start rounded-lg text-left"
                         >
-                          <StepIcon className="mr-1 h-4 w-4" />
-                          <span className="text-xs">{status.text}</span>
+                          <StepIcon className="mr-1 h-4 w-4 shrink-0" />
+                          <span className="min-w-0 truncate text-xs">
+                            {status.text}
+                          </span>
                         </Button>
                       </TableCell>
 

--- a/src/hooks/useListFilter.ts
+++ b/src/hooks/useListFilter.ts
@@ -1,0 +1,149 @@
+import { useCallback, useMemo, useState } from "react"
+
+/**
+ * 一覧フィルタ（検索・タグ・学級・日付範囲）の適用ロジック。
+ *
+ * 各画面のアイテム型は異なるため、フィルタ対象値の取り出しは `accessors` で注入する。
+ * 使う次元だけ accessor を渡せばよい（未指定の次元はフィルタ UI・判定ともに無効）。
+ *
+ * `accessors` は依存配列に含まれるため、呼び出し側ではモジュールレベル定数か
+ * `useMemo` で参照を安定させること。
+ */
+export interface ListFilterAccessors<T> {
+  /** 検索テキストの対象となる文字列群（名前・説明・タグ名など） */
+  searchTexts: (listItem: T) => (string | null | undefined)[]
+  /** タグフィルタ用のタグ ID 群 */
+  tagIds?: (listItem: T) => string[]
+  /** 学級フィルタ用の学級 ID 群 */
+  classroomIds?: (listItem: T) => string[]
+  /** 日付範囲フィルタ用の日付（ISO 文字列、未設定は null） */
+  date?: (listItem: T) => string | null
+}
+
+export interface UseListFilterResult<T> {
+  filteredItems: T[]
+  searchTerm: string
+  setSearchTerm: (value: string) => void
+  filterTagIds: Set<string>
+  toggleTagId: (tagId: string, checked: boolean) => void
+  clearTagIds: () => void
+  filterClassroomIds: Set<string>
+  toggleClassroomId: (classroomId: string, checked: boolean) => void
+  clearClassroomIds: () => void
+  /** 日付範囲の下端（YYYY-MM-DD、空文字は未指定） */
+  dateFrom: string
+  setDateFrom: (value: string) => void
+  /** 日付範囲の上端（YYYY-MM-DD、空文字は未指定） */
+  dateTo: string
+  setDateTo: (value: string) => void
+}
+
+export function useListFilter<T>(
+  items: T[],
+  accessors: ListFilterAccessors<T>
+): UseListFilterResult<T> {
+  const [searchTerm, setSearchTerm] = useState("")
+  const [filterTagIds, setFilterTagIds] = useState<Set<string>>(new Set())
+  const [filterClassroomIds, setFilterClassroomIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [dateFrom, setDateFrom] = useState("")
+  const [dateTo, setDateTo] = useState("")
+
+  const toggleTagId = useCallback((tagId: string, checked: boolean) => {
+    setFilterTagIds((prev) => {
+      const next = new Set(prev)
+      if (checked) {
+        next.add(tagId)
+      } else {
+        next.delete(tagId)
+      }
+      return next
+    })
+  }, [])
+
+  const clearTagIds = useCallback(() => setFilterTagIds(new Set()), [])
+
+  const toggleClassroomId = useCallback(
+    (classroomId: string, checked: boolean) => {
+      setFilterClassroomIds((prev) => {
+        const next = new Set(prev)
+        if (checked) {
+          next.add(classroomId)
+        } else {
+          next.delete(classroomId)
+        }
+        return next
+      })
+    },
+    []
+  )
+
+  const clearClassroomIds = useCallback(
+    () => setFilterClassroomIds(new Set()),
+    []
+  )
+
+  const filteredItems = useMemo(() => {
+    return items.filter((listItem) => {
+      // テキスト検索（対象文字列のいずれかに部分一致）
+      if (searchTerm.trim()) {
+        const term = searchTerm.trim().toLowerCase()
+        const hit = accessors
+          .searchTexts(listItem)
+          .some((text) => text?.toLowerCase().includes(term))
+        if (!hit) return false
+      }
+      // タグフィルタ（選択タグのいずれかを持つ = OR）
+      if (accessors.tagIds && filterTagIds.size > 0) {
+        const ids = new Set(accessors.tagIds(listItem))
+        const hasMatch = [...filterTagIds].some((tagId) => ids.has(tagId))
+        if (!hasMatch) return false
+      }
+      // 学級フィルタ（選択学級のいずれかを持つ = OR）
+      if (accessors.classroomIds && filterClassroomIds.size > 0) {
+        const ids = new Set(accessors.classroomIds(listItem))
+        const hasMatch = [...filterClassroomIds].some((classroomId) =>
+          ids.has(classroomId)
+        )
+        if (!hasMatch) return false
+      }
+      // 日付範囲フィルタ（表示(toLocaleDateString)と一致させるためローカル日で比較）
+      if (accessors.date && (dateFrom || dateTo)) {
+        const isoDate = accessors.date(listItem)
+        if (!isoDate) return false
+        const localDate = new Date(isoDate)
+        const day = `${localDate.getFullYear()}-${String(
+          localDate.getMonth() + 1
+        ).padStart(2, "0")}-${String(localDate.getDate()).padStart(2, "0")}`
+        if (dateFrom && day < dateFrom) return false
+        if (dateTo && day > dateTo) return false
+      }
+      return true
+    })
+  }, [
+    items,
+    accessors,
+    searchTerm,
+    filterTagIds,
+    filterClassroomIds,
+    dateFrom,
+    dateTo,
+  ])
+
+  return {
+    filteredItems,
+    searchTerm,
+    setSearchTerm,
+    filterTagIds,
+    toggleTagId,
+    clearTagIds,
+    filterClassroomIds,
+    toggleClassroomId,
+    clearClassroomIds,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+  }
+}

--- a/src/types/answerSheetBuilder.types.ts
+++ b/src/types/answerSheetBuilder.types.ts
@@ -5,6 +5,8 @@
  * レイアウト計算結果型は answerSheetLayout.types.ts を参照。
  */
 
+import type { Tag } from "@prisma/client"
+
 import type { AnswerSheetDefinition } from "./answerSheetDefinition.types"
 import type { ComputedMultiPageLayout } from "./answerSheetLayout.types"
 
@@ -72,6 +74,7 @@ export interface ASBDefinitionListItem {
   orientation?: string
   questionCount?: number
   totalPoints?: number
+  tags?: Tag[]
   updatedAt?: string
   createdAt?: string
 }

--- a/src/types/coursework.types.ts
+++ b/src/types/coursework.types.ts
@@ -102,10 +102,18 @@ export type CourseworkStudentWithMemberships =
     }
   }>
 
-/** 一覧表示用の軽量サマリ */
+/** 一覧表示用の軽量サマリ（フィルタ用に tags/classrooms を同梱） */
 export type CourseworkSummary = Omit<
   Prisma.CourseworkGetPayload<{
-    include: { _count: { select: { items: true; students: true } } }
+    include: {
+      _count: { select: { items: true; students: true } }
+      tags: {
+        include: { tag: { select: { id: true; name: true; color: true } } }
+      }
+      classrooms: {
+        include: { classroom: { select: { id: true; name: true } } }
+      }
+    }
   }>,
   "date"
 > & {

--- a/src/types/electron/courseworkApi.d.ts
+++ b/src/types/electron/courseworkApi.d.ts
@@ -206,6 +206,10 @@ export interface CourseworkAPI {
       courseworkId: string,
       tagIds: string[]
     ) => Promise<{ success: boolean; error?: string }>
+    addTag: (
+      courseworkId: string,
+      tagId: string
+    ) => Promise<{ success: boolean; error?: string }>
 
     // アーカイブ（.coursework のエクスポート／インポート）
     exportArchive: (

--- a/src/types/electron/tagApi.d.ts
+++ b/src/types/electron/tagApi.d.ts
@@ -1,4 +1,10 @@
-import type { ExamTag, Prisma, Tag, TagSubtotalGroup } from "@prisma/client"
+import type {
+  AsbDefinitionTag,
+  ExamTag,
+  Prisma,
+  Tag,
+  TagSubtotalGroup,
+} from "@prisma/client"
 
 /**
  * Tag（タグ）・TagSubtotalGroup・ExamTag関連API
@@ -6,6 +12,11 @@ import type { ExamTag, Prisma, Tag, TagSubtotalGroup } from "@prisma/client"
 
 /** タグ同梱の ExamTag（`examTagGetByExamId`/`examTagSetExamTags` が返す実形状）。 */
 export type ExamTagWithTag = Prisma.ExamTagGetPayload<{
+  include: { tag: true }
+}>
+
+/** タグ同梱の AsbDefinitionTag（getByDefinitionId/setDefinitionTags が返す実形状）。 */
+export type AsbDefinitionTagWithTag = Prisma.AsbDefinitionTagGetPayload<{
   include: { tag: true }
 }>
 
@@ -35,4 +46,17 @@ export interface TagAPI {
     examId: string,
     tagIds: string[]
   ) => Promise<ExamTagWithTag[]>
+
+  asbDefinitionTagGetByDefinitionId: (
+    asbDefinitionId: string
+  ) => Promise<AsbDefinitionTagWithTag[]>
+  asbDefinitionTagCreate: (data: {
+    asbDefinitionId: string
+    tagId: string
+  }) => Promise<AsbDefinitionTag>
+  asbDefinitionTagDelete: (id: string) => Promise<void>
+  asbDefinitionTagSetDefinitionTags: (
+    asbDefinitionId: string,
+    tagIds: string[]
+  ) => Promise<AsbDefinitionTagWithTag[]>
 }


### PR DESCRIPTION
Closes #1003

## 概要

試験一覧と同様のフィルタ機能を、解答用紙作成・試験外成績資料・成績算出の各一覧に実装。あわせて解答用紙にタグ機能を新設し、周辺 UI を是正する。

## 主な変更

- **共通部品**: `useListFilter`（汎用フィルタ hook）/ `ListFilterBar`（検索・タグ/学級 Popover・日付範囲・件数）/ `BulkTagAssignButton`（一括タグ付与）を新設
- **解答用紙タグ機能**: `AsbDefinitionTag` スキーマ + 手書き migration（`MIGRATION_CHECKSUMS` には足さず起動時 replay）+ prisma CRUD / IPC / preload / 型
- **coursework 拡張**: `getCourseworks` にタグ・学級 include、個別追加 API `addCourseworkTag`（upsert・冪等）で一括付与の既存タグ消失を防止
- **UI 是正**: 削除確認の AlertDialog モーダル化、成績算出の次ステップボタンの CSS はみ出し修正
- **code-review 対応**: 日付フィルタのローカル日比較、削除後 stale id への付与防止、フィルタ0件の「該当なし」表示

## 検証

- `npm run typecheck` 通過
- `npm run lint`（eslint + prettier --check）通過
- high effort の multi-agent code-review を実施し correctness 指摘を反映

## 残作業

詳細計画を `docs/list-filter-detail-refactor-plan.md` に記録（解答用紙の detail/edit/export 分離、`.asb` archive タグ対応、coursework/grade の 01-setup detail 化、DRY cleanup）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)