### PR TITLE
feat(06-student-answers): 置き場のない答案を送信前に警告する

### DIFF
--- a/__tests__/renderer/hooks/useTableDataGeneration.test.ts
+++ b/__tests__/renderer/hooks/useTableDataGeneration.test.ts
@@ -261,6 +261,53 @@ describe("useTableDataGeneration", () => {
     }
   })
 
+  it("upload: 有効マスに収まらない答案は unplacedItems へ回す", () => {
+    // 2生徒 × 2ページ ＝ 4マスに対して6件
+    const files = ["f1", "f2", "f3", "f4", "f5", "f6"].map(makeUnsavedAnswer)
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "student-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "upload",
+        enhancedIsCellDisabled: () => false,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
+      })
+    )
+
+    // あふれた2件は配置されず、呼び出し側が送信前に警告できるよう返る
+    expect(result.current.unplacedItems.map((file) => file.id)).toEqual([
+      "f5",
+      "f6",
+    ])
+    const placedFileIds = result.current.tableRows.flatMap((row) =>
+      row.cells.map((cell) => cell.file?.id).filter(Boolean)
+    )
+    expect(placedFileIds).toEqual(["f1", "f2", "f3", "f4"])
+  })
+
+  it("upload: 全て収まるときは unplacedItems が空", () => {
+    const files = [makeUnsavedAnswer("f1"), makeUnsavedAnswer("f2")]
+
+    const { result } = renderHook(() =>
+      useTableDataGeneration<UnsavedAnswerImage>({
+        files,
+        sortedStudents,
+        examPages: EXAM_PAGES,
+        fileOrder: "student-first",
+        disabledState: EMPTY_DISABLED_STATE,
+        mode: "upload",
+        enhancedIsCellDisabled: () => false,
+        cellsWithExistingAnswers: NO_EXISTING_ANSWERS,
+      })
+    )
+
+    expect(result.current.unplacedItems).toHaveLength(0)
+  })
+
   it("upload: 上書き無効なら既存答案のマスは埋めずに飛ばす", () => {
     const files = [makeUnsavedAnswer("f1")]
 

--- a/src/components/exams/06-student-answers/student-answer-table/components/UnplacedAnswersModal.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/UnplacedAnswersModal.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+interface UnplacedAnswersModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  /** 置き場が無くアップロードされない答案の表示名 */
+  unplacedFileNames: string[]
+  /** 実際にアップロードされる答案の件数 */
+  placedCount: number
+}
+
+// 一覧が長くなりすぎないよう先頭のみ挙げ、残りは件数で示す
+const NAME_PREVIEW_LIMIT = 10
+
+/**
+ * 表の空きマスより答案が多いときの確認モーダル。
+ *
+ * 自動配置は有効マスの数までしか行わないため、あふれた答案はアップロードされないまま
+ * 送信後に破棄される（仕様）。黙って消えると気づけないので、送信前にどの答案が
+ * 対象外になるかを示して続行するかを選ばせる。
+ */
+export function UnplacedAnswersModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  unplacedFileNames,
+  placedCount,
+}: UnplacedAnswersModalProps) {
+  const previewNames = unplacedFileNames.slice(0, NAME_PREVIEW_LIMIT)
+  const hiddenCount = unplacedFileNames.length - previewNames.length
+
+  const handleConfirm = () => {
+    onConfirm()
+    onClose()
+  }
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2 text-amber-700">
+            <AlertTriangle className="h-5 w-5" />
+            置き場のない答案があります
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            表の空きマスより答案が多いため、
+            {unplacedFileNames.length}件はどのマスにも配置されていません。
+            このまま実行すると、配置済みの{placedCount}
+            件だけがアップロードされ、残りは破棄されます。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded bg-amber-50 p-3 text-amber-900">
+            <p className="text-sm font-medium">
+              アップロードされない答案（{unplacedFileNames.length}件）
+            </p>
+            <ul className="mt-1 list-inside list-disc space-y-0.5 text-sm">
+              {previewNames.map((fileName) => (
+                <li key={fileName} className="truncate">
+                  {fileName}
+                </li>
+              ))}
+              {hiddenCount > 0 && <li>ほか{hiddenCount}件</li>}
+            </ul>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            全て取り込むには、キャンセルして受験生徒か模範解答のページを増やすか、
+            答案を分けてアップロードしてください。
+          </p>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onClose}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>
+            配置済みの{placedCount}件をアップロード
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 
 import { AnswerTableShell } from "@/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell"
+import { UnplacedAnswersModal } from "@/components/exams/06-student-answers/student-answer-table/components/UnplacedAnswersModal"
 import { useAnswerTableCore } from "@/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore"
 import { useMarkerCorrection } from "@/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection"
 import type { FilePreviewSource } from "@/components/exams/06-student-answers/student-answer-table/types"
@@ -57,9 +58,12 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
     return map
   }, [props.files])
 
+  // 置き場が無くアップロードされない答案がある場合の確認モーダル
+  const [isUnplacedModalOpen, setIsUnplacedModalOpen] = useState(false)
+
   // 配置済みファイルのアップロードデータを生成。書き込み先の生徒・ページは行が持つ
   // ExamStudent 実体・マスが持つ ExamPage 実体から直に取る（別配列との添字突き合わせをしない）。
-  const handleUpload = () => {
+  const buildUploadData = (): UploadData[] => {
     const uploadData: UploadData[] = []
     for (const { examStudent, cells } of core.tableRows) {
       for (const cell of cells) {
@@ -79,56 +83,77 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
         })
       }
     }
-    props.onUpload(uploadData)
+    return uploadData
+  }
+
+  // 空きマスより答案が多いとき、あふれた分は送信されないまま破棄される（仕様）。
+  // 黙って消さないよう、送信前に対象外の答案を示して続行可否を確認する。
+  const handleUpload = () => {
+    if (core.unplacedItems.length > 0) {
+      setIsUnplacedModalOpen(true)
+      return
+    }
+    props.onUpload(buildUploadData())
   }
 
   const enabledFiles = core.getEnabledFiles()
+  const placedCount = enabledFiles.length - core.unplacedItems.length
 
   return (
-    <AnswerTableShell
-      mode="upload"
-      maxPages={core.maxPages}
-      examPages={props.examPages}
-      enabledFilesCount={enabledFiles.length}
-      trashFiles={core.trashFiles.map((file) => ({
-        id: file.id,
-        name: file.name,
-        size: file.size,
-      }))}
-      onFileRestore={core.toggleFileDisabled}
-      isUploading={props.isUploading ?? false}
-      onUpload={handleUpload}
-      fileOrder={props.fileOrder ?? "page-first"}
-      onFileOrderChange={props.onFileOrderChange}
-      previewMode={core.previewMode}
-      onPreviewModeChange={core.handlePreviewModeChange}
-      hasNameRegion={core.hasNameRegion}
-      allowOverwrite={core.allowOverwrite}
-      onAllowOverwriteChange={core.setAllowOverwrite}
-      markerCorrectionEnabled={props.markerCorrectionEnabled}
-      markerCorrectionAvailable={props.markerCorrectionAvailable}
-      markerDiagnostics={props.markerDiagnostics}
-      onMarkerCorrectionChange={props.onMarkerCorrectionChange}
-      sensors={core.sensors}
-      activeFile={core.activeFile}
-      sortableItemIds={enabledFiles.map((file) => file.id)}
-      onDragStart={core.handleDragStart}
-      onDragEnd={core.handleDragEnd}
-      tableRows={core.tableRows}
-      disabledState={core.disabledState}
-      nameRegionAvailable={core.nameRegionAvailable}
-      cellsWithExistingAnswers={core.cellsWithExistingAnswers}
-      files={props.files}
-      imageLoadStates={props.imageLoadStates}
-      correctingFileIds={correctingFileIds}
-      fileDisplayById={fileDisplayById}
-      drawNameRegionCanvas={core.drawNameRegionCanvas}
-      toggleRowDisabled={core.toggleRowDisabled}
-      toggleColDisabled={core.toggleColDisabled}
-      toggleCellDisabled={core.toggleCellDisabled}
-      toggleFileDisabled={core.toggleFileDisabled}
-      orphanItems={core.orphanItems}
-      canvasRef={core.canvasRef}
-    />
+    <>
+      <AnswerTableShell
+        mode="upload"
+        maxPages={core.maxPages}
+        examPages={props.examPages}
+        enabledFilesCount={enabledFiles.length}
+        trashFiles={core.trashFiles.map((file) => ({
+          id: file.id,
+          name: file.name,
+          size: file.size,
+        }))}
+        onFileRestore={core.toggleFileDisabled}
+        isUploading={props.isUploading ?? false}
+        onUpload={handleUpload}
+        fileOrder={props.fileOrder ?? "page-first"}
+        onFileOrderChange={props.onFileOrderChange}
+        previewMode={core.previewMode}
+        onPreviewModeChange={core.handlePreviewModeChange}
+        hasNameRegion={core.hasNameRegion}
+        allowOverwrite={core.allowOverwrite}
+        onAllowOverwriteChange={core.setAllowOverwrite}
+        markerCorrectionEnabled={props.markerCorrectionEnabled}
+        markerCorrectionAvailable={props.markerCorrectionAvailable}
+        markerDiagnostics={props.markerDiagnostics}
+        onMarkerCorrectionChange={props.onMarkerCorrectionChange}
+        sensors={core.sensors}
+        activeFile={core.activeFile}
+        sortableItemIds={enabledFiles.map((file) => file.id)}
+        onDragStart={core.handleDragStart}
+        onDragEnd={core.handleDragEnd}
+        tableRows={core.tableRows}
+        disabledState={core.disabledState}
+        nameRegionAvailable={core.nameRegionAvailable}
+        cellsWithExistingAnswers={core.cellsWithExistingAnswers}
+        files={props.files}
+        imageLoadStates={props.imageLoadStates}
+        correctingFileIds={correctingFileIds}
+        fileDisplayById={fileDisplayById}
+        drawNameRegionCanvas={core.drawNameRegionCanvas}
+        toggleRowDisabled={core.toggleRowDisabled}
+        toggleColDisabled={core.toggleColDisabled}
+        toggleCellDisabled={core.toggleCellDisabled}
+        toggleFileDisabled={core.toggleFileDisabled}
+        orphanItems={core.orphanItems}
+        canvasRef={core.canvasRef}
+      />
+
+      <UnplacedAnswersModal
+        isOpen={isUnplacedModalOpen}
+        onClose={() => setIsUnplacedModalOpen(false)}
+        onConfirm={() => props.onUpload(buildUploadData())}
+        unplacedFileNames={core.unplacedItems.map((file) => file.name)}
+        placedCount={placedCount}
+      />
+    </>
   )
 }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
@@ -74,6 +74,7 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
     getDisabledFiles,
     tableRows,
     orphanItems,
+    unplacedItems,
     cellsWithExistingAnswers,
   } = useTableData<TItem>({
     files,
@@ -167,6 +168,7 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
     getEnabledFiles,
     tableRows,
     orphanItems,
+    unplacedItems,
     cellsWithExistingAnswers,
     // DnD
     sensors,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -101,7 +101,7 @@ export function useTableData<TItem extends AnswerImageIdentity>({
   }, [files, disabledState])
 
   // テーブル行の生成（行に ExamStudent 実体、各マスに ExamPage 実体を同梱）
-  const { tableRows, orphanItems } = useTableDataGeneration({
+  const { tableRows, orphanItems, unplacedItems } = useTableDataGeneration({
     files,
     sortedStudents,
     examPages,
@@ -118,6 +118,7 @@ export function useTableData<TItem extends AnswerImageIdentity>({
     getDisabledFiles: getDisabledFilesCallback,
     tableRows,
     orphanItems,
+    unplacedItems,
     cellsWithExistingAnswers,
   }
 }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -60,11 +60,13 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
   allowOverwrite = false,
   cellsWithExistingAnswers,
 }: UseTableDataGenerationParams<TItem>) {
-  const { tableRows, orphanItems } = useMemo(() => {
+  const { tableRows, orphanItems, unplacedItems } = useMemo(() => {
     const enabledFiles = getEnabledFiles(files, disabledState)
 
     const rows: AnswerTableRow<TItem>[] = []
     const orphans: TItem[] = []
+    // upload で有効マスに収まりきらなかったファイル（＝アップロード対象にならない）
+    const unplaced: TItem[] = []
 
     if (mode === "view") {
       // 確認モード（方式B）: 各答案を自身の実セル座標 (studentId, examPageId) に配置する。
@@ -148,7 +150,6 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
       }
 
       // ファイルと有効セルをマッピング（ファイル配列の順序で自動配置）。
-      // 有効セルより多いファイルは配置されない（＝アップロード対象にならない）。
       const filePlacement: CellValueMap<TItem> = new Map()
       validPositions.forEach((position, fileIndex) => {
         const file = enabledFiles[fileIndex]
@@ -161,6 +162,10 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
           )
         }
       })
+
+      // 有効マスより多いファイルは置き場が無く、アップロードされないまま消える。
+      // 黙って落とさないよう呼び出し側へ渡し、送信前に警告できるようにする。
+      unplaced.push(...enabledFiles.slice(validPositions.length))
 
       for (const examStudent of sortedStudents) {
         const cells = examPages.map<AnswerTableCell<TItem>>((examPage) => {
@@ -206,7 +211,7 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
       }
     }
 
-    return { tableRows: rows, orphanItems: orphans }
+    return { tableRows: rows, orphanItems: orphans, unplacedItems: unplaced }
   }, [
     files,
     sortedStudents,
@@ -219,5 +224,5 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
     cellsWithExistingAnswers,
   ])
 
-  return { tableRows, orphanItems }
+  return { tableRows, orphanItems, unplacedItems }
 }


### PR DESCRIPTION
> #1042 のマージでベースブランチが消え #1044 が自動クローズされたため、main 向けに作り直したPRです。内容は #1044 と同一（新 main の上へリベース済み）。

## 背景

upload モードの自動配置は有効マスの数までしかファイルを配置しません。空きマスより答案が多い場合、あふれた分は配置されず、`handleUpload` は配置済みのマスだけを走査するため送信対象にもなりません。その後 `useStudentAnswerUpload` が「N件の答案をアップロードしました」とトーストして `setFiles([])` するので、**あふれた答案は無警告のまま消えます**。

配置数の上限自体は仕様ですが、消えたことに気づく手段がないのが問題です。#1042 のコードレビューで検出されました。

## 変更

送信前に確認モーダルを出します。

- `useTableDataGeneration` が upload であふれた答案を `unplacedItems` として返す（view の `orphanItems` と対になる「解決不能な画像を黙って落とさない」経路）
- `useTableData` / `useAnswerTableCore` で持ち回り、`UploadAnswerTable` が送信前に判定
- `UnplacedAnswersModal`: 対象外になる答案名（先頭10件＋残件数）と実際に送信される件数を示し、続行かキャンセルかを選ばせる

あふれが無い場合はこれまで通り即送信で、モーダルは出ません。

## テスト

- `useTableDataGeneration.test.ts` に2件追加（あふれた分が `unplacedItems` に回ること／全て収まるときは空であること）
- 全 996 テスト通過 / `npm run typecheck` / `npm run lint` クリーン

## 未確認

モーダルの実表示は目視確認していません（テストと型チェックのみ）。

## 関連

- #1042 — 本PRが土台にしているリファクタ（マージ済み）
- #1043 — 同レビューで見つかった upload の到達不能な2機能

🤖 Generated with [Claude Code](https://claude.com/claude-code)