### PR TITLE
fix(06-student-answers): 答案削除で採点データを確実に削除し確認モーダルに内訳表示

### DIFF
--- a/__tests__/exam/integration/studentAnswerDelete.test.ts
+++ b/__tests__/exam/integration/studentAnswerDelete.test.ts
@@ -1,0 +1,485 @@
+/**
+ * deleteStudentAnswer / getStudentAnswerScoreSummary の採点データ整合性テスト
+ *
+ * 背景: StudentAnswerImage は採点系の子リレーションを持たず（採点は
+ * `(cropRegionId, studentId)` / `(compoundAnswerId, studentId)` 座標に紐づく）、
+ * 画像を消しても cascade は走らない。かつて画像だけを削除していたため採点が孤児化していた。
+ *
+ * 検証対象:
+ * - 削除でページ scoped の QuestionScore / ScoreDecision / CompoundAnswerScore が消える
+ * - DrawingAnnotation は親の cascade で消え、DeletedRecord に tombstone が残る
+ * - 他生徒・他ページの採点は巻き添えにしない
+ * - サマリは unscored の初期化行を「採点データあり」と誤判定しない
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import {
+  SCORE_TARGET_DELETED,
+  updateQuestionScore,
+} from "@/electron-src/lib/prisma/questionScore"
+import {
+  deleteStudentAnswer,
+  getStudentAnswerScoreSummary,
+} from "@/electron-src/lib/prisma/studentAnswer/crud"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 2生徒 × 2ページ × 1設問/ページ、全マス答案あり・全マス採点済み */
+async function buildSimpleExam() {
+  const exam = await createFullTestExam(testPrisma, {
+    studentCount: 2,
+    pageCount: 2,
+    cropRegionsPerPage: 1,
+    includeScores: true,
+    includeStudentAnswerImages: true,
+  })
+
+  const [studentA, studentB] = exam.students
+  const page1 = exam.pages.find((page) => page.pageNumber === 1)!
+  const page2 = exam.pages.find((page) => page.pageNumber === 2)!
+  const region1 = exam.cropRegions.find(
+    (region) => region.examPageId === page1.id
+  )!
+  const region2 = exam.cropRegions.find(
+    (region) => region.examPageId === page2.id
+  )!
+
+  const image = (pageId: string, studentId: string) =>
+    exam.studentAnswerImages.find(
+      (answerImage) =>
+        answerImage.examPageId === pageId && answerImage.studentId === studentId
+    )!
+  const score = (cropRegionId: string, studentId: string) =>
+    exam.questionScores.find(
+      (questionScore) =>
+        questionScore.cropRegionId === cropRegionId &&
+        questionScore.studentId === studentId
+    )!
+
+  const user = await testPrisma.user.findFirstOrThrow()
+
+  return {
+    exam,
+    studentA,
+    studentB,
+    page1,
+    page2,
+    region1,
+    region2,
+    image,
+    score,
+    user,
+  }
+}
+
+describe("deleteStudentAnswer", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("答案削除でそのマスの採点データが全て消え、他マスは残る", async () => {
+    const {
+      studentA,
+      studentB,
+      page1,
+      page2,
+      region1,
+      region2,
+      image,
+      score,
+      user,
+    } = await buildSimpleExam()
+
+    // studentA の p1 に確定値・注釈・複合回答の採点を足す
+    const annotation = await testPrisma.drawingAnnotation.create({
+      data: {
+        id: crypto.randomUUID(),
+        questionScoreId: score(region1.id, studentA.id).id,
+        type: "circle",
+        x: 5,
+        y: 5,
+        userId: user.id,
+      },
+    })
+    await testPrisma.scoreDecision.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: region1.id,
+        studentId: studentA.id,
+        verdict: "correct",
+        decidedByUserId: user.id,
+      },
+    })
+    const compoundAnswer = await testPrisma.compoundAnswer.create({
+      data: {
+        id: crypto.randomUUID(),
+        examPageId: page1.id,
+        label: "アイ",
+        answerFormat: "multi-digit",
+        correctAnswer: "42",
+        points: 5,
+      },
+    })
+    await testPrisma.compoundAnswerScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        compoundAnswerId: compoundAnswer.id,
+        studentId: studentA.id,
+        userId: user.id,
+        status: "correct",
+        recognizedAnswer: "42",
+      },
+    })
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+
+    // 画像本体
+    expect(
+      await testPrisma.studentAnswerImage.findUnique({
+        where: { id: image(page1.id, studentA.id).id },
+      })
+    ).toBeNull()
+
+    // 当該マス (p1 × A) の採点は全滅
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(0)
+    expect(
+      await testPrisma.scoreDecision.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(0)
+    expect(
+      await testPrisma.compoundAnswerScore.count({
+        where: { compoundAnswerId: compoundAnswer.id, studentId: studentA.id },
+      })
+    ).toBe(0)
+    // DrawingAnnotation は親 QuestionScore の cascade で消える
+    expect(
+      await testPrisma.drawingAnnotation.findUnique({
+        where: { id: annotation.id },
+      })
+    ).toBeNull()
+
+    // 他生徒（p1 × B）・他ページ（p2 × A）は巻き添えにしない
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentB.id },
+      })
+    ).toBe(1)
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region2.id, studentId: studentA.id },
+      })
+    ).toBe(1)
+    expect(
+      await testPrisma.studentAnswerImage.findUnique({
+        where: { id: image(page2.id, studentA.id).id },
+      })
+    ).not.toBeNull()
+  })
+
+  it("削除した DrawingAnnotation は tombstone に記録される（import での復活防止）", async () => {
+    const { studentA, page1, region1, image, score, user } =
+      await buildSimpleExam()
+
+    const annotation = await testPrisma.drawingAnnotation.create({
+      data: {
+        id: crypto.randomUUID(),
+        questionScoreId: score(region1.id, studentA.id).id,
+        type: "circle",
+        x: 5,
+        y: 5,
+        userId: user.id,
+      },
+    })
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+
+    const tombstone = await testPrisma.deletedRecord.findUnique({
+      where: {
+        tableName_recordId: {
+          tableName: "DrawingAnnotation",
+          recordId: annotation.id,
+        },
+      },
+    })
+    expect(tombstone).not.toBeNull()
+  })
+
+  it("削除直前の採点実績を返す（モーダルと同じ定義）", async () => {
+    const { studentA, page1, image } = await buildSimpleExam()
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+    expect(result.deletedSummary?.hasScoreData).toBe(true)
+    expect(result.deletedSummary?.scoredQuestionCount).toBe(1)
+  })
+
+  it("未採点の答案では採点実績なしを返す（トーストの文言が変わる）", async () => {
+    const { studentA, page1, region1, image } = await buildSimpleExam()
+
+    await testPrisma.questionScore.updateMany({
+      where: { cropRegionId: region1.id, studentId: studentA.id },
+      data: { status: "unscored", partialScore: null },
+    })
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+    expect(result.deletedSummary?.hasScoreData).toBe(false)
+  })
+
+  it("協調採点では全教員分の採点行が消える（自分の行だけ残さない）", async () => {
+    const { studentA, page1, region1, image, user } = await buildSimpleExam()
+
+    // 別教員2名の提案行を同じマスに追加（QuestionScore に unique は無い）
+    const otherTeachers = await Promise.all(
+      [1, 2].map((index) =>
+        testPrisma.user.create({
+          data: {
+            id: crypto.randomUUID(),
+            name: `別の教員${index}`,
+            username: `teacher-${crypto.randomUUID()}`,
+          },
+        })
+      )
+    )
+    for (const teacher of otherTeachers) {
+      await testPrisma.questionScore.create({
+        data: {
+          id: crypto.randomUUID(),
+          cropRegionId: region1.id,
+          studentId: studentA.id,
+          userId: teacher.id,
+          status: "incorrect",
+        },
+      })
+    }
+    // 3教員（元の1名 + 追加2名）分の行がある状態
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(3)
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+
+    // 教員を問わず全滅している（userId で絞っていないことの保証）
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(0)
+    for (const teacher of [user, ...otherTeachers]) {
+      expect(
+        await testPrisma.questionScore.count({
+          where: {
+            cropRegionId: region1.id,
+            studentId: studentA.id,
+            userId: teacher.id,
+          },
+        })
+      ).toBe(0)
+    }
+  })
+
+  it("削除後に別教員が同じ採点を保存すると target-deleted を返す（協調採点）", async () => {
+    const { studentA, page1, region1, image, score } = await buildSimpleExam()
+    const scoreId = score(region1.id, studentA.id).id
+
+    // 教員Aが答案を削除 → 教員Bが開いたままの採点を保存しようとする
+    expect(
+      (await deleteStudentAnswer(image(page1.id, studentA.id).id)).success
+    ).toBe(true)
+
+    const result = await updateQuestionScore(scoreId, { status: "correct" })
+    expect(result.success).toBe(false)
+    // 生の Prisma エラーではなく機械可読な理由が返る
+    expect(result.reason).toBe(SCORE_TARGET_DELETED)
+    expect(result.error).toContain("削除")
+  })
+
+  it("存在しない答案は失敗し、DB は変化しない", async () => {
+    const { region1, studentA } = await buildSimpleExam()
+
+    const result = await deleteStudentAnswer(crypto.randomUUID())
+    expect(result.success).toBe(false)
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(1)
+  })
+})
+
+describe("getStudentAnswerScoreSummary", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("採点済みなら hasScoreData=true と内訳を返す", async () => {
+    const { studentA, page1, region1, image, score, user } =
+      await buildSimpleExam()
+
+    await testPrisma.drawingAnnotation.create({
+      data: {
+        id: crypto.randomUUID(),
+        questionScoreId: score(region1.id, studentA.id).id,
+        type: "circle",
+        x: 5,
+        y: 5,
+        userId: user.id,
+      },
+    })
+
+    const result = await getStudentAnswerScoreSummary(
+      image(page1.id, studentA.id).id
+    )
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.summary.hasScoreData).toBe(true)
+    expect(result.summary.scoredQuestionCount).toBe(1)
+    expect(result.summary.drawingAnnotationCount).toBe(1)
+    expect(result.summary.scoreDecisionCount).toBe(0)
+  })
+
+  it("協調採点で1設問に複数教員の行があっても設問数で数える", async () => {
+    const { studentA, page1, region1, image } = await buildSimpleExam()
+
+    // 別教員の提案行を同じ設問に追加（QuestionScore に unique は無い）
+    const otherTeacher = await testPrisma.user.create({
+      data: {
+        id: crypto.randomUUID(),
+        name: "別の教員",
+        username: `teacher-${crypto.randomUUID()}`,
+      },
+    })
+    await testPrisma.questionScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: region1.id,
+        studentId: studentA.id,
+        userId: otherTeacher.id,
+        status: "incorrect",
+      },
+    })
+
+    const result = await getStudentAnswerScoreSummary(
+      image(page1.id, studentA.id).id
+    )
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    // 行数は2だが設問は1問
+    expect(result.summary.scoredQuestionCount).toBe(1)
+  })
+
+  it("部分点のみ入力された複合回答も採点済みとして数える", async () => {
+    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const user = await testPrisma.user.findFirstOrThrow()
+
+    // 設問側は未採点に戻し、複合回答の部分点だけがある状態にする
+    await testPrisma.questionScore.updateMany({
+      where: { cropRegionId: region1.id, studentId: studentA.id },
+      data: { status: "unscored", partialScore: null },
+    })
+    const compoundAnswer = await testPrisma.compoundAnswer.create({
+      data: {
+        id: crypto.randomUUID(),
+        examPageId: page1.id,
+        label: "アイ",
+        answerFormat: "multi-digit",
+        correctAnswer: "42",
+        points: 5,
+      },
+    })
+    await testPrisma.compoundAnswerScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        compoundAnswerId: compoundAnswer.id,
+        studentId: studentA.id,
+        userId: user.id,
+        status: "unscored",
+        recognizedAnswer: null,
+        partialScore: 3,
+      },
+    })
+
+    const result = await getStudentAnswerScoreSummary(
+      image(page1.id, studentA.id).id
+    )
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.summary.scoredCompoundAnswerCount).toBe(1)
+    expect(result.summary.hasScoreData).toBe(true)
+  })
+
+  it("unscored の初期化行だけなら hasScoreData=false", async () => {
+    const { studentA, page1, region1, image } = await buildSimpleExam()
+
+    // 初期化直後の状態（status=unscored・部分点なし）に戻す
+    await testPrisma.questionScore.updateMany({
+      where: { cropRegionId: region1.id, studentId: studentA.id },
+      data: { status: "unscored", partialScore: null },
+    })
+
+    const result = await getStudentAnswerScoreSummary(
+      image(page1.id, studentA.id).id
+    )
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.summary.hasScoreData).toBe(false)
+    expect(result.summary.scoredQuestionCount).toBe(0)
+  })
+
+  it("未採点でも削除時は初期化行ごと消える", async () => {
+    const { studentA, page1, region1, image } = await buildSimpleExam()
+
+    await testPrisma.questionScore.updateMany({
+      where: { cropRegionId: region1.id, studentId: studentA.id },
+      data: { status: "unscored", partialScore: null },
+    })
+
+    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    expect(result.success).toBe(true)
+    expect(
+      await testPrisma.questionScore.count({
+        where: { cropRegionId: region1.id, studentId: studentA.id },
+      })
+    ).toBe(0)
+  })
+})

--- a/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
+++ b/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
@@ -192,6 +192,81 @@ describe("applyStudentAnswerPlacements", () => {
     expect(annotations).toHaveLength(0)
   })
 
+  it("複合回答の採点も carry で追従し、discard で破棄される", async () => {
+    const { studentA, studentB, page1, page2, image } = await buildSimpleExam()
+    const user = await testPrisma.user.findFirstOrThrow()
+
+    const compoundAnswer = await testPrisma.compoundAnswer.create({
+      data: {
+        id: crypto.randomUUID(),
+        examPageId: page1.id,
+        label: "アイ",
+        answerFormat: "multi-digit",
+        correctAnswer: "42",
+        points: 5,
+      },
+    })
+    const compoundScoreA = await testPrisma.compoundAnswerScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        compoundAnswerId: compoundAnswer.id,
+        studentId: studentA.id,
+        userId: user.id,
+        status: "correct",
+        recognizedAnswer: "42",
+      },
+    })
+
+    // 同一ページで A → B へ carry（B 側に複合採点は無いので単独移動）
+    const carried = await applyStudentAnswerPlacements([
+      {
+        fileId: image(page1.id, studentA.id).id,
+        finalStudentId: studentB.id,
+        finalExamPageId: page1.id,
+        scorePolicy: "carry",
+      },
+      {
+        fileId: image(page1.id, studentB.id).id,
+        finalStudentId: studentA.id,
+        finalExamPageId: page1.id,
+        scorePolicy: "carry",
+      },
+    ])
+    expect(carried.success).toBe(true)
+
+    // 複合採点が B へ追従（unique 違反を起こさず1件のまま）
+    const afterCarry = await testPrisma.compoundAnswerScore.findMany({
+      where: { compoundAnswerId: compoundAnswer.id },
+    })
+    expect(afterCarry).toHaveLength(1)
+    expect(afterCarry[0].studentId).toBe(studentB.id)
+    expect(afterCarry[0].recognizedAnswer).toBe("42")
+    expect(afterCarry[0].id).toBe(compoundScoreA.id)
+
+    // ページ跨ぎ（discard）で複合採点は破棄される。
+    // carry 後この画像は B のもの。p2×B と入れ替える形で p1→p2 へ動かす。
+    const discarded = await applyStudentAnswerPlacements([
+      {
+        fileId: image(page1.id, studentA.id).id,
+        finalStudentId: studentB.id,
+        finalExamPageId: page2.id,
+        scorePolicy: "discard",
+      },
+      {
+        fileId: image(page2.id, studentB.id).id,
+        finalStudentId: studentB.id,
+        finalExamPageId: page1.id,
+        scorePolicy: "discard",
+      },
+    ])
+    expect(discarded.success).toBe(true)
+    expect(
+      await testPrisma.compoundAnswerScore.count({
+        where: { compoundAnswerId: compoundAnswer.id },
+      })
+    ).toBe(0)
+  })
+
   it("② ページ跨ぎ移動(discard): examPageId が更新され、移動元ページの採点が破棄される", async () => {
     const { studentA, page1, page2, region1, region2, image, score } =
       await buildSimpleExam()
@@ -264,7 +339,8 @@ describe("applyStudentAnswerPlacements", () => {
     const { studentA, studentB, page1, region1, image } =
       await buildSimpleExam()
 
-    // B の p1 画像を削除（採点は孤立して残る = deleteStudentAnswer 相当）。
+    // B の p1 画像だけを直接削除し、採点を孤立させる（deleteStudentAnswer は採点も
+    // 消すので、ここでは孤立状態を作るために低レベル API を使う）。
     // これで移動先 (p1,B) は空マスになり、B は r1 に孤立採点だけを持つ。
     await testPrisma.studentAnswerImage.delete({
       where: { id: image(page1.id, studentB.id).id },

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -21,6 +21,7 @@ import {
   deleteStudentAnswer,
   getStudentAnswerById,
   getStudentAnswersByExamId,
+  getStudentAnswerScoreSummary,
   getStudentAnswersDataset,
   setStudentAnswerAbsent,
   type StudentAnswerPlacementMove,
@@ -135,6 +136,14 @@ export function setupMiscHandlers(): void {
       examPages: result.examPages,
     }
   })
+
+  // 削除確認モーダルで「何が消えるか」を提示するための事前照会
+  registerSafeHandler(
+    "get-answer-sheet-score-summary",
+    async (answerSheetId: string) => {
+      return await getStudentAnswerScoreSummary(answerSheetId)
+    }
+  )
 
   registerHandler("delete-answer-sheet", async (answerSheetId: string) => {
     return await deleteStudentAnswer(answerSheetId)

--- a/electron-src/lib/prisma/auditLog.ts
+++ b/electron-src/lib/prisma/auditLog.ts
@@ -5,8 +5,6 @@
  *   （ログ欠落 < 主操作の失敗）。アクション定義は auditActions.ts を参照。
  */
 
-import type { PrismaClient } from "@prisma/client"
-
 import {
   type AuditActionKey,
   buildAuditSummary,
@@ -14,8 +12,7 @@ import {
 } from "./auditActions"
 import { getCurrentActorUserId } from "./auditActor"
 import prisma from "./client"
-
-type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+import type { Tx } from "./transactionClient"
 
 /** 単一フィールドの変更（before→after 差分） */
 export interface AuditChange {

--- a/electron-src/lib/prisma/deletedRecord.ts
+++ b/electron-src/lib/prisma/deletedRecord.ts
@@ -3,11 +3,8 @@
  * @description 物理削除されたレコードの追跡。インポート時の復活防止およびsqlite-nas-sync連携用。
  */
 
-import type { PrismaClient } from "@prisma/client"
-
 import prisma from "./client"
-
-type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]
+import type { Tx } from "./transactionClient"
 
 interface RecordDeletionOptions {
   userId?: string

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -5,6 +5,29 @@ import { resolveExamScopeByCropRegion, resolveStudentLabel } from "./auditScope"
 import prisma from "./client"
 import { recordDrawingAnnotationDeletionsForQuestionScores } from "./deletedRecord"
 
+/**
+ * 採点対象が既に無いことを表す機械可読な理由コード。
+ *
+ * 協調採点では、ある教員が答案画像を削除するとその答案の QuestionScore も同時に消える
+ * （deleteStudentAnswer）。同じマスを開いていた別教員の保存は id 指定なので必ず失敗するため、
+ * 呼び出し側が「保存失敗」と「答案が消えた」を区別できるようにする。
+ */
+export const SCORE_TARGET_DELETED = "target-deleted" as const
+
+/** 上記を利用者へ伝える文言（renderer はこれをそのまま表示してよい） */
+export const SCORE_TARGET_DELETED_MESSAGE =
+  "この答案は削除されたため採点を保存できません"
+
+/** Prisma の「更新/削除対象が見つからない」エラー（P2025）か */
+function isRecordNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2025"
+  )
+}
+
 /** QuestionScore.status を日本語表示に変換（監査ログ差分用） */
 const scoreStatusLabel = (status: string | null | undefined): string => {
   switch (status) {
@@ -363,7 +386,11 @@ export const updateQuestionScore = async (
       })
 
       if (!current) {
-        return { success: false, error: "Question score not found" }
+        return {
+          success: false,
+          reason: SCORE_TARGET_DELETED,
+          error: SCORE_TARGET_DELETED_MESSAGE,
+        }
       }
 
       // Version checking removed - scoreVersion field doesn't exist in new schema
@@ -380,11 +407,20 @@ export const updateQuestionScore = async (
       */
     }
 
-    // 差分記録用に変更前を取得
+    // 差分記録用に変更前を取得。ここで無ければ答案ごと削除された後なので、
+    // 生の Prisma エラーではなく「削除済み」として返す（協調採点で他教員が削除した場合）。
     const before = await prisma.questionScore.findUnique({
       where: { id },
       select: { status: true, partialScore: true },
     })
+
+    if (!before) {
+      return {
+        success: false,
+        reason: SCORE_TARGET_DELETED,
+        error: SCORE_TARGET_DELETED_MESSAGE,
+      }
+    }
 
     const updated = await prisma.questionScore.update({
       where: { id },
@@ -428,6 +464,14 @@ export const updateQuestionScore = async (
 
     return { success: true, score: updated }
   } catch (error) {
+    // 上の存在チェックとの隙間で削除された場合（P2025: 更新対象が無い）
+    if (isRecordNotFoundError(error)) {
+      return {
+        success: false,
+        reason: SCORE_TARGET_DELETED,
+        error: SCORE_TARGET_DELETED_MESSAGE,
+      }
+    }
     console.error("Failed to update question score:", error)
     return {
       success: false,

--- a/electron-src/lib/prisma/studentAnswer.ts
+++ b/electron-src/lib/prisma/studentAnswer.ts
@@ -15,11 +15,13 @@ export {
   deleteStudentAnswer,
   getStudentAnswerById,
   getStudentAnswersByExamId,
+  getStudentAnswerScoreSummary,
   getStudentAnswersDataset,
   type PlacementScorePolicy,
   // ステータス管理
   setStudentAnswerAbsent,
   type StudentAnswerPlacementMove,
+  type StudentAnswerScoreSummary,
   // CRUD操作
   uploadStudentAnswers,
 } from "./studentAnswer/index"

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -2,6 +2,7 @@
  * 答案のCRUD操作
  * - アップロード、取得、削除、関連付け
  */
+import type { Prisma } from "@prisma/client"
 import * as fs from "fs/promises"
 import * as path from "path"
 
@@ -20,6 +21,9 @@ import { correctImage } from "../../omr/imageCorrector"
 import { recordAuditLog } from "../auditLog"
 import { resolveExamScope, resolveExamScopeByPage } from "../auditScope"
 import prisma from "../client"
+import { recordDrawingAnnotationDeletionsForQuestionScores } from "../deletedRecord"
+import type { Tx } from "../transactionClient"
+import { getPageScoreScope, type PageScoreScope } from "./pageScope"
 
 /** ページごとのマスターマーカーキャッシュ */
 type MasterMarkerInfo = {
@@ -416,6 +420,151 @@ export async function getStudentAnswersDataset(examId: string) {
 /**
  * 答案の削除
  */
+/** 答案1枚に紐づく「実際に採点された」データの件数（削除確認モーダルの表示用） */
+export interface StudentAnswerScoreSummary {
+  /**
+   * 採点済みの設問数。協調採点では1設問に教員ごとの QuestionScore 行が並ぶため、
+   * 行数ではなく CropRegion 数で数える（行数だと教員数だけ水増しされる）。
+   */
+  scoredQuestionCount: number
+  /** 確定済みスコア（ScoreDecision）の件数 */
+  scoreDecisionCount: number
+  /** 答案上の書き込み（DrawingAnnotation）の件数 */
+  drawingAnnotationCount: number
+  /** 採点済みの複合回答数 */
+  scoredCompoundAnswerCount: number
+  /** 上記のいずれかが1件以上あるか */
+  hasScoreData: boolean
+}
+
+/**
+ * 「実際に採点された」QuestionScore の条件。
+ *
+ * `scoringInitializer` が全マスに status="unscored" の行を先行作成するため、行の有無を
+ * そのまま「採点済み」と扱うと常に true になる。判定と削除で定義がずれないよう定数にする
+ * （削除側は unscored の初期化行も含めて全て消す＝この条件は使わない）。
+ */
+const SCORED_QUESTION_SCORE_FILTER = {
+  OR: [{ status: { not: "unscored" } }, { partialScore: { not: null } }],
+} satisfies Prisma.QuestionScoreWhereInput
+
+/** 「実際に採点された」CompoundAnswerScore の条件（部分点のみ入力済みの状態も拾う） */
+const SCORED_COMPOUND_ANSWER_SCORE_FILTER = {
+  OR: [
+    { status: { not: "unscored" } },
+    { partialScore: { not: null } },
+    { recognizedAnswer: { not: null } },
+  ],
+} satisfies Prisma.CompoundAnswerScoreWhereInput
+
+/** 答案1枚（ページ scope × 生徒）の採点実績を数える */
+async function countStudentAnswerScoreData(
+  client: typeof prisma | Tx,
+  scope: PageScoreScope,
+  studentId: string
+): Promise<StudentAnswerScoreSummary> {
+  const { cropRegionIds, compoundAnswerIds } = scope
+
+  const [
+    scoredQuestionRegions,
+    scoreDecisionCount,
+    drawingAnnotationCount,
+    scoredCompoundAnswerCount,
+  ] = await Promise.all([
+    cropRegionIds.length === 0
+      ? []
+      : client.questionScore.findMany({
+          where: {
+            studentId,
+            cropRegionId: { in: cropRegionIds },
+            ...SCORED_QUESTION_SCORE_FILTER,
+          },
+          select: { cropRegionId: true },
+          distinct: ["cropRegionId"],
+        }),
+    cropRegionIds.length === 0
+      ? 0
+      : client.scoreDecision.count({
+          where: { studentId, cropRegionId: { in: cropRegionIds } },
+        }),
+    cropRegionIds.length === 0
+      ? 0
+      : client.drawingAnnotation.count({
+          where: {
+            questionScore: { studentId, cropRegionId: { in: cropRegionIds } },
+          },
+        }),
+    compoundAnswerIds.length === 0
+      ? 0
+      : client.compoundAnswerScore.count({
+          where: {
+            studentId,
+            compoundAnswerId: { in: compoundAnswerIds },
+            ...SCORED_COMPOUND_ANSWER_SCORE_FILTER,
+          },
+        }),
+  ])
+
+  const scoredQuestionCount = scoredQuestionRegions.length
+
+  return {
+    scoredQuestionCount,
+    scoreDecisionCount,
+    drawingAnnotationCount,
+    scoredCompoundAnswerCount,
+    hasScoreData:
+      scoredQuestionCount > 0 ||
+      scoreDecisionCount > 0 ||
+      drawingAnnotationCount > 0 ||
+      scoredCompoundAnswerCount > 0,
+  }
+}
+
+/**
+ * 答案1枚に紐づく採点データの件数を取得する（削除確認モーダルの事前照会）。
+ */
+export async function getStudentAnswerScoreSummary(answerSheetId: string) {
+  try {
+    const answerSheet = await prisma.studentAnswerImage.findUnique({
+      where: { id: answerSheetId },
+      select: { examPageId: true, studentId: true },
+    })
+
+    if (!answerSheet) {
+      throw new Error("答案が見つかりません")
+    }
+
+    const scope = await getPageScoreScope(prisma, answerSheet.examPageId)
+    const summary = await countStudentAnswerScoreData(
+      prisma,
+      scope,
+      answerSheet.studentId
+    )
+
+    return { success: true as const, summary }
+  } catch (error) {
+    console.error("Error loading answer sheet score summary:", error)
+    return {
+      success: false as const,
+      error:
+        error instanceof Error
+          ? error.message
+          : "採点データの確認に失敗しました",
+    }
+  }
+}
+
+/**
+ * 答案画像を採点データごと削除する。
+ *
+ * `StudentAnswerImage` には採点系の子リレーションが無く cascade は走らないため、
+ * ページ scoped で QuestionScore / ScoreDecision / CompoundAnswerScore を明示削除する
+ * （placementApply の discard と同じ手順。DrawingAnnotation は tombstone 記録後、
+ * 親 QuestionScore の cascade で消える）。
+ *
+ * DB をトランザクションで確定させてからファイルを消す。逆順だと DB 失敗時に画像だけが
+ * 失われて復旧できない（孤立ファイルが残る方が害が小さい）。
+ */
 export async function deleteStudentAnswer(answerSheetId: string) {
   try {
     const answerSheet = await prisma.studentAnswerImage.findUnique({
@@ -426,31 +575,100 @@ export async function deleteStudentAnswer(answerSheetId: string) {
       throw new Error("答案が見つかりません")
     }
 
-    // ファイルを削除
-    const { getAbsolutePathFromData } = await import("../../dataManager")
-    const filePath = getAbsolutePathFromData(answerSheet.imagePath)
+    const { summary, removedRows } = await prisma.$transaction(
+      async (tx) => {
+        const scope = await getPageScoreScope(tx, answerSheet.examPageId)
+        const studentId = answerSheet.studentId
+        const { cropRegionIds, compoundAnswerIds } = scope
 
+        // 削除前に「利用者から見た採点実績」を数えておく（モーダルの表示と同じ定義）。
+        // 削除自体は unscored の初期化行も含めて全て消すので、行数とは一致しない。
+        const scoreSummary = await countStudentAnswerScoreData(
+          tx,
+          scope,
+          studentId
+        )
+
+        let questionScoreRows = 0
+        let drawingAnnotationRows = 0
+        let scoreDecisionRows = 0
+        let compoundAnswerScoreRows = 0
+
+        if (cropRegionIds.length > 0) {
+          // QuestionScore: 子の DrawingAnnotation を tombstone してから削除（cascade で道連れ）
+          const questionScores = await tx.questionScore.findMany({
+            where: { studentId, cropRegionId: { in: cropRegionIds } },
+            select: { id: true },
+          })
+          const questionScoreIds = questionScores.map(
+            (questionScore) => questionScore.id
+          )
+
+          if (questionScoreIds.length > 0) {
+            drawingAnnotationRows = await tx.drawingAnnotation.count({
+              where: { questionScoreId: { in: questionScoreIds } },
+            })
+            await recordDrawingAnnotationDeletionsForQuestionScores(
+              questionScoreIds,
+              { tx }
+            )
+            const removed = await tx.questionScore.deleteMany({
+              where: { id: { in: questionScoreIds } },
+            })
+            questionScoreRows = removed.count
+          }
+
+          const removedDecisions = await tx.scoreDecision.deleteMany({
+            where: { studentId, cropRegionId: { in: cropRegionIds } },
+          })
+          scoreDecisionRows = removedDecisions.count
+        }
+
+        if (compoundAnswerIds.length > 0) {
+          const removedCompound = await tx.compoundAnswerScore.deleteMany({
+            where: { studentId, compoundAnswerId: { in: compoundAnswerIds } },
+          })
+          compoundAnswerScoreRows = removedCompound.count
+        }
+
+        await tx.studentAnswerImage.delete({ where: { id: answerSheetId } })
+
+        return {
+          summary: scoreSummary,
+          removedRows: {
+            questionScoreRows,
+            scoreDecisionRows,
+            drawingAnnotationRows,
+            compoundAnswerScoreRows,
+          },
+        }
+      },
+      // tombstone は SQLite に skipDuplicates が無く1行ずつ upsert するため、書き込みの多い
+      // 答案では既定の 5s を超えうる（超えると P2028 で削除ごとロールバックする）。
+      { timeout: 30000 }
+    )
+
+    // ファイル削除は DB コミット後。失敗しても孤立ファイルが残るだけなので警告に留める
+    // （パス解決の失敗も含めて握る。ここで例外を投げると削除済みの DB と矛盾する）。
     try {
-      await fs.unlink(filePath)
+      const { getAbsolutePathFromData } = await import("../../dataManager")
+      await fs.unlink(getAbsolutePathFromData(answerSheet.imagePath))
     } catch (fileError) {
       console.warn("Failed to delete file:", fileError)
     }
 
-    // データベースから削除
-    await prisma.studentAnswerImage.delete({
-      where: { id: answerSheetId },
-    })
-
-    const scope = await resolveExamScopeByPage(answerSheet.examPageId)
+    const auditScope = await resolveExamScopeByPage(answerSheet.examPageId)
     await recordAuditLog({
       action: "exam.answer.delete",
       entityType: "StudentAnswerImage",
       entityId: answerSheetId,
-      scopeId: scope.scopeId,
-      scopeLabel: scope.scopeLabel,
+      scopeId: auditScope.scopeId,
+      scopeLabel: auditScope.scopeLabel,
+      // 監査ログには実際に消えた行数を残す（未採点の初期化行を含む実データの記録）
+      summary: `答案画像を削除（QuestionScore ${removedRows.questionScoreRows} 行 / ScoreDecision ${removedRows.scoreDecisionRows} 行 / DrawingAnnotation ${removedRows.drawingAnnotationRows} 行 / CompoundAnswerScore ${removedRows.compoundAnswerScoreRows} 行を同時削除）`,
     })
 
-    return { success: true }
+    return { success: true, deletedSummary: summary }
   } catch (error) {
     console.error("Error deleting answer sheet:", error)
     return {

--- a/electron-src/lib/prisma/studentAnswer/index.ts
+++ b/electron-src/lib/prisma/studentAnswer/index.ts
@@ -12,7 +12,9 @@ export {
   deleteStudentAnswer,
   getStudentAnswerById,
   getStudentAnswersByExamId,
+  getStudentAnswerScoreSummary,
   getStudentAnswersDataset,
+  type StudentAnswerScoreSummary,
   uploadStudentAnswers,
 } from "./crud"
 

--- a/electron-src/lib/prisma/studentAnswer/pageScope.ts
+++ b/electron-src/lib/prisma/studentAnswer/pageScope.ts
@@ -1,0 +1,38 @@
+/**
+ * 採点のページ scoped 解決。
+ *
+ * 採点は答案画像ではなく `(cropRegionId, studentId)` / `(compoundAnswerId, studentId)` に
+ * 紐づくため、ページ（や答案画像）から採点へ辿るには必ずこの経由が要る。
+ * 削除（crud.ts）と配置適用（placementApply.ts）の双方が同じ定義を使うようここへ集約する。
+ */
+import type prisma from "../client"
+import type { Tx } from "../transactionClient"
+
+/** ページ1枚に属する採点の座標軸 */
+export interface PageScoreScope {
+  cropRegionIds: string[]
+  compoundAnswerIds: string[]
+}
+
+/** 指定ページの CropRegion / CompoundAnswer の id を引く */
+export async function getPageScoreScope(
+  client: typeof prisma | Tx,
+  examPageId: string
+): Promise<PageScoreScope> {
+  const [cropRegions, compoundAnswers] = await Promise.all([
+    client.cropRegion.findMany({
+      where: { examPageId },
+      select: { id: true },
+    }),
+    client.compoundAnswer.findMany({
+      where: { examPageId },
+      select: { id: true },
+    }),
+  ])
+  return {
+    cropRegionIds: cropRegions.map((cropRegion) => cropRegion.id),
+    compoundAnswerIds: compoundAnswers.map(
+      (compoundAnswer) => compoundAnswer.id
+    ),
+  }
+}

--- a/electron-src/lib/prisma/studentAnswer/placementApply.ts
+++ b/electron-src/lib/prisma/studentAnswer/placementApply.ts
@@ -3,15 +3,19 @@
  *
  * 設計（docs/06-student-answers-entity-first-plan.md §5）:
  * - 2軸移動: studentId だけでなく examPageId も更新する（移動先 ExamPage は id 直指定で受ける）。
- * - 採点はページ scoped: 移動元ページの CropRegion × 現生徒の QuestionScore/ScoreDecision のみ対象。
+ * - 採点はページ scoped: 移動元ページの CropRegion / CompoundAnswer × 現生徒の
+ *   QuestionScore / ScoreDecision / CompoundAnswerScore のみ対象。
  * - carry（追従・同一ページのみ）:
  *   - QuestionScore は unique が無いので **id 指定の updateMany で studentId 付け替え**（id 保持 →
  *     子の DrawingAnnotation を温存。swap も id 指定なので途中衝突なし）。
  *   - ScoreDecision は `@@unique([cropRegionId, studentId])` があるため **delete → 最終位置へ再作成**。
- * - discard: DrawingAnnotation を tombstone してから両スコア表を削除。
- * - **移動先セルの残存採点を掃除**: 移動先 (finalStudentId, 移動先ページの CropRegion) に既存の
- *   採点があり、それが「移動してくる採点（moving 集合）」でない場合は stale として削除する
- *   （さもないと carry で QuestionScore が二重計上、ScoreDecision は unique 違反になる）。
+ *   - CompoundAnswerScore も `@@unique([compoundAnswerId, studentId])` があるため同じく再作成方式。
+ * - discard: DrawingAnnotation を tombstone してから各スコア表（QuestionScore /
+ *   ScoreDecision / CompoundAnswerScore）を削除。
+ * - **移動先セルの残存採点を掃除**: 移動先 (finalStudentId, 移動先ページの CropRegion /
+ *   CompoundAnswer) に既存の採点があり、それが「移動してくる採点（moving 集合）」でない場合は
+ *   stale として削除する（さもないと carry で QuestionScore が二重計上、ScoreDecision と
+ *   CompoundAnswerScore は unique 違反になる）。
  * - 画像は `@@unique([examPageId, studentId])` の 2-cycle を避けるため **delete → 同一 id で再作成**。
  * - ガード: carry かつページ変化はエラー。finalStudentId=null（削除）は不可（削除は別操作）。
  *   移動先が batch 外の答案で占有されている場合もエラー（上書きはしない）。
@@ -22,6 +26,7 @@ import type { Prisma } from "@prisma/client"
 
 import prisma from "../client"
 import { recordDrawingAnnotationDeletionsForQuestionScores } from "../deletedRecord"
+import { getPageScoreScope, type PageScoreScope } from "./pageScope"
 
 /**
  * 移動1件ごとの採点データ処理方針（view 方式B）。
@@ -57,262 +62,332 @@ export async function applyStudentAnswerPlacements(
   }
 
   try {
-    await prisma.$transaction(async (tx) => {
-      // 1. 現在の配置を取得（再作成のため imagePath/createdAt も保持）
-      const currentAnswers = await Promise.all(
-        moves.map((move) =>
-          tx.studentAnswerImage.findUnique({
-            where: { id: move.fileId },
-            select: {
-              id: true,
-              studentId: true,
-              examPageId: true,
-              imagePath: true,
-              createdAt: true,
-              examPage: { select: { examId: true } },
+    await prisma.$transaction(
+      async (tx) => {
+        // 1. 現在の配置を取得（再作成のため imagePath/createdAt も保持）
+        const currentAnswers = await Promise.all(
+          moves.map((move) =>
+            tx.studentAnswerImage.findUnique({
+              where: { id: move.fileId },
+              select: {
+                id: true,
+                studentId: true,
+                examPageId: true,
+                imagePath: true,
+                createdAt: true,
+                examPage: { select: { examId: true } },
+              },
+            })
+          )
+        )
+        const missingIndex = currentAnswers.findIndex(
+          (currentAnswer) => !currentAnswer
+        )
+        if (missingIndex !== -1) {
+          throw new Error(`答案が見つかりません: ${moves[missingIndex].fileId}`)
+        }
+
+        // 2. ターゲット examPageId 解決 + carry ガード
+        type PlacementPlan = {
+          move: StudentAnswerPlacementMove
+          current: NonNullable<(typeof currentAnswers)[number]>
+          finalStudentId: string
+          targetExamPageId: string
+        }
+        const plans: PlacementPlan[] = []
+        for (let index = 0; index < moves.length; index++) {
+          const move = moves[index]
+          const current = currentAnswers[index]!
+          const finalStudentId = move.finalStudentId! // null は上で除外済み
+
+          // 移動先 ExamPage は id 直指定。同一試験のページであることのみ検証する
+          // （pageNumber 序数への解決はしない＝id 一次同定）。
+          const targetPage = await tx.examPage.findFirst({
+            where: {
+              id: move.finalExamPageId,
+              examId: current.examPage.examId,
+            },
+            select: { id: true },
+          })
+          if (!targetPage) {
+            throw new Error(
+              `移動先ページが見つかりません: ${move.finalExamPageId}`
+            )
+          }
+
+          const pageChanged = current.examPageId !== targetPage.id
+          if (move.scorePolicy === "carry" && pageChanged) {
+            throw new Error(
+              "ページを跨ぐ移動では採点情報の追従はできません（破棄を選択してください）"
+            )
+          }
+
+          plans.push({
+            move,
+            current,
+            finalStudentId,
+            targetExamPageId: targetPage.id,
+          })
+        }
+
+        // 移動先が batch 外の答案で占有されていないか（上書きは不可、入れ替えのみ）
+        const batchFileIds = plans.map((plan) => plan.move.fileId)
+        for (const plan of plans) {
+          const occupant = await tx.studentAnswerImage.findFirst({
+            where: {
+              examPageId: plan.targetExamPageId,
+              studentId: plan.finalStudentId,
+              id: { notIn: batchFileIds },
+            },
+            select: { id: true },
+          })
+          if (occupant) {
+            throw new Error(
+              "移動先に別の答案があります（入れ替えでのみ移動できます）"
+            )
+          }
+        }
+
+        // 3. 移動する採点（source）の収集。moving 集合も作る（移動先掃除で使う）。
+        const questionScoreIdsToDelete: string[] = [] // discard source + stale destination
+        const scoreDecisionIdsToDelete: string[] = [] // discard/carry source + stale destination
+        const questionScoreCarryUpdates: Array<{
+          ids: string[]
+          finalStudentId: string
+        }> = []
+        const scoreDecisionsToRecreate: Prisma.ScoreDecisionCreateManyInput[] =
+          []
+        // 複合回答も CropRegion と同じくページ scoped。`@@unique([compoundAnswerId, studentId])`
+        // があるため ScoreDecision と同様 delete → 再作成で付け替える。
+        const compoundAnswerScoreIdsToDelete: string[] = []
+        const compoundAnswerScoresToRecreate: Prisma.CompoundAnswerScoreCreateManyInput[] =
+          []
+        const movingQuestionScoreIds = new Set<string>()
+        const movingScoreDecisionIds = new Set<string>()
+        const movingCompoundAnswerScoreIds = new Set<string>()
+        // 移動先掃除のための (finalStudentId, 移動先ページの cropRegionIds/compoundAnswerIds)
+        const destinationScopes: Array<{
+          finalStudentId: string
+          cropRegionIds: string[]
+          compoundAnswerIds: string[]
+        }> = []
+
+        // ページ scope は crud.ts の削除と共有（getPageScoreScope）。同じページを何度も
+        // 引かないようトランザクション内でキャッシュする。
+        const scopeByPage = new Map<string, PageScoreScope>()
+        const getScope = async (examPageId: string) => {
+          const cached = scopeByPage.get(examPageId)
+          if (cached) return cached
+          const scope = await getPageScoreScope(tx, examPageId)
+          scopeByPage.set(examPageId, scope)
+          return scope
+        }
+
+        for (const plan of plans) {
+          const sourceScope = await getScope(plan.current.examPageId)
+          const targetScope = await getScope(plan.targetExamPageId)
+          const sourceCropRegionIds = sourceScope.cropRegionIds
+          const sourceCompoundAnswerIds = sourceScope.compoundAnswerIds
+          destinationScopes.push({
+            finalStudentId: plan.finalStudentId,
+            cropRegionIds: targetScope.cropRegionIds,
+            compoundAnswerIds: targetScope.compoundAnswerIds,
+          })
+
+          // 複合回答の採点（carry は同一ページ限定なので compoundAnswerId はそのまま使える）
+          if (sourceCompoundAnswerIds.length > 0) {
+            const compoundAnswerScores = await tx.compoundAnswerScore.findMany({
+              where: {
+                studentId: plan.current.studentId,
+                compoundAnswerId: { in: sourceCompoundAnswerIds },
+              },
+            })
+            compoundAnswerScores.forEach((compoundAnswerScore) =>
+              movingCompoundAnswerScoreIds.add(compoundAnswerScore.id)
+            )
+            compoundAnswerScoreIdsToDelete.push(
+              ...compoundAnswerScores.map(
+                (compoundAnswerScore) => compoundAnswerScore.id
+              )
+            )
+            if (plan.move.scorePolicy === "carry") {
+              compoundAnswerScoresToRecreate.push(
+                ...compoundAnswerScores.map((compoundAnswerScore) => ({
+                  id: compoundAnswerScore.id,
+                  compoundAnswerId: compoundAnswerScore.compoundAnswerId,
+                  studentId: plan.finalStudentId,
+                  userId: compoundAnswerScore.userId,
+                  recognizedAnswer: compoundAnswerScore.recognizedAnswer,
+                  status: compoundAnswerScore.status,
+                  partialScore: compoundAnswerScore.partialScore,
+                  createdAt: compoundAnswerScore.createdAt,
+                }))
+              )
+            }
+          }
+
+          if (sourceCropRegionIds.length === 0) continue
+
+          const questionScores = await tx.questionScore.findMany({
+            where: {
+              studentId: plan.current.studentId,
+              cropRegionId: { in: sourceCropRegionIds },
+            },
+            select: { id: true },
+          })
+          const scoreDecisions = await tx.scoreDecision.findMany({
+            where: {
+              studentId: plan.current.studentId,
+              cropRegionId: { in: sourceCropRegionIds },
             },
           })
-        )
-      )
-      const missingIndex = currentAnswers.findIndex(
-        (currentAnswer) => !currentAnswer
-      )
-      if (missingIndex !== -1) {
-        throw new Error(`答案が見つかりません: ${moves[missingIndex].fileId}`)
-      }
-
-      // 2. ターゲット examPageId 解決 + carry ガード
-      type PlacementPlan = {
-        move: StudentAnswerPlacementMove
-        current: NonNullable<(typeof currentAnswers)[number]>
-        finalStudentId: string
-        targetExamPageId: string
-      }
-      const plans: PlacementPlan[] = []
-      for (let index = 0; index < moves.length; index++) {
-        const move = moves[index]
-        const current = currentAnswers[index]!
-        const finalStudentId = move.finalStudentId! // null は上で除外済み
-
-        // 移動先 ExamPage は id 直指定。同一試験のページであることのみ検証する
-        // （pageNumber 序数への解決はしない＝id 一次同定）。
-        const targetPage = await tx.examPage.findFirst({
-          where: {
-            id: move.finalExamPageId,
-            examId: current.examPage.examId,
-          },
-          select: { id: true },
-        })
-        if (!targetPage) {
-          throw new Error(
-            `移動先ページが見つかりません: ${move.finalExamPageId}`
+          questionScores.forEach((questionScore) =>
+            movingQuestionScoreIds.add(questionScore.id)
           )
+          scoreDecisions.forEach((scoreDecision) =>
+            movingScoreDecisionIds.add(scoreDecision.id)
+          )
+
+          if (plan.move.scorePolicy === "discard") {
+            questionScoreIdsToDelete.push(
+              ...questionScores.map((questionScore) => questionScore.id)
+            )
+            scoreDecisionIdsToDelete.push(
+              ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
+            )
+          } else {
+            // carry: QuestionScore は id 指定で studentId 付け替え（注釈を温存）
+            if (questionScores.length > 0) {
+              questionScoreCarryUpdates.push({
+                ids: questionScores.map((questionScore) => questionScore.id),
+                finalStudentId: plan.finalStudentId,
+              })
+            }
+            // ScoreDecision は unique 回避のため delete → id 保持で最終位置へ再作成
+            scoreDecisionIdsToDelete.push(
+              ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
+            )
+            scoreDecisionsToRecreate.push(
+              ...scoreDecisions.map((scoreDecision) => ({
+                id: scoreDecision.id,
+                cropRegionId: scoreDecision.cropRegionId,
+                studentId: plan.finalStudentId,
+                verdict: scoreDecision.verdict,
+                score: scoreDecision.score,
+                comment: scoreDecision.comment,
+                decidedByUserId: scoreDecision.decidedByUserId,
+                decidedAt: scoreDecision.decidedAt,
+                createdAt: scoreDecision.createdAt,
+                sourceQuestionScoreId: scoreDecision.sourceQuestionScoreId,
+              }))
+            )
+          }
         }
 
-        const pageChanged = current.examPageId !== targetPage.id
-        if (move.scorePolicy === "carry" && pageChanged) {
-          throw new Error(
-            "ページを跨ぐ移動では採点情報の追従はできません（破棄を選択してください）"
-          )
+        // 3b. 移動先セルの残存採点（moving でないもの）を stale として掃除する。
+        for (const scope of destinationScopes) {
+          if (scope.compoundAnswerIds.length > 0) {
+            const staleCompoundAnswerScores =
+              await tx.compoundAnswerScore.findMany({
+                where: {
+                  studentId: scope.finalStudentId,
+                  compoundAnswerId: { in: scope.compoundAnswerIds },
+                },
+                select: { id: true },
+              })
+            for (const compoundAnswerScore of staleCompoundAnswerScores) {
+              if (!movingCompoundAnswerScoreIds.has(compoundAnswerScore.id)) {
+                compoundAnswerScoreIdsToDelete.push(compoundAnswerScore.id)
+              }
+            }
+          }
+
+          if (scope.cropRegionIds.length === 0) continue
+          const staleQuestionScores = await tx.questionScore.findMany({
+            where: {
+              studentId: scope.finalStudentId,
+              cropRegionId: { in: scope.cropRegionIds },
+            },
+            select: { id: true },
+          })
+          const staleScoreDecisions = await tx.scoreDecision.findMany({
+            where: {
+              studentId: scope.finalStudentId,
+              cropRegionId: { in: scope.cropRegionIds },
+            },
+            select: { id: true },
+          })
+          for (const questionScore of staleQuestionScores) {
+            if (!movingQuestionScoreIds.has(questionScore.id)) {
+              questionScoreIdsToDelete.push(questionScore.id)
+            }
+          }
+          for (const scoreDecision of staleScoreDecisions) {
+            if (!movingScoreDecisionIds.has(scoreDecision.id)) {
+              scoreDecisionIdsToDelete.push(scoreDecision.id)
+            }
+          }
         }
 
-        plans.push({
-          move,
-          current,
-          finalStudentId,
-          targetExamPageId: targetPage.id,
-        })
-      }
+        // 4. QuestionScore: DrawingAnnotation を tombstone してから削除
+        if (questionScoreIdsToDelete.length > 0) {
+          await recordDrawingAnnotationDeletionsForQuestionScores(
+            questionScoreIdsToDelete,
+            { tx }
+          )
+          await tx.questionScore.deleteMany({
+            where: { id: { in: questionScoreIdsToDelete } },
+          })
+        }
 
-      // 移動先が batch 外の答案で占有されていないか（上書きは不可、入れ替えのみ）
-      const batchFileIds = plans.map((plan) => plan.move.fileId)
-      for (const plan of plans) {
-        const occupant = await tx.studentAnswerImage.findFirst({
-          where: {
+        // 5. carry の QuestionScore: id 指定で studentId 付け替え（行=注釈を保持）
+        for (const carryUpdate of questionScoreCarryUpdates) {
+          await tx.questionScore.updateMany({
+            where: { id: { in: carryUpdate.ids } },
+            data: { studentId: carryUpdate.finalStudentId },
+          })
+        }
+
+        // 6. ScoreDecision: 対象を削除 → carry 分を最終位置へ再作成（unique 回避）
+        if (scoreDecisionIdsToDelete.length > 0) {
+          await tx.scoreDecision.deleteMany({
+            where: { id: { in: scoreDecisionIdsToDelete } },
+          })
+        }
+        if (scoreDecisionsToRecreate.length > 0) {
+          await tx.scoreDecision.createMany({ data: scoreDecisionsToRecreate })
+        }
+
+        // 6b. CompoundAnswerScore: 同様に削除 → carry 分を最終位置へ再作成
+        if (compoundAnswerScoreIdsToDelete.length > 0) {
+          await tx.compoundAnswerScore.deleteMany({
+            where: { id: { in: compoundAnswerScoreIdsToDelete } },
+          })
+        }
+        if (compoundAnswerScoresToRecreate.length > 0) {
+          await tx.compoundAnswerScore.createMany({
+            data: compoundAnswerScoresToRecreate,
+          })
+        }
+
+        // 7. 画像移動: delete → 同一 id で再作成（2-cycle 回避、id/imagePath/createdAt 保持）
+        await tx.studentAnswerImage.deleteMany({
+          where: { id: { in: batchFileIds } },
+        })
+        await tx.studentAnswerImage.createMany({
+          data: plans.map((plan) => ({
+            id: plan.move.fileId,
             examPageId: plan.targetExamPageId,
             studentId: plan.finalStudentId,
-            id: { notIn: batchFileIds },
-          },
-          select: { id: true },
+            imagePath: plan.current.imagePath,
+            createdAt: plan.current.createdAt,
+          })),
         })
-        if (occupant) {
-          throw new Error(
-            "移動先に別の答案があります（入れ替えでのみ移動できます）"
-          )
-        }
-      }
-
-      // 3. 移動する採点（source）の収集。moving 集合も作る（移動先掃除で使う）。
-      const questionScoreIdsToDelete: string[] = [] // discard source + stale destination
-      const scoreDecisionIdsToDelete: string[] = [] // discard/carry source + stale destination
-      const questionScoreCarryUpdates: Array<{
-        ids: string[]
-        finalStudentId: string
-      }> = []
-      const scoreDecisionsToRecreate: Prisma.ScoreDecisionCreateManyInput[] = []
-      const movingQuestionScoreIds = new Set<string>()
-      const movingScoreDecisionIds = new Set<string>()
-      // 移動先掃除のための (finalStudentId, 移動先ページの cropRegionIds)
-      const destinationScopes: Array<{
-        finalStudentId: string
-        cropRegionIds: string[]
-      }> = []
-
-      const cropRegionIdsByPage = new Map<string, string[]>()
-      const getCropRegionIds = async (examPageId: string) => {
-        const cached = cropRegionIdsByPage.get(examPageId)
-        if (cached) return cached
-        const cropRegions = await tx.cropRegion.findMany({
-          where: { examPageId },
-          select: { id: true },
-        })
-        const ids = cropRegions.map((cropRegion) => cropRegion.id)
-        cropRegionIdsByPage.set(examPageId, ids)
-        return ids
-      }
-
-      for (const plan of plans) {
-        const sourceCropRegionIds = await getCropRegionIds(
-          plan.current.examPageId
-        )
-        const targetCropRegionIds = await getCropRegionIds(
-          plan.targetExamPageId
-        )
-        destinationScopes.push({
-          finalStudentId: plan.finalStudentId,
-          cropRegionIds: targetCropRegionIds,
-        })
-
-        if (sourceCropRegionIds.length === 0) continue
-
-        const questionScores = await tx.questionScore.findMany({
-          where: {
-            studentId: plan.current.studentId,
-            cropRegionId: { in: sourceCropRegionIds },
-          },
-          select: { id: true },
-        })
-        const scoreDecisions = await tx.scoreDecision.findMany({
-          where: {
-            studentId: plan.current.studentId,
-            cropRegionId: { in: sourceCropRegionIds },
-          },
-        })
-        questionScores.forEach((questionScore) =>
-          movingQuestionScoreIds.add(questionScore.id)
-        )
-        scoreDecisions.forEach((scoreDecision) =>
-          movingScoreDecisionIds.add(scoreDecision.id)
-        )
-
-        if (plan.move.scorePolicy === "discard") {
-          questionScoreIdsToDelete.push(
-            ...questionScores.map((questionScore) => questionScore.id)
-          )
-          scoreDecisionIdsToDelete.push(
-            ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
-          )
-        } else {
-          // carry: QuestionScore は id 指定で studentId 付け替え（注釈を温存）
-          if (questionScores.length > 0) {
-            questionScoreCarryUpdates.push({
-              ids: questionScores.map((questionScore) => questionScore.id),
-              finalStudentId: plan.finalStudentId,
-            })
-          }
-          // ScoreDecision は unique 回避のため delete → id 保持で最終位置へ再作成
-          scoreDecisionIdsToDelete.push(
-            ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
-          )
-          scoreDecisionsToRecreate.push(
-            ...scoreDecisions.map((scoreDecision) => ({
-              id: scoreDecision.id,
-              cropRegionId: scoreDecision.cropRegionId,
-              studentId: plan.finalStudentId,
-              verdict: scoreDecision.verdict,
-              score: scoreDecision.score,
-              comment: scoreDecision.comment,
-              decidedByUserId: scoreDecision.decidedByUserId,
-              decidedAt: scoreDecision.decidedAt,
-              createdAt: scoreDecision.createdAt,
-              sourceQuestionScoreId: scoreDecision.sourceQuestionScoreId,
-            }))
-          )
-        }
-      }
-
-      // 3b. 移動先セルの残存採点（moving でないもの）を stale として掃除する。
-      for (const scope of destinationScopes) {
-        if (scope.cropRegionIds.length === 0) continue
-        const staleQuestionScores = await tx.questionScore.findMany({
-          where: {
-            studentId: scope.finalStudentId,
-            cropRegionId: { in: scope.cropRegionIds },
-          },
-          select: { id: true },
-        })
-        const staleScoreDecisions = await tx.scoreDecision.findMany({
-          where: {
-            studentId: scope.finalStudentId,
-            cropRegionId: { in: scope.cropRegionIds },
-          },
-          select: { id: true },
-        })
-        for (const questionScore of staleQuestionScores) {
-          if (!movingQuestionScoreIds.has(questionScore.id)) {
-            questionScoreIdsToDelete.push(questionScore.id)
-          }
-        }
-        for (const scoreDecision of staleScoreDecisions) {
-          if (!movingScoreDecisionIds.has(scoreDecision.id)) {
-            scoreDecisionIdsToDelete.push(scoreDecision.id)
-          }
-        }
-      }
-
-      // 4. QuestionScore: DrawingAnnotation を tombstone してから削除
-      if (questionScoreIdsToDelete.length > 0) {
-        await recordDrawingAnnotationDeletionsForQuestionScores(
-          questionScoreIdsToDelete,
-          { tx }
-        )
-        await tx.questionScore.deleteMany({
-          where: { id: { in: questionScoreIdsToDelete } },
-        })
-      }
-
-      // 5. carry の QuestionScore: id 指定で studentId 付け替え（行=注釈を保持）
-      for (const carryUpdate of questionScoreCarryUpdates) {
-        await tx.questionScore.updateMany({
-          where: { id: { in: carryUpdate.ids } },
-          data: { studentId: carryUpdate.finalStudentId },
-        })
-      }
-
-      // 6. ScoreDecision: 対象を削除 → carry 分を最終位置へ再作成（unique 回避）
-      if (scoreDecisionIdsToDelete.length > 0) {
-        await tx.scoreDecision.deleteMany({
-          where: { id: { in: scoreDecisionIdsToDelete } },
-        })
-      }
-      if (scoreDecisionsToRecreate.length > 0) {
-        await tx.scoreDecision.createMany({ data: scoreDecisionsToRecreate })
-      }
-
-      // 7. 画像移動: delete → 同一 id で再作成（2-cycle 回避、id/imagePath/createdAt 保持）
-      await tx.studentAnswerImage.deleteMany({
-        where: { id: { in: batchFileIds } },
-      })
-      await tx.studentAnswerImage.createMany({
-        data: plans.map((plan) => ({
-          id: plan.move.fileId,
-          examPageId: plan.targetExamPageId,
-          studentId: plan.finalStudentId,
-          imagePath: plan.current.imagePath,
-          createdAt: plan.current.createdAt,
-        })),
-      })
-    })
+      },
+      // 学級分の一括移動では plan ごとの照会と tombstone の逐次 upsert が積み上がり、
+      // 既定の 5s を超えうる（超えると P2028 で全体がロールバックする）。
+      { timeout: 30000 }
+    )
 
     return { success: true }
   } catch (error) {

--- a/electron-src/lib/prisma/transactionClient.ts
+++ b/electron-src/lib/prisma/transactionClient.ts
@@ -1,0 +1,9 @@
+import type { PrismaClient } from "@prisma/client"
+
+/**
+ * `$transaction` のコールバックが受け取るトランザクションクライアント。
+ *
+ * 各モジュールで同じ型を private に書き直すと Prisma のメジャー更新時に全箇所を
+ * 追う必要が出るため、定義はここ1箇所に集約する。
+ */
+export type Tx = Parameters<Parameters<PrismaClient["$transaction"]>[0]>[0]

--- a/electron-src/preload-apis/answerSheetApi.ts
+++ b/electron-src/preload-apis/answerSheetApi.ts
@@ -20,6 +20,8 @@ export function createAnswerSheetApi() {
       ipcRenderer.invoke("get-answer-sheets-by-exam-id", examId),
     getStudentAnswersDataset: (examId: string) =>
       ipcRenderer.invoke("get-student-answers-dataset", examId),
+    getStudentAnswerScoreSummary: (answerSheetId: string) =>
+      ipcRenderer.invoke("get-answer-sheet-score-summary", answerSheetId),
     deleteStudentAnswer: (answerSheetId: string) =>
       ipcRenderer.invoke("delete-answer-sheet", answerSheetId),
     associateStudentAnswerWithStudent: (

--- a/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
@@ -198,7 +198,6 @@ export function AnswerTableShell({
         fileId={slot.fileId}
         examStudent={slot.examStudent}
         examPage={slot.examPage}
-        hasScoreData
         onDelete={slot.onDelete}
       >
         {slot.children}

--- a/src/components/exams/06-student-answers/student-answer-table/components/DeleteConfirmationModal.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/DeleteConfirmationModal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { AlertTriangle } from "lucide-react"
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
 
 import {
   AlertDialog,
@@ -12,28 +13,90 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import type { StudentAnswerScoreSummary } from "@/electron-src/lib/prisma/studentAnswer/crud"
 
 interface DeleteConfirmationModalProps {
   isOpen: boolean
   onClose: () => void
   onConfirm: () => void
+  /** 採点データの照会に使う StudentAnswerImage.id */
+  fileId: string
   studentName?: string
   pageNumber?: number
-  hasScoreData?: boolean
+}
+
+/** 採点データの内訳を「◯◯ 3件」形式の行に整形する（0件は出さない） */
+function buildScoreDetails(summary: StudentAnswerScoreSummary): string[] {
+  const details: string[] = []
+  if (summary.scoredQuestionCount > 0) {
+    details.push(`採点済みの設問: ${summary.scoredQuestionCount}問`)
+  }
+  if (summary.scoreDecisionCount > 0) {
+    details.push(`確定した点数: ${summary.scoreDecisionCount}件`)
+  }
+  if (summary.drawingAnnotationCount > 0) {
+    details.push(`答案への書き込み: ${summary.drawingAnnotationCount}件`)
+  }
+  if (summary.scoredCompoundAnswerCount > 0) {
+    details.push(`採点済みの複合回答: ${summary.scoredCompoundAnswerCount}問`)
+  }
+  return details
 }
 
 export function DeleteConfirmationModal({
   isOpen,
   onClose,
   onConfirm,
+  fileId,
   studentName,
   pageNumber,
-  hasScoreData = false,
 }: DeleteConfirmationModalProps) {
+  const [summary, setSummary] = useState<StudentAnswerScoreSummary | null>(null)
+  const [isLoadingSummary, setIsLoadingSummary] = useState(false)
+  const [summaryError, setSummaryError] = useState<string | null>(null)
+
+  // 開いたときだけ照会する（全マス分を先読みすると採点データ量に比例して重くなる）。
+  // async 関数内で完結させ、preload が古い等で同期例外が飛んでも loading を必ず解除する。
+  useEffect(() => {
+    if (!isOpen) return
+
+    let isCurrent = true
+    setIsLoadingSummary(true)
+    setSummaryError(null)
+    setSummary(null)
+
+    const loadSummary = async () => {
+      try {
+        const result =
+          await window.electronAPI.getStudentAnswerScoreSummary(fileId)
+        if (!isCurrent) return
+        if (result.success) {
+          setSummary(result.summary)
+        } else {
+          setSummaryError(result.error ?? "採点データの確認に失敗しました")
+        }
+      } catch (error) {
+        if (!isCurrent) return
+        console.error("採点データ照会エラー:", error)
+        setSummaryError("採点データの確認に失敗しました")
+      } finally {
+        if (isCurrent) setIsLoadingSummary(false)
+      }
+    }
+
+    void loadSummary()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [isOpen, fileId])
+
   const handleConfirm = () => {
     onConfirm()
     onClose()
   }
+
+  const scoreDetails = summary ? buildScoreDetails(summary) : []
 
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
@@ -61,10 +124,34 @@ export function DeleteConfirmationModal({
             <ul className="mt-1 list-inside list-disc space-y-1 text-sm">
               <li>この操作は取り消せません</li>
               <li>答案画像ファイルが完全に削除されます</li>
-              {hasScoreData && (
-                <li className="font-medium">
-                  関連する採点データも全て削除されます
+              {isLoadingSummary && (
+                <li className="flex items-center gap-1">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  採点データを確認しています…
                 </li>
+              )}
+              {/* 照会に失敗したら「採点データは無い」と誤解させないよう、
+                  安全側に倒して無条件の警告を出す */}
+              {summaryError && (
+                <>
+                  <li>{summaryError}</li>
+                  <li className="font-medium">
+                    この答案に採点データがあれば全て削除されます
+                  </li>
+                </>
+              )}
+              {summary?.hasScoreData && (
+                <li className="font-medium">
+                  この答案の採点データも全て削除されます
+                  <ul className="mt-1 list-inside list-[circle] space-y-0.5 pl-4 font-normal">
+                    {scoreDetails.map((detail) => (
+                      <li key={detail}>{detail}</li>
+                    ))}
+                  </ul>
+                </li>
+              )}
+              {summary && !summary.hasScoreData && (
+                <li>この答案にはまだ採点データがありません</li>
               )}
             </ul>
           </div>
@@ -77,6 +164,7 @@ export function DeleteConfirmationModal({
           <AlertDialogCancel onClick={onClose}>キャンセル</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleConfirm}
+            disabled={isLoadingSummary}
             className="bg-red-600 hover:bg-red-700"
           >
             削除する

--- a/src/components/exams/06-student-answers/student-answer-table/components/DraggableAnswerCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/DraggableAnswerCell.tsx
@@ -21,7 +21,6 @@ interface DraggableAnswerCellProps {
   // 生徒・ページは実体のまま受け取る（座標 droppable の examPageId・削除確認の氏名/ページ表示に使う）
   examStudent: ExamStudentWithMemberships
   examPage: ExamPageColumn
-  hasScoreData?: boolean
   onDelete: () => void
   children: React.ReactNode
 }
@@ -38,7 +37,6 @@ export function DraggableAnswerCell({
   fileId,
   examStudent,
   examPage,
-  hasScoreData = false,
   onDelete,
   children,
 }: DraggableAnswerCellProps) {
@@ -92,9 +90,9 @@ export function DraggableAnswerCell({
         isOpen={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
         onConfirm={onDelete}
+        fileId={fileId}
         studentName={studentName}
         pageNumber={examPage.pageNumber}
-        hasScoreData={hasScoreData}
       />
     </TableCell>
   )

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
@@ -115,7 +115,12 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
           if (onReloadData) {
             await onReloadData()
           }
-          toast.success("答案画像を削除しました")
+          // 件数は出さない（未採点の初期化行を含む行数とモーダルの表示件数がずれるため）
+          toast.success(
+            result.deletedSummary?.hasScoreData
+              ? "答案画像と採点データを削除しました"
+              : "答案画像を削除しました"
+          )
         } else {
           console.error("答案削除エラー:", result.error)
           toast.error(result.error || "答案削除に失敗しました")

--- a/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -34,6 +34,20 @@ export function useBatchScoring({
   const questionScoresRef = useRef(questionScores)
   questionScoresRef.current = questionScores
 
+  /** 採点行を画面状態から取り除く（ref も同期してループ中の次反復に反映させる） */
+  const removeScoreFromState = useCallback(
+    (scoreId: string) => {
+      setQuestionScores((prev) =>
+        prev.filter((questionScore) => questionScore.id !== scoreId)
+      )
+      questionScoresRef.current = questionScoresRef.current.filter(
+        (questionScore) => questionScore.id !== scoreId
+      )
+    },
+    [setQuestionScores]
+  )
+
+  /** 楽観更新を DB の実値へ戻す。行ごと消えていた場合は画面からも取り除く。 */
   const rollbackUpdate = useCallback(
     async (scoreId: string) => {
       try {
@@ -55,13 +69,22 @@ export function useBatchScoring({
                 : questionScore
             )
           )
+          toast.error("採点の保存に失敗しました")
+          return
         }
+
+        // DB に無い＝他の教員が答案ごと削除した。楽観更新を残すと「保存済み」に
+        // 見えてしまうので画面からも消し、原因が分かる文言を出す。
+        removeScoreFromState(scoreId)
+        toast.error(
+          "この答案は削除されたため採点を保存できません（Shift+R で再読み込みしてください）"
+        )
       } catch {
         // ロールバック自体が失敗 → Shift+Rでの再読み込みに委ねる
+        toast.error("採点の保存に失敗しました")
       }
-      toast.error("採点の保存に失敗しました")
     },
-    [setQuestionScores]
+    [removeScoreFromState, setQuestionScores]
   )
 
   const rollbackCreate = useCallback(
@@ -235,6 +258,12 @@ export function useBatchScoring({
                       : questionScore
                   )
                 )
+              } else if (result.reason === "target-deleted") {
+                // 他の教員が答案ごと削除した。再照会しても無いので即座に取り除く。
+                removeScoreFromState(scoreId)
+                toast.error(
+                  "この答案は削除されたため採点を保存できません（Shift+R で再読み込みしてください）"
+                )
               } else {
                 // DB保存失敗 → ロールバック
                 rollbackUpdate(scoreId)
@@ -310,6 +339,7 @@ export function useBatchScoring({
       currentCropRegionId,
       studentAnswerImages,
       setQuestionScores,
+      removeScoreFromState,
       rollbackUpdate,
       rollbackCreate,
     ]

--- a/src/types/electron/scoringApi.d.ts
+++ b/src/types/electron/scoringApi.d.ts
@@ -1,5 +1,7 @@
 import type { QuestionScore } from "@prisma/client"
 
+import type { SCORE_TARGET_DELETED } from "@/electron-src/lib/prisma/questionScore"
+
 import type {
   QuestionScoreWithUser,
   SerializedQuestionScore,
@@ -52,6 +54,11 @@ export interface QuestionScoreOperationResult {
   success: boolean
   score?: SerializedQuestionScore
   error?: string
+  /**
+   * 失敗理由の機械可読コード。"target-deleted" は対象の採点が既に無い＝答案ごと
+   * 削除された場合（協調採点で他教員が削除）。単なる保存失敗と区別して扱うこと。
+   */
+  reason?: typeof SCORE_TARGET_DELETED
   conflictData?: SerializedQuestionScore
 }
 

--- a/src/types/electron/studentAnswerApi.d.ts
+++ b/src/types/electron/studentAnswerApi.d.ts
@@ -1,3 +1,4 @@
+import type { StudentAnswerScoreSummary } from "@/electron-src/lib/prisma/studentAnswer/crud"
 import type { PlacementScorePolicy } from "@/electron-src/lib/prisma/studentAnswer/placementApply"
 
 import type {
@@ -47,8 +48,16 @@ export interface StudentAnswerAPI {
     | ({ success: true } & StudentAnswersDataset)
     | { success: false; error?: string }
   >
+  getStudentAnswerScoreSummary: (
+    studentAnswerId: string
+  ) => Promise<
+    | { success: true; summary: StudentAnswerScoreSummary }
+    | { success: false; error?: string }
+  >
   deleteStudentAnswer: (studentAnswerId: string) => Promise<{
     success: boolean
+    /** 削除直前に数えた採点実績（削除確認モーダルと同じ定義） */
+    deletedSummary?: StudentAnswerScoreSummary
     error?: string
   }>
   associateStudentAnswerWithStudent: (


### PR DESCRIPTION
Closes #1026

## 概要

答案画像の削除で採点データが孤児化する問題を修正し、削除確認モーダルが実データを照会して内訳を表示するようにした。

## 変更内容

### 採点データを確実に削除（`studentAnswer/crud.ts`）

`placementApply` の discard と同じ手順に揃えた。

- ページ scoped で `QuestionScore` / `ScoreDecision` / `CompoundAnswerScore` を明示削除
- `DrawingAnnotation` は `recordDrawingAnnotationDeletionsForQuestionScores` で tombstone を記録してから親の cascade で削除（import での復活を防止）
- トランザクション化し、**ファイル削除を DB コミット後へ移動**。逆順だと DB 失敗時に画像だけ失われて復旧できない
- tombstone は SQLite に `skipDuplicates` が無く1行ずつ upsert するため、既定の 5s を超えると P2028 で全ロールバックする。`grade.ts` の先例に倣い `timeout: 30000` を設定

### 採点データの有無を実際に判定して表示

- `getStudentAnswerScoreSummary`（IPC `get-answer-sheet-score-summary`）を新設
- `scoringInitializer` が全マスに `status="unscored"` の行を先行作成するため、行の有無をそのまま採点済みとすると常に true になる。status / 部分点 / 注釈 / 確定値に実体があるものだけを数える（**削除時は unscored の初期化行も含めて全て消す**）
- 協調採点では1設問に教員ごとの行が並ぶため、設問数は `distinct: ["cropRegionId"]` で数える（行数だと教員数だけ水増しされる）
- `AnswerTableShell.tsx` の `hasScoreData` ハードコード `true` を削除
- **照会失敗時は安全側に倒し**、無条件の警告を表示（「データなし」と誤読させない）
- preload が古い場合の同期例外でボタンが永久に無効化されないよう `async` + `try/catch/finally` に変更

### placementApply の複合回答対応

`CompoundAnswerScore` は `@@unique([compoundAnswerId, studentId])` があるため、`ScoreDecision` と同じく delete → 再作成方式で carry。移動先の stale 掃除も対応（無いと carry で unique 違反になる）。

### 協調採点中の削除通知

答案ごと削除された採点への保存は `updateQuestionScore` が `target-deleted` を返す。従来はロールバックが DB を引き直して失敗し、**楽観更新が画面に残って保存済みに見えていた**。07-score-at-once は行を取り除いたうえで理由を通知する。

### 重複の集約

- ページ scope 解決 → `studentAnswer/pageScope.ts`
- `Tx` 型 → `prisma/transactionClient.ts`（既存の `auditLog.ts` / `deletedRecord.ts` の重複定義も差し替え）

## 仕様上の判断

**全教員分の採点を削除する**（`userId` で絞らない）。答案画像が無くなった以上その座標の採点は誰の提案であっても対象を失うため。自分の行だけ残すと孤児化という元の不具合に戻る。テストで各教員の `userId` 別に0件であることを保証している。

`ReturnSnapshot` は**意図的に保持**する。返却時点の凍結記録であり、現在データに追従して消すと差分機能が壊れる。粒度も試験×生徒でページ単位の削除とは合わない。

## テスト

`__tests__/exam/integration/studentAnswerDelete.test.ts` を新規追加（12件）。

- 当該マスの4種が全滅し、**他生徒・他ページを巻き添えにしない**
- 全教員分の行が消える（`userId` 別に0件）
- tombstone 記録
- unscored のみなら `hasScoreData=false`、未採点でも削除時は初期化行ごと消える
- 協調採点の重複カウント / 複合回答の部分点
- 削除後の保存が `target-deleted` を返す

`studentAnswerPlacementApply.test.ts` に複合回答の carry/discard を追加。

`npm run check-all` と `npx vitest run __tests__/exam/` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)