### PR TITLE
fix(build): Linux RPMビルドでbare-pathのprebuild取りこぼしを解消

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -143,9 +143,21 @@ module.exports = {
       }
 
       // bare-*パッケージの非ターゲットプリビルドバイナリを削除
-      // RPMビルド時にbrp-stripが.bareファイルをstripできず失敗するのを防止
+      // RPMビルド時にbrp-stripが.bareファイルをstripできず失敗するのを防止。
+      // ハードコードのリストは新しいbare-*依存で取りこぼす（bare-pathが漏れて
+      // RPMビルドが壊れた実績あり）ため、node_modules配下のprebuildsを持つ
+      // bare-*パッケージを自動検出する。
       const removeNonTargetBarePrebuilds = (basePath) => {
-        const bareModules = ["bare-url", "bare-os", "bare-fs"]
+        const nodeModulesPath = path.join(basePath, "node_modules")
+        const bareModules = fs.existsSync(nodeModulesPath)
+          ? fs
+              .readdirSync(nodeModulesPath)
+              .filter(
+                (name) =>
+                  name.startsWith("bare-") &&
+                  fs.existsSync(path.join(nodeModulesPath, name, "prebuilds"))
+              )
+          : []
         const targetPlatform =
           options.platform === "darwin"
             ? "darwin"


### PR DESCRIPTION
Closes #1040

## 背景
`Build and Release` の Linux版RPMパッケージングが `bare-path/prebuilds/android-arm/bare-path.bare` を `brp-strip` できず `Bad exit status (%install)` で失敗していた。

## 変更内容
- `forge.config.js` の非ターゲットprebuild削除フックを、ハードコードリスト（`bare-url`/`bare-os`/`bare-fs`）から **`node_modules` 配下でprebuildsを持つ全 `bare-*` の自動検出** に変更。
- これにより取りこぼしていた `bare-path` も削除対象になり、将来の新しい `bare-*` 依存でも再発しない。

## 補足
- `bare-path` は `archiver@8.0.0` → `bare-fs` → `bare-path` の既存 transitive 依存で、アプリコードの変更とは無関係。
- 検証: `forge.config.js` の正常ロード、prettier/eslint クリーン、自動検出が `bare-fs`/`bare-path`/`bare-url` を拾うこと、Linux経路でも呼ばれることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)