### PR TITLE
feat(grades): 観点間の制約ルールの設定JSONをRDBへ正規化する

### DIFF
--- a/__tests__/grade/integration/gradeConstraintCrud.test.ts
+++ b/__tests__/grade/integration/gradeConstraintCrud.test.ts
@@ -1,0 +1,209 @@
+/**
+ * GradeConstraint（観点間の制約ルール）の CRUD 統合テスト
+ *
+ * issue #1063 で設定JSONをリレーションへ正規化した際の、renderer 境界を跨ぐ形と
+ * 書き込みの原子性を検証する。評価ロジック単体のテストは
+ * __tests__/grades/gradeConstraints.test.ts にある。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import {
+  createGradeConstraint,
+  getGradeConstraints,
+  updateGradeConstraint,
+} from "@/electron-src/lib/prisma/gradeConstraint"
+import type { GradeConstraintInput } from "@/types/grade.types"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+async function createGradeWithItems() {
+  const grade = await testPrisma.grade.create({
+    data: { name: `制約テスト_${Date.now()}` },
+  })
+  const knowledge = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+  })
+  const hyotei = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "評定", order: 1 },
+  })
+  return { grade, knowledge, hyotei }
+}
+
+function buildInput(
+  overrides: Partial<GradeConstraintInput> = {}
+): GradeConstraintInput {
+  return {
+    name: "評定と観点の整合",
+    kind: "consistency",
+    targetGradeItemId: null,
+    aggregate: "average",
+    tolerance: 1.5,
+    viewpointGradeItemIds: [],
+    labelValues: { A: 5, B: 3, C: 1 },
+    exclusionLabels: [],
+    expression: "",
+    color: "#fecaca",
+    message: null,
+    enabled: true,
+    order: 0,
+    ...overrides,
+  }
+}
+
+describe("GradeConstraint の renderer 境界（issue #1063）", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  // Decimal のまま返すと IPC で {s,e,d} のオブジェクトになり、renderer 側の
+  // 数値比較（tolerance との差分判定・ラベル値の加算）が黙って壊れる。
+  // GradeConstraintData は number と宣言しているので型では捕まらない。
+  it("tolerance と labelValues.value を number で返す（Decimal を漏らさない）", async () => {
+    const { grade, knowledge, hyotei } = await createGradeWithItems()
+
+    const created = await createGradeConstraint({
+      gradeId: grade.id,
+      constraint: buildInput({
+        targetGradeItemId: hyotei.id,
+        viewpointGradeItemIds: [knowledge.id],
+      }),
+    })
+    expect(created.success).toBe(true)
+    expect(typeof created.constraint!.tolerance).toBe("number")
+    expect(created.constraint!.tolerance).toBe(1.5)
+    for (const labelValue of created.constraint!.labelValues) {
+      expect(typeof labelValue.value).toBe("number")
+    }
+    expect(
+      created.constraint!.labelValues.map((labelValue) => [
+        labelValue.label,
+        labelValue.value,
+      ])
+    ).toEqual([
+      ["A", 5],
+      ["B", 3],
+      ["C", 1],
+    ])
+
+    const listed = await getGradeConstraints(grade.id)
+    expect(typeof listed.constraints![0].tolerance).toBe("number")
+    expect(typeof listed.constraints![0].labelValues[0].value).toBe("number")
+
+    const updated = await updateGradeConstraint({
+      id: created.constraint!.id,
+      constraint: { tolerance: 2.25 },
+    })
+    expect(typeof updated.constraint!.tolerance).toBe("number")
+    expect(updated.constraint!.tolerance).toBe(2.25)
+  })
+
+  // 本体だけ作られて設定リレーションが入らないと、viewpoints ゼロ＝
+  // 「比較先以外の全項目」という設定していないルールとして動き出す。
+  it("設定リレーションの書き込みに失敗したら制約ごと作られない", async () => {
+    const { grade, hyotei } = await createGradeWithItems()
+
+    const result = await createGradeConstraint({
+      gradeId: grade.id,
+      constraint: buildInput({
+        targetGradeItemId: hyotei.id,
+        // 存在しない評価項目を集計対象に指定 → FK違反で設定の書き込みが失敗する
+        viewpointGradeItemIds: ["gi-does-not-exist"],
+      }),
+    })
+
+    expect(result.success).toBe(false)
+    const remaining = await testPrisma.gradeConstraint.findMany({
+      where: { gradeId: grade.id },
+    })
+    expect(remaining).toEqual([])
+  })
+
+  // 同一idの delete → create は NAS 同期の tombstone に抑止されて相手側で行が消える。
+  // 据え置く行は更新で通し、実際に外れた行だけ削除する。
+  it("設定を更新しても据え置く行は作り直さない", async () => {
+    const { grade, knowledge, hyotei } = await createGradeWithItems()
+    const attitude = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "態度", order: 2 },
+    })
+
+    const created = await createGradeConstraint({
+      gradeId: grade.id,
+      constraint: buildInput({
+        targetGradeItemId: hyotei.id,
+        viewpointGradeItemIds: [knowledge.id, attitude.id],
+      }),
+    })
+    const before = await testPrisma.gradeConstraintViewpoint.findMany({
+      where: { constraintId: created.constraint!.id },
+      orderBy: { order: "asc" },
+    })
+    const knowledgeRowCreatedAt = before.find(
+      (viewpoint) => viewpoint.gradeItemId === knowledge.id
+    )!.createdAt
+
+    // 態度を外して知識・技能だけにする
+    await updateGradeConstraint({
+      id: created.constraint!.id,
+      constraint: { viewpointGradeItemIds: [knowledge.id] },
+    })
+
+    const after = await testPrisma.gradeConstraintViewpoint.findMany({
+      where: { constraintId: created.constraint!.id },
+    })
+    expect(after).toHaveLength(1)
+    expect(after[0].gradeItemId).toBe(knowledge.id)
+    // 据え置いた行は作り直されていない（createdAt が保たれる）
+    expect(after[0].createdAt.getTime()).toBe(knowledgeRowCreatedAt.getTime())
+  })
+
+  it("ラベル値の入れ替えで外れたラベルだけ消える", async () => {
+    const { grade, knowledge, hyotei } = await createGradeWithItems()
+    const created = await createGradeConstraint({
+      gradeId: grade.id,
+      constraint: buildInput({
+        targetGradeItemId: hyotei.id,
+        viewpointGradeItemIds: [knowledge.id],
+        labelValues: { A: 5, B: 3, C: 1 },
+      }),
+    })
+    const beforeA = await testPrisma.gradeConstraintLabelValue.findFirst({
+      where: { constraintId: created.constraint!.id, label: "A" },
+    })
+
+    await updateGradeConstraint({
+      id: created.constraint!.id,
+      constraint: { labelValues: { A: 4, B: 3 } },
+    })
+
+    const after = await testPrisma.gradeConstraintLabelValue.findMany({
+      where: { constraintId: created.constraint!.id },
+      orderBy: { order: "asc" },
+    })
+    expect(after.map((labelValue) => labelValue.label)).toEqual(["A", "B"])
+    expect(Number(after[0].value)).toBe(4)
+    // A は値だけ変わって行は据え置き
+    expect(after[0].createdAt.getTime()).toBe(beforeA!.createdAt.getTime())
+  })
+})

--- a/__tests__/grade/integration/gradeItemCrud.test.ts
+++ b/__tests__/grade/integration/gradeItemCrud.test.ts
@@ -392,3 +392,127 @@ describe("GradeBoundary CRUD", () => {
     expect(result.boundarySets).toHaveLength(2)
   })
 })
+
+describe("評価項目の削除と制約ルール（issue #1063）", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await disconnectTestPrisma()
+  })
+
+  /** 比較先＝評定、集計対象＝渡した項目 の整合ルールを作る */
+  async function createConsistencyConstraint(
+    gradeId: string,
+    targetGradeItemId: string,
+    viewpointGradeItemIds: string[]
+  ) {
+    return testPrisma.gradeConstraint.create({
+      data: {
+        gradeId,
+        name: "評定と観点の整合",
+        kind: "consistency",
+        targetGradeItemId,
+        aggregate: "average",
+        tolerance: 1,
+        expression: "",
+        color: "#fecaca",
+        enabled: true,
+        order: 0,
+        viewpoints: {
+          create: viewpointGradeItemIds.map((gradeItemId, index) => ({
+            id: `${targetGradeItemId}:${gradeItemId}`,
+            gradeItemId,
+            order: index,
+          })),
+        },
+      },
+    })
+  }
+
+  // 集計対象が1つ減ると残りだけで平均を取り、判定の意味が黙って変わる。
+  // viewpoint 行は FK の Cascade で消えるため、削除側で無効化しないと検知できない。
+  it("集計対象の評価項目を削除すると、その制約ルールを無効化して知らせる", async () => {
+    const grade = await createTestGrade("削除と制約")
+    const knowledge = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    const thinking = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "思考・判断・表現", order: 1 },
+    })
+    const hyotei = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 2 },
+    })
+    const constraint = await createConsistencyConstraint(grade.id, hyotei.id, [
+      knowledge.id,
+      thinking.id,
+    ])
+
+    const result = await deleteGradeItem(thinking.id)
+
+    expect(result.success).toBe(true)
+    expect(result.disabledConstraintNames).toEqual(["評定と観点の整合"])
+
+    const after = await testPrisma.gradeConstraint.findUnique({
+      where: { id: constraint.id },
+      include: { viewpoints: true },
+    })
+    // 集計対象は Cascade で減るが、ルールは無効化され理由が残る。
+    // 理由は disabledReason へ書き、教員が書いた message は触らない
+    // （message は結果表のツールチップに違反理由として出るため）。
+    expect(after!.viewpoints).toHaveLength(1)
+    expect(after!.enabled).toBe(false)
+    expect(after!.disabledReason).toContain("思考・判断・表現")
+    expect(after!.message).toBeNull()
+  })
+
+  it("比較先の評価項目を削除すると参照はnullになり、ルールは残る", async () => {
+    const grade = await createTestGrade("削除と比較先")
+    const knowledge = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    const hyotei = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 1 },
+    })
+    const constraint = await createConsistencyConstraint(grade.id, hyotei.id, [
+      knowledge.id,
+    ])
+
+    const result = await deleteGradeItem(hyotei.id)
+
+    expect(result.success).toBe(true)
+    // 比較先の欠落は評価時に「未選択」として検知されるので、無効化はしない
+    expect(result.disabledConstraintNames).toEqual([])
+
+    const after = await testPrisma.gradeConstraint.findUnique({
+      where: { id: constraint.id },
+    })
+    expect(after!.targetGradeItemId).toBeNull()
+    expect(after!.enabled).toBe(true)
+  })
+
+  it("集計対象を含まない制約ルールは無効化されない", async () => {
+    const grade = await createTestGrade("削除と無関係ルール")
+    const knowledge = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    const unrelated = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "無関係", order: 1 },
+    })
+    const hyotei = await testPrisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 2 },
+    })
+    const constraint = await createConsistencyConstraint(grade.id, hyotei.id, [
+      knowledge.id,
+    ])
+
+    const result = await deleteGradeItem(unrelated.id)
+
+    expect(result.disabledConstraintNames).toEqual([])
+    const after = await testPrisma.gradeConstraint.findUnique({
+      where: { id: constraint.id },
+    })
+    expect(after!.enabled).toBe(true)
+  })
+})

--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -116,7 +116,7 @@ function buildGrade(
         absentOffset?: number
         treatExpectedAsMissing?: boolean
         estimationMode?: string
-        estimationSourceIds?: string
+        estimationSourceIds?: string[]
         inputMode?: string
         letterScales?: { label: string; score: number; order: number }[]
       }[]
@@ -145,7 +145,20 @@ function buildGrade(
   // これによりテストケース本体は旧シグネチャのまま、calculator の新ロジックを検証できる。
   const gradeItems = (overrides.gradeItems ?? []).map((gradeItem) => ({
     ...gradeItem,
-    dataSources: gradeItem.dataSources.map((dataSource) => {
+    dataSources: gradeItem.dataSources.map((rawDataSource) => {
+      // 推定に使う他データソースは中間テーブル（gradeDataSourceInclude 同梱）。
+      // テストケースは id 配列で書けるようにし、ここで行の形へ寄せる。
+      const dataSource = {
+        ...rawDataSource,
+        estimationSources: (rawDataSource.estimationSourceIds ?? []).map(
+          (sourceDataSourceId, index) => ({
+            id: `${rawDataSource.id}:${sourceDataSourceId}`,
+            dataSourceId: rawDataSource.id,
+            sourceDataSourceId,
+            order: index,
+          })
+        ),
+      }
       const isCoursework =
         dataSource.type === "manual" ||
         dataSource.type === "coursework" ||
@@ -1121,7 +1134,8 @@ describe("calculateGrades", () => {
               absentOffset: 0,
               treatExpectedAsMissing: false,
               estimationMode: "all",
-              estimationSourceIds: "[]",
+              // このケースは buildGrade を通さないので中間テーブルの形で持つ
+              estimationSources: [],
             },
           ],
         },

--- a/__tests__/grades/gradeConstraints.test.ts
+++ b/__tests__/grades/gradeConstraints.test.ts
@@ -71,10 +71,7 @@ function violatedIds(
   return [...violations.keys()].sort()
 }
 
-const baseConstraint: Omit<
-  GradeConstraintData,
-  "kind" | "config" | "expression"
-> = {
+const baseConstraint: Omit<GradeConstraintData, "kind" | "expression"> = {
   id: "c1",
   gradeId: "g1",
   name: "ルール",
@@ -82,6 +79,50 @@ const baseConstraint: Omit<
   message: null,
   enabled: true,
   order: 0,
+  targetGradeItemId: null,
+  aggregate: "average",
+  tolerance: 1,
+  disabledReason: null,
+  viewpoints: [],
+  labelValues: [],
+  exclusionLabels: [],
+}
+
+/** 集計対象の観点行（idは決定論的な合成キー） */
+function viewpointRows(
+  constraintId: string,
+  gradeItemIds: string[]
+): GradeConstraintData["viewpoints"] {
+  return gradeItemIds.map((gradeItemId, index) => ({
+    id: `${constraintId}:${gradeItemId}`,
+    gradeItemId,
+    order: index,
+  }))
+}
+
+/** ラベル→数値の対応行 */
+function labelValueRows(
+  constraintId: string,
+  labelValues: Record<string, number>
+): GradeConstraintData["labelValues"] {
+  return Object.entries(labelValues).map(([label, value], index) => ({
+    id: `${constraintId}:${label}`,
+    label,
+    value,
+    order: index,
+  }))
+}
+
+/** 混在禁止ラベル行 */
+function exclusionLabelRows(
+  constraintId: string,
+  labels: string[]
+): GradeConstraintData["exclusionLabels"] {
+  return labels.map((label, index) => ({
+    id: `${constraintId}:${label}`,
+    label,
+    order: index,
+  }))
 }
 
 describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）", () => {
@@ -156,13 +197,11 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
   const consistencyTargetItem: GradeConstraintData = {
     ...baseConstraint,
     kind: "consistency",
-    config: JSON.stringify({
-      labelValues: { A: 5, B: 3, C: 1 },
-      aggregate: "average",
-      tolerance: 1,
-      target: "評定",
-      viewpointItems: ["知識・技能", "思考・判断・表現", "態度"],
-    }),
+    targetGradeItemId: "gi-h",
+    aggregate: "average",
+    tolerance: 1,
+    viewpoints: viewpointRows("c1", ["gi-k", "gi-s", "gi-a"]),
+    labelValues: labelValueRows("c1", { A: 5, B: 3, C: 1 }),
     expression: "",
   }
 
@@ -180,7 +219,6 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
     const expr: GradeConstraintData = {
       ...baseConstraint,
       kind: "expression",
-      config: "{}",
       expression: 'item("評定") == 5 and has("C")',
     }
     const result = makeResult4([
@@ -195,7 +233,7 @@ describe("gradeConstraints: 混在禁止（mutual_exclusion）", () => {
   const exclusion: GradeConstraintData = {
     ...baseConstraint,
     kind: "mutual_exclusion",
-    config: JSON.stringify({ labels: ["A", "C"] }),
+    exclusionLabels: exclusionLabelRows("c1", ["A", "C"]),
     expression: "",
   }
 
@@ -214,7 +252,6 @@ describe("gradeConstraints: 式（expression）", () => {
     const expr: GradeConstraintData = {
       ...baseConstraint,
       kind: "expression",
-      config: "{}",
       expression: 'has("A") and has("C")',
     }
     const result = makeResult([
@@ -229,7 +266,6 @@ describe("gradeConstraints: 式（expression）", () => {
     const expr: GradeConstraintData = {
       ...baseConstraint,
       kind: "expression",
-      config: "{}",
       expression: 'label("態度") == "A" and label("知識・技能") == "C"',
     }
     const result = makeResult([
@@ -243,7 +279,6 @@ describe("gradeConstraints: 式（expression）", () => {
     const expr: GradeConstraintData = {
       ...baseConstraint,
       kind: "expression",
-      config: "{}",
       expression: "has(", // 構文エラー
     }
     const result = makeResult([makeStudent("s", ["A", "B", "C"])])
@@ -256,7 +291,6 @@ describe("gradeConstraints: 式（expression）", () => {
     const expr: GradeConstraintData = {
       ...baseConstraint,
       kind: "expression",
-      config: "{}",
       // 「知識・技能」の・抜け（タイプミス）
       expression: 'item("知識技能") < 3',
     }
@@ -284,7 +318,7 @@ describe("gradeConstraints: 補助", () => {
     const disabled: GradeConstraintData = {
       ...baseConstraint,
       kind: "mutual_exclusion",
-      config: JSON.stringify({ labels: ["A", "C"] }),
+      exclusionLabels: exclusionLabelRows("c1", ["A", "C"]),
       expression: "",
       enabled: false,
     }
@@ -292,16 +326,12 @@ describe("gradeConstraints: 補助", () => {
     expect(violatedIds(result, [disabled])).toEqual([])
   })
 
-  it("整合ルールの比較先(target)が未選択なら無言失火せずエラーになる", () => {
+  it("整合ルールの比較先が未選択なら無言失火せずエラーになる", () => {
     const noTarget: GradeConstraintData = {
       ...baseConstraint,
       kind: "consistency",
-      config: JSON.stringify({
-        labelValues: { A: 5, B: 3, C: 1 },
-        aggregate: "average",
-        tolerance: 1,
-        target: "",
-      }),
+      targetGradeItemId: null,
+      labelValues: labelValueRows("c1", { A: 5, B: 3, C: 1 }),
       expression: "",
     }
     const result = makeResult([makeStudent("s", ["A", "A", "A"])])
@@ -310,21 +340,201 @@ describe("gradeConstraints: 補助", () => {
     expect(errors.get("c1")).toContain("未選択")
   })
 
-  it("整合ルールの比較先(target)が実在しない項目ならエラーになる", () => {
+  it("整合ルールの比較先が算出対象に無ければエラーになる", () => {
     const badTarget: GradeConstraintData = {
       ...baseConstraint,
       kind: "consistency",
-      config: JSON.stringify({
-        labelValues: { A: 5, B: 3, C: 1 },
-        aggregate: "average",
-        tolerance: 1,
-        target: "評定", // makeResult の3項目には存在しない
-      }),
+      targetGradeItemId: "gi-missing", // makeResult の3項目には存在しない
+      labelValues: labelValueRows("c1", { A: 5, B: 3, C: 1 }),
       expression: "",
     }
     const result = makeResult([makeStudent("s", ["A", "A", "A"])])
     const { violations, errors } = evaluateConstraints(result, [badTarget])
     expect(violations.size).toBe(0)
-    expect(errors.get("c1")).toContain("評定")
+    expect(errors.get("c1")).toContain("見つかりません")
+  })
+})
+
+describe("gradeConstraints: 参照はidで持つ（issue #1063）", () => {
+  /** 評定を含む4項目。名前は呼び出し側から差し替えられる */
+  function makeItems(knowledgeName: string) {
+    return [
+      { id: "gi-k", name: knowledgeName, order: 0, dataSources: [] },
+      { id: "gi-s", name: "思考・判断・表現", order: 1, dataSources: [] },
+      { id: "gi-h", name: "評定", order: 2, dataSources: [] },
+    ]
+  }
+
+  function makeStudentFor(
+    items: ReturnType<typeof makeItems>,
+    labels: Record<string, string>
+  ): StudentGradeResult {
+    return {
+      studentId: "s1",
+      studentNumber: "s1",
+      lastName: "s1",
+      firstName: "",
+      attendanceNumber: null,
+      className: null,
+      gradeItemResults: items.map((gradeItem) => ({
+        gradeItemId: gradeItem.id,
+        gradeItemName: gradeItem.name,
+        isExcluded: false,
+        isAllMissing: false,
+        sourceScores: [],
+        weightedScore: 1,
+        weightedMaxScore: 1,
+        percentage: 50,
+        gradeLabel: labels[gradeItem.id],
+        originalGradeLabel: labels[gradeItem.id],
+        overrideGradeLabel: null,
+        frozen: null,
+      })),
+    }
+  }
+
+  const consistency: GradeConstraintData = {
+    ...baseConstraint,
+    kind: "consistency",
+    targetGradeItemId: "gi-h",
+    aggregate: "average",
+    tolerance: 1,
+    viewpoints: viewpointRows("c1", ["gi-k", "gi-s"]),
+    labelValues: labelValueRows("c1", { A: 5, B: 3, C: 1, "5": 5, "3": 3 }),
+    expression: "",
+  }
+
+  // 旧実装は評価項目を名前で照合していたため、リネームすると比較先も集計対象も
+  // 見失い、黙って「違反なし」に化けていた。idで持てば名前は判定に関与しない。
+  it("評価項目をリネームしても判定は変わらない", () => {
+    const violatingLabels = { "gi-k": "A", "gi-s": "A", "gi-h": "3" }
+
+    const before = makeItems("知識・技能")
+    const beforeResult: GradeCalculationResult = {
+      gradeId: "g1",
+      gradeName: "1学期",
+      classNames: [],
+      gradeItems: before,
+      students: [makeStudentFor(before, violatingLabels)],
+      boundarySets: [],
+    }
+
+    const after = makeItems("知識・技能（改称）")
+    const afterResult: GradeCalculationResult = {
+      ...beforeResult,
+      gradeItems: after,
+      students: [makeStudentFor(after, violatingLabels)],
+    }
+
+    // 観点平均5・評定3で乖離2 > 許容1 → どちらも違反として検出される
+    expect(violatedIds(beforeResult, [consistency])).toEqual(["s1"])
+    expect(violatedIds(afterResult, [consistency])).toEqual(["s1"])
+    expect(evaluateConstraints(afterResult, [consistency]).errors.size).toBe(0)
+  })
+
+  it("集計対象の観点が算出対象から消えたら無言失火せずエラーになる", () => {
+    const items = makeItems("知識・技能")
+    const result: GradeCalculationResult = {
+      gradeId: "g1",
+      gradeName: "1学期",
+      classNames: [],
+      gradeItems: items,
+      students: [
+        makeStudentFor(items, { "gi-k": "A", "gi-s": "A", "gi-h": "3" }),
+      ],
+      boundarySets: [],
+    }
+    const withMissingViewpoint: GradeConstraintData = {
+      ...consistency,
+      viewpoints: viewpointRows("c1", ["gi-k", "gi-gone"]),
+    }
+
+    const { violations, errors } = evaluateConstraints(result, [
+      withMissingViewpoint,
+    ])
+    // 残った観点だけで判定を続けると平均が変わり別の判定に化けるため、着色せず知らせる
+    expect(violations.size).toBe(0)
+    expect(errors.get("c1")).toContain("見つかりません")
+  })
+
+  // 旧実装は boundarySets を項目名で引いていた。id引きへ移す際に式評価側の
+  // 参照を直し忘れると、A/B/C の順位換算が効かなくなり item()/mean() が NaN になる。
+  // 既存テストが評定に数値ラベル "5" を使っていたため素通りしていた。
+  it("式ルールが非数値ラベル(A/B/C)を順位へ換算できる", () => {
+    const items = makeItems("知識・技能")
+    const result: GradeCalculationResult = {
+      gradeId: "g1",
+      gradeName: "1学期",
+      classNames: [],
+      gradeItems: items,
+      students: [
+        makeStudentFor(items, { "gi-k": "C", "gi-s": "A", "gi-h": "A" }),
+      ],
+      // 弱→強が C, B, A なので C は順位1
+      boundarySets: items.map((gradeItem) => ({
+        gradeItemId: gradeItem.id,
+        boundaries: [
+          { label: "C", minPercentage: 0 },
+          { label: "B", minPercentage: 50 },
+          { label: "A", minPercentage: 80 },
+        ],
+      })),
+    }
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      expression: 'item("知識・技能") == 1',
+      viewpoints: [],
+    }
+
+    const { violations, errors } = evaluateConstraints(result, [expr])
+    expect(errors.size).toBe(0)
+    expect([...violations.keys()]).toEqual(["s1"])
+  })
+
+  it("式ルールの mean() が非数値ラベルを集計できる", () => {
+    const items = makeItems("知識・技能")
+    const result: GradeCalculationResult = {
+      gradeId: "g1",
+      gradeName: "1学期",
+      classNames: [],
+      gradeItems: items,
+      students: [
+        makeStudentFor(items, { "gi-k": "A", "gi-s": "A", "gi-h": "C" }),
+      ],
+      boundarySets: items.map((gradeItem) => ({
+        gradeItemId: gradeItem.id,
+        boundaries: [
+          { label: "C", minPercentage: 0 },
+          { label: "B", minPercentage: 50 },
+          { label: "A", minPercentage: 80 },
+        ],
+      })),
+    }
+    // 観点平均3(=A) と評定1(=C) の乖離2 > 1
+    const expr: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "expression",
+      expression:
+        'abs(item("評定") - mean("知識・技能", "思考・判断・表現")) > 1',
+      viewpoints: [],
+    }
+
+    const { violations, errors } = evaluateConstraints(result, [expr])
+    expect(errors.size).toBe(0)
+    expect([...violations.keys()]).toEqual(["s1"])
+  })
+
+  it("混在禁止ラベルが1つ以下なら無言失火せずエラーになる", () => {
+    const singleLabel: GradeConstraintData = {
+      ...baseConstraint,
+      kind: "mutual_exclusion",
+      exclusionLabels: exclusionLabelRows("c1", ["A"]),
+      expression: "",
+    }
+    const result = makeResult([makeStudent("mix", ["A", "B", "C"])])
+    const { violations, errors } = evaluateConstraints(result, [singleLabel])
+    expect(violations.size).toBe(0)
+    expect(errors.get("c1")).toContain("2つ以上")
   })
 })

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -943,38 +943,66 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(dataSource!.courseworkItem!.courseworkId).toBe(existing.id)
   })
 
-  it("観点間の制約ルール(GradeConstraint)が往復で保持される (v1.7.0)", async () => {
+  it("観点間の制約ルール(GradeConstraint)が往復で保持される (v1.7.0/v1.11.0)", async () => {
     const suffix = Date.now()
     const grade = await prisma.grade.create({
       data: { name: `成績_constraint_${suffix}` },
     })
-    await prisma.gradeItem.create({
+    const knowledgeItem = await prisma.gradeItem.create({
       data: { gradeId: grade.id, name: "知識・技能", order: 0 },
     })
-    await prisma.gradeConstraint.create({
+    const hyoteiItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "評定", order: 1 },
+    })
+
+    const exclusionConstraint = await prisma.gradeConstraint.create({
       data: {
         gradeId: grade.id,
         name: "A・C混在禁止",
         kind: "mutual_exclusion",
-        config: JSON.stringify({ labels: ["A", "C"] }),
         expression: "",
         color: "#fecaca",
         message: "AとCは混在しません",
         enabled: true,
         order: 0,
+        exclusionLabels: {
+          create: [
+            { id: `x-${suffix}-A`, label: "A", order: 0 },
+            { id: `x-${suffix}-C`, label: "C", order: 1 },
+          ],
+        },
       },
     })
+
+    // v1.11.0: 比較先・集計対象は評価項目への参照として持つ（issue #1063）
     await prisma.gradeConstraint.create({
       data: {
         gradeId: grade.id,
         name: "評定と観点の整合",
-        kind: "expression",
-        config: "{}",
-        expression: 'abs(item("評定") - mean("知識・技能")) > 1',
+        kind: "consistency",
+        targetGradeItemId: hyoteiItem.id,
+        aggregate: "sum",
+        tolerance: 2,
+        expression: "",
         color: "#fde68a",
         message: null,
         enabled: false,
         order: 1,
+        viewpoints: {
+          create: [
+            {
+              id: `v-${suffix}-k`,
+              gradeItemId: knowledgeItem.id,
+              order: 0,
+            },
+          ],
+        },
+        labelValues: {
+          create: [
+            { id: `l-${suffix}-A`, label: "A", value: 5, order: 0 },
+            { id: `l-${suffix}-C`, label: "C", value: 1, order: 1 },
+          ],
+        },
       },
     })
 
@@ -985,14 +1013,33 @@ describe("grade-archive ラウンドトリップ", () => {
       (constraint) => constraint.kind === "mutual_exclusion"
     )!
     expect(exclusion.name).toBe("A・C混在禁止")
-    expect(exclusion.config).toBe(JSON.stringify({ labels: ["A", "C"] }))
+    expect(exclusion.exclusionLabels).toEqual(["A", "C"])
+    expect(exclusion.config).toBeUndefined()
+
+    const consistency = collected.gradeData.gradeConstraints!.find(
+      (constraint) => constraint.kind === "consistency"
+    )!
+    // uuid 一次・名前二次で持ち出す
+    expect(consistency.targetGradeItemId).toBe(hyoteiItem.id)
+    expect(consistency.targetGradeItemName).toBe("評定")
+    expect(consistency.viewpointGradeItemIds).toEqual([knowledgeItem.id])
+    expect(consistency.viewpointGradeItemNames).toEqual(["知識・技能"])
+    expect(consistency.labelValues).toEqual({ A: 5, C: 1 })
+    expect(consistency.aggregate).toBe("sum")
+    expect(consistency.tolerance).toBe(2)
 
     // インポート（新規Gradeとして作成される）
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
+    expect(exclusionConstraint.gradeId).toBe(grade.id)
 
     const imported = await prisma.gradeConstraint.findMany({
       where: { gradeId: result.gradeId! },
+      include: {
+        viewpoints: { orderBy: { order: "asc" } },
+        labelValues: { orderBy: { order: "asc" } },
+        exclusionLabels: { orderBy: { order: "asc" } },
+      },
       orderBy: { order: "asc" },
     })
     expect(imported).toHaveLength(2)
@@ -1000,10 +1047,38 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(imported[0].kind).toBe("mutual_exclusion")
     expect(imported[0].message).toBe("AとCは混在しません")
     expect(imported[0].enabled).toBe(true)
-    expect(imported[1].kind).toBe("expression")
-    expect(imported[1].expression).toBe(
-      'abs(item("評定") - mean("知識・技能")) > 1'
-    )
+    expect(imported[0].exclusionLabels.map((label) => label.label)).toEqual([
+      "A",
+      "C",
+    ])
+
+    // 参照は取り込み先の評価項目を指す（元Gradeの項目idのままではない）
+    const importedItems = await prisma.gradeItem.findMany({
+      where: { gradeId: result.gradeId! },
+    })
+    const importedHyotei = importedItems.find(
+      (gradeItem) => gradeItem.name === "評定"
+    )!
+    const importedKnowledge = importedItems.find(
+      (gradeItem) => gradeItem.name === "知識・技能"
+    )!
+    expect(importedHyotei.id).not.toBe(hyoteiItem.id)
+    expect(imported[1].kind).toBe("consistency")
+    expect(imported[1].targetGradeItemId).toBe(importedHyotei.id)
+    expect(
+      imported[1].viewpoints.map((viewpoint) => viewpoint.gradeItemId)
+    ).toEqual([importedKnowledge.id])
+    expect(imported[1].aggregate).toBe("sum")
+    expect(Number(imported[1].tolerance)).toBe(2)
+    expect(
+      imported[1].labelValues.map((labelValue) => [
+        labelValue.label,
+        Number(labelValue.value),
+      ])
+    ).toEqual([
+      ["A", 5],
+      ["C", 1],
+    ])
     expect(imported[1].enabled).toBe(false)
     expect(imported[1].color).toBe("#fde68a")
   })

--- a/__tests__/import-export/unit/gradeTransformerChain.test.ts
+++ b/__tests__/import-export/unit/gradeTransformerChain.test.ts
@@ -16,6 +16,7 @@ import type {
   GradeArchiveData,
   GradeArchiveManifest,
 } from "../../../src/types/gradeArchive.types"
+import { GRADE_CURRENT_VERSION } from "../../../src/types/gradeArchive.types"
 
 const manifest: GradeArchiveManifest = {
   version: "1.9.0",
@@ -129,7 +130,7 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
       transformGradeToLatest(buildV1_9_0Archive())
 
     expect(originalVersion).toBe("1.9.0")
-    expect(finalVersion).toBe("1.10.0")
+    expect(finalVersion).toBe(GRADE_CURRENT_VERSION)
     expect(appliedTransformations).toContainEqual({
       from: "1.9.0",
       to: "1.10.0",
@@ -139,7 +140,7 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
   it("manifest.version が現行へ更新される", () => {
     const { data } = transformGradeToLatest(buildV1_9_0Archive())
 
-    expect(data.manifest.version).toBe("1.10.0")
+    expect(data.manifest.version).toBe(GRADE_CURRENT_VERSION)
   })
 
   it("総合の名残が無い現行アーカイブは変換されず warning も出ない", () => {
@@ -164,7 +165,7 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
 
     expect(warnings).toEqual([])
     expect(appliedTransformations).toEqual([])
-    expect(originalVersion).toBe("1.10.0")
+    expect(originalVersion).toBe(GRADE_CURRENT_VERSION)
   })
 
   it("gradeOverrides を持たない旧アーカイブでも境界セットだけ正規化できる", () => {
@@ -179,5 +180,155 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
     expect(warnings.some((warning) => warning.includes("手動上書き"))).toBe(
       false
     )
+  })
+})
+
+/**
+ * v1.10.0 が実際に書き出していた形。制約ルールの設定は kind 別の JSON 文字列
+ * （config）で、評価項目を「名前」で参照していた（issue #1063 以前）。
+ */
+function buildV1_10_0Archive(): GradeArchiveData {
+  const archive = buildV1_9_0Archive()
+  // 総合の名残を取り除いて 1.10.0 相当の形にする
+  archive.boundariesData.boundarySets = [
+    {
+      gradeItemName: "知識・技能",
+      boundaries: [{ label: "A", minPercentage: 80, order: 0 }],
+    },
+  ]
+  archive.gradeData.gradeOverrides = []
+  archive.gradeData.gradeItems = [
+    { name: "知識・技能", order: 0, dataSources: [] },
+    { name: "評定", order: 1, dataSources: [] },
+  ]
+  archive.gradeData.gradeConstraints = [
+    {
+      name: "評定と観点の整合",
+      kind: "consistency",
+      config: JSON.stringify({
+        labelValues: { A: 5, B: 3, C: 1 },
+        aggregate: "sum",
+        tolerance: 2,
+        target: "評定",
+        viewpointItems: ["知識・技能"],
+      }),
+      expression: "",
+      color: "#fecaca",
+      message: "観点と評定が合いません",
+      enabled: true,
+      order: 0,
+    },
+    {
+      name: "A・C混在禁止",
+      kind: "mutual_exclusion",
+      config: JSON.stringify({ labels: ["A", "C"] }),
+      expression: "",
+      color: "#fde68a",
+      message: null,
+      enabled: true,
+      order: 1,
+    },
+    {
+      name: "壊れたconfig",
+      kind: "consistency",
+      config: "これはJSONではない",
+      expression: "",
+      color: "#fecaca",
+      message: null,
+      enabled: true,
+      order: 2,
+    },
+  ]
+  return archive
+}
+
+describe("transformGradeToLatest: 1.10.0 → 1.11.0（制約ルールの設定JSON展開）", () => {
+  it("config を構造化フィールドへ展開し、評価項目は名前で残す", () => {
+    const { data, appliedTransformations, originalVersion } =
+      transformGradeToLatest(buildV1_10_0Archive())
+
+    expect(originalVersion).toBe("1.10.0")
+    expect(appliedTransformations).toContainEqual({
+      from: "1.10.0",
+      to: "1.11.0",
+    })
+
+    const constraints = data.gradeData.gradeConstraints!
+    const consistency = constraints.find(
+      (constraint) => constraint.kind === "consistency"
+    )!
+    // uuid は旧アーカイブに無いので名前だけ（importer が名前フォールバックで解決する）
+    expect(consistency.targetGradeItemName).toBe("評定")
+    expect(consistency.targetGradeItemId).toBeUndefined()
+    expect(consistency.viewpointGradeItemNames).toEqual(["知識・技能"])
+    expect(consistency.labelValues).toEqual({ A: 5, B: 3, C: 1 })
+    expect(consistency.aggregate).toBe("sum")
+    expect(consistency.tolerance).toBe(2)
+    // 教員が書いた違反メッセージは触らない
+    expect(consistency.message).toBe("観点と評定が合いません")
+    // 展開後は config を残さない
+    expect(consistency.config).toBeUndefined()
+
+    const exclusion = constraints.find(
+      (constraint) => constraint.kind === "mutual_exclusion"
+    )!
+    expect(exclusion.exclusionLabels).toEqual(["A", "C"])
+    expect(exclusion.config).toBeUndefined()
+  })
+
+  it("壊れた config は既定値へ倒して取り込める形にする", () => {
+    const { data } = transformGradeToLatest(buildV1_10_0Archive())
+
+    const broken = data.gradeData.gradeConstraints!.find(
+      (constraint) => constraint.name === "壊れたconfig"
+    )!
+    // 旧 parseConfig の既定値フォールバックと同じ挙動（JSON.parse 失敗で既定値）
+    expect(broken.targetGradeItemName).toBeNull()
+    expect(broken.aggregate).toBe("average")
+    expect(broken.tolerance).toBe(1)
+    expect(broken.viewpointGradeItemNames).toEqual([])
+    expect(broken.config).toBeUndefined()
+  })
+
+  it("マニフェストを現行へ上げ、変換した件数を warning で知らせる", () => {
+    const { data, warnings } = transformGradeToLatest(buildV1_10_0Archive())
+
+    expect(data.manifest.version).toBe(GRADE_CURRENT_VERSION)
+    expect(warnings.some((warning) => warning.includes("1.10.0→1.11.0"))).toBe(
+      true
+    )
+  })
+
+  it("既に 1.11.0 の形なら変換しない", () => {
+    const archive = buildV1_10_0Archive()
+    archive.gradeData.gradeConstraints = [
+      {
+        name: "整合",
+        kind: "consistency",
+        targetGradeItemId: "gi-h",
+        targetGradeItemName: "評定",
+        aggregate: "average",
+        tolerance: 1,
+        viewpointGradeItemIds: ["gi-k"],
+        viewpointGradeItemNames: ["知識・技能"],
+        labelValues: { A: 5 },
+        exclusionLabels: [],
+        expression: "",
+        color: "#fecaca",
+        message: null,
+        enabled: true,
+        order: 0,
+      },
+    ]
+
+    const { appliedTransformations, originalVersion } =
+      transformGradeToLatest(archive)
+
+    expect(
+      appliedTransformations.some(
+        (transformation) => transformation.to === "1.11.0"
+      )
+    ).toBe(false)
+    expect(originalVersion).toBe(GRADE_CURRENT_VERSION)
   })
 })

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -208,6 +208,11 @@ describe("DateTime正規化マイグレーション", () => {
     "CourseworkTag",
     "CropRegionAssignment", // 20260726100000 で追加。normalize migration より後で ISO text 生成
     "GradeConstraint",
+    // 20260726110000 で追加（制約ルールの設定JSON正規化）。normalize migration より後で ISO text 生成
+    "GradeConstraintExclusionLabel",
+    "GradeConstraintLabelValue",
+    "GradeConstraintViewpoint",
+    "GradeDataSourceEstimationSource",
     "GradeFrozenScore", // 20260725150000 で追加。normalize migration より後で ISO text 生成
     "ReturnSnapshot",
   ])

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -45,6 +45,7 @@ export async function collectGradeArchiveData(
               cropRegion: true,
               courseworkItem: { include: { coursework: true } },
               coursework: { select: { id: true, name: true } },
+              estimationSources: { orderBy: { order: "asc" } },
             },
             orderBy: { order: "asc" },
           },
@@ -92,6 +93,15 @@ export async function collectGradeArchiveData(
         },
       },
       gradeConstraints: {
+        include: {
+          targetGradeItem: { select: { name: true } },
+          viewpoints: {
+            include: { gradeItem: { select: { name: true } } },
+            orderBy: { order: "asc" },
+          },
+          labelValues: { orderBy: { order: "asc" } },
+          exclusionLabels: { orderBy: { order: "asc" } },
+        },
         orderBy: { order: "asc" },
       },
       exportSettings: true,
@@ -108,6 +118,8 @@ export async function collectGradeArchiveData(
     name: gradeItem.name,
     order: gradeItem.order,
     dataSources: gradeItem.dataSources.map((dataSource) => ({
+      // 照合の一次キー。estimationSourceIds の解決に使う
+      id: dataSource.id,
       type: dataSource.type,
       name: dataSource.name,
       // v1.6.0: maxScore は廃止（満点は import 後に元データからライブ算出）。出力しない。
@@ -122,14 +134,9 @@ export async function collectGradeArchiveData(
       treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
       estimationMode: dataSource.estimationMode,
       estimationSourceIds: (() => {
-        if (typeof dataSource.estimationSourceIds === "string") {
-          try {
-            return JSON.parse(dataSource.estimationSourceIds)
-          } catch {
-            return []
-          }
-        }
-        return []
+        return dataSource.estimationSources.map(
+          (estimationSource) => estimationSource.sourceDataSourceId
+        )
       })(),
       // coursework: 評価項目参照（courseworkId は親資料 / courseworkItemId は項目）
       // coursework_total: 資料全体参照（courseworkId のみ・項目参照は null）
@@ -265,10 +272,29 @@ export async function collectGradeArchiveData(
     frozenAt: gradeFrozenScore.frozenAt.toISOString(),
   }))
 
+  // v1.11.0: 設定JSONを廃し、評価項目参照は uuid 一次・名前二次で持ち出す（issue #1063）
   const gradeConstraints = grade.gradeConstraints.map((gradeConstraint) => ({
     name: gradeConstraint.name,
     kind: gradeConstraint.kind,
-    config: gradeConstraint.config,
+    targetGradeItemId: gradeConstraint.targetGradeItemId,
+    targetGradeItemName: gradeConstraint.targetGradeItem?.name ?? null,
+    aggregate: gradeConstraint.aggregate,
+    tolerance: Number(gradeConstraint.tolerance),
+    viewpointGradeItemIds: gradeConstraint.viewpoints.map(
+      (viewpoint) => viewpoint.gradeItemId
+    ),
+    viewpointGradeItemNames: gradeConstraint.viewpoints.map(
+      (viewpoint) => viewpoint.gradeItem.name
+    ),
+    labelValues: Object.fromEntries(
+      gradeConstraint.labelValues.map((labelValue) => [
+        labelValue.label,
+        Number(labelValue.value),
+      ])
+    ),
+    exclusionLabels: gradeConstraint.exclusionLabels.map(
+      (exclusionLabel) => exclusionLabel.label
+    ),
     expression: gradeConstraint.expression,
     color: gradeConstraint.color,
     message: gradeConstraint.message,

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -11,6 +11,8 @@ import type {
 } from "../../../../src/types/gradeArchive.types"
 import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
+import { writeConstraintConfig } from "../../prisma/gradeConstraint"
+import { buildEstimationSourceRows } from "../../prisma/gradeDataSource"
 import { importCourseworkData } from "../coursework-archive/dataCreator"
 import { transformGradeToLatest } from "../grade-transformers"
 
@@ -275,6 +277,14 @@ export async function importGradeArchive(
         /** 名前が重複し、名前フォールバックでは一意に定まらない評価項目名 */
         const ambiguousGradeItemNames = new Set<string>()
 
+        /** アーカイブデータソースuuid → 作成した GradeDataSource.id（推定参照の解決用） */
+        const dataSourceIdByArchiveId = new Map<string, string>()
+        /** 推定の参照。全データソース作成後に張るため一旦ためる（前方参照があるため） */
+        const estimationLinks: {
+          dataSourceId: string
+          archiveSourceIds: string[]
+        }[] = []
+
         /**
          * アーカイブ側の評価項目参照から、作成した GradeItem.id を解決する。
          * uuid 一次・名前二次。名前が曖昧なときは取り違えるより落として警告する
@@ -484,7 +494,7 @@ export async function importGradeArchive(
               }
             }
 
-            await tx.gradeDataSource.create({
+            const createdDataSource = await tx.gradeDataSource.create({
               data: {
                 gradeItemId: gradeItem.id,
                 type: dsData.type,
@@ -502,12 +512,51 @@ export async function importGradeArchive(
                 absentOffset: dsData.absentOffset ?? 0,
                 treatExpectedAsMissing: dsData.treatExpectedAsMissing ?? false,
                 estimationMode: dsData.estimationMode ?? "all",
-                estimationSourceIds: JSON.stringify(
-                  dsData.estimationSourceIds ?? []
-                ),
               },
             })
+            // 推定の参照は全データソース作成後にまとめて張る（前方参照があるため）
+            if (dsData.id) {
+              dataSourceIdByArchiveId.set(dsData.id, createdDataSource.id)
+            }
+            if (dsData.estimationSourceIds?.length) {
+              estimationLinks.push({
+                dataSourceId: createdDataSource.id,
+                archiveSourceIds: dsData.estimationSourceIds,
+              })
+            }
           }
+        }
+
+        // 4.5. 推定に使う他データソースを張る。
+        //   export元idを新idへ解決できたものだけ作る。旧アーカイブ（v1.11.0未満）は
+        //   データソースidを持たないため解決できず、参照は捨てて警告する
+        //   （旧importerはexport元idをそのまま書き戻しており dangling になっていた）。
+        for (const estimationLink of estimationLinks) {
+          const resolvedSourceIds = estimationLink.archiveSourceIds
+            .map((archiveSourceId) =>
+              dataSourceIdByArchiveId.get(archiveSourceId)
+            )
+            .filter((sourceId): sourceId is string => sourceId !== undefined)
+          const droppedCount =
+            estimationLink.archiveSourceIds.length - resolvedSourceIds.length
+          if (droppedCount > 0) {
+            warnings.push(
+              `欠損推定の参照${droppedCount}件を解決できなかったため取り込みませんでした。` +
+                `該当データソースの推定設定を確認してください。`
+            )
+          }
+          if (resolvedSourceIds.length === 0) continue
+          await tx.gradeDataSource.update({
+            where: { id: estimationLink.dataSourceId },
+            data: {
+              estimationSources: {
+                create: buildEstimationSourceRows(
+                  estimationLink.dataSourceId,
+                  resolvedSourceIds
+                ),
+              },
+            },
+          })
         }
 
         // 5. （v1.4.0で廃止）旧 ManualScore 挿入は Coursework 復元(3.5)に統合済み
@@ -619,24 +668,91 @@ export async function importGradeArchive(
           }
         }
 
-        // 観点間の制約ルール（v1.7.0+。式は観点名参照のためID再マップ不要）
+        // 観点間の制約ルール（v1.7.0+）。
+        //   比較先・集計対象は評価項目への参照なので uuid 一次・名前二次で解決する
+        //   （v1.11.0 で設定JSONから昇格。issue #1063）。
+        //   式（expression）だけは自由記述で項目名を含むため文字列のまま取り込む。
         if (
           gradeData.gradeConstraints &&
           gradeData.gradeConstraints.length > 0
         ) {
           for (const gradeConstraint of gradeData.gradeConstraints) {
-            await tx.gradeConstraint.create({
+            const targetGradeItemId = resolveGradeItemId(
+              {
+                gradeItemId: gradeConstraint.targetGradeItemId ?? undefined,
+                gradeItemName: gradeConstraint.targetGradeItemName ?? null,
+              },
+              () => `制約ルール「${gradeConstraint.name}」の比較先`
+            )
+            const targetWasSpecified = Boolean(
+              gradeConstraint.targetGradeItemId ??
+              gradeConstraint.targetGradeItemName
+            )
+
+            const viewpointReferences = gradeConstraint.viewpointGradeItemIds
+              ?.length
+              ? gradeConstraint.viewpointGradeItemIds.map(
+                  (gradeItemId, index) => ({
+                    gradeItemId,
+                    gradeItemName:
+                      gradeConstraint.viewpointGradeItemNames?.[index] ?? null,
+                  })
+                )
+              : (gradeConstraint.viewpointGradeItemNames ?? []).map(
+                  (gradeItemName) => ({ gradeItemName })
+                )
+            const resolvedViewpointIds = viewpointReferences
+              .map((viewpointReference) =>
+                resolveGradeItemId(
+                  viewpointReference,
+                  () => `制約ルール「${gradeConstraint.name}」の集計対象`
+                )
+              )
+              .filter(
+                (gradeItemId): gradeItemId is string => gradeItemId !== null
+              )
+
+            // 参照を1つでも失うと判定の意味が変わる（集計対象が減れば平均が動き、
+            // 空になれば「比較先以外の全項目」という別の設定に化ける）。
+            // 黙って別物として動かさず、無効化して再設定を促す。
+            const lostTarget = targetWasSpecified && targetGradeItemId === null
+            const lostViewpoint =
+              resolvedViewpointIds.length !== viewpointReferences.length
+            const brokenReason = lostTarget
+              ? "取り込み時に比較先の評価項目を解決できなかったため無効化しました。再設定してください。"
+              : lostViewpoint
+                ? "取り込み時に集計対象の観点を解決できなかったため無効化しました。再設定してください。"
+                : null
+            if (brokenReason) {
+              warnings.push(
+                `制約ルール「${gradeConstraint.name}」: ${brokenReason}`
+              )
+            }
+
+            const createdConstraint = await tx.gradeConstraint.create({
               data: {
                 gradeId: grade.id,
                 name: gradeConstraint.name,
                 kind: gradeConstraint.kind,
-                config: gradeConstraint.config,
+                targetGradeItemId,
+                aggregate: gradeConstraint.aggregate ?? "average",
+                tolerance: gradeConstraint.tolerance ?? 1,
                 expression: gradeConstraint.expression,
                 color: gradeConstraint.color,
+                // 診断は disabledReason へ。message は教員が書いた違反の説明で、
+                // 結果表のツールチップに出るため汚さない。
                 message: gradeConstraint.message,
-                enabled: gradeConstraint.enabled,
+                disabledReason: brokenReason,
+                enabled: gradeConstraint.enabled && !brokenReason,
                 order: gradeConstraint.order,
               },
+            })
+
+            // 設定リレーションのidは親idから決定論的に作るため本体作成後に書く
+            await writeConstraintConfig(tx, createdConstraint.id, {
+              viewpointGradeItemIds: resolvedViewpointIds,
+              labelValues: gradeConstraint.labelValues ?? {},
+              exclusionLabels: gradeConstraint.exclusionLabels ?? [],
             })
           }
         }

--- a/electron-src/lib/import/grade-transformers/V1_10_0_to_V1_11_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_10_0_to_V1_11_0.ts
@@ -1,0 +1,88 @@
+/**
+ * 1.10.0 → 1.11.0: 観点間の制約ルールの設定JSON（config）を構造化フィールドへ展開する。
+ *
+ * 旧 config は評価項目を「名前」で参照していた（issue #1063）。アーカイブ側でも同じ形で
+ * 持っていたため、ここでは名前フィールドへ移すところまでを行う。uuidは旧アーカイブに
+ * 存在しないので、importer が名前フォールバックで解決する。
+ */
+
+import type {
+  ArchiveGradeConstraint,
+  GradeArchiveData,
+  GradeArchiveVersion,
+  GradeTransformResult,
+  GradeVersionTransformer,
+} from "../../../../src/types/gradeArchive.types"
+
+/** 旧 config の形（kind別。壊れたJSONは既定値へ落とす） */
+interface LegacyConstraintConfig {
+  labelValues?: Record<string, number>
+  aggregate?: string
+  tolerance?: number
+  target?: string
+  viewpointItems?: string[]
+  labels?: string[]
+}
+
+function parseLegacyConfig(raw: string): LegacyConstraintConfig {
+  try {
+    const parsed: unknown = JSON.parse(raw || "{}")
+    if (typeof parsed !== "object" || parsed === null) return {}
+    return parsed as LegacyConstraintConfig
+  } catch {
+    return {}
+  }
+}
+
+export class V1_10_0_to_V1_11_0_Transformer implements GradeVersionTransformer {
+  readonly fromVersion: GradeArchiveVersion = "1.10.0"
+  readonly toVersion: GradeArchiveVersion = "1.11.0"
+
+  transform(data: GradeArchiveData): GradeTransformResult {
+    const warnings: string[] = []
+    const legacyConstraints = (data.gradeData.gradeConstraints ?? []).filter(
+      (gradeConstraint) => gradeConstraint.config !== undefined
+    )
+
+    if (legacyConstraints.length === 0) {
+      return {
+        data: {
+          ...data,
+          manifest: { ...data.manifest, version: this.toVersion },
+        },
+        warnings,
+      }
+    }
+
+    const gradeConstraints: ArchiveGradeConstraint[] = (
+      data.gradeData.gradeConstraints ?? []
+    ).map((gradeConstraint) => {
+      if (gradeConstraint.config === undefined) return gradeConstraint
+      const legacy = parseLegacyConfig(gradeConstraint.config)
+      const { config: _config, ...rest } = gradeConstraint
+      return {
+        ...rest,
+        targetGradeItemName: legacy.target ?? null,
+        aggregate: legacy.aggregate ?? "average",
+        tolerance: legacy.tolerance ?? 1,
+        viewpointGradeItemNames: legacy.viewpointItems ?? [],
+        labelValues: legacy.labelValues ?? {},
+        exclusionLabels: legacy.labels ?? [],
+      }
+    })
+
+    warnings.push(
+      `1.10.0→1.11.0: 制約ルール${legacyConstraints.length}件の設定を評価項目名で復元しました。` +
+        `同名の評価項目が複数ある場合は取り込み後に「観点間の制約ルール」を確認してください。`
+    )
+
+    return {
+      data: {
+        ...data,
+        manifest: { ...data.manifest, version: this.toVersion },
+        gradeData: { ...data.gradeData, gradeConstraints },
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/grade-transformers/index.ts
+++ b/electron-src/lib/import/grade-transformers/index.ts
@@ -26,6 +26,7 @@ import { GRADE_CURRENT_VERSION } from "../../../../src/types/gradeArchive.types"
 import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 import { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
 import { V1_9_0_to_V1_10_0_Transformer } from "./V1_9_0_to_V1_10_0"
+import { V1_10_0_to_V1_11_0_Transformer } from "./V1_10_0_to_V1_11_0"
 
 const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
   courseworks: [],
@@ -39,6 +40,7 @@ const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
 const v1_3_0 = new V1_3_0_to_V1_4_0_Transformer()
 const v1_4_0 = new V1_4_0_to_V1_5_0_Transformer()
 const v1_9_0 = new V1_9_0_to_V1_10_0_Transformer()
+const v1_10_0 = new V1_10_0_to_V1_11_0_Transformer()
 
 /**
  * 総合（overall）の名残を持つか。境界セット・手動上書きのどちらかに targetType があるか、
@@ -55,6 +57,13 @@ function hasOverallResidue(data: GradeArchiveData): boolean {
       gradeOverride.gradeItemName === null
   )
   return boundaryResidue || overrideResidue
+}
+
+/** 制約ルールが旧 config（設定JSON）を持つか。持てば 1.10.0 以前の形 */
+function hasLegacyConstraintConfig(data: GradeArchiveData): boolean {
+  return (data.gradeData.gradeConstraints ?? []).some(
+    (gradeConstraint) => gradeConstraint.config !== undefined
+  )
 }
 
 /** manual 型 DataSource を持つか（点数未入力でも true） */
@@ -74,6 +83,7 @@ function detectOriginalVersion(data: GradeArchiveData): GradeArchiveVersion {
   if (data.courseworks) return "1.4.0"
   if (hasManualDataSource(data) || data.manualScoresData) return "1.3.0"
   if (hasOverallResidue(data)) return "1.9.0"
+  if (hasLegacyConstraintConfig(data)) return "1.10.0"
   return GRADE_CURRENT_VERSION
 }
 
@@ -118,6 +128,14 @@ export function transformGradeToLatest(
     current = result.data
     warnings.push(...result.warnings)
     appliedTransformations.push({ from: "1.9.0", to: "1.10.0" })
+  }
+
+  // 1.10.0 → 1.11.0: 制約ルールの設定JSON（config）を構造化フィールドへ展開
+  if (hasLegacyConstraintConfig(current)) {
+    const result = v1_10_0.transform(current)
+    current = result.data
+    warnings.push(...result.warnings)
+    appliedTransformations.push({ from: "1.10.0", to: "1.11.0" })
   }
 
   // マニフェストを現行バージョンへ

--- a/electron-src/lib/prisma/deterministicId.ts
+++ b/electron-src/lib/prisma/deterministicId.ts
@@ -1,0 +1,48 @@
+/**
+ * 中間テーブルの決定論的id生成。
+ *
+ * `@default(uuid())` に任せると、2端末が同じ組み合わせを作ったときに id 違い・`@@unique`
+ * 同値の行ができてNAS同期で衝突する。同一idなら行レベルLWWで1行へ収束する
+ * （CropRegionAssignment と同じ理由）。
+ *
+ * CropRegionAssignment は uuidv5 を使うが、ここでは単純な連結にしている。既存データを
+ * 移すマイグレーションが同じidを組み立てられる必要があり、SQLite に sha1 が無いため
+ * SQL 側で uuidv5 を再現できないため。親idはuuid（固定長36文字）なので、区切り文字が
+ * 子キー側に含まれていても解釈は一意に定まる。
+ */
+
+function joinIds(parentId: string, childKey: string): string {
+  return `${parentId}:${childKey}`
+}
+
+/** consistency ルールの集計対象観点（GradeConstraintViewpoint）のid */
+export function buildConstraintViewpointId(
+  constraintId: string,
+  gradeItemId: string
+): string {
+  return joinIds(constraintId, gradeItemId)
+}
+
+/** consistency ルールのラベル→数値対応（GradeConstraintLabelValue）のid */
+export function buildConstraintLabelValueId(
+  constraintId: string,
+  label: string
+): string {
+  return joinIds(constraintId, label)
+}
+
+/** mutual_exclusion ルールの混在禁止ラベル（GradeConstraintExclusionLabel）のid */
+export function buildConstraintExclusionLabelId(
+  constraintId: string,
+  label: string
+): string {
+  return joinIds(constraintId, label)
+}
+
+/** 欠損推定に使う他データソース（GradeDataSourceEstimationSource）のid */
+export function buildEstimationSourceId(
+  dataSourceId: string,
+  sourceDataSourceId: string
+): string {
+  return joinIds(dataSourceId, sourceDataSourceId)
+}

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -5,9 +5,13 @@
 import { diffFields, recordAuditLog } from "./auditLog"
 import prisma from "./client"
 import {
+  gradeConstraintInclude,
+  writeConstraintConfig,
+} from "./gradeConstraint"
+import {
+  buildEstimationSourceRows,
   gradeItemWithDataSourcesInclude,
   hydrateGrade,
-  parseEstimationSourceIds,
 } from "./gradeDataSource"
 import { serializePrisma } from "./serializePrisma"
 
@@ -280,7 +284,12 @@ export async function duplicateGrade(id: string) {
             gradeClassrooms: { orderBy: { order: "asc" } },
             gradeStudents: true,
             gradeItems: {
-              include: { dataSources: { orderBy: { order: "asc" } } },
+              include: {
+                dataSources: {
+                  include: { estimationSources: { orderBy: { order: "asc" } } },
+                  orderBy: { order: "asc" },
+                },
+              },
               orderBy: { order: "asc" },
             },
             boundarySets: {
@@ -288,7 +297,10 @@ export async function duplicateGrade(id: string) {
             },
             gradeOverrides: true,
             gradeItemExclusions: true,
-            gradeConstraints: { orderBy: { order: "asc" } },
+            gradeConstraints: {
+              include: gradeConstraintInclude,
+              orderBy: { order: "asc" },
+            },
             exportSettings: true,
           },
         })
@@ -392,12 +404,11 @@ export async function duplicateGrade(id: string) {
                 absentOffset: dataSource.absentOffset,
                 treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
                 estimationMode: dataSource.estimationMode,
-                estimationSourceIds: dataSource.estimationSourceIds,
               },
             })
             dataSourceIdMap.set(dataSource.id, newDataSource.id)
-            const oldEstimationSourceIds = parseEstimationSourceIds(
-              dataSource.estimationSourceIds
+            const oldEstimationSourceIds = dataSource.estimationSources.map(
+              (estimationSource) => estimationSource.sourceDataSourceId
             )
             if (oldEstimationSourceIds.length > 0) {
               dataSourcesToRelink.push({
@@ -408,7 +419,7 @@ export async function duplicateGrade(id: string) {
           }
         }
 
-        // 5.5. estimationSourceIds を新DataSource IDへ remap
+        // 5.5. 推定に使う他データソースを新DataSource IDへ remap
         //   （元Grade内に見つからないID＝不整合は落とす）。
         for (const relink of dataSourcesToRelink) {
           const remapped = relink.oldEstimationSourceIds
@@ -416,7 +427,11 @@ export async function duplicateGrade(id: string) {
             .filter((newSourceId): newSourceId is string => !!newSourceId)
           await tx.gradeDataSource.update({
             where: { id: relink.newId },
-            data: { estimationSourceIds: JSON.stringify(remapped) },
+            data: {
+              estimationSources: {
+                create: buildEstimationSourceRows(relink.newId, remapped),
+              },
+            },
           })
         }
 
@@ -471,20 +486,43 @@ export async function duplicateGrade(id: string) {
           })
         }
 
-        // 9. 観点間の制約ルール（式・configは観点名参照のためID再マップ不要／独立行）
-        if (source.gradeConstraints.length > 0) {
-          await tx.gradeConstraint.createMany({
-            data: source.gradeConstraints.map((gradeConstraint) => ({
+        // 9. 観点間の制約ルール。
+        //   比較先・集計対象は評価項目への参照なので新gradeItemIdへ再マップする
+        //   （旧configの観点名参照だったころは再マップ不要だった）。
+        //   式（expression）だけは自由記述で項目名を含むため、文字列のまま複製する。
+        for (const gradeConstraint of source.gradeConstraints) {
+          const newConstraint = await tx.gradeConstraint.create({
+            data: {
               gradeId: grade.id,
               name: gradeConstraint.name,
               kind: gradeConstraint.kind,
-              config: gradeConstraint.config,
+              targetGradeItemId: gradeConstraint.targetGradeItemId
+                ? remapItemId(gradeConstraint.targetGradeItemId)
+                : null,
+              aggregate: gradeConstraint.aggregate,
+              tolerance: gradeConstraint.tolerance,
               expression: gradeConstraint.expression,
               color: gradeConstraint.color,
               message: gradeConstraint.message,
               enabled: gradeConstraint.enabled,
               order: gradeConstraint.order,
-            })),
+            },
+          })
+
+          // 設定リレーションのidは親idから決定論的に作るため本体作成後に書く
+          await writeConstraintConfig(tx, newConstraint.id, {
+            viewpointGradeItemIds: gradeConstraint.viewpoints.map((viewpoint) =>
+              remapItemId(viewpoint.gradeItemId)
+            ),
+            labelValues: Object.fromEntries(
+              gradeConstraint.labelValues.map((labelValue) => [
+                labelValue.label,
+                Number(labelValue.value),
+              ])
+            ),
+            exclusionLabels: gradeConstraint.exclusionLabels.map(
+              (exclusionLabel) => exclusionLabel.label
+            ),
           })
         }
 

--- a/electron-src/lib/prisma/gradeConstraint.ts
+++ b/electron-src/lib/prisma/gradeConstraint.ts
@@ -1,11 +1,156 @@
 /**
  * GradeConstraint（観点間の制約ルール）のPrisma操作関数
+ *
+ * 設定は kind 別のJSONではなくリレーションで持つ（issue #1063）。比較先・集計対象は
+ * 評価項目への FK なので、項目をリネームしても参照は切れない。
  */
+
+import type { Prisma } from "@prisma/client"
 
 import type { GradeConstraintInput } from "../../../src/types/grade.types"
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
+import {
+  buildConstraintExclusionLabelId,
+  buildConstraintLabelValueId,
+  buildConstraintViewpointId,
+} from "./deterministicId"
+import { serializePrisma } from "./serializePrisma"
+
+/**
+ * 制約ルールが持つ設定リレーションの include（単一 SSOT）。
+ * 全生成元でこれを使い、返り値の形状を一致させる。
+ */
+export const gradeConstraintInclude = {
+  viewpoints: { orderBy: { order: "asc" } },
+  labelValues: { orderBy: { order: "asc" } },
+  exclusionLabels: { orderBy: { order: "asc" } },
+} satisfies Prisma.GradeConstraintInclude
+
+/** 集計対象の観点（GradeItem）の nested create 行。重複は畳む（`@@unique` 違反回避）。 */
+export function buildConstraintViewpointRows(
+  constraintId: string,
+  gradeItemIds: string[]
+) {
+  const unique = [...new Set(gradeItemIds)]
+  return unique.map((gradeItemId, index) => ({
+    id: buildConstraintViewpointId(constraintId, gradeItemId),
+    gradeItemId,
+    order: index,
+  }))
+}
+
+/** ラベル→数値の対応の nested create 行。 */
+export function buildConstraintLabelValueRows(
+  constraintId: string,
+  labelValues: Record<string, number>
+) {
+  return Object.entries(labelValues).map(([label, value], index) => ({
+    id: buildConstraintLabelValueId(constraintId, label),
+    label,
+    value,
+    order: index,
+  }))
+}
+
+/** 混在禁止ラベルの nested create 行。重複は畳む。 */
+export function buildConstraintExclusionLabelRows(
+  constraintId: string,
+  labels: string[]
+) {
+  const unique = [...new Set(labels)]
+  return unique.map((label, index) => ({
+    id: buildConstraintExclusionLabelId(constraintId, label),
+    label,
+    order: index,
+  }))
+}
+
+/**
+ * 制約ルールの設定リレーションを書く（作成・更新・複製・アーカイブ取込の共通経路）。
+ * 未指定（undefined）の項目は触らない。指定されたものは総入れ替えする。
+ *
+ * 据え置く行は update で通し、実際に外れた行だけ削除する。決定論idを使っているため
+ * 同一idの delete → create にすると、sqlite-nas-sync の tombstone（秒解像度）が
+ * 再作成行の updatedAt より後になったとき相手側で INSERT が抑止され、その端末だけ
+ * 設定が消える。
+ *
+ * 子行のidは親idから決まるので、親を作った後に呼ぶ。呼び出し側は必ず同一トランザクション
+ * で包むこと（本体だけ出来て設定が入らないと、viewpointsゼロ＝「比較先以外の全項目」
+ * という設定していないルールとして動き出す）。
+ */
+export async function writeConstraintConfig(
+  tx: Prisma.TransactionClient,
+  constraintId: string,
+  constraint: Partial<GradeConstraintInput>
+) {
+  if (constraint.viewpointGradeItemIds !== undefined) {
+    const rows = buildConstraintViewpointRows(
+      constraintId,
+      constraint.viewpointGradeItemIds
+    )
+    await tx.gradeConstraintViewpoint.deleteMany({
+      where: {
+        constraintId,
+        ...(rows.length > 0 && {
+          gradeItemId: { notIn: rows.map((row) => row.gradeItemId) },
+        }),
+      },
+    })
+    for (const row of rows) {
+      await tx.gradeConstraintViewpoint.upsert({
+        where: { id: row.id },
+        create: { ...row, constraintId },
+        update: { order: row.order },
+      })
+    }
+  }
+
+  if (constraint.labelValues !== undefined) {
+    const rows = buildConstraintLabelValueRows(
+      constraintId,
+      constraint.labelValues
+    )
+    await tx.gradeConstraintLabelValue.deleteMany({
+      where: {
+        constraintId,
+        ...(rows.length > 0 && {
+          label: { notIn: rows.map((row) => row.label) },
+        }),
+      },
+    })
+    for (const row of rows) {
+      await tx.gradeConstraintLabelValue.upsert({
+        where: { id: row.id },
+        create: { ...row, constraintId },
+        update: { value: row.value, order: row.order },
+      })
+    }
+  }
+
+  if (constraint.exclusionLabels !== undefined) {
+    const rows = buildConstraintExclusionLabelRows(
+      constraintId,
+      constraint.exclusionLabels
+    )
+    await tx.gradeConstraintExclusionLabel.deleteMany({
+      where: {
+        constraintId,
+        ...(rows.length > 0 && {
+          label: { notIn: rows.map((row) => row.label) },
+        }),
+      },
+    })
+    for (const row of rows) {
+      await tx.gradeConstraintExclusionLabel.upsert({
+        where: { id: row.id },
+        create: { ...row, constraintId },
+        update: { order: row.order },
+      })
+    }
+  }
+}
 
 /**
  * 成績の全制約ルールを取得（order昇順）
@@ -14,9 +159,12 @@ export async function getGradeConstraints(gradeId: string) {
   try {
     const constraints = await prisma.gradeConstraint.findMany({
       where: { gradeId },
+      include: gradeConstraintInclude,
       orderBy: { order: "asc" },
     })
-    return { success: true, constraints }
+    // tolerance / labelValues.value は Decimal 列。IPC を跨ぐ前に number へ倒さないと
+    // renderer 側の数値比較が黙って壊れる（型は number を主張するので気づけない）。
+    return { success: true, constraints: serializePrisma(constraints) }
   } catch (error) {
     console.error("Error getting grade constraints:", error)
     return {
@@ -34,18 +182,31 @@ export async function createGradeConstraint(data: {
   constraint: GradeConstraintInput
 }) {
   try {
-    const created = await prisma.gradeConstraint.create({
-      data: {
-        gradeId: data.gradeId,
-        name: data.constraint.name,
-        kind: data.constraint.kind,
-        config: data.constraint.config,
-        expression: data.constraint.expression,
-        color: data.constraint.color,
-        message: data.constraint.message,
-        enabled: data.constraint.enabled,
-        order: data.constraint.order,
-      },
+    // 本体と設定は同一トランザクションで書く。設定の書き込みが失敗したときに
+    // 本体だけ残ると、viewpointsゼロ＝「比較先以外の全項目」という設定していない
+    // ルールが結果表を着色しはじめる。
+    const created = await prisma.$transaction(async (tx) => {
+      const constraint = await tx.gradeConstraint.create({
+        data: {
+          gradeId: data.gradeId,
+          name: data.constraint.name,
+          kind: data.constraint.kind,
+          targetGradeItemId: data.constraint.targetGradeItemId,
+          aggregate: data.constraint.aggregate,
+          tolerance: data.constraint.tolerance,
+          expression: data.constraint.expression,
+          color: data.constraint.color,
+          message: data.constraint.message,
+          enabled: data.constraint.enabled,
+          order: data.constraint.order,
+        },
+      })
+      // 設定リレーションのidは自分のidから決定論的に作るため、本体作成後に書く
+      await writeConstraintConfig(tx, constraint.id, data.constraint)
+      return tx.gradeConstraint.findUniqueOrThrow({
+        where: { id: constraint.id },
+        include: gradeConstraintInclude,
+      })
     })
 
     const scope = await resolveGradeScope(data.gradeId)
@@ -57,7 +218,7 @@ export async function createGradeConstraint(data: {
       scopeLabel: scope.scopeLabel,
     })
 
-    return { success: true, constraint: created }
+    return { success: true, constraint: serializePrisma(created) }
   } catch (error) {
     console.error("Error creating grade constraint:", error)
     return {
@@ -75,18 +236,29 @@ export async function updateGradeConstraint(data: {
   constraint: Partial<GradeConstraintInput>
 }) {
   try {
-    const updated = await prisma.gradeConstraint.update({
-      where: { id: data.id },
-      data: {
-        name: data.constraint.name,
-        kind: data.constraint.kind,
-        config: data.constraint.config,
-        expression: data.constraint.expression,
-        color: data.constraint.color,
-        message: data.constraint.message,
-        enabled: data.constraint.enabled,
-        order: data.constraint.order,
-      },
+    const updated = await prisma.$transaction(async (tx) => {
+      await tx.gradeConstraint.update({
+        where: { id: data.id },
+        data: {
+          name: data.constraint.name,
+          kind: data.constraint.kind,
+          targetGradeItemId: data.constraint.targetGradeItemId,
+          aggregate: data.constraint.aggregate,
+          tolerance: data.constraint.tolerance,
+          expression: data.constraint.expression,
+          color: data.constraint.color,
+          message: data.constraint.message,
+          enabled: data.constraint.enabled,
+          order: data.constraint.order,
+          // 自動で無効化した理由は、利用者が有効へ戻した時点で役目を終える
+          ...(data.constraint.enabled === true && { disabledReason: null }),
+        },
+      })
+      await writeConstraintConfig(tx, data.id, data.constraint)
+      return tx.gradeConstraint.findUniqueOrThrow({
+        where: { id: data.id },
+        include: gradeConstraintInclude,
+      })
     })
 
     const scope = await resolveGradeScope(updated.gradeId)
@@ -98,7 +270,7 @@ export async function updateGradeConstraint(data: {
       scopeLabel: scope.scopeLabel,
     })
 
-    return { success: true, constraint: updated }
+    return { success: true, constraint: serializePrisma(updated) }
   } catch (error) {
     console.error("Error updating grade constraint:", error)
     return {

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -3,12 +3,14 @@
  */
 
 import type { Prisma } from "@prisma/client"
+import { randomUUID } from "crypto"
 
 import { toGradeDataSourceType } from "../../../src/types/grade.types"
 import type { GradeDataSourceMaxScoreRef } from "../../../src/types/prismaExtensions"
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScopeByItem } from "./auditScope"
 import prisma from "./client"
+import { buildEstimationSourceId } from "./deterministicId"
 import { serializePrisma } from "./serializePrisma"
 
 /**
@@ -65,6 +67,8 @@ export const gradeDataSourceInclude = {
       items: { select: { maxScore: true } },
     },
   },
+  // estimationMode="selected" のとき推定に使う他データソース（旧 estimationSourceIds のJSON配列）
+  estimationSources: { orderBy: { order: "asc" } },
 } satisfies Prisma.GradeDataSourceInclude
 
 /** GradeItem を dataSources 込みで取得する際の include（上記を内包）。 */
@@ -75,18 +79,22 @@ export const gradeItemWithDataSourcesInclude = {
   },
 } satisfies Prisma.GradeItemInclude
 
-/** estimationSourceIds（JSON文字列 or 既に配列）を string[] へ正規化する。 */
-export function parseEstimationSourceIds(value: unknown): string[] {
-  if (Array.isArray(value)) return value as string[]
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value)
-      return Array.isArray(parsed) ? parsed : []
-    } catch {
-      return []
-    }
-  }
-  return []
+/**
+ * 推定に使う他データソースの nested create 行を組み立てる。
+ * 自分自身への参照は推定の材料になりえないため落とす。重複も畳む（`@@unique` 違反回避）。
+ */
+export function buildEstimationSourceRows(
+  dataSourceId: string,
+  sourceDataSourceIds: string[]
+) {
+  const unique = [...new Set(sourceDataSourceIds)].filter(
+    (sourceDataSourceId) => sourceDataSourceId !== dataSourceId
+  )
+  return unique.map((sourceDataSourceId, index) => ({
+    id: buildEstimationSourceId(dataSourceId, sourceDataSourceId),
+    sourceDataSourceId,
+    order: index,
+  }))
 }
 
 /**
@@ -148,8 +156,12 @@ type EnrichedGradeDataSource = Prisma.GradeDataSourceGetPayload<{
 }>
 
 /**
- * serialize 済み DataSource に、仮想フィールド maxScore を（同梱済み元データから）付与し、
- * estimationSourceIds を string[] へ正規化する。レンダラへ返す全経路で必ず通す。
+ * serialize 済み DataSource に、仮想フィールド maxScore を（同梱済み元データから）付与する。
+ * レンダラへ返す全経路で必ず通す。
+ *
+ * 推定に使う他データソース（estimationSources）は中間テーブルの行をそのまま渡す。
+ * 旧 estimationSourceIds（JSON配列）と違い FK で守られているため、参照先が消えれば
+ * 行ごと消える。
  *
  * maxScore 算出専用に同梱した集計元（exam.examPages / subtotal.cropSubtotals /
  * coursework.items）は、算出後に落として renderer 返却形状（grade.types の Pick）へ一致させる
@@ -161,9 +173,6 @@ export function hydrateGradeDataSource(dataSource: EnrichedGradeDataSource) {
   return {
     ...rest,
     type: toGradeDataSourceType(dataSource.type),
-    estimationSourceIds: parseEstimationSourceIds(
-      dataSource.estimationSourceIds
-    ),
     maxScore,
     exam: exam && {
       id: exam.id,
@@ -254,8 +263,12 @@ export async function createDataSource(data: {
     })
     const nextOrder = (maxOrder._max.order ?? -1) + 1
 
+    // estimationSources のidは自分のidから決定論的に作るため、先にidを確定させる
+    const dataSourceId = randomUUID()
+
     const dataSource = await prisma.gradeDataSource.create({
       data: {
+        id: dataSourceId,
         gradeItemId: data.gradeItemId,
         type: data.type,
         examId: data.examId,
@@ -282,7 +295,12 @@ export async function createDataSource(data: {
           estimationMode: data.estimationMode,
         }),
         ...(data.estimationSourceIds !== undefined && {
-          estimationSourceIds: JSON.stringify(data.estimationSourceIds),
+          estimationSources: {
+            create: buildEstimationSourceRows(
+              dataSourceId,
+              data.estimationSourceIds
+            ),
+          },
         }),
       },
       include: gradeDataSourceInclude,
@@ -329,9 +347,13 @@ export async function updateDataSource(
 ) {
   try {
     const { estimationSourceIds, ...rest } = data
-    const updateData: Record<string, unknown> = { ...rest }
+    const updateData: Prisma.GradeDataSourceUpdateInput = { ...rest }
     if (estimationSourceIds !== undefined) {
-      updateData.estimationSourceIds = JSON.stringify(estimationSourceIds)
+      // 選択の置き換え。決定論idなので、同じ組み合わせを選び直せば同じ行に戻る。
+      updateData.estimationSources = {
+        deleteMany: {},
+        create: buildEstimationSourceRows(id, estimationSourceIds),
+      }
     }
     const dataSource = await prisma.gradeDataSource.update({
       where: { id },

--- a/electron-src/lib/prisma/gradeItem.ts
+++ b/electron-src/lib/prisma/gradeItem.ts
@@ -114,6 +114,11 @@ export async function updateGradeItem(id: string, data: { name?: string }) {
 
 /**
  * GradeItemを削除（Cascadeでdatasonrces も削除）
+ *
+ * 集計対象にこの項目を含む制約ルールは先に無効化する。`GradeConstraintViewpoint` は
+ * FK の Cascade で消えるため、放っておくと集計対象が黙って1つ減り、残った項目だけで
+ * 平均を取って別の判定に化ける（issue #1063 で潰したのと同じ形の無言failure）。
+ * 比較先（targetGradeItemId）は SetNull になり「評定が未選択」として検知されるので触らない。
  */
 export async function deleteGradeItem(id: string) {
   try {
@@ -122,7 +127,23 @@ export async function deleteGradeItem(id: string) {
       select: { name: true, gradeId: true },
     })
 
-    await prisma.gradeItem.delete({ where: { id } })
+    const disabledConstraintNames = await prisma.$transaction(async (tx) => {
+      const affected = await tx.gradeConstraint.findMany({
+        where: { viewpoints: { some: { gradeItemId: id } }, enabled: true },
+        select: { id: true, name: true },
+      })
+      // 理由は disabledReason へ。message は教員が書いた違反の説明で、結果表の
+      // ツールチップに出るため汚さない。
+      const reason = `評価項目「${before?.name ?? ""}」の削除で集計対象が変わるため無効化しました。再設定してください。`
+      for (const constraint of affected) {
+        await tx.gradeConstraint.update({
+          where: { id: constraint.id },
+          data: { enabled: false, disabledReason: reason },
+        })
+      }
+      await tx.gradeItem.delete({ where: { id } })
+      return affected.map((constraint) => constraint.name)
+    })
 
     const scope = before ? await resolveGradeScope(before.gradeId) : null
     await recordAuditLog({
@@ -134,7 +155,7 @@ export async function deleteGradeItem(id: string) {
       target: before?.name ?? null,
     })
 
-    return { success: true }
+    return { success: true, disabledConstraintNames }
   } catch (error) {
     console.error("Error deleting grade item:", error)
     return {

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -48,6 +48,7 @@ async function buildGradeCalcContext(gradeId: string) {
               exam: true,
               subtotal: true,
               cropRegion: true,
+              estimationSources: { orderBy: { order: "asc" } },
               courseworkItem: {
                 include: {
                   scores: true,
@@ -213,14 +214,9 @@ async function buildGradeCalcContext(gradeId: string) {
 
   // DataSource情報をまとめる（推定で使用）
   const dataSourceInfos: DataSourceInfo[] = allDataSources.map((dataSource) => {
-    let sourceIds: string[] = []
-    if (typeof dataSource.estimationSourceIds === "string") {
-      try {
-        sourceIds = JSON.parse(dataSource.estimationSourceIds)
-      } catch {
-        sourceIds = []
-      }
-    }
+    const sourceIds = dataSource.estimationSources.map(
+      (estimationSource) => estimationSource.sourceDataSourceId
+    )
     return {
       id: dataSource.id,
       name: dataSource.name,

--- a/prisma/migrations/20260726110000_normalize_grade_constraint_config/migration.sql
+++ b/prisma/migrations/20260726110000_normalize_grade_constraint_config/migration.sql
@@ -1,0 +1,307 @@
+-- 観点間の制約ルールの設定JSON（GradeConstraint.config）と、欠損推定の参照配列
+-- （GradeDataSource.estimationSourceIds）を正規化テーブルへ分離する（issue #1063）。
+--
+-- 旧 config は評価項目を「名前」で参照していたため、項目をリネームすると制約が失効した。
+-- 比較先（target）の失効は検証されて画面に出るが、集計対象（viewpointItems）の失効は
+-- 検証されず、一部だけ空振りすると残った項目だけで平均を取って判定が通っていた。
+-- estimationSourceIds は FK が効かず、参照先削除後も dangling id が残っていた。
+--
+-- 新テーブルのidは決定論的な合成キー（親id + ':' + 子キー）にする。`@default(uuid())`
+-- 相当だと2端末が同じペアを作ったときにid違い・UNIQUE同値の行ができてNAS同期で衝突する。
+-- 同一idなら行レベルLWWで1行へ収束する。SQLだけで再現できる必要があるため、
+-- CropRegionAssignment の uuidv5 ではなく合成キーを採る。
+
+-- CreateTable: consistency ルールの集計対象となる観点（旧 config.viewpointItems）
+CREATE TABLE "GradeConstraintViewpoint" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "constraintId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeConstraintViewpoint_constraintId_fkey" FOREIGN KEY ("constraintId") REFERENCES "GradeConstraint" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeConstraintViewpoint_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeConstraintViewpoint_constraintId_gradeItemId_key" ON "GradeConstraintViewpoint"("constraintId", "gradeItemId");
+
+-- CreateIndex
+CREATE INDEX "GradeConstraintViewpoint_constraintId_idx" ON "GradeConstraintViewpoint"("constraintId");
+
+-- CreateIndex
+CREATE INDEX "GradeConstraintViewpoint_gradeItemId_idx" ON "GradeConstraintViewpoint"("gradeItemId");
+
+-- CreateTable: consistency ルールのラベル→数値の対応（旧 config.labelValues）
+CREATE TABLE "GradeConstraintLabelValue" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "constraintId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "value" DECIMAL NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeConstraintLabelValue_constraintId_fkey" FOREIGN KEY ("constraintId") REFERENCES "GradeConstraint" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeConstraintLabelValue_constraintId_label_key" ON "GradeConstraintLabelValue"("constraintId", "label");
+
+-- CreateIndex
+CREATE INDEX "GradeConstraintLabelValue_constraintId_idx" ON "GradeConstraintLabelValue"("constraintId");
+
+-- CreateTable: mutual_exclusion ルールの混在禁止ラベル集合（旧 config.labels）
+CREATE TABLE "GradeConstraintExclusionLabel" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "constraintId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeConstraintExclusionLabel_constraintId_fkey" FOREIGN KEY ("constraintId") REFERENCES "GradeConstraint" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeConstraintExclusionLabel_constraintId_label_key" ON "GradeConstraintExclusionLabel"("constraintId", "label");
+
+-- CreateIndex
+CREATE INDEX "GradeConstraintExclusionLabel_constraintId_idx" ON "GradeConstraintExclusionLabel"("constraintId");
+
+-- CreateTable: 欠損推定に使う他データソース（旧 GradeDataSource.estimationSourceIds）
+CREATE TABLE "GradeDataSourceEstimationSource" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "dataSourceId" TEXT NOT NULL,
+    "sourceDataSourceId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeDataSourceEstimationSource_dataSourceId_fkey" FOREIGN KEY ("dataSourceId") REFERENCES "GradeDataSource" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GradeDataSourceEstimationSource_sourceDataSourceId_fkey" FOREIGN KEY ("sourceDataSourceId") REFERENCES "GradeDataSource" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GradeDataSourceEstimationSource_dataSourceId_sourceDataSourceId_key" ON "GradeDataSourceEstimationSource"("dataSourceId", "sourceDataSourceId");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSourceEstimationSource_dataSourceId_idx" ON "GradeDataSourceEstimationSource"("dataSourceId");
+
+-- CreateIndex
+CREATE INDEX "GradeDataSourceEstimationSource_sourceDataSourceId_idx" ON "GradeDataSourceEstimationSource"("sourceDataSourceId");
+
+-- AlterTable: 比較先・集計方法・許容差をスカラー列へ昇格する。
+-- 評価項目を削除したときは NULL にしてルール自体は残し、「評定が未選択」として
+-- 検知させる（黙って違反なしにしない）。
+ALTER TABLE "GradeConstraint" ADD COLUMN "targetGradeItemId" TEXT REFERENCES "GradeItem" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "GradeConstraint" ADD COLUMN "aggregate" TEXT NOT NULL DEFAULT 'average';
+ALTER TABLE "GradeConstraint" ADD COLUMN "tolerance" DECIMAL NOT NULL DEFAULT 1;
+-- 自動で無効化したときの理由。message（教員が書いた違反の説明で結果表のツールチップに
+-- 出る）へ診断文を混ぜると、再設定後も違反理由として表示され続けるため別列に置く。
+ALTER TABLE "GradeConstraint" ADD COLUMN "disabledReason" TEXT;
+
+-- CreateIndex
+CREATE INDEX "GradeConstraint_targetGradeItemId_idx" ON "GradeConstraint"("targetGradeItemId");
+
+-- 比較先（config.target）を名前から id へ解決する。
+-- GradeItem.name に一意制約は無いので同名が複数ありうる。どれか1つを推測で選ぶと
+-- 誤った項目と比較して誤った生徒を着色するため、曖昧なときは解決しない
+-- （アーカイブ取込の resolveGradeItemId と同じ扱い。両経路で結果を一致させる）。
+UPDATE "GradeConstraint"
+SET "targetGradeItemId" = (
+    SELECT "gradeItem"."id"
+    FROM "GradeItem" AS "gradeItem"
+    WHERE "gradeItem"."gradeId" = "GradeConstraint"."gradeId"
+      AND "gradeItem"."name" = json_extract("GradeConstraint"."config", '$.target')
+)
+WHERE "kind" = 'consistency'
+  AND json_valid("config")
+  AND json_extract("config", '$.target') IS NOT NULL
+  AND (
+    SELECT COUNT(*)
+    FROM "GradeItem" AS "gradeItem"
+    WHERE "gradeItem"."gradeId" = "GradeConstraint"."gradeId"
+      AND "gradeItem"."name" = json_extract("GradeConstraint"."config", '$.target')
+  ) = 1;
+
+-- 集計方法・許容差をスカラー列へ移す
+UPDATE "GradeConstraint"
+SET "aggregate" = COALESCE(json_extract("config", '$.aggregate'), 'average'),
+    "tolerance" = COALESCE(json_extract("config", '$.tolerance'), 1)
+WHERE json_valid("config");
+
+-- 集計対象の観点（config.viewpointItems）を名前から id へ解決して移す。
+--
+-- 比較先と違い、同名の項目が複数あっても全て集計対象にする。旧実装の判定は
+-- `selected.includes(viewpoint.name)` で同名項目を両方とも集計していたため、
+-- ここで落とすと移行が既存の判定を変えてしまう（集計対象は複数選べるので
+-- 取り違えにもならない）。比較先は1つしか選べないため曖昧なら解決しない。
+--
+-- 解決できない名前は行を作れない（FKで守るため）。取りこぼしは後段で検知して無効化する。
+INSERT INTO "GradeConstraintViewpoint" ("id", "constraintId", "gradeItemId", "order", "createdAt", "updatedAt")
+SELECT
+    "constraint"."id" || ':' || "gradeItem"."id",
+    "constraint"."id",
+    "gradeItem"."id",
+    CAST("element"."key" AS INTEGER),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM "GradeConstraint" AS "constraint"
+JOIN json_each(json_extract("constraint"."config", '$.viewpointItems')) AS "element"
+JOIN "GradeItem" AS "gradeItem"
+  ON "gradeItem"."gradeId" = "constraint"."gradeId"
+ AND "gradeItem"."name" = "element"."value"
+WHERE "constraint"."kind" = 'consistency'
+  AND json_valid("constraint"."config")
+  AND json_type("constraint"."config", '$.viewpointItems') = 'array'
+GROUP BY "constraint"."id", "gradeItem"."id";
+
+-- ラベル→数値の対応（config.labelValues）を移す。
+-- 旧データはオブジェクトなので配列のような添字を持たない。json_each の走査順に
+-- 0始まりの連番を振り直す（走査idをそのまま使うと値が飛ぶ）。
+INSERT INTO "GradeConstraintLabelValue" ("id", "constraintId", "label", "value", "order", "createdAt", "updatedAt")
+SELECT
+    "labelValue"."constraintId" || ':' || "labelValue"."label",
+    "labelValue"."constraintId",
+    "labelValue"."label",
+    "labelValue"."value",
+    ROW_NUMBER() OVER (PARTITION BY "labelValue"."constraintId" ORDER BY "labelValue"."scanOrder") - 1,
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM (
+    SELECT
+        "constraint"."id" AS "constraintId",
+        "element"."key" AS "label",
+        "element"."value" AS "value",
+        "element"."id" AS "scanOrder"
+    FROM "GradeConstraint" AS "constraint"
+    JOIN json_each(json_extract("constraint"."config", '$.labelValues')) AS "element"
+    WHERE json_valid("constraint"."config")
+      AND json_type("constraint"."config", '$.labelValues') = 'object'
+      AND "element"."type" IN ('integer', 'real')
+) AS "labelValue";
+
+-- 混在禁止ラベル（config.labels）を移す
+INSERT INTO "GradeConstraintExclusionLabel" ("id", "constraintId", "label", "order", "createdAt", "updatedAt")
+SELECT
+    "constraint"."id" || ':' || "element"."value",
+    "constraint"."id",
+    "element"."value",
+    CAST("element"."key" AS INTEGER),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM "GradeConstraint" AS "constraint"
+JOIN json_each(json_extract("constraint"."config", '$.labels')) AS "element"
+WHERE "constraint"."kind" = 'mutual_exclusion'
+  AND json_valid("constraint"."config")
+  AND json_type("constraint"."config", '$.labels') = 'array'
+  AND "element"."type" = 'text'
+GROUP BY "constraint"."id", "element"."value";
+
+-- ラベル→数値の既定値を補う。
+-- 旧実装の parseConfig は既定値 {A:5,B:3,C:1} に config をマージしていたため、
+-- labelValues が欠けた（あるいは壊れた）configでも Excel 流のスケールで評価されていた。
+-- 移行後は行が無いと順位換算へ落ちて判定が変わるので、1行も入らなかった
+-- consistency ルールには既定値を入れて従来の判定を保つ。
+INSERT INTO "GradeConstraintLabelValue" ("id", "constraintId", "label", "value", "order", "createdAt", "updatedAt")
+SELECT
+    "constraint"."id" || ':' || "fallback"."label",
+    "constraint"."id",
+    "fallback"."label",
+    "fallback"."value",
+    "fallback"."order",
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM "GradeConstraint" AS "constraint"
+JOIN (
+    SELECT 'A' AS "label", 5 AS "value", 0 AS "order"
+    UNION ALL SELECT 'B', 3, 1
+    UNION ALL SELECT 'C', 1, 2
+) AS "fallback"
+WHERE "constraint"."kind" = 'consistency'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "GradeConstraintLabelValue" AS "labelValue"
+    WHERE "labelValue"."constraintId" = "constraint"."id"
+  );
+
+-- 混在禁止ラベルの既定値も同様に補う（旧既定値は ["A","C"]）。
+INSERT INTO "GradeConstraintExclusionLabel" ("id", "constraintId", "label", "order", "createdAt", "updatedAt")
+SELECT
+    "constraint"."id" || ':' || "fallback"."label",
+    "constraint"."id",
+    "fallback"."label",
+    "fallback"."order",
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM "GradeConstraint" AS "constraint"
+JOIN (
+    SELECT 'A' AS "label", 0 AS "order"
+    UNION ALL SELECT 'C', 1
+) AS "fallback"
+WHERE "constraint"."kind" = 'mutual_exclusion'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "GradeConstraintExclusionLabel" AS "exclusionLabel"
+    WHERE "exclusionLabel"."constraintId" = "constraint"."id"
+  );
+
+-- 取りこぼしの検知: 比較先の名前があったのに解決できなかった consistency ルールを無効化する。
+-- 黙って「違反なし」に化けるのを避け、利用者に再設定を促す。
+-- 理由は disabledReason へ書く（message は教員が書いた違反の説明で、結果表の
+-- ツールチップに出るため汚さない）。
+UPDATE "GradeConstraint"
+SET "enabled" = 0,
+    "disabledReason" = '移行時に比較先の評価項目「' || json_extract("config", '$.target') || '」を解決できなかったため無効化しました。同名の評価項目が複数ある場合も解決できません。再設定してください。'
+WHERE "kind" = 'consistency'
+  AND json_valid("config")
+  AND json_extract("config", '$.target') IS NOT NULL
+  AND json_extract("config", '$.target') <> ''
+  AND "targetGradeItemId" IS NULL;
+
+-- 取りこぼしの検知: 集計対象が指定されていたのに一部でも解決できなかったルールを無効化する。
+-- 黙って「指定なし（＝比較先以外の全項目）」へ化けると判定の意味が変わるため。
+--
+-- 判定は行数ではなく「名前が何種類解決できたか」で行う。挿入側は
+-- (constraint, gradeItem) で GROUP BY しており、同名項目が複数あると名前1つが
+-- 複数行になるため、配列長と行数を直接比べると取りこぼしが無くても食い違う。
+UPDATE "GradeConstraint"
+SET "enabled" = 0,
+    "disabledReason" = '移行時に集計対象の観点を解決できなかったため無効化しました。再設定してください。'
+WHERE "kind" = 'consistency'
+  AND json_valid("config")
+  AND json_type("config", '$.viewpointItems') = 'array'
+  AND json_array_length("config", '$.viewpointItems') > 0
+  AND (
+      SELECT COUNT(DISTINCT "element"."value")
+      FROM json_each(json_extract("GradeConstraint"."config", '$.viewpointItems')) AS "element"
+  ) <> (
+      SELECT COUNT(DISTINCT "element"."value")
+      FROM json_each(json_extract("GradeConstraint"."config", '$.viewpointItems')) AS "element"
+      WHERE EXISTS (
+        SELECT 1
+        FROM "GradeItem" AS "gradeItem"
+        WHERE "gradeItem"."gradeId" = "GradeConstraint"."gradeId"
+          AND "gradeItem"."name" = "element"."value"
+      )
+  );
+
+-- 欠損推定の参照（estimationSourceIds）を移す。
+-- 実在しない参照（dangling id）は JOIN で落ちる。これが排除したかった状態そのもの。
+INSERT INTO "GradeDataSourceEstimationSource" ("id", "dataSourceId", "sourceDataSourceId", "order", "createdAt", "updatedAt")
+SELECT
+    "dataSource"."id" || ':' || "source"."id",
+    "dataSource"."id",
+    "source"."id",
+    CAST("element"."key" AS INTEGER),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00'
+FROM "GradeDataSource" AS "dataSource"
+JOIN json_each("dataSource"."estimationSourceIds") AS "element"
+JOIN "GradeDataSource" AS "source" ON "source"."id" = "element"."value"
+WHERE json_valid("dataSource"."estimationSourceIds")
+  AND json_type("dataSource"."estimationSourceIds") = 'array'
+  AND "source"."id" <> "dataSource"."id"
+GROUP BY "dataSource"."id", "source"."id";
+
+-- DropColumn: JSON埋め込みを撤去する
+ALTER TABLE "GradeConstraint" DROP COLUMN "config";
+ALTER TABLE "GradeDataSource" DROP COLUMN "estimationSourceIds";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,7 +168,7 @@ model StudentAnswerImage {
 }
 
 model CropRegion {
-  id                 String                @id @default(uuid())
+  id                 String                 @id @default(uuid())
   examPageId         String
   label              String
   type               String
@@ -178,9 +178,9 @@ model CropRegion {
   height             Float
   points             Int?
   orderIndex         Int?
-  createdAt          DateTime              @default(now())
-  updatedAt          DateTime              @default(now()) @updatedAt
-  examPage           ExamPage              @relation(fields: [examPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @default(now()) @updatedAt
+  examPage           ExamPage               @relation(fields: [examPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   cropSubtotals      CropSubtotal[]
   questionScores     QuestionScore[]
   gradeDataSources   GradeDataSource[]
@@ -684,23 +684,99 @@ model Grade {
 }
 
 /// 観点間の制約ルール（不適切な観点/評定の組合せを検知して着色）
+///
+/// 旧 `config`（kind別の設定JSON）は評価項目を「名前」で参照していたため、項目を
+/// リネームすると制約が失効した。集計対象（viewpointItems）は失効しても検証されず、
+/// 一部だけ空振りすると残りだけで平均を取って判定が通っていた。id参照へ昇格して
+/// リレーションで守る（issue #1063）。
 model GradeConstraint {
-  id         String   @id @default(uuid())
-  gradeId    String
-  name       String
-  kind       String // "consistency" | "mutual_exclusion" | "expression"
-  config     String   @default("{}") // ビルダー設定のJSON（kind別）
-  expression String   @default("") // kind="expression" 時のみ使用
-  color      String // 着色色（hex等）
-  message    String?
-  enabled    Boolean  @default(true)
-  order      Int      @default(0)
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id                String   @id @default(uuid())
+  gradeId           String
+  name              String
+  kind              String // "consistency" | "mutual_exclusion" | "expression"
+  /// kind="consistency": 比較先の「評定」項目。項目削除時はnullにし、ルール自体は残して
+  /// 「評定が未選択」として検知させる（黙って違反なしにしない）
+  targetGradeItemId String?
+  /// kind="consistency": 観点の集計方法 "average" | "sum"
+  aggregate         String   @default("average")
+  /// kind="consistency": 評定との許容差（これを超えたら違反）
+  tolerance         Decimal  @default(1)
+  expression        String   @default("") // kind="expression" 時のみ使用
+  color             String // 着色色（hex等）
+  /// 違反時に表示する教員の説明文。移行や取り込みの診断はここへ書かない
+  message           String?
+  /// 移行・取り込み・項目削除でこのルールを自動で無効化したときの理由。
+  /// message（教員が書いた違反の説明。結果表のツールチップに出る）を汚さないよう別に持つ
+  disabledReason    String?
+  enabled           Boolean  @default(true)
+  order             Int      @default(0)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  grade Grade @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  grade           Grade                           @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  targetGradeItem GradeItem?                      @relation("GradeConstraintTarget", fields: [targetGradeItemId], references: [id], onDelete: SetNull)
+  viewpoints      GradeConstraintViewpoint[]
+  labelValues     GradeConstraintLabelValue[]
+  exclusionLabels GradeConstraintExclusionLabel[]
 
   @@index([gradeId])
+  @@index([targetGradeItemId])
+}
+
+/// consistency ルールの集計対象となる観点（旧 config.viewpointItems）。
+/// 空なら target 以外の全項目を対象にする、という既定の意味は評価側が持つ。
+///
+/// idは決定論的に生成する（`buildConstraintViewpointId`）。`@default(uuid())` だと
+/// 2端末が同じ(ルール, 項目)を追加したときid違い・`@@unique`同値の行ができてNAS同期で
+/// 衝突する。同一idなら行レベルLWWで1行へ収束する。
+model GradeConstraintViewpoint {
+  id           String   @id
+  constraintId String
+  gradeItemId  String
+  order        Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  constraint GradeConstraint @relation(fields: [constraintId], references: [id], onDelete: Cascade)
+  gradeItem  GradeItem       @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+
+  @@unique([constraintId, gradeItemId])
+  @@index([constraintId])
+  @@index([gradeItemId])
+}
+
+/// consistency ルールのラベル→数値の対応（旧 config.labelValues。例 A=5, B=3, C=1）。
+/// labelは境界ラベルの文字列であり実体参照ではないため、そのまま値として持つ。
+/// idは決定論的に生成する（`buildConstraintLabelValueId`）。理由は GradeConstraintViewpoint と同じ。
+model GradeConstraintLabelValue {
+  id           String   @id
+  constraintId String
+  label        String
+  value        Decimal
+  order        Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  constraint GradeConstraint @relation(fields: [constraintId], references: [id], onDelete: Cascade)
+
+  @@unique([constraintId, label])
+  @@index([constraintId])
+}
+
+/// mutual_exclusion ルールの混在禁止ラベル集合（旧 config.labels。例 ["A", "C"]）。
+/// idは決定論的に生成する（`buildConstraintExclusionLabelId`）。理由は GradeConstraintViewpoint と同じ。
+model GradeConstraintExclusionLabel {
+  id           String   @id
+  constraintId String
+  label        String
+  order        Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  constraint GradeConstraint @relation(fields: [constraintId], references: [id], onDelete: Cascade)
+
+  @@unique([constraintId, label])
+  @@index([constraintId])
 }
 
 /// 評価項目（知識・技能、思考・判断・表現、評定 等）
@@ -712,12 +788,14 @@ model GradeItem {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  grade               Grade                @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  dataSources         GradeDataSource[]
-  boundarySets        GradeBoundarySet[]
-  gradeOverrides      GradeOverride[]
-  gradeFrozenScores   GradeFrozenScore[]
-  gradeItemExclusions GradeItemExclusion[]
+  grade                Grade                      @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  dataSources          GradeDataSource[]
+  boundarySets         GradeBoundarySet[]
+  gradeOverrides       GradeOverride[]
+  gradeFrozenScores    GradeFrozenScore[]
+  gradeItemExclusions  GradeItemExclusion[]
+  constraintTargets    GradeConstraint[]          @relation("GradeConstraintTarget")
+  constraintViewpoints GradeConstraintViewpoint[]
 
   @@index([gradeId])
 }
@@ -777,7 +855,6 @@ model GradeDataSource {
   absentOffset           Decimal  @default(0)
   treatExpectedAsMissing Boolean  @default(false)
   estimationMode         String   @default("all") // "all" | "selected"
-  estimationSourceIds    String   @default("[]") // JSON array of DataSource IDs
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 
@@ -788,12 +865,39 @@ model GradeDataSource {
   courseworkItem CourseworkItem? @relation(fields: [courseworkItemId], references: [id], onDelete: SetNull)
   coursework     Coursework?     @relation(fields: [courseworkId], references: [id], onDelete: SetNull)
 
+  /// estimationMode="selected" のとき推定に使う他データソース（旧 estimationSourceIds のJSON配列）
+  estimationSources      GradeDataSourceEstimationSource[] @relation("EstimationTarget")
+  /// 自分を推定材料として参照している側（削除時のカスケード用）
+  estimationReferencedBy GradeDataSourceEstimationSource[] @relation("EstimationSource")
+
   @@index([gradeItemId])
   @@index([examId])
   @@index([subtotalId])
   @@index([cropRegionId])
   @@index([courseworkItemId])
   @@index([courseworkId])
+}
+
+/// 欠損推定に使う他データソース（旧 GradeDataSource.estimationSourceIds のJSON配列）。
+/// JSON配列ではFKが効かず、参照先データソースを削除してもdangling idが残っていた（issue #1063）。
+///
+/// idは決定論的に生成する（`buildEstimationSourceId`）。理由は GradeConstraintViewpoint と同じ。
+model GradeDataSourceEstimationSource {
+  id                 String   @id
+  /// 推定を行う側
+  dataSourceId       String
+  /// 推定の材料に使う側（同一Grade内の他データソース）
+  sourceDataSourceId String
+  order              Int      @default(0)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  dataSource       GradeDataSource @relation("EstimationTarget", fields: [dataSourceId], references: [id], onDelete: Cascade)
+  sourceDataSource GradeDataSource @relation("EstimationSource", fields: [sourceDataSourceId], references: [id], onDelete: Cascade)
+
+  @@unique([dataSourceId, sourceDataSourceId])
+  @@index([dataSourceId])
+  @@index([sourceDataSourceId])
 }
 
 /// 評価項目ごとの対象生徒除外設定

--- a/src/components/grades/03-data-sources/DataSourcesContainer.tsx
+++ b/src/components/grades/03-data-sources/DataSourcesContainer.tsx
@@ -420,7 +420,16 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
               variant="ghost"
               size="icon"
               className="text-destructive h-7 w-7"
-              onClick={() => deleteGradeItem(gradeItem.id)}
+              onClick={async () => {
+                const result = await deleteGradeItem(gradeItem.id)
+                // 制約ルールの集計対象が変わると判定の意味が変わるため無効化される。
+                // 黙って着色が消えるのを避け、その場で知らせる。
+                if (result.disabledConstraintNames?.length) {
+                  toast.warning(
+                    `制約ルール「${result.disabledConstraintNames.join("」「")}」を無効化しました（集計対象が変わったため再設定してください）`
+                  )
+                }
+              }}
             >
               <Trash2 className="h-4 w-4" />
             </Button>

--- a/src/components/grades/03-data-sources/EstimationSettingsPopover.tsx
+++ b/src/components/grades/03-data-sources/EstimationSettingsPopover.tsx
@@ -77,7 +77,9 @@ export function EstimationSettingsPopover({
     dataSource.estimationMode
   )
   const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>(
-    dataSource.estimationSourceIds ?? []
+    dataSource.estimationSources.map(
+      (estimationSource) => estimationSource.sourceDataSourceId
+    )
   )
   const [treatExpectedAsMissing, setTreatExpectedAsMissing] = useState(
     dataSource.treatExpectedAsMissing
@@ -107,7 +109,11 @@ export function EstimationSettingsPopover({
       setRatio(String(dataSource.absentRatio))
       setOffset(String(dataSource.absentOffset))
       setEstimationMode(dataSource.estimationMode)
-      setSelectedSourceIds(dataSource.estimationSourceIds ?? [])
+      setSelectedSourceIds(
+        dataSource.estimationSources.map(
+          (estimationSource) => estimationSource.sourceDataSourceId
+        )
+      )
       setTreatExpectedAsMissing(dataSource.treatExpectedAsMissing)
     }
     setOpen(newOpen)
@@ -127,7 +133,7 @@ export function EstimationSettingsPopover({
     const methodLabel = ABSENT_METHOD_LABELS[dataSource.absentMethod]
     const sourceCount =
       dataSource.estimationMode === "selected"
-        ? (dataSource.estimationSourceIds ?? []).length
+        ? dataSource.estimationSources.length
         : allDataSources.filter(
             (candidateSource) => candidateSource.id !== dataSource.id
           ).length

--- a/src/components/grades/05-boundaries/ConsistencyFields.tsx
+++ b/src/components/grades/05-boundaries/ConsistencyFields.tsx
@@ -9,44 +9,59 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { DEFAULT_CONSISTENCY_CONFIG, parseConfig } from "@/lib/gradeConstraints"
-import type { ConsistencyConfig } from "@/types/grade.types"
-
-/** 整合ルールの設定JSONを復元 */
-export function parseConsistency(raw: string): ConsistencyConfig {
-  return parseConfig(raw, DEFAULT_CONSISTENCY_CONFIG)
-}
+import type {
+  ConstraintAggregate,
+  GradeConstraintInput,
+} from "@/types/grade.types"
 
 interface ConsistencyFieldsProps {
-  config: ConsistencyConfig
+  /** 比較先の「評定」にあたる評価項目。未選択なら null */
+  targetGradeItemId: string | null
+  aggregate: ConstraintAggregate
+  tolerance: number
+  /** 集計対象の観点の評価項目id。空なら比較先以外の全項目が対象 */
+  viewpointGradeItemIds: string[]
+  /** ラベル→数値の対応 */
+  labelValues: Record<string, number>
+  /** 境界セットに登場する全ラベル */
   labels: string[]
-  itemNames: string[]
-  onChange: (config: ConsistencyConfig) => void
+  gradeItems: { id: string; name: string }[]
+  onChange: (patch: Partial<GradeConstraintInput>) => void
 }
 
 export function ConsistencyFields({
-  config,
+  targetGradeItemId,
+  aggregate,
+  tolerance,
+  viewpointGradeItemIds,
+  labelValues,
   labels,
-  itemNames,
+  gradeItems,
   onChange,
 }: ConsistencyFieldsProps) {
   // ラベル値は A/B/C 等の非数値ラベルのみ（数値ラベルはそのまま数値化される）
   const valueLabels = (
-    labels.length > 0 ? labels : Object.keys(config.labelValues)
+    labels.length > 0 ? labels : Object.keys(labelValues)
   ).filter((label) => Number.isNaN(Number(label)))
 
-  const target = config.target
-  const viewpointNames = itemNames.filter((itemName) => itemName !== target)
-  const effectiveViewpoints =
-    config.viewpointItems && config.viewpointItems.length > 0
-      ? config.viewpointItems
-      : viewpointNames
+  const viewpointCandidates = gradeItems.filter(
+    (gradeItem) => gradeItem.id !== targetGradeItemId
+  )
+  // 未指定は「比較先以外の全項目」を意味するので、表示上は全候補を選択済みとして扱う
+  const effectiveViewpointIds =
+    viewpointGradeItemIds.length > 0
+      ? viewpointGradeItemIds
+      : viewpointCandidates.map((gradeItem) => gradeItem.id)
 
-  const toggleViewpoint = (name: string) => {
-    const viewpointSet = new Set(effectiveViewpoints)
-    if (viewpointSet.has(name)) viewpointSet.delete(name)
-    else viewpointSet.add(name)
-    onChange({ ...config, viewpointItems: [...viewpointSet] })
+  const targetName =
+    gradeItems.find((gradeItem) => gradeItem.id === targetGradeItemId)?.name ??
+    ""
+
+  const toggleViewpoint = (gradeItemId: string) => {
+    const viewpointSet = new Set(effectiveViewpointIds)
+    if (viewpointSet.has(gradeItemId)) viewpointSet.delete(gradeItemId)
+    else viewpointSet.add(gradeItemId)
+    onChange({ viewpointGradeItemIds: [...viewpointSet] })
   }
 
   return (
@@ -57,14 +72,13 @@ export function ConsistencyFields({
             評定（比較先の項目）
           </Label>
           <Select
-            value={target}
+            value={targetGradeItemId ?? ""}
             onValueChange={(value) =>
               onChange({
-                ...config,
-                target: value,
-                viewpointItems: itemNames.filter(
-                  (itemName) => itemName !== value
-                ),
+                targetGradeItemId: value,
+                viewpointGradeItemIds: gradeItems
+                  .filter((gradeItem) => gradeItem.id !== value)
+                  .map((gradeItem) => gradeItem.id),
               })
             }
           >
@@ -72,9 +86,9 @@ export function ConsistencyFields({
               <SelectValue placeholder="項目を選択" />
             </SelectTrigger>
             <SelectContent>
-              {itemNames.map((itemName) => (
-                <SelectItem key={itemName} value={itemName}>
-                  {itemName}
+              {gradeItems.map((gradeItem) => (
+                <SelectItem key={gradeItem.id} value={gradeItem.id}>
+                  {gradeItem.name}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -83,12 +97,9 @@ export function ConsistencyFields({
         <div>
           <Label className="text-muted-foreground text-xs">集計</Label>
           <Select
-            value={config.aggregate}
+            value={aggregate}
             onValueChange={(value) =>
-              onChange({
-                ...config,
-                aggregate: value as ConsistencyConfig["aggregate"],
-              })
+              onChange({ aggregate: value as ConstraintAggregate })
             }
           >
             <SelectTrigger className="mt-1 h-8 w-28">
@@ -105,10 +116,8 @@ export function ConsistencyFields({
           <Input
             type="number"
             step="0.1"
-            value={config.tolerance}
-            onChange={(e) =>
-              onChange({ ...config, tolerance: Number(e.target.value) })
-            }
+            value={tolerance}
+            onChange={(e) => onChange({ tolerance: Number(e.target.value) })}
             className="mt-1 h-8 w-20"
           />
         </div>
@@ -116,24 +125,24 @@ export function ConsistencyFields({
 
       <div>
         <Label className="text-muted-foreground text-xs">
-          集計する観点（{config.aggregate === "sum" ? "合計" : "平均"}
+          集計する観点（{aggregate === "sum" ? "合計" : "平均"}
           をとる項目）
         </Label>
         <div className="mt-1 flex flex-wrap gap-2">
-          {viewpointNames.map((name) => {
-            const active = effectiveViewpoints.includes(name)
+          {viewpointCandidates.map((gradeItem) => {
+            const active = effectiveViewpointIds.includes(gradeItem.id)
             return (
               <button
-                key={name}
+                key={gradeItem.id}
                 type="button"
-                onClick={() => toggleViewpoint(name)}
+                onClick={() => toggleViewpoint(gradeItem.id)}
                 className={`rounded border px-2 py-1 text-xs ${
                   active
                     ? "border-primary bg-primary/10 text-foreground font-medium"
                     : "text-muted-foreground"
                 }`}
               >
-                {name}
+                {gradeItem.name}
               </button>
             )
           })}
@@ -151,12 +160,11 @@ export function ConsistencyFields({
                 <span className="w-5 text-center font-medium">{label}</span>
                 <Input
                   type="number"
-                  value={config.labelValues[label] ?? 0}
+                  value={labelValues[label] ?? 0}
                   onChange={(e) =>
                     onChange({
-                      ...config,
                       labelValues: {
-                        ...config.labelValues,
+                        ...labelValues,
                         [label]: Number(e.target.value),
                       },
                     })
@@ -170,8 +178,8 @@ export function ConsistencyFields({
       )}
 
       <p className="text-muted-foreground text-xs">
-        「{target || "（未選択）"}」と、選んだ観点の
-        {config.aggregate === "sum" ? "合計" : "平均"}の差が {config.tolerance}{" "}
+        「{targetName || "（未選択）"}」と、選んだ観点の
+        {aggregate === "sum" ? "合計" : "平均"}の差が {tolerance}{" "}
         を超えたら違反とみなします。
       </p>
     </div>

--- a/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
+++ b/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
@@ -12,9 +12,11 @@ import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { useGradeConstraints } from "@/hooks/grades/useGradeConstraints"
 import {
-  DEFAULT_CONSISTENCY_CONFIG,
+  DEFAULT_CONSTRAINT_AGGREGATE,
   DEFAULT_CONSTRAINT_COLOR,
-  DEFAULT_MUTUAL_EXCLUSION_CONFIG,
+  DEFAULT_CONSTRAINT_LABEL_VALUES,
+  DEFAULT_CONSTRAINT_TOLERANCE,
+  DEFAULT_EXCLUSION_LABELS,
   evaluateConstraints,
   validateConstraintExpression,
 } from "@/lib/gradeConstraints"
@@ -26,11 +28,8 @@ import type {
   GradeConstraintKind,
 } from "@/types/grade.types"
 
-import { ConsistencyFields, parseConsistency } from "./ConsistencyFields"
-import {
-  MutualExclusionFields,
-  parseMutualExclusion,
-} from "./MutualExclusionFields"
+import { ConsistencyFields } from "./ConsistencyFields"
+import { MutualExclusionFields } from "./MutualExclusionFields"
 
 interface ConstraintRulesEditorProps {
   gradeId: string
@@ -68,18 +67,13 @@ function collectLabels(
 }
 
 /** 「評定」にあたる項目を推測（名前に「評定」を含む最後の項目、無ければ末尾） */
-function guessTargetItem(itemNames: string[]): string {
-  const byName = [...itemNames]
+function guessTargetGradeItem(
+  gradeItems: { id: string; name: string }[]
+): { id: string; name: string } | null {
+  const byName = [...gradeItems]
     .reverse()
-    .find((itemName) => itemName.includes("評定"))
-  return byName ?? itemNames[itemNames.length - 1] ?? ""
-}
-
-function defaultConfigFor(kind: GradeConstraintKind): string {
-  if (kind === "consistency") return JSON.stringify(DEFAULT_CONSISTENCY_CONFIG)
-  if (kind === "mutual_exclusion")
-    return JSON.stringify(DEFAULT_MUTUAL_EXCLUSION_CONFIG)
-  return "{}"
+    .find((gradeItem) => gradeItem.name.includes("評定"))
+  return byName ?? gradeItems[gradeItems.length - 1] ?? null
 }
 
 export function ConstraintRulesEditor({
@@ -95,11 +89,6 @@ export function ConstraintRulesEditor({
   )
 
   const labels = useMemo(() => collectLabels(boundarySets), [boundarySets])
-  // 項目名は同期的に得られる gradeItems から作る（calcResult の読込を待たない）
-  const itemNames = useMemo(
-    () => gradeItems.map((gradeItem) => gradeItem.name),
-    [gradeItems]
-  )
 
   // プレビュー用に成績算出結果を取得
   const loadCalc = useCallback(async () => {
@@ -121,16 +110,9 @@ export function ConstraintRulesEditor({
   }, [calcResult, constraints])
 
   const handleAdd = async (kind: GradeConstraintKind) => {
-    let config = defaultConfigFor(kind)
     // 整合ルールは現在の項目構成から「評定」と集計対象を推測して初期化
-    if (kind === "consistency" && itemNames.length > 0) {
-      const target = guessTargetItem(itemNames)
-      config = JSON.stringify({
-        ...DEFAULT_CONSISTENCY_CONFIG,
-        target,
-        viewpointItems: itemNames.filter((itemName) => itemName !== target),
-      })
-    }
+    const target =
+      kind === "consistency" ? guessTargetGradeItem(gradeItems) : null
     const input: GradeConstraintInput = {
       name:
         kind === "consistency"
@@ -139,7 +121,18 @@ export function ConstraintRulesEditor({
             ? "A・C混在禁止"
             : "新しいルール",
       kind,
-      config,
+      targetGradeItemId: target?.id ?? null,
+      aggregate: DEFAULT_CONSTRAINT_AGGREGATE,
+      tolerance: DEFAULT_CONSTRAINT_TOLERANCE,
+      viewpointGradeItemIds: target
+        ? gradeItems
+            .filter((gradeItem) => gradeItem.id !== target.id)
+            .map((gradeItem) => gradeItem.id)
+        : [],
+      labelValues:
+        kind === "consistency" ? DEFAULT_CONSTRAINT_LABEL_VALUES : {},
+      exclusionLabels:
+        kind === "mutual_exclusion" ? DEFAULT_EXCLUSION_LABELS : [],
       expression: kind === "expression" ? 'has("A") and has("C")' : "",
       color: DEFAULT_CONSTRAINT_COLOR,
       message: null,
@@ -197,7 +190,7 @@ export function ConstraintRulesEditor({
             key={constraint.id}
             constraint={constraint}
             labels={labels}
-            itemNames={itemNames}
+            gradeItems={gradeItems}
             hitCount={evaluation?.counts.get(constraint.id) ?? 0}
             errorMessage={evaluation?.errors.get(constraint.id) ?? null}
             onUpdate={(patch) => updateConstraint(constraint.id, patch)}
@@ -212,7 +205,7 @@ export function ConstraintRulesEditor({
 interface ConstraintCardProps {
   constraint: GradeConstraintData
   labels: string[]
-  itemNames: string[]
+  gradeItems: { id: string; name: string; order: number }[]
   hitCount: number
   errorMessage: string | null
   onUpdate: (patch: Partial<GradeConstraintInput>) => void
@@ -222,7 +215,7 @@ interface ConstraintCardProps {
 function ConstraintCard({
   constraint,
   labels,
-  itemNames,
+  gradeItems,
   hitCount,
   errorMessage,
   onUpdate,
@@ -284,18 +277,31 @@ function ConstraintCard({
 
       {constraint.kind === "consistency" && (
         <ConsistencyFields
-          config={parseConsistency(constraint.config)}
+          targetGradeItemId={constraint.targetGradeItemId}
+          aggregate={constraint.aggregate}
+          tolerance={constraint.tolerance}
+          viewpointGradeItemIds={constraint.viewpoints.map(
+            (viewpoint) => viewpoint.gradeItemId
+          )}
+          labelValues={Object.fromEntries(
+            constraint.labelValues.map((labelValue) => [
+              labelValue.label,
+              labelValue.value,
+            ])
+          )}
           labels={labels}
-          itemNames={itemNames}
-          onChange={(config) => onUpdate({ config: JSON.stringify(config) })}
+          gradeItems={gradeItems}
+          onChange={onUpdate}
         />
       )}
 
       {constraint.kind === "mutual_exclusion" && (
         <MutualExclusionFields
-          config={parseMutualExclusion(constraint.config)}
+          exclusionLabels={constraint.exclusionLabels.map(
+            (exclusionLabel) => exclusionLabel.label
+          )}
           labels={labels}
-          onChange={(config) => onUpdate({ config: JSON.stringify(config) })}
+          onChange={onUpdate}
         />
       )}
 
@@ -335,6 +341,12 @@ function ConstraintCard({
           placeholder="違反時にホバーで表示される説明（任意）"
         />
       </div>
+
+      {constraint.disabledReason && (
+        <p className="text-destructive text-xs">
+          自動で無効化されました: {constraint.disabledReason}
+        </p>
+      )}
 
       <div className="text-muted-foreground text-xs">
         {errorMessage ? (

--- a/src/components/grades/05-boundaries/MutualExclusionFields.tsx
+++ b/src/components/grades/05-boundaries/MutualExclusionFields.tsx
@@ -1,34 +1,27 @@
 "use client"
 
 import { Label } from "@/components/ui/label"
-import {
-  DEFAULT_MUTUAL_EXCLUSION_CONFIG,
-  parseConfig,
-} from "@/lib/gradeConstraints"
-import type { MutualExclusionConfig } from "@/types/grade.types"
-
-/** 混在禁止ルールの設定JSONを復元 */
-export function parseMutualExclusion(raw: string): MutualExclusionConfig {
-  return parseConfig(raw, DEFAULT_MUTUAL_EXCLUSION_CONFIG)
-}
+import type { GradeConstraintInput } from "@/types/grade.types"
 
 interface MutualExclusionFieldsProps {
-  config: MutualExclusionConfig
+  /** 同時に現れてはいけないラベル集合 */
+  exclusionLabels: string[]
+  /** 境界セットに登場する全ラベル（選択肢） */
   labels: string[]
-  onChange: (config: MutualExclusionConfig) => void
+  onChange: (patch: Partial<GradeConstraintInput>) => void
 }
 
 export function MutualExclusionFields({
-  config,
+  exclusionLabels,
   labels,
   onChange,
 }: MutualExclusionFieldsProps) {
-  const displayLabels = labels.length > 0 ? labels : config.labels
+  const displayLabels = labels.length > 0 ? labels : exclusionLabels
   const toggle = (label: string) => {
-    const next = config.labels.includes(label)
-      ? config.labels.filter((existingLabel) => existingLabel !== label)
-      : [...config.labels, label]
-    onChange({ ...config, labels: next })
+    const next = exclusionLabels.includes(label)
+      ? exclusionLabels.filter((existingLabel) => existingLabel !== label)
+      : [...exclusionLabels, label]
+    onChange({ exclusionLabels: next })
   }
   return (
     <div className="space-y-2 text-sm">
@@ -37,7 +30,7 @@ export function MutualExclusionFields({
       </Label>
       <div className="flex flex-wrap gap-2">
         {displayLabels.map((label) => {
-          const active = config.labels.includes(label)
+          const active = exclusionLabels.includes(label)
           return (
             <button
               key={label}

--- a/src/components/grades/06-results/ConstraintLegend.tsx
+++ b/src/components/grades/06-results/ConstraintLegend.tsx
@@ -1,23 +1,62 @@
+import { AlertTriangle } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import type { GradeConstraintData } from "@/types/grade.types"
 
-/** 制約ルールの色凡例 */
+interface ConstraintLegendProps {
+  constraints: GradeConstraintData[]
+  /**
+   * constraintId → 評価できなかった理由。
+   * 評価できないルールは着色されないため、黙って「違反なし」に見えてしまう。
+   * 境界設定画面を開かなくても気づけるよう、結果表でも警告する（issue #1063）。
+   */
+  errors: Map<string, string>
+}
+
+/** 制約ルールの色凡例と、評価できなかったルールの警告 */
 export function ConstraintLegend({
   constraints,
-}: {
-  constraints: GradeConstraintData[]
-}) {
+  errors,
+}: ConstraintLegendProps) {
+  const brokenConstraints = constraints.filter((constraint) =>
+    errors.has(constraint.id)
+  )
+
   return (
-    <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-      <span className="text-muted-foreground">制約ルール:</span>
-      {constraints.map((constraint) => (
-        <span key={constraint.id} className="flex items-center gap-1.5">
-          <span
-            className="inline-block h-3 w-3 rounded border"
-            style={{ backgroundColor: constraint.color }}
-          />
-          {constraint.name}
-        </span>
-      ))}
+    <div className="mt-4 space-y-3">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+        <span className="text-muted-foreground">制約ルール:</span>
+        {constraints.map((constraint) => (
+          <span key={constraint.id} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-3 w-3 rounded border"
+              style={{ backgroundColor: constraint.color }}
+            />
+            {constraint.name}
+          </span>
+        ))}
+      </div>
+
+      {brokenConstraints.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>
+            評価できない制約ルールが{brokenConstraints.length}件あります
+          </AlertTitle>
+          <AlertDescription>
+            <ul className="mt-1 list-disc space-y-0.5 pl-4 text-xs">
+              {brokenConstraints.map((constraint) => (
+                <li key={constraint.id}>
+                  「{constraint.name}」: {errors.get(constraint.id)}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-2 text-xs">
+              これらのルールは着色されていません。違反が無いのではなく、判定できていません。境界設定の「観点間の制約ルール」で設定を直してください。
+            </p>
+          </AlertDescription>
+        </Alert>
+      )}
     </div>
   )
 }

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -45,11 +45,12 @@ export function ResultsTable({
   const [sortKey, setSortKey] = useState<SortKey>("registrationOrder")
   const [sortAsc, setSortAsc] = useState(true)
 
-  // 制約ルール違反を評価（studentId → 違反一覧）
-  const violationsByStudent = useMemo(
-    () => evaluateConstraints(result, constraints).violations,
+  // 制約ルールを評価。違反（studentId → 違反一覧）と、評価できなかったルールの理由を得る
+  const constraintEvaluation = useMemo(
+    () => evaluateConstraints(result, constraints),
     [result, constraints]
   )
+  const violationsByStudent = constraintEvaluation.violations
 
   // 凡例に表示する有効ルール
   const activeConstraints = useMemo(
@@ -129,7 +130,10 @@ export function ResultsTable({
   return (
     <>
       {activeConstraints.length > 0 && (
-        <ConstraintLegend constraints={activeConstraints} />
+        <ConstraintLegend
+          constraints={activeConstraints}
+          errors={constraintEvaluation.errors}
+        />
       )}
       <div className="mt-6 overflow-x-auto rounded-lg border">
         <table className="w-full text-sm">

--- a/src/lib/gradeConstraints.ts
+++ b/src/lib/gradeConstraints.ts
@@ -10,26 +10,28 @@
 import { Parser, type Value } from "expr-eval"
 
 import type {
-  ConsistencyConfig,
+  ConstraintAggregate,
   ConstraintViolation,
   GradeCalculationResult,
   GradeConstraintData,
-  MutualExclusionConfig,
   StudentGradeResult,
 } from "@/types/grade.types"
 
-/** 整合ルールの既定設定（Excel流: A=5, B=3, C=1 の平均、許容±1）。target は項目選択時に設定 */
-export const DEFAULT_CONSISTENCY_CONFIG: ConsistencyConfig = {
-  labelValues: { A: 5, B: 3, C: 1 },
-  aggregate: "average",
-  tolerance: 1,
-  target: "",
+/** 整合ルールの既定のラベル→数値対応（Excel流: A=5, B=3, C=1） */
+export const DEFAULT_CONSTRAINT_LABEL_VALUES: Record<string, number> = {
+  A: 5,
+  B: 3,
+  C: 1,
 }
 
-/** 混在禁止ルールの既定設定（A・C混在禁止） */
-export const DEFAULT_MUTUAL_EXCLUSION_CONFIG: MutualExclusionConfig = {
-  labels: ["A", "C"],
-}
+/** 整合ルールの既定の集計方法 */
+export const DEFAULT_CONSTRAINT_AGGREGATE: ConstraintAggregate = "average"
+
+/** 整合ルールの既定の許容差 */
+export const DEFAULT_CONSTRAINT_TOLERANCE = 1
+
+/** 混在禁止ルールの既定ラベル（A・C混在禁止） */
+export const DEFAULT_EXCLUSION_LABELS = ["A", "C"]
 
 /** 制約ルールの既定色（薄い赤） */
 export const DEFAULT_CONSTRAINT_COLOR = "#fecaca"
@@ -57,24 +59,20 @@ const parser = new Parser({
 })
 
 interface ViewpointLabel {
+  gradeItemId: string
   name: string
   label: string
 }
 
 /**
- * 各 GradeItem の境界ラベルを昇順（弱→強）に並べ、項目名で引けるようにする。
+ * 各 GradeItem の境界ラベルを昇順（弱→強）に並べ、評価項目idで引けるようにする。
  * ラベルが数値でも labelValues にも無い場合の順位換算に使う。
  */
 function buildOrderedLabelsMap(
   result: GradeCalculationResult
 ): Map<string, string[]> {
-  const idToName = new Map(
-    result.gradeItems.map((gradeItem) => [gradeItem.id, gradeItem.name])
-  )
-  const byName = new Map<string, string[]>()
+  const byGradeItemId = new Map<string, string[]>()
   for (const boundarySet of result.boundarySets) {
-    const name = idToName.get(boundarySet.gradeItemId)
-    if (!name) continue
     // minPercentage 昇順 = 弱い評価が先頭
     const ordered = [...boundarySet.boundaries]
       .sort(
@@ -82,9 +80,18 @@ function buildOrderedLabelsMap(
           boundaryA.minPercentage - boundaryB.minPercentage
       )
       .map((boundary) => boundary.label)
-    byName.set(name, ordered)
+    byGradeItemId.set(boundarySet.gradeItemId, ordered)
   }
-  return byName
+  return byGradeItemId
+}
+
+/** ラベル→数値の対応行を引きやすい形へ畳む。 */
+function toLabelValueMap(
+  labelValues: GradeConstraintData["labelValues"]
+): Record<string, number> {
+  return Object.fromEntries(
+    labelValues.map((labelValue) => [labelValue.label, labelValue.value])
+  )
 }
 
 /**
@@ -115,6 +122,7 @@ function collectViewpointLabels(student: StudentGradeResult): ViewpointLabel[] {
   return student.gradeItemResults
     .filter((gradeItemResult) => !gradeItemResult.isExcluded)
     .map((gradeItemResult) => ({
+      gradeItemId: gradeItemResult.gradeItemId,
       name: gradeItemResult.gradeItemName,
       label: gradeItemResult.gradeLabel,
     }))
@@ -123,55 +131,74 @@ function collectViewpointLabels(student: StudentGradeResult): ViewpointLabel[] {
     )
 }
 
+/**
+ * 比較先（評定）と集計対象の観点を突き合わせる。
+ *
+ * 参照は評価項目idで引く。ここで対象が見つからないのは「その生徒では除外/未算出」
+ * のときだけで、設定の壊れ（項目の削除など）は evaluateConstraints の事前検証が
+ * エラーとして先に捕まえている。
+ */
 function evalConsistency(
-  config: ConsistencyConfig,
+  constraint: GradeConstraintData,
   viewpoints: ViewpointLabel[],
   ordered: Map<string, string[]>
 ): boolean {
-  // 「評定」を担う GradeItem を比較先にし、指定の観点（未指定なら残り全部）を集計対象にする
+  const { targetGradeItemId } = constraint
+  if (!targetGradeItemId) return false
+
   const targetItem = viewpoints.find(
-    (viewpoint) => viewpoint.name === config.target
+    (viewpoint) => viewpoint.gradeItemId === targetGradeItemId
   )
   if (!targetItem) return false
+
+  const labelValues = toLabelValueMap(constraint.labelValues)
   const targetVal = labelToValue(
     targetItem.label,
-    config.labelValues,
-    ordered.get(config.target)
+    labelValues,
+    ordered.get(targetGradeItemId)
   )
   if (targetVal === null) return false
 
-  const selected = config.viewpointItems ?? []
+  // 指定が無ければ比較先以外の全項目を集計対象にする
+  const selectedIds = new Set(
+    constraint.viewpoints.map((viewpoint) => viewpoint.gradeItemId)
+  )
   const aggregationViewpoints =
-    selected.length > 0
-      ? viewpoints.filter((viewpoint) => selected.includes(viewpoint.name))
-      : viewpoints.filter((viewpoint) => viewpoint.name !== config.target)
+    selectedIds.size > 0
+      ? viewpoints.filter((viewpoint) => selectedIds.has(viewpoint.gradeItemId))
+      : viewpoints.filter(
+          (viewpoint) => viewpoint.gradeItemId !== targetGradeItemId
+        )
   if (aggregationViewpoints.length === 0) return false
 
   const values = aggregationViewpoints
     .map((viewpoint) =>
       labelToValue(
         viewpoint.label,
-        config.labelValues,
-        ordered.get(viewpoint.name)
+        labelValues,
+        ordered.get(viewpoint.gradeItemId)
       )
     )
     .filter((value): value is number => value !== null)
   if (values.length === 0) return false
 
   const sum = values.reduce((acc, value) => acc + value, 0)
-  const aggregate = config.aggregate === "sum" ? sum : sum / values.length
+  const aggregate = constraint.aggregate === "sum" ? sum : sum / values.length
 
-  return Math.abs(targetVal - aggregate) > config.tolerance
+  return Math.abs(targetVal - aggregate) > constraint.tolerance
 }
 
 function evalMutualExclusion(
-  config: MutualExclusionConfig,
+  constraint: GradeConstraintData,
   viewpoints: ViewpointLabel[]
 ): boolean {
+  const forbidden = constraint.exclusionLabels.map(
+    (exclusionLabel) => exclusionLabel.label
+  )
   const present = new Set(
     viewpoints
       .map((viewpoint) => viewpoint.label)
-      .filter((label) => config.labels.includes(label))
+      .filter((label) => forbidden.includes(label))
   )
   return present.size >= 2
 }
@@ -186,9 +213,10 @@ function buildExpressionScope(
   ordered: Map<string, string[]>,
   allItemNames: Set<string>
 ): Record<string, Value> {
-  // 各項目の数値（ラベル値: 数値ラベルはそのまま、A/B/C等は弱→強の順位）
+  // 各項目の数値（ラベル値: 数値ラベルはそのまま、A/B/C等は弱→強の順位）。
+  // ordered は評価項目idで引く（式の中では項目を名前で書くが、順位表のキーはid）。
   const itemValue = (viewpoint: ViewpointLabel) =>
-    labelToValue(viewpoint.label, undefined, ordered.get(viewpoint.name))
+    labelToValue(viewpoint.label, undefined, ordered.get(viewpoint.gradeItemId))
 
   // 存在しない項目名の参照はタイプミスとみなしエラーにする（無言失火を防ぐ）。
   // 実在する項目だが当該生徒が除外されている場合は throw せず未定義扱い。
@@ -252,15 +280,6 @@ function buildExpressionScope(
   }
 }
 
-/** kind別の設定JSONを既定値にマージして復元する（不正JSONは既定値にフォールバック） */
-export function parseConfig<T>(raw: string, fallback: T): T {
-  try {
-    return { ...fallback, ...(JSON.parse(raw || "{}") as Partial<T>) }
-  } catch {
-    return fallback
-  }
-}
-
 /**
  * 式を検証（構文チェック）。問題なければ null、あればエラーメッセージ。
  */
@@ -291,13 +310,20 @@ export function evaluateConstraints(
   const allItemNames = new Set(
     result.gradeItems.map((gradeItem) => gradeItem.name)
   )
+  const knownGradeItemIds = new Set(
+    result.gradeItems.map((gradeItem) => gradeItem.id)
+  )
   const active = constraints
     .filter((constraint) => constraint.enabled)
     .sort((constraintA, constraintB) => constraintA.order - constraintB.order)
 
   // 事前検証（無言失火を防ぐためルール単位でエラーを記録）
   //  - expression: 構文チェックしてコンパイル
-  //  - consistency: 比較先（評定）の項目が選択済みかつ実在するか
+  //  - consistency: 比較先・集計対象の項目が選択済みかつ実在するか
+  //  - mutual_exclusion: 禁止ラベルが2つ以上あるか（1つ以下では原理的に違反しえない）
+  //
+  // 参照はFKで守られているため通常は壊れない。アーカイブ取込直後など、算出対象の
+  // 項目集合と食い違う復元経路でだけ起きうる。そのとき黙って「違反なし」に落とさない。
   const compiled = new Map<string, ReturnType<typeof parser.parse> | null>()
   for (const constraint of active) {
     if (constraint.kind === "expression") {
@@ -311,17 +337,25 @@ export function evaluateConstraints(
         )
       }
     } else if (constraint.kind === "consistency") {
-      const consistencyConfig = parseConfig(
-        constraint.config,
-        DEFAULT_CONSISTENCY_CONFIG
+      const missingViewpoints = constraint.viewpoints.filter(
+        (viewpoint) => !knownGradeItemIds.has(viewpoint.gradeItemId)
       )
-      if (!consistencyConfig.target) {
+      if (!constraint.targetGradeItemId) {
         errors.set(constraint.id, "評定（比較先の項目）が未選択です")
-      } else if (!allItemNames.has(consistencyConfig.target)) {
+      } else if (!knownGradeItemIds.has(constraint.targetGradeItemId)) {
         errors.set(
           constraint.id,
-          `評定の項目「${consistencyConfig.target}」が見つかりません`
+          "評定（比較先の項目）が算出対象に見つかりません"
         )
+      } else if (missingViewpoints.length > 0) {
+        errors.set(
+          constraint.id,
+          `集計対象の観点${missingViewpoints.length}件が算出対象に見つかりません`
+        )
+      }
+    } else if (constraint.kind === "mutual_exclusion") {
+      if (constraint.exclusionLabels.length < 2) {
+        errors.set(constraint.id, "混在を禁止するラベルを2つ以上選んでください")
       }
     }
   }
@@ -334,16 +368,9 @@ export function evaluateConstraints(
       let violated = false
       try {
         if (constraint.kind === "consistency") {
-          violated = evalConsistency(
-            parseConfig(constraint.config, DEFAULT_CONSISTENCY_CONFIG),
-            viewpoints,
-            ordered
-          )
+          violated = evalConsistency(constraint, viewpoints, ordered)
         } else if (constraint.kind === "mutual_exclusion") {
-          violated = evalMutualExclusion(
-            parseConfig(constraint.config, DEFAULT_MUTUAL_EXCLUSION_CONFIG),
-            viewpoints
-          )
+          violated = evalMutualExclusion(constraint, viewpoints)
         } else if (constraint.kind === "expression") {
           const compiledExpression = compiled.get(constraint.id)
           if (!compiledExpression) continue // パースエラーは着色しない

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -159,9 +159,12 @@ export interface GradeAPI {
       gradeItem?: import("../grade.types").GradeItemWithDataSources
       error?: string
     }>
-    deleteGradeItem: (
-      id: string
-    ) => Promise<{ success: boolean; error?: string }>
+    deleteGradeItem: (id: string) => Promise<{
+      success: boolean
+      error?: string
+      /** 集計対象がこの項目を含むため無効化した制約ルール名（利用者へ知らせる） */
+      disabledConstraintNames?: string[]
+    }>
     reorderGradeItems: (
       items: { id: string; order: number }[]
     ) => Promise<{ success: boolean; error?: string }>

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -3,7 +3,7 @@
  *
  * リレーション付きの型はすべて Prisma モデル（`@prisma/client`）から派生する（型規則: Prisma型を最優先）。
  * IPC 境界では electron-src/lib/prisma の serializePrisma() が Decimal を number へ変換し、
- * grade lib の hydrate が estimationSourceIds を string[] へ正規化し仮想 maxScore を付与するため、
+ * grade lib の hydrate が仮想 maxScore を付与するため、
  * それらのフィールドのみ Prisma モデルから上書きする（coursework.types.ts と同じパターン）。
  * 実施日（referenceDate）は string | null とする。
  * ネストした select は electron-src/lib/prisma/gradeDataSource.ts の gradeDataSourceInclude と対を成す。
@@ -19,7 +19,11 @@ import type {
   GradeBoundarySet,
   GradeClassroom,
   GradeConstraint,
+  GradeConstraintExclusionLabel,
+  GradeConstraintLabelValue,
+  GradeConstraintViewpoint,
   GradeDataSource,
+  GradeDataSourceEstimationSource,
   GradeItem,
   Subtotal,
 } from "@prisma/client"
@@ -98,7 +102,6 @@ export type GradeDataSourceWithRelations = Omit<
   | "absentRatio"
   | "absentOffset"
   | "estimationMode"
-  | "estimationSourceIds"
 > & {
   type: GradeDataSourceType
   weight: number
@@ -106,7 +109,16 @@ export type GradeDataSourceWithRelations = Omit<
   absentRatio: number
   absentOffset: number
   estimationMode: EstimationMode
-  estimationSourceIds: string[]
+  /**
+   * estimationMode="selected" のとき推定に使う他データソース。
+   * 旧 estimationSourceIds（JSON配列）と違い FK で守られているため、参照先が消えれば行ごと消える。
+   */
+  estimationSources: Array<
+    Pick<
+      GradeDataSourceEstimationSource,
+      "id" | "dataSourceId" | "sourceDataSourceId" | "order"
+    >
+  >
   /** 仮想フィールド。元データ（設問配点/評価項目満点）からライブ算出して付与される。 */
   maxScore: number
   exam: Pick<Exam, "id" | "examName" | "examDate"> | null
@@ -361,49 +373,59 @@ export type GradeConstraintKind =
   | "mutual_exclusion" // 特定ラベルの混在禁止（A・C混在など）
   | "expression" // 上級者向け自由記述式
 
-/** 整合ルールの設定 */
-export interface ConsistencyConfig {
-  /** ラベル→数値の対応（例 { A: 5, B: 3, C: 1 }） */
-  labelValues: Record<string, number>
-  /** 観点の集計方法 */
-  aggregate: "average" | "sum"
-  /** 許容する評定との差（これを超えたら違反） */
-  tolerance: number
-  /**
-   * 比較先の「評定」にあたる GradeItem 名（例「評定」）。
-   * その項目を評定とみなし、下の viewpointItems を集計して比較する。
-   */
-  target: string
-  /**
-   * 集計対象の観点 GradeItem 名の配列（例 知識・技能／思考・判断・表現／態度）。
-   * 空/未指定なら target 以外の全 GradeItem を対象にする。
-   */
-  viewpointItems?: string[]
-}
-
-/** 混在禁止ルールの設定 */
-export interface MutualExclusionConfig {
-  /** 同時に現れてはいけないラベル集合（例 ["A", "C"]） */
-  labels: string[]
-}
+/** 観点の集計方法 */
+export type ConstraintAggregate = "average" | "sum"
 
 /**
- * DBに保存される制約ルール1件。
- * config は kind別の設定JSON文字列（ConsistencyConfig / MutualExclusionConfig）、
- * expression は kind="expression" 時の式。kind のみ union へ narrowing する。
+ * DBに保存される制約ルール1件（設定リレーション込み）。
+ *
+ * 設定は kind 別のJSONではなくリレーションで持つ（issue #1063）。比較先・集計対象は
+ * 評価項目への FK なので、項目をリネームしても参照は切れない。
+ * expression は kind="expression" 時のみ使う。
+ * kind / aggregate は union へ、Decimal は number へ narrowing する。
  */
 export type GradeConstraintData = Omit<
   GradeConstraint,
-  "kind" | "createdAt" | "updatedAt"
+  "kind" | "aggregate" | "tolerance" | "createdAt" | "updatedAt"
 > & {
   kind: GradeConstraintKind
+  aggregate: ConstraintAggregate
+  tolerance: number
+  /** 集計対象の観点（空なら比較先以外の全項目が対象という意味になる） */
+  viewpoints: Array<
+    Pick<GradeConstraintViewpoint, "id" | "gradeItemId" | "order">
+  >
+  /** ラベル→数値の対応（例 A=5, B=3, C=1） */
+  labelValues: Array<
+    Pick<GradeConstraintLabelValue, "id" | "label" | "order"> & {
+      value: number
+    }
+  >
+  /** 混在禁止ラベル（mutual_exclusion 用） */
+  exclusionLabels: Array<
+    Pick<GradeConstraintExclusionLabel, "id" | "label" | "order">
+  >
 }
 
-/** 制約ルールの作成・更新入力 */
+/**
+ * 制約ルールの作成・更新入力。
+ * 設定部分（viewpointGradeItemIds / labelValues / exclusionLabels）は指定されたら総入れ替え、
+ * 未指定なら据え置き。
+ */
 export interface GradeConstraintInput {
   name: string
   kind: GradeConstraintKind
-  config: string
+  /** 比較先の「評定」にあたる評価項目。未選択なら null */
+  targetGradeItemId: string | null
+  aggregate: ConstraintAggregate
+  /** 許容する評定との差（これを超えたら違反） */
+  tolerance: number
+  /** 集計対象の観点の評価項目id。空配列なら「比較先以外の全項目」 */
+  viewpointGradeItemIds: string[]
+  /** ラベル→数値の対応（例 { A: 5, B: 3, C: 1 }） */
+  labelValues: Record<string, number>
+  /** 同時に現れてはいけないラベル集合（例 ["A", "C"]） */
+  exclusionLabels: string[]
   expression: string
   color: string
   message: string | null

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -117,16 +117,45 @@ export interface ArchiveGradeData {
     frozenAt: string
   }[]
   /** 観点間の制約ルール（後方互換: v1.7.0+。古いアーカイブではundefined） */
-  gradeConstraints?: {
-    name: string
-    kind: string
-    config: string
-    expression: string
-    color: string
-    message: string | null
-    enabled: boolean
-    order: number
-  }[]
+  gradeConstraints?: ArchiveGradeConstraint[]
+}
+
+/**
+ * 観点間の制約ルール1件。
+ *
+ * v1.11.0 で設定JSON（config）を廃し、評価項目への参照を uuid 一次・名前二次で持つ
+ * （issue #1063）。旧 config は名前だけで参照していたため、評価項目をリネームすると
+ * 制約が失効した。ArchiveGradeItem と同じ照合方式に揃える。
+ */
+export interface ArchiveGradeConstraint {
+  name: string
+  kind: string
+  /**
+   * @deprecated v1.11.0 で廃止。kind別の設定JSON（評価項目を名前で参照していた）。
+   * 旧アーカイブの読込にのみ使う。v1.11.0+ の export では出力しない。
+   */
+  config?: string
+  /** v1.11.0+: 比較先（評定）の評価項目uuid（照合の一次キー） */
+  targetGradeItemId?: string | null
+  /** v1.11.0+: 比較先の評価項目名（uuid不一致時の二次フォールバック） */
+  targetGradeItemName?: string | null
+  /** v1.11.0+: 観点の集計方法 "average" | "sum" */
+  aggregate?: string
+  /** v1.11.0+: 許容する評定との差 */
+  tolerance?: number
+  /** v1.11.0+: 集計対象の観点の評価項目uuid（照合の一次キー） */
+  viewpointGradeItemIds?: string[]
+  /** v1.11.0+: 集計対象の観点名（uuid不一致時の二次フォールバック。上の配列と同順） */
+  viewpointGradeItemNames?: string[]
+  /** v1.11.0+: ラベル→数値の対応（例 { A: 5, B: 3, C: 1 }） */
+  labelValues?: Record<string, number>
+  /** v1.11.0+: 混在禁止ラベル（mutual_exclusion 用） */
+  exclusionLabels?: string[]
+  expression: string
+  color: string
+  message: string | null
+  enabled: boolean
+  order: number
 }
 
 export interface ArchiveGradeItem {
@@ -143,6 +172,12 @@ export interface ArchiveGradeItem {
 }
 
 export interface ArchiveDataSource {
+  /**
+   * v1.11.0+: export元のデータソースuuid。estimationSourceIds の解決に使う。
+   * これが無い旧アーカイブでは estimationSourceIds を解決できず、推定の参照は捨てられる
+   * （旧importerは解決せずexport元idをそのまま書き戻しており、dangling idになっていた）。
+   */
+  id?: string
   type: string // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"（旧: "manual"）
   name: string
   /**
@@ -341,8 +376,16 @@ export interface GradeArchiveImportPreview {
  * 表記が不正確でも確実に正規化するため。詳細は grade-transformers/index.ts）。
  */
 export type GradeArchiveVersion =
-  "1.3.0" | "1.4.0" | "1.5.0" | "1.6.0" | "1.7.0" | "1.8.0" | "1.9.0" | "1.10.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.10.0"
+  | "1.3.0"
+  | "1.4.0"
+  | "1.5.0"
+  | "1.6.0"
+  | "1.7.0"
+  | "1.8.0"
+  | "1.9.0"
+  | "1.10.0"
+  | "1.11.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.11.0"
 
 export interface GradeTransformResult {
   data: GradeArchiveData


### PR DESCRIPTION
## 概要

観点間の制約ルールの設定JSON（`GradeConstraint.config`）と、欠損推定の参照配列
（`GradeDataSource.estimationSourceIds`）を撤廃し、評価項目・データソースへの参照を
FKと中間テーブルで守る。

Closes #1063

## 直した問題

旧 `config` は評価項目を**名前**で参照していた。リネーム導線は `03-data-sources` に実在し
（`DataSourcesContainer` → `updateGradeItem`）、`config` を追随更新する処理は無かった。

| 参照 | 失効したときの挙動（修正前） |
| --- | --- |
| `config.target` | 事前検証があり境界設定画面に赤字で出る（着色は止まる） |
| `config.viewpointItems` | **検証なし。一部だけ空振りすると残りだけで平均を取り判定が通る** |

下段が本体で、3項目平均のはずが1つリネームされて2項目平均になっても、エラーは出ず
着色の有無だけが変わる。検知漏れと誤検知の両方が起きる。加えて `errors` を消費して
いたのは `05-boundaries` だけで、結果表（`06-results`）は捨てていたため、境界設定画面を
開かない限り失効に気づけなかった。

`estimationSourceIds` はFKが効かず、参照先を削除しても dangling id が残っていた。

## 変更

### スキーマ

- `config` を撤廃し `targetGradeItemId`(FK) / `aggregate` / `tolerance` をスカラー列へ昇格。
  項目削除時は `SetNull` にしてルールは残し「評定が未選択」として検知させる
- `GradeConstraintViewpoint` / `GradeConstraintLabelValue` /
  `GradeConstraintExclusionLabel` / `GradeDataSourceEstimationSource` を新設
- 中間テーブルのidは決定論的な合成キー。`@default(uuid())` だと2端末が同じ組を作った
  ときにid違い・`@@unique`同値の行ができてNAS同期で衝突する（`CropRegionAssignment` と
  同じ理由。ただしSQLのマイグレーションでも同じidを組み立てる必要があり、SQLiteに
  sha1が無いため uuidv5 ではなく連結にした）
- 自動で無効化した理由は `disabledReason` へ。`message` は教員が書いた違反の説明で
  結果表のツールチップに出るため汚さない

### 移行（手書き migration）

名前からidへ解決できなかったものは黙って捨てず、無効化して理由を残す。

- 比較先は同名が複数あるとき解決しない（取り違えを避ける。アーカイブ取込と同じ扱い）
- 集計対象は同名を全て対象にする（旧実装 `selected.includes(name)` が両方集計していた
  動作を保つ。集計対象は複数選べるので取り違えにならない）
- 旧 `parseConfig` が補っていた既定値（`A=5,B=3,C=1` / `["A","C"]`）をbackfillする

### 無言failureの解消

- 集計対象と混在禁止ラベルの検証を追加し、参照切れを `errors` に記録する
- 結果表に警告バナーを新設（「違反が無いのではなく判定できていません」と明示）
- 評価項目の削除で集計対象がCascadeで減る場合、ルールを無効化してtoastで知らせる

### アーカイブ

- `.grade` を v1.11.0 へ。評価項目参照は uuid一次・名前二次で持ち出す
- `V1_10_0_to_V1_11_0` トランスフォーマーで旧 `config` を読めるようにする
- **既存の不具合も修正**: importer が `estimationSourceIds` にexport元idをそのまま
  書き戻しており、取り込み先では必ず dangling になっていた

## 検証

- 全テスト 1121件 通過（10件追加）、`check-all` 通過
- migration は空DBへの昇順適用（`freshInstallChain` がスキーマの列一致まで確認）と、
  実データ移行の両方を検証。同名項目・既定値補完・取りこぼし検知の各ケースを含む
- コードレビュー（多エージェント・high）の指摘10件をすべて修正。うち2件は機能を
  停止させる不具合で、修正前に失敗するテストを書いてから直した

## 未実施

- **実機での動作確認をしていない**。テストと静的検査は通っているが、Electron IPC を
  通した実際のUI操作（制約ルールの編集、結果表の着色、推定設定）は未確認
- migration を実データへ適用していない（合成データでのみ検証）
- 式（`expression`）は自由記述のため項目名参照のまま。リネームで壊れるが
  `requireKnownItem` がエラーを出すので沈黙はしない
