### PR TITLE
feat(answer-sheet-builder): OMRマーカーの印字を既定で有効にする

### DIFF
--- a/src/components/answer-sheet-builder/constants.ts
+++ b/src/components/answer-sheet-builder/constants.ts
@@ -86,7 +86,7 @@ export const DEFAULT_SETTINGS: GlobalSettings = {
     manuscriptCharDividerWidth: DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
     manuscriptLineDividerWidth: DEFAULT_MANUSCRIPT_DIVIDER_WIDTH,
   },
-  omrMarkers: { enabled: false, sizeMm: 5, offsetMm: 6 },
+  omrMarkers: { enabled: true, sizeMm: 5, offsetMm: 6 },
   fonts: {
     family: "Noto Sans JP",
     defaultSize: 6,


### PR DESCRIPTION
Closes #1058

## 変更内容

`DEFAULT_SETTINGS.omrMarkers.enabled` を `false` → `true` に変更（1行）。

## なぜ

`examConverter` は ASB → 試験の変換時に `Exam.markerCorrectionEnabled` へ `definition.settings.omrMarkers.enabled` をそのまま引き継ぐ。ASBの既定がオフだったため、ASB由来の試験でも答案アップロード時のマーク補正が既定で無効のままだった。

この変更により、

- 新規作成する解答用紙定義はOMRマーカーが既定で印字される
- そこから変換した試験はマーク補正が既定で有効になる

## 影響範囲

- 保存済みの解答用紙定義は `AsbDefinition.omrMarkersEnabled` 列から復元されるため影響なし
- スキーマ既定（`@default(false)`）は据え置き。保存時は `asbDefinitionConverters` が常に実値を渡すため列既定は使われず、マイグレーション不要
- `DEFAULT_SETTINGS` の `omrMarkers` に依存するテストは無し（スクリーンショット用フィクスチャは明示値を持つ）

## 確認

- `npx prettier --check` / `npx eslint` を対象ファイルに対して実行し問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
