### PR TITLE
feat(06-student-answers): 行・列の一括無効化を右クリックメニューに追加

### DIFF
--- a/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
@@ -16,6 +16,7 @@ import { EmptyTableCell } from "@/components/exams/06-student-answers/student-an
 import { OrphanAnswerCard } from "@/components/exams/06-student-answers/student-answer-table/components/OrphanAnswerCard"
 import { SortableTableCell } from "@/components/exams/06-student-answers/student-answer-table/components/SortableTableCell"
 import {
+  type BulkDisablingHandlers,
   type EmptyCellSlotProps,
   type FileCellSlotProps,
   TableContent,
@@ -71,7 +72,6 @@ interface AnswerTableShellProps {
   disabledState: ExtendedDisabledState
   nameRegionExamPageIds: Set<string>
   cellsWithExistingAnswers: CellLookup
-  files: AnswerImageIdentity[]
   affectedCells?: Set<string>
   imageLoadStates?: Record<string, "pending" | "loading" | "loaded" | "error">
   correctingFileIds?: Set<string>
@@ -83,6 +83,7 @@ interface AnswerTableShellProps {
   ) => Promise<string | null>
   toggleRowDisabled: (examStudentId: string) => void
   toggleColDisabled: (examPageId: string) => void
+  bulkDisabling?: BulkDisablingHandlers
   toggleCellDisabled: (studentId: string, examPageId: string) => void
   toggleFileDisabled: (fileId: string) => void
   onDeleteAnswerSheet?: (fileId: string) => void
@@ -128,7 +129,6 @@ export function AnswerTableShell({
   disabledState,
   nameRegionExamPageIds,
   cellsWithExistingAnswers,
-  files,
   affectedCells,
   imageLoadStates = {},
   correctingFileIds,
@@ -136,6 +136,7 @@ export function AnswerTableShell({
   drawNameRegionCanvas,
   toggleRowDisabled,
   toggleColDisabled,
+  bulkDisabling,
   toggleCellDisabled,
   toggleFileDisabled,
   onDeleteAnswerSheet,
@@ -223,8 +224,6 @@ export function AnswerTableShell({
       allowOverwrite={allowOverwrite}
       disabledReason={slot.disabledReason}
       onTogglePosition={slot.onTogglePosition}
-      onToggleAnswerDisabled={slot.onToggleAnswerDisabled}
-      hasNewFileToUpload={slot.hasNewFileToUpload}
     />
   )
 
@@ -240,7 +239,6 @@ export function AnswerTableShell({
         nameRegionExamPageIds={nameRegionExamPageIds}
         cellsWithExistingAnswers={cellsWithExistingAnswers}
         allowOverwrite={allowOverwrite}
-        files={files}
         affectedCells={affectedCells}
         imageLoadStates={imageLoadStates}
         correctingFileIds={correctingFileIds}
@@ -248,6 +246,7 @@ export function AnswerTableShell({
         drawNameRegionCanvas={drawNameRegionCanvas}
         toggleRowDisabled={toggleRowDisabled}
         toggleColDisabled={toggleColDisabled}
+        bulkDisabling={bulkDisabling}
         toggleCellDisabled={toggleCellDisabled}
         toggleFileDisabled={toggleFileDisabled}
         onDeleteAnswerSheet={onDeleteAnswerSheet}

--- a/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useDroppable } from "@dnd-kit/core"
-import { Ban, FileX, X } from "lucide-react"
+import { Ban, X } from "lucide-react"
 
 import type { EmptyTableCellProps } from "@/components/exams/06-student-answers/student-answer-table/types"
 import { encodeCellDroppableId } from "@/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils"
@@ -9,7 +9,6 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
-  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
 import { TableCell } from "@/components/ui/table"
@@ -24,8 +23,6 @@ export function EmptyTableCell({
   allowOverwrite = false,
   disabledReason,
   onTogglePosition,
-  onToggleAnswerDisabled,
-  hasNewFileToUpload = false,
 }: EmptyTableCellProps) {
   // 無効化理由のテキストを取得
   const getDisabledReasonText = () => {
@@ -122,18 +119,6 @@ export function EmptyTableCell({
                 </>
               )}
             </ContextMenuItem>
-            {hasNewFileToUpload && (
-              <>
-                <ContextMenuSeparator />
-                <ContextMenuItem
-                  onClick={onToggleAnswerDisabled}
-                  className="flex items-center gap-2"
-                >
-                  <FileX className="h-4 w-4" />
-                  答案無効
-                </ContextMenuItem>
-              </>
-            )}
           </ContextMenuContent>
         )}
       </ContextMenu>

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -1,3 +1,5 @@
+import { Ban, X } from "lucide-react"
+
 import { FilePreviewCell } from "@/components/exams/06-student-answers/student-answer-table/components/FilePreviewCell"
 import type {
   AnswerTableRow,
@@ -12,6 +14,12 @@ import type {
   AnswerImageIdentity,
   ExamPageColumn,
 } from "@/components/exams/06-student-answers/types"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 import {
   Table,
   TableBody,
@@ -51,9 +59,15 @@ export interface EmptyCellSlotProps {
   isPositionDisabled: boolean
   hasExistingAnswer: boolean
   disabledReason?: DisabledReason
-  hasNewFileToUpload: boolean
   onTogglePosition: () => void
-  onToggleAnswerDisabled: () => void
+}
+
+/** 行・列をまとめて無効化する操作。upload でのみ提供され、有無がメニューの表示可否になる。 */
+export interface BulkDisablingHandlers {
+  disableRowsExcept: (keptExamStudentId: string) => void
+  disableColsExcept: (keptExamPageId: string) => void
+  enableAllRows: () => void
+  enableAllCols: () => void
 }
 
 interface TableContentProps {
@@ -66,7 +80,6 @@ interface TableContentProps {
   nameRegionExamPageIds: Set<string>
   cellsWithExistingAnswers: CellLookup
   allowOverwrite: boolean
-  files: AnswerImageIdentity[]
   affectedCells?: Set<string>
   imageLoadStates?: Record<string, "pending" | "loading" | "loaded" | "error">
   correctingFileIds?: Set<string>
@@ -78,6 +91,8 @@ interface TableContentProps {
   ) => Promise<string | null>
   toggleRowDisabled: (examStudentId: string) => void
   toggleColDisabled: (examPageId: string) => void
+  // 行・列の一括無効化（upload のみ。view は行・列無効が配置に効かないので渡さない）
+  bulkDisabling?: BulkDisablingHandlers
   toggleCellDisabled: (studentId: string, examPageId: string) => void
   toggleFileDisabled: (fileId: string) => void
   onDeleteAnswerSheet?: (fileId: string) => void
@@ -95,7 +110,6 @@ export function TableContent({
   nameRegionExamPageIds,
   cellsWithExistingAnswers,
   allowOverwrite,
-  files,
   affectedCells,
   imageLoadStates = {},
   correctingFileIds,
@@ -103,6 +117,7 @@ export function TableContent({
   drawNameRegionCanvas,
   toggleRowDisabled,
   toggleColDisabled,
+  bulkDisabling,
   toggleCellDisabled,
   toggleFileDisabled,
   onDeleteAnswerSheet,
@@ -132,7 +147,31 @@ export function TableContent({
                   : undefined
               }
             >
-              ページ {examPage.pageNumber}
+              <ContextMenu>
+                <ContextMenuTrigger asChild disabled={!bulkDisabling}>
+                  <div>ページ {examPage.pageNumber}</div>
+                </ContextMenuTrigger>
+                {bulkDisabling && (
+                  <ContextMenuContent>
+                    <ContextMenuItem
+                      onClick={() =>
+                        bulkDisabling.disableColsExcept(examPage.id)
+                      }
+                      className="flex items-center gap-2"
+                    >
+                      <Ban className="h-4 w-4" />
+                      この列以外を無効
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      onClick={bulkDisabling.enableAllCols}
+                      className="flex items-center gap-2"
+                    >
+                      <X className="h-4 w-4" />
+                      列の無効をすべて解除
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                )}
+              </ContextMenu>
             </TableHead>
           ))}
         </TableRow>
@@ -155,14 +194,39 @@ export function TableContent({
                   : undefined
               }
             >
-              <div className="px-2 py-1">
-                <div className="text-sm font-medium">
-                  {examStudent.student.lastName} {examStudent.student.firstName}
-                </div>
-                <div className="text-xs text-gray-500">
-                  {examStudent.student.studentNumber}
-                </div>
-              </div>
+              <ContextMenu>
+                <ContextMenuTrigger asChild disabled={!bulkDisabling}>
+                  <div className="px-2 py-1">
+                    <div className="text-sm font-medium">
+                      {examStudent.student.lastName}{" "}
+                      {examStudent.student.firstName}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {examStudent.student.studentNumber}
+                    </div>
+                  </div>
+                </ContextMenuTrigger>
+                {bulkDisabling && (
+                  <ContextMenuContent>
+                    <ContextMenuItem
+                      onClick={() =>
+                        bulkDisabling.disableRowsExcept(examStudent.id)
+                      }
+                      className="flex items-center gap-2"
+                    >
+                      <Ban className="h-4 w-4" />
+                      この行以外を無効
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      onClick={bulkDisabling.enableAllRows}
+                      className="flex items-center gap-2"
+                    >
+                      <X className="h-4 w-4" />
+                      行の無効を解除（欠席を除く）
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                )}
+              </ContextMenu>
             </TableHead>
 
             {/* ファイルセル */}
@@ -180,14 +244,6 @@ export function TableContent({
                     examPage.id
                   )
 
-                // そのセルに新しく追加しようとしている画像ファイルがあるか
-                const newFileInCell = files.find(
-                  (file) =>
-                    file.studentId === examStudent.studentId &&
-                    file.examPageId === examPage.id &&
-                    !disabledState.files.has(file.id)
-                )
-
                 return (
                   <ClientCell key={examPage.id}>
                     {renderEmptyCell({
@@ -196,14 +252,8 @@ export function TableContent({
                       isPositionDisabled: cellData.type === "disabled",
                       hasExistingAnswer: hasExistingAnswerForEmpty,
                       disabledReason: cellData.disabledReason,
-                      hasNewFileToUpload: !!newFileInCell,
                       onTogglePosition: () =>
                         toggleCellDisabled(examStudent.studentId, examPage.id),
-                      onToggleAnswerDisabled: () => {
-                        if (newFileInCell) {
-                          toggleFileDisabled(newFileInCell.id)
-                        }
-                      },
                     })}
                   </ClientCell>
                 )

--- a/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
@@ -134,13 +134,18 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
         disabledState={core.disabledState}
         nameRegionExamPageIds={core.nameRegionExamPageIds}
         cellsWithExistingAnswers={core.cellsWithExistingAnswers}
-        files={props.files}
         imageLoadStates={props.imageLoadStates}
         correctingFileIds={correctingFileIds}
         fileDisplayById={fileDisplayById}
         drawNameRegionCanvas={core.drawNameRegionCanvas}
         toggleRowDisabled={core.toggleRowDisabled}
         toggleColDisabled={core.toggleColDisabled}
+        bulkDisabling={{
+          disableRowsExcept: core.disableRowsExcept,
+          disableColsExcept: core.disableColsExcept,
+          enableAllRows: core.enableAllRows,
+          enableAllCols: core.enableAllCols,
+        }}
         toggleCellDisabled={core.toggleCellDisabled}
         toggleFileDisabled={core.toggleFileDisabled}
         orphanItems={core.orphanItems}

--- a/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
@@ -80,7 +80,6 @@ export function ViewAnswerTable(
       disabledState={core.disabledState}
       nameRegionExamPageIds={core.nameRegionExamPageIds}
       cellsWithExistingAnswers={core.cellsWithExistingAnswers}
-      files={props.files}
       affectedCells={props.affectedCells}
       imageLoadStates={props.imageLoadStates}
       correctingFileIds={EMPTY_CORRECTING}

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useAnswerTableCore.ts
@@ -61,13 +61,17 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
+    disableRowsExcept,
+    disableColsExcept,
+    enableAllRows,
+    enableAllCols,
     toggleCellDisabled,
     toggleFileDisabled,
     isCellDisabled,
     initializeStudentsWithoutAnswers,
     allowOverwrite,
     setAllowOverwrite,
-  } = useDisabledState()
+  } = useDisabledState({ students, examPages })
 
   const {
     getEnabledFiles,
@@ -140,8 +144,8 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
 
   // 答案がない生徒の自動無効化（DBベース）
   useEffect(() => {
-    initializeStudentsWithoutAnswers(students)
-  }, [students, initializeStudentsWithoutAnswers])
+    initializeStudentsWithoutAnswers()
+  }, [initializeStudentsWithoutAnswers])
 
   const handlePreviewModeChange = (nextPreviewMode: PreviewMode) => {
     setPreviewMode(nextPreviewMode)
@@ -160,6 +164,10 @@ export function useAnswerTableCore<TItem extends AnswerImageIdentity>({
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
+    disableRowsExcept,
+    disableColsExcept,
+    enableAllRows,
+    enableAllCols,
     toggleCellDisabled,
     toggleFileDisabled,
     allowOverwrite,

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
@@ -1,7 +1,8 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
 import { manualDisabledReason } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import type { ExamPageColumn } from "@/components/exams/06-student-answers/types"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
 /**
@@ -9,8 +10,15 @@ import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
  * 同一性でキーする: 行 = examStudentId[]、列 = examPageId[]、
  * セル = {studentId, examPageId}[]（いずれも少数なので配列）、
  * files = Set<fileId>（アップロードで多数になりうるので O(1)）。
+ * 一括操作は名簿・ページ一覧を要するので、行・列の実体をフックが受け取る。
  */
-export function useDisabledState() {
+export function useDisabledState({
+  students,
+  examPages,
+}: {
+  students: ExamStudentWithMemberships[]
+  examPages: ExamPageColumn[]
+}) {
   const [disabledState, setDisabledState] = useState<ExtendedDisabledState>({
     rows: [],
     cols: [],
@@ -39,6 +47,53 @@ export function useDisabledState() {
         ? prev.cols.filter((colExamPageId) => colExamPageId !== examPageId)
         : [...prev.cols, examPageId],
     }))
+  }, [])
+
+  // 欠席生徒の行は初期状態で無効。解除の基準線になるのでここで一度だけ導出する。
+  const absentExamStudentIds = useMemo(
+    () =>
+      students
+        .filter((examStudent) => examStudent.status === "absent")
+        .map((examStudent) => examStudent.id),
+    [students]
+  )
+
+  // 差し替え用の再スキャンでは「この行（生徒）だけに配置したい」が普通なので、
+  // 対象を1つ残して他を無効にする一括操作を用意する。自動配置は有効マスを順に埋めるため、
+  // これで狙った生徒・ページから確実に埋まる（残す対象が無効だった場合は有効へ戻す）。
+  const disableRowsExcept = useCallback(
+    (keptExamStudentId: string) => {
+      setDisabledState((prev) => ({
+        ...prev,
+        rows: students
+          .map((examStudent) => examStudent.id)
+          .filter((examStudentId) => examStudentId !== keptExamStudentId),
+      }))
+    },
+    [students]
+  )
+
+  const disableColsExcept = useCallback(
+    (keptExamPageId: string) => {
+      setDisabledState((prev) => ({
+        ...prev,
+        cols: examPages
+          .map((examPage) => examPage.id)
+          .filter((examPageId) => examPageId !== keptExamPageId),
+      }))
+    },
+    [examPages]
+  )
+
+  // 一括解除は「手動で無効にした行」だけを戻す。欠席生徒の行まで有効にすると、
+  // 自動配置が欠席者のマスを埋めて答案が付いてしまう（初期無効化は一度きりで再適用されない）。
+  // 欠席行を有効にしたい場合は従来どおり、その行を名指しで有効化する。
+  const enableAllRows = useCallback(() => {
+    setDisabledState((prev) => ({ ...prev, rows: absentExamStudentIds }))
+  }, [absentExamStudentIds])
+
+  const enableAllCols = useCallback(() => {
+    setDisabledState((prev) => ({ ...prev, cols: [] }))
   }, [])
 
   const toggleCellDisabled = useCallback(
@@ -90,32 +145,29 @@ export function useDisabledState() {
   // 欠席生徒を初期状態で行無効にする。初回ロード時のみ適用し、以降は
   // students の参照変化で再適用しない（教員が手動で有効化した行を握り潰さないため）。
   const didInitAbsentRef = useRef(false)
-  const initializeStudentsWithoutAnswers = useCallback(
-    (students: ExamStudentWithMemberships[]) => {
-      if (didInitAbsentRef.current || students.length === 0) return
-      didInitAbsentRef.current = true
+  const initializeStudentsWithoutAnswers = useCallback(() => {
+    if (didInitAbsentRef.current || students.length === 0) return
+    didInitAbsentRef.current = true
 
-      const absentExamStudentIds = students
-        .filter((examStudent) => examStudent.status === "absent")
-        .map((examStudent) => examStudent.id)
-
-      if (absentExamStudentIds.length > 0) {
-        setDisabledState((prev) => {
-          const merged = [...prev.rows]
-          for (const examStudentId of absentExamStudentIds) {
-            if (!merged.includes(examStudentId)) merged.push(examStudentId)
-          }
-          return { ...prev, rows: merged }
-        })
-      }
-    },
-    []
-  )
+    if (absentExamStudentIds.length > 0) {
+      setDisabledState((prev) => {
+        const merged = [...prev.rows]
+        for (const examStudentId of absentExamStudentIds) {
+          if (!merged.includes(examStudentId)) merged.push(examStudentId)
+        }
+        return { ...prev, rows: merged }
+      })
+    }
+  }, [students, absentExamStudentIds])
 
   return {
     disabledState,
     toggleRowDisabled,
     toggleColDisabled,
+    disableRowsExcept,
+    disableColsExcept,
+    enableAllRows,
+    enableAllCols,
     toggleCellDisabled,
     toggleFileDisabled,
     isCellDisabled,

--- a/src/components/exams/06-student-answers/student-answer-table/types.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types.ts
@@ -114,8 +114,6 @@ export interface EmptyTableCellProps {
   disabledReason?:
     "row" | "column" | "position" | "existing_answer" | "absent_student"
   onTogglePosition?: () => void
-  onToggleAnswerDisabled?: () => void
-  hasNewFileToUpload?: boolean
 }
 
 export interface TableHeaderProps {


### PR DESCRIPTION
Closes #1043

## 背景

差し替え用の再スキャンでは特定の生徒・ページにだけ答案を配置したいのですが、これまで配置対象を絞る手段はヘッダーを1行ずつ左クリックしてトグルすることだけでした。

#1043 では「上書き有効時に既存答案のマスを優先配置する」案が挙がっていましたが、差し替え5枚が属するのは特定の生徒であって「既存答案があるマスのうち先頭5つ」ではないため、優先配置にしても落ちる先が別の間違ったマスに変わるだけで、しかも破壊されるマスに優先的に落ちます。推測ではなく明示操作で指定できるようにしました。

## 変更内容

### 行・列の一括無効化（新機能）

upload モードで、生徒名セル・ページ列ヘッダーの右クリックメニューに以下を追加しました。

- 「この行以外を無効」/「行の無効を解除（欠席を除く）」
- 「この列以外を無効」/「列の無効をすべて解除」

自動配置は有効マスを順に埋めるため、絞り込んでから落とせば狙った生徒・ページから確実に埋まります。view モードでは行・列の無効化が配置に効かないためメニューを出しません。

### 欠席生徒の保護

一括解除は手動で無効にした行だけを戻し、欠席生徒の行は無効のまま残します。欠席行の初期無効化は一度きりで再適用されないため、全解除すると自動配置が欠席者のマスを埋めてしまいます。調査したところ、送信データ生成（`buildUploadData`）にも保存側にも欠席チェックは無く、この初期無効化が唯一の防波堤でした。欠席行を有効にしたい場合は従来どおりその行を名指しで有効化します。

### 到達不能コードの削除（#1043）

空マスの右クリックにあった「答案無効」項目は、どちらのモードでも発火しませんでした。

- upload: 未保存画像の `studentId` / `examPageId` は常に null
- view: 答案のあるマスは必ずファイルセルになるため、有効なファイルが紐づく空マスは定義上存在しない

不要ファイルを外す導線はファイルセル側にあるため、削除しても失う操作はありません。検索専用だった `files` prop も表本体から外しました。

### 構造の整理

- 無効化フック（`useDisabledState`）が名簿とページ一覧を受け取る形にし、id 集合の供給と欠席 id の導出を一箇所へ集約
- upload 専用の一括操作は任意 prop `bulkDisabling` にまとめ、有無がメニューの表示可否になる形に（view へは渡さない）

## 検証

- `npm run typecheck`: クリーン
- `eslint` / `prettier`（変更ファイル）: クリーン
- vitest は globalSetup の `prisma db push` が AI 保護でブロックされるため未実行。今回の変更に対応するテストはありません
- 右クリックメニューの実挙動は要手動確認です

🤖 Generated with [Claude Code](https://claude.com/claude-code)