### PR TITLE
feat(grades): 欠測推定に順位法・標準偏差法を追加しモデル適合度Rを方法選択に表示

### DIFF
--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -71,7 +71,10 @@ import {
   setGradeClassroomOrders,
   updateGradeStudentOrders,
 } from "../lib/prisma/gradeStudent"
-import { calculateGrades } from "../lib/shared/calculations/gradeCalculator"
+import {
+  calculateGrades,
+  computeSourceFits,
+} from "../lib/shared/calculations/gradeCalculator"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 /** 成績（Grade）のCRUD・生徒管理・データソース・成績算出・Excel出力・アーカイブに関するIPCチャンネルを登録する */
@@ -439,6 +442,10 @@ export function setupGradeHandlers(): void {
 
   registerHandler("grade:calculateGrades", async (gradeId: string) => {
     return calculateGrades(gradeId)
+  })
+
+  registerHandler("grade:computeSourceFits", async (gradeId: string) => {
+    return computeSourceFits(gradeId)
   })
 
   // =====================================================================

--- a/electron-src/lib/shared/calculations/absentEstimation.ts
+++ b/electron-src/lib/shared/calculations/absentEstimation.ts
@@ -38,6 +38,20 @@ export interface AbsentEstimation {
   droppedPredictors?: EstimationDroppedPredictor[]
   /** 重回帰法がaverageにフォールバックした理由 */
   fallbackReason?: EstimationFallbackReason
+  /**
+   * 当てはまりの重相関 R（訓練データの実測 vs 予測、0〜1）。
+   * 予測は「実力の R 倍」まで広がる縮小率そのもの。1−R が中心（平均）へ寄る度合い。
+   * R=1 は定義上のつながり（合計=小計の和 等）で完全復元されている合図。
+   */
+  correlation?: number
+  /** 標準偏差法（zscore）: 対象生徒の他ソース平均標準得点（±何SD） */
+  standardizedStanding?: number
+  /** 順位法（equipercentile）: 対象生徒の他ソース平均パーセンタイル（0〜1） */
+  percentileRank?: number
+  /** 標準偏差法・順位法の載せ替え先となる当ソース実測分布の平均 */
+  targetMean?: number
+  /** 標準偏差法の載せ替え先となる当ソース実測分布の標準偏差 */
+  targetStandardDeviation?: number
 }
 
 /**
@@ -72,7 +86,249 @@ export function estimateAbsentScore(
       allDataSources
     )
   }
+  if (method === "equipercentile") {
+    return estimateByEquipercentile(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources
+    )
+  }
+  if (method === "zscore") {
+    return estimateByZScore(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources
+    )
+  }
   return null
+}
+
+/**
+ * 当ソース(dataSourceId)を実測した他生徒の素点分布（平均・母標準偏差・整列済み素点列）。
+ * 対象生徒自身は欠測なので母数から自然に外れる。標準偏差法・順位法の載せ替え先に使う。
+ */
+function collectTargetDistribution(
+  studentId: string,
+  dataSourceId: string,
+  rawScoreMap: Map<string, Map<string, number | null>>
+): { mean: number; sd: number; sorted: number[] } | null {
+  const scores: number[] = []
+  for (const [otherStudentId, otherScores] of rawScoreMap) {
+    if (otherStudentId === studentId) continue
+    const score = otherScores.get(dataSourceId)
+    if (score !== null && score !== undefined) scores.push(score)
+  }
+  if (scores.length < 2) return null
+  const mean = scores.reduce((sum, score) => sum + score, 0) / scores.length
+  const variance =
+    scores.reduce((sum, score) => sum + (score - mean) ** 2, 0) / scores.length
+  const sorted = [...scores].sort((scoreA, scoreB) => scoreA - scoreB)
+  return { mean, sd: Math.sqrt(variance), sorted }
+}
+
+/**
+ * 対象生徒が実測を持つ他ソースを、標準偏差法・順位法の説明変数として集める。
+ * average と同じく「自ソース以外・満点>0・対象生徒が実測を持つ」ソースが対象。
+ */
+function collectPredictorContributions(
+  studentId: string,
+  dataSourceId: string,
+  rawScoreMap: Map<string, Map<string, number | null>>,
+  allDataSources: DataSourceInfo[]
+): EstimationSourceContribution[] {
+  const studentScores = rawScoreMap.get(studentId)
+  if (!studentScores) return []
+  const contributions: EstimationSourceContribution[] = []
+  for (const dataSource of allDataSources) {
+    if (dataSource.id === dataSourceId) continue
+    if (dataSource.maxScore <= 0) continue
+    const score = studentScores.get(dataSource.id)
+    if (score === null || score === undefined) continue
+    contributions.push({
+      id: dataSource.id,
+      name: dataSource.name,
+      score,
+      maxScore: dataSource.maxScore,
+      ratio: score / dataSource.maxScore,
+    })
+  }
+  return contributions
+}
+
+/**
+ * 標準偏差法（線形イコーティング / z法）推定:
+ * 対象生徒の他ソースでの平均標準得点 z̄（±何SD の立ち位置）を、
+ * 当ソースを実測した生徒の実平均 μ・標準偏差 σ へ載せ替える: 予測 = μ + z̄・σ。
+ * 縮小（平均回帰）を打ち消し、当ソースのバラつきを保つ。
+ * どのソースにも分散が無い / 対象生徒に使える他ソースが無い場合は average にフォールバック。
+ */
+function estimateByZScore(
+  studentId: string,
+  dataSourceId: string,
+  maxScore: number,
+  rawScoreMap: Map<string, Map<string, number | null>>,
+  allDataSources: DataSourceInfo[]
+): AbsentEstimation | null {
+  const predictors = collectPredictorContributions(
+    studentId,
+    dataSourceId,
+    rawScoreMap,
+    allDataSources
+  )
+  if (predictors.length === 0) return null
+
+  // 各他ソースでの標準得点 z = (素点 − そのソースの平均) / そのソースのSD を平均する
+  const zValues: number[] = []
+  for (const predictor of predictors) {
+    const distribution = collectTargetDistribution(
+      studentId,
+      predictor.id,
+      rawScoreMap
+    )
+    if (!distribution || distribution.sd <= 0) continue
+    zValues.push((predictor.score - distribution.mean) / distribution.sd)
+  }
+  if (zValues.length === 0) {
+    return fallbackToAverage(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources,
+      "insufficient_samples"
+    )
+  }
+
+  const target = collectTargetDistribution(studentId, dataSourceId, rawScoreMap)
+  if (!target || target.sd <= 0) {
+    return fallbackToAverage(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources,
+      "insufficient_samples"
+    )
+  }
+
+  const standardizedStanding =
+    zValues.reduce((sum, z) => sum + z, 0) / zValues.length
+  const predicted = target.mean + standardizedStanding * target.sd
+
+  return {
+    value: clamp(predicted, 0, maxScore),
+    effectiveMethod: "zscore",
+    averageSources: predictors,
+    standardizedStanding,
+    targetMean: target.mean,
+    targetStandardDeviation: target.sd,
+  }
+}
+
+/**
+ * 順位法（等パーセンタイル・イコーティング）推定:
+ * 対象生徒の他ソースでの平均パーセンタイル（0〜1、上位ほど1）を求め、
+ * 当ソース実分布の同順位の点へ変換する。分布形を保存し、縮小しない。
+ * 使える他ソースが無い / 当ソースの実測が2名未満なら average にフォールバック。
+ */
+function estimateByEquipercentile(
+  studentId: string,
+  dataSourceId: string,
+  maxScore: number,
+  rawScoreMap: Map<string, Map<string, number | null>>,
+  allDataSources: DataSourceInfo[]
+): AbsentEstimation | null {
+  const predictors = collectPredictorContributions(
+    studentId,
+    dataSourceId,
+    rawScoreMap,
+    allDataSources
+  )
+  if (predictors.length === 0) return null
+
+  // 各他ソースでの対象生徒のパーセンタイル（中間順位法）を平均する
+  const percentiles: number[] = []
+  for (const predictor of predictors) {
+    const distribution = collectTargetDistribution(
+      studentId,
+      predictor.id,
+      rawScoreMap
+    )
+    if (!distribution) continue
+    percentiles.push(percentileRankOf(predictor.score, distribution.sorted))
+  }
+  if (percentiles.length === 0) {
+    return fallbackToAverage(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources,
+      "insufficient_samples"
+    )
+  }
+
+  const target = collectTargetDistribution(studentId, dataSourceId, rawScoreMap)
+  if (!target) {
+    return fallbackToAverage(
+      studentId,
+      dataSourceId,
+      maxScore,
+      rawScoreMap,
+      allDataSources,
+      "insufficient_samples"
+    )
+  }
+
+  const percentileRank =
+    percentiles.reduce((sum, percentile) => sum + percentile, 0) /
+    percentiles.length
+  const predicted = quantileOf(percentileRank, target.sorted)
+
+  return {
+    value: clamp(predicted, 0, maxScore),
+    effectiveMethod: "equipercentile",
+    averageSources: predictors,
+    percentileRank,
+    targetMean: target.mean,
+  }
+}
+
+/**
+ * value が昇順配列 sorted の中で占めるパーセンタイル（0〜1）を中間順位法で返す。
+ * = (value 未満の個数 + 同値の個数/2) / 全体数。分布の端でも 0/1 に貼り付かない。
+ */
+function percentileRankOf(value: number, sorted: number[]): number {
+  const n = sorted.length
+  if (n === 0) return 0.5
+  let below = 0
+  let equal = 0
+  for (const score of sorted) {
+    if (score < value) below++
+    else if (score === value) equal++
+  }
+  return (below + equal / 2) / n
+}
+
+/**
+ * パーセンタイル p（0〜1）に対応する昇順配列 sorted の点を線形補間で返す（順位法の逆変換）。
+ * 位置 = p × (n − 1) の前後を按分する。
+ */
+function quantileOf(p: number, sorted: number[]): number {
+  const n = sorted.length
+  if (n === 0) return 0
+  if (n === 1) return sorted[0]
+  const clampedP = Math.max(0, Math.min(1, p))
+  const position = clampedP * (n - 1)
+  const lowerIndex = Math.floor(position)
+  const upperIndex = Math.ceil(position)
+  if (lowerIndex === upperIndex) return sorted[lowerIndex]
+  const fraction = position - lowerIndex
+  return sorted[lowerIndex] * (1 - fraction) + sorted[upperIndex] * fraction
 }
 
 /**
@@ -272,12 +528,21 @@ function estimateByRegression(
     }
   })
 
+  // 当てはまりの重相関 R（自由度補正済み）＝縮小率。採用列数−1 が独立説明変数の数。
+  const correlation = multipleCorrelationR(
+    X,
+    Y,
+    beta,
+    retainedColumns.length - 1
+  )
+
   return {
     value: clamp(predicted, 0, maxScore),
     effectiveMethod: "regression",
     intercept: beta[0],
     regressionTerms,
     ...(droppedPredictors.length > 0 && { droppedPredictors }),
+    ...(correlation !== undefined && { correlation }),
   }
 }
 
@@ -430,6 +695,106 @@ function gaussianEliminationSolve(
   }
 
   return solution
+}
+
+/**
+ * 当てはまりの重相関 R（0〜1）を自由度補正済みで返す。訓練データの実測 vs 予測から
+ * 調整済み決定係数 adjR² = 1 − (1−R²)(n−1)/(n−k−1) を出し R=√max(0, adjR²) とする。
+ * 素の R²（=1−SS_res/SS_tot）は説明変数 k が多く標本 n が小さいほど1へ膨らむため、
+ * 残差自由度 n−k−1 で補正して過大評価を抑える。予測は「実力の R 倍」まで広がる縮小率。
+ * @param X 設計行列（各行 [1, x1, …]、切片列含む）
+ * @param Y 実測値
+ * @param beta 係数（全長 p、従属列は0）
+ * @param predictorCount 独立な説明変数の数（切片を除く採用列数 = 採用列数−1）
+ * @returns 補正済み R、または算出不能（分散ゼロ / 残差自由度なし）時 undefined
+ */
+function multipleCorrelationR(
+  X: number[][],
+  Y: number[],
+  beta: number[],
+  predictorCount: number
+): number | undefined {
+  const n = X.length
+  const p = beta.length
+  const meanY = Y.reduce((sum, y) => sum + y, 0) / n
+  let ssRes = 0
+  let ssTot = 0
+  for (let k = 0; k < n; k++) {
+    let fitted = 0
+    for (let j = 0; j < p; j++) fitted += beta[j] * X[k][j]
+    ssRes += (Y[k] - fitted) ** 2
+    ssTot += (Y[k] - meanY) ** 2
+  }
+  if (ssTot <= 0) return undefined
+  const dfResidual = n - predictorCount - 1
+  if (dfResidual <= 0) return undefined // 残差自由度なし＝R²は必ず1（無意味）
+  const r2 = 1 - ssRes / ssTot
+  const adjustedR2 = 1 - ((1 - r2) * (n - 1)) / dfResidual
+  return Math.sqrt(Math.max(0, adjustedR2))
+}
+
+/**
+ * 当ソース(dataSourceId)を predictorIds からどれだけ説明できるかのモデル適合度 R（重相関、0〜1）。
+ * 欠測者の有無に依らず「当ソースを実測した全生徒」で回帰を当て、実測 vs 予測の R を返す。
+ * データ側の予測しやすさ＝重回帰の縮小率でもあり、手法選択時の判断材料として表示する。
+ *
+ * 訓練行は「当ソース＋全 predictor が揃った生徒」のみ（complete-case）。多重共線性の列は
+ * ランク落ちで除外。独立列が無い / サンプル不足 / 当ソースに分散が無い場合は null。
+ * @returns { correlation, sampleSize } または算出不能時 null
+ */
+export function computeSourceFit(
+  dataSourceId: string,
+  predictorIds: string[],
+  rawScoreMap: Map<string, Map<string, number | null>>
+): { correlation: number; sampleSize: number } | null {
+  if (predictorIds.length === 0) return null
+
+  const X: number[][] = []
+  const Y: number[] = []
+  for (const [, scores] of rawScoreMap) {
+    const y = scores.get(dataSourceId)
+    if (y === null || y === undefined) continue
+    const row: number[] = [1]
+    let complete = true
+    for (const predictorId of predictorIds) {
+      const x = scores.get(predictorId)
+      if (x === null || x === undefined) {
+        complete = false
+        break
+      }
+      row.push(x)
+    }
+    if (!complete) continue
+    X.push(row)
+    Y.push(y)
+  }
+
+  if (X.length < 3) return null
+  const p = X[0].length
+  const retainedColumns = selectIndependentColumns(X, p)
+  // 切片のみ（独立な説明変数ゼロ）や残差自由度が無いサンプル数では R を出さない
+  if (retainedColumns.length <= 1) return null
+  if (X.length < retainedColumns.length + 1) return null
+
+  const reducedBeta = solveNormalEquations(X, Y, retainedColumns)
+  if (!reducedBeta) return null
+  const beta = Array(p).fill(0)
+  retainedColumns.forEach((column, k) => {
+    beta[column] = reducedBeta[k]
+  })
+
+  const correlation = multipleCorrelationR(
+    X,
+    Y,
+    beta,
+    retainedColumns.length - 1
+  )
+  if (correlation === undefined) return null
+
+  return {
+    correlation,
+    sampleSize: X.length,
+  }
 }
 
 /**

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -7,6 +7,7 @@
 import type {
   AbsentMethod,
   EstimationDetail,
+  EstimationTargetDistribution,
   GradeCalculationResult,
   GradeItemResult,
   SourceScoreResult,
@@ -21,12 +22,354 @@ import { computeLiveMaxScore } from "../../prisma/gradeDataSource"
 import {
   adjustEstimate,
   applyAdjustmentAndClamp,
+  computeSourceFit,
   estimateAbsentScore,
 } from "./absentEstimation"
 import type { DataSourceInfo, ExamDataCache } from "./gradeCalculatorTypes"
 import { determineGradeLabel } from "./gradeLabel"
 import { getRawScore } from "./rawScoreCalculator"
 import { resolveEffectiveScores } from "./scoreResolution"
+
+/**
+ * 素点行列（rawScoreMap）と推定に必要な付随データを構築する。
+ * calculateGrades のパス1と computeSourceFits が共有する（素点組み立ての単一実装＝SSOT）。
+ * @returns 構築した文脈。Grade が存在しない場合は null。
+ */
+async function buildGradeCalcContext(gradeId: string) {
+  // 1. Grade + リレーションを取得
+  const grade = await prisma.grade.findUnique({
+    where: { id: gradeId },
+    include: {
+      gradeClassrooms: {
+        include: { classroom: true },
+        orderBy: { order: "asc" },
+      },
+      gradeItems: {
+        include: {
+          dataSources: {
+            include: {
+              exam: true,
+              subtotal: true,
+              cropRegion: true,
+              courseworkItem: {
+                include: {
+                  scores: true,
+                  letterScales: { orderBy: { order: "asc" } },
+                },
+              },
+              coursework: {
+                include: {
+                  items: {
+                    include: {
+                      scores: true,
+                      letterScales: { orderBy: { order: "asc" } },
+                    },
+                  },
+                },
+              },
+            },
+            orderBy: { order: "asc" },
+          },
+        },
+        orderBy: { order: "asc" },
+      },
+      boundarySets: {
+        include: { boundaries: { orderBy: { order: "asc" } } },
+      },
+    },
+  })
+
+  if (!grade) return null
+
+  // 2. 試験の登録生徒一覧を取得
+  const examStudents = await prisma.gradeStudent.findMany({
+    where: { gradeId },
+    include: {
+      student: {
+        include: {
+          memberships: {
+            include: { classroom: { select: { id: true, name: true } } },
+          },
+        },
+      },
+    },
+    orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
+  })
+
+  const classroomIds = grade.gradeClassrooms.map(
+    (gradeClassroom) => gradeClassroom.classroomId
+  )
+
+  // 3. 上書きデータを取得
+  const overrides = await prisma.gradeOverride.findMany({
+    where: { gradeId },
+  })
+  const overrideMap = new Map<string, string>()
+  for (const override of overrides) {
+    const key = `${override.studentId}:${override.targetType}:${override.gradeItemId ?? "__overall__"}`
+    overrideMap.set(key, override.overrideLabel)
+  }
+
+  // 3.5. 除外データを取得
+  const exclusions = await prisma.gradeItemExclusion.findMany({
+    where: { gradeId },
+  })
+  const exclusionSet = new Set(
+    exclusions.map(
+      (exclusion) => `${exclusion.studentId}:${exclusion.gradeItemId}`
+    )
+  )
+
+  // 4. 全DataSourceから使用される試験試験IDを収集
+  const allDataSources = grade.gradeItems.flatMap(
+    (gradeItem) => gradeItem.dataSources
+  )
+  const examIds = [
+    ...new Set(
+      allDataSources
+        .filter(
+          (dataSource) =>
+            (dataSource.type === "exam_total" ||
+              dataSource.type === "subtotal" ||
+              dataSource.type === "crop_region") &&
+            dataSource.examId
+        )
+        .map((dataSource) => dataSource.examId!)
+    ),
+  ]
+
+  // 5. 試験試験のスコアデータを事前取得
+  const examDataCache = new Map<string, ExamDataCache>()
+
+  for (const examId of examIds) {
+    const [questionScores, scoreDecisions, examPages] = await Promise.all([
+      prisma.questionScore.findMany({
+        where: { cropRegion: { examPage: { examId: examId } } },
+        select: {
+          id: true,
+          studentId: true,
+          cropRegionId: true,
+          status: true,
+          partialScore: true,
+          updatedAt: true,
+        },
+      }),
+      prisma.scoreDecision.findMany({
+        where: { cropRegion: { examPage: { examId: examId } } },
+        select: {
+          studentId: true,
+          cropRegionId: true,
+          verdict: true,
+          score: true,
+          decidedAt: true,
+          sourceQuestionScoreId: true,
+        },
+      }),
+      prisma.examPage.findMany({
+        where: { examId: examId },
+        include: { cropRegions: true },
+      }),
+    ])
+    const cropRegions = examPages.flatMap((examPage) => examPage.cropRegions)
+    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+    const { resolved: resolvedScores } = resolveEffectiveScores(
+      questionScores,
+      scoreDecisions
+    )
+    examDataCache.set(examId, {
+      questionScores: resolvedScores.map((resolvedScore) => ({
+        studentId: resolvedScore.studentId,
+        cropRegionId: resolvedScore.cropRegionId,
+        status: resolvedScore.status,
+        partialScore: resolvedScore.partialScore,
+      })),
+      cropRegions: cropRegions.map((cropRegion) => ({
+        id: cropRegion.id,
+        type: cropRegion.type,
+        points: cropRegion.points,
+      })),
+    })
+  }
+
+  // 5.5. 見込→欠測対応: examIdごとのExamStudent状態をプリロード
+  // Map<examId, Map<studentId, status>>
+  const examExamStudentStatusMap = new Map<string, Map<string, string>>()
+  for (const examId of examIds) {
+    const examStudentStatuses = await prisma.examStudent.findMany({
+      where: { examId: examId },
+      select: { studentId: true, status: true },
+    })
+    const statusMap = new Map<string, string>()
+    for (const examStudent of examStudentStatuses) {
+      statusMap.set(examStudent.studentId, examStudent.status)
+    }
+    examExamStudentStatusMap.set(examId, statusMap)
+  }
+
+  // 満点は元データ（設問配点 / 評価項目満点）からライブ算出する。
+  // GradeDataSource.maxScore 列のスナップショットは使わない（元データ追従）。
+  // 生徒ループの外で1ソース1回だけ算出してマップ化する。
+  const liveMaxScoreMap = new Map<string, number>()
+  for (const dataSource of allDataSources) {
+    liveMaxScoreMap.set(dataSource.id, await computeLiveMaxScore(dataSource))
+  }
+
+  // DataSource情報をまとめる（推定で使用）
+  const dataSourceInfos: DataSourceInfo[] = allDataSources.map((dataSource) => {
+    let sourceIds: string[] = []
+    if (typeof dataSource.estimationSourceIds === "string") {
+      try {
+        sourceIds = JSON.parse(dataSource.estimationSourceIds)
+      } catch {
+        sourceIds = []
+      }
+    }
+    return {
+      id: dataSource.id,
+      name: dataSource.name,
+      maxScore: liveMaxScoreMap.get(dataSource.id) ?? 0,
+      absentMethod: (dataSource.absentMethod ?? "null") as AbsentMethod,
+      absentRatio: Number(dataSource.absentRatio ?? 1),
+      absentOffset: Number(dataSource.absentOffset ?? 0),
+      estimationMode: dataSource.estimationMode ?? "all",
+      estimationSourceIds: sourceIds,
+    }
+  })
+
+  // === パス1: 全生徒 × 全DataSourceの rawScore を収集 ===
+  // Map<studentId, Map<dataSourceId, number | null>>
+  const rawScoreMap = new Map<string, Map<string, number | null>>()
+
+  for (const examStudent of examStudents) {
+    const studentScores = new Map<string, number | null>()
+    for (const dataSource of allDataSources) {
+      let raw = await getRawScore(
+        examStudent.student.id,
+        dataSource,
+        examDataCache
+      )
+
+      // 見込→欠測対応: treatExpectedAsMissing が true かつ
+      // 試験試験の ExamStudent.status === "expected" → null扱い
+      if (
+        raw !== null &&
+        dataSource.treatExpectedAsMissing &&
+        dataSource.examId
+      ) {
+        const statusMap = examExamStudentStatusMap.get(dataSource.examId)
+        if (statusMap?.get(examStudent.student.id) === "expected") {
+          raw = null
+        }
+      }
+
+      studentScores.set(dataSource.id, raw)
+    }
+    rawScoreMap.set(examStudent.student.id, studentScores)
+  }
+
+  return {
+    grade,
+    examStudents,
+    classroomIds,
+    overrideMap,
+    exclusionSet,
+    liveMaxScoreMap,
+    dataSourceInfos,
+    rawScoreMap,
+    allDataSources,
+  }
+}
+
+/**
+ * 構造的兄弟ソースの同定キー。同一試験（examId）または同一資料（courseworkId）に属する
+ * ソースは「合計＝小計の和」等の定義上の従属関係を持つ。生徒がその試験/資料を欠席すると
+ * 兄弟も同時に欠測するため、モデル適合度 R の説明変数からは除外する（復元でなく予測のRを出す）。
+ * グループに属さないソースは自身の id を返し、他と兄弟にならない。
+ */
+function siblingGroupKey(dataSource: {
+  id: string
+  examId: string | null
+  coursework: { id: string } | null
+  courseworkItem: { courseworkId: string } | null
+}): string {
+  if (dataSource.examId) return `exam:${dataSource.examId}`
+  if (dataSource.coursework) return `cw:${dataSource.coursework.id}`
+  if (dataSource.courseworkItem) {
+    return `cw:${dataSource.courseworkItem.courseworkId}`
+  }
+  return `self:${dataSource.id}`
+}
+
+/**
+ * 各データソースの「モデル適合度 R」を保存済みの推定ソース設定で算出する。
+ * 手法選択（03-データソース）画面で「このソースが他ソースからどれだけ当てられるか」を示す。
+ * R は手法に依らないデータ側の予測しやすさ＝重回帰の縮小率で、
+ * 高いほど重回帰でも中心へ寄りにくい（順位法・標準偏差法は縮小そのものを避ける）。
+ * @returns 各 dataSourceId → { correlation, sampleSize }（算出不能なソースは null）
+ */
+export async function computeSourceFits(gradeId: string): Promise<{
+  success: boolean
+  fits?: Record<string, { correlation: number; sampleSize: number } | null>
+  error?: string
+}> {
+  try {
+    const context = await buildGradeCalcContext(gradeId)
+    if (!context) {
+      return { success: false, error: "Grade exam not found" }
+    }
+    const { dataSourceInfos, rawScoreMap, allDataSources } = context
+
+    // 構造的兄弟（同一試験/資料）の同定キー。R算出時に説明変数から除外する。
+    const groupKeyById = new Map<string, string>()
+    for (const dataSource of allDataSources) {
+      groupKeyById.set(dataSource.id, siblingGroupKey(dataSource))
+    }
+
+    const fits: Record<
+      string,
+      { correlation: number; sampleSize: number } | null
+    > = {}
+    for (const dataSourceInfo of dataSourceInfos) {
+      const targetGroupKey = groupKeyById.get(dataSourceInfo.id)
+      // 推定ソース: selected なら指定ID、all なら自ソース以外。満点0（算出ソース無し）は常に除く。
+      // さらに両モードとも構造的兄弟（同一試験/資料）を除外する。合計=観点の和 等の派生関係は
+      // R=1（＝予測ではなく復元）を生み現実の予測精度を表さないため。
+      //
+      // これは実際の推定挙動とも整合する: 生徒が試験を丸ごと欠席すると兄弟（同一試験の他観点/合計）も
+      // 同時に欠測し、estimateByRegression の availablePredictors から自動的に外れる。合計・観点は
+      // 派生値なので「兄弟だけ在る partial 欠測」は起きず、Rと推定が乖離するケースは生じない。
+      // selected で兄弟のみ選んだ退化構成では R=算出不能 になるが、その構成では実推定も兄弟を使えず
+      // average へ落ちるため、算出不能の表示は誠実（レビュー指摘#1への回答）。
+      const predictorIds = (
+        dataSourceInfo.estimationMode === "selected"
+          ? dataSourceInfos.filter((candidate) =>
+              dataSourceInfo.estimationSourceIds.includes(candidate.id)
+            )
+          : dataSourceInfos.filter(
+              (candidate) => candidate.id !== dataSourceInfo.id
+            )
+      )
+        .filter((candidate) => candidate.maxScore > 0)
+        .filter(
+          (candidate) => groupKeyById.get(candidate.id) !== targetGroupKey
+        )
+        .map((candidate) => candidate.id)
+
+      fits[dataSourceInfo.id] = computeSourceFit(
+        dataSourceInfo.id,
+        predictorIds,
+        rawScoreMap
+      )
+    }
+    return { success: true, fits }
+  } catch (error) {
+    console.error("Error computing source fits:", error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}
 
 /**
  * 成績を算出する
@@ -37,239 +380,35 @@ export async function calculateGrades(gradeId: string): Promise<{
   error?: string
 }> {
   try {
-    // 1. Grade + リレーションを取得
-    const grade = await prisma.grade.findUnique({
-      where: { id: gradeId },
-      include: {
-        gradeClassrooms: {
-          include: { classroom: true },
-          orderBy: { order: "asc" },
-        },
-        gradeItems: {
-          include: {
-            dataSources: {
-              include: {
-                exam: true,
-                subtotal: true,
-                cropRegion: true,
-                courseworkItem: {
-                  include: {
-                    scores: true,
-                    letterScales: { orderBy: { order: "asc" } },
-                  },
-                },
-                coursework: {
-                  include: {
-                    items: {
-                      include: {
-                        scores: true,
-                        letterScales: { orderBy: { order: "asc" } },
-                      },
-                    },
-                  },
-                },
-              },
-              orderBy: { order: "asc" },
-            },
-          },
-          orderBy: { order: "asc" },
-        },
-        boundarySets: {
-          include: { boundaries: { orderBy: { order: "asc" } } },
-        },
-      },
-    })
-
-    if (!grade) {
+    // 素点行列と付随データ（推定に必要な文脈）をまとめて構築。
+    // computeSourceFits（手法選択画面のモデル適合度R）と共有する（SSOT）。
+    const context = await buildGradeCalcContext(gradeId)
+    if (!context) {
       return { success: false, error: "Grade exam not found" }
     }
+    const {
+      grade,
+      examStudents,
+      classroomIds,
+      overrideMap,
+      exclusionSet,
+      liveMaxScoreMap,
+      dataSourceInfos,
+      rawScoreMap,
+    } = context
 
-    // 2. 試験の登録生徒一覧を取得
-    const examStudents = await prisma.gradeStudent.findMany({
-      where: { gradeId },
-      include: {
-        student: {
-          include: {
-            memberships: {
-              include: { classroom: { select: { id: true, name: true } } },
-            },
-          },
-        },
-      },
-      orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
-    })
-
-    const classroomIds = grade.gradeClassrooms.map(
-      (gradeClassroom) => gradeClassroom.classroomId
-    )
-
-    // 3. 上書きデータを取得
-    const overrides = await prisma.gradeOverride.findMany({
-      where: { gradeId },
-    })
-    const overrideMap = new Map<string, string>()
-    for (const override of overrides) {
-      const key = `${override.studentId}:${override.targetType}:${override.gradeItemId ?? "__overall__"}`
-      overrideMap.set(key, override.overrideLabel)
-    }
-
-    // 3.5. 除外データを取得
-    const exclusions = await prisma.gradeItemExclusion.findMany({
-      where: { gradeId },
-    })
-    const exclusionSet = new Set(
-      exclusions.map(
-        (exclusion) => `${exclusion.studentId}:${exclusion.gradeItemId}`
+    // 各ソースの実測素点分布（平均・標準偏差）はソース単位で一定なので、生徒ループの外で
+    // 1ソース1回だけ算出してマップ化する。閲覧生徒は除外しない（＝クラスの実測分布として
+    // 全生徒共通の値。以前は閲覧生徒を除いていたため生徒ごとに平均がわずかに変動していた）。
+    const distributionBySource = new Map<
+      string,
+      EstimationTargetDistribution | undefined
+    >()
+    for (const dataSourceInfo of dataSourceInfos) {
+      distributionBySource.set(
+        dataSourceInfo.id,
+        computeSourceDistribution(dataSourceInfo.id, rawScoreMap)
       )
-    )
-
-    // 4. 全DataSourceから使用される試験試験IDを収集
-    const allDataSources = grade.gradeItems.flatMap(
-      (gradeItem) => gradeItem.dataSources
-    )
-    const examIds = [
-      ...new Set(
-        allDataSources
-          .filter(
-            (dataSource) =>
-              (dataSource.type === "exam_total" ||
-                dataSource.type === "subtotal" ||
-                dataSource.type === "crop_region") &&
-              dataSource.examId
-          )
-          .map((dataSource) => dataSource.examId!)
-      ),
-    ]
-
-    // 5. 試験試験のスコアデータを事前取得
-    const examDataCache = new Map<string, ExamDataCache>()
-
-    for (const examId of examIds) {
-      const [questionScores, scoreDecisions, examPages] = await Promise.all([
-        prisma.questionScore.findMany({
-          where: { cropRegion: { examPage: { examId: examId } } },
-          select: {
-            id: true,
-            studentId: true,
-            cropRegionId: true,
-            status: true,
-            partialScore: true,
-            updatedAt: true,
-          },
-        }),
-        prisma.scoreDecision.findMany({
-          where: { cropRegion: { examPage: { examId: examId } } },
-          select: {
-            studentId: true,
-            cropRegionId: true,
-            verdict: true,
-            score: true,
-            decidedAt: true,
-            sourceQuestionScoreId: true,
-          },
-        }),
-        prisma.examPage.findMany({
-          where: { examId: examId },
-          include: { cropRegions: true },
-        }),
-      ])
-      const cropRegions = examPages.flatMap((examPage) => examPage.cropRegions)
-      // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
-      const { resolved: resolvedScores } = resolveEffectiveScores(
-        questionScores,
-        scoreDecisions
-      )
-      examDataCache.set(examId, {
-        questionScores: resolvedScores.map((resolvedScore) => ({
-          studentId: resolvedScore.studentId,
-          cropRegionId: resolvedScore.cropRegionId,
-          status: resolvedScore.status,
-          partialScore: resolvedScore.partialScore,
-        })),
-        cropRegions: cropRegions.map((cropRegion) => ({
-          id: cropRegion.id,
-          type: cropRegion.type,
-          points: cropRegion.points,
-        })),
-      })
-    }
-
-    // 5.5. 見込→欠測対応: examIdごとのExamStudent状態をプリロード
-    // Map<examId, Map<studentId, status>>
-    const examExamStudentStatusMap = new Map<string, Map<string, string>>()
-    for (const examId of examIds) {
-      const examStudentStatuses = await prisma.examStudent.findMany({
-        where: { examId: examId },
-        select: { studentId: true, status: true },
-      })
-      const statusMap = new Map<string, string>()
-      for (const examStudent of examStudentStatuses) {
-        statusMap.set(examStudent.studentId, examStudent.status)
-      }
-      examExamStudentStatusMap.set(examId, statusMap)
-    }
-
-    // 満点は元データ（設問配点 / 評価項目満点）からライブ算出する。
-    // GradeDataSource.maxScore 列のスナップショットは使わない（元データ追従）。
-    // 生徒ループの外で1ソース1回だけ算出してマップ化する。
-    const liveMaxScoreMap = new Map<string, number>()
-    for (const dataSource of allDataSources) {
-      liveMaxScoreMap.set(dataSource.id, await computeLiveMaxScore(dataSource))
-    }
-
-    // DataSource情報をまとめる（推定で使用）
-    const dataSourceInfos: DataSourceInfo[] = allDataSources.map(
-      (dataSource) => {
-        let sourceIds: string[] = []
-        if (typeof dataSource.estimationSourceIds === "string") {
-          try {
-            sourceIds = JSON.parse(dataSource.estimationSourceIds)
-          } catch {
-            sourceIds = []
-          }
-        }
-        return {
-          id: dataSource.id,
-          name: dataSource.name,
-          maxScore: liveMaxScoreMap.get(dataSource.id) ?? 0,
-          absentMethod: (dataSource.absentMethod ?? "null") as AbsentMethod,
-          absentRatio: Number(dataSource.absentRatio ?? 1),
-          absentOffset: Number(dataSource.absentOffset ?? 0),
-          estimationMode: dataSource.estimationMode ?? "all",
-          estimationSourceIds: sourceIds,
-        }
-      }
-    )
-
-    // === パス1: 全生徒 × 全DataSourceの rawScore を収集 ===
-    // Map<studentId, Map<dataSourceId, number | null>>
-    const rawScoreMap = new Map<string, Map<string, number | null>>()
-
-    for (const examStudent of examStudents) {
-      const studentScores = new Map<string, number | null>()
-      for (const dataSource of allDataSources) {
-        let raw = await getRawScore(
-          examStudent.student.id,
-          dataSource,
-          examDataCache
-        )
-
-        // 見込→欠測対応: treatExpectedAsMissing が true かつ
-        // 試験試験の ExamStudent.status === "expected" → null扱い
-        if (
-          raw !== null &&
-          dataSource.treatExpectedAsMissing &&
-          dataSource.examId
-        ) {
-          const statusMap = examExamStudentStatusMap.get(dataSource.examId)
-          if (statusMap?.get(examStudent.student.id) === "expected") {
-            raw = null
-          }
-        }
-
-        studentScores.set(dataSource.id, raw)
-      }
-      rawScoreMap.set(examStudent.student.id, studentScores)
     }
 
     // === パス2: 推定 + 重み付け ===
@@ -368,6 +507,11 @@ export async function calculateGrades(gradeId: string): Promise<{
                 regressionTerms: estimation.regressionTerms,
                 droppedPredictors: estimation.droppedPredictors,
                 fallbackReason: estimation.fallbackReason,
+                correlation: estimation.correlation,
+                standardizedStanding: estimation.standardizedStanding,
+                percentileRank: estimation.percentileRank,
+                targetMean: estimation.targetMean,
+                targetStandardDeviation: estimation.targetStandardDeviation,
               }
             }
           }
@@ -395,6 +539,10 @@ export async function calculateGrades(gradeId: string): Promise<{
             weightedScore,
             isEstimated,
             estimation: estimationDetail,
+            // このテストを実際に受けた生徒の素点分布（平均・標準偏差）。
+            // 素点がクラスの実態のどこに位置するか（説明責任の判断材料）を内訳表に併記。
+            // ソース単位で事前算出した共通の分布を参照（全生徒で同一値）。
+            distribution: distributionBySource.get(dataSource.id),
             letterValue: courseworkScore?.letterValue ?? null,
             adjustment:
               courseworkScore?.adjustment !== null &&
@@ -559,5 +707,34 @@ export async function calculateGrades(gradeId: string): Promise<{
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
     }
+  }
+}
+
+/**
+ * 当該データソース（テスト）を実測した全生徒の素点分布（平均・母標準偏差）を算出する。
+ * 実測値（rawScoreMap の非null）のみを母数とし、欠席（null）は含めない。閲覧生徒も含めた
+ * クラスの実測分布なので、どの生徒の内訳popoverでも同一値になる（＝表示ラベルと一致）。
+ * 標準偏差算出のため2名以上を要する。ソース単位で一定のため生徒ループの外で1回だけ呼ぶ。
+ *
+ * 注: 標準偏差法・順位法の載せ替えで使う absentEstimation.collectTargetDistribution とは
+ * 意味論が異なる（あちらは対象生徒を母数から除く leave-one-out ＋整列列を返す）ため別実装。
+ */
+function computeSourceDistribution(
+  dataSourceId: string,
+  rawScoreMap: Map<string, Map<string, number | null>>
+): EstimationTargetDistribution | undefined {
+  const scores: number[] = []
+  for (const [, studentScores] of rawScoreMap) {
+    const score = studentScores.get(dataSourceId)
+    if (score !== null && score !== undefined) scores.push(score)
+  }
+  if (scores.length < 2) return undefined
+  const mean = scores.reduce((sum, score) => sum + score, 0) / scores.length
+  const variance =
+    scores.reduce((sum, score) => sum + (score - mean) ** 2, 0) / scores.length
+  return {
+    sampleSize: scores.length,
+    mean,
+    standardDeviation: Math.sqrt(variance),
   }
 }

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -198,6 +198,8 @@ export function createGradeApi() {
         ),
       calculateGrades: (gradeId: string) =>
         ipcRenderer.invoke("grade:calculateGrades", gradeId),
+      computeSourceFits: (gradeId: string) =>
+        ipcRenderer.invoke("grade:computeSourceFits", gradeId),
       getExamCandidates: () => ipcRenderer.invoke("grade:getExamCandidates"),
       getExamSubtotalGroups: (examId: string) =>
         ipcRenderer.invoke("grade:getExamSubtotalGroups", examId),

--- a/src/components/grades/03-data-sources/DataSourceRow.tsx
+++ b/src/components/grades/03-data-sources/DataSourceRow.tsx
@@ -24,6 +24,8 @@ interface DataSourceRowProps {
   dataSource: GradeDataSourceWithRelations
   /** 同じGrade内の全DataSource（推定ソース選択用） */
   allDataSources: GradeDataSourceWithRelations[]
+  /** このソースのモデル適合度 R（手法選択popoverの判断材料） */
+  sourceFit?: { correlation: number; sampleSize: number } | null
   /** 欠測一括設定モード中はチェックボックスを表示する */
   batchMode: boolean
   /** 一括設定の選択状態 */
@@ -49,6 +51,7 @@ interface DataSourceRowProps {
 export function DataSourceRow({
   dataSource,
   allDataSources,
+  sourceFit,
   batchMode,
   selected,
   onToggleSelect,
@@ -177,6 +180,7 @@ export function DataSourceRow({
         <EstimationSettingsPopover
           dataSource={dataSource}
           allDataSources={allDataSources}
+          sourceFit={sourceFit}
           onUpdate={onUpdate}
         />
       </div>

--- a/src/components/grades/03-data-sources/DataSourcesContainer.tsx
+++ b/src/components/grades/03-data-sources/DataSourcesContainer.tsx
@@ -41,6 +41,7 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
   const {
     exam,
     loading,
+    sourceFits,
     createGradeItem,
     updateGradeItem,
     deleteGradeItem,
@@ -158,7 +159,10 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
   }
 
   const usesEstimationSources =
-    batchMethod === "average" || batchMethod === "regression"
+    batchMethod === "average" ||
+    batchMethod === "regression" ||
+    batchMethod === "equipercentile" ||
+    batchMethod === "zscore"
 
   const toggleBatchEstimationSourceId = (id: string) => {
     setBatchEstimationSourceIds((prev) =>
@@ -277,6 +281,8 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
                 <SelectItem value="zero">0点</SelectItem>
                 <SelectItem value="average">平均比率法</SelectItem>
                 <SelectItem value="regression">重回帰法</SelectItem>
+                <SelectItem value="equipercentile">順位法</SelectItem>
+                <SelectItem value="zscore">標準偏差法</SelectItem>
               </SelectContent>
             </Select>
             {batchMethod !== "null" && batchMethod !== "zero" && (
@@ -432,6 +438,7 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
                     key={dataSource.id}
                     dataSource={dataSource}
                     allDataSources={allDataSources}
+                    sourceFit={sourceFits[dataSource.id]}
                     batchMode={batchMode}
                     selected={selectedDataSourceIds.has(dataSource.id)}
                     onToggleSelect={toggleDsSelection}

--- a/src/components/grades/03-data-sources/EstimationSettingsPopover.tsx
+++ b/src/components/grades/03-data-sources/EstimationSettingsPopover.tsx
@@ -30,12 +30,26 @@ const ABSENT_METHOD_LABELS: Record<AbsentMethod, string> = {
   zero: "0点",
   average: "平均比率法",
   regression: "重回帰法",
+  equipercentile: "順位法",
+  zscore: "標準偏差法",
+}
+
+/** 他ソースを説明変数に使う推定方法（推定ソース選択UI・R表示の対象） */
+function methodUsesPredictors(method: AbsentMethod): boolean {
+  return (
+    method === "average" ||
+    method === "regression" ||
+    method === "equipercentile" ||
+    method === "zscore"
+  )
 }
 
 interface EstimationSettingsPopoverProps {
   dataSource: GradeDataSourceWithRelations
   /** 同じGrade内の全DataSource（自ソース含む、チェックリスト用） */
   allDataSources: GradeDataSourceWithRelations[]
+  /** このソースのモデル適合度 R（他ソースからの予測しやすさ） */
+  sourceFit?: { correlation: number; sampleSize: number } | null
   onUpdate: (
     id: string,
     data: {
@@ -52,6 +66,7 @@ interface EstimationSettingsPopoverProps {
 export function EstimationSettingsPopover({
   dataSource,
   allDataSources,
+  sourceFit,
   onUpdate,
 }: EstimationSettingsPopoverProps) {
   const [open, setOpen] = useState(false)
@@ -173,8 +188,39 @@ export function EstimationSettingsPopover({
                 <SelectItem value="zero">0点</SelectItem>
                 <SelectItem value="average">平均比率法</SelectItem>
                 <SelectItem value="regression">重回帰法</SelectItem>
+                <SelectItem value="equipercentile">順位法</SelectItem>
+                <SelectItem value="zscore">標準偏差法</SelectItem>
               </SelectContent>
             </Select>
+            {/* このソースが他ソースからどれだけ当てられるか（手法選択の判断材料）。
+                R は手法に依らないデータ側の予測しやすさ＝重回帰の縮小率。
+                高いほど重回帰でも中心へ寄りにくく、低いほど順位法・標準偏差法の
+                「縮小を避ける」利点が効く。 */}
+            {methodUsesPredictors(method) &&
+              (sourceFit ? (
+                <p className="text-muted-foreground text-xs">
+                  予測しやすさ 相関 R ={" "}
+                  <span className="font-medium tabular-nums">
+                    {sourceFit.correlation.toFixed(2)}
+                  </span>
+                  {sourceFit.correlation >= 0.999 ? (
+                    <span className="text-amber-700 dark:text-amber-300">
+                      （他ソースから完全再現＝定義上のつながり。予測ではなく復元）
+                    </span>
+                  ) : (
+                    <>
+                      （実力の約{Math.round(sourceFit.correlation * 100)}
+                      %を反映／残り約
+                      {100 - Math.round(sourceFit.correlation * 100)}
+                      %は中心へ寄る・n={sourceFit.sampleSize}）
+                    </>
+                  )}
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  予測しやすさ R: 算出不能（サンプルまたは共通ソース不足）
+                </p>
+              ))}
           </div>
 
           {method !== "null" && (
@@ -205,8 +251,8 @@ export function EstimationSettingsPopover({
                 </div>
               )}
 
-              {/* ソース選択（average/regressionのみ） */}
-              {(method === "average" || method === "regression") && (
+              {/* ソース選択（他ソースを説明変数に使う手法のみ） */}
+              {methodUsesPredictors(method) && (
                 <div className="space-y-2">
                   <Label className="text-xs">推定に使用するソース</Label>
                   <RadioGroup

--- a/src/components/grades/06-results/GradeItemBreakdownPopover.tsx
+++ b/src/components/grades/06-results/GradeItemBreakdownPopover.tsx
@@ -18,6 +18,8 @@ const ABSENT_METHOD_LABELS: Record<string, string> = {
   zero: "0点",
   average: "平均比率法",
   regression: "重回帰法",
+  equipercentile: "順位法",
+  zscore: "標準偏差法",
 }
 
 const FALLBACK_REASON_LABELS: Record<string, string> = {
@@ -342,7 +344,7 @@ function EstimationExplain({
 
       {estimation.fallbackReason && (
         <p className="text-amber-700 dark:text-amber-300">
-          ※ 重回帰法は
+          ※ 選択した推定法は
           {FALLBACK_REASON_LABELS[estimation.fallbackReason] ??
             estimation.fallbackReason}
           のため平均比率法にフォールバック
@@ -367,6 +369,41 @@ function EstimationExplain({
           droppedPredictors={estimation.droppedPredictors}
         />
       )}
+
+      {isRegression && estimation.correlation !== undefined && (
+        <p className="mt-1 text-amber-700/80 dark:text-amber-300/80">
+          予測の確かさ: 相関 R = {fmt(estimation.correlation, 2)}
+          {estimation.correlation >= 0.999
+            ? "（他ソースから完全再現＝定義上のつながり。予測ではなく復元）"
+            : `（実力の約${Math.round(estimation.correlation * 100)}%を反映／残り約${100 - Math.round(estimation.correlation * 100)}%は中心へ寄る）`}
+        </p>
+      )}
+
+      {estimation.effectiveMethod === "zscore" &&
+        estimation.standardizedStanding !== undefined &&
+        estimation.targetMean !== undefined &&
+        estimation.targetStandardDeviation !== undefined && (
+          <p className="mt-1 text-amber-700/80 dark:text-amber-300/80">
+            他ソースでの平均標準得点 z ={" "}
+            {estimation.standardizedStanding >= 0 ? "+" : ""}
+            {fmt(
+              estimation.standardizedStanding,
+              2
+            )} を、当ソース分布（平均 {fmt(estimation.targetMean)} ／ 標準偏差{" "}
+            {fmt(estimation.targetStandardDeviation)}
+            ）へ載せ替え（縮小を打ち消す）
+          </p>
+        )}
+
+      {estimation.effectiveMethod === "equipercentile" &&
+        estimation.percentileRank !== undefined && (
+          <p className="mt-1 text-amber-700/80 dark:text-amber-300/80">
+            他ソースでの平均順位 上位{" "}
+            {Math.round((1 - estimation.percentileRank) * 100)}
+            %（パーセンタイル {Math.round(estimation.percentileRank * 100)}
+            ）を、 当ソース実分布の同順位の点へ変換（分布を保存）
+          </p>
+        )}
 
       <div className="mt-1.5 space-y-0.5 border-t border-amber-300/60 pt-1 dark:border-amber-700/60">
         <EstimationFlowRow
@@ -453,6 +490,18 @@ export function GradeItemBreakdownPopover({
       ? `${itemResult.percentage.toFixed(1)}%`
       : "-",
   ])
+  // 各ソース（テスト）の実測分布。素点がクラスのどこに位置するかの判断材料として
+  // 平均列・標準偏差列を右側に併記する（分布が無ければ "—"）。列内は桁揃え。
+  const distMeanColumn = alignColumn(
+    sources.map((source) =>
+      source.distribution ? fmt(source.distribution.mean) : "—"
+    )
+  )
+  const distSdColumn = alignColumn(
+    sources.map((source) =>
+      source.distribution ? fmt(source.distribution.standardDeviation) : "—"
+    )
+  )
 
   return (
     <Popover>
@@ -465,10 +514,11 @@ export function GradeItemBreakdownPopover({
           {pctText}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-[32rem] p-3" align="start">
+      <PopoverContent className="w-[40rem] p-3" align="start">
         <p className="mb-1 text-xs font-semibold">{itemResult.gradeItemName}</p>
         <p className="text-muted-foreground mb-2 text-[10px]">
-          換算 = (素点 ÷ 満点) × 換算満点 ※欠点は除外
+          換算 = (素点 ÷ 満点) × 換算満点 ※欠点は除外／平均・標準偏差 =
+          この試験を受けた生徒の実測分布（素点の位置づけ用）
         </p>
         <table className="w-full table-fixed text-xs">
           <thead>
@@ -478,6 +528,8 @@ export function GradeItemBreakdownPopover({
               <th className={PARENT_TH_NUM}>満点</th>
               <th className={PARENT_TH_NUM}>換算</th>
               <th className={PARENT_TH_NUM}>換算満点</th>
+              <th className={PARENT_TH_NUM}>平均</th>
+              <th className={PARENT_TH_NUM}>標準偏差</th>
             </tr>
           </thead>
           <tbody>
@@ -513,6 +565,12 @@ export function GradeItemBreakdownPopover({
                   <NumCell className="py-1">{maxScoreColumn[index]}</NumCell>
                   <NumCell className="py-1">{weightedColumn[index]}</NumCell>
                   <NumCell className="py-1">{weightMaxColumn[index]}</NumCell>
+                  <NumCell className="text-muted-foreground py-1">
+                    {distMeanColumn[index]}
+                  </NumCell>
+                  <NumCell className="text-muted-foreground py-1">
+                    {distSdColumn[index]}
+                  </NumCell>
                 </tr>
               )
             })}
@@ -528,6 +586,8 @@ export function GradeItemBreakdownPopover({
               <NumCell className="pt-1">
                 {weightMaxColumn[weightMaxColumn.length - 2]}
               </NumCell>
+              <NumCell className="text-muted-foreground pt-1">—</NumCell>
+              <NumCell className="text-muted-foreground pt-1">—</NumCell>
             </tr>
             <tr className="font-medium">
               <td className="pt-1" colSpan={4}>
@@ -536,6 +596,8 @@ export function GradeItemBreakdownPopover({
               <NumCell className="pt-1">
                 {weightMaxColumn[weightMaxColumn.length - 1]}
               </NumCell>
+              <NumCell className="text-muted-foreground pt-1">—</NumCell>
+              <NumCell className="text-muted-foreground pt-1">—</NumCell>
             </tr>
           </tfoot>
         </table>

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -6,10 +6,29 @@ import type {
   GradeWithRelations,
 } from "@/types/grade.types"
 
+/** 各データソースのモデル適合度 R（このソースが他ソースからどれだけ当てられるか） */
+export type SourceFitMap = Record<
+  string,
+  { correlation: number; sampleSize: number } | null
+>
+
 /** 成績評定項目とデータソースのCRUD操作を管理するフック */
 export function useDataSources(gradeId: string) {
   const [exam, setExam] = useState<GradeWithRelations | null>(null)
   const [loading, setLoading] = useState(true)
+  // モデル適合度Rは重い算出のため本体読込と切り離し、非同期に後追いで反映する
+  const [sourceFits, setSourceFits] = useState<SourceFitMap>({})
+
+  const loadSourceFits = useCallback(async () => {
+    try {
+      const result = await window.electronAPI.grade.computeSourceFits(gradeId)
+      if (result.success && result.fits) {
+        setSourceFits(result.fits)
+      }
+    } catch (error) {
+      console.error("Error computing source fits:", error)
+    }
+  }, [gradeId])
 
   const loadData = useCallback(async () => {
     try {
@@ -27,6 +46,13 @@ export function useDataSources(gradeId: string) {
   useEffect(() => {
     loadData()
   }, [loadData])
+
+  // R の再算出は buildGradeCalcContext（全試験のスコア取得＋解決）を伴い重いため、
+  // loadData には載せず初回マウントと「Rに影響する変更」のみで走らせる（名前・換算満点・
+  // 並べ替え・評価項目リネームでは再算出しない）。
+  useEffect(() => {
+    void loadSourceFits()
+  }, [loadSourceFits])
 
   const createGradeItem = useCallback(
     async (name: string) => {
@@ -60,10 +86,12 @@ export function useDataSources(gradeId: string) {
       const result = await window.electronAPI.grade.deleteGradeItem(id)
       if (result.success) {
         await loadData()
+        // 評価項目削除は配下ソース（＝予測変数の集合）を減らすため R を再算出
+        void loadSourceFits()
       }
       return result
     },
-    [loadData]
+    [loadData, loadSourceFits]
   )
 
   const createDataSource = useCallback(
@@ -81,10 +109,12 @@ export function useDataSources(gradeId: string) {
       const result = await window.electronAPI.grade.createDataSource(data)
       if (result.success) {
         await loadData()
+        // ソース追加は予測変数/対象を増やすため R を再算出
+        void loadSourceFits()
       }
       return result
     },
-    [loadData]
+    [loadData, loadSourceFits]
   )
 
   const updateDataSource = useCallback(
@@ -104,10 +134,20 @@ export function useDataSources(gradeId: string) {
       const result = await window.electronAPI.grade.updateDataSource(id, data)
       if (result.success) {
         await loadData()
+        // 推定に影響する変更（推定法・ソース選択・見込→欠測）のときのみ R を再算出。
+        // 名前・換算満点のみの編集では R は変わらないので重い再算出をしない。
+        if (
+          data.absentMethod !== undefined ||
+          data.estimationMode !== undefined ||
+          data.estimationSourceIds !== undefined ||
+          data.treatExpectedAsMissing !== undefined
+        ) {
+          void loadSourceFits()
+        }
       }
       return result
     },
-    [loadData]
+    [loadData, loadSourceFits]
   )
 
   // 一括更新は専用IPCを持たず、普遍的な個別更新IPCをターゲット分だけ回す。
@@ -145,6 +185,8 @@ export function useDataSources(gradeId: string) {
       // 個別更新は独立にコミットされ、一部失敗でもDBは変わり得る。
       // UIを実DBへ追従させるため成否に関わらず必ず再読込する。
       await loadData()
+      // 一括設定は推定法・ソース選択を変えるため R を再算出
+      void loadSourceFits()
       return {
         success: results.every(
           (settledResult) =>
@@ -152,7 +194,7 @@ export function useDataSources(gradeId: string) {
         ),
       }
     },
-    [loadData]
+    [loadData, loadSourceFits]
   )
 
   const deleteDataSource = useCallback(
@@ -160,10 +202,12 @@ export function useDataSources(gradeId: string) {
       const result = await window.electronAPI.grade.deleteDataSource(id)
       if (result.success) {
         await loadData()
+        // ソース削除は予測変数の集合を減らすため R を再算出
+        void loadSourceFits()
       }
       return result
     },
-    [loadData]
+    [loadData, loadSourceFits]
   )
 
   const reorderDataSources = useCallback(
@@ -180,6 +224,7 @@ export function useDataSources(gradeId: string) {
   return {
     exam,
     loading,
+    sourceFits,
     createGradeItem,
     updateGradeItem,
     deleteGradeItem,

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -290,6 +290,12 @@ export interface GradeAPI {
       result?: import("../grade.types").GradeCalculationResult
       error?: string
     }>
+    /** 各データソースのモデル適合度 R（手法選択画面の判断材料）を保存設定で算出 */
+    computeSourceFits: (gradeId: string) => Promise<{
+      success: boolean
+      fits?: Record<string, { correlation: number; sampleSize: number } | null>
+      error?: string
+    }>
     getExamCandidates: () => Promise<{
       success: boolean
       exams?: Array<{ id: string; examName: string; examDate: Date | null }>

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -27,8 +27,14 @@ import type {
 import type { CourseworkItemWithLetterScales } from "./coursework.types"
 import { defineStringUnion } from "./stringUnion"
 
-/** 欠測時推定方法 */
-export type AbsentMethod = "null" | "zero" | "average" | "regression"
+/**
+ * 欠測時推定方法。
+ * - regression: OLS重回帰。二乗誤差最小＝中心へ縮小（平均回帰）あり。当てやすいが低得点層で甘く出やすい。
+ * - equipercentile（順位法）: 他ソースでの平均順位を、当ソース実分布の同順位の点へ変換。分布を保存し縮小しない。
+ * - zscore（標準偏差法）: 他ソースでの平均標準得点(±SD)を、当ソースの実平均±SDへ載せ替え。縮小を打ち消す。
+ */
+export type AbsentMethod =
+  "null" | "zero" | "average" | "regression" | "equipercentile" | "zscore"
 
 /** 推定ソース選択モード */
 export type EstimationMode = "all" | "selected"
@@ -207,6 +213,12 @@ export interface SourceScoreResult {
   isEstimated: boolean
   /** 欠測推定の内訳（isEstimated=true のときのみ。どの方法・式で推定したか） */
   estimation: EstimationDetail | null
+  /**
+   * このデータソース（テスト）を実際に受けた生徒の素点分布。
+   * 素点がクラスの実態のどこに位置するか（説明責任の判断材料）を内訳表に併記する。
+   * 実測（他生徒の非null素点）のみから算出。2名未満は undefined。
+   */
+  distribution?: EstimationTargetDistribution
   /** 文字モード時に入力された評価記号（manual型のみ） */
   letterValue: string | null
   /** 適用された加点・減点（manual型のみ。0なら調整なし） */
@@ -281,6 +293,35 @@ export interface EstimationDetail {
   droppedPredictors?: EstimationDroppedPredictor[]
   /** 重回帰法がaverageにフォールバックした理由（あれば） */
   fallbackReason?: EstimationFallbackReason
+  /**
+   * 重回帰の当てはまりの相関 R（0〜1）。予測が実力を追える度合い＝縮小率。
+   * R が高いほど中心（平均）へ寄りにくく、推定の信頼度が高い。
+   */
+  correlation?: number
+  /**
+   * 標準偏差法（zscore）: 他ソースでの平均標準得点（±何SD）。
+   * これを当ソースの実平均±SDへ載せ替えて予測する（縮小を打ち消す）。
+   */
+  standardizedStanding?: number
+  /**
+   * 順位法（equipercentile）: 他ソースでの平均パーセンタイル（0〜1、上位ほど1）。
+   * これを当ソース実分布の同順位の点へ変換して予測する（分布を保存）。
+   */
+  percentileRank?: number
+  /** 標準偏差法・順位法の載せ替え先となる当ソース実測分布の平均 */
+  targetMean?: number
+  /** 標準偏差法の載せ替え先となる当ソース実測分布の標準偏差 */
+  targetStandardDeviation?: number
+}
+
+/** 推定対象データソースの実測素点分布（評価者向けの判断材料） */
+export interface EstimationTargetDistribution {
+  /** 実測がある生徒数（この統計の母数） */
+  sampleSize: number
+  /** 実測素点の平均 */
+  mean: number
+  /** 実測素点の標準偏差（母標準偏差） */
+  standardDeviation: number
 }
 
 /** 成績算出結果全体 */


### PR DESCRIPTION
Closes #1015

## 概要
欠測時推定に **順位法(等パーセンタイル)** と **標準偏差法(z法)** を追加し、方法選択popoverに **モデル適合度 R**(このソースが他ソースからどれだけ当てられるか)を表示する。重回帰法の平均回帰(縮小)を避ける手法と、推定の確からしさを事前判断する指標を提供する。

## 変更点
### 新推定手法
- 順位法: 他ソースの平均順位→当ソース実分布の同順位点。分布保存・縮小なし。
- 標準偏差法: 他ソースの平均標準得点→当ソース実平均±SDへ載せ替え。縮小を打ち消す。
- 個別/一括ドロップダウン・内訳popover説明・ソース選択UI対応。

### モデル適合度 R
- `computeSourceFit`/`computeSourceFits` 新設、IPC `grade:computeSourceFits` で03画面へ供給。
- 構造的兄弟(同一試験/資料)を予測変数から除外(欠席時に同時欠測=復元でなく予測のR)。
- 自由度補正済みR²で小標本の過大評価を抑制。

### リファクタ・レビュー指摘対応
- 素点行列を `buildGradeCalcContext` に抽出し `calculateGrades` と共有(SSOT)。
- 実測分布は全実測者(閲覧生徒含む)でソース単位に1回だけ算出(ラベル一致・O(生徒²×ソース)解消)。
- フォールバック文言の手法非依存化、R式を `multipleCorrelationR` に一本化、R再算出を推定影響変更時のみに限定。

## テスト
- ユニット(合成データ)で z法/順位法/computeSourceFit の数理を検証。
- 実データで回帰なし・分布一意性・調整済みR(テスト系0.77〜0.92 / 資料系0.59〜0.70)を確認。
- typecheck / eslint / prettier クリア。DBスキーマ変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)