### PR TITLE
fix(db): 新規インストールで解答用紙作成が失敗する2つの真因を修正

### DIFF
--- a/__tests__/migration/deployPendingMigrations.test.ts
+++ b/__tests__/migration/deployPendingMigrations.test.ts
@@ -1,0 +1,245 @@
+/**
+ * deployPendingMigrations のテスト
+ *
+ * migration.sql を better-sqlite3 の exec で適用することにより、
+ * 複数文・PRAGMA・文字列リテラル内のセミコロンが正しく扱われることを検証する。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_ROOT = path.join(os.tmpdir(), "deploy-migrations-test")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.join(TEST_ROOT, "migrations")
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+/** _prisma_migrations を持つ最小のDBを用意する */
+const createBaseDatabase = () => {
+  withDatabase((db) => {
+    db.exec(`
+      CREATE TABLE "_prisma_migrations" (
+        "id" TEXT PRIMARY KEY NOT NULL,
+        "checksum" TEXT NOT NULL,
+        "finished_at" DATETIME,
+        "migration_name" TEXT NOT NULL,
+        "logs" TEXT,
+        "rolled_back_at" DATETIME,
+        "started_at" DATETIME NOT NULL DEFAULT current_timestamp,
+        "applied_steps_count" INTEGER NOT NULL DEFAULT 0
+      )
+    `)
+  })
+}
+
+/** 名前と本文を指定して migration ディレクトリを作る */
+const writeMigration = (name: string, sql: string) => {
+  const dir = path.join(MIGRATIONS_DIR, name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, "migration.sql"), sql)
+}
+
+// getDatabasePath と getMigrationsDir をテスト用のパスへ向ける
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(MIGRATIONS_DIR, { recursive: true })
+  createBaseDatabase()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+const loadDeployer = async () => {
+  const module =
+    await import("../../electron-src/lib/prisma/schema/migrationDeployer")
+  return module.deployPendingMigrations
+}
+
+describe("deployPendingMigrations", () => {
+  it("複数文のマイグレーションを適用し、適用済みとして記録する", async () => {
+    writeMigration(
+      "20260101000000_multi",
+      `CREATE TABLE "A" (id TEXT PRIMARY KEY);
+       CREATE TABLE "B" (id TEXT PRIMARY KEY);
+       CREATE INDEX "A_id_idx" ON "A"(id);`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(1)
+
+    const tables = withDatabase(
+      (db) =>
+        db
+          .prepare(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('A','B')`
+          )
+          .all() as { name: string }[]
+    )
+    expect(tables.map((row) => row.name).sort()).toEqual(["A", "B"])
+
+    const applied = withDatabase(
+      (db) =>
+        db
+          .prepare(
+            `SELECT migration_name FROM "_prisma_migrations" WHERE migration_name = '20260101000000_multi'`
+          )
+          .all() as { migration_name: string }[]
+    )
+    expect(applied).toHaveLength(1)
+  })
+
+  it("文字列リテラル内のセミコロンを含む文でも壊れない", async () => {
+    // 素朴な split(";") では 'a;b' の途中で分割され構文エラーになる
+    writeMigration(
+      "20260101000001_semicolon",
+      `CREATE TABLE "Note" (id TEXT PRIMARY KEY, body TEXT);
+       INSERT INTO "Note" (id, body) VALUES ('n1', 'first; second; third');`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(1)
+
+    const body = withDatabase(
+      (db) =>
+        (
+          db.prepare(`SELECT body FROM "Note" WHERE id = 'n1'`).get() as {
+            body: string
+          }
+        ).body
+    )
+    expect(body).toBe("first; second; third")
+  })
+
+  it("トリガ本体（BEGIN...END内のセミコロン）を含む文を適用できる", async () => {
+    writeMigration(
+      "20260101000002_trigger",
+      `CREATE TABLE "Log" (id TEXT PRIMARY KEY, note TEXT);
+       CREATE TABLE "Audit" (note TEXT);
+       CREATE TRIGGER "log_ai" AFTER INSERT ON "Log"
+       BEGIN
+         INSERT INTO "Audit" (note) VALUES (NEW.note);
+       END;`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(1)
+
+    withDatabase((db) => {
+      db.prepare(`INSERT INTO "Log" (id, note) VALUES ('l1', 'hello')`).run()
+      const audit = db.prepare(`SELECT note FROM "Audit"`).get() as {
+        note: string
+      }
+      expect(audit.note).toBe("hello")
+    })
+  })
+
+  it("適用済みのマイグレーションは再適用しない", async () => {
+    writeMigration(
+      "20260101000000_first",
+      `CREATE TABLE "First" (id TEXT PRIMARY KEY);`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(1)
+    // 2回目は未適用ゼロ
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(0)
+  })
+
+  it("複数マイグレーションを名前順に適用する", async () => {
+    writeMigration(
+      "20260101000000_a",
+      `CREATE TABLE "T1" (id TEXT PRIMARY KEY);`
+    )
+    writeMigration(
+      "20260101000001_b",
+      `ALTER TABLE "T1" ADD COLUMN "extra" TEXT;`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(2)
+
+    const columns = withDatabase((db) =>
+      (db.prepare(`PRAGMA table_info("T1")`).all() as { name: string }[]).map(
+        (column) => column.name
+      )
+    )
+    expect(columns).toContain("extra")
+  })
+
+  it("失敗したマイグレーションはバックアップから復元され、記録されない", async () => {
+    // 事前に実データを入れておき、復元で戻ることを確認する
+    withDatabase((db) => {
+      db.exec(`CREATE TABLE "Keep" (id TEXT PRIMARY KEY)`)
+      db.prepare(`INSERT INTO "Keep" VALUES ('keep-me')`).run()
+    })
+
+    writeMigration(
+      "20260101000000_broken",
+      `CREATE TABLE "Half" (id TEXT PRIMARY KEY);
+       THIS IS NOT VALID SQL;`
+    )
+    const deploy = await loadDeployer()
+
+    expect(() => deploy({ migrationsDir: MIGRATIONS_DIR })).toThrow(
+      /20260101000000_broken/
+    )
+
+    // 復元後: 壊れかけの Half は存在せず、_prisma_migrations に記録も無い
+    const state = withDatabase((db) => ({
+      hasHalf:
+        (
+          db
+            .prepare(
+              `SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name='Half'`
+            )
+            .get() as { count: number }
+        ).count > 0,
+      recorded: (
+        db
+          .prepare(
+            `SELECT COUNT(*) as count FROM "_prisma_migrations" WHERE migration_name='20260101000000_broken'`
+          )
+          .get() as { count: number }
+      ).count,
+      keep: (
+        db.prepare(`SELECT id FROM "Keep" WHERE id='keep-me'`).get() as
+          { id: string } | undefined
+      )?.id,
+    }))
+
+    expect(state.hasHalf).toBe(false)
+    expect(state.recorded).toBe(0)
+    expect(state.keep).toBe("keep-me")
+  })
+
+  it("_prisma_migrations テーブルが無ければ何もしない", async () => {
+    fs.rmSync(DB_PATH, { force: true })
+    withDatabase((db) => {
+      db.exec(`CREATE TABLE "Unrelated" (id TEXT PRIMARY KEY)`)
+    })
+    writeMigration(
+      "20260101000000_x",
+      `CREATE TABLE "X" (id TEXT PRIMARY KEY);`
+    )
+    const deploy = await loadDeployer()
+
+    expect(deploy({ migrationsDir: MIGRATIONS_DIR })).toBe(0)
+  })
+})

--- a/__tests__/migration/freshInstallChain.test.ts
+++ b/__tests__/migration/freshInstallChain.test.ts
@@ -1,0 +1,177 @@
+/**
+ * 新規インストールの初期化連鎖の統合テスト
+ *
+ * bootstrapSchema（init適用）→ createBaseline → deployPendingMigrations（実マイグレーション全適用）
+ * を実際の prisma/migrations に対して通し、次を保証する:
+ * - 同梱マイグレーションが空DBに昇順で全適用できる（順序破壊・SQL不正の検知）
+ * - 適用後のDB（＝init名と異なる進化済みスキーマ）を bootstrapSchema が
+ *   "existing" と判定し一切変更しない（起動不能回帰の統合レベルでの防止）
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { deployPendingMigrations } from "../../electron-src/lib/prisma/schema/migrationDeployer"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "fresh-install-chain")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const REAL_MIGRATIONS = path.resolve(__dirname, "../../prisma/migrations")
+
+// deployPendingMigrations は接続先を getDatabasePath() で決めるため、テストDBへ向ける
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const tableNames = (): string[] =>
+  withDatabase((db) =>
+    (
+      db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+        )
+        .all() as { name: string }[]
+    ).map((row) => row.name)
+  )
+
+const localMigrationNames = (): string[] =>
+  fs
+    .readdirSync(REAL_MIGRATIONS, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("新規インストールの初期化連鎖", () => {
+  it("空DBにinit＋全マイグレーションを適用でき、以後 bootstrapSchema は existing を返す", async () => {
+    // 1. init スキーマ適用
+    expect(bootstrapSchema(DB_PATH)).toBe("created")
+
+    // 2. ベースライン（init を適用済みとして記録）
+    const prisma = createPrismaClientForPath(DB_PATH)
+    try {
+      await createBaseline(prisma)
+    } finally {
+      await prisma.$disconnect()
+    }
+
+    // 3. init 以降の実マイグレーションを全適用
+    const applied = deployPendingMigrations({ migrationsDir: REAL_MIGRATIONS })
+    const expectedPending = localMigrationNames().filter(
+      (name) => name !== "20260322232329_init"
+    ).length
+    expect(applied).toBe(expectedPending)
+    expect(applied).toBeGreaterThan(0)
+
+    // 4. 進化後のスキーマ検証: 後発マイグレーションのテーブルが在り、init名は消えている
+    const tables = new Set(tableNames())
+    expect(tables.has("Classroom")).toBe(true) // Class→Classroom リネーム後
+    expect(tables.has("AsbDefinitionTag")).toBe(true) // 後発マイグレーションで追加
+    expect(tables.has("classes")).toBe(false) // init 名は残っていない
+    expect(tables.has("Subject")).toBe(false)
+
+    // 5. 起動不能回帰の防止: 進化済みDBを bootstrapSchema が existing 扱いで不変にする
+    const before = fs.readFileSync(DB_PATH)
+    expect(bootstrapSchema(DB_PATH)).toBe("existing")
+    expect(fs.readFileSync(DB_PATH).equals(before)).toBe(true)
+
+    // 6. 冪等: 再デプロイは0件
+    expect(deployPendingMigrations({ migrationsDir: REAL_MIGRATIONS })).toBe(0)
+  })
+
+  it("適用後のスキーマが db push 基準（schema.prisma）と全テーブルで列一致する", async () => {
+    // fresh chain を構築
+    bootstrapSchema(DB_PATH)
+    const prisma = createPrismaClientForPath(DB_PATH)
+    try {
+      await createBaseline(prisma)
+    } finally {
+      await prisma.$disconnect()
+    }
+    deployPendingMigrations({ migrationsDir: REAL_MIGRATIONS })
+
+    // 基準: globalSetup が prisma db push で作る test-database.db（schema.prisma 忠実）
+    const groundTruthPath = path.resolve(
+      __dirname,
+      "../../data/test-database.db"
+    )
+    if (!fs.existsSync(groundTruthPath)) {
+      throw new Error(
+        "基準DB(test-database.db)が無い。globalSetup が db push で作成する想定"
+      )
+    }
+
+    const columnsByTable = (dbPath: string): Map<string, string[]> => {
+      const db = new Database(dbPath)
+      try {
+        const names = (
+          db
+            .prepare(
+              `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name <> '_prisma_migrations'`
+            )
+            .all() as { name: string }[]
+        ).map((row) => row.name)
+        return new Map(
+          names.map((tableName) => [
+            tableName,
+            (
+              db.prepare(`PRAGMA table_info("${tableName}")`).all() as {
+                name: string
+              }[]
+            )
+              .map((column) => column.name)
+              .sort(),
+          ])
+        )
+      } finally {
+        db.close()
+      }
+    }
+
+    const truth = columnsByTable(groundTruthPath)
+    const chain = columnsByTable(DB_PATH)
+
+    // 基準に在るテーブルが chain にも在り、列が完全一致すること
+    // （20260613160451 の AsbDefinition 4列取りこぼしのような列ドリフトを検知する）
+    const drift: string[] = []
+    for (const [tableName, truthColumns] of truth) {
+      const chainColumns = chain.get(tableName)
+      if (!chainColumns) {
+        drift.push(`テーブル欠落: ${tableName}`)
+        continue
+      }
+      const missing = truthColumns.filter((c) => !chainColumns.includes(c))
+      const extra = chainColumns.filter((c) => !truthColumns.includes(c))
+      if (missing.length > 0 || extra.length > 0) {
+        drift.push(
+          `${tableName}: 欠落[${missing.join(",")}] 余分[${extra.join(",")}]`
+        )
+      }
+    }
+
+    expect(drift).toEqual([])
+  })
+})

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -197,6 +197,7 @@ describe("DateTime正規化マイグレーション", () => {
   // 歴史migrationは編集禁止のため、ここで明示的にホワイトリスト管理する。
   const POST_MIGRATION_TABLES = new Set([
     "AsbCharGuide",
+    "AsbDefinitionTag", // 20260713000000 で追加。normalize migration より後で ISO text 生成
     "AuditLog",
     "Coursework",
     "CourseworkClassroom", // 旧 CourseworkClass（20260704010000 でリネーム）

--- a/__tests__/migration/schemaBootstrap.test.ts
+++ b/__tests__/migration/schemaBootstrap.test.ts
@@ -1,0 +1,256 @@
+/**
+ * 初期スキーマブートストラップのテスト
+ *
+ * DBの状態（空／テーブルあり）ごとの振る舞いと、
+ * テーブルを持つDB（init名と異なるマイグレーション済みDBを含む）を
+ * 一切変更しないことを検証する。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  INDEX_SQL,
+  MIGRATION_SQL,
+} from "../../electron-src/lib/prisma/schema/migrationSql"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+
+const TEST_DIR = path.resolve(__dirname, "../../data/test-bootstrap")
+
+/** 初期スキーマが作成するテーブル数 */
+const SCHEMA_TABLE_COUNT = Array.from(
+  MIGRATION_SQL.matchAll(/CREATE TABLE "([^"]+)"/g)
+).length
+
+const dbPathFor = (caseName: string) =>
+  path.join(TEST_DIR, caseName, "database.db")
+
+const countTables = (dbPath: string): number => {
+  const db = new Database(dbPath)
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+    )
+    .get() as { count: number }
+  db.close()
+  return Number(row.count)
+}
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(
+  dbPath: string,
+  operation: (db: SqliteDatabase) => T
+): T => {
+  const db = new Database(dbPath)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+/** initスキーマとは異なるテーブル構成のDBを用意する（マイグレーション済み等を模す） */
+const createNonInitDatabase = (dbPath: string, insertRow: boolean) => {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+  withDatabase(dbPath, (db) => {
+    // Class→Classroom などリネーム後の名前。init名（classes/Subject等）とは一致しない
+    db.exec(`CREATE TABLE "Classroom" (id TEXT PRIMARY KEY)`)
+    db.exec(`CREATE TABLE "Tag" (id TEXT PRIMARY KEY)`)
+    if (insertRow)
+      db.prepare(`INSERT INTO "Classroom" VALUES ('keep-me')`).run()
+  })
+}
+
+beforeEach(() => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true })
+  fs.mkdirSync(TEST_DIR, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true })
+})
+
+describe("bootstrapSchema", () => {
+  it("ファイルが存在しない場合はディレクトリごと作成してスキーマを適用する", () => {
+    const dbPath = dbPathFor("missing")
+
+    expect(bootstrapSchema(dbPath)).toBe("created")
+    expect(fs.existsSync(dbPath)).toBe(true)
+    expect(countTables(dbPath)).toBe(SCHEMA_TABLE_COUNT)
+  })
+
+  it("0バイトのファイルにもスキーマを適用する", () => {
+    const dbPath = dbPathFor("empty-file")
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+    fs.writeFileSync(dbPath, "")
+
+    expect(bootstrapSchema(dbPath)).toBe("created")
+    expect(countTables(dbPath)).toBe(SCHEMA_TABLE_COUNT)
+  })
+
+  it("スキーマが揃っていれば existing を返し、データを保持する", () => {
+    const dbPath = dbPathFor("complete")
+    bootstrapSchema(dbPath)
+    withDatabase(dbPath, (db) => {
+      db.prepare(
+        `INSERT INTO "User" (id, username, name, createdAt, updatedAt) VALUES ('u1','admin','管理者','2026-07-23','2026-07-23')`
+      ).run()
+    })
+
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+
+    const userCount = withDatabase(
+      dbPath,
+      (db) =>
+        (
+          db.prepare(`SELECT COUNT(*) as count FROM "User"`).get() as {
+            count: number
+          }
+        ).count
+    )
+    expect(Number(userCount)).toBe(1)
+  })
+
+  it("連続実行しても状態が変わらない（冪等）", () => {
+    const dbPath = dbPathFor("idempotent")
+
+    expect(bootstrapSchema(dbPath)).toBe("created")
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+    expect(countTables(dbPath)).toBe(SCHEMA_TABLE_COUNT)
+  })
+
+  it("initと異なるテーブル名でも、テーブルが在れば existing として一切変更しない", () => {
+    // マイグレーションで進化したDBは init 時のテーブル名（classes/Subject等）を持たない。
+    // それらを「不完全」と誤判定して作り直す/例外を投げると既存ユーザーが起動不能になる
+    const dbPath = dbPathFor("migrated")
+    createNonInitDatabase(dbPath, true)
+
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+
+    // 元のテーブル・データがそのまま残っている（init スキーマで上書きされない）
+    const state = withDatabase(dbPath, (db) => ({
+      tables: (
+        db
+          .prepare(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
+          )
+          .all() as { name: string }[]
+      ).map((row) => row.name),
+      keep: (
+        db.prepare(`SELECT id FROM "Classroom"`).get() as
+          { id: string } | undefined
+      )?.id,
+    }))
+    expect(state.tables).toEqual(["Classroom", "Tag"])
+    expect(state.keep).toBe("keep-me")
+  })
+
+  it("テーブルが在ればデータが無くても existing（作り直さない）", () => {
+    const dbPath = dbPathFor("nonempty-no-data")
+    createNonInitDatabase(dbPath, false)
+
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+    // init スキーマは適用されない（Classroom/Tag の2テーブルのまま）
+    expect(countTables(dbPath)).toBe(2)
+  })
+
+  it("ヘッダを持つ非空ファイルでテーブル0なら再初期化しない（desyncデータ喪失の隠蔽防止）", () => {
+    // -wal を失い main .db だけ残ったような「ヘッダはあるがテーブル0」の既存DBを模す。
+    // ここで init を適用・seed すると喪失を隠蔽するため、bootstrapSchema は
+    // 手を触れず existing を返し、上位でエラーを顕在化させる。
+    const dbPath = dbPathFor("desync-empty")
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+    withDatabase(dbPath, (db) => {
+      // SQLiteヘッダを書くだけ（テーブルは作らない）→ 非0バイト・テーブル0
+      db.pragma("user_version = 1")
+    })
+    expect(fs.statSync(dbPath).size).toBeGreaterThan(0)
+
+    expect(bootstrapSchema(dbPath)).toBe("existing")
+    // init スキーマは適用されない（テーブル0のまま＝勝手に作り直さない）
+    expect(countTables(dbPath)).toBe(0)
+  })
+
+  it("スキーマ適用はトランザクションで囲まれ、失敗時にテーブルを残さない", () => {
+    const dbPath = dbPathFor("rollback")
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+
+    withDatabase(dbPath, (db) => {
+      expect(() =>
+        db.transaction(() => {
+          db.exec(MIGRATION_SQL)
+          db.exec(`THIS IS NOT SQL`)
+        })()
+      ).toThrow()
+    })
+
+    expect(countTables(dbPath)).toBe(0)
+  })
+})
+
+/** テーブル名と、インデックスを「対象列＋UNIQUE性」で表した集合を読み取る */
+const readSchemaShape = (dbPath: string) =>
+  withDatabase(dbPath, (db) => {
+    const tableNames = (
+      db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
+        )
+        .all() as { name: string }[]
+    ).map((row) => row.name)
+
+    // インデックス名は init マイグレーションと MIGRATION_SQL で異なる場合があるため、
+    // 名前ではなく「どの列にどんな制約が掛かっているか」で比較する
+    const indexes = tableNames.flatMap((tableName) =>
+      (
+        db.prepare(`PRAGMA index_list("${tableName}")`).all() as {
+          name: string
+          unique: number
+        }[]
+      ).map((index) => {
+        const columns = (
+          db.prepare(`PRAGMA index_info("${index.name}")`).all() as {
+            name: string
+          }[]
+        ).map((column) => column.name)
+        return `${tableName}:${index.unique ? "unique" : "index"}:${columns.join(",")}`
+      })
+    )
+
+    return { tableNames, indexes: indexes.sort() }
+  })
+
+describe("初期スキーマSQL", () => {
+  it("init マイグレーションと同じテーブル・インデックス構成を作成する", () => {
+    const initSqlPath = path.resolve(
+      __dirname,
+      "../../prisma/migrations/20260322232329_init/migration.sql"
+    )
+    const bootstrapPath = dbPathFor("compare-bootstrap")
+    const initPath = dbPathFor("compare-init")
+    fs.mkdirSync(path.dirname(initPath), { recursive: true })
+
+    // init マイグレーションには SQLite の予約名を使うインデックス定義が含まれており、
+    // 現行の SQLite では作成できないため通常名に読み替えて適用する（比較は列単位で行う）
+    const initSql = fs
+      .readFileSync(initSqlPath, "utf-8")
+      .replace(/Pragma writable_schema=[01];\n?/g, "")
+      .replace(
+        /"sqlite_autoindex_Subtotal_2"/,
+        '"Subtotal_subtotalGroupId_name_key"'
+      )
+
+    bootstrapSchema(bootstrapPath)
+    withDatabase(initPath, (db) => {
+      db.exec(initSql)
+    })
+
+    // MIGRATION_SQL / INDEX_SQL は init マイグレーションの複製であり、
+    // 片方だけ変更されると新規インストールのみが壊れるため差分を検出する
+    expect(readSchemaShape(bootstrapPath)).toEqual(readSchemaShape(initPath))
+    expect(INDEX_SQL).toContain("CREATE UNIQUE INDEX")
+  })
+})

--- a/__tests__/playwrightElectron.config.ts
+++ b/__tests__/playwrightElectron.config.ts
@@ -5,6 +5,15 @@ import { defineConfig, devices } from "@playwright/test"
  */
 export default defineConfig({
   testDir: "./tests/electron",
+  /* 起動前に main/preload ビルドと better-sqlite3 の Electron ABI を用意する */
+  globalSetup: "./tests/electron/globalSetup.ts",
+  /* レンダラーが参照する Next.js dev サーバー（既存があれば再利用） */
+  webServer: {
+    command: "npx next dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+  },
   /* 並列実行を制限（Electronアプリの同時起動を避ける） */
   fullyParallel: false,
   workers: 1,

--- a/__tests__/tests/electron/answerSheetBuilder.spec.ts
+++ b/__tests__/tests/electron/answerSheetBuilder.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * 解答用紙作成（ASB）の e2e
+ *
+ * 「新規インストールで『新規作成』が無反応」というバグを実アプリで再現・検証する。
+ * 根本原因は2つ:
+ *   1. DB初期化がファイル有無判定の競合でクラッシュ（bootstrapSchema で解消）
+ *   2. AsbDefinition の原稿用紙罫線4列が migration 取りこぼしで欠落し
+ *      saveDefinition が ColumnNotFound で失敗（20260725000000 migration で復元）
+ * 空のデータディレクトリ（＝新規インストール）で「新規作成」がエディタへ遷移することを確認する。
+ */
+import { expect, test } from "@playwright/test"
+import * as fs from "fs"
+
+import { launchApp, type LaunchedApp, loginAsAdmin } from "./helpers/launchApp"
+
+let launched: LaunchedApp
+
+test.afterEach(async () => {
+  if (launched) await launched.close()
+})
+
+test("新規インストールで解答用紙の新規作成がエディタへ遷移する", async () => {
+  launched = await launchApp()
+  const { page, dataDir } = launched
+
+  // DB初期化が成功し database.db が作成されている（クラッシュしていない）
+  await expect
+    .poll(() => fs.existsSync(`${dataDir}/database.db`), { timeout: 30_000 })
+    .toBe(true)
+
+  await loginAsAdmin(page)
+
+  await page.goto("http://localhost:3000/answer-sheet-builder", {
+    waitUntil: "domcontentloaded",
+  })
+
+  // 「新規作成」→ 作成に成功するとエディタ（/01-edit）へ遷移する
+  await page.getByRole("button", { name: "新規作成" }).click()
+
+  await expect(page).toHaveURL(/\/answer-sheet-builder\/[^/]+\/01-edit/, {
+    timeout: 15_000,
+  })
+})

--- a/__tests__/tests/electron/globalSetup.ts
+++ b/__tests__/tests/electron/globalSetup.ts
@@ -1,0 +1,24 @@
+/**
+ * Electron e2e のグローバルセットアップ
+ *
+ * - better-sqlite3 を Electron ABI にそろえる（vitest 実行後は Node ABI になっているため）
+ * - メインプロセス／preload をビルドして main/ に出力する
+ *
+ * 注意: 本 e2e の後に vitest を実行する場合、globalSetup が better-sqlite3 を
+ * 自動で Node ABI に戻すため、追加操作は不要。
+ */
+import { execSync } from "child_process"
+import * as path from "path"
+
+const ROOT = path.resolve(__dirname, "../../..")
+
+export default function globalSetup() {
+  const run = (command: string) =>
+    execSync(command, { cwd: ROOT, stdio: "inherit" })
+
+  // better-sqlite3 を Electron 向けに（冪等スクリプト）
+  run("node scripts/ensure-sqlite-abi.js electron")
+  // メインプロセス・preload をビルド
+  run("node scripts/buildMain.js")
+  run("node scripts/buildPreload.js")
+}

--- a/__tests__/tests/electron/helpers/launchApp.ts
+++ b/__tests__/tests/electron/helpers/launchApp.ts
@@ -1,0 +1,62 @@
+/**
+ * Electron アプリ起動ヘルパー（e2e 共通）
+ *
+ * 一時データディレクトリ（SCORE_AT_ONCE_DATA_DIR）を割り当てて起動するため、
+ * 実運用の data/database.db には一切触れず、新規インストール状態を再現できる。
+ */
+import {
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test"
+import electronPath from "electron"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+
+const ROOT = path.resolve(__dirname, "../../../..")
+
+export interface LaunchedApp {
+  app: ElectronApplication
+  page: Page
+  dataDir: string
+  close: () => Promise<void>
+}
+
+/** 空のデータディレクトリで Electron を起動し、最初のウィンドウを返す */
+export async function launchApp(): Promise<LaunchedApp> {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "score-at-once-e2e-"))
+
+  const app = await electron.launch({
+    executablePath: electronPath as unknown as string,
+    args: [path.join(ROOT, "main/electron-src/index.js")],
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      SCORE_AT_ONCE_DATA_DIR: dataDir,
+      NODE_ENV: "development",
+    },
+    timeout: 60_000,
+  })
+
+  const page = await app.firstWindow({ timeout: 60_000 })
+  await page.waitForLoadState("domcontentloaded")
+
+  return {
+    app,
+    page,
+    dataDir,
+    close: async () => {
+      await app.close().catch(() => {})
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    },
+  }
+}
+
+/** シード済み管理者ユーザーでログインする */
+export async function loginAsAdmin(page: Page): Promise<void> {
+  await page.goto("http://localhost:3000/login", {
+    waitUntil: "domcontentloaded",
+  })
+  await page.getByRole("button", { name: "採点を開始" }).first().click()
+}

--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -1,36 +1,16 @@
 import { PrismaClient } from "@prisma/client"
-import * as fs from "fs"
-import * as path from "path"
 
-import {
-  createSharedPrismaClient,
-  getDatabasePath,
-} from "./prisma/databaseInitializer"
+import { createSharedPrismaClient } from "./prisma/databaseInitializer"
 
 /**
  * データベースセットアップユーティリティ
  */
 export class DatabaseSetup {
   private prisma: PrismaClient
-  private dbPath: string
 
   constructor() {
     // パッケージ化環境対応のPrismaクライアントを使用
     this.prisma = createSharedPrismaClient()
-    this.dbPath = getDatabasePath()
-  }
-
-  /**
-   * データベースファイルが存在するかチェック
-   */
-  isDatabaseExists(): boolean {
-    const absolutePath = path.resolve(this.dbPath)
-    try {
-      return fs.existsSync(absolutePath)
-    } catch (error) {
-      console.error(`❌ Error checking database existence:`, error)
-      return false
-    }
   }
 
   /**
@@ -44,23 +24,6 @@ export class DatabaseSetup {
     } catch (error) {
       console.error("❌ Database content check failed:", error)
       return true // エラーの場合は空とみなす
-    }
-  }
-
-  /**
-   * データベースディレクトリを作成
-   */
-  ensureDatabaseDirectory(): void {
-    const dbDir = path.dirname(path.resolve(this.dbPath))
-    try {
-      if (!fs.existsSync(dbDir)) {
-        fs.mkdirSync(dbDir, { recursive: true, mode: 0o755 })
-      }
-    } catch (error) {
-      console.error(`❌ Failed to create database directory: ${dbDir}`, error)
-      throw new Error(
-        `Database directory creation failed: ${error instanceof Error ? error.message : error}`
-      )
     }
   }
 
@@ -196,35 +159,45 @@ export class DatabaseSetup {
   }
 
   /**
+   * 未適用マイグレーションを適用する。
+   *
+   * deployPendingMigrations は独自の better-sqlite3 接続でDDLを実行するため、
+   * 実行前に this.prisma を切断して同一DBファイルへの二重接続を避ける。
+   * これにより DDL 実行中のロック競合と、失敗時のバックアップ復元（ファイル上書き）が
+   * Windows で this.prisma のファイルロックに阻まれる問題を防ぐ。
+   * this.prisma は次回クエリ時に自動再接続される。
+   */
+  private async runDeployPendingMigrations(): Promise<void> {
+    const { deployPendingMigrations } =
+      await import("./prisma/schema/migrationDeployer")
+    await this.prisma.$disconnect()
+    deployPendingMigrations()
+  }
+
+  /**
    * データベースの初期セットアップを実行
    */
   async setupIfNeeded(): Promise<boolean> {
     try {
-      const dbExists = this.isDatabaseExists()
       let setupPerformed = false
 
-      if (!dbExists) {
+      // DBファイルの作成とスキーマ適用（判定はテーブルの有無に基づく）
+      const { initializeDatabase } =
+        await import("./prisma/databaseInitializer")
+      const result = initializeDatabase()
+
+      if (result === "created") {
         // --- 新規DB ---
-        this.ensureDatabaseDirectory()
+        // ベースラインを挿入（将来のprisma migrate用）
+        const { createBaseline } =
+          await import("./prisma/schema/baselineMigrations")
+        await createBaseline(this.prisma)
 
-        const { initializeDatabase } =
-          await import("./prisma/databaseInitializer")
-        const wasCreated = await initializeDatabase()
+        // 初期スキーマ以降の未適用マイグレーションを適用
+        await this.runDeployPendingMigrations()
 
-        if (wasCreated) {
-          // ベースラインを挿入（将来のprisma migrate用）
-          const { createBaseline } =
-            await import("./prisma/schema/baselineMigrations")
-          await createBaseline(this.prisma)
-
-          // 初期スキーマ以降の未適用マイグレーションを適用
-          const { deployPendingMigrations } =
-            await import("./prisma/schema/migrationDeployer")
-          await deployPendingMigrations(this.prisma)
-
-          await this.runSeed()
-          setupPerformed = true
-        }
+        await this.runSeed()
+        setupPerformed = true
       } else {
         // --- 既存DB ---
         await this.migrateExistingDatabase()
@@ -281,9 +254,7 @@ export class DatabaseSetup {
       await ensureBaselineUpToDate(this.prisma)
 
       // 将来のマイグレーションのみ適用
-      const { deployPendingMigrations } =
-        await import("./prisma/schema/migrationDeployer")
-      await deployPendingMigrations(this.prisma)
+      await this.runDeployPendingMigrations()
       return
     }
 
@@ -301,9 +272,7 @@ export class DatabaseSetup {
       await createBaseline(this.prisma)
 
       // 将来のマイグレーション適用
-      const { deployPendingMigrations } =
-        await import("./prisma/schema/migrationDeployer")
-      await deployPendingMigrations(this.prisma)
+      await this.runDeployPendingMigrations()
 
       console.info(
         `Database migrated from ${version} to current schema with Prisma baseline`

--- a/electron-src/lib/prisma/databaseInitializer.ts
+++ b/electron-src/lib/prisma/databaseInitializer.ts
@@ -1,11 +1,12 @@
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
 import { PrismaClient } from "@prisma/client"
-import * as fs from "fs/promises"
 import * as path from "path"
 
 import { getDataDirectory } from "../dataManager"
-import { checkDatabaseExists } from "./databaseUtils"
-import { INDEX_SQL, MIGRATION_SQL } from "./schema/migrationSql"
+import {
+  bootstrapSchema,
+  type SchemaBootstrapResult,
+} from "./schema/schemaBootstrap"
 
 /**
  * データベースファイルの絶対パスを返す
@@ -41,112 +42,10 @@ export const createSharedPrismaClient = (): PrismaClient => {
   return createPrismaClientForPath(getDatabasePath())
 }
 
-/** 初回起動時にDBファイルを作成しスキーマを適用する。既にDBが存在する場合はfalseを返す */
-export const initializeDatabase = async (): Promise<boolean> => {
-  try {
-    // データベースファイルの存在確認
-    const dbExists = await checkDatabaseExists()
-
-    if (!dbExists) {
-      // データディレクトリが存在することを確認
-      const dataDir = getDataDirectory()
-      await fs.mkdir(dataDir, { recursive: true, mode: 0o755 })
-
-      // 空のデータベースファイルを作成
-      const dbPath = getDatabasePath()
-      await fs.writeFile(dbPath, "", { mode: 0o644 })
-
-      // ファイルが実際に作成されたか確認
-      try {
-        await fs.stat(dbPath)
-      } catch (error) {
-        console.error("Failed to verify database file creation:", error)
-        throw new Error(`Database file creation verification failed: ${error}`)
-      }
-
-      // Prismaクライアントでデータベースを初期化
-      const prisma = createSharedPrismaClient()
-
-      try {
-        // Prisma接続にタイムアウトを設定（プラットフォーム対応改善）
-        let connectionSuccessful = false
-        const maxRetries = 3
-        let attempt = 0
-
-        while (attempt < maxRetries && !connectionSuccessful) {
-          attempt++
-
-          try {
-            const connectPromise = prisma.$connect()
-            const timeoutPromise = new Promise((_, reject) => {
-              setTimeout(
-                () =>
-                  reject(
-                    new Error(
-                      `Database connection timeout after 20 seconds (attempt ${attempt})`
-                    )
-                  ),
-                20000 // タイムアウトを20秒に延長
-              )
-            })
-
-            await Promise.race([connectPromise, timeoutPromise])
-            connectionSuccessful = true
-            break
-          } catch (connectError) {
-            if (attempt < maxRetries) {
-              const waitTime = attempt * 2000 // 2秒、4秒と段階的に延長
-              await new Promise((resolve) => setTimeout(resolve, waitTime))
-            } else {
-              // 最後の試行失敗時
-              console.error("All connection attempts failed:", connectError)
-              throw new Error(
-                `Database connection failed after ${maxRetries} attempts: ${connectError instanceof Error ? connectError.message : connectError}`
-              )
-            }
-          }
-        }
-
-        // 直接SQLを実行してスキーマを作成
-        if (!connectionSuccessful) {
-          throw new Error("Failed to establish database connection")
-        }
-
-        // SQLを複数のステートメントに分割して実行
-        const allSQL = MIGRATION_SQL + INDEX_SQL
-        const statements = allSQL
-          .split(";")
-          .filter((statement) => statement.trim())
-
-        for (const statement of statements) {
-          if (statement.trim()) {
-            await prisma.$executeRawUnsafe(statement.trim())
-          }
-        }
-
-        return true
-      } catch (error) {
-        console.error("Failed to initialize database schema:", error)
-
-        // データベースファイルを削除して再試行
-        try {
-          await fs.unlink(dbPath)
-        } catch (unlinkError) {
-          console.error(
-            "Failed to remove corrupted database file:",
-            unlinkError
-          )
-        }
-
-        throw error
-      } finally {
-        await prisma.$disconnect()
-      }
-    } else {
-      return false
-    }
-  } catch (error) {
-    console.error("Database initialization failed:", error)
-    throw error
-  }
+/**
+ * 空のDBに初期スキーマを適用する。既にテーブルを持つDBは "existing" を返す。
+ * 実処理は bootstrapSchema に委譲する（呼び出し側で例外はハンドリングされる）。
+ */
+export const initializeDatabase = (): SchemaBootstrapResult => {
+  return bootstrapSchema(getDatabasePath())
 }

--- a/electron-src/lib/prisma/databaseUtils.ts
+++ b/electron-src/lib/prisma/databaseUtils.ts
@@ -1,7 +1,4 @@
 import { PrismaClient } from "@prisma/client"
-import * as fs from "fs/promises"
-
-import { getDatabasePath } from "./databaseInitializer"
 
 /** 指定テーブルのカラム名一覧をPRAGMA table_infoで取得する */
 export const getTableColumns = async (
@@ -27,16 +24,4 @@ export const tableExists = async (
     `SELECT name FROM sqlite_master WHERE type='table' AND name='${tableName}'`
   )
   return result.length > 0
-}
-
-/** データベースファイル（database.db）がディスク上に存在するか確認する */
-export const checkDatabaseExists = async (): Promise<boolean> => {
-  const databasePath = getDatabasePath()
-
-  try {
-    await fs.access(databasePath)
-    return true
-  } catch {
-    return false
-  }
 }

--- a/electron-src/lib/prisma/schema/migrationDeployer.ts
+++ b/electron-src/lib/prisma/schema/migrationDeployer.ts
@@ -1,112 +1,121 @@
-import { PrismaClient } from "@prisma/client"
+import Database from "better-sqlite3"
 import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 
-import { tableExists } from "../databaseUtils"
+import { getDatabasePath } from "../databaseInitializer"
+import { hasTable, type SqliteDatabase } from "../sqliteSchemaUtils"
 import { createBackup, restoreBackup } from "./bridgeMigrations"
+
+/** _prisma_migrations から適用済みマイグレーション名の集合を取得する */
+const listAppliedMigrationNames = (db: SqliteDatabase): Set<string> => {
+  const rows = db
+    .prepare(
+      `SELECT "migration_name" FROM "_prisma_migrations" WHERE "rolled_back_at" IS NULL`
+    )
+    .all() as { migration_name: string }[]
+  return new Set(rows.map((row) => row.migration_name))
+}
 
 /**
  * prisma/migrations/ ディレクトリから未適用のマイグレーションを検出し、順番に適用する。
  * _prisma_migrationsテーブルを参照・更新して適用状態を管理する。
  * 適用前にDBファイルをバックアップし、失敗時は復元する。
+ *
+ * SQLの実行は better-sqlite3 の exec に委ね、複数文・PRAGMA・文字列リテラル内の
+ * セミコロンを SQLite 本体に正しく解釈させる（自前の `split(";")` は使わない）。
+ * また各文は自動コミットで実行されるため、RENAME 系マイグレーションの
+ * `PRAGMA foreign_keys` が意図どおり効く。
  */
-export const deployPendingMigrations = async (
-  prisma: PrismaClient
-): Promise<number> => {
-  if (!(await tableExists(prisma, "_prisma_migrations"))) {
-    console.warn(
-      "deployPendingMigrations: _prisma_migrations table not found, skipping"
-    )
-    return 0
-  }
-
-  const migrationsDir = getMigrationsDir()
+export const deployPendingMigrations = (options?: {
+  migrationsDir?: string
+}): number => {
+  const migrationsDir = options?.migrationsDir ?? getMigrationsDir()
   if (!migrationsDir || !fs.existsSync(migrationsDir)) {
     console.warn(`Migrations directory not found: ${migrationsDir}`)
     return 0
   }
 
-  // 適用済みマイグレーション名を取得
-  const applied = await prisma.$queryRawUnsafe<{ migration_name: string }[]>(
-    `SELECT "migration_name" FROM "_prisma_migrations" WHERE "rolled_back_at" IS NULL ORDER BY "migration_name"`
-  )
-  const appliedNames = new Set(applied.map((row) => row.migration_name))
+  const db = new Database(path.resolve(getDatabasePath()))
+  db.pragma("busy_timeout = 5000")
 
-  // 未適用のマイグレーションを抽出
-  const pendingDirs = listLocalMigrationNames().filter((dirName) => {
-    if (appliedNames.has(dirName)) return false
-    return fs.existsSync(path.join(migrationsDir, dirName, "migration.sql"))
-  })
-
-  if (pendingDirs.length === 0) return 0
-
-  // 適用前にバックアップを作成（PRAGMAを含むSQLはトランザクション化できないため、
-  // 失敗時はファイルレベルで復元する）
-  const backupPath = createBackup()
-
-  let appliedCount = 0
-
-  for (const dirName of pendingDirs) {
-    const sqlPath = path.join(migrationsDir, dirName, "migration.sql")
-    const sql = fs.readFileSync(sqlPath, "utf-8")
-    const checksum = crypto.createHash("sha256").update(sql).digest("hex")
-
-    console.info(`Applying migration: ${dirName}`)
-    const startedAt = new Date().toISOString()
-
-    try {
-      // SQLを文単位で分割して実行
-      // コメント行を除去してからSQL本体の有無を判定する
-      const statements = sql
-        .split(";")
-        .map((statement) => statement.trim())
-        .filter((statement) => {
-          if (statement.length === 0) return false
-          // ブロックコメント・行コメントを除去した後に実行可能なSQLが残るか判定
-          const stripped = statement
-            .replace(/\/\*[\s\S]*?\*\//g, "") // ブロックコメント除去
-            .replace(/--[^\n]*/g, "") // 行コメント除去
-            .trim()
-          return stripped.length > 0
-        })
-
-      for (const stmt of statements) {
-        await prisma.$executeRawUnsafe(stmt)
-      }
-
-      // 適用成功を記録
-      const migrationId = generateUuid()
-      const finishedAt = new Date().toISOString()
-      await prisma.$executeRawUnsafe(
-        `INSERT INTO "_prisma_migrations" ("id", "checksum", "finished_at", "migration_name", "started_at", "applied_steps_count")
-         VALUES ('${migrationId}', '${checksum}', '${finishedAt}', '${dirName}', '${startedAt}', 1)`
+  try {
+    if (!hasTable(db, "_prisma_migrations")) {
+      console.warn(
+        "deployPendingMigrations: _prisma_migrations table not found, skipping"
       )
-
-      appliedCount++
-      console.info(`Migration applied: ${dirName}`)
-    } catch (error) {
-      console.error(`Migration failed: ${dirName}`, error)
-      if (backupPath) {
-        console.info("Restoring database from pre-migration backup...")
-        restoreBackup(backupPath)
-      }
-      throw new Error(
-        `Migration ${dirName} failed: ${error instanceof Error ? error.message : error}`
-      )
+      return 0
     }
-  }
 
-  if (appliedCount > 0) {
-    console.info(`${appliedCount} migration(s) applied successfully`)
-  }
+    const appliedNames = listAppliedMigrationNames(db)
 
-  return appliedCount
+    // 未適用のマイグレーションを抽出
+    const pendingDirs = listLocalMigrationNames(migrationsDir).filter(
+      (dirName) => {
+        if (appliedNames.has(dirName)) return false
+        return fs.existsSync(path.join(migrationsDir, dirName, "migration.sql"))
+      }
+    )
+
+    if (pendingDirs.length === 0) return 0
+
+    // 適用前にバックアップを作成（PRAGMAを含むSQLはトランザクション化できないため、
+    // 失敗時はファイルレベルで復元する）
+    const backupPath = createBackup()
+
+    const recordApplied = db.prepare(
+      `INSERT INTO "_prisma_migrations" ("id", "checksum", "finished_at", "migration_name", "started_at", "applied_steps_count")
+       VALUES (?, ?, ?, ?, ?, 1)`
+    )
+
+    let appliedCount = 0
+
+    for (const dirName of pendingDirs) {
+      const sqlPath = path.join(migrationsDir, dirName, "migration.sql")
+      const sql = fs.readFileSync(sqlPath, "utf-8")
+      const checksum = crypto.createHash("sha256").update(sql).digest("hex")
+
+      console.info(`Applying migration: ${dirName}`)
+      const startedAt = new Date().toISOString()
+
+      try {
+        db.exec(sql)
+        recordApplied.run(
+          crypto.randomUUID(),
+          checksum,
+          new Date().toISOString(),
+          dirName,
+          startedAt
+        )
+        appliedCount++
+        console.info(`Migration applied: ${dirName}`)
+      } catch (error) {
+        console.error(`Migration failed: ${dirName}`, error)
+        // restore はファイル上書きのため、先に接続を閉じる（Windowsでのロック回避）
+        db.close()
+        if (backupPath) {
+          console.info("Restoring database from pre-migration backup...")
+          restoreBackup(backupPath)
+        }
+        throw new Error(
+          `Migration ${dirName} failed: ${error instanceof Error ? error.message : error}`
+        )
+      }
+    }
+
+    if (appliedCount > 0) {
+      console.info(`${appliedCount} migration(s) applied successfully`)
+    }
+
+    return appliedCount
+  } finally {
+    if (db.open) db.close()
+  }
 }
 
 /** prisma/migrations/ に同梱されているマイグレーション名を昇順で返す */
-export const listLocalMigrationNames = (): string[] => {
-  const migrationsDir = getMigrationsDir()
+export const listLocalMigrationNames = (dir?: string): string[] => {
+  const migrationsDir = dir ?? getMigrationsDir()
   if (!migrationsDir || !fs.existsSync(migrationsDir)) return []
   return fs
     .readdirSync(migrationsDir, { withFileTypes: true })
@@ -138,12 +147,4 @@ const getMigrationsDir = (): string | null => {
   }
 
   return null
-}
-
-const generateUuid = (): string => {
-  const hex = (charCount: number) =>
-    Array.from({ length: charCount }, () =>
-      Math.floor(Math.random() * 16).toString(16)
-    ).join("")
-  return `${hex(8)}-${hex(4)}-4${hex(3)}-${(8 + Math.floor(Math.random() * 4)).toString(16)}${hex(3)}-${hex(12)}`
 }

--- a/electron-src/lib/prisma/schema/migrationSql.ts
+++ b/electron-src/lib/prisma/schema/migrationSql.ts
@@ -735,12 +735,6 @@ CREATE INDEX "ExamStudent_examId_customOrder_idx" ON "ExamStudent"("examId", "cu
 CREATE UNIQUE INDEX "ExamStudent_examId_studentId_key" ON "ExamStudent"("examId", "studentId");
 
 -- CreateIndex
-CREATE INDEX "Subtotal_subtotalGroupId_idx" ON "Subtotal"("subtotalGroupId");
-
--- CreateIndex
-CREATE INDEX "Subtotal_subtotalGroupId_order_idx" ON "Subtotal"("subtotalGroupId", "order");
-
--- CreateIndex
 CREATE UNIQUE INDEX "Subtotal_subtotalGroupId_name_key" ON "Subtotal"("subtotalGroupId", "name");
 
 -- CreateIndex

--- a/electron-src/lib/prisma/schema/schemaBootstrap.ts
+++ b/electron-src/lib/prisma/schema/schemaBootstrap.ts
@@ -1,0 +1,75 @@
+/**
+ * 初期スキーマのブートストラップ
+ *
+ * SQLiteファイルを開き、テーブルが1つも無い「空のDB」にだけ初期スキーマを適用する。
+ * 既に何らかのテーブルを持つDB（新規init直後・マイグレーション済み・レガシー等）は
+ * すべて "existing" として扱い、バージョン検出やブリッジ移行は呼び出し側の
+ * migrateExistingDatabase に委ねる。
+ *
+ * 設計上の約束:
+ * - 判定はファイルの有無ではなく「テーブルの有無」で行う（存在確認と作成の競合を作らない）
+ * - スキーマ適用はトランザクションで囲む（中断してもテーブルを半端に残さない）
+ * - 既にテーブルを持つDBには一切書き込まない（データ破壊・スキーマ上書きをしない）
+ */
+
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as path from "path"
+
+import { countUserTables, type SqliteDatabase } from "../sqliteSchemaUtils"
+import { INDEX_SQL, MIGRATION_SQL } from "./migrationSql"
+
+/** ブートストラップの結果。created=初期スキーマを適用した、existing=既存DBだった */
+export type SchemaBootstrapResult = "created" | "existing"
+
+/** 初期スキーマをトランザクション内で適用する */
+const applySchema = (db: SqliteDatabase): void => {
+  db.transaction(() => {
+    db.exec(MIGRATION_SQL)
+    db.exec(INDEX_SQL)
+  })()
+}
+
+/**
+ * 指定パスのSQLiteに、必要なら初期スキーマを適用する。
+ *
+ * - テーブルが1つも無い「真に新規」のDB（ファイル無し／0バイト）に初期スキーマを適用し "created" を返す
+ * - 既にテーブルを持つDBは一切変更せず "existing" を返す（移行判断は呼び出し側に委ねる）
+ * - 既にヘッダを持つ非空ファイルなのにテーブルが0の場合は、-wal desync 等でデータを
+ *   失った既存DBの可能性があるため**再初期化しない**（"existing" を返す）。ここで init を
+ *   適用・seed すると喪失を隠蔽してしまうため、上位でエラーとして顕在化させる。
+ */
+export const bootstrapSchema = (dbPath: string): SchemaBootstrapResult => {
+  const absolutePath = path.resolve(dbPath)
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true, mode: 0o755 })
+
+  // 開く前に「既にデータを持ちうるファイルか」を判定する。
+  // new Database() は 0 バイトのファイルにもヘッダを書くため、判定は必ず open 前に行う。
+  const preexistingNonEmpty =
+    fs.existsSync(absolutePath) && fs.statSync(absolutePath).size > 0
+
+  // ファイルが存在しない場合はSQLiteが作成する。
+  // -wal/-shm が残っていれば、この接続で自動的にリプレイされ既存テーブルが見える。
+  const db = new Database(absolutePath)
+  // 共有ドライブ（NAS）で他クライアントが一時的にロックしている場合に備える
+  db.pragma("busy_timeout = 5000")
+
+  try {
+    if (countUserTables(db) > 0) return "existing"
+
+    // テーブルが無い。真に新規（ファイル無し／0バイト）のときだけ init を適用する。
+    // 既存の非空ファイルなのにテーブルが無いのは異常（desync 等）なので再初期化しない。
+    if (preexistingNonEmpty) {
+      console.warn(
+        `Database file exists but contains no tables; refusing to reinitialize ` +
+          `to avoid masking possible data loss (e.g. lost -wal sidecar): ${absolutePath}`
+      )
+      return "existing"
+    }
+
+    applySchema(db)
+    return "created"
+  } finally {
+    db.close()
+  }
+}

--- a/electron-src/lib/prisma/sqliteSchemaUtils.ts
+++ b/electron-src/lib/prisma/sqliteSchemaUtils.ts
@@ -1,0 +1,30 @@
+/**
+ * better-sqlite3 生接続に対するスキーマ検査ユーティリティ（共通）
+ *
+ * schemaBootstrap / migrationDeployer など、Prisma を介さず sqlite_master を
+ * 直接参照する箇所で共有する。テーブル検出方法の変更を一箇所に集約する。
+ */
+import type Database from "better-sqlite3"
+
+/** better-sqlite3 の Database インスタンス型 */
+export type SqliteDatabase = InstanceType<typeof Database>
+
+/** DBに実在するユーザーテーブルの数を返す（SQLite内部テーブルを除く） */
+export const countUserTables = (db: SqliteDatabase): number => {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`
+    )
+    .get() as { count: number }
+  return Number(row.count)
+}
+
+/** 指定テーブルが存在するかを返す */
+export const hasTable = (db: SqliteDatabase, tableName: string): boolean => {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as count FROM sqlite_master WHERE type = 'table' AND name = ?`
+    )
+    .get(tableName) as { count: number }
+  return Number(row.count) > 0
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "screenshot": "npm run screenshot:setup && npm run screenshot:test",
     "db:seed": "node prisma/seed.js",
     "db:setup": "prisma migrate dev && npm run db:seed",
-    "db:reset": "prisma migrate reset --force && npm run db:seed"
+    "db:reset": "prisma migrate reset --force && npm run db:seed",
+    "test:e2e": "playwright test --config=__tests__/playwrightElectron.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/prisma/migrations/20260725000000_restore_asb_manuscript_divider_columns/migration.sql
+++ b/prisma/migrations/20260725000000_restore_asb_manuscript_divider_columns/migration.sql
@@ -1,0 +1,73 @@
+-- AsbDefinition の原稿用紙罫線4列を復元する。
+-- 20260613160451_asb_definition_vertical_layout がテーブル再作成時に
+-- borderManuscriptCharDivider / borderManuscriptLineDivider とその Width を
+-- 取りこぼしたため、新規インストール経路の DB では該当列が欠落し
+-- Prisma が ColumnNotFound で AsbDefinition の書き込みに失敗していた。
+-- 4列は既定値を持つため、既に列を持つ DB（db push 由来）でも安全に再作成できる。
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AsbDefinition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL DEFAULT '新しい解答用紙',
+    "renderMode" TEXT NOT NULL DEFAULT 'answer-sheet',
+    "labelPresetMajor" TEXT,
+    "labelPresetSub" TEXT,
+    "labelPresetBranch" TEXT,
+    "paperSize" TEXT NOT NULL DEFAULT 'A4',
+    "orientation" TEXT NOT NULL DEFAULT 'portrait',
+    "verticalLayout" BOOLEAN NOT NULL DEFAULT false,
+    "baseRowHeight" REAL NOT NULL DEFAULT 12,
+    "numberDisplayMode" TEXT NOT NULL DEFAULT 'multirow',
+    "marginTop" REAL NOT NULL DEFAULT 15,
+    "marginBottom" REAL NOT NULL DEFAULT 15,
+    "marginLeft" REAL NOT NULL DEFAULT 10,
+    "marginRight" REAL NOT NULL DEFAULT 10,
+    "colWidthMajorNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthSubNumber" REAL NOT NULL DEFAULT 10,
+    "colWidthBranchNumber" REAL NOT NULL DEFAULT 10,
+    "majorQuestionSpacing" REAL NOT NULL DEFAULT 5,
+    "headerHeight" REAL NOT NULL DEFAULT 0,
+    "borderOuterBorder" TEXT NOT NULL DEFAULT 'solid',
+    "borderMajorDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderMajorNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderSubNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderBranchNumberDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderOuterBorderWidth" REAL DEFAULT 0.7,
+    "borderMajorDividerWidth" REAL DEFAULT 0.5,
+    "borderSubDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchDividerWidth" REAL DEFAULT 0.3,
+    "borderMajorNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderSubNumberDividerWidth" REAL DEFAULT 0.4,
+    "borderBranchNumberDividerWidth" REAL DEFAULT 0.3,
+    "borderManuscriptCharDivider" TEXT NOT NULL DEFAULT 'dashed',
+    "borderManuscriptLineDivider" TEXT NOT NULL DEFAULT 'solid',
+    "borderManuscriptCharDividerWidth" REAL DEFAULT 0.2,
+    "borderManuscriptLineDividerWidth" REAL DEFAULT 0.2,
+    "omrMarkersEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "omrMarkersSizeMm" REAL NOT NULL DEFAULT 5,
+    "omrMarkersOffsetMm" REAL NOT NULL DEFAULT 3,
+    "fontFamily" TEXT NOT NULL DEFAULT 'Noto Sans JP',
+    "fontDefaultSize" REAL NOT NULL DEFAULT 6,
+    "fontMajorNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontSubNumberSize" REAL NOT NULL DEFAULT 6,
+    "fontBranchNumberSize" REAL NOT NULL DEFAULT 5,
+    "multiColumnEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "multiColumnCount" INTEGER NOT NULL DEFAULT 2,
+    "multiColumnGapMm" REAL NOT NULL DEFAULT 5,
+    "multiColumnDividerLine" TEXT,
+    "multiColumnDividerLineWidth" REAL NOT NULL DEFAULT 0.3,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL, "borderOuterBorderDashRatio" REAL, "borderOuterBorderGapRatio" REAL, "borderMajorDividerDashRatio" REAL, "borderMajorDividerGapRatio" REAL, "borderSubDividerDashRatio" REAL, "borderSubDividerGapRatio" REAL, "borderBranchDividerDashRatio" REAL, "borderBranchDividerGapRatio" REAL, "borderMajorNumberDividerDashRatio" REAL, "borderMajorNumberDividerGapRatio" REAL, "borderSubNumberDividerDashRatio" REAL, "borderSubNumberDividerGapRatio" REAL, "borderBranchNumberDividerDashRatio" REAL, "borderBranchNumberDividerGapRatio" REAL, "borderManuscriptCharDividerDashRatio" REAL, "borderManuscriptCharDividerGapRatio" REAL, "borderManuscriptLineDividerDashRatio" REAL, "borderManuscriptLineDividerGapRatio" REAL,
+    CONSTRAINT "AsbDefinition_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_AsbDefinition" ("id", "name", "renderMode", "labelPresetMajor", "labelPresetSub", "labelPresetBranch", "paperSize", "orientation", "verticalLayout", "baseRowHeight", "numberDisplayMode", "marginTop", "marginBottom", "marginLeft", "marginRight", "colWidthMajorNumber", "colWidthSubNumber", "colWidthBranchNumber", "majorQuestionSpacing", "headerHeight", "borderOuterBorder", "borderMajorDivider", "borderSubDivider", "borderBranchDivider", "borderMajorNumberDivider", "borderSubNumberDivider", "borderBranchNumberDivider", "borderOuterBorderWidth", "borderMajorDividerWidth", "borderSubDividerWidth", "borderBranchDividerWidth", "borderMajorNumberDividerWidth", "borderSubNumberDividerWidth", "borderBranchNumberDividerWidth", "omrMarkersEnabled", "omrMarkersSizeMm", "omrMarkersOffsetMm", "fontFamily", "fontDefaultSize", "fontMajorNumberSize", "fontSubNumberSize", "fontBranchNumberSize", "multiColumnEnabled", "multiColumnCount", "multiColumnGapMm", "multiColumnDividerLine", "multiColumnDividerLineWidth", "createdAt", "updatedAt", "userId", "borderOuterBorderDashRatio", "borderOuterBorderGapRatio", "borderMajorDividerDashRatio", "borderMajorDividerGapRatio", "borderSubDividerDashRatio", "borderSubDividerGapRatio", "borderBranchDividerDashRatio", "borderBranchDividerGapRatio", "borderMajorNumberDividerDashRatio", "borderMajorNumberDividerGapRatio", "borderSubNumberDividerDashRatio", "borderSubNumberDividerGapRatio", "borderBranchNumberDividerDashRatio", "borderBranchNumberDividerGapRatio", "borderManuscriptCharDividerDashRatio", "borderManuscriptCharDividerGapRatio", "borderManuscriptLineDividerDashRatio", "borderManuscriptLineDividerGapRatio") SELECT "id", "name", "renderMode", "labelPresetMajor", "labelPresetSub", "labelPresetBranch", "paperSize", "orientation", "verticalLayout", "baseRowHeight", "numberDisplayMode", "marginTop", "marginBottom", "marginLeft", "marginRight", "colWidthMajorNumber", "colWidthSubNumber", "colWidthBranchNumber", "majorQuestionSpacing", "headerHeight", "borderOuterBorder", "borderMajorDivider", "borderSubDivider", "borderBranchDivider", "borderMajorNumberDivider", "borderSubNumberDivider", "borderBranchNumberDivider", "borderOuterBorderWidth", "borderMajorDividerWidth", "borderSubDividerWidth", "borderBranchDividerWidth", "borderMajorNumberDividerWidth", "borderSubNumberDividerWidth", "borderBranchNumberDividerWidth", "omrMarkersEnabled", "omrMarkersSizeMm", "omrMarkersOffsetMm", "fontFamily", "fontDefaultSize", "fontMajorNumberSize", "fontSubNumberSize", "fontBranchNumberSize", "multiColumnEnabled", "multiColumnCount", "multiColumnGapMm", "multiColumnDividerLine", "multiColumnDividerLineWidth", "createdAt", "updatedAt", "userId", "borderOuterBorderDashRatio", "borderOuterBorderGapRatio", "borderMajorDividerDashRatio", "borderMajorDividerGapRatio", "borderSubDividerDashRatio", "borderSubDividerGapRatio", "borderBranchDividerDashRatio", "borderBranchDividerGapRatio", "borderMajorNumberDividerDashRatio", "borderMajorNumberDividerGapRatio", "borderSubNumberDividerDashRatio", "borderSubNumberDividerGapRatio", "borderBranchNumberDividerDashRatio", "borderBranchNumberDividerGapRatio", "borderManuscriptCharDividerDashRatio", "borderManuscriptCharDividerGapRatio", "borderManuscriptLineDividerDashRatio", "borderManuscriptLineDividerGapRatio" FROM "AsbDefinition";
+DROP TABLE "AsbDefinition";
+ALTER TABLE "new_AsbDefinition" RENAME TO "AsbDefinition";
+CREATE INDEX "AsbDefinition_userId_idx" ON "AsbDefinition"("userId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
@@ -63,6 +63,34 @@ const ASB_FILTER_ACCESSORS: ListFilterAccessors<ASBDefinitionListItem> = {
   date: (definition) => definition.updatedAt ?? null,
 }
 
+/** preload API を取得する。未初期化ならトーストで通知して null を返す */
+function requireBuilderApi() {
+  const api = window.electronAPI?.answerSheetBuilder
+  if (!api) {
+    toast.error("アプリの初期化が完了していません", {
+      description: "アプリを再起動してください",
+    })
+    return null
+  }
+  return api
+}
+
+/**
+ * ユーザーIDと preload API をまとめて取得する。
+ * どちらかが欠けていればトーストで通知して null を返す。
+ */
+function requireBuilderContext(userId: string | undefined) {
+  if (!userId) {
+    toast.error("ログイン情報を取得できませんでした", {
+      description: "一度ログアウトして再ログインしてください",
+    })
+    return null
+  }
+  const api = requireBuilderApi()
+  if (!api) return null
+  return { userId, api }
+}
+
 /**
  * 解答用紙定義の一覧表示・作成・複製・削除を行うコンポーネント。
  */
@@ -182,19 +210,30 @@ export function AnswerSheetDefinitionList() {
   }
 
   const handleCreate = useCallback(async () => {
-    if (!user?.id) return
-    const api = window.electronAPI?.answerSheetBuilder
-    if (!api) return
+    const context = requireBuilderContext(user?.id)
+    if (!context) return
+    const { api, userId } = context
 
-    const newId = crypto.randomUUID()
-    const { createDefaultDefinition } = await import("./constants")
-    const definition = createDefaultDefinition()
-    definition.id = newId
+    try {
+      const newId = crypto.randomUUID()
+      const { createDefaultDefinition } = await import("./constants")
+      const definition = createDefaultDefinition()
+      definition.id = newId
 
-    const result = await api.saveDefinition(definition, user.id)
-    if (result.success) {
+      const result = await api.saveDefinition(definition, userId)
+      if (!result.success) {
+        toast.error("解答用紙の作成に失敗しました", {
+          description: result.error,
+        })
+        return
+      }
       // 作成直後は編集したいので作成ページへ直行
       router.push(`/answer-sheet-builder/${newId}/01-edit`)
+    } catch (error) {
+      console.error("Error creating definition:", error)
+      toast.error("解答用紙の作成に失敗しました", {
+        description: error instanceof Error ? error.message : String(error),
+      })
     }
   }, [user?.id, router])
 
@@ -223,7 +262,7 @@ export function AnswerSheetDefinitionList() {
   }
 
   const handleExport = useCallback(async (definitionId: string) => {
-    const api = window.electronAPI?.answerSheetBuilder
+    const api = requireBuilderApi()
     if (!api) return
 
     const result = await api.exportDefinition(definitionId)
@@ -235,19 +274,16 @@ export function AnswerSheetDefinitionList() {
   }, [])
 
   const handleImport = useCallback(async () => {
-    if (!user?.id) return
-    const api = window.electronAPI?.answerSheetBuilder
-    if (!api) return
+    const context = requireBuilderContext(user?.id)
+    if (!context) return
+    const { api, userId } = context
 
     // 1. ファイル選択
     const fileResult = await api.selectImportFile()
     if (!fileResult.success || !fileResult.filePath) return
 
     // 2. インポート実行
-    const importResult = await api.importDefinition(
-      fileResult.filePath,
-      user.id
-    )
+    const importResult = await api.importDefinition(fileResult.filePath, userId)
     if (importResult.success) {
       toast.success("定義を読み込みました")
       if (importResult.warnings?.length) {


### PR DESCRIPTION
Closes #1033

## 背景
新規インストール環境で解答用紙の「新規作成」が無反応、または保存時に `The column borderManuscriptCharDivider does not exist in the current database.` エラーになる（複数のユーザー報告）。原因は独立した2つのバグ。

## 変更内容

### 真因1: DB初期化のクラッシュループ
- `electron-src/lib/prisma/schema/schemaBootstrap.ts`（新設）: 判定を「ファイル有無」から「テーブル有無」へ。スキーマ適用をトランザクション化し、既存DBには一切書き込まない。**ヘッダを持つ非空ファイルでテーブル0なら再初期化しない**（WAL desync等のデータ喪失隠蔽を防止）。
- `migrationDeployer.ts`: `split(";")` を廃し better-sqlite3 `exec()` へ（複数文/PRAGMA/文字列内セミコロンを正しく処理、FK PRAGMAが効く）。deploy中はPrisma切断でWindows復元ロック回避。
- 旧 `initializeDatabase` の存在確認・削除ロジックを撤去。

### 真因2: AsbDefinition の原稿用紙罫線4列の欠落
- `prisma/migrations/20260725000000_restore_asb_manuscript_divider_columns/`（新設）: `20260613160451` がテーブル再作成時に取りこぼした4列を前進migrationで復元。**4列あり/なし両DBで安全な再作成方式**（`ALTER ADD` は列を持つDBで起動不能になるため不採用）。

### その他
- `AnswerSheetDefinitionList.tsx`: 保存失敗をトースト表示、ガード共通化。
- `migrationSql.ts`: schema.prisma/実init migrationに無いSubtotalインデックス2件のドリフト解消。
- `sqliteSchemaUtils.ts`（新設）: テーブル検出ヘルパーを集約。
- テスト追加: `schemaBootstrap` / `deployPendingMigrations` / `freshInstallChain`（スキーマドリフト回帰テスト）/ git管理のElectron e2e（`npm run test:e2e`）。
- `normalizeDatetime` 網羅テストの誤検知（AsbDefinitionTag）を是正。

## データ安全性
- 一般ユーザー（チェーン適用済み／新規インストール）のDBは該当列を持たないため**完全に無損失**（既定値で追加のみ）。
- NAS協調採点構成では migration はローカルDB対象で、共有ファイルには触れない（調査済み・安全）。

## 検証
- 全989テストパス、typecheck / eslint / prettier クリーン。
- 実アプリ（空データディレクトリ＝新規インストール）で新規作成→エディタ遷移を確認。
- 実運用の大容量DBに migration が無損失で自己適用されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)