### PR TITLE
fix(ui): モーダルの初期フォーカスを確定化する

### DIFF
--- a/src/app/login/PasscodeModal.tsx
+++ b/src/app/login/PasscodeModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -18,6 +18,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp"
 import { Label } from "@/components/ui/label"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface PasscodeModalProps {
   isOpen: boolean
@@ -39,6 +40,18 @@ export function PasscodeModal({
   const [passcode, setPasscode] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")
+  const { inputRef: passcodeInputRef, onOpenAutoFocus } =
+    useDialogAutoFocus(isOpen)
+
+  // 呼び出し側（login/page.tsx）は選択中ユーザーを保持したまま isOpen だけを
+  // 落とすため、このコンポーネントはアンマウントされず state が残る。
+  // 前回の誤ったパスコードとエラーを持ち越さないよう、開くたびに作り直す。
+  useEffect(() => {
+    if (isOpen) {
+      setPasscode("")
+      setError("")
+    }
+  }, [isOpen])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -66,6 +79,7 @@ export function PasscodeModal({
     if (user.passcodeType === "4digit") {
       return (
         <InputOTP
+          ref={passcodeInputRef}
           maxLength={4}
           value={passcode}
           onChange={setPasscode}
@@ -84,6 +98,7 @@ export function PasscodeModal({
     if (user.passcodeType === "6digit") {
       return (
         <InputOTP
+          ref={passcodeInputRef}
           maxLength={6}
           value={passcode}
           onChange={setPasscode}
@@ -104,11 +119,12 @@ export function PasscodeModal({
     if (user.passcodeType === "alphanumeric") {
       return (
         <Input
+          ref={passcodeInputRef}
+          id="passcode"
           type="password"
           value={passcode}
           onChange={(e) => setPasscode(e.target.value)}
           placeholder="パスコードを入力"
-          autoFocus
         />
       )
     }
@@ -131,7 +147,10 @@ export function PasscodeModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[350px]">
+      <DialogContent
+        className="sm:max-w-[350px]"
+        onOpenAutoFocus={onOpenAutoFocus}
+      >
         <DialogHeader>
           <DialogTitle>{user.name}</DialogTitle>
           <DialogDescription>

--- a/src/components/classroom/ClassroomModal.tsx
+++ b/src/components/classroom/ClassroomModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface ClassroomModalProps {
   isOpen: boolean
@@ -50,7 +51,7 @@ export default function ClassroomModal({
   const [description, setDescription] = useState("")
   const [isVisible, setIsVisible] = useState(true)
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
-  const nameInputRef = useRef<HTMLInputElement>(null)
+  const { inputRef: nameInputRef, onOpenAutoFocus } = useDialogAutoFocus(isOpen)
 
   useEffect(() => {
     let cancelled = false
@@ -110,16 +111,7 @@ export default function ClassroomModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent
-        className="sm:max-w-md"
-        onOpenAutoFocus={(e) => {
-          // autoFocus属性はRadixのFocusScope・開いた直後のstateリセット再レンダーと
-          // 競合し、本番ビルドではフォーカスがinputに乗らないことがある。
-          // ここで明示的に学級名inputへフォーカスを確定させる。
-          e.preventDefault()
-          nameInputRef.current?.focus()
-        }}
-      >
+      <DialogContent className="sm:max-w-md" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle>
             {classroomToEdit ? "学級情報を編集" : "新しい学級を作成"}

--- a/src/components/common/BulkTagAssignButton.tsx
+++ b/src/components/common/BulkTagAssignButton.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Tag } from "lucide-react"
-import { useRef, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface BulkTagAssignButtonProps {
   /** 選択中の件数（0 のときは呼び出し側で非表示にする想定） */
@@ -31,11 +32,19 @@ export function BulkTagAssignButton({
 }: BulkTagAssignButtonProps) {
   const [open, setOpen] = useState(false)
   const [tagInput, setTagInput] = useState("")
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [isAssigning, setIsAssigning] = useState(false)
+  const { inputRef, onOpenAutoFocus } = useDialogAutoFocus(open)
 
   const handleAssign = async (tagName: string) => {
-    if (!tagName.trim()) return
-    await onAssign(tagName.trim())
+    // onAssign は選択中の全件へ付与するため、Enter 連打や連続クリックで
+    // 二重に走らせると付与が二巡し、選択解除後の空振りと重複エラーになる。
+    if (!tagName.trim() || isAssigning) return
+    setIsAssigning(true)
+    try {
+      await onAssign(tagName.trim())
+    } finally {
+      setIsAssigning(false)
+    }
     setTagInput("")
     setOpen(false)
   }
@@ -48,7 +57,11 @@ export function BulkTagAssignButton({
           タグを一括追加
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 p-3" align="start">
+      <PopoverContent
+        className="w-64 p-3"
+        align="start"
+        onOpenAutoFocus={onOpenAutoFocus}
+      >
         <div className="space-y-2">
           <p className="text-muted-foreground text-xs">
             選択中の{selectedCount}件にタグを追加
@@ -65,7 +78,6 @@ export function BulkTagAssignButton({
             }}
             placeholder="タグ名を入力してEnter"
             className="h-8 text-sm"
-            autoFocus
           />
           {allTags.length > 0 && (
             <div className="max-h-28 overflow-y-auto">

--- a/src/components/exams/07-score-at-once/ScoringMain/PartialScoreModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/PartialScoreModal.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 /** キーバインディングの型 */
 interface KeyBindings {
@@ -65,6 +66,9 @@ export default function PartialScoreModal({
   const pendingKeyDisplay = formatKeyDisplay(pendingKey)
   const cancelKeyDisplay = formatKeyDisplay(cancelKey)
 
+  const { inputRef: scoreInputRef, onOpenAutoFocus } =
+    useDialogAutoFocus(isOpen)
+
   /** Input内でのキーボードハンドラー */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -105,7 +109,7 @@ export default function PartialScoreModal({
   )
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             部分点入力
@@ -119,6 +123,7 @@ export default function PartialScoreModal({
           {/* 入力表示エリア */}
           <div className="relative">
             <Input
+              ref={scoreInputRef}
               value={value}
               className="h-16 border-blue-300 bg-blue-50 text-center font-mono text-2xl text-blue-700"
               placeholder="0"
@@ -128,7 +133,6 @@ export default function PartialScoreModal({
                 }
               }}
               onKeyDown={handleKeyDown}
-              autoFocus
             />
             {value.endsWith(".") && (
               <div className="absolute top-1/2 right-4 -translate-y-1/2 transform animate-pulse text-2xl text-blue-500">

--- a/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider.tsx
@@ -393,18 +393,24 @@ export function ShortcutProvider({ children }: ShortcutProviderProps) {
       // input要素内では、モーダル制御キー以外をスルー
       // これにより、通常の文字入力（0-9, a-z, .等）とBackspace等は正常に動作する
       if (isInputElement) {
-        // ユーザー設定から部分点・保留・キャンセルのキーを取得
+        // モーダル用コマンド（modal.*）は when 句が partialScoreModalOpen だけで
+        // !inputFocus を含まない＝モーダルのinputにフォーカスがある状態でも
+        // 動く前提で登録されている。ここで弾くと再割当したキーが死ぬため、
+        // modal.* の割当キーは部分点・保留と同様に後続の評価へ通す。
+        // モーダルが開いていなければ when 句が偽になり通常の入力として扱われる。
         const modalControlKeys = [
           keyBindings["scoring.partial"],
           keyBindings["scoring.pending"],
-          keyBindings["modal.cancel"],
+          ...Object.entries(keyBindings)
+            .filter(([commandId]) => commandId.startsWith("modal."))
+            .map(([, boundKey]) => boundKey),
         ].filter(Boolean)
 
         if (!modalControlKeys.includes(key)) {
           // モーダル制御キー以外は通常の入力として処理（Backspace含む）
           return
         }
-        // 部分点/保留/キャンセルキーの場合は、後続のコマンド評価に進む
+        // 部分点/保留/モーダル操作キーの場合は、後続のコマンド評価に進む
       }
 
       // 逆引き: key -> commandId[] (複数のコマンドが同じキーにバインドされている可能性)

--- a/src/components/exams/forms/CreateExamWindow.tsx
+++ b/src/components/exams/forms/CreateExamWindow.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface CreateExamWindowProps {
   onClose: () => void
@@ -34,6 +35,9 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
   const [currentTagInput, setCurrentTagInput] = useState("")
   const [allTags, setAllTags] = useState<{ id: string; name: string }[]>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
+  // このコンポーネントは親が条件付きでマウントする＝常に開いた状態
+  const { inputRef: examNameInputRef, onOpenAutoFocus } =
+    useDialogAutoFocus(true)
   const { createExam } = useExams()
 
   // 既存タグを取得
@@ -111,7 +115,7 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle>新規試験作成</DialogTitle>
           <DialogDescription>
@@ -125,11 +129,11 @@ const CreateExamWindow: React.FC<CreateExamWindowProps> = ({
             </Label>
             <Input
               id="examName"
+              ref={examNameInputRef}
               value={examName}
               onChange={(e) => setExamName(e.target.value)}
               className="col-span-3"
               placeholder="例: 2学期中間試験"
-              autoFocus
             />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">

--- a/src/components/student/StudentModal.tsx
+++ b/src/components/student/StudentModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Prisma } from "@prisma/client"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 // StudentModalに必要な最小限のフィールド（createdAt/updatedAtは不要）
 interface StudentForEdit {
@@ -50,7 +51,8 @@ export default function StudentModal({
     undefined
   )
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
-  const studentIdInputRef = useRef<HTMLInputElement>(null)
+  const { inputRef: studentIdInputRef, onOpenAutoFocus } =
+    useDialogAutoFocus(isOpen)
 
   useEffect(() => {
     let canceled = false
@@ -125,16 +127,7 @@ export default function StudentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent
-        className="sm:max-w-md"
-        onOpenAutoFocus={(e) => {
-          // autoFocus属性はRadixのFocusScope・開いた直後のstateリセット再レンダーと
-          // 競合し、本番ビルドではフォーカスがinputに乗らないことがある。
-          // ここで明示的に学籍番号inputへフォーカスを確定させる。
-          e.preventDefault()
-          studentIdInputRef.current?.focus()
-        }}
-      >
+      <DialogContent className="sm:max-w-md" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle>
             {studentToEdit ? "生徒情報を編集" : "新しい生徒を追加"}

--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -27,6 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface TagItem {
   id: string
@@ -131,6 +132,7 @@ function TagModal({
 }) {
   const [name, setName] = useState("")
   const [color, setColor] = useState<string | null>(null)
+  const { inputRef: nameInputRef, onOpenAutoFocus } = useDialogAutoFocus(open)
 
   useEffect(() => {
     if (open) {
@@ -150,7 +152,7 @@ function TagModal({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-sm">
+      <DialogContent className="sm:max-w-sm" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle>{tag ? "タグを編集" : "新規タグ作成"}</DialogTitle>
         </DialogHeader>
@@ -158,6 +160,7 @@ function TagModal({
           <div className="grid grid-cols-4 items-center gap-4">
             <Label className="text-right">タグ名</Label>
             <Input
+              ref={nameInputRef}
               value={name}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => {
@@ -168,7 +171,6 @@ function TagModal({
               }}
               className="col-span-3"
               placeholder="例: 数学"
-              autoFocus
             />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">

--- a/src/components/ui/password-dialog.tsx
+++ b/src/components/ui/password-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { AlertCircle, Lock } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useDialogAutoFocus } from "@/hooks/useDialogAutoFocus"
 
 interface PasswordDialogProps {
   isOpen: boolean
@@ -36,7 +37,7 @@ export function PasswordDialog({
 }: PasswordDialogProps) {
   const [password, setPassword] = useState("")
   const [isShaking, setIsShaking] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const { inputRef, onOpenAutoFocus } = useDialogAutoFocus(isOpen)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -98,6 +99,17 @@ export function PasswordDialog({
     }
   }, [isOpen])
 
+  // パスワード違いの再試行では、呼び出し側（usePdfPasswordConversion）が
+  // isOpen を true のまま isLoading だけ戻すため、Dialog は再マウントされず
+  // onOpenAutoFocus も [isOpen] のリセット効果も再発火しない。
+  // 誤ったパスワードが残ったまま無フォーカスになるので、ここで入力を作り直す。
+  useEffect(() => {
+    if (isOpen && !isLoading && error && !isFirstAttempt) {
+      setPassword("")
+      inputRef.current?.focus()
+    }
+  }, [isOpen, isLoading, error, isFirstAttempt, inputRef])
+
   const handleClose = () => {
     setPassword("")
     onClose()
@@ -105,7 +117,7 @@ export function PasswordDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" onOpenAutoFocus={onOpenAutoFocus}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Lock className="h-5 w-5 text-amber-600" />
@@ -130,7 +142,6 @@ export function PasswordDialog({
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="PDFのパスワードを入力"
-              autoFocus
               disabled={isLoading}
               className={isShaking ? "animate-pulse border-red-500" : ""}
               style={{

--- a/src/hooks/useDialogAutoFocus.ts
+++ b/src/hooks/useDialogAutoFocus.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Radix の Dialog / Popover を開いたときに、指定の input へ確定的にフォーカスを当てる。
+ *
+ * `autoFocus` 属性頼みにすると、React の `.focus()`・Radix `FocusScope` の
+ * マウント時オートフォーカス・開いた直後の state リセット再レンダーが同一フレームで
+ * 競合し、本番（minify済み）ビルドではフォーカスが input ではなく Content
+ * コンテナに残ることがある（issue #916）。
+ *
+ * 返り値の `inputRef` を対象 input に、`onOpenAutoFocus` を
+ * `DialogContent` / `PopoverContent` に渡して使う。
+ */
+export function useDialogAutoFocus(open: boolean) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // 閉じるアニメーション（duration-200）の最中に開き直すと、Radix Presence が
+  // Content ノードを保持したままになり FocusScope のマウント効果＝
+  // onOpenAutoFocus が再発火しない。open の変化でも当て直して取りこぼしを防ぐ。
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus()
+    }
+  }, [open])
+
+  const onOpenAutoFocus = (event: Event) => {
+    const input = inputRef.current
+    // フォーカスできない状態（未マウント・disabled）では preventDefault すると
+    // Radix のフォールバックまで潰してフォーカスが focus scope の外に残るため、
+    // 既定の挙動に委ねる。
+    if (!input || input.disabled) {
+      return
+    }
+    event.preventDefault()
+    input.focus()
+  }
+
+  return { inputRef, onOpenAutoFocus }
+}


### PR DESCRIPTION
## 概要

Radix Dialog / Popover の初期フォーカスを `autoFocus` 属性頼みから `onOpenAutoFocus` での明示指定へ統一します。#916 の横展開（残り4ファイル）＋ 共通フックへの集約です。

`autoFocus` は React の `.focus()`・Radix `FocusScope` のマウント時オートフォーカス・開いた直後の state リセット再レンダーと同一フレームで競合し、本番（minify済み）ビルドではフォーカスが input ではなく Content コンテナに残ることがあります。

## 変更内容

### 新規: `src/hooks/useDialogAutoFocus.ts`

6重に写経していた同型ハンドラを1箇所へ集約し、併せて2つの穴を塞ぎました。

- `open` の変化でも `focus()` を当て直す — 閉じるアニメ（`duration-200`）中に開き直すと Radix Presence が Content ノードを保持したままになり、`onOpenAutoFocus` が再発火しない
- 対象 input が未マウント / `disabled` のときは `preventDefault()` せず Radix 既定のフォールバックへ委ねる — 潰すとフォーカスが focus scope の外（`<body>`）に残り、キーボード操作で辿れなくなる

### フックへ寄せた Dialog / Popover（8箇所）

| ファイル | 対象 |
| --- | --- |
| `src/components/ui/password-dialog.tsx` | PDFパスワード |
| `src/components/exams/forms/CreateExamWindow.tsx` | 試験名 |
| `src/components/exams/07-score-at-once/ScoringMain/PartialScoreModal.tsx` | 部分点 |
| `src/components/tag/TagsPageContainer.tsx` | タグ名 |
| `src/app/login/PasscodeModal.tsx` | パスコード |
| `src/components/common/BulkTagAssignButton.tsx` | タグ一括追加（Popover） |
| `src/components/classroom/ClassroomModal.tsx` | 学級名（既に `onOpenAutoFocus` 化済み → 挙動を統一） |
| `src/components/student/StudentModal.tsx` | 学籍番号（同上） |

### レビュー指摘の修正（`/code-review` high で9件検出、8件修正）

- **`ShortcutProvider.tsx`**: input 内でのキー透過リストを `modal.*` 全体へ拡張。`modal.input0-9` / `inputDot` / `backspace` は `when: \"partialScoreModalOpen\"` で `!inputFocus` を含まない＝モーダルの input にフォーカスがある状態で動く前提で登録されているため、フォーカス確定後に再割当キーが死ぬのを防ぐ。モーダルが閉じている間は `when` 句が偽になるだけなので通常のタイプには影響しない
- **`password-dialog.tsx`**: パスワード違いの再試行では `isOpen` が true のまま `isLoading` だけ戻るため、`onOpenAutoFocus` も `[isOpen]` のリセット効果も再発火せず、誤ったパスワードが残ったまま無フォーカスになっていた（再入力が前の値へ追記される）。入力クリア＋再フォーカスを追加
- **`PasscodeModal.tsx`**: 呼び出し側がアンマウントしないため前回の誤パスコードと error が残っていたのを、開くたびにリセット。`id=\"passcode\"` を付与して `htmlFor` の空振り（アクセシブル名なし）も解消。数字パスコード（`InputOTP`）にも同じ ref を通し、3方式を1つの機構へ統一
- **`BulkTagAssignButton.tsx`**: 到達可能になった Enter に二重実行ガードを追加（`onAssign` は選択中の全件へ付与するため、二巡すると重複エラーと空振りが同時に出る）

見送った1件: 「`autoFocus` を消すだけで Radix 既定が同じ input を掴むので手書き実装は不要」という指摘は、#916 の本番再現が未検証で、疑わしい Radix 既定に賭け直す形になるため適用していません。指摘が挙げていた重複コストはフック集約で解消しました。

## 検証

- `npx tsc --noEmit` / `eslint` / `prettier` クリーン
- これらのコンポーネントを参照するテストは `__tests__` に存在しないため vitest は未実行
- **本番（パッケージ）ビルドでのフォーカス確認は未実施** — #916 の主目的である検証項目は残るため、#916 はクローズしません

Refs #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)