### PR TITLE
chore(deps): electron を 43.2.0 へメジャー更新し ABI 判定を厳密化する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "autoprefixer": "^10.5.0",
         "concurrently": "^10.0.3",
         "dotenv": "^17.4.2",
-        "electron": "^42.4.0",
+        "electron": "^43.2.0",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.2.6",
@@ -10964,9 +10964,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.7.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.7.1.tgz",
-      "integrity": "sha512-fmjFv4Ebbs/FNZg6a/IAu25lBb8vo/HBVa2vtE2GvYlgAC7/fu8dx1b2pL2wV1yWlfMI2q3Npe4eVYSFGirnwA==",
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "autoprefixer": "^10.5.0",
     "concurrently": "^10.0.3",
     "dotenv": "^17.4.2",
-    "electron": "^42.4.0",
+    "electron": "^43.2.0",
     "esbuild": "^0.28.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.2.6",

--- a/scripts/ensure-sqlite-abi.js
+++ b/scripts/ensure-sqlite-abi.js
@@ -15,6 +15,10 @@
  *      `--build-from-source` で Electronヘッダからコンパイルさせる必要がある。
  *   3. electron-rebuild / npm rebuild は build/Release に既存バイナリがあると
  *      キャッシュ復元で済ませ上書きしない。リビルド前に削除して強制再生成する。
+ *   4. ABIは「Node向けかElectron向けか」の2値ではない。Electronのメジャー更新で
+ *      Electron側のABIも変わる（42=146, 43=148）。2値判定のままだと旧メジャー向けの
+ *      バイナリを「既にelectron向け」と誤認し、リビルドを省いてアプリ起動時に落ちる。
+ *      そのためElectronは要求ABIの一致まで確認する。
  *
  * 使い方:
  *   node scripts/ensure-sqlite-abi.js electron   # Electronアプリ起動前
@@ -39,6 +43,23 @@ const BUILD_RELEASE = path.resolve(
 )
 
 /**
+ * 現在インストールされている Electron が要求する NODE_MODULE_VERSION を返す。
+ *
+ * Electron のメジャー更新で ABI は変わる（42=146, 43=148）。「Electron向けかどうか」
+ * だけでなく「どのElectronのABIか」まで見ないと、旧メジャー向けバイナリを
+ * 「既にelectron向け」と誤認してアプリ起動時に落ちる。
+ * @returns {number|null} 判定できない場合は null（その場合は常にリビルドする）
+ */
+function expectedElectronAbi() {
+  try {
+    const electronVersion = require("electron/package.json").version
+    return Number(require("node-abi").getAbi(electronVersion, "electron"))
+  } catch {
+    return null
+  }
+}
+
+/**
  * 現在 build/Release に置かれているバイナリのターゲットを判定する。
  *
  * 必ず子プロセスで判定する: ネイティブ部は一度 new Database() で開くとプロセス内に
@@ -46,42 +67,74 @@ const BUILD_RELEASE = path.resolve(
  * 古いバイナリが見え続ける。リビルド前後で同じプロセスから判定すると誤検知するため。
  *
  * require() はネイティブ部を遅延ロードするので、実際に DB を開いて dlopen を強制する。
- * @returns {"node"|"electron"|"none"}
- *   - "node":     素のNodeで開けた = Node向けビルド
- *   - "electron": ABI不一致で開けない = Electron向けビルド
- *   - "none":     バイナリ欠落など判定不能 = 要リビルド
+ * ABI不一致のエラーメッセージ先頭の NODE_MODULE_VERSION がバイナリ側のABIなので、
+ * それを取り出して「どのElectron向けか」まで特定する。
+ * @returns {{kind:"node"}|{kind:"electron",abi:number}|{kind:"none"}}
  */
 function detectCurrentTarget() {
   const probe =
     "try{const D=require('better-sqlite3');new D(':memory:').close();" +
     "process.stdout.write('node')}" +
-    "catch(e){process.stdout.write(String(e&&e.message).includes('NODE_MODULE_VERSION')?'electron':'none')}"
+    "catch(e){process.stdout.write('ERR:'+String(e&&e.message).replace(/\\s+/g,' '))}"
+  let out
   try {
-    const out = execSync(`node -e "${probe}"`, {
+    out = execSync(`node -e "${probe}"`, {
       cwd: path.resolve(__dirname, ".."),
       stdio: ["ignore", "pipe", "ignore"],
     })
-    return out.toString().trim() || "none"
+      .toString()
+      .trim()
   } catch {
-    return "none"
+    return { kind: "none" }
   }
+  if (out === "node") return { kind: "node" }
+  // 「compiled against ... NODE_MODULE_VERSION <X>. This version of Node.js requires
+  //  NODE_MODULE_VERSION <Y>」の最初の数値がバイナリ側のABI。
+  const matched = out.match(/NODE_MODULE_VERSION (\d+)/)
+  if (matched) return { kind: "electron", abi: Number(matched[1]) }
+  return { kind: "none" }
 }
 
 const current = detectCurrentTarget()
+const wantedAbi = expectedElectronAbi()
 
-if (current === target) {
+/** 現状が要求ターゲットを満たしているか。Electron は ABI 一致まで要求する。 */
+const satisfied =
+  target === "node"
+    ? current.kind === "node"
+    : current.kind === "electron" &&
+      wantedAbi !== null &&
+      current.abi === wantedAbi
+
+if (satisfied) {
   console.log(
-    `[ensure-sqlite-abi] better-sqlite3 は既に ${target} 向けです。リビルド不要。`
+    `[ensure-sqlite-abi] better-sqlite3 は既に ${target} 向けです（ABI ${
+      current.kind === "electron" ? current.abi : process.versions.modules
+    }）。リビルド不要。`
   )
   process.exit(0)
 }
 
+const currentLabel =
+  current.kind === "electron"
+    ? `electron(ABI ${current.abi})`
+    : current.kind === "node"
+      ? "node"
+      : "不明"
+const targetLabel =
+  target === "electron" && wantedAbi !== null
+    ? `electron(ABI ${wantedAbi})`
+    : target
 console.log(
-  `[ensure-sqlite-abi] better-sqlite3 を ${target} 向けにリビルドします（現在: ${current}）...`
+  `[ensure-sqlite-abi] better-sqlite3 を ${targetLabel} 向けにリビルドします（現在: ${currentLabel}）...`
 )
 
 // 既存バイナリを消してキャッシュ復元による上書きスキップを防ぐ。
+// Electronのメジャー更新時は bin/<platform>-<abi>/ に旧ABIのキャッシュが残り、
+// electron-rebuild がそれを復元して新ABI向けのビルドを省くことがあるため一緒に消す。
 if (fs.existsSync(BUILD_RELEASE)) fs.rmSync(BUILD_RELEASE)
+const BIN_CACHE = path.resolve(__dirname, "../node_modules/better-sqlite3/bin")
+if (fs.existsSync(BIN_CACHE)) fs.rmSync(BIN_CACHE, { recursive: true })
 
 const cmd =
   target === "electron"
@@ -92,11 +145,21 @@ execSync(cmd, { stdio: "inherit" })
 
 // 生成結果を検証（取り違え再発の早期検知）。
 const after = detectCurrentTarget()
-if (after !== target) {
+const afterSatisfied =
+  target === "node"
+    ? after.kind === "node"
+    : after.kind === "electron" && wantedAbi !== null && after.abi === wantedAbi
+if (!afterSatisfied) {
+  const afterLabel =
+    after.kind === "electron"
+      ? `electron(ABI ${after.abi})`
+      : after.kind === "node"
+        ? "node"
+        : "不明"
   console.error(
-    `[ensure-sqlite-abi] リビルド後も ${target} 向けになっていません（実測: ${after}）。`
+    `[ensure-sqlite-abi] リビルド後も ${targetLabel} 向けになっていません（実測: ${afterLabel}）。`
   )
   process.exit(1)
 }
 
-console.log(`[ensure-sqlite-abi] 完了（${target} 向け）。`)
+console.log(`[ensure-sqlite-abi] 完了（${targetLabel} 向け）。`)


### PR DESCRIPTION
electron 42.7.1 → **43.2.0**（Chromium 150 / Node 24.18 / V8 15.0、ABI 146 → 148）。lockfile の差分は **electron 1件のみ**で、他パッケージも pdfjs-dist も動いていません。

## better-sqlite3 をどう扱ったか

ここが今回の調査の肝でした。

- Electron 43 対応を入れた **better-sqlite3 12.11.2 / 12.12.0 は GitHub にリリースがあるが npm に公開されていない**（npm 上の 12.x は 12.11.1 が最終）
- npm から入る Electron 43 対応版は **13.x のみ**
- しかし `@prisma/adapter-better-sqlite3@7.9.0` が `better-sqlite3: ^12.6.0` を **peer ではなく hard dependency** で抱えているため、13 に上げると 12.x と 13.x が二重にツリーに入る

本試験は `--build-from-source` でコンパイルする方針なので、**12.11.1 のソースが Electron 43 のヘッダで通るかを実測**しました。結果は問題なし（コンパイル・実行とも成功）。よって **better-sqlite3 は 12.11.1 のまま据え置き**、二重化を回避しています。

将来 better-sqlite3 13 に上げれば N-API 化により ABI の綱引き自体が不要になりますが、上記の adapter 依存が解決してからにすべきです。

## ensure-sqlite-abi.js の修正（この更新で実際に踏んだ不具合）

従来の判定は「素の Node で開けるか否か」の **2値** で、**Electron 同士の ABI 差を区別できませんでした**。そのため ABI 146（Electron 42）の古いバイナリを掴んだまま「既に electron 向けです。リビルド不要」と報告し、Electron 43 では起動時に落ちます。実際に本作業中にこの現象を踏みました。

- Electron は `node-abi` で要求 ABI を求め、**一致するまでリビルド**するようにした
- ABI 不一致エラーからバイナリ側の `NODE_MODULE_VERSION` を抽出し、実測 ABI をログに出すようにした
- `bin/<platform>-<abi>/` の旧 ABI キャッシュもリビルド前に削除（electron-rebuild がこれを復元して新 ABI のビルドを省くため）

これがないと、既存の開発環境から 43 に上げた人が「リビルド不要」と言われた上でアプリが起動しない、という分かりにくい壊れ方をします。

## 検証

- better-sqlite3 12.11.1 が Electron 43 ヘッダでソースビルド成功
- **Electron 43 実機で全ネイティブモジュールがロード・動作**: better-sqlite3 12.11.1 / sharp 0.35.3 (libvips 8.18.3) / bcrypt / onnxruntime-node 1.27.0
- `npm run dev` で実 DB をロードし「Application startup completed successfully」、ページ配信まで確認
- `npm run build` 成功
- `electron-forge package --platform=darwin` 成功（Electron 43.2.0 同梱、ABI 148 バイナリと pdfjs worker の同梱を確認）
- `ensure-sqlite-abi.js` の electron/node 双方向切替と冪等性を実測

### Electron 43 の破壊的変更の影響確認

| 変更 | 本試験への影響 |
|---|---|
| `nativeImage` のカラープロファイルを sRGB に正規化 | **該当なし**（`nativeImage` を一切使用していない） |
| `dialog` の `showHiddenFiles` 削除（Linux） | **該当なし**（未使用） |
| Linux のフレームレスウィンドウが既定で角丸 | `frame: false` は2箇所あるがいずれも `show: false` + `offscreen: true` のオフスクリーンウィンドウで、コンポジタを経由しないため影響は想定されない。Linux 実機で PDF/SVG 出力に角欠けが出た場合は `roundedCorners: false` を追加する |
| ダウンロード既定先の変更 | 該当なし |

## テストスイートを回していない理由

lockfile の差分が electron 1件のみで、electron は devDependency かつ vitest の実行経路（素の Node）に一切登場しないためです。代わりに Electron 側の検証（実機起動・全ネイティブモジュール・パッケージング）を厚めに行いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcGWeHzmrkm49gPMdjUfzZ