### PR TITLE
refactor(06-student-answers): 答案テーブルの行・列結合を添字から実体へ是正

### DIFF
--- a/__tests__/renderer/hooks/useTableDataGeneration.test.ts
+++ b/__tests__/renderer/hooks/useTableDataGeneration.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+/**
+ * 06-student-answers 答案テーブルの行生成（useTableDataGeneration）の検証。
+ *
+ * 守りたい不変条件は「行の生徒とマスのページが、そのマスに置かれた答案の
+ * 書き込み先（studentId / examPageId）と必ず一致すること」。
+ * ここがずれると別の生徒の答案として保存されるため、表示ではなく保存の正しさに直結する。
+ * 行は ExamStudent 実体、マスは ExamPage 実体を同梱して返るので、添字の一致に依存しない。
+ */
+
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useTableDataGeneration } from "@/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration"
+import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  ExamPageColumn,
+  UnsavedAnswerImage,
+} from "@/components/exams/06-student-answers/types"
+import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
+
+const EXAM_ID = "eeeeeeee-0000-4000-8000-000000000000"
+const EPOCH = new Date("2026-01-01T00:00:00.000Z")
+
+const STUDENT_A = "11111111-1111-4111-8111-111111111111"
+const STUDENT_B = "22222222-2222-4222-8222-222222222222"
+const PAGE_1 = "aaaaaaaa-0001-4001-8001-000000000001"
+const PAGE_2 = "aaaaaaaa-0002-4002-8002-000000000002"
+
+function makeExamStudent(
+  examStudentId: string,
+  studentId: string,
+  studentNumber: string,
+  customOrder: number
+): ExamStudentWithMemberships {
+  return {
+    id: examStudentId,
+    examId: EXAM_ID,
+    studentId,
+    status: "participating",
+    customOrder,
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    student: {
+      id: studentId,
+      studentNumber,
+      lastName: "山田",
+      firstName: studentNumber,
+      lastNameKana: "ヤマダ",
+      firstNameKana: "タロウ",
+      enrollmentYear: 2026,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+      memberships: [],
+      _count: { studentAnswerImages: 0 },
+    },
+  }
+}
+
+function makeUnsavedAnswer(id: string): UnsavedAnswerImage {
+  return {
+    id,
+    studentId: null,
+    examPageId: null,
+    imagePath: null,
+    buffer: new ArrayBuffer(1),
+    name: id,
+    originalFileName: `${id}.png`,
+    fileType: "image/png",
+    isSelected: false,
+  }
+}
+
+function makePlacedAnswer(
+  id: string,
+  studentId: string | null,
+  examPageId: string | null
+): UnsavedAnswerImage {
+  return { ...makeUnsavedAnswer(id), studentId, examPageId }
+}
+
+const EMPTY_DISABLED_STATE: ExtendedDisabledState = {
+  rows: [],
+  cols: [],
+  cells: [],
+  files: new Set(),
+}
+
+const EXAM_PAGES: ExamPageColumn[] = [
+  { id: PAGE_1, pageNumber: 1 },
+  { id: PAGE_2, pageNumber: 2 },
+]
+
+/** 行・マスを「行の生徒番号 / マスのページ番号 → 置かれた答案id」へ畳んだ検査用の表現 */
+function summarize(
+  tableRows: ReturnType<
+    typeof useTableDataGeneration<UnsavedAnswerImage>
+  >["tableRows"]
+) {
+  return tableRows.map((row) => ({
+    studentId: row.examStudent.studentId,
+    cells: row.cells.map((cell) => ({
+      examPageId: cell.examPage.id,
+      type: cell.type,
+      fileId: cell.file?.id ?? null,
+    })),
+  }))
+}
+
+describe("useTableDataGeneration", () => {
+  // 生徒の並びは customOrder 順（B が先）。行の実体がその並びに追随することを見る。
+  const sortedStudents = [
+    makeExamStudent("es-b", STUDENT_B, "002", 1),
+    makeExamStudent("es-a", STUDENT_A, "001", 2),
+  ]
+
+  it("upload: 自動配置された答案は、その行の生徒とマスのページに対応する", () => {
+    const files = [makeUnsavedAnswer("f1"), makeUnsavedAnswer("f2")]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "student-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "upload",
+        enhancedIsCellDisabled: () => false,
+      })
+    )
+
+    // student-first なので先頭生徒（customOrder 1 の B）の p1・p2 から順に埋まる
+    expect(summarize(result.current.tableRows)).toEqual([
+      {
+        studentId: STUDENT_B,
+        cells: [
+          { examPageId: PAGE_1, type: "file", fileId: "f1" },
+          { examPageId: PAGE_2, type: "file", fileId: "f2" },
+        ],
+      },
+      {
+        studentId: STUDENT_A,
+        cells: [
+          { examPageId: PAGE_1, type: "empty", fileId: null },
+          { examPageId: PAGE_2, type: "empty", fileId: null },
+        ],
+      },
+    ])
+  })
+
+  it("upload: page-first では同一ページを生徒順に埋める", () => {
+    const files = [makeUnsavedAnswer("f1"), makeUnsavedAnswer("f2")]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "page-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "upload",
+        enhancedIsCellDisabled: () => false,
+      })
+    )
+
+    const rows = summarize(result.current.tableRows)
+    expect(rows[0].studentId).toBe(STUDENT_B)
+    expect(rows[0].cells[0]).toEqual({
+      examPageId: PAGE_1,
+      type: "file",
+      fileId: "f1",
+    })
+    expect(rows[1].studentId).toBe(STUDENT_A)
+    expect(rows[1].cells[0]).toEqual({
+      examPageId: PAGE_1,
+      type: "file",
+      fileId: "f2",
+    })
+  })
+
+  it("view: 答案は自身の (studentId, examPageId) のマスに載る", () => {
+    const files = [
+      makePlacedAnswer("f1", STUDENT_A, PAGE_2),
+      makePlacedAnswer("f2", STUDENT_B, PAGE_1),
+    ]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "page-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "view",
+        enhancedIsCellDisabled: () => true,
+      })
+    )
+
+    expect(result.current.orphanItems).toHaveLength(0)
+    expect(summarize(result.current.tableRows)).toEqual([
+      {
+        studentId: STUDENT_B,
+        cells: [
+          { examPageId: PAGE_1, type: "file", fileId: "f2" },
+          { examPageId: PAGE_2, type: "disabled", fileId: null },
+        ],
+      },
+      {
+        studentId: STUDENT_A,
+        cells: [
+          { examPageId: PAGE_1, type: "disabled", fileId: null },
+          { examPageId: PAGE_2, type: "file", fileId: "f1" },
+        ],
+      },
+    ])
+  })
+
+  it("view: 名簿にない生徒・列にないページの答案は孤立答案になる", () => {
+    const withdrawn = "99999999-9999-4999-8999-999999999999"
+    const removedPage = "aaaaaaaa-0009-4009-8009-000000000009"
+    const files = [
+      makePlacedAnswer("f1", withdrawn, PAGE_1),
+      makePlacedAnswer("f2", STUDENT_A, removedPage),
+    ]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "page-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "view",
+        enhancedIsCellDisabled: () => true,
+      })
+    )
+
+    expect(result.current.orphanItems.map((orphan) => orphan.id)).toEqual([
+      "f1",
+      "f2",
+    ])
+    for (const row of result.current.tableRows) {
+      for (const cell of row.cells) {
+        expect(cell.file).toBeUndefined()
+      }
+    }
+  })
+
+  it("upload: 上書き無効なら既存答案のマスは埋めずに飛ばす", () => {
+    const files = [makeUnsavedAnswer("f1")]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "student-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "upload",
+        enhancedIsCellDisabled: () => false,
+        allowOverwrite: false,
+        // 先頭マス（生徒B・p1）は既に DB 答案が居る
+        existingAnswers: [makePlacedAnswer("db1", STUDENT_B, PAGE_1)],
+      })
+    )
+
+    const rows = summarize(result.current.tableRows)
+    expect(rows[0].cells[0]).toEqual({
+      examPageId: PAGE_1,
+      type: "disabled",
+      fileId: null,
+    })
+    // 新規ファイルは占有マスを飛ばして次の空きマス（生徒B・p2）へ入る
+    expect(rows[0].cells[1]).toEqual({
+      examPageId: PAGE_2,
+      type: "file",
+      fileId: "f1",
+    })
+  })
+})

--- a/__tests__/renderer/hooks/useTableDataGeneration.test.ts
+++ b/__tests__/renderer/hooks/useTableDataGeneration.test.ts
@@ -13,6 +13,8 @@ import { describe, expect, it } from "vitest"
 
 import { useTableDataGeneration } from "@/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration"
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type { CellLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import { addCellToLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
   ExamPageColumn,
   UnsavedAnswerImage,
@@ -79,12 +81,21 @@ function makePlacedAnswer(
   return { ...makeUnsavedAnswer(id), studentId, examPageId }
 }
 
+/** 指定マスだけ「既存答案あり」とするルックアップ */
+function existingAnswerAt(studentId: string, examPageId: string): CellLookup {
+  const lookup: CellLookup = new Map()
+  addCellToLookup(lookup, studentId, examPageId)
+  return lookup
+}
+
 const EMPTY_DISABLED_STATE: ExtendedDisabledState = {
   rows: [],
   cols: [],
   cells: [],
   files: new Set(),
 }
+
+const NO_EXISTING_ANSWERS: CellLookup = new Map()
 
 const EXAM_PAGES: ExamPageColumn[] = [
   { id: PAGE_1, pageNumber: 1 },
@@ -126,6 +137,7 @@ describe("useTableDataGeneration", () => {
         disabledState: EMPTY_DISABLED_STATE,
         mode: "upload",
         enhancedIsCellDisabled: () => false,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
       })
     )
 
@@ -160,6 +172,7 @@ describe("useTableDataGeneration", () => {
         disabledState: EMPTY_DISABLED_STATE,
         mode: "upload",
         enhancedIsCellDisabled: () => false,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
       })
     )
 
@@ -193,6 +206,7 @@ describe("useTableDataGeneration", () => {
         disabledState: EMPTY_DISABLED_STATE,
         mode: "view",
         enhancedIsCellDisabled: () => true,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
       })
     )
 
@@ -232,6 +246,7 @@ describe("useTableDataGeneration", () => {
         disabledState: EMPTY_DISABLED_STATE,
         mode: "view",
         enhancedIsCellDisabled: () => true,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
       })
     )
 
@@ -260,7 +275,7 @@ describe("useTableDataGeneration", () => {
         enhancedIsCellDisabled: () => false,
         allowOverwrite: false,
         // 先頭マス（生徒B・p1）は既に DB 答案が居る
-        existingAnswers: [makePlacedAnswer("db1", STUDENT_B, PAGE_1)],
+        cellsWithExistingAnswers: existingAnswerAt(STUDENT_B, PAGE_1),
       })
     )
 

--- a/__tests__/renderer/utils/dragDropUtils.test.ts
+++ b/__tests__/renderer/utils/dragDropUtils.test.ts
@@ -14,7 +14,10 @@ import {
   diffFilesAgainstBaseline,
   encodeCellDroppableId,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils"
-import { partitionAnswerItemsByPlacement } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import {
+  getCellValue,
+  partitionAnswerItemsByPlacement,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type { AnswerImageIdentity } from "@/components/exams/06-student-answers/types"
 
 function makeFile(
@@ -245,9 +248,9 @@ describe("partitionAnswerItemsByPlacement（孤立答案 [4]/[5]）", () => {
       examPageIds
     )
     expect(orphans).toHaveLength(0)
-    // studentIndex-pageIndex（0始まり）
-    expect(placedByCell.get("0-0")?.id).toBe("f1")
-    expect(placedByCell.get("1-1")?.id).toBe("f2")
+    // 配置は (studentId, examPageId) で引く（序数キーではない）
+    expect(getCellValue(placedByCell, STUDENT_A, PAGE_1)?.id).toBe("f1")
+    expect(getCellValue(placedByCell, STUDENT_B, PAGE_2)?.id).toBe("f2")
   })
 
   it("[4] studentId が現ロスターに無い答案（除籍）は孤立答案になる", () => {

--- a/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
@@ -23,7 +23,7 @@ import {
 import { TableDragOverlay } from "@/components/exams/06-student-answers/student-answer-table/components/TableDragOverlay"
 import { TableHeader } from "@/components/exams/06-student-answers/student-answer-table/components/TableHeader"
 import type {
-  CellData,
+  AnswerTableRow,
   ExtendedDisabledState,
   FilePreviewSource,
   PreviewMode,
@@ -35,7 +35,6 @@ import type {
   PlacementStrategy,
 } from "@/components/exams/06-student-answers/types"
 import { Card, CardContent } from "@/components/ui/card"
-import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
 interface AnswerTableShellProps {
   mode: "upload" | "view"
@@ -67,9 +66,8 @@ interface AnswerTableShellProps {
   onDragStart: (event: DragStartEvent) => void
   onDragEnd: (event: DragEndEvent) => void
 
-  // テーブルデータ
-  tableData: CellData<AnswerImageIdentity>[][]
-  sortedStudents: ExamStudentWithMemberships[]
+  // テーブルデータ（行に ExamStudent 実体、各マスに ExamPage 実体を同梱）
+  tableRows: AnswerTableRow<AnswerImageIdentity>[]
   disabledState: ExtendedDisabledState
   nameRegionAvailable: Record<number, boolean>
   cellsWithExistingAnswers: CellLookup
@@ -126,8 +124,7 @@ export function AnswerTableShell({
   sortableItemIds,
   onDragStart,
   onDragEnd,
-  tableData,
-  sortedStudents,
+  tableRows,
   disabledState,
   nameRegionAvailable,
   cellsWithExistingAnswers,
@@ -167,7 +164,7 @@ export function AnswerTableShell({
     mode === "view" && orphanItems.length > 0
       ? (() => {
           const rosterStudentIds = new Set(
-            sortedStudents.map((examStudent) => examStudent.studentId)
+            tableRows.map((row) => row.examStudent.studentId)
           )
           return orphanItems.map((orphan) => ({
             orphan,
@@ -237,8 +234,7 @@ export function AnswerTableShell({
   const tableBody = (
     <>
       <TableContent
-        tableData={tableData}
-        sortedStudents={sortedStudents}
+        tableRows={tableRows}
         examPages={examPages}
         disabledState={disabledState}
         mode={mode}

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -1,6 +1,6 @@
 import { FilePreviewCell } from "@/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell"
 import type {
-  CellData,
+  AnswerTableRow,
   ExtendedDisabledState,
   FilePreviewSource,
   PreviewMode,
@@ -25,8 +25,9 @@ import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 // セルの DnD ラッパーはスロット（render prop）で外から注入する。
 // 表本体（TableContent）は @dnd-kit も sortable/droppable セルも import せず、
 // グリッドのレイアウトとセル中身の描画（プレビュー・空・無効理由）だけを担う。
-// 列は ExamPage 実体で回し、セルの同定・照合は examPageId で行う。表示値（pageNumber・
-// 氏名・プレビュー）は行（ExamStudent 実体）・列（ExamPage 実体）・fileDisplayById から導出する。
+// 行は AnswerTableRow が持つ ExamStudent 実体、列は各マスが持つ ExamPage 実体で回す
+// （添字で別配列と突き合わせない）。表示値（pageNumber・氏名・プレビュー）は行・列の実体と
+// fileDisplayById から導出する。
 // ============================================================================
 
 /** ファイルセル（答案あり）のラッパーへ渡す情報。children は FilePreviewCell。
@@ -56,8 +57,8 @@ export interface EmptyCellSlotProps {
 }
 
 interface TableContentProps {
-  tableData: CellData<AnswerImageIdentity>[][]
-  sortedStudents: ExamStudentWithMemberships[]
+  // 行（ExamStudent 実体）とマス（ExamPage 実体を同梱）。列ヘッダーだけは examPages で描く。
+  tableRows: AnswerTableRow<AnswerImageIdentity>[]
   examPages: ExamPageColumn[]
   disabledState: ExtendedDisabledState
   mode: "upload" | "view"
@@ -86,8 +87,7 @@ interface TableContentProps {
 }
 
 export function TableContent({
-  tableData,
-  sortedStudents,
+  tableRows,
   examPages,
   disabledState,
   mode,
@@ -138,39 +138,37 @@ export function TableContent({
         </TableRow>
       </UITableHeader>
       <TableBody>
-        {tableData.map((row, studentIndex) => (
-          <TableRow key={sortedStudents[studentIndex].studentId}>
+        {tableRows.map(({ examStudent, cells }) => (
+          <TableRow key={examStudent.id}>
             {/* 生徒名セル */}
             <TableHead
               className={`border text-center ${
                 mode === "upload" ? "cursor-pointer" : ""
               } ${
-                disabledState.rows.includes(sortedStudents[studentIndex].id)
+                disabledState.rows.includes(examStudent.id)
                   ? "bg-gray-200"
                   : "bg-white"
               }`}
               onClick={
                 mode === "upload"
-                  ? () => toggleRowDisabled(sortedStudents[studentIndex].id)
+                  ? () => toggleRowDisabled(examStudent.id)
                   : undefined
               }
             >
               <div className="px-2 py-1">
                 <div className="text-sm font-medium">
-                  {sortedStudents[studentIndex].student.lastName}{" "}
-                  {sortedStudents[studentIndex].student.firstName}
+                  {examStudent.student.lastName} {examStudent.student.firstName}
                 </div>
                 <div className="text-xs text-gray-500">
-                  {sortedStudents[studentIndex].student.studentNumber}
+                  {examStudent.student.studentNumber}
                 </div>
               </div>
             </TableHead>
 
             {/* ファイルセル */}
-            {row.map((cellData, pageIndex) => {
-              // セル座標から生徒・ページ（実体）を導出（セルは同一性を保持しない）
-              const examStudent = sortedStudents[studentIndex]
-              const examPage = examPages[pageIndex]
+            {cells.map((cellData) => {
+              // 列（ExamPage 実体）はマス自身が持つ。行の実体は上の分割代入から使う。
+              const examPage = cellData.examPage
 
               if (cellData.type === "disabled" || cellData.type === "empty") {
                 // 既存答案があるか（オーバーレイ用・upload のみ）

--- a/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
@@ -36,8 +36,7 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
   const { correctingFileIds } = useMarkerCorrection({
     examId: props.examId,
     files: props.files,
-    tableData: core.tableData,
-    examPages: props.examPages,
+    tableRows: core.tableRows,
     markerCorrectionEnabled: props.markerCorrectionEnabled ?? false,
     markerAvailablePages: props.markerAvailablePages ?? EMPTY_PAGES,
     onFilesChange: props.onFilesChange,
@@ -58,31 +57,28 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
     return map
   }, [props.files])
 
-  // 配置済みファイルのアップロードデータを生成。生徒・配置先ページはセル座標（行 ExamStudent・
-  // 列 ExamPage 実体）から導出し、examPageId を直指定する。
+  // 配置済みファイルのアップロードデータを生成。書き込み先の生徒・ページは行が持つ
+  // ExamStudent 実体・マスが持つ ExamPage 実体から直に取る（別配列との添字突き合わせをしない）。
   const handleUpload = () => {
     const uploadData: UploadData[] = []
-    core.tableData.forEach((row, studentIndex) => {
-      row.forEach((cell, pageIndex) => {
+    for (const { examStudent, cells } of core.tableRows) {
+      for (const cell of cells) {
         // 未保存画像のみ本物の buffer を持つ（占有信号は buffer なし＝対象外）。
-        if (cell.type === "file" && cell.file && cell.file.buffer) {
-          const examStudent = core.sortedStudents[studentIndex]
-          const examPage = props.examPages[pageIndex]
-          uploadData.push({
-            name: cell.file.name,
-            fileName: cell.file.name,
-            originalFileName: cell.file.originalFileName,
-            type: cell.file.fileType,
-            buffer: cell.file.buffer,
-            studentId: examStudent.studentId,
-            examPageId: examPage.id,
-            overwrite: core.allowOverwrite,
-            correctWithMarkers: false, // クライアント側で補正済み
-            correctionStatus: cell.file.correctionStatus,
-          })
-        }
-      })
-    })
+        if (cell.type !== "file" || !cell.file?.buffer) continue
+        uploadData.push({
+          name: cell.file.name,
+          fileName: cell.file.name,
+          originalFileName: cell.file.originalFileName,
+          type: cell.file.fileType,
+          buffer: cell.file.buffer,
+          studentId: examStudent.studentId,
+          examPageId: cell.examPage.id,
+          overwrite: core.allowOverwrite,
+          correctWithMarkers: false, // クライアント側で補正済み
+          correctionStatus: cell.file.correctionStatus,
+        })
+      }
+    }
     props.onUpload(uploadData)
   }
 
@@ -118,8 +114,7 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
       sortableItemIds={enabledFiles.map((file) => file.id)}
       onDragStart={core.handleDragStart}
       onDragEnd={core.handleDragEnd}
-      tableData={core.tableData}
-      sortedStudents={core.sortedStudents}
+      tableRows={core.tableRows}
       disabledState={core.disabledState}
       nameRegionAvailable={core.nameRegionAvailable}
       cellsWithExistingAnswers={core.cellsWithExistingAnswers}

--- a/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
@@ -76,8 +76,7 @@ export function ViewAnswerTable(
       sortableItemIds={[]}
       onDragStart={core.handleDragStart}
       onDragEnd={core.handleDragEnd}
-      tableData={core.tableData}
-      sortedStudents={core.sortedStudents}
+      tableRows={core.tableRows}
       disabledState={core.disabledState}
       nameRegionAvailable={core.nameRegionAvailable}
       cellsWithExistingAnswers={core.cellsWithExistingAnswers}

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
@@ -70,10 +70,9 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
   } = useDisabledState()
 
   const {
-    sortedStudents,
     getEnabledFiles,
     getDisabledFiles,
-    tableData,
+    tableRows,
     orphanItems,
     cellsWithExistingAnswers,
   } = useTableData<TItem>({
@@ -165,9 +164,8 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
     allowOverwrite,
     setAllowOverwrite,
     // テーブルデータ
-    sortedStudents,
     getEnabledFiles,
-    tableData,
+    tableRows,
     orphanItems,
     cellsWithExistingAnswers,
     // DnD

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
@@ -1,16 +1,12 @@
 import { useEffect, useRef, useState } from "react"
 
-import type { CellData } from "@/components/exams/06-student-answers/student-answer-table/types"
-import type {
-  ExamPageColumn,
-  UnsavedAnswerImage,
-} from "@/components/exams/06-student-answers/types"
+import type { AnswerTableRow } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type { UnsavedAnswerImage } from "@/components/exams/06-student-answers/types"
 
 interface UseMarkerCorrectionArgs {
   examId: string
   files: UnsavedAnswerImage[]
-  tableData: CellData<UnsavedAnswerImage>[][]
-  examPages: ExamPageColumn[]
+  tableRows: AnswerTableRow<UnsavedAnswerImage>[]
   markerCorrectionEnabled: boolean
   markerAvailablePages: Set<number>
   onFilesChange: (files: UnsavedAnswerImage[]) => void
@@ -24,15 +20,14 @@ interface UseMarkerCorrectionResult {
  * 配置戦略に応じた動的マーカー補正フック
  *
  * 仕組み:
- * - tableData から各ファイルのマスターページ番号を決定
+ * - tableRows から各ファイルのマスターページ番号を決定
  * - file.correctedForPage と異なれば再補正（または復元）
  * - トグルOFF、マスター無し、未配置ファイルは元に戻す
  */
 export function useMarkerCorrection({
   examId,
   files,
-  tableData,
-  examPages,
+  tableRows,
   markerCorrectionEnabled,
   markerAvailablePages,
   onFilesChange,
@@ -61,14 +56,13 @@ export function useMarkerCorrection({
     // ファイルID → 対応マスターページ番号 のマップを構築
     const targetMap = new Map<string, number>()
     if (markerCorrectionEnabled) {
-      for (const row of tableData) {
-        // マスターページ番号はセルの列（ExamPage 実体）の pageNumber から導出する
-        row.forEach((cell, pageIndex) => {
-          const examPage = examPages[pageIndex]
-          if (cell.file && examPage) {
-            targetMap.set(cell.file.id, examPage.pageNumber)
+      for (const row of tableRows) {
+        // マスターページ番号はマスが持つ列（ExamPage 実体）の pageNumber から導出する
+        for (const cell of row.cells) {
+          if (cell.file) {
+            targetMap.set(cell.file.id, cell.examPage.pageNumber)
           }
-        })
+        }
       }
     }
 
@@ -213,8 +207,7 @@ export function useMarkerCorrection({
   }, [
     examId,
     files,
-    tableData,
-    examPages,
+    tableRows,
     markerCorrectionEnabled,
     markerAvailablePages,
     onFilesChange,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -100,8 +100,8 @@ export function useTableData<TItem extends AnswerImageIdentity>({
     return getDisabledFiles(files, disabledState)
   }, [files, disabledState])
 
-  // テーブルデータの生成
-  const { tableData, orphanItems } = useTableDataGeneration({
+  // テーブル行の生成（行に ExamStudent 実体、各マスに ExamPage 実体を同梱）
+  const { tableRows, orphanItems } = useTableDataGeneration({
     files,
     sortedStudents,
     examPages,
@@ -114,10 +114,9 @@ export function useTableData<TItem extends AnswerImageIdentity>({
   })
 
   return {
-    sortedStudents,
     getEnabledFiles: getEnabledFilesCallback,
     getDisabledFiles: getDisabledFilesCallback,
-    tableData,
+    tableRows,
     orphanItems,
     cellsWithExistingAnswers,
   }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -110,7 +110,7 @@ export function useTableData<TItem extends AnswerImageIdentity>({
     mode,
     enhancedIsCellDisabled,
     allowOverwrite,
-    existingAnswers,
+    cellsWithExistingAnswers,
   })
 
   return {

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -10,7 +10,6 @@ import type {
   CellValueMap,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import {
-  addCellToLookup,
   getCellValue,
   getEnabledFiles,
   lookupHasCell,
@@ -37,14 +36,16 @@ interface UseTableDataGenerationParams<TItem extends AnswerImageIdentity> {
     examPageId: string
   ) => boolean
   allowOverwrite?: boolean
-  existingAnswers?: AnswerImageIdentity[]
+  // 既存答案（DB答案の占有信号）があるマス。呼び出し側が導出済みのものを受け取り、
+  // ここで組み直さない（オーバーレイ表示と配置判断で同じ集合を使うため）。
+  cellsWithExistingAnswers: CellLookup
 }
 
 /**
  * テーブル行の生成を行うカスタムフック（entity-first）。
  * 行は ExamStudent 実体、列は ExamPage 実体で回し、各マスに列の実体を同梱して返す。
- * 生徒・ページの同定は常に id（studentId / examPageId）で行い、配列の添字は
- * upload の配置順を決めるソートキーとしてのみ使う（同定には使わない）。
+ * 生徒・ページの同定は常に id（studentId / examPageId）で行い、序数は一切使わない
+ * （upload の配置順もループの入れ子の向きで表現する）。
  * view では、表のマスに配置できない答案（除籍・列に無い examPageId＝孤立答案）を
  * `orphanItems` として返す（呼び出し側が専用枠で再配置できる）。
  */
@@ -57,7 +58,7 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
   mode,
   enhancedIsCellDisabled,
   allowOverwrite = false,
-  existingAnswers = [],
+  cellsWithExistingAnswers,
 }: UseTableDataGenerationParams<TItem>) {
   const { tableRows, orphanItems } = useMemo(() => {
     const enabledFiles = getEnabledFiles(files, disabledState)
@@ -102,89 +103,52 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
     } else {
       // アップロードモード: 配置戦略に基づく自動配置（新規ファイル用）
 
-      // 既存答案（DB答案の占有信号）があるセルを id 対で引けるようにする。
-      // 上書き有効時は収集しない（＝上書き可なら占有を無視して素直に詰める既存動作）。
-      const existingAnswerCells: CellLookup = new Map()
-      if (!allowOverwrite) {
-        for (const answer of existingAnswers) {
-          if (!answer.studentId || !answer.examPageId) continue
-          addCellToLookup(
-            existingAnswerCells,
-            answer.studentId,
-            answer.examPageId
-          )
-        }
-      }
+      // 上書き無効のときだけ、既存答案（DB答案の占有信号）のあるマスを避けて詰める。
+      const skipsExistingAnswers = !allowOverwrite
 
-      // 有効セル（無効でないセル）を実体で列挙する。studentIndex / pageIndex は
-      // 「どの順にファイルを詰めるか」の並べ替えキー専用で、セルの同定には使わない。
+      // 有効セル（無効でないセル）を詰める順に列挙する。順序は入れ子の向きで表現し、
+      // page-first は列を外側、student-first は行を外側に回す（序数の比較子を持たない）。
       const validPositions: Array<{
         examStudent: ExamStudentWithMemberships
         examPage: ExamPageColumn
-        studentIndex: number
-        pageIndex: number
       }> = []
-      sortedStudents.forEach((examStudent, studentIndex) => {
-        examPages.forEach((examPage, pageIndex) => {
-          const isManuallyDisabled =
-            manualDisabledReason(disabledState, examStudent, examPage.id) !==
-            undefined
-
-          // 既存答案がある場合は上書き設定をチェック
-          const hasExistingAnswer = lookupHasCell(
-            existingAnswerCells,
+      const collectPosition = (
+        examStudent: ExamStudentWithMemberships,
+        examPage: ExamPageColumn
+      ) => {
+        const isManuallyDisabled =
+          manualDisabledReason(disabledState, examStudent, examPage.id) !==
+          undefined
+        const shouldSkipExisting =
+          skipsExistingAnswers &&
+          lookupHasCell(
+            cellsWithExistingAnswers,
             examStudent.studentId,
             examPage.id
           )
-          const shouldSkipExisting = hasExistingAnswer && !allowOverwrite
 
-          if (!isManuallyDisabled && !shouldSkipExisting) {
-            validPositions.push({
-              examStudent,
-              examPage,
-              studentIndex,
-              pageIndex,
-            })
-          }
-        })
-      })
-
-      // 既存答案がある位置を優先してソート（上書き有効時のみ）
-      validPositions.sort((positionA, positionB) => {
-        const positionAHasExisting = lookupHasCell(
-          existingAnswerCells,
-          positionA.examStudent.studentId,
-          positionA.examPage.id
-        )
-        const positionBHasExisting = lookupHasCell(
-          existingAnswerCells,
-          positionB.examStudent.studentId,
-          positionB.examPage.id
-        )
-
-        // 既存答案がある位置を優先（上書き有効時）
-        if (allowOverwrite && positionAHasExisting && !positionBHasExisting)
-          return -1
-        if (allowOverwrite && !positionAHasExisting && positionBHasExisting)
-          return 1
-
-        // 同じ条件の場合は配置戦略に基づいてソート
-        if (fileOrder === "page-first") {
-          // ページ順: ページ番号を優先してソート
-          if (positionA.pageIndex !== positionB.pageIndex) {
-            return positionA.pageIndex - positionB.pageIndex
-          }
-          return positionA.studentIndex - positionB.studentIndex
-        } else {
-          // 生徒順: 生徒番号を優先してソート（デフォルト）
-          if (positionA.studentIndex !== positionB.studentIndex) {
-            return positionA.studentIndex - positionB.studentIndex
-          }
-          return positionA.pageIndex - positionB.pageIndex
+        if (!isManuallyDisabled && !shouldSkipExisting) {
+          validPositions.push({ examStudent, examPage })
         }
-      })
+      }
+      if (fileOrder === "page-first") {
+        // ページ順: 同一ページを生徒順に埋めてから次のページへ
+        for (const examPage of examPages) {
+          for (const examStudent of sortedStudents) {
+            collectPosition(examStudent, examPage)
+          }
+        }
+      } else {
+        // 生徒順（デフォルト）: 同一生徒のページを埋めてから次の生徒へ
+        for (const examStudent of sortedStudents) {
+          for (const examPage of examPages) {
+            collectPosition(examStudent, examPage)
+          }
+        }
+      }
 
-      // ファイルと有効セルをマッピング（ファイル配列の順序で自動配置）
+      // ファイルと有効セルをマッピング（ファイル配列の順序で自動配置）。
+      // 有効セルより多いファイルは配置されない（＝アップロード対象にならない）。
       const filePlacement: CellValueMap<TItem> = new Map()
       validPositions.forEach((position, fileIndex) => {
         const file = enabledFiles[fileIndex]
@@ -220,12 +184,14 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
           if (file) return { examPage, type: "file", file }
 
           // 既存答案があり上書き無効の場合は無効セルとして表示
-          const hasExistingAnswer = lookupHasCell(
-            existingAnswerCells,
-            examStudent.studentId,
-            examPage.id
-          )
-          if (hasExistingAnswer && !allowOverwrite) {
+          if (
+            skipsExistingAnswers &&
+            lookupHasCell(
+              cellsWithExistingAnswers,
+              examStudent.studentId,
+              examPage.id
+            )
+          ) {
             return {
               examPage,
               type: "disabled",
@@ -250,7 +216,7 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
     mode,
     enhancedIsCellDisabled,
     allowOverwrite,
-    existingAnswers,
+    cellsWithExistingAnswers,
   ])
 
   return { tableRows, orphanItems }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -1,13 +1,22 @@
 import { useMemo } from "react"
 
 import type {
-  CellData,
+  AnswerTableCell,
+  AnswerTableRow,
   ExtendedDisabledState,
 } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  CellLookup,
+  CellValueMap,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import {
+  addCellToLookup,
+  getCellValue,
   getEnabledFiles,
+  lookupHasCell,
   manualDisabledReason,
   partitionAnswerItemsByPlacement,
+  setCellValue,
 } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
   AnswerImageIdentity,
@@ -32,9 +41,12 @@ interface UseTableDataGenerationParams<TItem extends AnswerImageIdentity> {
 }
 
 /**
- * テーブルデータの生成を行うカスタムフック（entity-first）。
- * 列は ExamPage 実体で回す。view では、表のマスに配置できない答案（除籍・列に無い
- * examPageId＝孤立答案）を `orphanItems` として返す（呼び出し側が専用枠で再配置できる）。
+ * テーブル行の生成を行うカスタムフック（entity-first）。
+ * 行は ExamStudent 実体、列は ExamPage 実体で回し、各マスに列の実体を同梱して返す。
+ * 生徒・ページの同定は常に id（studentId / examPageId）で行い、配列の添字は
+ * upload の配置順を決めるソートキーとしてのみ使う（同定には使わない）。
+ * view では、表のマスに配置できない答案（除籍・列に無い examPageId＝孤立答案）を
+ * `orphanItems` として返す（呼び出し側が専用枠で再配置できる）。
  */
 export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
   files,
@@ -47,15 +59,15 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
   allowOverwrite = false,
   existingAnswers = [],
 }: UseTableDataGenerationParams<TItem>) {
-  const { tableData, orphanItems } = useMemo(() => {
+  const { tableRows, orphanItems } = useMemo(() => {
     const enabledFiles = getEnabledFiles(files, disabledState)
 
-    const data: CellData<TItem>[][] = []
+    const rows: AnswerTableRow<TItem>[] = []
     const orphans: TItem[] = []
 
     if (mode === "view") {
       // 確認モード（方式B）: 各答案を自身の実セル座標 (studentId, examPageId) に配置する。
-      // 配列順ではなく座標基準にすることで、DnD の move/swap が座標更新だけで完結し、
+      // 配列順ではなく id 対を基準にすることで、DnD の move/swap が座標更新だけで完結し、
       // 任意マスへの移動・占有マスとの入れ替えが素直に描画へ反映される。
       // 配置できない答案（除籍・列に無い examPageId）は placeable にならず orphans に落ちる。
       const { placedByCell, orphans: orphanItems } =
@@ -66,90 +78,89 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
         )
       orphans.push(...orphanItems)
 
-      // テーブルデータを生成
-      for (
-        let studentIndex = 0;
-        studentIndex < sortedStudents.length;
-        studentIndex++
-      ) {
-        const examStudent = sortedStudents[studentIndex]
-        const row: CellData<TItem>[] = []
+      for (const examStudent of sortedStudents) {
+        const cells = examPages.map<AnswerTableCell<TItem>>((examPage) => {
+          const file = getCellValue(
+            placedByCell,
+            examStudent.studentId,
+            examPage.id
+          )
 
-        for (let pageIndex = 0; pageIndex < examPages.length; pageIndex++) {
-          const examPage = examPages[pageIndex]
-          const file = placedByCell.get(`${studentIndex}-${pageIndex}`)
+          // 答案が居るセルは常にファイルセル（動的無効化は答案なしセルにのみ効く）
+          if (file) return { examPage, type: "file", file }
 
-          if (file) {
-            // 答案が居るセルは常にファイルセル（動的無効化は答案なしセルにのみ効く）
-            row.push({ type: "file", file })
-          } else if (enhancedIsCellDisabled(examStudent, examPage.id)) {
-            // 答案なしセル。確認モードは表示上「答案なし」
-            row.push({ type: "disabled" })
-          } else {
-            row.push({ type: "empty" })
+          // 答案なしセル。確認モードは表示上「答案なし」
+          if (enhancedIsCellDisabled(examStudent, examPage.id)) {
+            return { examPage, type: "disabled" }
           }
-        }
 
-        data.push(row)
+          return { examPage, type: "empty" }
+        })
+
+        rows.push({ examStudent, cells })
       }
     } else {
       // アップロードモード: 配置戦略に基づく自動配置（新規ファイル用）
 
-      // 既存答案がある位置を特定（上書き無効時にスキップするため）
-      const examPageIndexById = new Map<string, number>()
-      examPages.forEach((examPage, pageIndex) => {
-        examPageIndexById.set(examPage.id, pageIndex)
-      })
-      const studentIndexById = new Map<string, number>()
-      sortedStudents.forEach((examStudent, studentIndex) => {
-        studentIndexById.set(examStudent.studentId, studentIndex)
-      })
-
-      const existingAnswerPositions = new Set<string>()
-      if (!allowOverwrite && existingAnswers) {
-        existingAnswers.forEach((answer) => {
-          if (!answer.studentId || !answer.examPageId) return
-          const studentIndex = studentIndexById.get(answer.studentId)
-          const pageIndex = examPageIndexById.get(answer.examPageId)
-          if (studentIndex !== undefined && pageIndex !== undefined) {
-            existingAnswerPositions.add(`${studentIndex}-${pageIndex}`)
-          }
-        })
+      // 既存答案（DB答案の占有信号）があるセルを id 対で引けるようにする。
+      // 上書き有効時は収集しない（＝上書き可なら占有を無視して素直に詰める既存動作）。
+      const existingAnswerCells: CellLookup = new Map()
+      if (!allowOverwrite) {
+        for (const answer of existingAnswers) {
+          if (!answer.studentId || !answer.examPageId) continue
+          addCellToLookup(
+            existingAnswerCells,
+            answer.studentId,
+            answer.examPageId
+          )
+        }
       }
 
-      // 有効セル（無効でないセル）の位置を事前に計算
-      const validPositions: Array<{ studentIndex: number; pageIndex: number }> =
-        []
-      for (
-        let studentIndex = 0;
-        studentIndex < sortedStudents.length;
-        studentIndex++
-      ) {
-        const examStudent = sortedStudents[studentIndex]
-        for (let pageIndex = 0; pageIndex < examPages.length; pageIndex++) {
-          const examPage = examPages[pageIndex]
-          const placementKey = `${studentIndex}-${pageIndex}`
-
+      // 有効セル（無効でないセル）を実体で列挙する。studentIndex / pageIndex は
+      // 「どの順にファイルを詰めるか」の並べ替えキー専用で、セルの同定には使わない。
+      const validPositions: Array<{
+        examStudent: ExamStudentWithMemberships
+        examPage: ExamPageColumn
+        studentIndex: number
+        pageIndex: number
+      }> = []
+      sortedStudents.forEach((examStudent, studentIndex) => {
+        examPages.forEach((examPage, pageIndex) => {
           const isManuallyDisabled =
             manualDisabledReason(disabledState, examStudent, examPage.id) !==
             undefined
 
           // 既存答案がある場合は上書き設定をチェック
-          const hasExistingAnswer = existingAnswerPositions.has(placementKey)
+          const hasExistingAnswer = lookupHasCell(
+            existingAnswerCells,
+            examStudent.studentId,
+            examPage.id
+          )
           const shouldSkipExisting = hasExistingAnswer && !allowOverwrite
 
           if (!isManuallyDisabled && !shouldSkipExisting) {
-            validPositions.push({ studentIndex, pageIndex })
+            validPositions.push({
+              examStudent,
+              examPage,
+              studentIndex,
+              pageIndex,
+            })
           }
-        }
-      }
+        })
+      })
 
       // 既存答案がある位置を優先してソート（上書き有効時のみ）
       validPositions.sort((positionA, positionB) => {
-        const positionAKey = `${positionA.studentIndex}-${positionA.pageIndex}`
-        const positionBKey = `${positionB.studentIndex}-${positionB.pageIndex}`
-        const positionAHasExisting = existingAnswerPositions.has(positionAKey)
-        const positionBHasExisting = existingAnswerPositions.has(positionBKey)
+        const positionAHasExisting = lookupHasCell(
+          existingAnswerCells,
+          positionA.examStudent.studentId,
+          positionA.examPage.id
+        )
+        const positionBHasExisting = lookupHasCell(
+          existingAnswerCells,
+          positionB.examStudent.studentId,
+          positionB.examPage.id
+        )
 
         // 既存答案がある位置を優先（上書き有効時）
         if (allowOverwrite && positionAHasExisting && !positionBHasExisting)
@@ -174,64 +185,62 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
       })
 
       // ファイルと有効セルをマッピング（ファイル配列の順序で自動配置）
-      const filePositionMap = new Map<string, TItem>()
+      const filePlacement: CellValueMap<TItem> = new Map()
       validPositions.forEach((position, fileIndex) => {
         const file = enabledFiles[fileIndex]
         if (file) {
-          const key = `${position.studentIndex}-${position.pageIndex}`
-          filePositionMap.set(key, file)
+          setCellValue(
+            filePlacement,
+            position.examStudent.studentId,
+            position.examPage.id,
+            file
+          )
         }
       })
 
-      // テーブルデータを生成
-      for (
-        let studentIndex = 0;
-        studentIndex < sortedStudents.length;
-        studentIndex++
-      ) {
-        const examStudent = sortedStudents[studentIndex]
-        const row: CellData<TItem>[] = []
-
-        for (let pageIndex = 0; pageIndex < examPages.length; pageIndex++) {
-          const examPage = examPages[pageIndex]
-
+      for (const examStudent of sortedStudents) {
+        const cells = examPages.map<AnswerTableCell<TItem>>((examPage) => {
           // 手動無効化の判定と理由を1回の評価で確定（ちゃんとやる側）
           const manualReason = manualDisabledReason(
             disabledState,
             examStudent,
             examPage.id
           )
-
           if (manualReason) {
             // 手動無効化セル（無効理由も権威的にここで確定）
-            row.push({ type: "disabled", disabledReason: manualReason })
-          } else {
-            // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
-            const key = `${studentIndex}-${pageIndex}`
-            const file = filePositionMap.get(key)
+            return { examPage, type: "disabled", disabledReason: manualReason }
+          }
 
-            // 既存答案がある場合の処理
-            const hasExistingAnswer = existingAnswerPositions.has(key)
-            const shouldShowAsDisabled = hasExistingAnswer && !allowOverwrite
+          // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
+          const file = getCellValue(
+            filePlacement,
+            examStudent.studentId,
+            examPage.id
+          )
+          if (file) return { examPage, type: "file", file }
 
-            if (file) {
-              // ファイルあり（自動配置されたファイル）
-              row.push({ type: "file", file })
-            } else if (shouldShowAsDisabled) {
-              // 既存答案があり上書き無効の場合は無効セルとして表示
-              row.push({ type: "disabled", disabledReason: "existing_answer" })
-            } else {
-              // ファイルなし（空セル）
-              row.push({ type: "empty" })
+          // 既存答案があり上書き無効の場合は無効セルとして表示
+          const hasExistingAnswer = lookupHasCell(
+            existingAnswerCells,
+            examStudent.studentId,
+            examPage.id
+          )
+          if (hasExistingAnswer && !allowOverwrite) {
+            return {
+              examPage,
+              type: "disabled",
+              disabledReason: "existing_answer",
             }
           }
-        }
 
-        data.push(row)
+          return { examPage, type: "empty" }
+        })
+
+        rows.push({ examStudent, cells })
       }
     }
 
-    return { tableData: data, orphanItems: orphans }
+    return { tableRows: rows, orphanItems: orphans }
   }, [
     files,
     sortedStudents,
@@ -244,5 +253,5 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
     existingAnswers,
   ])
 
-  return { tableData, orphanItems }
+  return { tableRows, orphanItems }
 }

--- a/src/components/exams/06-student-answers/student-answer-table/types.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types.ts
@@ -36,18 +36,25 @@ export interface ExtendedDisabledState {
   files: Set<string> // fileId — アップロードで多数になりうるので Set（O(1)）
 }
 
-// Cell data structure for table rendering.
-// セルは「そのマスに置かれた物（file）と無効理由」だけを持つ。
-// 生徒・ページ・position はグリッド座標 [studentIndex][pageIndex] と
-// sortedStudents / examPages から導出する（セルにエンティティを複製させない）。
+// 表の1マス。列の実体（ExamPage）を同梱し、そのマスに置かれた物（file）と無効理由を持つ。
+// 行（AnswerTableRow）が生徒の実体を持つため、「行・列とマスの対応」は添字の一致という
+// 暗黙の約束ではなく構造で保証される（序数を同定に使わない）。
 // upload は file が UnsavedAnswerImage、view は PlacedAnswerImage。
-export interface CellData<
+export interface AnswerTableCell<
   TItem extends AnswerImageIdentity = AnswerImageIdentity,
 > {
+  examPage: ExamPageColumn
   type: "file" | "empty" | "disabled"
   file?: TItem
-  disabledReason?:
-    "row" | "column" | "position" | "existing_answer" | "absent_student"
+  disabledReason?: DisabledReason
+}
+
+// 表の1行。行の実体（ExamStudent）と、その行のマスを列順（examPages の順）に持つ。
+export interface AnswerTableRow<
+  TItem extends AnswerImageIdentity = AnswerImageIdentity,
+> {
+  examStudent: ExamStudentWithMemberships
+  cells: AnswerTableCell<TItem>[]
 }
 
 /**

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -53,6 +53,35 @@ export function lookupHasCell(
 }
 
 /**
+ * (studentId, examPageId) → 値 を O(1) で引く入れ子マップ。
+ * CellLookup が「そのセルに該当するか」の真偽だけを持つのに対し、こちらはセルに
+ * 紐づく実体（配置された答案など）を保持する。合成文字列キーも序数も使わない。
+ */
+export type CellValueMap<T> = Map<string, Map<string, T>>
+
+export function setCellValue<T>(
+  cellValues: CellValueMap<T>,
+  studentId: string,
+  examPageId: string,
+  value: T
+): void {
+  const pages = cellValues.get(studentId)
+  if (pages) {
+    pages.set(examPageId, value)
+  } else {
+    cellValues.set(studentId, new Map([[examPageId, value]]))
+  }
+}
+
+export function getCellValue<T>(
+  cellValues: CellValueMap<T>,
+  studentId: string,
+  examPageId: string
+): T | undefined {
+  return cellValues.get(studentId)?.get(examPageId)
+}
+
+/**
  * 手動無効化（行・列・個別セル）の理由を返す唯一の場所。無効でなければ undefined。
  * 「無効か」の真偽と「なぜ無効か」を1回の評価で確定する（判定の二重走査を避ける）。
  * 既存答案(existing_answer)・確認モードの動的無効はここでは扱わない（呼び出し側の責務）。
@@ -190,7 +219,7 @@ export function getDisabledFiles<T extends AnswerImageIdentity>(
  * 除籍（studentId が現ロスターに無い）・ページ削除（列に無い examPageId）などで座標配置できず、
  * 表からは不可視になる（＝孤立答案）。呼び出し側で専用枠に描画して再配置できるようにする。
  *
- * placedByCell のキーは `${studentIndex}-${pageIndex}`（0始まりのグリッド座標）。
+ * placedByCell は (studentId, examPageId) で引く CellValueMap（序数キーは使わない）。
  * 同一セルに複数の配置可能答案が解決された場合は先着のみを配置し、後続は孤立扱いに
  * する（黙って上書きして消さない＝表からも孤立枠からも見えなくなる事故を防ぐ。
  * 実データは @@unique([examPageId, studentId]) によりセル衝突は構造的に起きないが、
@@ -198,34 +227,29 @@ export function getDisabledFiles<T extends AnswerImageIdentity>(
  */
 export function partitionAnswerItemsByPlacement<T extends AnswerImageIdentity>(
   items: T[],
-  sortedStudentIds: string[],
+  rosterStudentIds: string[],
   examPageIds: string[]
-): { placedByCell: Map<string, T>; orphans: T[] } {
-  const studentIndexById = new Map<string, number>()
-  sortedStudentIds.forEach((studentId, studentIndex) => {
-    studentIndexById.set(studentId, studentIndex)
-  })
-  const pageIndexById = new Map<string, number>()
-  examPageIds.forEach((examPageId, pageIndex) => {
-    pageIndexById.set(examPageId, pageIndex)
-  })
+): { placedByCell: CellValueMap<T>; orphans: T[] } {
+  const rosterStudentIdSet = new Set(rosterStudentIds)
+  const columnPageIdSet = new Set(examPageIds)
 
-  const placedByCell = new Map<string, T>()
+  const placedByCell: CellValueMap<T> = new Map()
   const orphans: T[] = []
 
   for (const answerItem of items) {
-    const studentIndex = answerItem.studentId
-      ? studentIndexById.get(answerItem.studentId)
-      : undefined
-    const pageIndex = answerItem.examPageId
-      ? pageIndexById.get(answerItem.examPageId)
-      : undefined
-    const isPlaceable = studentIndex !== undefined && pageIndex !== undefined
-    const cellKey = `${studentIndex}-${pageIndex}`
+    const { studentId, examPageId } = answerItem
+    const isPlaceable =
+      studentId !== null &&
+      examPageId !== null &&
+      rosterStudentIdSet.has(studentId) &&
+      columnPageIdSet.has(examPageId)
 
     // 配置可能でも同一セルが既に埋まっていれば孤立へ退避する（上書きで消さない）
-    if (isPlaceable && !placedByCell.has(cellKey)) {
-      placedByCell.set(cellKey, answerItem)
+    if (
+      isPlaceable &&
+      getCellValue(placedByCell, studentId, examPageId) === undefined
+    ) {
+      setCellValue(placedByCell, studentId, examPageId, answerItem)
     } else {
       orphans.push(answerItem)
     }

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -25,37 +25,9 @@ export function hasCell(
 }
 
 /**
- * (studentId, examPageId) の集合を O(1) 照合するルックアップ。
- * 文字列合成キー（`${a}:${b}`）を使わず studentId → examPageId集合 の入れ子で持つ。
- * グリッド全体分に膨らみうる派生集合（既存答案・動的無効）向け。
- */
-export type CellLookup = Map<string, Set<string>>
-
-export function addCellToLookup(
-  lookup: CellLookup,
-  studentId: string,
-  examPageId: string
-): void {
-  const pages = lookup.get(studentId)
-  if (pages) {
-    pages.add(examPageId)
-  } else {
-    lookup.set(studentId, new Set([examPageId]))
-  }
-}
-
-export function lookupHasCell(
-  lookup: CellLookup,
-  studentId: string,
-  examPageId: string
-): boolean {
-  return lookup.get(studentId)?.has(examPageId) ?? false
-}
-
-/**
  * (studentId, examPageId) → 値 を O(1) で引く入れ子マップ。
- * CellLookup が「そのセルに該当するか」の真偽だけを持つのに対し、こちらはセルに
- * 紐づく実体（配置された答案など）を保持する。合成文字列キーも序数も使わない。
+ * 文字列合成キー（`${a}:${b}`）も序数も使わず、studentId → examPageId → 値 で持つ。
+ * グリッド全体分に膨らみうる派生（既存答案・動的無効・配置解決）向け。
  */
 export type CellValueMap<T> = Map<string, Map<string, T>>
 
@@ -79,6 +51,25 @@ export function getCellValue<T>(
   examPageId: string
 ): T | undefined {
   return cellValues.get(studentId)?.get(examPageId)
+}
+
+/** 値を持たず所属だけを表すセル集合（CellValueMap の存在判定専用の姿）。 */
+export type CellLookup = CellValueMap<true>
+
+export function addCellToLookup(
+  lookup: CellLookup,
+  studentId: string,
+  examPageId: string
+): void {
+  setCellValue(lookup, studentId, examPageId, true)
+}
+
+export function lookupHasCell(
+  lookup: CellLookup,
+  studentId: string,
+  examPageId: string
+): boolean {
+  return getCellValue(lookup, studentId, examPageId) ?? false
 }
 
 /**


### PR DESCRIPTION
## 背景

#965 の7項目のうち6項目は、その後の entity-first リファクタ（#986）と型整理（#1018）で既に解消済みでした。

| 指摘項目 | 解消 |
| --- | --- |
| IntersectionObserver の死んだ遅延読込経路 | #986 |
| `handleUploadToCell` の `console.log` スタブ | #986 |
| file セルの「このセルにアップロード」空振りメニュー | #986 |
| `studentName` の到達しないデッド三項 | #986 |
| `useDragDropState` の依存配列重複 | #986 |
| `FilePreviewCellProps` のインライン交差型で型が2分散 | #1018 |
| **行 React key が `studentId`（行同一性は `examStudentId`）** | **本PR** |

## 本PRでやること

残った nit（行 React key）を直すにあたり、その根にある構造の問題まで是正します。

`tableData` は `CellData[][]` という裸の2次元配列で、セル自身が同一性を持たず、行と `sortedStudents`・列と `examPages` の対応は**「同じ順で生成したから添字が一致するはず」という暗黙の約束**だけで支えられていました。「同定は必ず id、序数は key にしない」という本リポジトリの規約に反します。

さらにこれは表示だけの問題ではありません。`UploadAnswerTable` の `handleUpload` が同じ添字結合で**DB書き込み先の `studentId` / `examPageId` を決めていた**ため、行がずれれば別の生徒の答案として保存され得る状態でした。

`CellData` を廃し、**行が `ExamStudent` 実体を、各マスが `ExamPage` 実体を同梱する** `AnswerTableRow` / `AnswerTableCell` へ置き換え、対応を「約束」ではなく構造で保証します。

```ts
export interface AnswerTableCell<TItem> {
  examPage: ExamPageColumn
  type: "file" | "empty" | "disabled"
  file?: TItem
  disabledReason?: DisabledReason
}

export interface AnswerTableRow<TItem> {
  examStudent: ExamStudentWithMemberships
  cells: AnswerTableCell<TItem>[]
}
```

## 変更点

**1コミット目 — 行・列結合の実体化**

- `types.ts`: `CellData` → `AnswerTableCell`（`examPage` 同梱）＋ `AnswerTableRow`
- `useTableDataGeneration.ts`: `tableData` → `tableRows`。配置解決を id 対キーへ
- `TableContent.tsx` / `AnswerTableShell.tsx`: `sortedStudents` prop を廃し行の実体から描画。行 React key も `studentId` → `ExamStudent.id`
- `UploadAnswerTable.tsx`: 書き込み先を行・マスの実体から直接取得
- `useMarkerCorrection.ts`: 列をマスの `examPage` から取得し `examPages` 引数を廃止

**2コミット目 — レビュー指摘の反映**

- `validPositions` のソートを廃止。配置順はループの入れ子の向き（page-first は列を外側、student-first は行を外側）で表現し、比較子と `studentIndex` / `pageIndex` の保持をやめた。**これにより 06 から序数が完全に消えた**
- 既存答案ルックアップを `useTableData` の `cellsWithExistingAnswers` に一本化。同じ事実を `useTableDataGeneration` 内で組み直していた重複を解消し、警告オーバーレイと配置判断が同じ集合を見るようにした
- `CellLookup` を `CellValueMap<true>` として定義し直し、入れ子マップの遅延初期化配管の二重実装（Set 版 / Map 版）を解消

## 振る舞いの変更

**なし。** 自動配置（page-first / student-first）・上書き判定・孤立答案の分類はすべて現行どおりです。

ソート廃止についての等価性: `validPositions` の構築順は `student-first` 比較子の結果と一致し（安定ソート）、`page-first` は入れ子を入れ替えるだけなので出力は同一です。上書き有効時に既存答案のマスを優先する分岐は、既存答案集合が `!allowOverwrite` でしか収集されないため元から到達しておらず、削除で振る舞いは変わりません（未実装機能として #1043 に切り出し）。

## テスト

- `__tests__/renderer/hooks/useTableDataGeneration.test.ts` を新規追加（5件）。行の生徒とマスのページが、そのマスに置かれた答案の書き込み先と一致することを固定。upload の配置順・上書き無効時のスキップ・view の座標配置・孤立答案も併せて固定
- `__tests__/renderer/utils/dragDropUtils.test.ts` を `placedByCell` の新シグネチャへ更新
- 全 994 テスト通過 / `npm run typecheck` / `npm run lint` クリーン

## レビューで出た既存欠陥（本PRの範囲外）

- #1043 — upload の2機能が到達不能（上書き時の優先配置・新規ファイル投入の警告）
- #1044 — 置き場のない答案が無警告に破棄される件の警告モーダル（本PRの上に積んだPR）

## 未確認

実アプリでの目視確認は行っていません（テストと型チェックのみ）。upload の自動配置は UI 操作を伴うため、マージ前に `npm run dev` での確認を推奨します。

Closes #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)