### PR TITLE
feat(07-score-at-once): 一覧表示に白さ順・濃さ順の並べ替えを追加

### DIFF
--- a/__tests__/exam/unit/regionWhiteness.test.ts
+++ b/__tests__/exam/unit/regionWhiteness.test.ts
@@ -1,0 +1,163 @@
+/**
+ * 答案の採点領域の白さ算出 テスト
+ *
+ * 空欄の答案が「白い」側に並ぶこと、記入量に応じて平均輝度が下がること、
+ * 画像1枚から複数の採点領域が独立に測られることを検証する。
+ */
+
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import sharp from "sharp"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import { measureAnswerWhiteness } from "../../../electron-src/lib/scoring/regionWhiteness"
+import type { WhitenessTargetRegion } from "../../../src/types/answerWhiteness.types"
+
+const IMAGE_WIDTH = 200
+const IMAGE_HEIGHT = 100
+
+/** 上半分・下半分に分かれた2つの採点領域 */
+const TOP_REGION: WhitenessTargetRegion = {
+  cropRegionId: "region-top",
+  x: 0,
+  y: 0,
+  width: 1,
+  height: 0.5,
+}
+const BOTTOM_REGION: WhitenessTargetRegion = {
+  cropRegionId: "region-bottom",
+  x: 0,
+  y: 0.5,
+  width: 1,
+  height: 0.5,
+}
+
+let workDirectory: string
+
+/**
+ * 白紙に黒い矩形を描いたPNGを作る。
+ * marks は画像ピクセル座標の矩形。
+ */
+async function createAnswerImage(
+  fileName: string,
+  marks: { left: number; top: number; width: number; height: number }[]
+): Promise<string> {
+  const pixels = Buffer.alloc(IMAGE_WIDTH * IMAGE_HEIGHT * 3, 255)
+
+  for (const mark of marks) {
+    for (let y = mark.top; y < mark.top + mark.height; y += 1) {
+      for (let x = mark.left; x < mark.left + mark.width; x += 1) {
+        const offset = (y * IMAGE_WIDTH + x) * 3
+        pixels[offset] = 0
+        pixels[offset + 1] = 0
+        pixels[offset + 2] = 0
+      }
+    }
+  }
+
+  const filePath = path.join(workDirectory, fileName)
+  await sharp(pixels, {
+    raw: { width: IMAGE_WIDTH, height: IMAGE_HEIGHT, channels: 3 },
+  })
+    .png()
+    .toFile(filePath)
+
+  return filePath
+}
+
+describe("measureAnswerWhiteness", () => {
+  let blankPath: string
+  let lightPath: string
+  let heavyPath: string
+
+  beforeAll(async () => {
+    workDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "region-whiteness-test-")
+    )
+
+    blankPath = await createAnswerImage("blank.png", [])
+    // 上半分に少しだけ記入（10x10）
+    lightPath = await createAnswerImage("light.png", [
+      { left: 10, top: 10, width: 10, height: 10 },
+    ])
+    // 上半分にたくさん記入（100x40）
+    heavyPath = await createAnswerImage("heavy.png", [
+      { left: 10, top: 5, width: 100, height: 40 },
+    ])
+  })
+
+  afterAll(() => {
+    fs.rmSync(workDirectory, { recursive: true, force: true })
+  })
+
+  it("空欄の答案は平均輝度255になる", async () => {
+    const [answer] = await measureAnswerWhiteness(
+      [{ studentAnswerImageId: "answer-blank", imagePath: blankPath }],
+      [TOP_REGION]
+    )
+
+    expect(answer.studentAnswerImageId).toBe("answer-blank")
+    expect(answer.regions[0].meanLuminance).toBe(255)
+  })
+
+  it("記入量が多いほど平均輝度が低い", async () => {
+    const answers = await measureAnswerWhiteness(
+      [
+        { studentAnswerImageId: "answer-blank", imagePath: blankPath },
+        { studentAnswerImageId: "answer-light", imagePath: lightPath },
+        { studentAnswerImageId: "answer-heavy", imagePath: heavyPath },
+      ],
+      [TOP_REGION]
+    )
+
+    const [blank, light, heavy] = answers.map((answer) => answer.regions[0])
+
+    expect(blank.meanLuminance).toBeGreaterThan(light.meanLuminance)
+    expect(light.meanLuminance).toBeGreaterThan(heavy.meanLuminance)
+  })
+
+  it("同じ画像でも採点領域ごとに独立して測られる", async () => {
+    const [answer] = await measureAnswerWhiteness(
+      [{ studentAnswerImageId: "answer-light", imagePath: lightPath }],
+      [TOP_REGION, BOTTOM_REGION]
+    )
+
+    const top = answer.regions.find(
+      (region) => region.cropRegionId === TOP_REGION.cropRegionId
+    )
+    const bottom = answer.regions.find(
+      (region) => region.cropRegionId === BOTTOM_REGION.cropRegionId
+    )
+
+    // 記入は上半分だけなので、下半分は完全な白のまま
+    expect(top?.meanLuminance).toBeLessThan(255)
+    expect(bottom?.meanLuminance).toBe(255)
+  })
+
+  it("読み込めない画像はスキップし、他の答案の算出は継続する", async () => {
+    const answers = await measureAnswerWhiteness(
+      [
+        {
+          studentAnswerImageId: "answer-missing",
+          imagePath: path.join(workDirectory, "not-exist.png"),
+        },
+        { studentAnswerImageId: "answer-blank", imagePath: blankPath },
+      ],
+      [TOP_REGION]
+    )
+
+    expect(answers.map((answer) => answer.studentAnswerImageId)).toEqual([
+      "answer-blank",
+    ])
+  })
+
+  it("採点領域が空なら何も算出しない", async () => {
+    const answers = await measureAnswerWhiteness(
+      [{ studentAnswerImageId: "answer-blank", imagePath: blankPath }],
+      []
+    )
+
+    expect(answers).toEqual([])
+  })
+})

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -1,5 +1,12 @@
+import path from "path"
+
+import type {
+  WhitenessTargetAnswerImage,
+  WhitenessTargetRegion,
+} from "../../src/types/answerWhiteness.types"
 import type { SerializedQuestionScore } from "../../src/types/prismaExtensions"
 import { toScoringStatus } from "../../src/types/scoringStatus.types"
+import { getAbsolutePathFromData } from "../lib/dataManager"
 import {
   type BatchScoreEntry,
   batchUpdateQuestionScores,
@@ -17,7 +24,8 @@ import {
 } from "../lib/prisma/questionScore"
 import { upsertScoreDecision } from "../lib/prisma/scoreDecision"
 import { initializeScoringRecords } from "../lib/prisma/scoringInitializer"
-import { registerHandler } from "./ipcHandlerUtils"
+import { measureAnswerWhiteness } from "../lib/scoring/regionWhiteness"
+import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
 /**
  * QuestionScoreをIPC用に変換（Decimal→number、Dateはそのまま、
@@ -208,4 +216,26 @@ export function setupScoringHandlers(): void {
   registerHandler("initialize-scoring-records", async (examId: string) => {
     return await initializeScoringRecords(examId)
   })
+
+  // グリッド採点の白さ順ソート用: 答案画像ごとに全採点領域の白さを算出する
+  registerSafeHandler(
+    "measure-answer-whiteness",
+    async (args: {
+      answerImages: WhitenessTargetAnswerImage[]
+      regions: WhitenessTargetRegion[]
+    }) => {
+      const answerImages = args.answerImages.map((answerImage) => ({
+        studentAnswerImageId: answerImage.studentAnswerImageId,
+        imagePath: path.isAbsolute(answerImage.imagePath)
+          ? answerImage.imagePath
+          : getAbsolutePathFromData(answerImage.imagePath),
+      }))
+
+      return {
+        success: true,
+        answers: await measureAnswerWhiteness(answerImages, args.regions),
+      }
+    },
+    "答案の白さ算出に失敗しました"
+  )
 }

--- a/electron-src/lib/scoring/regionWhiteness.ts
+++ b/electron-src/lib/scoring/regionWhiteness.ts
@@ -1,0 +1,122 @@
+/**
+ * 答案の採点領域の「白さ」（空欄らしさ）算出
+ *
+ * グリッド採点の白さ順ソート用。空欄・白紙の答案を先頭に集めるためのソートキーを作る。
+ *
+ * 画像1枚につきデコードは必ず1回だけ行い、そのページの全採点領域分をまとめて算出する。
+ * PNGは画像全体が1本の圧縮ストリームで途中打ち切りができないため、領域ごとにsharpの
+ * extractを呼ぶとデコードが領域数だけ繰り返され、実測で20倍以上遅くなる（1684x2382の
+ * 答案52枚・10設問で 1.3秒 → 33秒）。一方、デコード済みバッファに対する領域の走査は
+ * 1領域あたり0.2ms程度で、設問数はコストにほぼ影響しない。
+ *
+ * 指標は平均輝度のみ。閾値を持たないので、調整の必要な定数がひとつも無い。
+ * これは意図的な選択で、実採点データ（数学の単元/定期テスト直近6件・129設問・
+ * 無答1225件/記入10052件）で教員の付けた「無答」を正解ラベルに比較した結果、
+ * 閾値を導入しても得るものが無かったことによる。
+ *   - 平均輝度が最良（無答の平均順位0.091、先頭20%に無答の87.5%、
+ *     最後の無答も平均23.2%の位置まで。無作為な並びなら平均順位0.50）
+ *   - 暗画素率は僅差で下（閾値245で平均順位0.093、200で0.096）。
+ *     閾値を160〜245で振っても頭打ちで、平均輝度を超えない
+ *   - 領域を5%内側に詰める・孤立点を収縮で消す、はいずれも改善しない
+ *     （収縮は明確に悪化。細い鉛筆線ごと消えるため）
+ *   - 指標の差より試験ごとの差の方が一桁大きい（先頭20%の捕捉率が試験別に
+ *     83.9%〜94.2%）。残差は指標選択ではなく答案・設問の性質側にある
+ * 領域内の画素を測る系の指標はこの辺りが上限で、これ以上は答案の位置合わせを伴う
+ * 模範解答との差分など、別の系統が必要になる。
+ */
+
+import sharp from "sharp"
+
+import type {
+  AnswerWhiteness,
+  RegionWhiteness,
+  WhitenessTargetRegion,
+} from "../../../src/types/answerWhiteness.types"
+
+/** 測定対象の答案画像（imagePathは解決済みの絶対パス） */
+interface WhitenessTargetImage {
+  studentAnswerImageId: string
+  imagePath: string
+}
+
+/**
+ * グレースケール1chのRAWバッファから、相対矩形の平均輝度を求める。
+ * 矩形は画像の範囲でクランプする。
+ */
+function measureRegion(
+  pixels: Buffer,
+  imageWidth: number,
+  imageHeight: number,
+  region: WhitenessTargetRegion
+): RegionWhiteness {
+  const x0 = Math.max(0, Math.floor(region.x * imageWidth))
+  const y0 = Math.max(0, Math.floor(region.y * imageHeight))
+  const x1 = Math.min(
+    imageWidth,
+    Math.ceil((region.x + region.width) * imageWidth)
+  )
+  const y1 = Math.min(
+    imageHeight,
+    Math.ceil((region.y + region.height) * imageHeight)
+  )
+
+  let luminanceSum = 0
+  let pixelCount = 0
+
+  for (let y = y0; y < y1; y += 1) {
+    const rowOffset = y * imageWidth
+    for (let x = x0; x < x1; x += 1) {
+      luminanceSum += pixels[rowOffset + x]
+      pixelCount += 1
+    }
+  }
+
+  // 画像の外に出た領域など、画素が1つも無い場合。空欄側（先頭）に紛れ込ませないよう
+  // 「最も暗い」扱いにして末尾へ送る。
+  if (pixelCount === 0) {
+    return { cropRegionId: region.cropRegionId, meanLuminance: 0 }
+  }
+
+  return {
+    cropRegionId: region.cropRegionId,
+    meanLuminance: luminanceSum / pixelCount,
+  }
+}
+
+/**
+ * 答案画像ごとに、指定された全採点領域の白さを算出する。
+ *
+ * 読み込めない画像はスキップする（結果に含めない）。呼び出し側は白さ不明として扱う。
+ * メモリ上に載るのは常に1枚分のRAWバッファのみになるよう逐次処理する。
+ */
+export async function measureAnswerWhiteness(
+  answerImages: WhitenessTargetImage[],
+  regions: WhitenessTargetRegion[]
+): Promise<AnswerWhiteness[]> {
+  if (regions.length === 0) return []
+
+  const results: AnswerWhiteness[] = []
+
+  for (const answerImage of answerImages) {
+    try {
+      const { data, info } = await sharp(answerImage.imagePath)
+        .greyscale()
+        .raw()
+        .toBuffer({ resolveWithObject: true })
+
+      results.push({
+        studentAnswerImageId: answerImage.studentAnswerImageId,
+        regions: regions.map((region) =>
+          measureRegion(data, info.width, info.height, region)
+        ),
+      })
+    } catch (error) {
+      console.warn(
+        `答案画像の白さ算出に失敗しました: ${answerImage.imagePath}`,
+        error
+      )
+    }
+  }
+
+  return results
+}

--- a/electron-src/preload-apis/scoringApi.ts
+++ b/electron-src/preload-apis/scoringApi.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from "electron"
 
 import type {
+  WhitenessTargetAnswerImage,
+  WhitenessTargetRegion,
+} from "../../src/types/answerWhiteness.types"
+import type {
   CreateQuestionScoreArgs,
   UpdateQuestionScoreArgs,
 } from "../../src/types/electron/scoringApi"
@@ -58,5 +62,9 @@ export function createScoringApi() {
         userId: string
       }>
     ) => ipcRenderer.invoke("batch-update-question-scores", entries),
+    measureAnswerWhiteness: (args: {
+      answerImages: WhitenessTargetAnswerImage[]
+      regions: WhitenessTargetRegion[]
+    }) => ipcRenderer.invoke("measure-answer-whiteness", args),
   }
 }

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -11,6 +11,7 @@ import {
   ShortcutProvider,
   useShortcutContext,
 } from "@/components/exams/07-score-at-once/ScoringMain/contexts/ShortcutProvider"
+import { useAnswerWhiteness } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness"
 import { useBatchScoringWithProgress } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useBatchScoringWithProgress"
 import { usePartialScore } from "@/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore"
 import { useScoringActions } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useScoringActions"
@@ -78,6 +79,7 @@ function ScoringMainViewContent() {
     autoScroll,
     showStudentNames,
     layoutDirection,
+    answerSortOrder,
     expandMargin,
     clickScoringConfig,
     clickScoringDebounceMs,
@@ -88,6 +90,7 @@ function ScoringMainViewContent() {
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
+    setAnswerSortOrder,
     setExpandMargin,
     setClickAction,
     setClickScoringDebounceMs,
@@ -173,6 +176,14 @@ function ScoringMainViewContent() {
     (cropRegion) => cropRegion.id === currentCropRegionId
   )
 
+  /** 白さ順ソート用: 一覧表示中のページの白さを先読みする */
+  const { whitenessByAnswerId, isWhitenessReady } = useAnswerWhiteness({
+    studentAnswerImages,
+    cropRegions,
+    currentExamPageId: currentCropRegion?.examPageId ?? null,
+    enabled: gradingMode === "grid",
+  })
+
   /** Effect処理フック */
   useScoringEffects({
     gradingMode,
@@ -247,6 +258,8 @@ function ScoringMainViewContent() {
     gradingMode,
     questionChangeVersion,
     manualSelectionVersion,
+    answerSortOrder,
+    whitenessByAnswerId,
   })
 
   const handleReplaceSelection = useCallback(
@@ -754,6 +767,9 @@ function ScoringMainViewContent() {
               autoScroll={autoScroll}
               onAutoScrollChange={handleAutoScrollChange}
               gradingMode={gradingMode}
+              answerSortOrder={answerSortOrder}
+              onAnswerSortOrderChange={setAnswerSortOrder}
+              isWhitenessReady={isWhitenessReady}
               expandMargin={expandMargin}
               onExpandMarginChange={setExpandMargin}
               students={students}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerSortOrder.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerSortOrder.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview 一覧表示の並び順設定フック
+ * @description KV方式ユーザー設定の永続化（楽観的更新）
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import type { AnswerSortOrder } from "@/components/exams/07-score-at-once/types"
+import { useAuth } from "@/contexts/AuthContext"
+import {
+  parsePreference,
+  serializePreference,
+  USER_PREFERENCE_SCHEMA,
+} from "@/lib/userPreferences"
+
+const DEFAULT = USER_PREFERENCE_SCHEMA.answerSortOrder
+  .default as AnswerSortOrder
+
+/** 一覧表示の並び順（表示順・白さ順）をユーザー設定として永続化するフック */
+export function useAnswerSortOrder() {
+  const { user } = useAuth()
+  const userId = user?.id
+
+  const [answerSortOrder, setAnswerSortOrderState] =
+    useState<AnswerSortOrder>(DEFAULT)
+  const initializedUserIdRef = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (initializedUserIdRef.current === userId) return
+    if (!userId) return
+
+    initializedUserIdRef.current = userId
+
+    const load = async () => {
+      if (!window.electronAPI?.settings) return
+
+      try {
+        const result = await window.electronAPI.settings.getUserPreference(
+          userId,
+          "answerSortOrder"
+        )
+        if (result.success) {
+          setAnswerSortOrderState(
+            parsePreference(
+              "answerSortOrder",
+              result.value ?? null
+            ) as AnswerSortOrder
+          )
+        }
+      } catch (error) {
+        console.error("answerSortOrderの読み込みに失敗しました:", error)
+      }
+    }
+
+    load()
+  }, [userId])
+
+  const setAnswerSortOrder = useCallback(
+    (value: AnswerSortOrder) => {
+      setAnswerSortOrderState(value)
+      if (userId && window.electronAPI?.settings) {
+        window.electronAPI.settings
+          .setUserPreference(
+            userId,
+            "answerSortOrder",
+            serializePreference("answerSortOrder", value)
+          )
+          .catch((error) =>
+            console.error("answerSortOrderの保存に失敗しました:", error)
+          )
+      }
+    },
+    [userId]
+  )
+
+  return { answerSortOrder, setAnswerSortOrder }
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness.ts
@@ -1,0 +1,161 @@
+/**
+ * @fileoverview 答案の白さ（空欄らしさ）算出フック
+ * @description 一覧表示を開いた時点で、そのページの全答案×全採点領域の白さを先読みする。
+ */
+
+import { useEffect, useRef, useState } from "react"
+
+import type {
+  CropRegionWithExamPage,
+  StudentAnswerImageWithExamStudents,
+} from "@/components/exams/07-score-at-once/types"
+import type {
+  RegionWhiteness,
+  WhitenessTargetRegion,
+} from "@/types/answerWhiteness.types"
+
+/** studentAnswerImage.id → cropRegion.id → 白さ */
+export type WhitenessByAnswerId = Map<string, Map<string, RegionWhiteness>>
+
+interface UseAnswerWhitenessProps {
+  studentAnswerImages: StudentAnswerImageWithExamStudents[]
+  cropRegions: CropRegionWithExamPage[]
+  /** 一覧に表示しているページ */
+  currentExamPageId: string | null
+  /** 一覧表示中のみ算出する */
+  enabled: boolean
+}
+
+/** 算出済みか判定するための、対象ページの答案画像の顔ぶれ */
+function buildMeasurementSignature(
+  answerImages: StudentAnswerImageWithExamStudents[]
+): string {
+  return answerImages
+    .map((answerImage) => `${answerImage.id}:${answerImage.imagePath ?? ""}`)
+    .sort()
+    .join("|")
+}
+
+/**
+ * 一覧表示中のページについて、答案ごとの採点領域の白さを算出して保持するフック。
+ *
+ * 算出はページ単位で1回だけ行い、そのページの全採点領域分をまとめて得る。設問を
+ * 切り替えても再算出は発生しない（画像1枚のデコードコストに対し、領域を増やす
+ * コストは無視できるため。詳細は electron-src/lib/scoring/regionWhiteness.ts）。
+ */
+export function useAnswerWhiteness({
+  studentAnswerImages,
+  cropRegions,
+  currentExamPageId,
+  enabled,
+}: UseAnswerWhitenessProps) {
+  const [whitenessByAnswerId, setWhitenessByAnswerId] =
+    useState<WhitenessByAnswerId>(new Map())
+  const [measuredExamPageIds, setMeasuredExamPageIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [isMeasuring, setIsMeasuring] = useState(false)
+
+  /** ページごとの算出済みシグネチャ（答案が増減したら再算出する） */
+  const measuredSignatureRef = useRef<Map<string, string>>(new Map())
+  /** 算出中にページが切り替わった場合に古い結果を捨てるためのトークン */
+  const measurementTokenRef = useRef(0)
+
+  const pageAnswerImages = currentExamPageId
+    ? studentAnswerImages.filter(
+        (answerImage) =>
+          answerImage.examPageId === currentExamPageId && answerImage.imagePath
+      )
+    : []
+  const signature = buildMeasurementSignature(pageAnswerImages)
+
+  // 毎レンダーで新しい配列になるため、effectの依存には入れずrefで最新値を渡す。
+  // 再算出の要否はsignature（答案の顔ぶれ）で判定する。
+  const pageAnswerImagesRef = useRef(pageAnswerImages)
+  pageAnswerImagesRef.current = pageAnswerImages
+  const cropRegionsRef = useRef(cropRegions)
+  cropRegionsRef.current = cropRegions
+
+  useEffect(() => {
+    if (!enabled) return
+    if (!currentExamPageId) return
+
+    const pageAnswerImages = pageAnswerImagesRef.current
+    if (pageAnswerImages.length === 0) return
+    if (measuredSignatureRef.current.get(currentExamPageId) === signature)
+      return
+
+    const pageRegions: WhitenessTargetRegion[] = cropRegionsRef.current
+      .filter((cropRegion) => cropRegion.examPageId === currentExamPageId)
+      .map((cropRegion) => ({
+        cropRegionId: cropRegion.id,
+        x: cropRegion.x,
+        y: cropRegion.y,
+        width: cropRegion.width,
+        height: cropRegion.height,
+      }))
+
+    if (pageRegions.length === 0) return
+
+    const examPageId = currentExamPageId
+    measuredSignatureRef.current.set(examPageId, signature)
+    measurementTokenRef.current += 1
+    const token = measurementTokenRef.current
+
+    const measure = async () => {
+      setIsMeasuring(true)
+      try {
+        const result = await window.electronAPI.measureAnswerWhiteness({
+          answerImages: pageAnswerImages.map((answerImage) => ({
+            studentAnswerImageId: answerImage.id,
+            imagePath: answerImage.imagePath ?? "",
+          })),
+          regions: pageRegions,
+        })
+
+        // 算出中に別ページへ移った場合は破棄する
+        if (token !== measurementTokenRef.current) return
+
+        if (!result.success || !result.answers) {
+          // 失敗したページは次に開いたときに再試行する
+          measuredSignatureRef.current.delete(examPageId)
+          console.error("答案の白さ算出に失敗しました:", result.error)
+          return
+        }
+
+        const answers = result.answers
+        setWhitenessByAnswerId((prev) => {
+          const next = new Map(prev)
+          for (const answer of answers) {
+            next.set(
+              answer.studentAnswerImageId,
+              new Map(
+                answer.regions.map((region) => [region.cropRegionId, region])
+              )
+            )
+          }
+          return next
+        })
+        setMeasuredExamPageIds((prev) => new Set(prev).add(examPageId))
+      } catch (error) {
+        measuredSignatureRef.current.delete(examPageId)
+        console.error("答案の白さ算出に失敗しました:", error)
+      } finally {
+        if (token === measurementTokenRef.current) {
+          setIsMeasuring(false)
+        }
+      }
+    }
+
+    measure()
+  }, [enabled, currentExamPageId, signature])
+
+  return {
+    whitenessByAnswerId,
+    /** 表示中のページの白さが揃っているか（並び順の選択可否に使う） */
+    isWhitenessReady: currentExamPageId
+      ? measuredExamPageIds.has(currentExamPageId)
+      : false,
+    isMeasuringWhiteness: isMeasuring,
+  }
+}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -8,7 +8,9 @@ import {
   useState,
 } from "react"
 
+import type { WhitenessByAnswerId } from "@/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness"
 import type {
+  AnswerSortOrder,
   CropRegionWithExamPage,
   GradingMode,
   MasterGridItem,
@@ -52,6 +54,8 @@ interface UseScoringFilterProps {
   gradingMode: GradingMode
   questionChangeVersion: number
   manualSelectionVersion: number
+  answerSortOrder: AnswerSortOrder
+  whitenessByAnswerId: WhitenessByAnswerId
 }
 
 /** 採点ステータスによるフィルタリングと表示対象の答案リスト管理を行うフック */
@@ -66,6 +70,8 @@ export function useScoringFilter({
   gradingMode,
   questionChangeVersion,
   manualSelectionVersion,
+  answerSortOrder,
+  whitenessByAnswerId,
 }: UseScoringFilterProps) {
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({
     unscored: true,
@@ -184,8 +190,44 @@ export function useScoringFilter({
       }
     )
 
+    // 白さ順・濃さ順（一覧表示のみ）。並べる基準は平均輝度のみで、閾値は持たない
+    // （実採点データの「無答」を正解として比較した結果に基づく。
+    //   詳細は electron-src/lib/scoring/regionWhiteness.ts の冒頭コメント）。
+    // sortは安定なので、輝度が同値の答案は直前の表示順（customOrder）のまま残る。
+    // 白さが未算出の答案は、どちらの向きでも末尾へ送る。
+    if (
+      gradingMode === "grid" &&
+      (answerSortOrder === "whiteness" || answerSortOrder === "darkness")
+    ) {
+      const cropRegionId = currentCropRegion.id
+      // 濃さ順は白さ順の逆向き
+      const direction = answerSortOrder === "darkness" ? -1 : 1
+
+      studentScoringData.sort((scoringDataA, scoringDataB) => {
+        const whitenessA = whitenessByAnswerId
+          .get(scoringDataA.id)
+          ?.get(cropRegionId)
+        const whitenessB = whitenessByAnswerId
+          .get(scoringDataB.id)
+          ?.get(cropRegionId)
+
+        if (!whitenessA && !whitenessB) return 0
+        if (!whitenessA) return 1
+        if (!whitenessB) return -1
+
+        return direction * (whitenessB.meanLuminance - whitenessA.meanLuminance)
+      })
+    }
+
     return studentScoringData
-  }, [currentCropRegion, studentAnswerImages, questionScores])
+  }, [
+    currentCropRegion,
+    studentAnswerImages,
+    questionScores,
+    gradingMode,
+    answerSortOrder,
+    whitenessByAnswerId,
+  ])
 
   const updateVisibleAnswers = useCallback(
     (customFilterSettings?: FilterSettings) => {

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringSettings.ts
@@ -3,6 +3,7 @@
  * @description 各設定は独立したフックで管理され、このフックは互換性のために統合して返す。
  */
 
+import { useAnswerSortOrder } from "./useAnswerSortOrder"
 import { useAutoScroll } from "./useAutoScroll"
 import { useClickScoringConfig } from "./useClickScoringConfig"
 import { useExpandMargin } from "./useExpandMargin"
@@ -17,6 +18,7 @@ export function useScoringSettings() {
   const { autoScroll, setAutoScroll } = useAutoScroll()
   const { showStudentNames, setShowStudentNames } = useShowStudentNames()
   const { layoutDirection, setLayoutDirection } = useLayoutDirection()
+  const { answerSortOrder, setAnswerSortOrder } = useAnswerSortOrder()
   const { expandMargin, setExpandMargin } = useExpandMargin()
   const {
     clickScoringConfig,
@@ -38,6 +40,7 @@ export function useScoringSettings() {
     autoScroll,
     showStudentNames,
     layoutDirection,
+    answerSortOrder,
     expandMargin,
     clickScoringConfig,
     clickScoringDebounceMs,
@@ -48,6 +51,7 @@ export function useScoringSettings() {
     setAutoScroll,
     setShowStudentNames,
     setLayoutDirection,
+    setAnswerSortOrder,
     setExpandMargin,
     setClickAction,
     setClickScoringDebounceMs,

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/NavigationControls.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { LayoutDirection } from "@/components/exams/07-score-at-once/types"
+import type {
+  AnswerSortOrder,
+  LayoutDirection,
+} from "@/components/exams/07-score-at-once/types"
 import {
   Select,
   SelectContent,
@@ -18,6 +21,10 @@ interface NavigationControlsProps {
   gradingMode?: "grid" | "individual"
   expandMargin?: number
   onExpandMarginChange?: (value: number) => void
+  answerSortOrder?: AnswerSortOrder
+  onAnswerSortOrderChange?: (order: AnswerSortOrder) => void
+  /** 白さの算出が完了しているか（未完了なら白さ順を選べない） */
+  isWhitenessReady?: boolean
 }
 
 const LAYOUT_OPTIONS = [
@@ -25,6 +32,12 @@ const LAYOUT_OPTIONS = [
   { value: "left-down", label: "左→下", description: "左に進んでから下へ" },
   { value: "down-right", label: "下→右", description: "下に進んでから右へ" },
   { value: "down-left", label: "下→左", description: "下に進んでから左へ" },
+]
+
+const SORT_OPTIONS = [
+  { value: "custom", label: "表示順", needsWhiteness: false },
+  { value: "whiteness", label: "白さ順", needsWhiteness: true },
+  { value: "darkness", label: "濃さ順", needsWhiteness: true },
 ]
 
 export default function NavigationControls({
@@ -35,6 +48,9 @@ export default function NavigationControls({
   gradingMode = "grid",
   expandMargin,
   onExpandMarginChange,
+  answerSortOrder,
+  onAnswerSortOrderChange,
+  isWhitenessReady = false,
 }: NavigationControlsProps) {
   const isColumnLayout =
     layoutDirection === "down-right" || layoutDirection === "down-left"
@@ -88,6 +104,37 @@ export default function NavigationControls({
               {expandMargin}%
             </span>
           </div>
+        </div>
+      )}
+
+      {/* 並び順 */}
+      {answerSortOrder && onAnswerSortOrderChange && (
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 text-xs text-gray-500">並び順</span>
+          <Select
+            value={answerSortOrder}
+            onValueChange={(value) =>
+              onAnswerSortOrderChange(value as AnswerSortOrder)
+            }
+          >
+            <SelectTrigger className="h-7 flex-1 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SORT_OPTIONS.map((option) => {
+                const isPending = option.needsWhiteness && !isWhitenessReady
+                return (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                    disabled={isPending}
+                  >
+                    {isPending ? `${option.label}（解析中…）` : option.label}
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
         </div>
       )}
 

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -24,6 +24,7 @@ import NavigationControls from "@/components/exams/07-score-at-once/ScoringSideP
 import QuestionNavigator from "@/components/exams/07-score-at-once/ScoringSidePanel/QuestionNavigator"
 import ScoringToolbar from "@/components/exams/07-score-at-once/ScoringSidePanel/ScoringToolbar"
 import type {
+  AnswerSortOrder,
   CropRegionWithExamPage,
   LayoutDirection,
   MasterAnswerDisplayMode,
@@ -122,6 +123,10 @@ interface ScoringSidePanelProps {
   autoScroll: boolean
   onAutoScrollChange: (enabled: boolean) => void
   gradingMode: "grid" | "individual"
+  // 一覧表示の並び順
+  answerSortOrder: AnswerSortOrder
+  onAnswerSortOrderChange: (order: AnswerSortOrder) => void
+  isWhitenessReady: boolean
   // 表示領域拡張
   expandMargin?: number
   onExpandMarginChange?: (value: number) => void
@@ -206,6 +211,9 @@ export function ScoringSidePanel({
   autoScroll,
   onAutoScrollChange,
   gradingMode,
+  answerSortOrder,
+  onAnswerSortOrderChange,
+  isWhitenessReady,
   expandMargin,
   onExpandMarginChange,
   students,
@@ -422,6 +430,9 @@ export function ScoringSidePanel({
                 gradingMode={gradingMode}
                 expandMargin={expandMargin}
                 onExpandMarginChange={onExpandMarginChange}
+                answerSortOrder={answerSortOrder}
+                onAnswerSortOrderChange={onAnswerSortOrderChange}
+                isWhitenessReady={isWhitenessReady}
               />
             </div>
           </SidePanelSection>

--- a/src/components/exams/07-score-at-once/types.ts
+++ b/src/components/exams/07-score-at-once/types.ts
@@ -43,6 +43,16 @@ export type LayoutDirection =
   "right-down" | "left-down" | "down-right" | "down-left"
 
 /**
+ * 一覧表示の並び順
+ * - "custom": 表示順（ExamStudent.customOrder）
+ * - "whiteness": 白さ順（空欄に近い答案が先頭）
+ * - "darkness": 濃さ順（記入の多い答案が先頭）
+ *
+ * 白さ順・濃さ順は一覧表示でのみ適用される。
+ */
+export type AnswerSortOrder = "custom" | "whiteness" | "darkness"
+
+/**
  * クライアントサイド用のQuestionScore型
  * partialScoreをDecimalからnumberに変更（UI状態管理用）
  */

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -14,6 +14,11 @@ export const USER_PREFERENCE_SCHEMA = {
     validate: (v: string) =>
       ["right-down", "left-down", "down-right", "down-left"].includes(v),
   },
+  answerSortOrder: {
+    type: "string" as const,
+    default: "custom",
+    validate: (v: string) => ["custom", "whiteness", "darkness"].includes(v),
+  },
   expandMargin: { type: "number" as const, default: 0 },
   selectionBorderColor: {
     type: "string?" as const,
@@ -59,6 +64,7 @@ export type PreferenceValueType = {
   autoScroll: boolean
   itemsPerLine: number
   layoutDirection: string
+  answerSortOrder: string
   expandMargin: number
   selectionBorderColor: string | null
   scoringStatusColors: string | null

--- a/src/types/answerWhiteness.types.ts
+++ b/src/types/answerWhiteness.types.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview 答案の採点領域の「白さ」（空欄らしさ）の型定義
+ * @description グリッド採点の白さ順ソート用。メインプロセスで算出しIPCで受け渡す。
+ */
+
+/** 白さを測る採点領域（答案画像に対する0-1相対座標） */
+export interface WhitenessTargetRegion {
+  cropRegionId: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** 白さの測定対象となる答案画像 */
+export interface WhitenessTargetAnswerImage {
+  studentAnswerImageId: string
+  /** データディレクトリからの相対パス、または絶対パス */
+  imagePath: string
+}
+
+/** 1つの採点領域の白さ */
+export interface RegionWhiteness {
+  cropRegionId: string
+  /** 平均輝度（0-255）。大きいほど白い＝空欄に近い */
+  meanLuminance: number
+}
+
+/** 1枚の答案画像について、対象ページの全採点領域の白さ */
+export interface AnswerWhiteness {
+  studentAnswerImageId: string
+  regions: RegionWhiteness[]
+}

--- a/src/types/electron/scoringApi.d.ts
+++ b/src/types/electron/scoringApi.d.ts
@@ -3,6 +3,11 @@ import type { QuestionScore } from "@prisma/client"
 import type { SCORE_TARGET_DELETED } from "@/electron-src/lib/prisma/questionScore"
 
 import type {
+  AnswerWhiteness,
+  WhitenessTargetAnswerImage,
+  WhitenessTargetRegion,
+} from "../answerWhiteness.types"
+import type {
   QuestionScoreWithUser,
   SerializedQuestionScore,
 } from "../prismaExtensions"
@@ -152,6 +157,15 @@ export interface ScoringAPI {
   ) => Promise<{
     success: boolean
     updatedCount: number
+    error?: string
+  }>
+  /** 答案画像ごとに、指定した全採点領域の白さ（空欄らしさ）を算出する */
+  measureAnswerWhiteness: (args: {
+    answerImages: WhitenessTargetAnswerImage[]
+    regions: WhitenessTargetRegion[]
+  }) => Promise<{
+    success: boolean
+    answers?: AnswerWhiteness[]
     error?: string
   }>
 }


### PR DESCRIPTION
## 概要

グリッド採点（一覧表示）に「白さ順」と、その逆の「濃さ順」の並べ替えを追加します。空欄の答案が先頭に集まるため、既存のドラッグ選択と一括採点でまとめて無答処理できます。

Closes #835

## 実装

### 算出

- 採点領域の**平均輝度**をメインプロセス（sharp）で算出
- **画像1枚につきデコードは1回だけ**行い、そのページの全採点領域分をまとめて得る
  - PNGは画像全体が1本の圧縮ストリームで途中打ち切りができないため、設問ごとに `sharp().extract()` を呼ぶとデコードが設問数だけ繰り返される（実測で1684x2382の答案52枚・10設問が 1.3秒 → 33秒）
  - デコード済みバッファに対する領域の走査は1領域あたり0.2ms程度で、設問数はコストにほぼ影響しない
- 結果はレンダラー側のstateに保持。**設問を切り替えても再算出は発生しない**
- 一覧を開いた時点でバックグラウンド算出し、完了するまで並び順の選択肢を無効化（「解析中…」表示）
- 実測で40枚約1秒、200枚でも1.5秒程度

### 並べ替え

- 並び順は**表示順・白さ順・濃さ順**の3択。`UserPreference`（KV）へ永続化するため**スキーマ変更は不要**
- 並べ替えは `useScoringFilter` の `allScoringData` に適用。表示順・キーボードナビ・初期選択・「表示中の未採点を一括採点」の対象がすべてこの配列から派生するため、ここ1か所で全部が揃う
- `Array.prototype.sort` が安定なことを利用し、輝度が同値の答案は表示順（customOrder）のまま残す
- 白さが未算出の答案は、白さ順・濃さ順のどちらでも末尾へ送る
- **一覧表示のみ**に適用。個別表示は選択IDで答案を解決しているため、モードを往復しても表示中の生徒は変わらない

## 指標の選定（実データ検証）

閾値や調整用の定数を**一切持たない**実装になっています。これは意図的な選択で、実採点データで比較した結果に基づきます。

**検証方法**: `数学　単元テスト` / `数学　定期テスト` タグの直近6試験（129設問・無答1225件・記入10052件）について、教員が付けた `status='no_answer'` を正解ラベルとし、指標が無答をどれだけ前方に集められるかを測定。

| 指標 | 無答の平均順位 | 先頭20%に入る無答 | 無答90%到達の深さ | 最後の無答の位置 |
| --- | --- | --- | --- | --- |
| **平均輝度（採用）** | **0.091** | **87.5%** | 21.1% | 23.2% |
| 暗画素率 閾値245 | 0.093 | 87.1% | 22.0% | 24.4% |
| 暗画素率 閾値200 | 0.096 | 86.3% | 22.6% | 24.7% |
| 平均輝度+5%内側詰め | 0.094 | 86.3% | 18.7% | 20.5% |
| 暗画素率 孤立点除去 | （AUCで明確に悪化） | | | |

無作為な並びなら平均順位0.50・先頭20%に20%。

- **閾値を導入しても得るものが無い**ため、平均輝度のみを採用し定数を排除
- 領域の内側詰め・孤立点の収縮除去はいずれも改善しない（収縮は細い鉛筆線ごと消えるため明確に悪化）
- 指標の差より**試験ごとの差の方が一桁大きい**（先頭20%の捕捉率が試験別に83.9%〜94.2%）。残差は指標選択ではなく答案・設問の性質側にある

検証結果は `electron-src/lib/scoring/regionWhiteness.ts` の冒頭コメントに記録しています。「暗画素率を足せば良くなるのでは」と後から考えた人が同じ実験をやり直さずに済むようにするためです。

## 変更ファイル

**メインプロセス**
- `electron-src/lib/scoring/regionWhiteness.ts`（新規）
- `electron-src/ipc-handlers/scoringHandlers.ts` — `measure-answer-whiteness` ハンドラ追加
- `electron-src/preload-apis/scoringApi.ts` / `src/types/electron/scoringApi.d.ts`
- `src/types/answerWhiteness.types.ts`（新規）

**レンダラー**
- `ScoringMain/hooks/useAnswerWhiteness.ts`（新規）— ページ単位の先読み
- `ScoringMain/hooks/useAnswerSortOrder.ts`（新規）＋ `src/lib/userPreferences.ts` — 設定の永続化
- `ScoringMain/hooks/useScoringFilter.ts` — 並べ替えの適用
- `ScoringSidePanel/NavigationControls.tsx` — 「並び順」Select
- `ScoringMain/ScoringMainView.tsx` / `ScoringSidePanel.tsx` / `types.ts` / `useScoringSettings.ts` — 配線

**テスト**
- `__tests__/exam/unit/regionWhiteness.test.ts`（新規・5件）

## 確認

- `npm run typecheck` 通過
- `npm run lint` 通過
- `npx vitest run __tests__/exam __tests__/renderer` 225件通過

## 関連

- 検証中に確認した「答案画像がローカルにキャッシュされずNAS上の実体を直接読んでいる」件は #1052 として別issueに切り出しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ed9cbvsmYjoDiCk3UEWRY
