### PR TITLE
refactor(grade): 総合(overall)を撤去し成績アーカイブの照合をuuid一次へ

### DIFF
--- a/__tests__/grade/integration/gradeFrozenScore.test.ts
+++ b/__tests__/grade/integration/gradeFrozenScore.test.ts
@@ -97,11 +97,7 @@ async function buildFixture(): Promise<Fixture> {
   })
 
   const boundarySet = await testPrisma.gradeBoundarySet.create({
-    data: {
-      gradeId: grade.id,
-      targetType: "grade_item",
-      gradeItemId: gradeItem.id,
-    },
+    data: { gradeId: grade.id, gradeItemId: gradeItem.id },
   })
   await testPrisma.gradeBoundary.createMany({
     data: [
@@ -228,7 +224,6 @@ describe("成績値の確定（凍結）", () => {
       data: {
         gradeId: fixture.gradeId,
         studentId: fixture.studentId,
-        targetType: "grade_item",
         gradeItemId: fixture.gradeItemId,
         overrideLabel: "B",
       },
@@ -255,7 +250,6 @@ describe("成績値の確定（凍結）", () => {
       data: {
         gradeId: fixture.gradeId,
         studentId: fixture.studentId,
-        targetType: "grade_item",
         gradeItemId: fixture.gradeItemId,
         overrideLabel: "C",
       },

--- a/__tests__/grade/integration/gradeItemCrud.test.ts
+++ b/__tests__/grade/integration/gradeItemCrud.test.ts
@@ -316,26 +316,7 @@ describe("GradeBoundary CRUD", () => {
     await cleanupTestDatabase()
   })
 
-  it("overall境界セットを作成できる", async () => {
-    const grade = await createTestGrade()
-
-    const result = await upsertBoundarySet({
-      gradeId: grade.id,
-      targetType: "overall",
-      gradeItemId: null,
-      boundaries: [
-        { label: "A", minPercentage: 80, order: 0 },
-        { label: "B", minPercentage: 60, order: 1 },
-        { label: "C", minPercentage: 0, order: 2 },
-      ],
-    })
-
-    expect(result.success).toBe(true)
-    expect(result.boundarySet!.boundaries).toHaveLength(3)
-    expect(result.boundarySet!.targetType).toBe("overall")
-  })
-
-  it("grade_item境界セットを作成できる", async () => {
+  it("評価項目の境界セットを作成できる", async () => {
     const grade = await createTestGrade()
     const gradeItemResult = await createGradeItem({
       gradeId: grade.id,
@@ -344,7 +325,6 @@ describe("GradeBoundary CRUD", () => {
 
     const result = await upsertBoundarySet({
       gradeId: grade.id,
-      targetType: "grade_item",
       gradeItemId: gradeItemResult.gradeItem!.id,
       boundaries: [
         { label: "A", minPercentage: 90, order: 0 },
@@ -358,18 +338,20 @@ describe("GradeBoundary CRUD", () => {
 
   it("同一キーで再upsertすると境界が置換される", async () => {
     const grade = await createTestGrade()
+    const gradeItemResult = await createGradeItem({
+      gradeId: grade.id,
+      name: "知識・技能",
+    })
 
     await upsertBoundarySet({
       gradeId: grade.id,
-      targetType: "overall",
-      gradeItemId: null,
+      gradeItemId: gradeItemResult.gradeItem!.id,
       boundaries: [{ label: "A", minPercentage: 80, order: 0 }],
     })
 
     const result = await upsertBoundarySet({
       gradeId: grade.id,
-      targetType: "overall",
-      gradeItemId: null,
+      gradeItemId: gradeItemResult.gradeItem!.id,
       boundaries: [
         { label: "S", minPercentage: 95, order: 0 },
         { label: "A", minPercentage: 80, order: 1 },
@@ -384,21 +366,23 @@ describe("GradeBoundary CRUD", () => {
 
   it("getBoundarySetsByGradeIdで全セットを取得できる", async () => {
     const grade = await createTestGrade()
-    const gradeItemResult = await createGradeItem({
+    const firstItem = await createGradeItem({
       gradeId: grade.id,
-      name: "項目",
+      name: "項目1",
+    })
+    const secondItem = await createGradeItem({
+      gradeId: grade.id,
+      name: "項目2",
     })
 
     await upsertBoundarySet({
       gradeId: grade.id,
-      targetType: "overall",
-      gradeItemId: null,
+      gradeItemId: firstItem.gradeItem!.id,
       boundaries: [{ label: "A", minPercentage: 80, order: 0 }],
     })
     await upsertBoundarySet({
       gradeId: grade.id,
-      targetType: "grade_item",
-      gradeItemId: gradeItemResult.gradeItem!.id,
+      gradeItemId: secondItem.gradeItem!.id,
       boundaries: [{ label: "B", minPercentage: 70, order: 0 }],
     })
 

--- a/__tests__/grade/integration/manualScoreCrud.test.ts
+++ b/__tests__/grade/integration/manualScoreCrud.test.ts
@@ -53,11 +53,14 @@ describe("GradeBoundary 追加テスト", () => {
       const grade = await testPrisma.grade.create({
         data: { name: "PJ" },
       })
+      const gradeItemResult = await createGradeItem({
+        gradeId: grade.id,
+        name: "知識・技能",
+      })
 
       const upserted = await upsertBoundarySet({
         gradeId: grade.id,
-        targetType: "overall",
-        gradeItemId: null,
+        gradeItemId: gradeItemResult.gradeItem!.id,
         boundaries: [
           { label: "A", minPercentage: 80, order: 0 },
           { label: "B", minPercentage: 60, order: 1 },
@@ -78,11 +81,14 @@ describe("GradeBoundary 追加テスト", () => {
       const grade = await testPrisma.grade.create({
         data: { name: "PJ" },
       })
+      const gradeItemResult = await createGradeItem({
+        gradeId: grade.id,
+        name: "知識・技能",
+      })
 
       const upserted = await upsertBoundarySet({
         gradeId: grade.id,
-        targetType: "overall",
-        gradeItemId: null,
+        gradeItemId: gradeItemResult.gradeItem!.id,
         boundaries: [
           { label: "A", minPercentage: 80, order: 0 },
           { label: "B", minPercentage: 60, order: 1 },

--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -123,8 +123,7 @@ function buildGrade(
     }[]
     boundarySets?: {
       id: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       boundaries: {
         label: string
         minPercentage: unknown
@@ -267,18 +266,7 @@ describe("calculateGrades", () => {
       boundarySets: [
         {
           id: "bs1",
-          targetType: "grade_item",
           gradeItemId: "gi1",
-          boundaries: [
-            { label: "A", minPercentage: 80, order: 0 },
-            { label: "B", minPercentage: 60, order: 1 },
-            { label: "C", minPercentage: 0, order: 2 },
-          ],
-        },
-        {
-          id: "bs2",
-          targetType: "overall",
-          gradeItemId: null,
           boundaries: [
             { label: "A", minPercentage: 80, order: 0 },
             { label: "B", minPercentage: 60, order: 1 },
@@ -304,10 +292,6 @@ describe("calculateGrades", () => {
     expect(gradeItemResult.percentage).toBeCloseTo(85, 1)
     expect(gradeItemResult.gradeLabel).toBe("A")
     expect(gradeItemResult.isAllMissing).toBe(false)
-
-    // 総合
-    expect(student.overallPercentage).toBeCloseTo(85, 1)
-    expect(student.overallGradeLabel).toBe("A")
   })
 
   it("複数GradeItemの重み付け合計が正しく計算される", async () => {
@@ -374,10 +358,6 @@ describe("calculateGrades", () => {
     // gi2: 40/50 * 50 = 40 (50max → 80%)
     expect(student.gradeItemResults[1].weightedScore).toBeCloseTo(40)
     expect(student.gradeItemResults[1].percentage).toBeCloseTo(80)
-
-    // overall: (40 + 40) / (50 + 50) * 100 = 80%
-    expect(student.overallScore).toBeCloseTo(80)
-    expect(student.overallPercentage).toBeCloseTo(80)
   })
 
   it("manualScoreがnullの場合は換算合計0点として成績算出する", async () => {
@@ -418,8 +398,6 @@ describe("calculateGrades", () => {
     expect(student.gradeItemResults[0].weightedMaxScore).toBe(100)
     expect(student.gradeItemResults[0].percentage).toBe(0)
     expect(student.gradeItemResults[0].isAllMissing).toBe(true)
-    expect(student.overallScore).toBe(0)
-    expect(student.overallPercentage).toBe(0)
   })
 
   it("境界ラベルが降順で正しくマッチする", async () => {
@@ -451,8 +429,7 @@ describe("calculateGrades", () => {
       boundarySets: [
         {
           id: "bs1",
-          targetType: "overall",
-          gradeItemId: null,
+          gradeItemId: "gi1",
           boundaries: [
             { label: "A", minPercentage: 80, order: 0 },
             { label: "B", minPercentage: 60, order: 1 },
@@ -469,7 +446,7 @@ describe("calculateGrades", () => {
     const student = result.result!.students[0]
 
     // 65% → B (60以上80未満)
-    expect(student.overallGradeLabel).toBe("B")
+    expect(student.gradeItemResults[0].gradeLabel).toBe("B")
   })
 
   it("GradeItem内の複数DataSourceが正しく合算される", async () => {
@@ -689,13 +666,13 @@ describe("calculateGrades", () => {
     expect(student.gradeItemResults[1].percentage).toBeNull()
     expect(student.gradeItemResults[1].sourceScores).toHaveLength(0)
 
-    // 総合スコアはgi1のみ（100点満点で85%）
-    expect(student.overallMaxScore).toBe(100)
-    expect(student.overallScore).toBeCloseTo(85)
-    expect(student.overallPercentage).toBeCloseTo(85)
+    // 除外されていない gi1 は通常どおり算出される（100点満点で85%）
+    expect(student.gradeItemResults[0].weightedMaxScore).toBe(100)
+    expect(student.gradeItemResults[0].weightedScore).toBeCloseTo(85)
+    expect(student.gradeItemResults[0].percentage).toBeCloseTo(85)
   })
 
-  it("全GradeItem除外時は総合スコアnull", async () => {
+  it("全GradeItem除外時は各項目のスコアがnullになる", async () => {
     const grade = buildGrade({
       gradeItems: [
         {
@@ -733,9 +710,9 @@ describe("calculateGrades", () => {
     const student = result.result!.students[0]
 
     expect(student.gradeItemResults[0].isExcluded).toBe(true)
-    expect(student.overallMaxScore).toBe(0)
-    expect(student.overallScore).toBeNull()
-    expect(student.overallPercentage).toBeNull()
+    expect(student.gradeItemResults[0].weightedMaxScore).toBe(0)
+    expect(student.gradeItemResults[0].weightedScore).toBeNull()
+    expect(student.gradeItemResults[0].percentage).toBeNull()
   })
 
   it("除外なしの既存動作維持（isExcluded: false）", async () => {
@@ -774,7 +751,7 @@ describe("calculateGrades", () => {
 
     expect(student.gradeItemResults[0].isExcluded).toBe(false)
     expect(student.gradeItemResults[0].weightedScore).toBeCloseTo(80)
-    expect(student.overallPercentage).toBeCloseTo(80)
+    expect(student.gradeItemResults[0].percentage).toBeCloseTo(80)
   })
 
   // ===========================================================================
@@ -816,7 +793,6 @@ describe("calculateGrades", () => {
       boundarySets: [
         {
           id: "bs1",
-          targetType: "grade_item",
           gradeItemId: "gi1",
           boundaries: [
             { label: "A", minPercentage: 90, order: 0 },

--- a/__tests__/grade/unit/gradeDetailSheet.test.ts
+++ b/__tests__/grade/unit/gradeDetailSheet.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Excel「詳細」シートの列構成（createDetailSheet）の検証。
+ *
+ * 守りたい不変条件は「ヘッダー行と各生徒の行のセル数が常に一致すること」。
+ * 列は評価項目の dataSources が決めるべきもので、特定の生徒の sourceScores から
+ * 導いてはならない — 除外された生徒は sourceScores が空になるため、基準にした生徒が
+ * 除外だと行のほうが長くなり、以降の点数が別の評価項目のヘッダーの下へずれる。
+ * ずれた表は「整った表」に見えるので、気づかれないまま誤読される。
+ */
+
+import * as ExcelJS from "exceljs"
+import { describe, expect, it } from "vitest"
+
+import { createDetailSheet } from "@/electron-src/lib/export/gradeExcel/gradeSheetCreator"
+import type {
+  GradeCalculationResult,
+  GradeItemResult,
+  SourceScoreResult,
+  StudentGradeResult,
+} from "@/types/grade.types"
+
+const GRADE_ITEMS: GradeCalculationResult["gradeItems"] = [
+  {
+    id: "gi-knowledge",
+    name: "知識・技能",
+    order: 0,
+    dataSources: [
+      { id: "ds-mid", name: "中間" },
+      { id: "ds-final", name: "期末" },
+    ],
+  },
+  {
+    id: "gi-thinking",
+    name: "思考・判断・表現",
+    order: 1,
+    dataSources: [{ id: "ds-report", name: "レポート" }],
+  },
+]
+
+function makeSourceScore(
+  dataSourceId: string,
+  dataSourceName: string,
+  weightedScore: number
+): SourceScoreResult {
+  return {
+    dataSourceId,
+    dataSourceName,
+    type: "coursework",
+    rawScore: weightedScore,
+    maxScore: 100,
+    weight: 50,
+    weightedScore,
+    isEstimated: false,
+    estimation: null,
+    letterValue: null,
+    adjustment: null,
+    adjustmentReason: null,
+    comment: null,
+  }
+}
+
+function makeItemResult(
+  gradeItem: GradeCalculationResult["gradeItems"][number],
+  options: { excluded?: boolean } = {}
+): GradeItemResult {
+  const excluded = options.excluded ?? false
+  return {
+    gradeItemId: gradeItem.id,
+    gradeItemName: gradeItem.name,
+    isExcluded: excluded,
+    isAllMissing: false,
+    // 除外された生徒は算出側で sourceScores が空になる（gradeCalculator の除外分岐）
+    sourceScores: excluded
+      ? []
+      : gradeItem.dataSources.map((dataSource, index) =>
+          makeSourceScore(dataSource.id, dataSource.name, 10 + index)
+        ),
+    weightedScore: excluded ? null : 42,
+    weightedMaxScore: excluded ? 0 : 100,
+    percentage: excluded ? null : 42,
+    gradeLabel: excluded ? null : "B",
+    originalGradeLabel: excluded ? null : "B",
+    overrideGradeLabel: null,
+    frozen: null,
+  }
+}
+
+function makeStudent(
+  id: string,
+  excludedItemIds: string[] = []
+): StudentGradeResult {
+  return {
+    studentId: id,
+    studentNumber: id,
+    lastName: id,
+    firstName: "",
+    attendanceNumber: 1,
+    className: null,
+    gradeItemResults: GRADE_ITEMS.map((gradeItem) =>
+      makeItemResult(gradeItem, {
+        excluded: excludedItemIds.includes(gradeItem.id),
+      })
+    ),
+  }
+}
+
+function makeResult(students: StudentGradeResult[]): GradeCalculationResult {
+  return {
+    gradeId: "g1",
+    gradeName: "1学期成績",
+    classNames: [],
+    gradeItems: GRADE_ITEMS,
+    students,
+    boundarySets: [],
+  }
+}
+
+/** 詳細シートを生成し、ヘッダー行と各データ行のセル数を返す */
+function cellCounts(result: GradeCalculationResult): {
+  header: number
+  rows: number[]
+} {
+  const workbook = new ExcelJS.Workbook()
+  createDetailSheet(workbook, result)
+  const sheet = workbook.getWorksheet("詳細")!
+  const header = sheet.getRow(1).cellCount
+  const rows: number[] = []
+  for (let rowNumber = 2; rowNumber <= sheet.rowCount; rowNumber++) {
+    rows.push(sheet.getRow(rowNumber).cellCount)
+  }
+  return { header, rows }
+}
+
+describe("createDetailSheet: 列構成", () => {
+  // 番号 + 氏名 + (知識2ソース + 合計) + (思考1ソース + 合計) = 7
+  const EXPECTED_COLUMNS = 7
+
+  it("ヘッダーは評価項目の dataSources から決まる", () => {
+    const workbook = new ExcelJS.Workbook()
+    createDetailSheet(workbook, makeResult([makeStudent("s1")]))
+    const headerRow = workbook.getWorksheet("詳細")!.getRow(1)
+
+    expect(headerRow.values).toEqual([
+      undefined, // ExcelJS は 1-indexed で先頭が空く
+      "番号",
+      "氏名",
+      "知識・技能/中間",
+      "知識・技能/期末",
+      "知識・技能 合計",
+      "思考・判断・表現/レポート",
+      "思考・判断・表現 合計",
+    ])
+  })
+
+  it("1人目の生徒が除外でも、ヘッダーと全行のセル数が一致する", () => {
+    // 回帰の核: 以前はヘッダーを students[0] から導いていたため、1人目が除外だと
+    // その項目のヘッダーが「合計」1列に縮み、非除外の生徒の行だけが長くなっていた。
+    const { header, rows } = cellCounts(
+      makeResult([
+        makeStudent("s1", ["gi-knowledge"]), // 1人目が知識・技能で除外
+        makeStudent("s2"),
+        makeStudent("s3"),
+      ])
+    )
+
+    expect(header).toBe(EXPECTED_COLUMNS)
+    expect(rows).toEqual([EXPECTED_COLUMNS, EXPECTED_COLUMNS, EXPECTED_COLUMNS])
+  })
+
+  it("全生徒が除外でもヘッダーと行のセル数が一致する", () => {
+    const { header, rows } = cellCounts(
+      makeResult([
+        makeStudent("s1", ["gi-knowledge", "gi-thinking"]),
+        makeStudent("s2", ["gi-knowledge", "gi-thinking"]),
+      ])
+    )
+
+    expect(header).toBe(EXPECTED_COLUMNS)
+    expect(rows).toEqual([EXPECTED_COLUMNS, EXPECTED_COLUMNS])
+  })
+
+  it("1人目が除外でも、非除外の生徒の点数が正しい列に載る", () => {
+    const workbook = new ExcelJS.Workbook()
+    createDetailSheet(
+      workbook,
+      makeResult([makeStudent("s1", ["gi-knowledge"]), makeStudent("s2")])
+    )
+    const sheet = workbook.getWorksheet("詳細")!
+
+    // s1(3行目ではなく2行目): 知識は除外3セル分、思考は実数
+    expect(sheet.getRow(2).values).toEqual([
+      undefined,
+      1,
+      "s1 ",
+      "除外",
+      "除外",
+      "除外",
+      10, // 思考/レポート
+      42, // 思考 合計
+    ])
+    // s2: 知識の2ソース + 合計、思考の1ソース + 合計がずれずに並ぶ
+    expect(sheet.getRow(3).values).toEqual([
+      undefined,
+      1,
+      "s2 ",
+      10, // 知識/中間
+      11, // 知識/期末
+      42, // 知識 合計
+      10, // 思考/レポート
+      42, // 思考 合計
+    ])
+  })
+
+  it("sourceScores の並びが dataSources と違っても id で正しい列に載る", () => {
+    // 添字一致に依存していないことの確認（並びは実装詳細であって契約ではない）
+    const student = makeStudent("s1")
+    const knowledge = student.gradeItemResults[0]
+    knowledge.sourceScores = [...knowledge.sourceScores].reverse()
+
+    const workbook = new ExcelJS.Workbook()
+    createDetailSheet(workbook, makeResult([student]))
+    const sheet = workbook.getWorksheet("詳細")!
+
+    // 中間=10 / 期末=11 が、並べ替え後もそれぞれの列に載る
+    // （ExcelJS は 1 始まり: 1=番号, 2=氏名, 3=知識/中間, 4=知識/期末）
+    expect(sheet.getRow(2).getCell(3).value).toBe(10)
+    expect(sheet.getRow(2).getCell(4).value).toBe(11)
+  })
+})

--- a/__tests__/grades/gradeConstraints.test.ts
+++ b/__tests__/grades/gradeConstraints.test.ts
@@ -18,9 +18,9 @@ import type {
 } from "@/types/grade.types"
 
 const GRADE_ITEMS = [
-  { id: "gi-knowledge", name: "知識・技能", order: 0 },
-  { id: "gi-thinking", name: "思考・判断・表現", order: 1 },
-  { id: "gi-attitude", name: "態度", order: 2 },
+  { id: "gi-knowledge", name: "知識・技能", order: 0, dataSources: [] },
+  { id: "gi-thinking", name: "思考・判断・表現", order: 1, dataSources: [] },
+  { id: "gi-attitude", name: "態度", order: 2, dataSources: [] },
 ]
 
 /** 観点3つのラベルから生徒結果を作る */
@@ -49,12 +49,6 @@ function makeStudent(
       overrideGradeLabel: null,
       frozen: null,
     })),
-    overallScore: null,
-    overallMaxScore: 0,
-    overallPercentage: null,
-    overallGradeLabel: null,
-    originalOverallGradeLabel: null,
-    overrideOverallGradeLabel: null,
   }
 }
 
@@ -94,10 +88,10 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
   // 実データ構成: 知識・技能/思考・判断・表現/態度(A/B/C) + 評定(5..1) の4項目。
   // すべて GradeItem 同士の比較。評定 GradeItem を比較先にする。
   const ITEMS_WITH_HYOTEI = [
-    { id: "gi-k", name: "知識・技能", order: 0 },
-    { id: "gi-s", name: "思考・判断・表現", order: 1 },
-    { id: "gi-a", name: "態度", order: 2 },
-    { id: "gi-h", name: "評定", order: 3 },
+    { id: "gi-k", name: "知識・技能", order: 0, dataSources: [] },
+    { id: "gi-s", name: "思考・判断・表現", order: 1, dataSources: [] },
+    { id: "gi-a", name: "態度", order: 2, dataSources: [] },
+    { id: "gi-h", name: "評定", order: 3, dataSources: [] },
   ]
 
   function makeStudent4(
@@ -134,12 +128,6 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
         overrideGradeLabel: null,
         frozen: null,
       })),
-      overallScore: null,
-      overallMaxScore: 1,
-      overallPercentage: null,
-      overallGradeLabel: null, // overall は未設定
-      originalOverallGradeLabel: null,
-      overrideOverallGradeLabel: null,
     }
   }
 
@@ -152,7 +140,6 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
       students,
       boundarySets: [
         {
-          targetType: "grade_item",
           gradeItemId: "gi-h",
           boundaries: [
             { label: "5", minPercentage: 80 },

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -1074,6 +1074,377 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(imported[0].frozenByUserId).toBeNull()
   })
 
+  it("同名の評価項目があっても uuid 照合で取り違えない (v1.10.0)", async () => {
+    // 評価項目名は unique ではない（GradeItem に (gradeId, name) 制約が無い）。
+    // 名前だけで照合すると、境界・上書き・確定値が別の同名項目へ付いてしまう。
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SD${suffix}`,
+        lastName: "同名",
+        firstName: "太郎",
+        lastNameKana: "ドウメイ",
+        firstNameKana: "タロウ",
+      },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_dup_${suffix}` },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    // 同じ名前の評価項目を2つ作る（1つ目は「寄せられる先」になりうる側）
+    await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 0 },
+    })
+    const secondItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 1 },
+    })
+    // 確定値・上書き・境界はすべて「2つ目」に付ける
+    await prisma.gradeFrozenScore.create({
+      data: {
+        gradeId: grade.id,
+        studentId: student.id,
+        gradeItemId: secondItem.id,
+        weightedScore: 0.7,
+        weightedMaxScore: 1,
+        percentage: 70,
+        gradeLabel: "3",
+      },
+    })
+    await prisma.gradeOverride.create({
+      data: {
+        gradeId: grade.id,
+        studentId: student.id,
+        gradeItemId: secondItem.id,
+        overrideLabel: "4",
+      },
+    })
+    const boundarySet = await prisma.gradeBoundarySet.create({
+      data: { gradeId: grade.id, gradeItemId: secondItem.id },
+    })
+    await prisma.gradeBoundary.create({
+      data: {
+        gradeBoundarySetId: boundarySet.id,
+        label: "3",
+        minPercentage: 50,
+        order: 0,
+      },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    // 参照は uuid を持ち出している
+    expect(collected.gradeData.gradeItems[1].id).toBe(secondItem.id)
+    expect(collected.gradeData.gradeFrozenScores![0].gradeItemId).toBe(
+      secondItem.id
+    )
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    // 取り込み先でも「2つ目」の評価項目に付いていること（1つ目へ寄らない）
+    const importedItems = await prisma.gradeItem.findMany({
+      where: { gradeId: result.gradeId! },
+      orderBy: { order: "asc" },
+    })
+    expect(importedItems).toHaveLength(2)
+    const importedSecondId = importedItems[1].id
+
+    const frozen = await prisma.gradeFrozenScore.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(frozen).toHaveLength(1)
+    expect(frozen[0].gradeItemId).toBe(importedSecondId)
+
+    const overrides = await prisma.gradeOverride.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0].gradeItemId).toBe(importedSecondId)
+
+    const boundarySets = await prisma.gradeBoundarySet.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(boundarySets).toHaveLength(1)
+    expect(boundarySets[0].gradeItemId).toBe(importedSecondId)
+  })
+
+  it("uuid を持たない旧アーカイブで同名項目があれば、取り違えず警告して落とす", async () => {
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SL${suffix}`,
+        lastName: "旧版",
+        firstName: "花子",
+        lastNameKana: "キュウハン",
+        firstNameKana: "ハナコ",
+      },
+    })
+    await prisma.classroom.create({ data: { name: `C${suffix}` } })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_legacy_${suffix}` },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 0 },
+    })
+    await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 1 },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    const archive = toArchive(grade.id, collected)
+    // uuid を持たない v1.9.0 以前のアーカイブを再現する
+    archive.gradeData.gradeItems = archive.gradeData.gradeItems.map(
+      (gradeItem) => ({ ...gradeItem, id: undefined })
+    )
+    archive.gradeData.gradeOverrides = [
+      {
+        studentNumber: `SL${suffix}`,
+        gradeItemName: "評定",
+        overrideLabel: "4",
+      },
+    ]
+
+    const result = await importGradeArchive(archive)
+    expect(result.success).toBe(true)
+
+    // どちらの項目か決められないので取り込まず、その旨を警告する
+    const overrides = await prisma.gradeOverride.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(overrides).toHaveLength(0)
+    expect(
+      result.warnings?.some((warning) => warning.includes("同名の評価項目"))
+    ).toBe(true)
+  })
+
+  it("学籍番号・学級名・試験名が変わっても uuid で照合できる (v1.10.0)", async () => {
+    // uuid 一次照合の核。名前や学籍番号は取り込み先で変わりうる（改姓・学級名変更・
+    // 試験名の付け替え）が、同一PC由来なら uuid で確実に当たる。
+    const suffix = Date.now()
+    const classroom = await prisma.classroom.create({
+      data: { name: `旧学級_${suffix}` },
+    })
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `OLD${suffix}`,
+        lastName: "変更",
+        firstName: "前",
+        lastNameKana: "ヘンコウ",
+        firstNameKana: "マエ",
+      },
+    })
+    await prisma.studentClassroomMembership.create({
+      data: { classroomId: classroom.id, studentId: student.id },
+    })
+    const exam = await prisma.exam.create({
+      data: { examName: `旧試験_${suffix}` },
+    })
+
+    const grade = await prisma.grade.create({
+      data: { name: `成績_uuid_${suffix}` },
+    })
+    await prisma.gradeClassroom.create({
+      data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id, customOrder: 3 },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeDataSource.create({
+      data: {
+        gradeItemId: gradeItem.id,
+        type: "exam_total",
+        examId: exam.id,
+        name: "期末",
+        weight: 100,
+        order: 0,
+      },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.studentRefs[0].id).toBe(student.id)
+    expect(collected.gradeData.classroomRefs[0].id).toBe(classroom.id)
+    expect(collected.gradeData.gradeItems[0].dataSources[0].examId).toBe(
+      exam.id
+    )
+
+    // 取り込み前に名前・学籍番号をすべて変える（名前照合なら全滅する状況）
+    await prisma.student.update({
+      where: { id: student.id },
+      data: { studentNumber: `NEW${suffix}`, lastName: "変更後" },
+    })
+    await prisma.classroom.update({
+      where: { id: classroom.id },
+      data: { name: `新学級_${suffix}` },
+    })
+    await prisma.exam.update({
+      where: { id: exam.id },
+      data: { examName: `新試験_${suffix}` },
+    })
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    // 学級・生徒・試験すべてが uuid で解決されている
+    const importedClassrooms = await prisma.gradeClassroom.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(importedClassrooms).toHaveLength(1)
+    expect(importedClassrooms[0].classroomId).toBe(classroom.id)
+
+    const importedStudents = await prisma.gradeStudent.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    expect(importedStudents).toHaveLength(1)
+    expect(importedStudents[0].studentId).toBe(student.id)
+    expect(importedStudents[0].customOrder).toBe(3)
+
+    const importedDataSources = await prisma.gradeDataSource.findMany({
+      where: { gradeItem: { gradeId: result.gradeId! } },
+    })
+    expect(importedDataSources).toHaveLength(1)
+    expect(importedDataSources[0].examId).toBe(exam.id)
+  })
+
+  it("uuid を持たない旧アーカイブは従来どおり学籍番号・名前で照合する", async () => {
+    const suffix = Date.now()
+    const classroom = await prisma.classroom.create({
+      data: { name: `学級L_${suffix}` },
+    })
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `LG${suffix}`,
+        lastName: "旧式",
+        firstName: "太郎",
+        lastNameKana: "キュウシキ",
+        firstNameKana: "タロウ",
+      },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_legacyref_${suffix}` },
+    })
+    await prisma.gradeClassroom.create({
+      data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    const archive = toArchive(grade.id, collected)
+    // v1.9.0 以前を再現: 外部参照から uuid を落とす
+    archive.gradeData.studentRefs = archive.gradeData.studentRefs.map(
+      (studentRef) => ({ ...studentRef, id: undefined })
+    )
+    archive.gradeData.classroomRefs = archive.gradeData.classroomRefs.map(
+      (classroomRef) => ({ ...classroomRef, id: undefined })
+    )
+
+    const result = await importGradeArchive(archive)
+    expect(result.success).toBe(true)
+
+    expect(
+      await prisma.gradeStudent.findMany({
+        where: { gradeId: result.gradeId! },
+      })
+    ).toHaveLength(1)
+    expect(
+      await prisma.gradeClassroom.findMany({
+        where: { gradeId: result.gradeId! },
+      })
+    ).toHaveLength(1)
+  })
+
+  it("同名の小計が別試験にあっても、参照先の試験の小計に紐づく (v1.10.0)", async () => {
+    // 旧実装は subtotal.findMany({ where: { name } }) と試験で絞らずに検索し
+    // 先頭を採っていたため、別試験の同名小計に紐づきうる状態だった。
+    const suffix = Date.now()
+    const targetExam = await prisma.exam.create({
+      data: { examName: `対象試験_${suffix}` },
+    })
+    const otherExam = await prisma.exam.create({
+      data: { examName: `無関係試験_${suffix}` },
+    })
+    // どちらの試験にも同じ名前の小計を持つグループを付ける
+    const makeSubtotal = async (examId: string, groupName: string) => {
+      const group = await prisma.subtotalGroup.create({
+        data: { name: groupName },
+      })
+      await prisma.examSubtotalGroup.create({
+        data: { examId, subtotalGroupId: group.id },
+      })
+      return prisma.subtotal.create({
+        data: { subtotalGroupId: group.id, name: "大問1", order: 0 },
+      })
+    }
+    // 無関係な試験の小計を先に作る（先頭採用なら誤ってこちらに当たる）
+    const otherSubtotal = await makeSubtotal(
+      otherExam.id,
+      `他グループ_${suffix}`
+    )
+    const targetSubtotal = await makeSubtotal(
+      targetExam.id,
+      `対象グループ_${suffix}`
+    )
+
+    const grade = await prisma.grade.create({
+      data: { name: `成績_subtotal_${suffix}` },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeDataSource.create({
+      data: {
+        gradeItemId: gradeItem.id,
+        type: "subtotal",
+        examId: targetExam.id,
+        subtotalId: targetSubtotal.id,
+        name: "大問1参照",
+        weight: 100,
+        order: 0,
+      },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    expect(collected.gradeData.gradeItems[0].dataSources[0].subtotalId).toBe(
+      targetSubtotal.id
+    )
+
+    // uuid あり: 一次照合で対象の小計に当たる
+    const withUuid = await importGradeArchive(toArchive(grade.id, collected))
+    expect(withUuid.success).toBe(true)
+    const uuidSources = await prisma.gradeDataSource.findMany({
+      where: { gradeItem: { gradeId: withUuid.gradeId! } },
+    })
+    expect(uuidSources[0].subtotalId).toBe(targetSubtotal.id)
+
+    // uuid なし（v1.9.0 以前）: 名前フォールバックでも試験で絞られ、
+    // 無関係な試験の同名小計には当たらない
+    const legacyArchive = toArchive(grade.id, collected)
+    legacyArchive.gradeData.gradeItems = legacyArchive.gradeData.gradeItems.map(
+      (item) => ({
+        ...item,
+        dataSources: item.dataSources.map((dataSource) => ({
+          ...dataSource,
+          subtotalId: undefined,
+        })),
+      })
+    )
+    const legacy = await importGradeArchive(legacyArchive)
+    expect(legacy.success).toBe(true)
+    const legacySources = await prisma.gradeDataSource.findMany({
+      where: { gradeItem: { gradeId: legacy.gradeId! } },
+    })
+    expect(legacySources[0].subtotalId).toBe(targetSubtotal.id)
+    expect(legacySources[0].subtotalId).not.toBe(otherSubtotal.id)
+  })
+
   it("gradeFrozenScores が無いGradeも問題なく往復する（後方互換）", async () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_nofrozen_${Date.now()}` },

--- a/__tests__/import-export/unit/gradeTransformerChain.test.ts
+++ b/__tests__/import-export/unit/gradeTransformerChain.test.ts
@@ -1,0 +1,183 @@
+/**
+ * grade-archive バージョン変換チェーン（transformGradeToLatest）の検証。
+ *
+ * 守りたい不変条件は「旧 .grade を読み込んだとき、現行形式へ正規化され、
+ * 失われるデータは warning として必ず利用者に伝わること」。
+ *
+ * 検出は manifest.version ではなくデータ形状で行う設計なので、テストも
+ * 「旧バージョンが実際に書き出していた形」をフィクスチャにする。version 文字列を
+ * 現行値に偽装したフィクスチャは検出経路を素通りしてしまい検証にならない。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { transformGradeToLatest } from "../../../electron-src/lib/import/grade-transformers"
+import type {
+  GradeArchiveData,
+  GradeArchiveManifest,
+} from "../../../src/types/gradeArchive.types"
+
+const manifest: GradeArchiveManifest = {
+  version: "1.9.0",
+  appVersion: "0.15.0",
+  exportedAt: "2026-07-01T00:00:00.000Z",
+  gradeId: "g1",
+  gradeName: "1学期成績",
+  counts: {
+    gradeItems: 1,
+    dataSources: 0,
+    manualScores: 0,
+    boundarySets: 2,
+    boundaries: 0,
+    classrooms: 0,
+    students: 0,
+  },
+}
+
+/**
+ * v1.9.0 が実際に書き出していた形。境界セット・手動上書きが targetType を持ち、
+ * 総合は gradeItemName が null。courseworkArchive は 1.5.0 以降の現行形式。
+ */
+function buildV1_9_0Archive(): GradeArchiveData {
+  return {
+    manifest,
+    gradeData: {
+      grade: { name: "1学期成績", description: null, referenceDate: null },
+      gradeItems: [{ name: "知識・技能", order: 0, dataSources: [] }],
+      classroomRefs: [],
+      examRefs: [],
+      studentRefs: [],
+      gradeOverrides: [
+        {
+          studentNumber: "S001",
+          targetType: "grade_item",
+          gradeItemName: "知識・技能",
+          overrideLabel: "A",
+        },
+        {
+          studentNumber: "S001",
+          targetType: "overall",
+          gradeItemName: null,
+          overrideLabel: "5",
+        },
+      ],
+    },
+    courseworkArchive: {
+      courseworks: [],
+      studentsData: [],
+      classesData: [],
+      membershipsData: [],
+      tagsData: [],
+      counts: {
+        courseworks: 0,
+        items: 0,
+        scores: 0,
+        students: 0,
+        classrooms: 0,
+      },
+    },
+    boundariesData: {
+      boundarySets: [
+        {
+          targetType: "grade_item",
+          gradeItemName: "知識・技能",
+          boundaries: [{ label: "A", minPercentage: 80, order: 0 }],
+        },
+        {
+          targetType: "overall",
+          gradeItemName: null,
+          boundaries: [{ label: "5", minPercentage: 84, order: 0 }],
+        },
+      ],
+    },
+  }
+}
+
+describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => {
+  it("総合の境界セット・手動上書きが破棄され、評価項目のものは残る", () => {
+    const { data } = transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(data.boundariesData.boundarySets).toHaveLength(1)
+    expect(data.boundariesData.boundarySets[0].gradeItemName).toBe("知識・技能")
+    expect(data.gradeData.gradeOverrides).toHaveLength(1)
+    expect(data.gradeData.gradeOverrides![0].gradeItemName).toBe("知識・技能")
+    expect(data.gradeData.gradeOverrides![0].overrideLabel).toBe("A")
+  })
+
+  it("破棄した件数が warning として利用者に伝わる（黙って消さない）", () => {
+    const { warnings } = transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(warnings.some((warning) => warning.includes("成績境界セット"))).toBe(
+      true
+    )
+    expect(warnings.some((warning) => warning.includes("手動上書き"))).toBe(
+      true
+    )
+    // 件数が本文に出ていること（0件でも warning が出る誤りの検出）
+    expect(warnings.join("\n")).toContain("1 件")
+  })
+
+  it("targetType は新形式へ持ち越さない", () => {
+    const { data } = transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(data.boundariesData.boundarySets[0].targetType).toBeUndefined()
+    expect(data.gradeData.gradeOverrides![0].targetType).toBeUndefined()
+  })
+
+  it("元バージョンを 1.9.0 と報告し、適用した変換と矛盾しない", () => {
+    const { originalVersion, finalVersion, appliedTransformations } =
+      transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(originalVersion).toBe("1.9.0")
+    expect(finalVersion).toBe("1.10.0")
+    expect(appliedTransformations).toContainEqual({
+      from: "1.9.0",
+      to: "1.10.0",
+    })
+  })
+
+  it("manifest.version が現行へ更新される", () => {
+    const { data } = transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(data.manifest.version).toBe("1.10.0")
+  })
+
+  it("総合の名残が無い現行アーカイブは変換されず warning も出ない", () => {
+    const archive = buildV1_9_0Archive()
+    // 現行形式＝targetType 無し・gradeItemName は必ず非null
+    archive.boundariesData.boundarySets = [
+      {
+        gradeItemName: "知識・技能",
+        boundaries: [{ label: "A", minPercentage: 80, order: 0 }],
+      },
+    ]
+    archive.gradeData.gradeOverrides = [
+      {
+        studentNumber: "S001",
+        gradeItemName: "知識・技能",
+        overrideLabel: "A",
+      },
+    ]
+
+    const { warnings, appliedTransformations, originalVersion } =
+      transformGradeToLatest(archive)
+
+    expect(warnings).toEqual([])
+    expect(appliedTransformations).toEqual([])
+    expect(originalVersion).toBe("1.10.0")
+  })
+
+  it("gradeOverrides を持たない旧アーカイブでも境界セットだけ正規化できる", () => {
+    const archive = buildV1_9_0Archive()
+    delete archive.gradeData.gradeOverrides
+
+    const { data, warnings } = transformGradeToLatest(archive)
+
+    expect(data.boundariesData.boundarySets).toHaveLength(1)
+    expect(data.gradeData.gradeOverrides).toBeUndefined()
+    // 上書きは元々0件なので上書き側の warning は出ない
+    expect(warnings.some((warning) => warning.includes("手動上書き"))).toBe(
+      false
+    )
+  })
+})

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -657,12 +657,7 @@ export async function seedGradeProject(
   ]
   for (const gradeItemId of gradeItemIds) {
     const boundarySet = await db.gradeBoundarySet.create({
-      data: {
-        id: randomUUID(),
-        gradeId,
-        targetType: "grade_item",
-        gradeItemId,
-      },
+      data: { id: randomUUID(), gradeId, gradeItemId },
     })
     for (
       let boundaryIndex = 0;
@@ -679,24 +674,6 @@ export async function seedGradeProject(
         },
       })
     }
-  }
-  const overallBoundarySet = await db.gradeBoundarySet.create({
-    data: { id: randomUUID(), gradeId, targetType: "overall" },
-  })
-  for (
-    let boundaryIndex = 0;
-    boundaryIndex < boundaryLabels.length;
-    boundaryIndex++
-  ) {
-    await db.gradeBoundary.create({
-      data: {
-        id: randomUUID(),
-        gradeBoundarySetId: overallBoundarySet.id,
-        label: boundaryLabels[boundaryIndex].label,
-        minPercentage: boundaryLabels[boundaryIndex].minPercentage,
-        order: boundaryIndex,
-      },
-    })
   }
 
   console.log(`  [SEED] 成績算出プロジェクト (gradeId=${gradeId})`)

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -344,8 +344,7 @@ export function setupGradeHandlers(): void {
     "grade:upsertBoundarySet",
     async (data: {
       gradeId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       boundaries: { label: string; minPercentage: number; order: number }[]
     }) => {
       return upsertBoundarySet(data)
@@ -365,8 +364,7 @@ export function setupGradeHandlers(): void {
     async (data: {
       gradeId: string
       studentId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       overrideLabel: string
     }) => {
       return upsertGradeOverride(data)
@@ -378,8 +376,7 @@ export function setupGradeHandlers(): void {
     async (data: {
       gradeId: string
       studentId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
     }) => {
       return deleteGradeOverride(data)
     }

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -7,6 +7,7 @@ import { app } from "electron"
 import * as fs from "fs"
 
 import type { GradeArchiveManifest } from "../../../../src/types/gradeArchive.types"
+import { GRADE_CURRENT_VERSION } from "../../../../src/types/gradeArchive.types"
 import { recordAuditLog } from "../../prisma/auditLog"
 import { collectGradeArchiveData } from "./gradeArchiveDataCollector"
 
@@ -26,10 +27,10 @@ export async function createGradeArchive(
     const data = await collectGradeArchiveData(gradeId)
 
     const manifest: GradeArchiveManifest = {
-      // v1.6.0: GradeDataSource.maxScore 廃止（満点はライブ算出・export では未出力）。
-      //   v1.5.0: 試験外成績資料を coursework-archive 形式（UUIDベース）で内包。
-      //   ※ v1.5.0 以前は読み取り後方互換のみ。バージョン履歴は gradeArchive.types.ts 参照。
-      version: "1.6.0",
+      // バージョンは定数から取る。文字列を直書きすると GRADE_CURRENT_VERSION を上げても
+      // 書き出す manifest が古いままになる（exam / coursework / asb と同じ扱いに揃える）。
+      // バージョン履歴は gradeArchive.types.ts の GradeArchiveVersion コメント参照。
+      version: GRADE_CURRENT_VERSION,
       appVersion: getAppVersion(),
       exportedAt: new Date().toISOString(),
       gradeId,

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -103,6 +103,8 @@ export async function collectGradeArchiveData(
   )
 
   const gradeItems = grade.gradeItems.map((gradeItem) => ({
+    // 照合の一次キー。名前は unique でないので id を必ず持ち出す
+    id: gradeItem.id,
     name: gradeItem.name,
     order: gradeItem.order,
     dataSources: gradeItem.dataSources.map((dataSource) => ({
@@ -151,6 +153,11 @@ export async function collectGradeArchiveData(
         dataSource.type === "coursework"
           ? (dataSource.courseworkItem?.name ?? null)
           : null,
+      // 参照の一次キー。試験名・小計名・領域ラベルはいずれも同定に足りないので
+      // id を持ち出す（小計名はグループ内でしか一意でない）
+      examId: dataSource.examId,
+      subtotalId: dataSource.subtotalId,
+      cropRegionId: dataSource.cropRegionId,
     })),
   }))
 
@@ -167,12 +174,14 @@ export async function collectGradeArchiveData(
         dataSource.exam
     )
     .map((dataSource) => ({
+      id: dataSource.examId ?? undefined,
       examName: dataSource.exam!.examName,
       examDate: dataSource.exam!.examDate?.toISOString() ?? null,
       dataSourceName: dataSource.name,
     }))
 
   const classroomRefs = grade.gradeClassrooms.map((gradeClassroom) => ({
+    id: gradeClassroom.classroomId,
     name: gradeClassroom.classroom.name,
   }))
 
@@ -181,6 +190,7 @@ export async function collectGradeArchiveData(
       (studentMembership) => classroomIds.has(studentMembership.classroomId)
     )
     return {
+      id: gradeStudent.studentId,
       studentNumber: gradeStudent.student.studentNumber,
       classroomName: membership?.classroom.name ?? null,
       customOrder: gradeStudent.customOrder,
@@ -202,8 +212,8 @@ export async function collectGradeArchiveData(
   const manualScoresCount = courseworkArchive.counts.scores
 
   const boundarySets = grade.boundarySets.map((boundarySet) => ({
-    targetType: boundarySet.targetType,
-    gradeItemName: boundarySet.gradeItem?.name ?? null,
+    gradeItemId: boundarySet.gradeItemId,
+    gradeItemName: boundarySet.gradeItem.name,
     boundaries: boundarySet.boundaries.map((boundary) => ({
       label: boundary.label,
       minPercentage: Number(boundary.minPercentage),
@@ -224,14 +234,15 @@ export async function collectGradeArchiveData(
   const gradeItemExclusions = grade.gradeItemExclusions.map(
     (gradeItemExclusion) => ({
       studentNumber: gradeItemExclusion.student.studentNumber,
+      gradeItemId: gradeItemExclusion.gradeItemId,
       gradeItemName: gradeItemExclusion.gradeItem.name,
     })
   )
 
   const gradeOverrides = grade.gradeOverrides.map((gradeOverride) => ({
     studentNumber: gradeOverride.student.studentNumber,
-    targetType: gradeOverride.targetType,
-    gradeItemName: gradeOverride.gradeItem?.name ?? null,
+    gradeItemId: gradeOverride.gradeItemId,
+    gradeItemName: gradeOverride.gradeItem.name,
     overrideLabel: gradeOverride.overrideLabel,
   }))
 
@@ -239,6 +250,7 @@ export async function collectGradeArchiveData(
   // 無いため出さない（取り込み側で null＝操作者不明になる）。
   const gradeFrozenScores = grade.gradeFrozenScores.map((gradeFrozenScore) => ({
     studentNumber: gradeFrozenScore.student.studentNumber,
+    gradeItemId: gradeFrozenScore.gradeItemId,
     gradeItemName: gradeFrozenScore.gradeItem.name,
     weightedScore:
       gradeFrozenScore.weightedScore !== null

--- a/electron-src/lib/export/gradeExcel/gradeSheetCreator.ts
+++ b/electron-src/lib/export/gradeExcel/gradeSheetCreator.ts
@@ -21,7 +21,6 @@ export function createGradeResultSheet(
     headers.push(`${gradeItem.name} (%)`)
     headers.push(`${gradeItem.name} 成績`)
   }
-  headers.push("総合 (%)", "総合成績")
 
   const headerRow = sheet.addRow(headers)
   headerRow.font = { bold: true }
@@ -78,13 +77,6 @@ export function createGradeResultSheet(
       }
     }
 
-    row.push(
-      student.overallPercentage !== null
-        ? Math.round(student.overallPercentage * 10) / 10
-        : null
-    )
-    row.push(student.overallGradeLabel)
-
     const excelRow = sheet.addRow(row)
 
     // 除外セルにスタイル適用
@@ -124,21 +116,16 @@ export function createDetailSheet(
 ): void {
   const sheet = workbook.addWorksheet("詳細")
 
-  // ヘッダー: 番号 / 氏名 / 各GradeItem内の各dataSource
+  // ヘッダー: 番号 / 氏名 / 各GradeItem内の各dataSource。
+  // 列は評価項目そのものの dataSources から決める。特定の生徒の sourceScores を
+  // 基準にしてはならない（除外された生徒は空になり、行ごとに列数が食い違う）。
   const headers = ["番号", "氏名"]
   for (const gradeItem of result.gradeItems) {
-    const firstStudent = result.students[0]
-    const gradeItemResult = firstStudent?.gradeItemResults.find(
-      (gradeItemResult) => gradeItemResult.gradeItemId === gradeItem.id
-    )
-    if (gradeItemResult) {
-      for (const sourceScore of gradeItemResult.sourceScores) {
-        headers.push(`${gradeItem.name}/${sourceScore.dataSourceName}`)
-      }
+    for (const dataSource of gradeItem.dataSources) {
+      headers.push(`${gradeItem.name}/${dataSource.name}`)
     }
     headers.push(`${gradeItem.name} 合計`)
   }
-  headers.push("総合")
 
   const headerRow = sheet.addRow(headers)
   headerRow.font = { bold: true }
@@ -153,7 +140,7 @@ export function createDetailSheet(
     }
   })
 
-  // 番号・氏名以外のヘッダー（データソース名・各観点の合計・総合）はすべて縦書きに
+  // 番号・氏名以外のヘッダー（データソース名・各評価項目の合計）はすべて縦書きに
   // （名前が長く横幅を取るため）
   for (let i = 3; i <= headers.length; i++) {
     headerRow.getCell(i).alignment = {
@@ -174,53 +161,48 @@ export function createDetailSheet(
     const detailExcludedCellIndices: number[] = []
     let colIndex = 2 // 0=番号, 1=氏名
 
+    // ヘッダーと同じく評価項目の dataSources を列の定義として使い、除外でも結果欠落でも
+    // 必ず「dataSources 件数 + 合計1列」を出す。行ごとの列数を構造で揃え、ずれを起こさない。
     for (const gradeItem of result.gradeItems) {
       const gradeItemResult = student.gradeItemResults.find(
         (gradeItemResult) => gradeItemResult.gradeItemId === gradeItem.id
       )
-      if (gradeItemResult) {
-        if (gradeItemResult.isExcluded) {
-          // 除外: DataSource列分 + 合計列の全てを「除外」表示
-          const firstStudent = result.students[0]
-          const referenceGradeItemResult = firstStudent?.gradeItemResults.find(
-            (gradeItemResult) => gradeItemResult.gradeItemId === gradeItem.id
-          )
-          const sourceCount = referenceGradeItemResult?.sourceScores.length ?? 0
-          for (let i = 0; i < sourceCount; i++) {
-            row.push("除外")
-            detailExcludedCellIndices.push(colIndex)
-            colIndex++
-          }
+      const isExcluded = gradeItemResult?.isExcluded ?? false
+
+      for (const dataSource of gradeItem.dataSources) {
+        if (isExcluded) {
           row.push("除外")
           detailExcludedCellIndices.push(colIndex)
-          colIndex++
         } else {
-          for (const sourceScore of gradeItemResult.sourceScores) {
-            row.push(
-              sourceScore.weightedScore !== null
-                ? Math.round(sourceScore.weightedScore * 100) / 100
-                : null
-            )
-            if (sourceScore.isEstimated) {
-              estimatedCellIndices.push(colIndex)
-            }
-            colIndex++
-          }
+          // 位置ではなく dataSourceId で引く（順序の一致に依存しない）
+          const sourceScore = gradeItemResult?.sourceScores.find(
+            (sourceScore) => sourceScore.dataSourceId === dataSource.id
+          )
           row.push(
-            gradeItemResult.weightedScore !== null
-              ? Math.round(gradeItemResult.weightedScore * 100) / 100
+            sourceScore !== undefined && sourceScore.weightedScore !== null
+              ? Math.round(sourceScore.weightedScore * 100) / 100
               : null
           )
-          colIndex++
+          if (sourceScore?.isEstimated) {
+            estimatedCellIndices.push(colIndex)
+          }
         }
+        colIndex++
       }
-    }
 
-    row.push(
-      student.overallScore !== null
-        ? Math.round(student.overallScore * 100) / 100
-        : null
-    )
+      if (isExcluded) {
+        row.push("除外")
+        detailExcludedCellIndices.push(colIndex)
+      } else {
+        row.push(
+          gradeItemResult !== undefined &&
+            gradeItemResult.weightedScore !== null
+            ? Math.round(gradeItemResult.weightedScore * 100) / 100
+            : null
+        )
+      }
+      colIndex++
+    }
 
     const excelRow = sheet.addRow(row)
 

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -14,23 +14,52 @@ import prisma from "../../prisma/client"
 import { importCourseworkData } from "../coursework-archive/dataCreator"
 import { transformGradeToLatest } from "../grade-transformers"
 
+/** アーカイブ側の生徒参照の最小形（uuid一次・学籍番号二次で解決する） */
+interface ArchiveStudentReference {
+  id?: string
+  studentNumber: string
+}
+
+/**
+ * アーカイブの生徒参照から既存 Student を解決する。
+ * uuid 一次（同一PC由来／exam-archive 経由で uuid ごと作られた生徒に当たる）、
+ * 学籍番号二次（別PCで先に登録された生徒に当たる）。
+ * grade-archive は生徒マスタを作らない（既存への lookup のみ）方針なので、
+ * どちらでも当たらなければ null を返し、呼び出し側がスキップする。
+ */
+async function resolveStudent(
+  tx: Prisma.TransactionClient,
+  reference: ArchiveStudentReference
+) {
+  if (reference.id) {
+    const byId = await tx.student.findUnique({ where: { id: reference.id } })
+    if (byId) return byId
+  }
+  return tx.student.findUnique({
+    where: { studentNumber: reference.studentNumber },
+  })
+}
+
 /**
  * インポート前のプレビュー（照合結果）
  */
 export async function previewGradeArchiveImport(
   rawData: GradeArchiveData
 ): Promise<GradeArchiveImportPreview> {
-  // 旧バージョンを現行（courseworkArchive 形式）へ正規化してから照合する
-  const { data } = transformGradeToLatest(rawData)
+  // 旧バージョンを現行（courseworkArchive 形式）へ正規化してから照合する。
+  // 変換で失われるデータの警告は取り込み前に見せる必要があるので捨てない。
+  const { data, warnings } = transformGradeToLatest(rawData)
   const { gradeData } = data
   const courseworkArchive = data.courseworkArchive
 
   // Classroom照合（複数学級対応）
   const classroomMatches = await Promise.all(
     gradeData.classroomRefs.map(async (ref) => {
-      const existing = await prisma.classroom.findUnique({
-        where: { name: ref.name },
-      })
+      const existing =
+        (ref.id
+          ? await prisma.classroom.findUnique({ where: { id: ref.id } })
+          : null) ??
+        (await prisma.classroom.findUnique({ where: { name: ref.name } }))
       return { found: !!existing, name: ref.name }
     })
   )
@@ -38,10 +67,18 @@ export async function previewGradeArchiveImport(
   // Exam照合
   const examMatches = await Promise.all(
     gradeData.examRefs.map(async (ref) => {
-      const exams = await prisma.exam.findMany({
-        where: { examName: ref.examName },
-        select: { id: true },
-      })
+      const byId = ref.id
+        ? await prisma.exam.findUnique({
+            where: { id: ref.id },
+            select: { id: true },
+          })
+        : null
+      const exams = byId
+        ? [byId]
+        : await prisma.exam.findMany({
+            where: { examName: ref.examName },
+            select: { id: true },
+          })
       return {
         examName: ref.examName,
         found: exams.length > 0,
@@ -60,21 +97,45 @@ export async function previewGradeArchiveImport(
     })
   )
 
-  // Student照合
-  const courseworkStudentNumbers =
-    courseworkArchive?.studentsData.map((student) => student.studentNumber) ??
-    []
-  const studentNumbers = [
-    ...courseworkStudentNumbers,
-    ...gradeData.studentRefs.map((studentRef) => studentRef.studentNumber),
+  // Student照合（uuid一次・学籍番号二次）。import 本体と同じ順序で数えないと
+  // 「見つかりません」の件数が実際の取り込み結果とずれる。
+  const studentReferences = [
+    ...(courseworkArchive?.studentsData ?? []),
+    ...gradeData.studentRefs,
   ]
-  const uniqueNumbers = [...new Set(studentNumbers)]
+  const uniqueStudentReferences = new Map<
+    string,
+    { id?: string; studentNumber: string }
+  >()
+  for (const studentReference of studentReferences) {
+    // 学籍番号で名寄せする（同じ生徒が資料側と成績側の両方に現れる）
+    if (!uniqueStudentReferences.has(studentReference.studentNumber)) {
+      uniqueStudentReferences.set(studentReference.studentNumber, {
+        id: studentReference.id,
+        studentNumber: studentReference.studentNumber,
+      })
+    }
+  }
   const existingStudents = await prisma.student.findMany({
-    where: { studentNumber: { in: uniqueNumbers } },
-    select: { studentNumber: true },
+    select: { id: true, studentNumber: true },
   })
+  const existingStudentIds = new Set(
+    existingStudents.map((student) => student.id)
+  )
   const existingNumberSet = new Set(
     existingStudents.map((student) => student.studentNumber)
+  )
+  const resolvedStudentNumbers = [...uniqueStudentReferences.values()].filter(
+    (studentReference) =>
+      (studentReference.id !== undefined &&
+        existingStudentIds.has(studentReference.id)) ||
+      existingNumberSet.has(studentReference.studentNumber)
+  )
+  const uniqueNumbers = [...uniqueStudentReferences.keys()]
+  const resolvedNumberSet = new Set(
+    resolvedStudentNumbers.map(
+      (studentReference) => studentReference.studentNumber
+    )
   )
 
   // 埋め込み資料のマッチング候補（uuid一次・名前二次）を算出
@@ -109,13 +170,12 @@ export async function previewGradeArchiveImport(
     manifest: data.manifest,
     classroomMatches,
     examMatches,
-    studentMatchCount: uniqueNumbers.filter((studentNumber) =>
-      existingNumberSet.has(studentNumber)
-    ).length,
+    studentMatchCount: resolvedNumberSet.size,
     studentMissingCount: uniqueNumbers.filter(
-      (studentNumber) => !existingNumberSet.has(studentNumber)
+      (studentNumber) => !resolvedNumberSet.has(studentNumber)
     ).length,
     courseworkMatches,
+    warnings,
   }
 }
 
@@ -164,12 +224,14 @@ export async function importGradeArchive(
           })
         }
 
-        // 2. Classroom照合→GradeClassroom作成
+        // 2. Classroom照合→GradeClassroom作成（uuid一次・名前二次）
         for (let i = 0; i < gradeData.classroomRefs.length; i++) {
           const ref = gradeData.classroomRefs[i]
-          const classroom = await tx.classroom.findUnique({
-            where: { name: ref.name },
-          })
+          const classroom =
+            (ref.id
+              ? await tx.classroom.findUnique({ where: { id: ref.id } })
+              : null) ??
+            (await tx.classroom.findUnique({ where: { name: ref.name } }))
           if (classroom) {
             await tx.gradeClassroom.create({
               data: {
@@ -181,11 +243,9 @@ export async function importGradeArchive(
           }
         }
 
-        // 3. Student照合→GradeStudent作成
+        // 3. Student照合→GradeStudent作成（uuid一次・学籍番号二次）
         for (const studentRef of gradeData.studentRefs) {
-          const student = await tx.student.findUnique({
-            where: { studentNumber: studentRef.studentNumber },
-          })
+          const student = await resolveStudent(tx, studentRef)
           if (student) {
             await tx.gradeStudent.create({
               data: {
@@ -201,6 +261,45 @@ export async function importGradeArchive(
         //   transformGradeToLatest により旧 v1.3.0(manual)/v1.4.0(名前ベース) は
         //   現行の courseworkArchive 形式へ正規化済み。独立 coursework モジュールへ委譲し、
         //   既存生徒・学級への lookup のみ（allowCreate=false）で grade の従来挙動を維持する。
+        // 評価項目の参照解決。アーカイブ側の uuid → 作成した GradeItem.id という
+        // 「旧世界→新世界」の対応で、DB のどこにも存在しない取り込み固有の情報
+        // （coursework の itemIdToActual と同じ性質）。DB にある構造の写しではない。
+        /** アーカイブ評価項目uuid → 作成した GradeItem.id（照合の一次キー） */
+        const gradeItemIdByArchiveId = new Map<string, string>()
+        /**
+         * 評価項目名 → 作成した GradeItem.id。uuid を持たない v1.9.0 以前の
+         * アーカイブ専用のフォールバック。GradeItem には (gradeId, name) の unique が
+         * 無く名前は衝突しうるので、一次キーには使わない。
+         */
+        const gradeItemIdByName = new Map<string, string>()
+        /** 名前が重複し、名前フォールバックでは一意に定まらない評価項目名 */
+        const ambiguousGradeItemNames = new Set<string>()
+
+        /**
+         * アーカイブ側の評価項目参照から、作成した GradeItem.id を解決する。
+         * uuid 一次・名前二次。名前が曖昧なときは取り違えるより落として警告する
+         * （境界・上書き・確定値は成績そのもので、誤った項目へ付けるほうが害が大きい）。
+         */
+        const resolveGradeItemId = (
+          reference: { gradeItemId?: string; gradeItemName: string | null },
+          describeTarget: () => string
+        ): string | null => {
+          if (reference.gradeItemId) {
+            const byArchiveId = gradeItemIdByArchiveId.get(
+              reference.gradeItemId
+            )
+            if (byArchiveId) return byArchiveId
+          }
+          if (!reference.gradeItemName) return null
+          if (ambiguousGradeItemNames.has(reference.gradeItemName)) {
+            warnings.push(
+              `${describeTarget()}: 同名の評価項目「${reference.gradeItemName}」が複数あり対象を特定できないため取り込みませんでした`
+            )
+            return null
+          }
+          return gradeItemIdByName.get(reference.gradeItemName) ?? null
+        }
+
         /** アーカイブ項目uuid → 実 CourseworkItem.id（DataSource 再リンクの一次キー） */
         const itemIdToActual = new Map<string, string>()
         /** `${courseworkName}:${itemName}` → 実 CourseworkItem.id（名前フォールバック） */
@@ -231,13 +330,23 @@ export async function importGradeArchive(
 
         // 4. GradeItem + DataSource作成
         for (const giData of gradeData.gradeItems) {
-          const gi = await tx.gradeItem.create({
+          const gradeItem = await tx.gradeItem.create({
             data: {
               gradeId: grade.id,
               name: giData.name,
               order: giData.order,
             },
           })
+          // 作った直後に対応を控える。後段の参照解決はこれで賄い、
+          // 書き込みトランザクション中に評価項目を引き直さない。
+          if (giData.id) {
+            gradeItemIdByArchiveId.set(giData.id, gradeItem.id)
+          }
+          if (gradeItemIdByName.has(giData.name)) {
+            ambiguousGradeItemNames.add(giData.name)
+          } else {
+            gradeItemIdByName.set(giData.name, gradeItem.id)
+          }
 
           for (const dsData of giData.dataSources) {
             // 旧アーカイブ互換: project_total → exam_total
@@ -298,15 +407,26 @@ export async function importGradeArchive(
               }
             }
 
+            // 試験照合。uuid 一次（同一PC由来なら確実に当たる）→ ユーザーが
+            // ウィザードで指定したマッピング → 試験名。試験名は unique でないため
+            // 名前だけだと同名試験を取り違える。
             let examId: string | null = null
             if (
-              dsData.examName &&
-              (dsData.type === "exam_total" ||
-                dsData.type === "subtotal" ||
-                dsData.type === "crop_region")
+              dsData.type === "exam_total" ||
+              dsData.type === "subtotal" ||
+              dsData.type === "crop_region"
             ) {
-              examId = examMapping?.[dsData.examName] ?? null
-              if (!examId) {
+              if (dsData.examId) {
+                const byId = await tx.exam.findUnique({
+                  where: { id: dsData.examId },
+                  select: { id: true },
+                })
+                examId = byId?.id ?? null
+              }
+              if (!examId && dsData.examName) {
+                examId = examMapping?.[dsData.examName] ?? null
+              }
+              if (!examId && dsData.examName) {
                 const exams = await tx.exam.findMany({
                   where: { examName: dsData.examName },
                   select: { id: true },
@@ -315,34 +435,58 @@ export async function importGradeArchive(
               }
             }
 
-            // Subtotal照合（名前ベース）
+            // Subtotal照合（uuid一次・名前二次）。
+            // 名前フォールバックは必ず当該試験の小計グループへ絞る。小計名は
+            // グループ内でしか一意でなく、絞らないと別の試験の同名小計に当たる。
             let subtotalId: string | null = null
-            if (dsData.type === "subtotal" && dsData.subtotalName && examId) {
-              const subtotals = await tx.subtotal.findMany({
-                where: { name: dsData.subtotalName },
-              })
-              subtotalId = subtotals[0]?.id ?? null
+            if (dsData.type === "subtotal" && examId) {
+              if (dsData.subtotalId) {
+                const byId = await tx.subtotal.findUnique({
+                  where: { id: dsData.subtotalId },
+                  select: { id: true },
+                })
+                subtotalId = byId?.id ?? null
+              }
+              if (!subtotalId && dsData.subtotalName) {
+                const subtotals = await tx.subtotal.findMany({
+                  where: {
+                    name: dsData.subtotalName,
+                    subtotalGroup: {
+                      examSubtotalGroups: { some: { examId } },
+                    },
+                  },
+                  select: { id: true },
+                })
+                subtotalId = subtotals[0]?.id ?? null
+              }
             }
 
-            // CropRegion照合（ラベルベース）
+            // CropRegion照合（uuid一次・ラベル二次）。
+            // ラベルは同一試験内でも重複しうるので一次キーにはしない。
             let cropRegionId: string | null = null
-            if (
-              dsData.type === "crop_region" &&
-              dsData.cropRegionLabel &&
-              examId
-            ) {
-              const regions = await tx.cropRegion.findMany({
-                where: {
-                  label: dsData.cropRegionLabel,
-                  examPage: { examId: examId },
-                },
-              })
-              cropRegionId = regions[0]?.id ?? null
+            if (dsData.type === "crop_region" && examId) {
+              if (dsData.cropRegionId) {
+                const byId = await tx.cropRegion.findUnique({
+                  where: { id: dsData.cropRegionId },
+                  select: { id: true },
+                })
+                cropRegionId = byId?.id ?? null
+              }
+              if (!cropRegionId && dsData.cropRegionLabel) {
+                const regions = await tx.cropRegion.findMany({
+                  where: {
+                    label: dsData.cropRegionLabel,
+                    examPage: { examId: examId },
+                  },
+                  select: { id: true },
+                })
+                cropRegionId = regions[0]?.id ?? null
+              }
             }
 
             await tx.gradeDataSource.create({
               data: {
-                gradeItemId: gi.id,
+                gradeItemId: gradeItem.id,
                 type: dsData.type,
                 examId,
                 subtotalId,
@@ -370,25 +514,16 @@ export async function importGradeArchive(
 
         // 6. BoundarySet/Boundary挿入
         for (const bsData of boundariesData.boundarySets) {
-          let gradeItemId: string | null = null
-          if (bsData.gradeItemName) {
-            // GradeItem名で照合（同じ試験内）
-            const gradeItem = await tx.gradeItem.findFirst({
-              where: {
-                gradeId: grade.id,
-                name: bsData.gradeItemName,
-              },
-            })
-            gradeItemId = gradeItem?.id ?? null
-            if (!gradeItemId) continue
-          }
+          // 対象は必ず評価項目（総合は v1.10.0 で撤去済み。transformer が破棄する）
+          if (!bsData.gradeItemName) continue
+          const gradeItemId = resolveGradeItemId(
+            bsData,
+            () => `成績境界セット（${bsData.gradeItemName}）`
+          )
+          if (gradeItemId === null) continue
 
           const boundarySet = await tx.gradeBoundarySet.create({
-            data: {
-              gradeId: grade.id,
-              targetType: bsData.targetType,
-              gradeItemId,
-            },
+            data: { gradeId: grade.id, gradeItemId },
           })
 
           if (bsData.boundaries.length > 0) {
@@ -409,24 +544,20 @@ export async function importGradeArchive(
           gradeData.gradeItemExclusions.length > 0
         ) {
           for (const excl of gradeData.gradeItemExclusions) {
-            const student = await tx.student.findUnique({
-              where: { studentNumber: excl.studentNumber },
-            })
+            const student = await resolveStudent(tx, excl)
             if (!student) continue
 
-            const gradeItem = await tx.gradeItem.findFirst({
-              where: {
-                gradeId: grade.id,
-                name: excl.gradeItemName,
-              },
-            })
-            if (!gradeItem) continue
+            const gradeItemId = resolveGradeItemId(
+              excl,
+              () => `生徒「${excl.studentNumber}」の評価項目除外`
+            )
+            if (gradeItemId === null) continue
 
             await tx.gradeItemExclusion.create({
               data: {
                 gradeId: grade.id,
                 studentId: student.id,
-                gradeItemId: gradeItem.id,
+                gradeItemId,
               },
             })
           }
@@ -435,28 +566,21 @@ export async function importGradeArchive(
         // 8. GradeOverride挿入（後方互換: optionalフィールド）
         if (gradeData.gradeOverrides && gradeData.gradeOverrides.length > 0) {
           for (const gradeOverride of gradeData.gradeOverrides) {
-            const student = await tx.student.findUnique({
-              where: { studentNumber: gradeOverride.studentNumber },
-            })
+            const student = await resolveStudent(tx, gradeOverride)
             if (!student) continue
 
-            let gradeItemId: string | null = null
-            if (gradeOverride.gradeItemName) {
-              const gradeItem = await tx.gradeItem.findFirst({
-                where: {
-                  gradeId: grade.id,
-                  name: gradeOverride.gradeItemName,
-                },
-              })
-              if (!gradeItem) continue
-              gradeItemId = gradeItem.id
-            }
+            // 対象は必ず評価項目（総合は v1.10.0 で撤去済み。transformer が破棄する）
+            if (!gradeOverride.gradeItemName) continue
+            const gradeItemId = resolveGradeItemId(
+              gradeOverride,
+              () => `生徒「${gradeOverride.studentNumber}」の成績上書き`
+            )
+            if (gradeItemId === null) continue
 
             await tx.gradeOverride.create({
               data: {
                 gradeId: grade.id,
                 studentId: student.id,
-                targetType: gradeOverride.targetType,
                 gradeItemId,
                 overrideLabel: gradeOverride.overrideLabel,
               },
@@ -471,24 +595,20 @@ export async function importGradeArchive(
           gradeData.gradeFrozenScores.length > 0
         ) {
           for (const gradeFrozenScore of gradeData.gradeFrozenScores) {
-            const student = await tx.student.findUnique({
-              where: { studentNumber: gradeFrozenScore.studentNumber },
-            })
+            const student = await resolveStudent(tx, gradeFrozenScore)
             if (!student) continue
 
-            const gradeItem = await tx.gradeItem.findFirst({
-              where: {
-                gradeId: grade.id,
-                name: gradeFrozenScore.gradeItemName,
-              },
-            })
-            if (!gradeItem) continue
+            const gradeItemId = resolveGradeItemId(
+              gradeFrozenScore,
+              () => `生徒「${gradeFrozenScore.studentNumber}」の確定成績値`
+            )
+            if (gradeItemId === null) continue
 
             await tx.gradeFrozenScore.create({
               data: {
                 gradeId: grade.id,
                 studentId: student.id,
-                gradeItemId: gradeItem.id,
+                gradeItemId,
                 weightedScore: gradeFrozenScore.weightedScore,
                 weightedMaxScore: gradeFrozenScore.weightedMaxScore,
                 percentage: gradeFrozenScore.percentage,

--- a/electron-src/lib/import/grade-transformers/V1_9_0_to_V1_10_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_9_0_to_V1_10_0.ts
@@ -1,0 +1,79 @@
+import type {
+  GradeArchiveData,
+  GradeArchiveVersion,
+  GradeTransformResult,
+  GradeVersionTransformer,
+} from "../../../../src/types/gradeArchive.types"
+
+/**
+ * 1.9.0 → 1.10.0: 総合（overall）の撤去。
+ *
+ * 総合は「除外されていない全評価項目の加重平均」で、評定を評価項目として持つ運用では
+ * 評定そのものを観点と一緒に平均へ混ぜる無意味な集計だった。境界を作る導線も UI に無い。
+ * v1.10.0 では境界セット・手動上書きの対象が必ず評価項目になり、targetType を持たない。
+ *
+ * 旧アーカイブの総合エントリ（targetType === "overall"、または対象評価項目名を持たない）は
+ * 移し先が無いので破棄する。破棄した件数は warning で利用者に見せる（黙って消さない）。
+ */
+export class V1_9_0_to_V1_10_0_Transformer implements GradeVersionTransformer {
+  readonly fromVersion: GradeArchiveVersion = "1.9.0"
+  readonly toVersion: GradeArchiveVersion = "1.10.0"
+
+  transform(data: GradeArchiveData): GradeTransformResult {
+    const warnings: string[] = []
+
+    const boundarySets = data.boundariesData.boundarySets.filter(
+      (boundarySet) =>
+        boundarySet.targetType !== "overall" &&
+        boundarySet.gradeItemName !== null
+    )
+    const droppedBoundarySets =
+      data.boundariesData.boundarySets.length - boundarySets.length
+
+    const gradeOverrides = data.gradeData.gradeOverrides?.filter(
+      (gradeOverride) =>
+        gradeOverride.targetType !== "overall" &&
+        gradeOverride.gradeItemName !== null
+    )
+    const droppedOverrides =
+      (data.gradeData.gradeOverrides?.length ?? 0) -
+      (gradeOverrides?.length ?? 0)
+
+    if (droppedBoundarySets > 0) {
+      warnings.push(
+        `1.9.0→1.10.0: 総合の成績境界セット ${droppedBoundarySets} 件を破棄しました（総合は撤去され、評定は評価項目として扱います）`
+      )
+    }
+    if (droppedOverrides > 0) {
+      warnings.push(
+        `1.9.0→1.10.0: 総合評定の手動上書き ${droppedOverrides} 件を破棄しました（総合は撤去され、評定は評価項目として扱います）`
+      )
+    }
+
+    // targetType は落として持ち回らない（新形式には存在しないフィールド）
+    return {
+      data: {
+        ...data,
+        manifest: { ...data.manifest, version: this.toVersion },
+        gradeData: {
+          ...data.gradeData,
+          // targetType だけを落とす。参照キー（uuid・名前）はそのまま持ち越す
+          gradeOverrides: gradeOverrides?.map((gradeOverride) => ({
+            studentNumber: gradeOverride.studentNumber,
+            gradeItemId: gradeOverride.gradeItemId,
+            gradeItemName: gradeOverride.gradeItemName,
+            overrideLabel: gradeOverride.overrideLabel,
+          })),
+        },
+        boundariesData: {
+          boundarySets: boundarySets.map((boundarySet) => ({
+            gradeItemId: boundarySet.gradeItemId,
+            gradeItemName: boundarySet.gradeItemName,
+            boundaries: boundarySet.boundaries,
+          })),
+        },
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/grade-transformers/index.ts
+++ b/electron-src/lib/import/grade-transformers/index.ts
@@ -11,6 +11,7 @@
  *                                        点数の有無に関わらず変換し "manual" 型を残さない）
  *   - courseworks（名前ベース配列）あり → 1.4.0 → 1.5.0（courseworkArchive へ）
  *   - courseworkArchive あり           → 既に現行形式（1.5.0/1.6.0 とも同形。変換不要）
+ *   - 境界セット/上書きに targetType あり → 1.9.0 → 1.10.0（総合エントリを破棄）
  * 1.6.0 は GradeDataSource.maxScore 列の廃止のみで、外部成績の構造は 1.5.0 と同形のため
  * 専用の transformer は持たない（ArchiveDataSource.maxScore は optional で旧読込互換）。
  */
@@ -24,6 +25,7 @@ import type {
 import { GRADE_CURRENT_VERSION } from "../../../../src/types/gradeArchive.types"
 import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 import { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
+import { V1_9_0_to_V1_10_0_Transformer } from "./V1_9_0_to_V1_10_0"
 
 const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
   courseworks: [],
@@ -36,6 +38,24 @@ const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
 
 const v1_3_0 = new V1_3_0_to_V1_4_0_Transformer()
 const v1_4_0 = new V1_4_0_to_V1_5_0_Transformer()
+const v1_9_0 = new V1_9_0_to_V1_10_0_Transformer()
+
+/**
+ * 総合（overall）の名残を持つか。境界セット・手動上書きのどちらかに targetType があるか、
+ * 対象評価項目名を持たないエントリがあれば 1.9.0 以前の形。
+ */
+function hasOverallResidue(data: GradeArchiveData): boolean {
+  const boundaryResidue = data.boundariesData.boundarySets.some(
+    (boundarySet) =>
+      boundarySet.targetType !== undefined || boundarySet.gradeItemName === null
+  )
+  const overrideResidue = (data.gradeData.gradeOverrides ?? []).some(
+    (gradeOverride) =>
+      gradeOverride.targetType !== undefined ||
+      gradeOverride.gradeItemName === null
+  )
+  return boundaryResidue || overrideResidue
+}
 
 /** manual 型 DataSource を持つか（点数未入力でも true） */
 function hasManualDataSource(data: GradeArchiveData): boolean {
@@ -44,11 +64,16 @@ function hasManualDataSource(data: GradeArchiveData): boolean {
   )
 }
 
-/** データ形状から元バージョンを推定（報告用） */
+/**
+ * データ形状から元バージョンを推定（報告用）。
+ * 総合の名残の判定は外部成績の形より先に見る — courseworkArchive を持つ 1.9.0 でも
+ * 総合エントリが残っていれば元は 1.9.0 であり、現行版と報告してはいけない
+ * （appliedTransformations に 1.9.0→1.10.0 を積みながら originalVersion=1.10.0 という矛盾になる）。
+ */
 function detectOriginalVersion(data: GradeArchiveData): GradeArchiveVersion {
-  if (data.courseworkArchive) return GRADE_CURRENT_VERSION
   if (data.courseworks) return "1.4.0"
   if (hasManualDataSource(data) || data.manualScoresData) return "1.3.0"
+  if (hasOverallResidue(data)) return "1.9.0"
   return GRADE_CURRENT_VERSION
 }
 
@@ -85,6 +110,14 @@ export function transformGradeToLatest(
   // 外部成績を持たない旧アーカイブは空の courseworkArchive を補う
   if (!current.courseworkArchive) {
     current = { ...current, courseworkArchive: EMPTY_COURSEWORK_ARCHIVE }
+  }
+
+  // 1.9.0 → 1.10.0: 総合（overall）の撤去。移し先が無いので破棄し warning で知らせる
+  if (hasOverallResidue(current)) {
+    const result = v1_9_0.transform(current)
+    current = result.data
+    warnings.push(...result.warnings)
+    appliedTransformations.push({ from: "1.9.0", to: "1.10.0" })
   }
 
   // マニフェストを現行バージョンへ

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -301,11 +301,10 @@ export async function duplicateGrade(id: string) {
           new Set(allGrades.map((grade) => grade.name))
         )
 
-        // 旧gradeItemId → 新gradeItemId。非nullなのに解決できなければ複製元が壊れて
-        // いるため throw してロールバックする（矛盾した行を作らない）。
+        // 旧gradeItemId → 新gradeItemId。解決できなければ複製元が壊れているため
+        // throw してロールバックする（矛盾した行を作らない）。
         const itemIdMap = new Map<string, string>()
-        const remapItemId = (oldId: string | null): string | null => {
-          if (!oldId) return null
+        const remapItemId = (oldId: string): string => {
           const newId = itemIdMap.get(oldId)
           if (!newId) {
             throw new Error(`GradeItem ${oldId} の複製先が見つかりません`)
@@ -426,7 +425,6 @@ export async function duplicateGrade(id: string) {
           const newBoundarySet = await tx.gradeBoundarySet.create({
             data: {
               gradeId: grade.id,
-              targetType: boundarySet.targetType,
               gradeItemId: remapItemId(boundarySet.gradeItemId),
             },
           })
@@ -448,7 +446,6 @@ export async function duplicateGrade(id: string) {
             data: source.gradeOverrides.map((gradeOverride) => ({
               gradeId: grade.id,
               studentId: gradeOverride.studentId,
-              targetType: gradeOverride.targetType,
               gradeItemId: remapItemId(gradeOverride.gradeItemId),
               overrideLabel: gradeOverride.overrideLabel,
             })),

--- a/electron-src/lib/prisma/gradeBoundary.ts
+++ b/electron-src/lib/prisma/gradeBoundary.ts
@@ -4,7 +4,6 @@
 
 import type { Prisma } from "@prisma/client"
 
-import { toGradeBoundaryTargetType } from "../../../src/types/grade.types"
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
@@ -21,15 +20,9 @@ export async function getBoundarySetsByGradeId(gradeId: string) {
         gradeItem: { select: { id: true, name: true, order: true } },
         boundaries: { orderBy: { order: "asc" } },
       },
-      orderBy: [{ targetType: "asc" }, { gradeItem: { order: "asc" } }],
+      orderBy: { gradeItem: { order: "asc" } },
     })
-    return {
-      success: true,
-      boundarySets: serializePrisma(boundarySets).map((boundarySet) => ({
-        ...boundarySet,
-        targetType: toGradeBoundaryTargetType(boundarySet.targetType),
-      })),
-    }
+    return { success: true, boundarySets: serializePrisma(boundarySets) }
   } catch (error) {
     console.error("Error getting boundary sets:", error)
     return {
@@ -44,19 +37,19 @@ export async function getBoundarySetsByGradeId(gradeId: string) {
  */
 export async function upsertBoundarySet(data: {
   gradeId: string
-  targetType: string // "grade_item" | "overall"
-  gradeItemId: string | null
+  gradeItemId: string
   boundaries: { label: string; minPercentage: number; order: number }[]
 }) {
   try {
     const result = await prisma.$transaction(
       async (tx: Prisma.TransactionClient) => {
         // 既存セットを検索
-        const existing = await tx.gradeBoundarySet.findFirst({
+        const existing = await tx.gradeBoundarySet.findUnique({
           where: {
-            gradeId: data.gradeId,
-            targetType: data.targetType,
-            gradeItemId: data.gradeItemId,
+            gradeId_gradeItemId: {
+              gradeId: data.gradeId,
+              gradeItemId: data.gradeItemId,
+            },
           },
         })
 
@@ -69,11 +62,7 @@ export async function upsertBoundarySet(data: {
           })
         } else {
           const newSet = await tx.gradeBoundarySet.create({
-            data: {
-              gradeId: data.gradeId,
-              targetType: data.targetType,
-              gradeItemId: data.gradeItemId,
-            },
+            data: { gradeId: data.gradeId, gradeItemId: data.gradeItemId },
           })
           setId = newSet.id
         }
@@ -109,14 +98,7 @@ export async function upsertBoundarySet(data: {
       scopeLabel: scope.scopeLabel,
     })
 
-    const boundarySet = serializePrisma(result)
-    return {
-      success: true,
-      boundarySet: boundarySet && {
-        ...boundarySet,
-        targetType: toGradeBoundaryTargetType(boundarySet.targetType),
-      },
-    }
+    return { success: true, boundarySet: serializePrisma(result) }
   } catch (error) {
     console.error("Error upserting boundary set:", error)
     return {

--- a/electron-src/lib/prisma/gradeOverride.ts
+++ b/electron-src/lib/prisma/gradeOverride.ts
@@ -2,8 +2,6 @@
  * GradeOverride（成績ラベル上書き）のPrisma操作関数
  */
 
-import type { Prisma } from "@prisma/client"
-
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
@@ -27,45 +25,32 @@ export async function getGradeOverridesByExamId(gradeId: string) {
 }
 
 /**
- * 上書きを upsert（findFirst + create/update パターン: SQLite の NULL 制約問題回避）
+ * 上書きを upsert。対象は生徒×評価項目で、gradeItemId は NOT NULL なので
+ * 複合uniqueをそのまま使える（NULL が unique 制約をすり抜ける問題は起きない）。
  */
 export async function upsertGradeOverride(data: {
   gradeId: string
   studentId: string
-  targetType: string
-  gradeItemId: string | null
+  gradeItemId: string
   overrideLabel: string
 }) {
   try {
-    const result = await prisma.$transaction(
-      async (tx: Prisma.TransactionClient) => {
-        const existing = await tx.gradeOverride.findFirst({
-          where: {
-            gradeId: data.gradeId,
-            studentId: data.studentId,
-            targetType: data.targetType,
-            gradeItemId: data.gradeItemId,
-          },
-        })
-
-        if (existing) {
-          return tx.gradeOverride.update({
-            where: { id: existing.id },
-            data: { overrideLabel: data.overrideLabel },
-          })
-        } else {
-          return tx.gradeOverride.create({
-            data: {
-              gradeId: data.gradeId,
-              studentId: data.studentId,
-              targetType: data.targetType,
-              gradeItemId: data.gradeItemId,
-              overrideLabel: data.overrideLabel,
-            },
-          })
-        }
-      }
-    )
+    const result = await prisma.gradeOverride.upsert({
+      where: {
+        gradeId_studentId_gradeItemId: {
+          gradeId: data.gradeId,
+          studentId: data.studentId,
+          gradeItemId: data.gradeItemId,
+        },
+      },
+      create: {
+        gradeId: data.gradeId,
+        studentId: data.studentId,
+        gradeItemId: data.gradeItemId,
+        overrideLabel: data.overrideLabel,
+      },
+      update: { overrideLabel: data.overrideLabel },
+    })
 
     const scope = await resolveGradeScope(data.gradeId)
     await recordAuditLog({
@@ -92,16 +77,16 @@ export async function upsertGradeOverride(data: {
 export async function deleteGradeOverride(data: {
   gradeId: string
   studentId: string
-  targetType: string
-  gradeItemId: string | null
+  gradeItemId: string
 }) {
   try {
-    const existing = await prisma.gradeOverride.findFirst({
+    const existing = await prisma.gradeOverride.findUnique({
       where: {
-        gradeId: data.gradeId,
-        studentId: data.studentId,
-        targetType: data.targetType,
-        gradeItemId: data.gradeItemId,
+        gradeId_studentId_gradeItemId: {
+          gradeId: data.gradeId,
+          studentId: data.studentId,
+          gradeItemId: data.gradeItemId,
+        },
       },
     })
     if (existing) {

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -1,6 +1,6 @@
 /**
  * 成績算出エンジン
- * GradeItem × DataSource ベースで観点別・総合成績を算出
+ * GradeItem × DataSource ベースで評価項目ごとの成績を算出（評定も評価項目の一つ）
  * 欠測時の代替スコア推定（average / regression / zero）に対応
  */
 
@@ -13,10 +13,7 @@ import type {
   SourceScoreResult,
   StudentGradeResult,
 } from "../../../../src/types/grade.types"
-import {
-  toGradeBoundaryTargetType,
-  toGradeDataSourceType,
-} from "../../../../src/types/grade.types"
+import { toGradeDataSourceType } from "../../../../src/types/grade.types"
 import prisma from "../../prisma/client"
 import { computeLiveMaxScore } from "../../prisma/gradeDataSource"
 import {
@@ -106,7 +103,7 @@ async function buildGradeCalcContext(gradeId: string) {
   })
   const overrideMap = new Map<string, string>()
   for (const override of overrides) {
-    const key = `${override.studentId}:${override.targetType}:${override.gradeItemId ?? "__overall__"}`
+    const key = `${override.studentId}:${override.gradeItemId}`
     overrideMap.set(key, override.overrideLabel)
   }
 
@@ -635,15 +632,13 @@ export async function calculateGrades(
 
         // 境界セットからラベルを決定
         const boundarySet = grade.boundarySets.find(
-          (boundarySet) =>
-            boundarySet.targetType === "grade_item" &&
-            boundarySet.gradeItemId === gradeItem.id
+          (boundarySet) => boundarySet.gradeItemId === gradeItem.id
         )
         const originalGradeLabel = determineGradeLabel(
           percentage,
           boundarySet?.boundaries ?? []
         )
-        const itemOverrideKey = `${student.id}:grade_item:${gradeItem.id}`
+        const itemOverrideKey = `${student.id}:${gradeItem.id}`
         const overrideGradeLabel = overrideMap.get(itemOverrideKey) ?? null
         // ライブの実効値＝自動算出を手動上書きで調整した後の値。確定操作はこれを取り込む。
         const liveGradeLabel = overrideGradeLabel ?? originalGradeLabel
@@ -704,40 +699,6 @@ export async function calculateGrades(
         })
       }
 
-      // 総合スコア（除外・欠点のGradeItemは分母・分子から除外）
-      const includedResults = gradeItemResults.filter(
-        (gradeItemResult) => !gradeItemResult.isExcluded
-      )
-      const nonNullItems = includedResults.filter(
-        (gradeItemResult) => gradeItemResult.weightedScore !== null
-      )
-      const overallMaxScore = nonNullItems.reduce(
-        (sum, gradeItemResult) => sum + gradeItemResult.weightedMaxScore,
-        0
-      )
-      const overallScore =
-        nonNullItems.length > 0
-          ? nonNullItems.reduce(
-              (sum, gradeItemResult) => sum + gradeItemResult.weightedScore!,
-              0
-            )
-          : null
-      const overallPercentage =
-        overallScore !== null && overallMaxScore > 0
-          ? (overallScore / overallMaxScore) * 100
-          : null
-
-      const overallBoundarySet = grade.boundarySets.find(
-        (boundarySet) => boundarySet.targetType === "overall"
-      )
-      const originalOverallGradeLabel = determineGradeLabel(
-        overallPercentage,
-        overallBoundarySet?.boundaries ?? []
-      )
-      const overallOverrideKey = `${student.id}:overall:__overall__`
-      const overrideOverallGradeLabel =
-        overrideMap.get(overallOverrideKey) ?? null
-
       students.push({
         studentId: student.id,
         studentNumber: student.studentNumber,
@@ -746,13 +707,6 @@ export async function calculateGrades(
         attendanceNumber: membership?.attendanceNumber ?? null,
         className: membership?.classroom.name ?? null,
         gradeItemResults,
-        overallScore,
-        overallMaxScore,
-        overallPercentage,
-        overallGradeLabel:
-          overrideOverallGradeLabel ?? originalOverallGradeLabel,
-        originalOverallGradeLabel,
-        overrideOverallGradeLabel,
       })
     }
 
@@ -768,10 +722,14 @@ export async function calculateGrades(
           id: gradeItem.id,
           name: gradeItem.name,
           order: gradeItem.order,
+          // 内訳列の定義。生徒の除外に左右されない項目そのものの構成を渡す
+          dataSources: gradeItem.dataSources.map((dataSource) => ({
+            id: dataSource.id,
+            name: dataSource.name,
+          })),
         })),
         students,
         boundarySets: grade.boundarySets.map((boundarySet) => ({
-          targetType: toGradeBoundaryTargetType(boundarySet.targetType),
           gradeItemId: boundarySet.gradeItemId,
           boundaries: [...boundarySet.boundaries]
             .sort(

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -122,8 +122,7 @@ export function createGradeApi() {
         ipcRenderer.invoke("grade:getBoundarySets", gradeId),
       upsertBoundarySet: (data: {
         gradeId: string
-        targetType: string
-        gradeItemId: string | null
+        gradeItemId: string
         boundaries: {
           label: string
           minPercentage: number
@@ -135,15 +134,13 @@ export function createGradeApi() {
       upsertGradeOverride: (data: {
         gradeId: string
         studentId: string
-        targetType: string
-        gradeItemId: string | null
+        gradeItemId: string
         overrideLabel: string
       }) => ipcRenderer.invoke("grade:upsertGradeOverride", data),
       deleteGradeOverride: (data: {
         gradeId: string
         studentId: string
-        targetType: string
-        gradeItemId: string | null
+        gradeItemId: string
       }) => ipcRenderer.invoke("grade:deleteGradeOverride", data),
       getGradeConstraints: (gradeId: string) =>
         ipcRenderer.invoke("grade:getGradeConstraints", gradeId),

--- a/prisma/migrations/20260725170000_drop_grade_overall_target/migration.sql
+++ b/prisma/migrations/20260725170000_drop_grade_overall_target/migration.sql
@@ -1,0 +1,67 @@
+-- 総合（overall）の撤去。
+--
+-- 総合は「除外されていない全評価項目の加重平均」で、評定を評価項目として持つ運用では
+-- 評定そのものを観点と一緒に平均へ混ぜる無意味な集計だった。UI にも総合の境界を作る
+-- 導線が無く、結果表にも列が無い。残っていたのは残骸なので targetType ごと撤去する。
+--
+-- 撤去に伴い gradeItemId を NOT NULL にできる。総合が唯一の NULL ケースだったため。
+-- これで SQLite が unique 制約で NULL を互いに別物と扱う罠（GradeOverride が
+-- findFirst + create/update で回避していたもの）も同時に消える。
+
+-- 総合の行を先に削除する。gradeItemId が NULL なので、そのままでは NOT NULL 化した
+-- 新テーブルへ移せない。GradeBoundary は onDelete:Cascade で追随する。
+DELETE FROM "GradeBoundary" WHERE "gradeBoundarySetId" IN (
+    SELECT "id" FROM "GradeBoundarySet" WHERE "targetType" = 'overall'
+);
+DELETE FROM "GradeBoundarySet" WHERE "targetType" = 'overall';
+DELETE FROM "GradeOverride" WHERE "targetType" = 'overall';
+
+-- 念のため、targetType が 'grade_item' でも gradeItemId が NULL の不整合行を落とす
+-- （NOT NULL 化した新テーブルへの INSERT が失敗するのを防ぐ）。
+DELETE FROM "GradeBoundary" WHERE "gradeBoundarySetId" IN (
+    SELECT "id" FROM "GradeBoundarySet" WHERE "gradeItemId" IS NULL
+);
+DELETE FROM "GradeBoundarySet" WHERE "gradeItemId" IS NULL;
+DELETE FROM "GradeOverride" WHERE "gradeItemId" IS NULL;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_GradeBoundarySet" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeBoundarySet_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeBoundarySet_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_GradeBoundarySet" ("createdAt", "gradeId", "gradeItemId", "id", "updatedAt") SELECT "createdAt", "gradeId", "gradeItemId", "id", "updatedAt" FROM "GradeBoundarySet";
+DROP TABLE "GradeBoundarySet";
+ALTER TABLE "new_GradeBoundarySet" RENAME TO "GradeBoundarySet";
+CREATE INDEX "GradeBoundarySet_gradeId_idx" ON "GradeBoundarySet"("gradeId");
+CREATE UNIQUE INDEX "GradeBoundarySet_gradeId_gradeItemId_key" ON "GradeBoundarySet"("gradeId", "gradeItemId");
+
+CREATE TABLE "new_GradeOverride" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "overrideLabel" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GradeOverride_gradeId_fkey" FOREIGN KEY ("gradeId") REFERENCES "Grade" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeOverride_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "Student" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeOverride_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_GradeOverride" ("createdAt", "gradeId", "gradeItemId", "id", "overrideLabel", "studentId", "updatedAt") SELECT "createdAt", "gradeId", "gradeItemId", "id", "overrideLabel", "studentId", "updatedAt" FROM "GradeOverride";
+DROP TABLE "GradeOverride";
+ALTER TABLE "new_GradeOverride" RENAME TO "GradeOverride";
+CREATE INDEX "GradeOverride_gradeId_idx" ON "GradeOverride"("gradeId");
+CREATE INDEX "GradeOverride_studentId_idx" ON "GradeOverride"("studentId");
+CREATE INDEX "GradeOverride_gradeItemId_idx" ON "GradeOverride"("gradeItemId");
+CREATE UNIQUE INDEX "GradeOverride_gradeId_studentId_gradeItemId_key" ON "GradeOverride"("gradeId", "studentId", "gradeItemId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -800,39 +800,41 @@ model GradeItemExclusion {
   @@index([gradeItemId])
 }
 
-/// 成績境界セット（GradeItemごとまたは総合）
+/// 評価項目ごとの成績境界セット。
+///
+/// 「総合」という対象は持たない — 評定は評価項目（GradeItem）の一つとして扱うのが本来で、
+/// 総合は全評価項目の加重平均という意味を成さない集計だった（評定そのものを観点と一緒に
+/// 平均へ混ぜていた）。UI にも総合の境界を作る導線が無く、残っていたのは残骸。
 model GradeBoundarySet {
   id          String   @id @default(uuid())
   gradeId     String
-  targetType  String // "grade_item" | "overall"
-  gradeItemId String?
+  gradeItemId String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   grade      Grade           @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  gradeItem  GradeItem?      @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+  gradeItem  GradeItem       @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
   boundaries GradeBoundary[]
 
-  @@unique([gradeId, targetType, gradeItemId])
+  @@unique([gradeId, gradeItemId])
   @@index([gradeId])
 }
 
-/// 成績ラベルの手動上書き
+/// 成績ラベルの手動上書き（生徒×評価項目）。総合の行は持たない（GradeBoundarySet と同じ理由）
 model GradeOverride {
   id            String   @id @default(uuid())
   gradeId       String
   studentId     String
-  targetType    String // "grade_item" | "overall"
-  gradeItemId   String?
+  gradeItemId   String
   overrideLabel String
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  grade     Grade      @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  student   Student    @relation(fields: [studentId], references: [id], onDelete: Cascade)
-  gradeItem GradeItem? @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+  grade     Grade     @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  student   Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  gradeItem GradeItem @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
 
-  @@unique([gradeId, studentId, targetType, gradeItemId])
+  @@unique([gradeId, studentId, gradeItemId])
   @@index([gradeId])
   @@index([studentId])
   @@index([gradeItemId])
@@ -855,13 +857,13 @@ model GradeFrozenScore {
   gradeItemId String
 
   /// 確定時の重み付け得点。全ソース欠測など算出不能なら null
-  weightedScore Decimal?
+  weightedScore    Decimal?
   /// 確定時の重み付け満点（重みの合計）
   weightedMaxScore Decimal
   /// 確定時の達成率(%)。算出不能なら null
-  percentage Decimal?
+  percentage       Decimal?
   /// 確定時の成績ラベル。境界未設定なら null
-  gradeLabel String?
+  gradeLabel       String?
 
   /// 確定操作を行った操作者。システム操作は null
   frozenByUserId String?

--- a/src/components/grades/05-boundaries/BoundariesContainer.tsx
+++ b/src/components/grades/05-boundaries/BoundariesContainer.tsx
@@ -29,24 +29,18 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
 
   const gradeItems = exam.gradeItems
 
-  const getExistingBoundaries = (
-    targetType: string,
-    gradeItemId: string | null
-  ) => {
+  const getExistingBoundaries = (gradeItemId: string) => {
     const matchedBoundarySet = boundarySets.find(
-      (boundarySet) =>
-        boundarySet.targetType === targetType &&
-        boundarySet.gradeItemId === gradeItemId
+      (boundarySet) => boundarySet.gradeItemId === gradeItemId
     )
     return matchedBoundarySet?.boundaries ?? []
   }
 
   const handleSave = async (
-    targetType: string,
-    gradeItemId: string | null,
+    gradeItemId: string,
     boundaries: { label: string; minPercentage: number; order: number }[]
   ) => {
-    await saveBoundarySet({ targetType, gradeItemId, boundaries })
+    await saveBoundarySet({ gradeItemId, boundaries })
   }
 
   return (
@@ -61,15 +55,11 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
           <Card key={gradeItem.id} className="space-y-3 p-4">
             <h3 className="text-base font-semibold">{gradeItem.name}</h3>
             <BoundaryPresetSelector
-              onSelect={(boundaries) =>
-                handleSave("grade_item", gradeItem.id, boundaries)
-              }
+              onSelect={(boundaries) => handleSave(gradeItem.id, boundaries)}
             />
             <BoundaryEditor
-              boundaries={getExistingBoundaries("grade_item", gradeItem.id)}
-              onSave={(boundaries) =>
-                handleSave("grade_item", gradeItem.id, boundaries)
-              }
+              boundaries={getExistingBoundaries(gradeItem.id)}
+              onSave={(boundaries) => handleSave(gradeItem.id, boundaries)}
             />
           </Card>
         ))}

--- a/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
+++ b/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
@@ -62,7 +62,6 @@ function collectLabels(
 ): string[] {
   const set = new Set<string>()
   for (const boundarySet of boundarySets) {
-    if (boundarySet.targetType !== "grade_item") continue
     for (const boundary of boundarySet.boundaries) set.add(boundary.label)
   }
   return Array.from(set)

--- a/src/components/grades/06-results/GradeDistributionChart.tsx
+++ b/src/components/grades/06-results/GradeDistributionChart.tsx
@@ -40,9 +40,7 @@ export function GradeDistributionChart({
 
           // boundarySetsからminPercentage降順でソート
           const boundarySet = result.boundarySets?.find(
-            (candidateSet) =>
-              candidateSet.targetType === "grade_item" &&
-              candidateSet.gradeItemId === gradeItem.id
+            (candidateSet) => candidateSet.gradeItemId === gradeItem.id
           )
           const labelOrder = new Map<string, number>()
           if (boundarySet) {

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -18,8 +18,7 @@ interface ResultsTableProps {
   constraints?: GradeConstraintData[]
   onGradeOverride: (params: {
     studentId: string
-    targetType: "grade_item" | "overall"
-    gradeItemId: string | null
+    gradeItemId: string
     overrideLabel: string | null
   }) => void
   /** 対象セルを現在のライブ値で確定し直す */
@@ -33,7 +32,7 @@ type SortKey = "registrationOrder" | "attendanceNumber" | string
 /**
  * 成績算出結果の一覧テーブル
  *
- * 生徒ごとの各評価項目パーセンテージ・成績ラベル・総合成績を表示する。
+ * 生徒ごとの各評価項目パーセンテージ・成績ラベルを表示する（評定も評価項目の一つ）。
  * 各列ヘッダーをクリックしてソート可能。
  */
 export function ResultsTable({
@@ -58,15 +57,13 @@ export function ResultsTable({
     [constraints]
   )
 
-  // 各列に対応するboundaryLabels（minPercentage降順）を算出
+  // 評価項目ごとのboundaryLabels（minPercentage降順）を算出
   const boundaryLabelsMap = useMemo(() => {
     const map: Record<string, string[]> = {}
     for (const boundarySet of result.boundarySets ?? []) {
-      const key =
-        boundarySet.targetType === "overall"
-          ? "__overall__"
-          : (boundarySet.gradeItemId ?? "__unknown__")
-      map[key] = boundarySet.boundaries.map((boundary) => boundary.label)
+      map[boundarySet.gradeItemId] = boundarySet.boundaries.map(
+        (boundary) => boundary.label
+      )
     }
     return map
   }, [result.boundarySets])
@@ -235,7 +232,6 @@ export function ResultsTable({
                             onCommit={(newLabel) =>
                               onGradeOverride({
                                 studentId: student.studentId,
-                                targetType: "grade_item",
                                 gradeItemId: gradeItem.id,
                                 overrideLabel: newLabel,
                               })

--- a/src/components/grades/07-export/GradeExcelPreview.tsx
+++ b/src/components/grades/07-export/GradeExcelPreview.tsx
@@ -45,32 +45,6 @@ export function GradeExcelPreview({
     [result.students, selectedSet]
   )
 
-  // 詳細シートの列構成（GradeItemごとのデータソース名）。
-  // 除外などで空にならないよう、各GradeItemで非除外の結果を持つ生徒から導出する。
-  const detailColumns = useMemo(
-    () =>
-      result.gradeItems.map((gradeItem) => {
-        let sourceNames: string[] = []
-        for (const student of result.students) {
-          const gradeItemResult = student.gradeItemResults.find(
-            (gradeItemResult) => gradeItemResult.gradeItemId === gradeItem.id
-          )
-          if (
-            gradeItemResult &&
-            !gradeItemResult.isExcluded &&
-            gradeItemResult.sourceScores.length > 0
-          ) {
-            sourceNames = gradeItemResult.sourceScores.map(
-              (sourceScore) => sourceScore.dataSourceName
-            )
-            break
-          }
-        }
-        return { gradeItem, sourceNames }
-      }),
-    [result.gradeItems, result.students]
-  )
-
   const studentName = (student: StudentGradeResult) =>
     `${student.lastName} ${student.firstName}`
 
@@ -106,9 +80,6 @@ export function GradeExcelPreview({
                     {gradeItem.name}
                   </th>
                 ))}
-                <th colSpan={2} className="border px-1 py-0.5 text-center">
-                  総合
-                </th>
               </tr>
               <tr>
                 <th className="border px-1 py-0.5" />
@@ -116,7 +87,6 @@ export function GradeExcelPreview({
                 {result.gradeItems.map((gradeItem) => (
                   <ResultSubHeader key={gradeItem.id} />
                 ))}
-                <ResultSubHeader />
               </tr>
             </thead>
             <tbody>
@@ -148,11 +118,6 @@ export function GradeExcelPreview({
                       />
                     )
                   })}
-                  <ResultCells
-                    percentage={round1(student.overallPercentage)}
-                    label={student.overallGradeLabel}
-                    className="font-medium"
-                  />
                 </tr>
               ))}
             </tbody>
@@ -166,27 +131,25 @@ export function GradeExcelPreview({
               <tr>
                 <th className="border px-1 py-0.5 text-left">番号</th>
                 <th className="border px-1 py-0.5 text-left">氏名</th>
-                {detailColumns.map(({ gradeItem, sourceNames }) => (
+                {result.gradeItems.map((gradeItem) => (
                   <th
                     key={gradeItem.id}
-                    colSpan={sourceNames.length + 1}
+                    colSpan={gradeItem.dataSources.length + 1}
                     className="border px-1 py-0.5 text-center"
                   >
                     {gradeItem.name}
                   </th>
                 ))}
-                <th className="border px-1 py-0.5 text-center">総合</th>
               </tr>
               <tr>
                 <th className="border px-1 py-0.5" />
                 <th className="border px-1 py-0.5" />
-                {detailColumns.map(({ gradeItem, sourceNames }) => (
+                {result.gradeItems.map((gradeItem) => (
                   <DetailSubHeaders
                     key={gradeItem.id}
-                    sourceNames={sourceNames}
+                    dataSources={gradeItem.dataSources}
                   />
                 ))}
-                <VerticalHeader>合計</VerticalHeader>
               </tr>
             </thead>
             <tbody>
@@ -198,7 +161,7 @@ export function GradeExcelPreview({
                   <td className="border px-1 py-0.5 whitespace-nowrap">
                     {studentName(student)}
                   </td>
-                  {detailColumns.map(({ gradeItem, sourceNames }) => {
+                  {result.gradeItems.map((gradeItem) => {
                     const itemResult = student.gradeItemResults.find(
                       (gradeItemResult) =>
                         gradeItemResult.gradeItemId === gradeItem.id
@@ -207,21 +170,18 @@ export function GradeExcelPreview({
                       return (
                         <ExcludedCells
                           key={gradeItem.id}
-                          count={sourceNames.length + 1}
+                          count={gradeItem.dataSources.length + 1}
                         />
                       )
                     }
                     return (
                       <DetailCells
                         key={gradeItem.id}
-                        gir={itemResult}
-                        sourceCount={sourceNames.length}
+                        gradeItemResult={itemResult}
+                        dataSources={gradeItem.dataSources}
                       />
                     )
                   })}
-                  <td className="border px-1 py-0.5 text-right font-medium">
-                    {round2(student.overallScore) ?? "-"}
-                  </td>
                 </tr>
               ))}
             </tbody>
@@ -262,12 +222,17 @@ function ResultCells({
   )
 }
 
-function DetailSubHeaders({ sourceNames }: { sourceNames: string[] }) {
+function DetailSubHeaders({
+  dataSources,
+}: {
+  dataSources: GradeCalculationResult["gradeItems"][number]["dataSources"]
+}) {
   return (
     <>
-      {sourceNames.map((name, i) => (
-        <VerticalHeader key={i} normal>
-          {name}
+      {dataSources.map((dataSource) => (
+        // key は安定した id（表示名は重複しうる）
+        <VerticalHeader key={dataSource.id} normal>
+          {dataSource.name}
         </VerticalHeader>
       ))}
       <VerticalHeader>合計</VerticalHeader>
@@ -300,23 +265,25 @@ function VerticalHeader({
 }
 
 function DetailCells({
-  gir,
-  sourceCount,
+  gradeItemResult,
+  dataSources,
 }: {
-  gir:
+  gradeItemResult:
     | GradeCalculationResult["students"][number]["gradeItemResults"][number]
     | undefined
-  sourceCount: number
+  dataSources: GradeCalculationResult["gradeItems"][number]["dataSources"]
 }) {
-  // 表示する列数を sourceCount に合わせる（生徒間で列数を揃える）
-  const cells: React.ReactNode[] = []
-  for (let i = 0; i < sourceCount; i++) {
-    const sourceScore = gir?.sourceScores[i]
+  // 列は評価項目の dataSources が決める。値は添字ではなく dataSourceId で引くので、
+  // 生徒ごとに sourceScores の並びや件数が違っても対応がずれない。
+  const cells: React.ReactNode[] = dataSources.map((dataSource) => {
+    const sourceScore = gradeItemResult?.sourceScores.find(
+      (sourceScore) => sourceScore.dataSourceId === dataSource.id
+    )
     const value = sourceScore ? (round2(sourceScore.weightedScore) ?? "-") : "-"
     const estimated = sourceScore?.isEstimated ?? false
-    cells.push(
+    return (
       <td
-        key={i}
+        key={dataSource.id}
         className={`border px-1 py-0.5 text-right ${
           estimated ? "text-amber-600 italic" : ""
         }`}
@@ -325,10 +292,10 @@ function DetailCells({
         {value}
       </td>
     )
-  }
+  })
   cells.push(
     <td key="total" className="border px-1 py-0.5 text-right font-medium">
-      {round2(gir?.weightedScore ?? null) ?? "-"}
+      {round2(gradeItemResult?.weightedScore ?? null) ?? "-"}
     </td>
   )
   return <>{cells}</>

--- a/src/components/grades/list/GradeImportDialog.tsx
+++ b/src/components/grades/list/GradeImportDialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { TriangleAlert } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
@@ -118,6 +119,21 @@ export function GradeImportDialog({
               </Badge>
             )}
           </div>
+
+          {/* 変換で失われるデータの警告（取り込み前に見せる） */}
+          {preview.warnings.length > 0 && (
+            <div className="mb-4 rounded border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-700 dark:bg-amber-950/40">
+              <div className="mb-1 flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-300">
+                <TriangleAlert className="h-4 w-4" />
+                取り込み時に失われるデータがあります
+              </div>
+              <ul className="text-muted-foreground list-disc space-y-0.5 pl-5">
+                {preview.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {/* 資料ごとの判断 */}
           {preview.courseworkMatches.length === 0 ? (

--- a/src/hooks/grades/useBoundaries.ts
+++ b/src/hooks/grades/useBoundaries.ts
@@ -39,8 +39,7 @@ export function useBoundaries(gradeId: string) {
 
   const saveBoundarySet = useCallback(
     async (data: {
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       boundaries: { label: string; minPercentage: number; order: number }[]
     }) => {
       const result = await window.electronAPI.grade.upsertBoundarySet({

--- a/src/hooks/grades/useGradeResults.ts
+++ b/src/hooks/grades/useGradeResults.ts
@@ -5,8 +5,7 @@ import type { GradeCalculationResult } from "@/types/grade.types"
 
 interface SetGradeOverrideParams {
   studentId: string
-  targetType: "grade_item" | "overall"
-  gradeItemId: string | null
+  gradeItemId: string
   /** 上書きラベル。null の場合は上書きを削除（自動計算に戻す） */
   overrideLabel: string | null
 }
@@ -69,15 +68,12 @@ export function useGradeResults(gradeId: string) {
 
       // 確定済みセルは確定値が最優先なので、上書きを保存しただけでは表示が動かない。
       // 調整の結果をその場で取り込み直す（＝そのセルだけ再確定）必要がある。
-      const editedItemResult =
-        params.gradeItemId === null
-          ? undefined
-          : result.students
-              .find((student) => student.studentId === params.studentId)
-              ?.gradeItemResults.find(
-                (gradeItemResult) =>
-                  gradeItemResult.gradeItemId === params.gradeItemId
-              )
+      const editedItemResult = result.students
+        .find((student) => student.studentId === params.studentId)
+        ?.gradeItemResults.find(
+          (gradeItemResult) =>
+            gradeItemResult.gradeItemId === params.gradeItemId
+        )
       const wasFrozen = Boolean(editedItemResult?.frozen)
 
       // 楽観的更新（再確定が要る場合は確定後の再計算で反映するので行わない）
@@ -88,16 +84,6 @@ export function useGradeResults(gradeId: string) {
             ...prev,
             students: prev.students.map((student) => {
               if (student.studentId !== params.studentId) return student
-
-              if (params.targetType === "overall") {
-                const effectiveLabel =
-                  params.overrideLabel ?? student.originalOverallGradeLabel
-                return {
-                  ...student,
-                  overallGradeLabel: effectiveLabel,
-                  overrideOverallGradeLabel: params.overrideLabel,
-                }
-              }
 
               return {
                 ...student,
@@ -123,7 +109,6 @@ export function useGradeResults(gradeId: string) {
           await window.electronAPI.grade.upsertGradeOverride({
             gradeId,
             studentId: params.studentId,
-            targetType: params.targetType,
             gradeItemId: params.gradeItemId,
             overrideLabel: params.overrideLabel,
           })
@@ -131,12 +116,11 @@ export function useGradeResults(gradeId: string) {
           await window.electronAPI.grade.deleteGradeOverride({
             gradeId,
             studentId: params.studentId,
-            targetType: params.targetType,
             gradeItemId: params.gradeItemId,
           })
         }
 
-        if (wasFrozen && params.gradeItemId !== null) {
+        if (wasFrozen) {
           await window.electronAPI.grade.freezeGradeScores({
             gradeId,
             targets: [

--- a/src/lib/gradeConstraints.ts
+++ b/src/lib/gradeConstraints.ts
@@ -73,8 +73,6 @@ function buildOrderedLabelsMap(
   )
   const byName = new Map<string, string[]>()
   for (const boundarySet of result.boundarySets) {
-    if (boundarySet.targetType !== "grade_item" || !boundarySet.gradeItemId)
-      continue
     const name = idToName.get(boundarySet.gradeItemId)
     if (!name) continue
     // minPercentage 昇順 = 弱い評価が先頭

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -217,8 +217,7 @@ export interface GradeAPI {
     }>
     upsertBoundarySet: (data: {
       gradeId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       boundaries: { label: string; minPercentage: number; order: number }[]
     }) => Promise<{
       success: boolean
@@ -231,15 +230,13 @@ export interface GradeAPI {
     upsertGradeOverride: (data: {
       gradeId: string
       studentId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
       overrideLabel: string
     }) => Promise<{ success: boolean; override?: unknown; error?: string }>
     deleteGradeOverride: (data: {
       gradeId: string
       studentId: string
-      targetType: string
-      gradeItemId: string | null
+      gradeItemId: string
     }) => Promise<{ success: boolean; error?: string }>
     getGradeConstraints: (gradeId: string) => Promise<{
       success: boolean

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -67,22 +67,6 @@ export type GradeDataSourceType = (typeof GRADE_DATA_SOURCE_TYPES)[number]
 export const { is: isGradeDataSourceType, to: toGradeDataSourceType } =
   defineStringUnion(GRADE_DATA_SOURCE_TYPES, "manual")
 
-/**
- * 境界セットの対象種別の唯一の定義源（SSOT）。
- * `GradeBoundarySet.targetType` も DB 上 `String`。観点別（grade_item）か総合（overall）か。
- */
-export const GRADE_BOUNDARY_TARGET_TYPES = ["grade_item", "overall"] as const
-
-export type GradeBoundaryTargetType =
-  (typeof GRADE_BOUNDARY_TARGET_TYPES)[number]
-
-/**
- * 型ガード `isGradeBoundaryTargetType` と境界コンバータ `toGradeBoundaryTargetType`
- * （想定外値は grade_item）。targetType は grade_item|overall の2値ハード不変。
- */
-export const { is: isGradeBoundaryTargetType, to: toGradeBoundaryTargetType } =
-  defineStringUnion(GRADE_BOUNDARY_TARGET_TYPES, "grade_item")
-
 /** 成績算出試験（リレーション付き） */
 export type GradeWithRelations = Omit<Grade, "referenceDate"> & {
   referenceDate: string | null
@@ -138,13 +122,12 @@ export type GradeDataSourceWithRelations = Omit<
   coursework: Pick<Coursework, "id" | "name"> | null
 }
 
-/** 境界セット（境界リスト付き） */
-export type GradeBoundarySetWithItemAndBoundaries = Omit<
-  Pick<GradeBoundarySet, "id" | "gradeId" | "targetType" | "gradeItemId">,
-  "targetType"
+/** 境界セット（境界リスト付き）。対象は必ず評価項目で、総合は存在しない */
+export type GradeBoundarySetWithItemAndBoundaries = Pick<
+  GradeBoundarySet,
+  "id" | "gradeId" | "gradeItemId"
 > & {
-  targetType: GradeBoundaryTargetType
-  gradeItem: Pick<GradeItem, "id" | "name" | "order"> | null
+  gradeItem: Pick<GradeItem, "id" | "name" | "order">
   boundaries: GradeBoundaryData[]
 }
 
@@ -164,18 +147,8 @@ export interface StudentGradeResult {
   firstName: string
   attendanceNumber: number | null
   className: string | null
-  /** GradeItemごとの成績 */
+  /** GradeItemごとの成績。評定もこの中の一項目で、これとは別の「総合」は持たない */
   gradeItemResults: GradeItemResult[]
-  /** 総合スコア */
-  overallScore: number | null
-  overallMaxScore: number
-  overallPercentage: number | null
-  /** 実効値（上書きがあればそれ、なければ自動算出値） */
-  overallGradeLabel: string | null
-  /** 自動算出値（常に設定） */
-  originalOverallGradeLabel: string | null
-  /** 上書き値（nullなら上書きなし） */
-  overrideOverallGradeLabel: string | null
 }
 
 /**
@@ -358,12 +331,22 @@ export interface GradeCalculationResult {
   gradeId: string
   gradeName: string
   classNames: string[]
-  gradeItems: { id: string; name: string; order: number }[]
+  /**
+   * 評価項目とその内訳列の定義。
+   * dataSources は「その評価項目が何列で構成されるか」の唯一の根拠で、出力の列は
+   * 必ずここから決める。特定の生徒の sourceScores から列数を導いてはならない
+   * （除外された生徒は sourceScores が空になるため、行ごとに列数が食い違う）。
+   */
+  gradeItems: {
+    id: string
+    name: string
+    order: number
+    dataSources: { id: string; name: string }[]
+  }[]
   students: StudentGradeResult[]
-  /** 境界セットデータ（override方向判定用） */
+  /** 境界セットデータ（override方向判定用）。対象は必ず評価項目 */
   boundarySets: {
-    targetType: GradeBoundaryTargetType
-    gradeItemId: string | null
+    gradeItemId: string
     boundaries: { label: string; minPercentage: number }[]
   }[]
 }

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -56,13 +56,21 @@ export interface ArchiveGradeData {
   /** 成績出力設定（後方互換: v1.2.0+。GradeExportSettingsと1:1） */
   exportSettings?: { settingsJson: string } | null
   gradeItems: ArchiveGradeItem[]
-  classroomRefs: { name: string }[]
+  /**
+   * 対象学級。v1.10.0+ は uuid を持ち、照合は uuid 一次・名前二次
+   * （exam / coursework アーカイブと同じ方式）。旧アーカイブには id が無い。
+   */
+  classroomRefs: { id?: string; name: string }[]
+  /** 参照する試験。v1.10.0+ は uuid を持ち、照合は uuid 一次・試験名二次 */
   examRefs: {
+    id?: string
     examName: string
     examDate: string | null
     dataSourceName: string
   }[]
+  /** 対象生徒。v1.10.0+ は uuid を持ち、照合は uuid 一次・学籍番号二次 */
   studentRefs: {
+    id?: string
     studentNumber: string
     classroomName: string | null
     customOrder: number | null
@@ -70,12 +78,22 @@ export interface ArchiveGradeData {
   /** GradeItem除外設定（後方互換: optional） */
   gradeItemExclusions?: {
     studentNumber: string
+    /** v1.10.0+: 参照先評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
+    gradeItemId?: string
+    /** 参照先評価項目名（uuid不一致時・旧アーカイブのフォールバック） */
     gradeItemName: string
   }[]
   /** 成績ラベル手動上書き（後方互換: optional） */
   gradeOverrides?: {
     studentNumber: string
-    targetType: string
+    /**
+     * @deprecated v1.10.0 で総合（overall）を撤去。旧アーカイブにのみ現れる。
+     * "overall" の行は transformer が破棄する。
+     */
+    targetType?: string
+    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
+    gradeItemId?: string
+    /** 対象評価項目名。v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
     gradeItemName: string | null
     overrideLabel: string
   }[]
@@ -88,6 +106,9 @@ export interface ArchiveGradeData {
    */
   gradeFrozenScores?: {
     studentNumber: string
+    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
+    gradeItemId?: string
+    /** 対象評価項目名（uuid不一致時・旧アーカイブのフォールバック） */
     gradeItemName: string
     weightedScore: number | null
     weightedMaxScore: number
@@ -109,6 +130,13 @@ export interface ArchiveGradeData {
 }
 
 export interface ArchiveGradeItem {
+  /**
+   * v1.10.0+: export元の評価項目uuid（照合の一次キー）。
+   * 評価項目名は unique でなく（GradeItem に (gradeId, name) の制約は無い）教員が
+   * 自由に付けられるため、名前だけでは同名の項目を区別できない。旧アーカイブには
+   * 無いので optional で、その場合のみ名前フォールバックへ落ちる。
+   */
+  id?: string
   name: string
   order: number
   dataSources: ArchiveDataSource[]
@@ -146,6 +174,19 @@ export interface ArchiveDataSource {
   courseworkName?: string | null
   /** v1.4.0+: type==="coursework" の参照先評価項目名（名前フォールバック） */
   courseworkItemName?: string | null
+  /** v1.10.0+: 参照先試験のuuid（照合の一次キー）。旧アーカイブには無い */
+  examId?: string | null
+  /**
+   * v1.10.0+: 参照先小計のuuid（照合の一次キー）。旧アーカイブには無い。
+   * 小計名は `@@unique([subtotalGroupId, name])` でグループ内でしか一意でなく、
+   * 名前だけでは別の試験の同名小計に当たりうる。
+   */
+  subtotalId?: string | null
+  /**
+   * v1.10.0+: 参照先採点領域のuuid（照合の一次キー）。旧アーカイブには無い。
+   * 領域ラベルは同一試験内でも重複しうる。
+   */
+  cropRegionId?: string | null
   /**
    * 旧 v1.3.0 の入力モード（"numeric" | "letter"）。読取専用の後方互換用。
    * v1.4.0 以降は CourseworkItem.inputMode が保持する。
@@ -233,7 +274,14 @@ export interface ArchiveManualScoresData {
 
 export interface ArchiveBoundariesData {
   boundarySets: {
-    targetType: string // "grade_item" | "overall"
+    /**
+     * @deprecated v1.10.0 で総合（overall）を撤去。旧アーカイブにのみ現れる。
+     * "overall" のセットは transformer が破棄する。
+     */
+    targetType?: string
+    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
+    gradeItemId?: string
+    /** 対象評価項目名。v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
     gradeItemName: string | null
     boundaries: {
       label: string
@@ -255,6 +303,12 @@ export interface GradeArchiveImportPreview {
   studentMissingCount: number
   /** v1.4.0+: 埋め込み資料ごとのマッチング候補（ユーザー判断用） */
   courseworkMatches: GradeArchiveCourseworkMatch[]
+  /**
+   * 旧バージョンからの変換で失われるデータの警告（取り込み前に見せる）。
+   * 例: v1.10.0 で撤去された総合の境界セット・上書きの破棄。
+   * 取り込み後のトーストだけでは「確定してから知る」ことになるため preview にも載せる。
+   */
+  warnings: string[]
 }
 
 // =============================================================================
@@ -276,13 +330,19 @@ export interface GradeArchiveImportPreview {
  *   専用 transformer は無し（加算的変更）。
  * - 1.9.0: 成績値の確定（GradeFrozenScore）を追加。gradeFrozenScores は optional で
  *   旧アーカイブ読込時は「確定なし」扱い。構造は加算的なため専用 transformer は無し。
+ * - 1.10.0: 総合（overall）を撤去。境界セット・手動上書きの targetType を廃し、対象は
+ *   必ず評価項目になった。旧アーカイブの総合エントリは破棄されるため、加算的変更ではなく
+ *   専用 transformer（V1_9_0_to_V1_10_0）を持つ。
+ *   併せて外部参照（評価項目・生徒・学級・試験・小計・採点領域）の照合を
+ *   uuid 一次・名前二次へ（exam / coursework アーカイブと同じ方式）。
+ *   これらの名前・ラベルはいずれも同定に足りず、名前だけでは取り違える。
  *
  * 検出は manifest.version 文字列ではなくデータ形状で行う（旧アーカイブのバージョン
  * 表記が不正確でも確実に正規化するため。詳細は grade-transformers/index.ts）。
  */
 export type GradeArchiveVersion =
-  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0" | "1.8.0" | "1.9.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.9.0"
+  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0" | "1.8.0" | "1.9.0" | "1.10.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.10.0"
 
 export interface GradeTransformResult {
   data: GradeArchiveData


### PR DESCRIPTION
## 概要

issue #1050 の対応。成績の「総合(overall)」を撤去し、あわせて成績アーカイブの外部参照の照合を uuid 一次へ統一する。

## 1. 総合(overall)の撤去

総合は「除外されていない全評価項目の加重平均」で、評定を評価項目として持つ運用では**評定そのものを観点と一緒に平均へ混ぜる**無意味な集計だった。`05-boundaries` に総合の境界を作る導線が無く結果表にも列が無い一方、Excel だけが「総合 (%)」「総合成績」の2列を出し続けていた。

- `GradeBoundarySet` / `GradeOverride` から `targetType` を削除し `gradeItemId` を **NOT NULL 化**。総合が唯一の NULL ケースだったため、**SQLite が unique 制約で NULL を互いに別物と扱う罠**（`GradeOverride` が `findFirst` + create/update で回避していたもの）も同時に消えた
- `StudentGradeResult` の overall 6フィールドと Excel の総合2列を撤去
- migration は総合行を削除してからテーブル再構築

## 2. Excel 詳細シートの列ずれ

列の定義を、先頭生徒の `sourceScores` から**評価項目の `dataSources`** へ移した。これで除外があっても結果が欠けていても、1つの評価項目は必ず「データソース数＋合計1列」を出すので、行ごとに列数が変わりようがない。列数を揃えるのが約束ではなく構造になる。

値の参照も添字から `dataSourceId` へ変更し、順序の一致に依存しないようにした。プレビュー側の「非除外の生徒を探して列数を決める」走査ヒューリスティックも不要になったので削除している。

## 3. アーカイブの照合を uuid 一次へ（v1.10.0）

grade-archive だけが名前ベースで取り残されていた。**評価項目・生徒・学級・試験・小計・採点領域の6種すべて**を uuid 一次・名前二次に統一した。

とくに影響が大きかったもの:

- **評価項目**: `GradeItem` に `(gradeId, name)` の unique が無く UI も同名を弾かない。同名の「評定」が2つあると、境界・上書き・**確定した成績値**が黙って先頭へ寄っていた
- **小計**: `subtotal.findMany({ where: { name } })` に**試験の絞り込みが無く**、全試験を横断して先頭を採っていた。`Subtotal` はグループ内でしか一意でないため、無関係な試験の同名小計に紐づきうる。uuid 一次にしたうえで、名前フォールバックも当該試験の小計グループへ絞った

旧アーカイブで名前が曖昧な場合は、先勝ちで寄せず**落として警告**する（境界・上書き・確定値は成績そのもので、誤った項目へ付けるほうが害が大きい）。

importer は評価項目を毎回 `findFirst` で引き直すのをやめ、作成時の「アーカイブ uuid → 新 id」対応で解決する。これは DB の写しではなく取り込み固有の対応で、coursework の `itemIdToActual` と同じ性質のもの。

## 4. あわせて直したもの

- `previewGradeArchiveImport` が変換器の warning を捨てており、**総合エントリの破棄を取り込み前に知らせられなかった**。`GradeArchiveImportPreview.warnings` として取り込み確認ダイアログに表示する
- `detectOriginalVersion` が 1.9.0 を判定できず、変換した旧アーカイブを `originalVersion=1.10.0` と矛盾した報告をしていた
- `manifest.version` が `"1.6.0"` 固定だった。**1.7.0 追加時から書き出しが古いまま**で、他3アーカイブは定数を使っているのに grade だけリテラルだった（検出が形状ベースのため実害は出ていない）

## 検証

- `npm run typecheck` / `eslint` クリーン
- `npx vitest run` **96 files / 1030 tests** 全通過
- migration を**実データのコピー**へ適用して確認（総合の境界セット1件＋境界5件のみ削除、手動上書き39件は保持、FK 整合・dangling 参照なし）
- `freshInstallChain` が空DBへ init＋全 migration を昇順適用し、`schema.prisma` の `db push` 基準と全テーブル列一致することを確認

**新規テスト**

- `__tests__/grade/unit/gradeDetailSheet.test.ts`（5件）— 1人目が除外でもヘッダーと全行のセル数が一致すること、並びが違っても id で正しい列に載ること
- `__tests__/import-export/unit/gradeTransformerChain.test.ts`（7件）— grade の変換器チェーンはこれまでテストが1件も無かった。旧 v1.9.0 が実際に書き出していた形をフィクスチャにしている
- 往復テストに4件追加 — uuid 照合、同名評価項目の取り違え防止、同名小計の試験スコープ、旧アーカイブの名前フォールバック

**変異テスト実施**（いずれも該当テストが落ちることを確認）: 総合フィルタの無効化 / `students[0]` 基準ヘッダーへの復帰 / uuid 一次照合の除去 / 小計の試験スコープ除去 / migration の列名 typo

## 未検証

**実アプリでの動作確認（`npm run dev`）は行っていません。** 05-boundaries / 06-results / 07-export のプレビュー / インポートダイアログの警告表示は、手元でのご確認をお願いします。

## 積み残し（別対応）

- grade-archive は `allowCreate: false` で**生徒マスタを作らない**。exam-archive は uuid ごと作成する。照合方法の統一と違い「取り込みが生徒を増やすか」という仕様判断で、プレビューの「見つかりません」表示の意味も変わるため触っていない
- `examMapping` のキーが試験名のまま（uuid 一次照合が先に効くため実害は出にくい）

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)
