### PR TITLE
refactor(answer-sheet-builder): 「変換」導線を書き出しページへ移動

### DIFF
--- a/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetBuilderMainView.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowLeft, FolderOpen, Redo2, Undo2 } from "lucide-react"
+import { ArrowLeft, Redo2, Undo2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -15,7 +15,6 @@ import { useAuth } from "@/contexts/AuthContext"
 import type { RenderMode } from "@/types/answerSheetDefinition.types"
 
 import { countAsbQuestions } from "./answerSheetStats"
-import { ExamIntegrationDialog } from "./components/export/ExamIntegrationDialog"
 import { GlobalSettingsForm } from "./components/form/GlobalSettingsForm"
 import { HeaderFieldEditor } from "./components/form/HeaderFieldEditor"
 import { LineStylePicker } from "./components/form/LineStylePicker"
@@ -113,8 +112,6 @@ export function AnswerSheetBuilderMainView({
 
   useUndoRedoShortcuts({ undo, redo, canUndo, canRedo })
 
-  const [examDialogOpen, setExamDialogOpen] = useState(false)
-
   // 問題統計（設問数はレイアウトの解答セル数、合計配点は定義から集計）
   const allCells = multiPageLayout.pages.flatMap((page) => page.cells)
   const totalQuestions = allCells.filter(
@@ -181,16 +178,6 @@ export function AnswerSheetBuilderMainView({
             title="やり直し (Ctrl+Shift+Z)"
           >
             <Redo2 className="h-3.5 w-3.5" />
-          </Button>
-          <Separator orientation="vertical" className="mx-1 h-5 self-center" />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs"
-            onClick={() => setExamDialogOpen(true)}
-          >
-            <FolderOpen className="mr-1 h-3 w-3" />
-            変換
           </Button>
         </div>
 
@@ -333,15 +320,6 @@ export function AnswerSheetBuilderMainView({
           borderConfig={definition.settings.borderConfig}
         />
       </div>
-
-      {/* ダイアログ */}
-      <ExamIntegrationDialog
-        open={examDialogOpen}
-        onOpenChange={setExamDialogOpen}
-        definition={definition}
-        totalQuestions={totalQuestions}
-        totalPoints={totalPoints}
-      />
     </div>
   )
 }

--- a/src/components/answer-sheet-builder/AnswerSheetExportView.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetExportView.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
 
+import { ExamIntegrationCard } from "./components/export/ExamIntegrationCard"
 import { useAnswerSheetExport } from "./hooks/useAnswerSheetExport"
 
 interface AnswerSheetExportViewProps {
@@ -126,6 +127,8 @@ export function AnswerSheetExportView({
           </div>
         </div>
       </Button>
+
+      <ExamIntegrationCard definition={definition} />
     </div>
   )
 }

--- a/src/components/answer-sheet-builder/components/export/ExamIntegrationCard.tsx
+++ b/src/components/answer-sheet-builder/components/export/ExamIntegrationCard.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { FolderOpen } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import type { AnswerSheetDefinition } from "@/types/answerSheetDefinition.types"
+
+import { countAsbQuestions } from "../../answerSheetStats"
+import { useMultiPageLayout } from "../../hooks/useAnswerSheetLayout"
+import { ExamIntegrationDialog } from "./ExamIntegrationDialog"
+
+interface ExamIntegrationCardProps {
+  definition: AnswerSheetDefinition
+}
+
+/**
+ * 解答用紙定義から採点試験を作成する導線。
+ * 書き出しページの出力ボタン群と同じ体裁で変換ダイアログを開く。
+ */
+export function ExamIntegrationCard({ definition }: ExamIntegrationCardProps) {
+  const [examDialogOpen, setExamDialogOpen] = useState(false)
+  const multiPageLayout = useMultiPageLayout(definition)
+
+  const totalQuestions = multiPageLayout.pages
+    .flatMap((page) => page.cells)
+    .filter((cell) => cell.cellType === "answer").length
+  const { totalPoints } = countAsbQuestions(definition.majorQuestions)
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="h-12 w-full justify-start gap-3"
+        onClick={() => setExamDialogOpen(true)}
+      >
+        <FolderOpen className="h-5 w-5 text-amber-500" />
+        <div className="text-left">
+          <div className="text-sm font-medium">採点試験に変換</div>
+          <div className="text-muted-foreground text-xs">
+            模範解答・採点領域・配点を自動作成
+          </div>
+        </div>
+      </Button>
+
+      <ExamIntegrationDialog
+        open={examDialogOpen}
+        onOpenChange={setExamDialogOpen}
+        definition={definition}
+        totalQuestions={totalQuestions}
+        totalPoints={totalPoints}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
Closes #1028

## 概要

解答用紙作成ページのアクションバーにあった「変換」ボタンを、「2. 書き出し」ページの出力カード群へ移動しました。

## 変更内容

- **`components/export/ExamIntegrationCard.tsx`（新規）** — 「採点試験に変換」ボタンと `ExamIntegrationDialog` を内包。設問数・合計配点は `useMultiPageLayout` / `countAsbQuestions` で自身が算出する
- **`AnswerSheetExportView.tsx`** — PDF出力・PNG出力・印刷に続く4つ目のカードとして配置
- **`AnswerSheetBuilderMainView.tsx`** — 「変換」ボタン・`examDialogOpen` state・ダイアログ本体を削除。アクションバーは元に戻す／やり直しのみに

ダイアログの中身と変換ロジック（`useExamIntegration`）は変更なし。フッター統計もそのまま。

## 確認

- `npm run typecheck` 通過
- `npm run lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)