### PR TITLE
fix(08-export): 返却差分パネルを生徒選択タブへ移設しレイアウトと件数不一致を修正

### DIFF
--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -10,12 +10,12 @@ import {
 import ExportProgressModal from "@/components/exams/08-export/components/ExportProgressModal"
 import ExportWarningModal from "@/components/exams/08-export/components/ExportWarningModal"
 import { PdfCanvasRenderer } from "@/components/exams/08-export/components/PdfCanvasRenderer"
-import { ReturnDiffPanel } from "@/components/exams/08-export/components/ReturnDiffPanel"
 import { StudentSelectionCard } from "@/components/exams/08-export/components/StudentSelectionCard"
 import { useDataFileExports } from "@/components/exams/08-export/hooks/useDataFileExports"
 import { useExcelPreview } from "@/components/exams/08-export/hooks/useExcelPreview"
 import { useExportPage } from "@/components/exams/08-export/hooks/useExportPage"
 import { useIndividualReportPreview } from "@/components/exams/08-export/hooks/useIndividualReportPreview"
+import { useReturnDiff } from "@/components/exams/08-export/hooks/useReturnDiff"
 import { useScoredAnswerPdfExport } from "@/components/exams/08-export/hooks/useScoredAnswerPdfExport"
 import { useScoredAnswerPreview } from "@/components/exams/08-export/hooks/useScoredAnswerPreview"
 import { buildScoringMarkConfigForPdf } from "@/components/exams/08-export/utils/buildScoringMarkConfigForPdf"
@@ -39,6 +39,7 @@ export default function ExportMainView() {
   const {
     exam,
     students,
+    allStudents,
     availableClassrooms,
     loading,
     searchTerm,
@@ -75,6 +76,15 @@ export default function ExportMainView() {
     () => Array.from(selectedStudents),
     [selectedStudents]
   )
+
+  // 答案返却・差分（左カードのパネルと右カードの記録ボタンで状態を共有）
+  const {
+    diffByStudent,
+    changedStudentIds,
+    hasAnySnapshot,
+    capturing: capturingReturn,
+    capture: captureReturn,
+  } = useReturnDiff(exam?.id ?? "")
 
   const {
     previewData,
@@ -267,14 +277,7 @@ export default function ExportMainView() {
       <PageHeader title="採点結果のファイル出力" helpButton={helpButton} />
 
       <div className="container mx-auto flex min-h-0 flex-1 flex-col gap-6 px-4 py-6">
-        <ReturnDiffPanel
-          examId={exam?.id ?? ""}
-          students={students}
-          selectedStudentIds={selectedStudentIds}
-          onSelectStudentIds={replaceSelection}
-        />
-
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2 lg:grid-rows-1">
           <div className="h-full min-h-0">
             <StudentSelectionCard
               examId={exam?.id}
@@ -290,6 +293,16 @@ export default function ExportMainView() {
               toggleStudent={toggleStudent}
               addStudents={addStudents}
               removeStudents={removeStudents}
+              // 答案返却・差分（生徒選択タブ内に表示）
+              // 差分の件数・詳細は表示フィルタと独立させるため未フィルタの全生徒を渡す
+              allStudents={allStudents}
+              selectedStudentIds={selectedStudentIds}
+              onSelectStudentIds={replaceSelection}
+              diffByStudent={diffByStudent}
+              changedStudentIds={changedStudentIds}
+              hasAnySnapshot={hasAnySnapshot}
+              capturingReturn={capturingReturn}
+              captureReturn={captureReturn}
               // プレビュー関連
               exportTab={exportTab}
               previewData={previewData}
@@ -329,6 +342,8 @@ export default function ExportMainView() {
               onExportGradingData={handleExportGradingData}
               onExportRData={handleExportRData}
               onExportIndividualReports={handleExportIndividualReports}
+              captureReturn={captureReturn}
+              capturingReturn={capturingReturn}
               activeTab={exportTab}
               onTabChange={setExportTab}
             />

--- a/src/components/exams/08-export/components/CaptureReturnVersionButton.tsx
+++ b/src/components/exams/08-export/components/CaptureReturnVersionButton.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { FileCheck } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+interface CaptureReturnVersionButtonProps {
+  /** 記録対象（現在の選択） */
+  selectedStudentIds: string[]
+  /** 返却版記録の実行中フラグ */
+  capturing: boolean
+  /** 指定生徒を返却版として記録する */
+  capture: (studentIds: string[]) => Promise<boolean>
+  /** ボタンのラベル（件数を含めるかは呼び出し側が決める） */
+  label: string
+  /** サイズ（既定 sm） */
+  size?: React.ComponentProps<typeof Button>["size"]
+  /** 追加クラス（固定幅など） */
+  className?: string
+}
+
+/**
+ * 「返却版として記録」ボタン。
+ * 左カード（ReturnDiffPanel）と右カード（ExportOptionsCard）で共通利用し、
+ * ラベルとサイズ・幅のみを呼び出し側で差し替える。処理・無効化条件は一箇所に集約。
+ */
+export function CaptureReturnVersionButton({
+  selectedStudentIds,
+  capturing,
+  capture,
+  label,
+  size = "sm",
+  className,
+}: CaptureReturnVersionButtonProps) {
+  return (
+    <Button
+      variant="outline"
+      size={size}
+      className={className}
+      onClick={() => capture(selectedStudentIds)}
+      disabled={capturing || selectedStudentIds.length === 0}
+    >
+      <FileCheck className="mr-1 h-4 w-4" />
+      {label}
+    </Button>
+  )
+}

--- a/src/components/exams/08-export/components/ExportOptionsCard.tsx
+++ b/src/components/exams/08-export/components/ExportOptionsCard.tsx
@@ -2,6 +2,7 @@
 
 import { Download } from "lucide-react"
 
+import { CaptureReturnVersionButton } from "@/components/exams/08-export/components/CaptureReturnVersionButton"
 import { IndividualReportSettings } from "@/components/exams/08-export/components/IndividualReportSettings"
 import ScoringMarkSettings, {
   ScoringMarkConfig,
@@ -33,8 +34,53 @@ interface ExportOptionsCardProps {
   onExportGradingData: () => void
   onExportRData: (format: "csv" | "json") => void
   onExportIndividualReports: () => void
+  /** 指定生徒を返却版として記録する */
+  captureReturn: (studentIds: string[]) => Promise<boolean>
+  /** 返却版記録の実行中フラグ */
+  capturingReturn: boolean
   activeTab: ExportTabType
   onTabChange: (tab: ExportTabType) => void
+}
+
+/**
+ * ダウンロードボタン（可変幅）＋返却版記録ボタン（固定幅）の行。
+ * スクロール領域の外に固定表示する用途で使う。記録ボタンは共通コンポーネントを
+ * 呼び出し側で生成して captureButton として受け取る。
+ */
+function DownloadRow({
+  downloadLabel,
+  onDownload,
+  disabled,
+  noStudentSelected,
+  captureButton,
+}: {
+  downloadLabel: string
+  onDownload: () => void
+  disabled: boolean
+  noStudentSelected: boolean
+  captureButton: React.ReactNode
+}) {
+  return (
+    <div>
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          size="lg"
+          onClick={onDownload}
+          disabled={disabled}
+        >
+          <Download className="mr-2 h-4 w-4" />
+          {downloadLabel}
+        </Button>
+        {captureButton}
+      </div>
+      {noStudentSelected && (
+        <p className="text-muted-foreground mt-2 text-center text-xs">
+          生徒を選択してください
+        </p>
+      )}
+    </div>
+  )
 }
 
 export function ExportOptionsCard({
@@ -51,9 +97,24 @@ export function ExportOptionsCard({
   onExportGradingData,
   onExportRData,
   onExportIndividualReports,
+  captureReturn,
+  capturingReturn,
   activeTab,
   onTabChange,
 }: ExportOptionsCardProps) {
+  const noStudentSelected = selectedStudents.size === 0
+
+  // 記録ボタンは全タブ共通（左カードの ReturnDiffPanel と同一コンポーネント）
+  const captureButton = (
+    <CaptureReturnVersionButton
+      selectedStudentIds={Array.from(selectedStudents)}
+      capturing={capturingReturn}
+      capture={captureReturn}
+      label="返却版として記録"
+      size="lg"
+      className="w-44 shrink-0"
+    />
+  )
   const handleOrientationChange = (value: PdfOrientation) => {
     setExportOptions({
       ...exportOptions,
@@ -88,177 +149,162 @@ export function ExportOptionsCard({
 
       <TabsContent
         value="scored-answers"
-        className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto"
+        className="mt-4 flex min-h-0 flex-1 flex-col gap-4"
       >
-        {/* ダウンロードボタン */}
-        <div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={onExportScoredAnswers}
-            disabled={selectedStudents.size === 0 || isExporting}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            採点済み答案PDFをダウンロード
-          </Button>
-          {selectedStudents.size === 0 && (
-            <p className="text-muted-foreground mt-2 text-center text-xs">
-              生徒を選択してください
-            </p>
-          )}
+        {/* ダウンロードボタン（スクロール外に固定） */}
+        <div className="shrink-0">
+          <DownloadRow
+            downloadLabel="採点済み答案PDFをダウンロード"
+            onDownload={onExportScoredAnswers}
+            disabled={noStudentSelected || isExporting}
+            noStudentSelected={noStudentSelected}
+            captureButton={captureButton}
+          />
         </div>
 
-        {/* PDF用紙設定 */}
-        <div className="space-y-3">
-          <h4 className="text-base font-semibold">PDF用紙設定</h4>
-          <div>
-            <Label className="text-sm font-medium">用紙の向き</Label>
-            <div className="mt-2 flex gap-2">
-              <Button
-                variant={
-                  exportOptions.pdfOrientation === "portrait"
-                    ? "default"
-                    : "outline"
-                }
-                size="sm"
-                onClick={() => handleOrientationChange("portrait")}
-              >
-                A4縦 (ポートレート)
-              </Button>
-              <Button
-                variant={
-                  exportOptions.pdfOrientation === "landscape"
-                    ? "default"
-                    : "outline"
-                }
-                size="sm"
-                onClick={() => handleOrientationChange("landscape")}
-              >
-                A4横 (ランドスケープ)
-              </Button>
+        <div className="relative min-h-0 flex-1 space-y-4 overflow-y-auto">
+          {/* PDF用紙設定 */}
+          <div className="space-y-3">
+            <h4 className="text-base font-semibold">PDF用紙設定</h4>
+            <div>
+              <Label className="text-sm font-medium">用紙の向き</Label>
+              <div className="mt-2 flex gap-2">
+                <Button
+                  variant={
+                    exportOptions.pdfOrientation === "portrait"
+                      ? "default"
+                      : "outline"
+                  }
+                  size="sm"
+                  onClick={() => handleOrientationChange("portrait")}
+                >
+                  A4縦 (ポートレート)
+                </Button>
+                <Button
+                  variant={
+                    exportOptions.pdfOrientation === "landscape"
+                      ? "default"
+                      : "outline"
+                  }
+                  size="sm"
+                  onClick={() => handleOrientationChange("landscape")}
+                >
+                  A4横 (ランドスケープ)
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* 並列処理設定 */}
-        <div className="space-y-3">
-          <h4 className="text-base font-semibold">処理設定</h4>
-          <div>
-            <div className="flex items-center justify-between">
-              <Label className="text-sm font-medium">並列処理数</Label>
-              <span className="text-sm font-medium">
-                {exportOptions.parallelCount}
-              </span>
+          {/* 並列処理設定 */}
+          <div className="space-y-3">
+            <h4 className="text-base font-semibold">処理設定</h4>
+            <div>
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">並列処理数</Label>
+                <span className="text-sm font-medium">
+                  {exportOptions.parallelCount}
+                </span>
+              </div>
+              <Slider
+                value={[exportOptions.parallelCount]}
+                onValueChange={handleParallelCountChange}
+                min={1}
+                max={8}
+                step={1}
+                className="mt-2"
+              />
+              <p className="text-muted-foreground mt-1 text-xs">
+                値を大きくすると処理が速くなりますが、メモリ使用量が増えます
+              </p>
             </div>
-            <Slider
-              value={[exportOptions.parallelCount]}
-              onValueChange={handleParallelCountChange}
-              min={1}
-              max={8}
-              step={1}
-              className="mt-2"
-            />
-            <p className="text-muted-foreground mt-1 text-xs">
-              値を大きくすると処理が速くなりますが、メモリ使用量が増えます
-            </p>
           </div>
-        </div>
 
-        {/* 採点マーク設定 */}
-        <ScoringMarkSettings
-          config={scoringMarkConfig}
-          onChange={setScoringMarkConfig}
-        />
+          {/* 採点マーク設定 */}
+          <ScoringMarkSettings
+            config={scoringMarkConfig}
+            onChange={setScoringMarkConfig}
+          />
+        </div>
       </TabsContent>
 
       <TabsContent
         value="grading-data"
-        className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto"
+        className="mt-4 flex min-h-0 flex-1 flex-col gap-4"
       >
-        {/* ダウンロードボタン */}
-        <div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={onExportGradingData}
-            disabled={selectedStudents.size === 0 || isExporting}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            採点データExcelをダウンロード
-          </Button>
-          {selectedStudents.size === 0 && (
-            <p className="text-muted-foreground mt-2 text-center text-xs">
-              生徒を選択してください
+        {/* ダウンロードボタン（スクロール外に固定） */}
+        <div className="shrink-0">
+          <DownloadRow
+            downloadLabel="採点データExcelをダウンロード"
+            onDownload={onExportGradingData}
+            disabled={noStudentSelected || isExporting}
+            noStudentSelected={noStudentSelected}
+            captureButton={captureButton}
+          />
+        </div>
+
+        <div className="relative min-h-0 flex-1 space-y-4 overflow-y-auto">
+          <div className="space-y-3">
+            <h4 className="text-base font-semibold">Excel出力設定</h4>
+            <p className="text-muted-foreground text-sm">
+              採点データをExcel形式で出力します。設定は現在ありません。
             </p>
-          )}
-        </div>
+          </div>
 
-        <div className="space-y-3">
-          <h4 className="text-base font-semibold">Excel出力設定</h4>
-          <p className="text-muted-foreground text-sm">
-            採点データをExcel形式で出力します。設定は現在ありません。
-          </p>
-        </div>
-
-        {/* R / exametrika 向けデータ出力（#834） */}
-        <div className="space-y-3 border-t pt-4">
-          <h4 className="text-base font-semibold">
-            分析用データ（R / exametrika）
-          </h4>
-          <p className="text-muted-foreground text-sm">
-            設問×生徒の正誤行列を出力します。欠席・未採点は欠測値として扱います。
-          </p>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={() => onExportRData("csv")}
-              disabled={selectedStudents.size === 0 || isExporting}
-            >
-              <Download className="mr-2 h-4 w-4" />
-              CSV
-            </Button>
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={() => onExportRData("json")}
-              disabled={selectedStudents.size === 0 || isExporting}
-            >
-              <Download className="mr-2 h-4 w-4" />
-              JSON
-            </Button>
+          {/* R / exametrika 向けデータ出力（#834） */}
+          <div className="space-y-3 border-t pt-4">
+            <h4 className="text-base font-semibold">
+              分析用データ（R / exametrika）
+            </h4>
+            <p className="text-muted-foreground text-sm">
+              設問×生徒の正誤行列を出力します。欠席・未採点は欠測値として扱います。
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => onExportRData("csv")}
+                disabled={selectedStudents.size === 0 || isExporting}
+              >
+                <Download className="mr-2 h-4 w-4" />
+                CSV
+              </Button>
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => onExportRData("json")}
+                disabled={selectedStudents.size === 0 || isExporting}
+              >
+                <Download className="mr-2 h-4 w-4" />
+                JSON
+              </Button>
+            </div>
           </div>
         </div>
       </TabsContent>
 
       <TabsContent
         value="individual-reports"
-        className="mt-4 min-h-0 flex-1 space-y-4 overflow-y-auto"
+        className="mt-4 flex min-h-0 flex-1 flex-col gap-4"
       >
-        {/* ダウンロードボタン */}
-        <div>
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={onExportIndividualReports}
-            disabled={selectedStudents.size === 0 || isExporting}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            個人成績表PDFをダウンロード
-          </Button>
-          {selectedStudents.size === 0 && (
-            <p className="text-muted-foreground mt-2 text-center text-xs">
-              生徒を選択してください
-            </p>
-          )}
+        {/* ダウンロードボタン（スクロール外に固定） */}
+        <div className="shrink-0">
+          <DownloadRow
+            downloadLabel="個人成績表PDFをダウンロード"
+            onDownload={onExportIndividualReports}
+            disabled={noStudentSelected || isExporting}
+            noStudentSelected={noStudentSelected}
+            captureButton={captureButton}
+          />
         </div>
 
-        {/* 設定パネル */}
-        <IndividualReportSettings
-          examId={examId}
-          options={individualReportOptions}
-          onChange={setIndividualReportOptions}
-        />
+        <div className="relative min-h-0 flex-1 space-y-4 overflow-y-auto">
+          {/* 設定パネル */}
+          <IndividualReportSettings
+            examId={examId}
+            options={individualReportOptions}
+            onChange={setIndividualReportOptions}
+          />
+        </div>
       </TabsContent>
     </Tabs>
   )

--- a/src/components/exams/08-export/components/ReturnDiffPanel.tsx
+++ b/src/components/exams/08-export/components/ReturnDiffPanel.tsx
@@ -1,29 +1,32 @@
 "use client"
 
-import { ArrowRight, FileCheck, Filter, PencilLine } from "lucide-react"
+import {
+  ArrowRight,
+  FileCheck,
+  Filter,
+  HelpCircle,
+  PencilLine,
+} from "lucide-react"
 import { useState } from "react"
 
+import { CaptureReturnVersionButton } from "@/components/exams/08-export/components/CaptureReturnVersionButton"
 import type { Student } from "@/components/exams/08-export/types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import type {
   ReturnScoreCellState,
   ReturnStudentDiff,
 } from "@/electron-src/lib/prisma/returnSnapshot"
-
-import { useReturnDiff } from "../hooks/useReturnDiff"
 
 /** 採点判定コードを日本語表示に変換 */
 const statusLabel = (status: string): string => {
@@ -56,32 +59,39 @@ const cellText = (cell: ReturnScoreCellState | null): string => {
 }
 
 interface ReturnDiffPanelProps {
-  examId: string
   /** 表示名解決用の生徒一覧（フィルタ前の全件が望ましい） */
   students: Student[]
   /** 現在の選択（「返却版として記録」対象・件数表示に使う） */
   selectedStudentIds: string[]
   /** 選択を差し替える（「変更があった生徒のみ選択」） */
   onSelectStudentIds: (studentIds: string[]) => void
+  /** 生徒ID → 返却版との差分 */
+  diffByStudent: Map<string, ReturnStudentDiff>
+  /** 返却版から変更があった生徒IDの集合 */
+  changedStudentIds: Set<string>
+  /** 返却版スナップショットが1件でも存在するか */
+  hasAnySnapshot: boolean
+  /** 返却版記録の実行中フラグ */
+  capturing: boolean
+  /** 指定生徒を返却版として記録する */
+  capture: (studentIds: string[]) => Promise<boolean>
 }
 
 /**
  * 答案返却・差分パネル。
  * 「返却版として記録」と、前回返却分から変更があった生徒の検出・絞り込みを行う。
+ * 返却差分の状態は親（ExportMainView）で管理し props で受け取る。
  */
 export function ReturnDiffPanel({
-  examId,
   students,
   selectedStudentIds,
   onSelectStudentIds,
+  diffByStudent,
+  changedStudentIds,
+  hasAnySnapshot,
+  capturing,
+  capture,
 }: ReturnDiffPanelProps) {
-  const {
-    diffByStudent,
-    changedStudentIds,
-    hasAnySnapshot,
-    capturing,
-    capture,
-  } = useReturnDiff(examId)
   const [detailOpen, setDetailOpen] = useState(false)
 
   // 変更があった生徒の差分（受験生徒実体をペアで保持。順序は students の並びに従う）
@@ -99,110 +109,115 @@ export function ReturnDiffPanel({
     onSelectStudentIds(Array.from(changedStudentIds))
   }
 
-  const handleCapture = async () => {
-    await capture(selectedStudentIds)
-  }
-
   return (
-    <Card className="shrink-0">
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 text-base">
-          <FileCheck className="h-4 w-4" />
-          答案返却・差分
-        </CardTitle>
-        <CardDescription>
-          現在の採点内容を「返却版」として記録すると、以降に採点（スコア・採点マーク）を
-          修正した生徒だけを抽出して再印刷できます。
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2">
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <CaptureReturnVersionButton
+          selectedStudentIds={selectedStudentIds}
+          capturing={capturing}
+          capture={capture}
+          label={`選択中の${selectedStudentIds.length}名を返却版として記録`}
+        />
+
+        {hasAnySnapshot && (
           <Button
             variant="outline"
             size="sm"
-            onClick={handleCapture}
-            disabled={capturing || selectedStudentIds.length === 0}
+            onClick={selectChangedOnly}
+            disabled={changedStudentIds.size === 0}
           >
-            <FileCheck className="mr-1 h-4 w-4" />
-            選択中の{selectedStudentIds.length}名を返却版として記録
+            <Filter className="mr-1 h-4 w-4" />
+            変更があった生徒のみ選択（{changedStudentIds.size}名）
           </Button>
+        )}
 
-          {hasAnySnapshot && (
+        {/* 機能説明（Popover） */}
+        <Popover>
+          <PopoverTrigger asChild>
             <Button
-              variant="outline"
-              size="sm"
-              onClick={selectChangedOnly}
-              disabled={changedStudentIds.size === 0}
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground h-8 w-8"
+              aria-label="答案返却・差分の説明"
             >
-              <Filter className="mr-1 h-4 w-4" />
-              変更があった生徒のみ選択（{changedStudentIds.size}名）
+              <HelpCircle className="h-4 w-4" />
             </Button>
-          )}
-        </div>
+          </PopoverTrigger>
+          <PopoverContent className="w-80 text-sm">
+            <div className="flex items-center gap-2 font-medium">
+              <FileCheck className="h-4 w-4" />
+              答案返却・差分
+            </div>
+            <p className="text-muted-foreground mt-2">
+              現在の採点内容を「返却版」として記録すると、以降に採点（スコア・採点マーク）を
+              修正した生徒だけを抽出して再印刷できます。
+            </p>
+          </PopoverContent>
+        </Popover>
+      </div>
 
-        {hasAnySnapshot ? (
-          changedDiffs.length > 0 ? (
-            <Collapsible open={detailOpen} onOpenChange={setDetailOpen}>
-              <CollapsibleTrigger asChild>
-                <Button variant="ghost" size="sm" className="px-2">
-                  {detailOpen ? "変更内容を隠す" : "変更内容を表示"}（
-                  {changedDiffs.length}名）
-                </Button>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2 max-h-64 space-y-3 overflow-y-auto pr-1">
-                {changedDiffs.map(({ examStudent, diff }) => (
-                  <div
-                    key={diff.studentId}
-                    className="border-border rounded-md border p-3 text-sm"
-                  >
-                    <div className="mb-1 flex items-center gap-2 font-medium">
-                      {examStudent.student.lastName}{" "}
-                      {examStudent.student.firstName}
-                      {diff.annotationChanged && (
-                        <Badge variant="secondary" className="gap-1">
-                          <PencilLine className="h-3 w-3" />
-                          採点マーク変更
-                        </Badge>
-                      )}
-                    </div>
-                    {diff.scoreChanges.length > 0 ? (
-                      <ul className="text-muted-foreground space-y-0.5">
-                        {diff.scoreChanges.map((scoreChange) => (
-                          <li
-                            key={scoreChange.cropRegionId}
-                            className="flex items-center gap-1.5"
-                          >
-                            <span className="text-foreground">
-                              {scoreChange.label || "設問"}:
-                            </span>
-                            <span>{cellText(scoreChange.before)}</span>
-                            <ArrowRight className="h-3 w-3 shrink-0" />
-                            <span className="text-foreground">
-                              {cellText(scoreChange.after)}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <div className="text-muted-foreground">
-                        採点マークのみ変更
-                      </div>
+      {hasAnySnapshot ? (
+        changedDiffs.length > 0 ? (
+          <Collapsible open={detailOpen} onOpenChange={setDetailOpen}>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="sm" className="px-2">
+                {detailOpen ? "変更内容を隠す" : "変更内容を表示"}（
+                {changedDiffs.length}名）
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-2 max-h-64 space-y-3 overflow-y-auto pr-1">
+              {changedDiffs.map(({ examStudent, diff }) => (
+                <div
+                  key={diff.studentId}
+                  className="border-border rounded-md border p-3 text-sm"
+                >
+                  <div className="mb-1 flex items-center gap-2 font-medium">
+                    {examStudent.student.lastName}{" "}
+                    {examStudent.student.firstName}
+                    {diff.annotationChanged && (
+                      <Badge variant="secondary" className="gap-1">
+                        <PencilLine className="h-3 w-3" />
+                        採点マーク変更
+                      </Badge>
                     )}
                   </div>
-                ))}
-              </CollapsibleContent>
-            </Collapsible>
-          ) : (
-            <p className="text-muted-foreground text-sm">
-              前回返却時から変更があった生徒はいません。
-            </p>
-          )
+                  {diff.scoreChanges.length > 0 ? (
+                    <ul className="text-muted-foreground space-y-0.5">
+                      {diff.scoreChanges.map((scoreChange) => (
+                        <li
+                          key={scoreChange.cropRegionId}
+                          className="flex items-center gap-1.5"
+                        >
+                          <span className="text-foreground">
+                            {scoreChange.label || "設問"}:
+                          </span>
+                          <span>{cellText(scoreChange.before)}</span>
+                          <ArrowRight className="h-3 w-3 shrink-0" />
+                          <span className="text-foreground">
+                            {cellText(scoreChange.after)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-muted-foreground">
+                      採点マークのみ変更
+                    </div>
+                  )}
+                </div>
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
         ) : (
           <p className="text-muted-foreground text-sm">
-            まだ返却版が記録されていません。出力対象の生徒を選んで「返却版として記録」してください。
+            前回返却時から変更があった生徒はいません。
           </p>
-        )}
-      </CardContent>
-    </Card>
+        )
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          まだ返却版が記録されていません。出力対象の生徒を選んで「返却版として記録」してください。
+        </p>
+      )}
+    </div>
   )
 }

--- a/src/components/exams/08-export/components/StudentSelectionCard.tsx
+++ b/src/components/exams/08-export/components/StudentSelectionCard.tsx
@@ -35,11 +35,13 @@ import type {
   IndividualReportData,
   IndividualReportOptions,
 } from "@/electron-src/lib/export/individual-report/types"
+import type { ReturnStudentDiff } from "@/electron-src/lib/prisma/returnSnapshot"
 
 import type { ExcelPreviewData } from "../hooks/useExcelPreview"
 import { ExcelPreview } from "./ExcelPreview"
 import type { ExportTabType } from "./ExportOptionsCard"
 import { IndividualReportPreview } from "./individual-report/IndividualReportPreview"
+import { ReturnDiffPanel } from "./ReturnDiffPanel"
 import { ScoredAnswerPreview } from "./ScoredAnswerPreview"
 import { StatisticsClassroomSelector } from "./StatisticsClassroomSelector"
 
@@ -57,6 +59,16 @@ interface StudentSelectionCardProps {
   toggleStudent: (studentId: string) => void
   addStudents: (studentIds: string[]) => void
   removeStudents: (studentIds: string[]) => void
+  // 答案返却・差分（生徒選択タブ内に表示）
+  /** 表示フィルタ前の全生徒（差分の件数・詳細を表示フィルタと独立させるため） */
+  allStudents: Student[]
+  selectedStudentIds: string[]
+  onSelectStudentIds: (studentIds: string[]) => void
+  diffByStudent: Map<string, ReturnStudentDiff>
+  changedStudentIds: Set<string>
+  hasAnySnapshot: boolean
+  capturingReturn: boolean
+  captureReturn: (studentIds: string[]) => Promise<boolean>
   // プレビュー関連
   exportTab?: ExportTabType
   previewData?: IndividualReportData | null
@@ -92,6 +104,14 @@ export function StudentSelectionCard({
   toggleStudent,
   addStudents,
   removeStudents,
+  allStudents,
+  selectedStudentIds,
+  onSelectStudentIds,
+  diffByStudent,
+  changedStudentIds,
+  hasAnySnapshot,
+  capturingReturn,
+  captureReturn,
   exportTab,
   previewData,
   isPreviewLoading,
@@ -292,6 +312,20 @@ export function StudentSelectionCard({
           </div>
         </div>
 
+        {/* 答案返却・差分（生徒一覧の上） */}
+        <div className="mb-2 shrink-0">
+          <ReturnDiffPanel
+            students={allStudents}
+            selectedStudentIds={selectedStudentIds}
+            onSelectStudentIds={onSelectStudentIds}
+            diffByStudent={diffByStudent}
+            changedStudentIds={changedStudentIds}
+            hasAnySnapshot={hasAnySnapshot}
+            capturing={capturingReturn}
+            capture={captureReturn}
+          />
+        </div>
+
         {/* 3行目: 生徒リスト - 残りの高さを使用 */}
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="text-muted-foreground mb-1 flex items-center justify-between text-xs">
@@ -300,7 +334,7 @@ export function StudentSelectionCard({
               {selectedStudents.size}人選択中 / {students.length}人表示中
             </span>
           </div>
-          <div className="flex-1 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
+          <div className="relative flex-1 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
             {students.map((examStudent) => (
               <div
                 key={examStudent.studentId}

--- a/src/components/exams/08-export/hooks/useExportPage.ts
+++ b/src/components/exams/08-export/hooks/useExportPage.ts
@@ -336,6 +336,8 @@ export function useExportPage() {
     // データ
     exam,
     students: filteredStudents,
+    // 表示フィルタ前の全生徒（返却差分の件数・詳細を表示フィルタと独立させるため）
+    allStudents: students,
     availableClassrooms,
     loading,
 


### PR DESCRIPTION
## 概要
採点結果のファイル出力ページ（`/exams/[examId]/08-export`）のレイアウト不具合と返却差分パネルの UX/実装上の問題を修正します。

Closes #1030

## 変更点

### レイアウト
- **謎の下余白スクロールを解消**: shadcn/Radix の `sr-only`（`position: absolute`）が包含ブロック `<html>` に落ち、`overflow-y-auto` のクリップをすり抜けて html を伸ばしていた。スクロール領域に `relative` を付与して修正（実測で html scrollHeight 1318→916）。
- グリッド行を `lg:grid-rows-1` で `minmax(0,1fr)` 制約。
- ダウンロードボタンをスクロール外に固定、右に固定幅の記録ボタンを配置。

### 答案返却・差分パネル
- 上部カードを廃止し**生徒選択タブ内（生徒一覧の上）**へ移動、説明は Popover 化。
- **件数不一致バグを修正**: 差分の件数・詳細を表示フィルタと独立させ、未フィルタの全生徒（`allStudents`）で算出。

### リファクタ
- 記録ボタンを共通コンポーネント `CaptureReturnVersionButton` に集約（ラベル差し替えのみ、処理を一箇所へ）。ボタンは2つ表示のまま実装の二重化を解消。

## テスト
- 型チェック（tsc）・ESLint・Prettier クリーン
- ブラウザ実測: 全タブ overflow 0 / 学級フィルタ後も件数 2/2 一致 / 記録ボタンが両カードで共通コンポーネントから描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)