### PR TITLE
fix(roster): 並び順リセットを全生徒対象に修正しデフォルト順比較へタイブレーク追加

### DIFF
--- a/electron-src/lib/prisma/examStudent.ts
+++ b/electron-src/lib/prisma/examStudent.ts
@@ -260,21 +260,20 @@ export async function updateStudentOrders(
   studentOrders: { studentId: string; customOrder: number }[]
 ) {
   try {
-    // 各生徒の並び順を更新
-    for (const { studentId, customOrder } of studentOrders) {
-      // customOrderが-1の場合はnullにリセット（デフォルト順序）
-      const orderValue = customOrder === -1 ? null : customOrder
-
-      await prisma.examStudent.updateMany({
-        where: {
-          examId,
-          studentId,
-        },
-        data: {
-          customOrder: orderValue,
-        },
-      })
-    }
+    // 各生徒の並び順を単一トランザクションで更新
+    await prisma.$transaction(
+      studentOrders.map(({ studentId, customOrder }) =>
+        prisma.examStudent.updateMany({
+          where: {
+            examId,
+            studentId,
+          },
+          data: {
+            customOrder,
+          },
+        })
+      )
+    )
 
     const scope = await resolveExamScope(examId)
     await recordAuditLog({

--- a/src/app/exams/[examId]/05-students/page.tsx
+++ b/src/app/exams/[examId]/05-students/page.tsx
@@ -141,6 +141,7 @@ export default function StudentsPage() {
               selectedStudents={selectedStudentsForRemoval}
               onStudentSelectionChange={handleStudentSelectionChange}
               onSelectAll={handleSelectAll}
+              students={students}
               filteredStudents={filteredStudents}
               placementByStudent={placementByStudent}
               examId={examId}

--- a/src/components/common/roster-table/RosterTable.tsx
+++ b/src/components/common/roster-table/RosterTable.tsx
@@ -189,6 +189,7 @@ export function RosterTable({
     handleSelectAll,
     handleResetOrder,
   } = useRosterTable({
+    allRows: rows,
     filteredRows,
     selectedIds,
     onSelectionChange: handleSelectionChange,
@@ -301,7 +302,7 @@ export function RosterTable({
             <AlertDialogTitle>並び順をリセットしますか？</AlertDialogTitle>
             <AlertDialogDescription className="space-y-2">
               <span className="block">
-                手動で設定した並び順を、学級の関連付け設定に基づいて再設定します。
+                手動で設定した並び順を、学級の関連付け設定に基づいて再設定します（検索・フィルタ中でも全生徒が対象になります）。
               </span>
               <span className="block font-medium">リセット後の並び順：</span>
               <span className="text-muted-foreground block pl-4">

--- a/src/components/common/roster-table/useRosterTable.ts
+++ b/src/components/common/roster-table/useRosterTable.ts
@@ -22,7 +22,7 @@ function compareByCustomOrder(rowA: RosterRow, rowB: RosterRow): number {
   return compareByDefault(rowA, rowB)
 }
 
-/** 学級順→出席番号順（デフォルト順） */
+/** 学級順→出席番号順（デフォルト順）。同順位はふりがな→生徒番号で決定的に順序付ける */
 function compareByDefault(rowA: RosterRow, rowB: RosterRow): number {
   const rowAClassroomOrder = rowA.classroomInfo.classroomOrder ?? 99999
   const rowBClassroomOrder = rowB.classroomInfo.classroomOrder ?? 99999
@@ -31,10 +31,17 @@ function compareByDefault(rowA: RosterRow, rowB: RosterRow): number {
   }
   const rowAAttendance = rowA.classroomInfo.attendanceNumber ?? 99999
   const rowBAttendance = rowB.classroomInfo.attendanceNumber ?? 99999
-  return rowAAttendance - rowBAttendance
+  if (rowAAttendance !== rowBAttendance) {
+    return rowAAttendance - rowBAttendance
+  }
+  const kanaComparison = rowA.kana.localeCompare(rowB.kana, "ja")
+  if (kanaComparison !== 0) return kanaComparison
+  return rowA.studentNumber.localeCompare(rowB.studentNumber, "ja")
 }
 
 interface UseRosterTableParams {
+  /** 全対象の行（フィルタ未適用。順序リセットはこちらを対象にする） */
+  allRows: RosterRow[]
   /** 表示対象（フィルタ適用済み）の行 */
   filteredRows: RosterRow[]
   /** 選択中の studentId 集合（制御） */
@@ -55,6 +62,7 @@ interface UseRosterTableParams {
  * 試験名簿の挙動（複数選択ドラッグ・Shift範囲選択・学級順リセット）を踏襲する。
  */
 export function useRosterTable({
+  allRows,
   filteredRows,
   selectedIds,
   onSelectionChange,
@@ -177,15 +185,17 @@ export function useRosterTable({
     [onSelectAll]
   )
 
-  // リセット（学級順→出席番号順で customOrder を振り直す）
+  // リセット（学級順→出席番号順で customOrder を振り直す。
+  // 表示中の行だけでなく全対象を振り直さないと、フィルタ適用中のリセットで
+  // 非表示行の旧 customOrder と衝突して並びが壊れる）
   const handleResetOrder = useCallback(async () => {
-    const defaultSorted = [...sortedRows].sort(compareByDefault)
+    const defaultSorted = [...allRows].sort(compareByDefault)
     const newOrders = defaultSorted.map((row, index) => ({
       studentId: row.id,
       customOrder: index,
     }))
     await onOrderUpdate(newOrders)
-  }, [sortedRows, onOrderUpdate])
+  }, [allRows, onOrderUpdate])
 
   const activeRow = useMemo(
     () =>

--- a/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
+++ b/src/components/exams/05-students/components/exam-students-page/hooks/useExamStudentsData.ts
@@ -55,7 +55,17 @@ function compareExamStudents(
 
     const attendanceA = placementA?.attendanceNumber ?? 99999
     const attendanceB = placementB?.attendanceNumber ?? 99999
-    return attendanceA - attendanceB
+    if (attendanceA !== attendanceB) return attendanceA - attendanceB
+
+    // 同順位はふりがな→生徒番号で決定的に順序付ける
+    const kanaA = `${examStudentA.student.lastNameKana} ${examStudentA.student.firstNameKana}`
+    const kanaB = `${examStudentB.student.lastNameKana} ${examStudentB.student.firstNameKana}`
+    const kanaComparison = kanaA.localeCompare(kanaB, "ja")
+    if (kanaComparison !== 0) return kanaComparison
+    return examStudentA.student.studentNumber.localeCompare(
+      examStudentB.student.studentNumber,
+      "ja"
+    )
   }
 }
 

--- a/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
+++ b/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
@@ -81,6 +81,7 @@ export function SortableStudentTableContainer(
     onSelectAll,
     onStudentStatusUpdate,
     onStudentOrderUpdate,
+    students,
     filteredStudents,
     placementByStudent,
     examId,
@@ -94,6 +95,14 @@ export function SortableStudentTableContainer(
 
   const [showResetDialog, setShowResetDialog] = useState(false)
   const [isResetting, setIsResetting] = useState(false)
+
+  const allRows = useMemo(
+    () =>
+      students.map((examStudent) =>
+        toRosterRow(examStudent, placementByStudent[examStudent.studentId])
+      ),
+    [students, placementByStudent]
+  )
 
   const filteredRows = useMemo(
     () =>
@@ -125,6 +134,7 @@ export function SortableStudentTableContainer(
     handleSelectAll,
     handleResetOrder,
   } = useRosterTable({
+    allRows,
     filteredRows,
     selectedIds: selectedStudents,
     onSelectionChange: onStudentSelectionChange,
@@ -309,7 +319,7 @@ export function SortableStudentTableContainer(
             <AlertDialogTitle>並び順をリセットしますか？</AlertDialogTitle>
             <AlertDialogDescription className="space-y-2">
               <span className="block">
-                手動で設定した並び順を、学級の関連付け設定に基づいて再設定します。
+                手動で設定した並び順を、学級の関連付け設定に基づいて再設定します（検索・フィルタ中でも全生徒が対象になります）。
               </span>
               <span className="block font-medium">リセット後の並び順：</span>
               <span className="text-muted-foreground block pl-4">

--- a/src/components/exams/05-students/components/sortable-student-table/types.ts
+++ b/src/components/exams/05-students/components/sortable-student-table/types.ts
@@ -16,6 +16,8 @@ export interface SortableStudentTableProps {
   selectedStudents: Set<string>
   onStudentSelectionChange: (studentId: string, isSelected: boolean) => void
   onSelectAll: (isSelected: boolean) => void
+  /** 全受験生徒（フィルタ未適用。順序リセットの対象） */
+  students: ExamStudentWithMemberships[]
   filteredStudents: ExamStudentWithMemberships[]
   /** ExamClassroom 由来の表示学級情報（studentId キーの side data） */
   placementByStudent: Record<string, ExamClassroomPlacement>


### PR DESCRIPTION
Closes #1022

## 変更内容

### リセットを全生徒対象に修正
- `useRosterTable` に `allRows`（フィルタ未適用の全行）パラメータを追加し、`handleResetOrder` は常に全対象を「学級の関連付け順→出席番号順」でソートして customOrder を振り直すよう修正
- 試験（05-students の `SortableStudentTableContainer`）は全受験生徒を props（`students`）で受け取り、成績・資料共通の `RosterTable` は保持済みの全行を渡す
- 確認ダイアログに「検索・フィルタ中でも全生徒が対象」と明記

### デフォルト順比較のタイブレーク統一
- 共通 `compareByDefault` と試験側 `compareExamStudents` を「学級順 → 出席番号順 → ふりがな → 生徒番号」に統一し、学級未所属・出席番号なしの生徒も決定的に並ぶよう修正

### 付随修正
- 試験の `updateStudentOrders`（electron）を逐次更新から単一トランザクションへ変更（grade/coursework と整合）
- 未使用の `-1 → null` 変換の死にコードを削除

## 設計判断

`customOrder` は「常に実体化」されるアーキテクチャ（追加経路が必ず焼き込み、pdfExport / gradeCalculator / studentAnswer が DB 順に直接依存）のため、null クリア方式ではなく振り直し方式を維持している。

## テスト

- `npm run typecheck` / `npm run lint` パス
- 関連統合テスト48件パス（`gradeStudentCrud` / `courseworkCrud` / `examStudentClassroom`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)