### PR TITLE
fix(exams): 試験削除で画像ファイルを削除し確認モーダルの件数表示を修正

### DIFF
--- a/__tests__/exam/integration/examDelete.test.ts
+++ b/__tests__/exam/integration/examDelete.test.ts
@@ -1,0 +1,90 @@
+/**
+ * 試験削除の統合テスト
+ *
+ * deleteExam が DB レコードを cascade 削除するだけでなく、
+ * 試験ディレクトリ配下の画像ファイルも削除することを検証する。
+ */
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+
+// getExamDirectory がこのディレクトリを基準にするよう、import より前に設定する
+const TEST_DATA_DIR = path.join(os.tmpdir(), "score-at-once-exam-delete-test")
+process.env.SCORE_AT_ONCE_DATA_DIR = TEST_DATA_DIR
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { getExamDirectory } from "@/electron-src/lib/dataManager"
+import { createExam, deleteExam } from "@/electron-src/lib/prisma/exam"
+
+import {
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+
+const prisma = getTestPrismaClient()
+
+describe("deleteExam", () => {
+  let userId: string
+
+  beforeAll(async () => {
+    const user = await prisma.user.create({
+      data: {
+        name: "削除テスト教員",
+        username: `exam-delete-${Date.now()}`,
+      },
+    })
+    userId = user.id
+  })
+
+  afterAll(async () => {
+    await prisma.user.delete({ where: { id: userId } })
+    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true })
+    await disconnectTestPrisma()
+  })
+
+  it("試験ディレクトリの画像ファイルごと削除する", async () => {
+    const exam = await createExam({ examName: "削除対象の試験" }, userId)
+
+    const examPage = await prisma.examPage.create({
+      data: { examId: exam.id, pageNumber: 1 },
+    })
+    const masterAnswersDir = path.join(
+      getExamDirectory(exam.id),
+      "master-answers"
+    )
+    await fs.mkdir(masterAnswersDir, { recursive: true })
+    const imagePath = path.join(masterAnswersDir, "page-1.png")
+    await fs.writeFile(imagePath, "dummy-image")
+    await prisma.masterImage.create({
+      data: {
+        examPageId: examPage.id,
+        imagePath: path.relative(TEST_DATA_DIR, imagePath),
+      },
+    })
+
+    await deleteExam(exam.id)
+
+    expect(await prisma.exam.findUnique({ where: { id: exam.id } })).toBeNull()
+    // cascade で子レコードも消えていること
+    expect(
+      await prisma.examPage.findUnique({ where: { id: examPage.id } })
+    ).toBeNull()
+    // 画像ファイルとディレクトリが残っていないこと
+    await expect(fs.stat(getExamDirectory(exam.id))).rejects.toThrow()
+  })
+
+  it("試験ディレクトリが存在しない場合も削除に失敗しない", async () => {
+    const exam = await createExam({ examName: "ファイル無しの試験" }, userId)
+
+    await expect(deleteExam(exam.id)).resolves.toBeTruthy()
+    expect(await prisma.exam.findUnique({ where: { id: exam.id } })).toBeNull()
+  })
+})

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -1,5 +1,7 @@
 import type { Prisma as PrismaTypes } from "@prisma/client"
+import * as fs from "fs/promises"
 
+import { getExamDirectory } from "../dataManager"
 import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 import { examPageWithContentInclude } from "./examPage"
@@ -127,6 +129,10 @@ export const getExamById = async (id: string) => {
           },
         },
         orderBy: { tag: { order: "asc" } },
+      },
+      // 試験削除時に参照を失う（examIdがSetNull・cropRegion経由はcascade削除）成績データソース
+      gradeDataSources: {
+        select: { id: true },
       },
     },
   })
@@ -260,7 +266,7 @@ export const updateExam = async (
   return exam
 }
 
-/** 試験を削除する */
+/** 試験を削除する（DBレコードのcascade削除に加え、画像ファイルのディレクトリも削除する） */
 export const deleteExam = async (id: string) => {
   const before = await prisma.exam.findUnique({
     where: { id },
@@ -270,6 +276,14 @@ export const deleteExam = async (id: string) => {
   const exam = await prisma.exam.delete({
     where: { id },
   })
+
+  // 模範解答・答案の画像はDBのcascadeでは消えないため、試験ディレクトリごと削除する。
+  // ファイル削除の失敗で試験削除自体を巻き戻さない（DBは既に削除済み）。
+  try {
+    await fs.rm(getExamDirectory(id), { recursive: true, force: true })
+  } catch (fileError) {
+    console.warn(`Failed to delete exam directory for ${id}:`, fileError)
+  }
 
   await recordAuditLog({
     action: "exam.delete",

--- a/src/app/exams/[examId]/page.tsx
+++ b/src/app/exams/[examId]/page.tsx
@@ -38,6 +38,7 @@ export default function ExamDetailPage() {
     modelAnswerCount,
     answerSheetCount,
     cropRegionCount,
+    gradeDataSourceCount,
     updateExam,
   } = useExamDetail(examId)
 
@@ -196,6 +197,10 @@ export default function ExamDetailPage() {
           {exam && (
             <DeleteExamModal
               exam={exam}
+              masterImageCount={modelAnswerCount}
+              answerSheetCount={answerSheetCount}
+              cropRegionCount={cropRegionCount}
+              gradeDataSourceCount={gradeDataSourceCount}
               open={showDeleteModal}
               onOpenChange={setShowDeleteModal}
               onExamDeleted={handleExamDeleted}

--- a/src/components/exams/shared/DeleteExamModal.tsx
+++ b/src/components/exams/shared/DeleteExamModal.tsx
@@ -1,18 +1,21 @@
 "use client"
 
-import { Exam } from "@prisma/client"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import ConfirmationModal from "@/components/common/ConfirmationModal"
+import type { ExamForDetail } from "@/types/prismaExtensions"
 
 interface DeleteExamModalProps {
-  exam: Exam & {
-    masterImages?: unknown[]
-    answerSheets?: unknown[]
-    cropRegions?: unknown[]
-    examTags?: { tag: { id: string; name: string } }[]
-  }
+  exam: ExamForDetail
+  /** 模範解答画像の件数（useExamDetailで集計） */
+  masterImageCount: number
+  /** 答案画像の件数（useExamDetailで集計） */
+  answerSheetCount: number
+  /** 採点領域の件数（useExamDetailで集計） */
+  cropRegionCount: number
+  /** この試験を参照している成績データソースの件数 */
+  gradeDataSourceCount: number
   open: boolean
   onOpenChange: (open: boolean) => void
   onExamDeleted: () => void
@@ -20,30 +23,15 @@ interface DeleteExamModalProps {
 
 export default function DeleteExamModal({
   exam,
+  masterImageCount,
+  answerSheetCount,
+  cropRegionCount,
+  gradeDataSourceCount,
   open,
   onOpenChange,
   onExamDeleted,
 }: DeleteExamModalProps) {
   const [isLoading, setIsLoading] = useState(false)
-  const [examData, setExamData] = useState<{
-    masterImageCount: number
-    answerSheetCount: number
-    cropRegionCount: number
-  }>({
-    masterImageCount: 0,
-    answerSheetCount: 0,
-    cropRegionCount: 0,
-  })
-
-  useEffect(() => {
-    if (exam) {
-      setExamData({
-        masterImageCount: exam.masterImages?.length || 0,
-        answerSheetCount: exam.answerSheets?.length || 0,
-        cropRegionCount: exam.cropRegions?.length || 0,
-      })
-    }
-  }, [exam])
 
   const handleDelete = async () => {
     if (!exam) return
@@ -62,10 +50,15 @@ export default function DeleteExamModal({
     }
   }
 
-  const hasData =
-    examData.masterImageCount > 0 ||
-    examData.answerSheetCount > 0 ||
-    examData.cropRegionCount > 0
+  const deletedDataLabels = [
+    { label: "模範解答", count: masterImageCount },
+    { label: "採点領域", count: cropRegionCount },
+    { label: "答案", count: answerSheetCount },
+  ]
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${entry.label}${entry.count}件`)
+
+  const hasData = deletedDataLabels.length > 0
 
   // 試験情報をアイテムとして構成
   const examItems = exam
@@ -103,7 +96,15 @@ export default function DeleteExamModal({
       ? [
           {
             type: "warning" as const,
-            message: `削除されるデータ: 模範解答${examData.masterImageCount}件、採点領域${examData.cropRegionCount}件、答案${examData.answerSheetCount}件`,
+            message: `削除されるデータ: ${deletedDataLabels.join("、")}（採点結果と画像ファイルを含む）`,
+          },
+        ]
+      : []),
+    ...(gradeDataSourceCount > 0
+      ? [
+          {
+            type: "warning" as const,
+            message: `この試験を参照している成績データソース${gradeDataSourceCount}件が参照を失います。該当する成績の評価項目を確認してください。`,
           },
         ]
       : []),

--- a/src/hooks/useExamDetail.ts
+++ b/src/hooks/useExamDetail.ts
@@ -98,6 +98,7 @@ export function useExamDetail(examId: string) {
       (count, page) => count + (page.cropRegions?.length || 0),
       0
     ) || 0
+  const gradeDataSourceCount = exam?.gradeDataSources?.length || 0
 
   return {
     exam,
@@ -107,6 +108,7 @@ export function useExamDetail(examId: string) {
     modelAnswerCount,
     answerSheetCount,
     cropRegionCount,
+    gradeDataSourceCount,
     updateExam,
   }
 }

--- a/src/types/prismaExtensions.ts
+++ b/src/types/prismaExtensions.ts
@@ -171,6 +171,7 @@ export type ExamForDetail = Prisma.ExamGetPayload<{
     examTags: {
       select: { tag: { select: { id: true; name: true; color: true } } }
     }
+    gradeDataSources: { select: { id: true } }
   }
 }> & {
   /** IPCハンドラーで平坦化されるcropRegions（進捗計算用・スコアは軽量／partialScore は number にシリアライズ済み） */


### PR DESCRIPTION
Closes #1024

## 変更内容

### 削除確認モーダルの件数表示を修正

`DeleteExamModal` の props を `unknown[]` の optional から明示的な件数（`masterImageCount` / `answerSheetCount` / `cropRegionCount`）に変更し、`useExamDetail` が既に `examPages` から集計している正しい値を `page.tsx` から渡すようにしました。0件の項目は文言から省きます。

### 試験削除時に画像ファイルを削除

`deleteExam` で `data/exams/<examId>/` を丸ごと削除するようにしました。DB は既に削除済みのため、ファイル削除の失敗で主操作を巻き戻すことはせず警告ログに留めています。

### 成績データソースへの影響を警告

`getExamById` に `gradeDataSources` の件数取得を追加し、参照を失う件数をモーダルで警告します。

## テスト

`__tests__/exam/integration/examDelete.test.ts` を追加しました。

- 試験ディレクトリの画像ファイルごと削除されること（cascade で子レコードが消えることも併せて検証）
- ディレクトリが存在しない場合も削除に失敗しないこと

ファイル削除処理を無効化すると前者が落ちることを確認済みです（ミューテーション検証）。

## 確認

- `npm run typecheck` 通過
- `npm run lint` 通過
- `npx vitest run` は 957 passed / 1 failed。失敗する `normalizeDatetime.test.ts` は本 PR 適用前の main でも同様に失敗する既知の事象です。

## 補足

既存の孤児ディレクトリ3件・5.9MB は、全テーブルの全文検索で生きた参照がないことを確認したうえで別途削除済みです（AuditLog の履歴行のみが ID を保持していますが、ファイルパスは持たないため影響ありません）。