### PR TITLE
feat(exam): 採点層を ExamStudent 経由へ配線変更する（Phase A）

### DIFF
--- a/__tests__/calculations/classroomAverageRows.test.ts
+++ b/__tests__/calculations/classroomAverageRows.test.ts
@@ -43,6 +43,7 @@ function makeStudent(
   q1: number | null
 ): ScoringData {
   return {
+    examStudentId: id,
     studentId: id,
     studentName: id,
     studentNumber: id,

--- a/__tests__/calculations/computeReportData.test.ts
+++ b/__tests__/calculations/computeReportData.test.ts
@@ -73,6 +73,7 @@ function createMinimalReport(
       tags: [],
     },
     scoringData: {
+      examStudentId: "es1",
       studentId: "s1",
       studentName: "テスト太郎",
       studentNumber: "001",

--- a/__tests__/calculations/discriminationIndex.test.ts
+++ b/__tests__/calculations/discriminationIndex.test.ts
@@ -40,6 +40,7 @@ function makeScoringData(
       ? totalScore
       : scores.reduce((sum, score) => sum + (score.score ?? 0), 0)
   return {
+    examStudentId: `exam-${studentId}`,
     studentId,
     studentName: `生徒${studentId}`,
     studentNumber: studentId,

--- a/__tests__/calculations/scoreResolution.test.ts
+++ b/__tests__/calculations/scoreResolution.test.ts
@@ -24,7 +24,7 @@ function score(overrides: Partial<ResolvableScore> = {}): ResolvableScore {
   seq++
   return {
     id: `id-${String(seq).padStart(4, "0")}`,
-    studentId: "student-1",
+    examStudentId: "student-1",
     cropRegionId: "region-1",
     status: "correct",
     partialScore: null,
@@ -37,7 +37,7 @@ function decision(
   overrides: Partial<ResolvableDecision> = {}
 ): ResolvableDecision {
   return {
-    studentId: "student-1",
+    examStudentId: "student-1",
     cropRegionId: "region-1",
     verdict: "partial",
     score: 5,
@@ -55,7 +55,7 @@ describe("resolveEffectiveScores - 提案のみ", () => {
     const { resolved, conflicts } = resolveEffectiveScores([scoreRow])
     expect(resolved).toHaveLength(1)
     expect(resolved[0]).toMatchObject({
-      studentId: "student-1",
+      examStudentId: "student-1",
       cropRegionId: "region-1",
       status: "correct",
       partialScore: null,
@@ -67,9 +67,9 @@ describe("resolveEffectiveScores - 提案のみ", () => {
   })
 
   it("生徒×設問ごとに独立して解決される", () => {
-    const scoreA = score({ studentId: "s1", cropRegionId: "r1" })
-    const scoreB = score({ studentId: "s1", cropRegionId: "r2" })
-    const scoreC = score({ studentId: "s2", cropRegionId: "r1" })
+    const scoreA = score({ examStudentId: "s1", cropRegionId: "r1" })
+    const scoreB = score({ examStudentId: "s1", cropRegionId: "r2" })
+    const scoreC = score({ examStudentId: "s2", cropRegionId: "r1" })
     const { resolved, conflicts } = resolveEffectiveScores([
       scoreA,
       scoreB,
@@ -121,7 +121,11 @@ describe("resolveEffectiveScores - 提案のみ", () => {
     const { resolved, conflicts } = resolveEffectiveScores([teacherA, teacherB])
     expect(resolved).toEqual([])
     expect(conflicts).toEqual([
-      { studentId: "student-1", cropRegionId: "region-1", candidateCount: 2 },
+      {
+        examStudentId: "student-1",
+        cropRegionId: "region-1",
+        candidateCount: 2,
+      },
     ])
   })
 
@@ -155,13 +159,6 @@ describe("resolveEffectiveScores - 提案のみ", () => {
     const result2 = resolveEffectiveScores([scoreB, scoreA])
     expect(result1.resolved[0].questionScoreId).toBe("id-zzz")
     expect(result2.resolved[0].questionScoreId).toBe("id-zzz")
-  })
-
-  it("studentIdがnullの行は無視される", () => {
-    const orphan = score({ studentId: null })
-    const { resolved, conflicts } = resolveEffectiveScores([orphan])
-    expect(resolved).toEqual([])
-    expect(conflicts).toEqual([])
   })
 
   it("旧データのfinal行は提案より優先される（耐性）", () => {

--- a/__tests__/calculations/spAnalysis.test.ts
+++ b/__tests__/calculations/spAnalysis.test.ts
@@ -13,12 +13,12 @@ import {
 
 /** 二値パターンから SpInputStudent を作る。1=正答, 0=誤答, null=未採点 */
 function makeStudent(
-  studentId: string,
+  examStudentId: string,
   pattern: (0 | 1 | null)[]
 ): SpInputStudent {
   return {
-    studentId,
-    studentName: studentId,
+    examStudentId,
+    studentName: examStudentId,
     items: pattern.map((value, i) => ({
       questionId: `q${i + 1}`,
       label: `q${i + 1}`,
@@ -41,7 +41,7 @@ describe("computeSpTable", () => {
     expect(result).not.toBeNull()
     const spTable = result!
     // 生徒は正答数降順
-    expect(spTable.students.map((student) => student.studentId)).toEqual([
+    expect(spTable.students.map((student) => student.examStudentId)).toEqual([
       "S1",
       "S2",
       "S3",
@@ -71,10 +71,10 @@ describe("computeSpTable", () => {
     expect(result.problems[0].correctCount).toBe(3)
 
     const student3 = result.students.find(
-      (student) => student.studentId === "S3"
+      (student) => student.examStudentId === "S3"
     )!
     const student4 = result.students.find(
-      (student) => student.studentId === "S4"
+      (student) => student.examStudentId === "S4"
     )!
     // 手計算: S3 CS=1.5, S4 CS=0
     expect(student3.cautionIndex).toBeCloseTo(1.5, 6)
@@ -90,7 +90,7 @@ describe("computeSpTable", () => {
     const spTable = computeSpTable(data)!
     // S2 は p1,p2 正答・p3 誤答（並びは p1,p2,p3）
     const student2 = spTable.students.find(
-      (student) => student.studentId === "S2"
+      (student) => student.examStudentId === "S2"
     )!
     expect(student2.cells).toEqual([true, true, false])
   })
@@ -105,7 +105,7 @@ describe("computeSpTable", () => {
     const spTable = computeSpTable(data)!
     expect(spTable.studentCount).toBe(3)
     expect(
-      spTable.students.find((student) => student.studentId === "S4")
+      spTable.students.find((student) => student.examStudentId === "S4")
     ).toBeUndefined()
   })
 

--- a/__tests__/calculations/statisticsCalculator.test.ts
+++ b/__tests__/calculations/statisticsCalculator.test.ts
@@ -21,6 +21,7 @@ function createScoringData(
   overrides: Partial<ScoringData> & { studentId: string }
 ): ScoringData {
   return {
+    examStudentId: `exam-${overrides.studentId}`,
     studentName: "テスト生徒",
     studentNumber: "001",
     scores: [],
@@ -37,6 +38,7 @@ describe("calculateSubtotalStatistics", () => {
   it("score が null の生徒を統計から除外する", () => {
     const data: ScoringData[] = [
       createScoringData({
+        examStudentId: "s1",
         studentId: "s1",
         subtotalScores: [
           {
@@ -51,6 +53,7 @@ describe("calculateSubtotalStatistics", () => {
         ],
       }),
       createScoringData({
+        examStudentId: "s2",
         studentId: "s2",
         subtotalScores: [
           {
@@ -65,6 +68,7 @@ describe("calculateSubtotalStatistics", () => {
         ],
       }),
       createScoringData({
+        examStudentId: "s3",
         studentId: "s3",
         subtotalScores: [
           {
@@ -89,6 +93,7 @@ describe("calculateSubtotalStatistics", () => {
   it("全員 null の場合は空配列で統計計算（平均0）", () => {
     const data: ScoringData[] = [
       createScoringData({
+        examStudentId: "s1",
         studentId: "s1",
         subtotalScores: [
           {
@@ -103,6 +108,7 @@ describe("calculateSubtotalStatistics", () => {
         ],
       }),
       createScoringData({
+        examStudentId: "s2",
         studentId: "s2",
         subtotalScores: [
           {
@@ -127,6 +133,7 @@ describe("calculateSubtotalStatistics", () => {
   it("0点の生徒は統計に含まれる", () => {
     const data: ScoringData[] = [
       createScoringData({
+        examStudentId: "s1",
         studentId: "s1",
         subtotalScores: [
           {
@@ -141,6 +148,7 @@ describe("calculateSubtotalStatistics", () => {
         ],
       }),
       createScoringData({
+        examStudentId: "s2",
         studentId: "s2",
         subtotalScores: [
           {
@@ -168,6 +176,7 @@ describe("collectSubtotalRawScores", () => {
   it("score が null の生徒を除外する", () => {
     const data: ScoringData[] = [
       createScoringData({
+        examStudentId: "s1",
         studentId: "s1",
         status: "participating",
         subtotalScores: [
@@ -183,6 +192,7 @@ describe("collectSubtotalRawScores", () => {
         ],
       }),
       createScoringData({
+        examStudentId: "s2",
         studentId: "s2",
         status: "participating",
         subtotalScores: [
@@ -209,6 +219,7 @@ describe("collectSubtotalRawScores", () => {
   it("0点は除外されない", () => {
     const data: ScoringData[] = [
       createScoringData({
+        examStudentId: "s1",
         studentId: "s1",
         status: "participating",
         subtotalScores: [

--- a/__tests__/calculations/subtotalCalculator.test.ts
+++ b/__tests__/calculations/subtotalCalculator.test.ts
@@ -60,12 +60,12 @@ function createCropRegion(
 }
 
 function createQuestionScore(
-  studentId: string,
+  examStudentId: string,
   cropRegionId: string,
   status: string,
   partialScore: number | null = null
 ): QuestionScoreForSubtotal {
-  return { studentId, cropRegionId, status, partialScore }
+  return { examStudentId, cropRegionId, status, partialScore }
 }
 
 // ================== calculateSubtotalScoreBySubtotalId ==================

--- a/__tests__/calculations/validateScoringData.test.ts
+++ b/__tests__/calculations/validateScoringData.test.ts
@@ -36,6 +36,7 @@ function studentData(
   scores: ReturnType<typeof scoreDetail>[]
 ): ScoringData {
   return {
+    examStudentId: `exam-student-${studentName}`,
     studentId: `student-${studentName}`,
     studentName,
     studentNumber: "1",
@@ -156,7 +157,7 @@ function summary(): ExamDecisionSummary {
         decidedCount: 1,
         cells: [
           {
-            studentId: "student-A",
+            examStudentId: "student-A",
             studentName: "田中 太郎",
             cropRegionId: "region-1",
             reason: "conflict",
@@ -165,7 +166,7 @@ function summary(): ExamDecisionSummary {
             scoreImpact: 5,
           },
           {
-            studentId: "student-B",
+            examStudentId: "student-B",
             studentName: "鈴木 花子",
             cropRegionId: "region-1",
             reason: "stale",
@@ -186,7 +187,7 @@ function summary(): ExamDecisionSummary {
         decidedCount: 0,
         cells: [
           {
-            studentId: "student-C",
+            examStudentId: "student-C",
             studentName: "佐藤 次郎",
             cropRegionId: "region-2",
             reason: "conflict",
@@ -204,7 +205,7 @@ describe("buildConflictWarnings", () => {
   it("stale（確定後の新提案）は出力前警告に出さない — 確定値が出力されるため", () => {
     const warnings = buildConflictWarnings(summary())
 
-    expect(warnings.map((warning) => warning.studentId)).toEqual([
+    expect(warnings.map((warning) => warning.examStudentId)).toEqual([
       "student-A",
       "student-C",
     ])
@@ -220,7 +221,9 @@ describe("buildConflictWarnings", () => {
 
   it("選択生徒でフィルタする（空配列は全生徒）", () => {
     expect(
-      buildConflictWarnings(summary(), ["student-C"]).map((w) => w.studentId)
+      buildConflictWarnings(summary(), ["student-C"]).map(
+        (w) => w.examStudentId
+      )
     ).toEqual(["student-C"])
     expect(buildConflictWarnings(summary(), []).length).toBe(2)
   })

--- a/__tests__/exam/integration/examStudentRemoval.test.ts
+++ b/__tests__/exam/integration/examStudentRemoval.test.ts
@@ -1,0 +1,243 @@
+/**
+ * 試験から生徒を外したとき、その受験者に紐づく採点データが全て消えることの検証。
+ *
+ * #962 以前は ExamStudent を参照する子テーブルが1つも無く、削除経路
+ * （removeStudentsFromExam）が手書きで消していた分しか消えなかった。
+ * 取りこぼした行は試験のどの画面にも現れないのに成績算出では素点として算入される
+ * 「孤児」になっていた。採点層を ExamStudent の子にしたことで、この 1 回の削除が
+ * DB の cascade で全ての子を巻き取る。
+ *
+ * 削除確認モーダル（StudentRemovalConfirmModal）が以前から約束していた挙動であり、
+ * このテストはその約束が実際に守られていることを固定する。
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { removeStudentsFromExam } from "@/electron-src/lib/prisma/examStudent"
+import { checkGradingDataForStudent } from "@/electron-src/lib/prisma/gradingData"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/**
+ * 2生徒・1ページ・1設問の試験に、受験者へぶら下がる採点層を一通り作る。
+ * 対象の5テーブル（答案・採点・確定・複合回答・返却版）を全て埋める。
+ */
+async function buildExamWithFullScoringLayer() {
+  const exam = await createFullTestExam(testPrisma, {
+    studentCount: 2,
+    pageCount: 1,
+    cropRegionsPerPage: 1,
+    includeScores: true,
+    includeAnnotations: true,
+    includeStudentAnswerImages: true,
+  })
+
+  const [examStudentA, examStudentB] = exam.examStudents
+  const cropRegion = exam.cropRegions[0]
+  const user = await testPrisma.user.findFirstOrThrow()
+
+  const compoundAnswer = await testPrisma.compoundAnswer.create({
+    data: {
+      id: crypto.randomUUID(),
+      examPageId: exam.pages[0].id,
+      label: "アイ",
+      answerFormat: "multi-digit",
+      correctAnswer: "42",
+      points: 5,
+    },
+  })
+
+  for (const examStudent of [examStudentA, examStudentB]) {
+    await testPrisma.scoreDecision.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: cropRegion.id,
+        examStudentId: examStudent.id,
+        verdict: "correct",
+        decidedByUserId: user.id,
+      },
+    })
+    await testPrisma.compoundAnswerScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        compoundAnswerId: compoundAnswer.id,
+        examStudentId: examStudent.id,
+        userId: user.id,
+        status: "correct",
+        recognizedAnswer: "42",
+      },
+    })
+    await testPrisma.returnSnapshot.create({
+      data: {
+        id: crypto.randomUUID(),
+        examStudentId: examStudent.id,
+        scoresJson: JSON.stringify({ v: 1, scores: [], annotations: [] }),
+        totalScore: 10,
+        capturedByUserId: user.id,
+      },
+    })
+  }
+
+  return { exam, examStudentA, examStudentB, user }
+}
+
+/** その受験者に紐づく採点層の行数（全テーブル合計と内訳） */
+async function countScoringRows(examStudentId: string) {
+  const [
+    studentAnswerImages,
+    questionScores,
+    scoreDecisions,
+    compoundAnswerScores,
+    returnSnapshots,
+    drawingAnnotations,
+  ] = await Promise.all([
+    testPrisma.studentAnswerImage.count({ where: { examStudentId } }),
+    testPrisma.questionScore.count({ where: { examStudentId } }),
+    testPrisma.scoreDecision.count({ where: { examStudentId } }),
+    testPrisma.compoundAnswerScore.count({ where: { examStudentId } }),
+    testPrisma.returnSnapshot.count({ where: { examStudentId } }),
+    testPrisma.drawingAnnotation.count({
+      where: { questionScore: { examStudentId } },
+    }),
+  ])
+  return {
+    studentAnswerImages,
+    questionScores,
+    scoreDecisions,
+    compoundAnswerScores,
+    returnSnapshots,
+    drawingAnnotations,
+  }
+}
+
+describe("removeStudentsFromExam", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("外した生徒の採点データが5テーブルとも残らない", async () => {
+    const { exam, examStudentA, examStudentB } =
+      await buildExamWithFullScoringLayer()
+
+    // 前提: 削除前は5テーブルすべてに行がある
+    const before = await countScoringRows(examStudentA.id)
+    expect(before.studentAnswerImages).toBeGreaterThan(0)
+    expect(before.questionScores).toBeGreaterThan(0)
+    expect(before.scoreDecisions).toBeGreaterThan(0)
+    expect(before.compoundAnswerScores).toBeGreaterThan(0)
+    expect(before.returnSnapshots).toBeGreaterThan(0)
+
+    const result = await removeStudentsFromExam(exam.exam.id, [
+      examStudentA.studentId,
+    ])
+    expect(result.success).toBe(true)
+
+    expect(await countScoringRows(examStudentA.id)).toEqual({
+      studentAnswerImages: 0,
+      questionScores: 0,
+      scoreDecisions: 0,
+      compoundAnswerScores: 0,
+      returnSnapshots: 0,
+      drawingAnnotations: 0,
+    })
+
+    // 受験者自身も消えている
+    expect(
+      await testPrisma.examStudent.findUnique({
+        where: { id: examStudentA.id },
+      })
+    ).toBeNull()
+
+    // 残した生徒の採点は巻き添えにしない
+    const remaining = await countScoringRows(examStudentB.id)
+    expect(remaining.questionScores).toBeGreaterThan(0)
+    expect(remaining.scoreDecisions).toBe(1)
+    expect(remaining.compoundAnswerScores).toBe(1)
+    expect(remaining.returnSnapshots).toBe(1)
+  })
+
+  it("生徒（人）そのものは消えない — 消えるのはその試験の受験だけ", async () => {
+    const { exam, examStudentA } = await buildExamWithFullScoringLayer()
+
+    await removeStudentsFromExam(exam.exam.id, [examStudentA.studentId])
+
+    const student = await testPrisma.student.findUnique({
+      where: { id: examStudentA.studentId },
+    })
+    expect(student).not.toBeNull()
+  })
+
+  it("削除確認の件数は cascade で消える範囲を数える（安全と誤表示しない）", async () => {
+    const { exam, examStudentA } = await buildExamWithFullScoringLayer()
+
+    // 答案と採点行だけを先に消し、確定・複合回答・返却版だけが残った状態にする。
+    // 数える範囲が削除範囲より狭いと、ここで「採点データなし」と誤表示してしまう。
+    await testPrisma.studentAnswerImage.deleteMany({
+      where: { examStudentId: examStudentA.id },
+    })
+    await testPrisma.questionScore.deleteMany({
+      where: { examStudentId: examStudentA.id },
+    })
+
+    const gradingData = await checkGradingDataForStudent(
+      exam.exam.id,
+      examStudentA.studentId
+    )
+
+    expect(gradingData.answerSheetCount).toBe(0)
+    expect(gradingData.questionScoreCount).toBe(0)
+    expect(gradingData.scoreDecisionCount).toBe(1)
+    expect(gradingData.compoundAnswerScoreCount).toBe(1)
+    expect(gradingData.returnSnapshotCount).toBe(1)
+    // 「採点データがないため安全に削除できます」を出してはいけない
+    expect(gradingData.hasData).toBe(true)
+    expect(gradingData.totalGradingItems).toBe(3)
+  })
+
+  it("外した生徒を再追加しても採点は復元されない（破棄は取り消せない）", async () => {
+    const { exam, examStudentA } = await buildExamWithFullScoringLayer()
+
+    await removeStudentsFromExam(exam.exam.id, [examStudentA.studentId])
+
+    const readded = await testPrisma.examStudent.create({
+      data: {
+        id: crypto.randomUUID(),
+        examId: exam.exam.id,
+        studentId: examStudentA.studentId,
+        status: "participating",
+      },
+    })
+
+    expect(await countScoringRows(readded.id)).toEqual({
+      studentAnswerImages: 0,
+      questionScores: 0,
+      scoreDecisions: 0,
+      compoundAnswerScores: 0,
+      returnSnapshots: 0,
+      drawingAnnotations: 0,
+    })
+  })
+})

--- a/__tests__/exam/integration/exportPlacementKey.test.ts
+++ b/__tests__/exam/integration/exportPlacementKey.test.ts
@@ -1,0 +1,99 @@
+/**
+ * 書き出しの採番学級（学年・学級名・出席番号）が実際に反映されることの固定。
+ *
+ * `studentPlacements` は renderer が採番解決して main へ渡すマップで、**キーは Student.id**
+ * （学級所属 StudentClassroomMembership は人に紐づくため）。採点層を ExamStudent 経由へ
+ * 配線変更したとき、この引き当てまで機械的に `examStudent.id` へ変えてしまうと、
+ * `Record<string, StudentExportPlacement>` は型が何も言わないので typecheck は通り、
+ * 実行時だけ全件ミスして memberships[0] へ黙ってフォールバックする
+ * （＝Excel と個人成績表の学級名・出席番号が誤ったまま配布される）。
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { fetchExportData } from "@/electron-src/lib/export/excel/dataFetcher"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+describe("書き出しの採番学級の引き当て", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("Student.id キーの studentPlacements が出力へ反映される", async () => {
+    const fixture = await createFullTestExam(testPrisma, {
+      studentCount: 1,
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      includeScores: true,
+    })
+    const [examStudent] = fixture.examStudents
+    const [student] = fixture.students
+
+    const result = await fetchExportData(
+      fixture.exam.id,
+      [examStudent.id],
+      // renderer が渡す形（キーは人としての生徒ID）
+      {
+        [student.id]: {
+          grade: 3,
+          className: "3年A組",
+          attendanceNumber: 7,
+        },
+      }
+    )
+
+    expect(result.success).toBe(true)
+    const [scoringData] = result.scoringData!
+    expect(scoringData.grade).toBe("3")
+    expect(scoringData.className).toBe("3年A組")
+    expect(scoringData.attendanceNumber).toBe(7)
+  })
+
+  it("受験者IDをキーにしたマップは引き当たらない（取り違えの検知）", async () => {
+    const fixture = await createFullTestExam(testPrisma, {
+      studentCount: 1,
+      pageCount: 1,
+      cropRegionsPerPage: 1,
+      includeScores: true,
+    })
+    const [examStudent] = fixture.examStudents
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id], {
+      [examStudent.id]: {
+        grade: 3,
+        className: "3年A組",
+        attendanceNumber: 7,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    const [scoringData] = result.scoringData!
+    // 引き当たらず memberships[0] へフォールバックするので、渡した値にはならない
+    expect(scoringData.className).not.toBe("3年A組")
+    expect(scoringData.attendanceNumber).not.toBe(7)
+  })
+})

--- a/__tests__/exam/integration/returnSnapshot.test.ts
+++ b/__tests__/exam/integration/returnSnapshot.test.ts
@@ -50,14 +50,16 @@ describe("ReturnSnapshot capture/diff", () => {
       includeScores: true,
       includeAnnotations: true,
     })
-    const studentIds = fixture.students.map((student) => student.id)
+    const examStudentIds = fixture.examStudents.map(
+      (examStudent) => examStudent.id
+    )
 
     const captureResult = await captureReturnSnapshot({
       examId: fixture.exam.id,
-      studentIds,
+      examStudentIds,
     })
     expect(captureResult.success).toBe(true)
-    expect(captureResult.capturedCount).toBe(studentIds.length)
+    expect(captureResult.capturedCount).toBe(examStudentIds.length)
 
     const diff = await getReturnDiff(fixture.exam.id)
     expect(diff.success).toBe(true)
@@ -74,8 +76,10 @@ describe("ReturnSnapshot capture/diff", () => {
     const fixture = await createFullTestExam(testPrisma, {
       includeScores: true,
     })
-    const studentIds = fixture.students.map((student) => student.id)
-    await captureReturnSnapshot({ examId: fixture.exam.id, studentIds })
+    const examStudentIds = fixture.examStudents.map(
+      (examStudent) => examStudent.id
+    )
+    await captureReturnSnapshot({ examId: fixture.exam.id, examStudentIds })
 
     // 1件の採点を correct → incorrect に変更
     const target = fixture.questionScores[0]
@@ -89,7 +93,7 @@ describe("ReturnSnapshot capture/diff", () => {
     expect(changed).toHaveLength(1)
 
     const studentDiff = changed[0]
-    expect(studentDiff.studentId).toBe(target.studentId)
+    expect(studentDiff.examStudentId).toBe(target.examStudentId)
     const cell = studentDiff.scoreChanges.find(
       (scoreChange) => scoreChange.cropRegionId === target.cropRegionId
     )
@@ -106,8 +110,10 @@ describe("ReturnSnapshot capture/diff", () => {
       includeScores: true,
       includeAnnotations: true,
     })
-    const studentIds = fixture.students.map((student) => student.id)
-    await captureReturnSnapshot({ examId: fixture.exam.id, studentIds })
+    const examStudentIds = fixture.examStudents.map(
+      (examStudent) => examStudent.id
+    )
+    await captureReturnSnapshot({ examId: fixture.exam.id, examStudentIds })
 
     // 注釈のテキストを変更
     const annotation = fixture.drawingAnnotations[0]
@@ -128,8 +134,10 @@ describe("ReturnSnapshot capture/diff", () => {
       includeScores: true,
       includeAnnotations: true,
     })
-    const studentIds = fixture.students.map((student) => student.id)
-    await captureReturnSnapshot({ examId: fixture.exam.id, studentIds })
+    const examStudentIds = fixture.examStudents.map(
+      (examStudent) => examStudent.id
+    )
+    await captureReturnSnapshot({ examId: fixture.exam.id, examStudentIds })
 
     await testPrisma.drawingAnnotation.delete({
       where: { id: fixture.drawingAnnotations[0].id },
@@ -146,20 +154,22 @@ describe("ReturnSnapshot capture/diff", () => {
       includeScores: true,
     })
     // 1人だけ返却版として記録する
-    const [first, ...rest] = fixture.students.map((student) => student.id)
+    const [first, ...rest] = fixture.examStudents.map(
+      (examStudent) => examStudent.id
+    )
     await captureReturnSnapshot({
       examId: fixture.exam.id,
-      studentIds: [first],
+      examStudentIds: [first],
     })
 
     const diff = await getReturnDiff(fixture.exam.id)
     const firstDiff = diff.diffs.find(
-      (studentDiff) => studentDiff.studentId === first
+      (studentDiff) => studentDiff.examStudentId === first
     )
     expect(firstDiff?.hasSnapshot).toBe(true)
     for (const id of rest) {
       const studentDiff = diff.diffs.find(
-        (candidate) => candidate.studentId === id
+        (candidate) => candidate.examStudentId === id
       )
       expect(studentDiff?.hasSnapshot).toBe(false)
       expect(studentDiff?.changed).toBe(false)

--- a/__tests__/exam/integration/studentAnswerDelete.test.ts
+++ b/__tests__/exam/integration/studentAnswerDelete.test.ts
@@ -2,7 +2,7 @@
  * deleteStudentAnswer / getStudentAnswerScoreSummary の採点データ整合性テスト
  *
  * 背景: StudentAnswerImage は採点系の子リレーションを持たず（採点は
- * `(cropRegionId, studentId)` / `(compoundAnswerId, studentId)` 座標に紐づく）、
+ * `(cropRegionId, examStudentId)` / `(compoundAnswerId, examStudentId)` 座標に紐づく）、
  * 画像を消しても cascade は走らない。かつて画像だけを削除していたため採点が孤児化していた。
  *
  * 検証対象:
@@ -52,7 +52,7 @@ async function buildSimpleExam() {
     includeStudentAnswerImages: true,
   })
 
-  const [studentA, studentB] = exam.students
+  const [examStudentA, examStudentB] = exam.examStudents
   const page1 = exam.pages.find((page) => page.pageNumber === 1)!
   const page2 = exam.pages.find((page) => page.pageNumber === 2)!
   const region1 = exam.cropRegions.find(
@@ -62,24 +62,25 @@ async function buildSimpleExam() {
     (region) => region.examPageId === page2.id
   )!
 
-  const image = (pageId: string, studentId: string) =>
+  const image = (pageId: string, examStudentId: string) =>
     exam.studentAnswerImages.find(
       (answerImage) =>
-        answerImage.examPageId === pageId && answerImage.studentId === studentId
+        answerImage.examPageId === pageId &&
+        answerImage.examStudentId === examStudentId
     )!
-  const score = (cropRegionId: string, studentId: string) =>
+  const score = (cropRegionId: string, examStudentId: string) =>
     exam.questionScores.find(
       (questionScore) =>
         questionScore.cropRegionId === cropRegionId &&
-        questionScore.studentId === studentId
+        questionScore.examStudentId === examStudentId
     )!
 
   const user = await testPrisma.user.findFirstOrThrow()
 
   return {
     exam,
-    studentA,
-    studentB,
+    examStudentA,
+    examStudentB,
     page1,
     page2,
     region1,
@@ -103,8 +104,8 @@ describe("deleteStudentAnswer", () => {
 
   it("答案削除でそのマスの採点データが全て消え、他マスは残る", async () => {
     const {
-      studentA,
-      studentB,
+      examStudentA,
+      examStudentB,
       page1,
       page2,
       region1,
@@ -114,11 +115,11 @@ describe("deleteStudentAnswer", () => {
       user,
     } = await buildSimpleExam()
 
-    // studentA の p1 に確定値・注釈・複合回答の採点を足す
+    // examStudentA の p1 に確定値・注釈・複合回答の採点を足す
     const annotation = await testPrisma.drawingAnnotation.create({
       data: {
         id: crypto.randomUUID(),
-        questionScoreId: score(region1.id, studentA.id).id,
+        questionScoreId: score(region1.id, examStudentA.id).id,
         type: "circle",
         x: 5,
         y: 5,
@@ -129,7 +130,7 @@ describe("deleteStudentAnswer", () => {
       data: {
         id: crypto.randomUUID(),
         cropRegionId: region1.id,
-        studentId: studentA.id,
+        examStudentId: examStudentA.id,
         verdict: "correct",
         decidedByUserId: user.id,
       },
@@ -148,37 +149,42 @@ describe("deleteStudentAnswer", () => {
       data: {
         id: crypto.randomUUID(),
         compoundAnswerId: compoundAnswer.id,
-        studentId: studentA.id,
+        examStudentId: examStudentA.id,
         userId: user.id,
         status: "correct",
         recognizedAnswer: "42",
       },
     })
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
 
     // 画像本体
     expect(
       await testPrisma.studentAnswerImage.findUnique({
-        where: { id: image(page1.id, studentA.id).id },
+        where: { id: image(page1.id, examStudentA.id).id },
       })
     ).toBeNull()
 
     // 当該マス (p1 × A) の採点は全滅
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(0)
     expect(
       await testPrisma.scoreDecision.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(0)
     expect(
       await testPrisma.compoundAnswerScore.count({
-        where: { compoundAnswerId: compoundAnswer.id, studentId: studentA.id },
+        where: {
+          compoundAnswerId: compoundAnswer.id,
+          examStudentId: examStudentA.id,
+        },
       })
     ).toBe(0)
     // DrawingAnnotation は親 QuestionScore の cascade で消える
@@ -191,29 +197,29 @@ describe("deleteStudentAnswer", () => {
     // 他生徒（p1 × B）・他ページ（p2 × A）は巻き添えにしない
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentB.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentB.id },
       })
     ).toBe(1)
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region2.id, studentId: studentA.id },
+        where: { cropRegionId: region2.id, examStudentId: examStudentA.id },
       })
     ).toBe(1)
     expect(
       await testPrisma.studentAnswerImage.findUnique({
-        where: { id: image(page2.id, studentA.id).id },
+        where: { id: image(page2.id, examStudentA.id).id },
       })
     ).not.toBeNull()
   })
 
   it("削除した DrawingAnnotation は親 QuestionScore の cascade で消える", async () => {
-    const { studentA, page1, region1, image, score, user } =
+    const { examStudentA, page1, region1, image, score, user } =
       await buildSimpleExam()
 
     const annotation = await testPrisma.drawingAnnotation.create({
       data: {
         id: crypto.randomUUID(),
-        questionScoreId: score(region1.id, studentA.id).id,
+        questionScoreId: score(region1.id, examStudentA.id).id,
         type: "circle",
         x: 5,
         y: 5,
@@ -221,7 +227,9 @@ describe("deleteStudentAnswer", () => {
       },
     })
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
 
     // 削除の伝搬は sqlite-nas-sync の `_tombstone` が担うため、
@@ -234,29 +242,34 @@ describe("deleteStudentAnswer", () => {
   })
 
   it("削除直前の採点実績を返す（モーダルと同じ定義）", async () => {
-    const { studentA, page1, image } = await buildSimpleExam()
+    const { examStudentA, page1, image } = await buildSimpleExam()
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
     expect(result.deletedSummary?.hasScoreData).toBe(true)
     expect(result.deletedSummary?.scoredQuestionCount).toBe(1)
   })
 
   it("未採点の答案では採点実績なしを返す（トーストの文言が変わる）", async () => {
-    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image } = await buildSimpleExam()
 
     await testPrisma.questionScore.updateMany({
-      where: { cropRegionId: region1.id, studentId: studentA.id },
+      where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       data: { status: "unscored", partialScore: null },
     })
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
     expect(result.deletedSummary?.hasScoreData).toBe(false)
   })
 
   it("協調採点では全教員分の採点行が消える（自分の行だけ残さない）", async () => {
-    const { studentA, page1, region1, image, user } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image, user } =
+      await buildSimpleExam()
 
     // 別教員2名の提案行を同じマスに追加（QuestionScore に unique は無い）
     const otherTeachers = await Promise.all(
@@ -275,7 +288,7 @@ describe("deleteStudentAnswer", () => {
         data: {
           id: crypto.randomUUID(),
           cropRegionId: region1.id,
-          studentId: studentA.id,
+          examStudentId: examStudentA.id,
           userId: teacher.id,
           status: "incorrect",
         },
@@ -284,17 +297,19 @@ describe("deleteStudentAnswer", () => {
     // 3教員（元の1名 + 追加2名）分の行がある状態
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(3)
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
 
     // 教員を問わず全滅している（userId で絞っていないことの保証）
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(0)
     for (const teacher of [user, ...otherTeachers]) {
@@ -302,7 +317,7 @@ describe("deleteStudentAnswer", () => {
         await testPrisma.questionScore.count({
           where: {
             cropRegionId: region1.id,
-            studentId: studentA.id,
+            examStudentId: examStudentA.id,
             userId: teacher.id,
           },
         })
@@ -311,12 +326,13 @@ describe("deleteStudentAnswer", () => {
   })
 
   it("削除後に別教員が同じ採点を保存すると target-deleted を返す（協調採点）", async () => {
-    const { studentA, page1, region1, image, score } = await buildSimpleExam()
-    const scoreId = score(region1.id, studentA.id).id
+    const { examStudentA, page1, region1, image, score } =
+      await buildSimpleExam()
+    const scoreId = score(region1.id, examStudentA.id).id
 
     // 教員Aが答案を削除 → 教員Bが開いたままの採点を保存しようとする
     expect(
-      (await deleteStudentAnswer(image(page1.id, studentA.id).id)).success
+      (await deleteStudentAnswer(image(page1.id, examStudentA.id).id)).success
     ).toBe(true)
 
     const result = await updateQuestionScore(scoreId, { status: "correct" })
@@ -327,13 +343,13 @@ describe("deleteStudentAnswer", () => {
   })
 
   it("存在しない答案は失敗し、DB は変化しない", async () => {
-    const { region1, studentA } = await buildSimpleExam()
+    const { region1, examStudentA } = await buildSimpleExam()
 
     const result = await deleteStudentAnswer(crypto.randomUUID())
     expect(result.success).toBe(false)
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(1)
   })
@@ -351,13 +367,13 @@ describe("getStudentAnswerScoreSummary", () => {
   })
 
   it("採点済みなら hasScoreData=true と内訳を返す", async () => {
-    const { studentA, page1, region1, image, score, user } =
+    const { examStudentA, page1, region1, image, score, user } =
       await buildSimpleExam()
 
     await testPrisma.drawingAnnotation.create({
       data: {
         id: crypto.randomUUID(),
-        questionScoreId: score(region1.id, studentA.id).id,
+        questionScoreId: score(region1.id, examStudentA.id).id,
         type: "circle",
         x: 5,
         y: 5,
@@ -366,7 +382,7 @@ describe("getStudentAnswerScoreSummary", () => {
     })
 
     const result = await getStudentAnswerScoreSummary(
-      image(page1.id, studentA.id).id
+      image(page1.id, examStudentA.id).id
     )
     expect(result.success).toBe(true)
     if (!result.success) return
@@ -377,7 +393,7 @@ describe("getStudentAnswerScoreSummary", () => {
   })
 
   it("協調採点で1設問に複数教員の行があっても設問数で数える", async () => {
-    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image } = await buildSimpleExam()
 
     // 別教員の提案行を同じ設問に追加（QuestionScore に unique は無い）
     const otherTeacher = await testPrisma.user.create({
@@ -391,14 +407,14 @@ describe("getStudentAnswerScoreSummary", () => {
       data: {
         id: crypto.randomUUID(),
         cropRegionId: region1.id,
-        studentId: studentA.id,
+        examStudentId: examStudentA.id,
         userId: otherTeacher.id,
         status: "incorrect",
       },
     })
 
     const result = await getStudentAnswerScoreSummary(
-      image(page1.id, studentA.id).id
+      image(page1.id, examStudentA.id).id
     )
     expect(result.success).toBe(true)
     if (!result.success) return
@@ -407,12 +423,12 @@ describe("getStudentAnswerScoreSummary", () => {
   })
 
   it("部分点のみ入力された複合回答も採点済みとして数える", async () => {
-    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image } = await buildSimpleExam()
     const user = await testPrisma.user.findFirstOrThrow()
 
     // 設問側は未採点に戻し、複合回答の部分点だけがある状態にする
     await testPrisma.questionScore.updateMany({
-      where: { cropRegionId: region1.id, studentId: studentA.id },
+      where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       data: { status: "unscored", partialScore: null },
     })
     const compoundAnswer = await testPrisma.compoundAnswer.create({
@@ -429,7 +445,7 @@ describe("getStudentAnswerScoreSummary", () => {
       data: {
         id: crypto.randomUUID(),
         compoundAnswerId: compoundAnswer.id,
-        studentId: studentA.id,
+        examStudentId: examStudentA.id,
         userId: user.id,
         status: "unscored",
         recognizedAnswer: null,
@@ -438,7 +454,7 @@ describe("getStudentAnswerScoreSummary", () => {
     })
 
     const result = await getStudentAnswerScoreSummary(
-      image(page1.id, studentA.id).id
+      image(page1.id, examStudentA.id).id
     )
     expect(result.success).toBe(true)
     if (!result.success) return
@@ -447,16 +463,16 @@ describe("getStudentAnswerScoreSummary", () => {
   })
 
   it("unscored の初期化行だけなら hasScoreData=false", async () => {
-    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image } = await buildSimpleExam()
 
     // 初期化直後の状態（status=unscored・部分点なし）に戻す
     await testPrisma.questionScore.updateMany({
-      where: { cropRegionId: region1.id, studentId: studentA.id },
+      where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       data: { status: "unscored", partialScore: null },
     })
 
     const result = await getStudentAnswerScoreSummary(
-      image(page1.id, studentA.id).id
+      image(page1.id, examStudentA.id).id
     )
     expect(result.success).toBe(true)
     if (!result.success) return
@@ -465,18 +481,20 @@ describe("getStudentAnswerScoreSummary", () => {
   })
 
   it("未採点でも削除時は初期化行ごと消える", async () => {
-    const { studentA, page1, region1, image } = await buildSimpleExam()
+    const { examStudentA, page1, region1, image } = await buildSimpleExam()
 
     await testPrisma.questionScore.updateMany({
-      where: { cropRegionId: region1.id, studentId: studentA.id },
+      where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       data: { status: "unscored", partialScore: null },
     })
 
-    const result = await deleteStudentAnswer(image(page1.id, studentA.id).id)
+    const result = await deleteStudentAnswer(
+      image(page1.id, examStudentA.id).id
+    )
     expect(result.success).toBe(true)
     expect(
       await testPrisma.questionScore.count({
-        where: { cropRegionId: region1.id, studentId: studentA.id },
+        where: { cropRegionId: region1.id, examStudentId: examStudentA.id },
       })
     ).toBe(0)
   })

--- a/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
+++ b/__tests__/exam/integration/studentAnswerPlacementApply.test.ts
@@ -1,9 +1,9 @@
 /**
  * applyStudentAnswerPlacements（view 方式B: 2軸移動 + carry/discard）の採点安全性テスト
  *
- * 検証対象（docs/06-student-answers-cell-architecture-plan.md §3-4）:
+ * 検証対象:
  * - 2軸移動: examPageId が実際に更新される（旧 batchUpdate は finalPageNumber を無視していた）
- * - carry（同一ページ）: 採点が studentId 付け替えで追従し、DrawingAnnotation が温存される
+ * - carry（同一ページ）: 採点が examStudentId 付け替えで追従し、DrawingAnnotation が温存される
  * - discard: 影響採点（両スコア表）が削除され、注釈は cascade で道連れになる
  * - ガード: carry かつページ変化はエラー（DBは不変）
  */
@@ -41,7 +41,7 @@ async function buildSimpleExam() {
     includeStudentAnswerImages: true,
   })
 
-  const [studentA, studentB] = exam.students
+  const [examStudentA, examStudentB] = exam.examStudents
   const page1 = exam.pages.find((page) => page.pageNumber === 1)!
   const page2 = exam.pages.find((page) => page.pageNumber === 2)!
   const region1 = exam.cropRegions.find(
@@ -51,22 +51,23 @@ async function buildSimpleExam() {
     (region) => region.examPageId === page2.id
   )!
 
-  const image = (pageId: string, studentId: string) =>
+  const image = (pageId: string, examStudentId: string) =>
     exam.studentAnswerImages.find(
       (answerImage) =>
-        answerImage.examPageId === pageId && answerImage.studentId === studentId
+        answerImage.examPageId === pageId &&
+        answerImage.examStudentId === examStudentId
     )!
-  const score = (cropRegionId: string, studentId: string) =>
+  const score = (cropRegionId: string, examStudentId: string) =>
     exam.questionScores.find(
       (questionScore) =>
         questionScore.cropRegionId === cropRegionId &&
-        questionScore.studentId === studentId
+        questionScore.examStudentId === examStudentId
     )!
 
   return {
     exam,
-    studentA,
-    studentB,
+    examStudentA,
+    examStudentB,
     page1,
     page2,
     region1,
@@ -88,13 +89,13 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("① 同一ページの生徒swap: carry で採点が追従し DrawingAnnotation が温存される", async () => {
-    const { studentA, studentB, page1, region1, image, score } =
+    const { examStudentA, examStudentB, page1, region1, image, score } =
       await buildSimpleExam()
 
-    const scoreA = score(region1.id, studentA.id)
-    const scoreB = score(region1.id, studentB.id)
+    const scoreA = score(region1.id, examStudentA.id)
+    const scoreB = score(region1.id, examStudentB.id)
 
-    // scoreA（studentA の r1 採点）に注釈を付ける
+    // scoreA（examStudentA の r1 採点）に注釈を付ける
     const annotation = await testPrisma.drawingAnnotation.create({
       data: {
         id: crypto.randomUUID(),
@@ -108,36 +109,36 @@ describe("applyStudentAnswerPlacements", () => {
 
     const result = await applyStudentAnswerPlacements([
       {
-        fileId: image(page1.id, studentA.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page1.id, examStudentA.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "carry",
       },
       {
-        fileId: image(page1.id, studentB.id).id,
-        finalStudentId: studentA.id,
+        fileId: image(page1.id, examStudentB.id).id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page1.id,
         scorePolicy: "carry",
       },
     ])
     expect(result.success).toBe(true)
 
-    // 画像の studentId が入れ替わり、ページは p1 のまま
+    // 画像の examStudentId が入れ替わり、ページは p1 のまま
     const imgAfterA = await testPrisma.studentAnswerImage.findUniqueOrThrow({
-      where: { id: image(page1.id, studentA.id).id },
+      where: { id: image(page1.id, examStudentA.id).id },
     })
-    expect(imgAfterA.studentId).toBe(studentB.id)
+    expect(imgAfterA.examStudentId).toBe(examStudentB.id)
     expect(imgAfterA.examPageId).toBe(page1.id)
 
-    // 採点が studentId 付け替えで追従（行=id は保持）
+    // 採点が examStudentId 付け替えで追従（行=id は保持）
     const scoreAAfter = await testPrisma.questionScore.findUniqueOrThrow({
       where: { id: scoreA.id },
     })
     const scoreBAfter = await testPrisma.questionScore.findUniqueOrThrow({
       where: { id: scoreB.id },
     })
-    expect(scoreAAfter.studentId).toBe(studentB.id)
-    expect(scoreBAfter.studentId).toBe(studentA.id)
+    expect(scoreAAfter.examStudentId).toBe(examStudentB.id)
+    expect(scoreBAfter.examStudentId).toBe(examStudentA.id)
 
     // DrawingAnnotation は同じ questionScore に紐付いたまま温存
     const annotationAfter = await testPrisma.drawingAnnotation.findUnique({
@@ -148,10 +149,10 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("① 同一ページ discard: 影響採点が削除され注釈も消える", async () => {
-    const { studentA, studentB, page1, region1, image, score } =
+    const { examStudentA, examStudentB, page1, region1, image, score } =
       await buildSimpleExam()
 
-    const scoreA = score(region1.id, studentA.id)
+    const scoreA = score(region1.id, examStudentA.id)
     await testPrisma.drawingAnnotation.create({
       data: {
         id: crypto.randomUUID(),
@@ -165,14 +166,14 @@ describe("applyStudentAnswerPlacements", () => {
 
     const result = await applyStudentAnswerPlacements([
       {
-        fileId: image(page1.id, studentA.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page1.id, examStudentA.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
       {
-        fileId: image(page1.id, studentB.id).id,
-        finalStudentId: studentA.id,
+        fileId: image(page1.id, examStudentB.id).id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
@@ -193,7 +194,8 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("複合回答の採点も carry で追従し、discard で破棄される", async () => {
-    const { studentA, studentB, page1, page2, image } = await buildSimpleExam()
+    const { examStudentA, examStudentB, page1, page2, image } =
+      await buildSimpleExam()
     const user = await testPrisma.user.findFirstOrThrow()
 
     const compoundAnswer = await testPrisma.compoundAnswer.create({
@@ -210,7 +212,7 @@ describe("applyStudentAnswerPlacements", () => {
       data: {
         id: crypto.randomUUID(),
         compoundAnswerId: compoundAnswer.id,
-        studentId: studentA.id,
+        examStudentId: examStudentA.id,
         userId: user.id,
         status: "correct",
         recognizedAnswer: "42",
@@ -220,14 +222,14 @@ describe("applyStudentAnswerPlacements", () => {
     // 同一ページで A → B へ carry（B 側に複合採点は無いので単独移動）
     const carried = await applyStudentAnswerPlacements([
       {
-        fileId: image(page1.id, studentA.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page1.id, examStudentA.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "carry",
       },
       {
-        fileId: image(page1.id, studentB.id).id,
-        finalStudentId: studentA.id,
+        fileId: image(page1.id, examStudentB.id).id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page1.id,
         scorePolicy: "carry",
       },
@@ -239,7 +241,7 @@ describe("applyStudentAnswerPlacements", () => {
       where: { compoundAnswerId: compoundAnswer.id },
     })
     expect(afterCarry).toHaveLength(1)
-    expect(afterCarry[0].studentId).toBe(studentB.id)
+    expect(afterCarry[0].examStudentId).toBe(examStudentB.id)
     expect(afterCarry[0].recognizedAnswer).toBe("42")
     expect(afterCarry[0].id).toBe(compoundScoreA.id)
 
@@ -247,14 +249,14 @@ describe("applyStudentAnswerPlacements", () => {
     // carry 後この画像は B のもの。p2×B と入れ替える形で p1→p2 へ動かす。
     const discarded = await applyStudentAnswerPlacements([
       {
-        fileId: image(page1.id, studentA.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page1.id, examStudentA.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page2.id,
         scorePolicy: "discard",
       },
       {
-        fileId: image(page2.id, studentB.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page2.id, examStudentB.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
@@ -268,23 +270,23 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("② ページ跨ぎ移動(discard): examPageId が更新され、移動元ページの採点が破棄される", async () => {
-    const { studentA, page1, page2, region1, region2, image, score } =
+    const { examStudentA, page1, page2, region1, region2, image, score } =
       await buildSimpleExam()
 
-    const imgP1A = image(page1.id, studentA.id)
-    const imgP2A = image(page2.id, studentA.id)
+    const imgP1A = image(page1.id, examStudentA.id)
+    const imgP2A = image(page2.id, examStudentA.id)
 
     // A の p1画像 と p2画像 を入れ替え（両方ページが変わる→discard）
     const result = await applyStudentAnswerPlacements([
       {
         fileId: imgP1A.id,
-        finalStudentId: studentA.id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page2.id,
         scorePolicy: "discard",
       },
       {
         fileId: imgP2A.id,
-        finalStudentId: studentA.id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
@@ -304,24 +306,24 @@ describe("applyStudentAnswerPlacements", () => {
     // A の r1・r2 採点は破棄
     expect(
       await testPrisma.questionScore.findUnique({
-        where: { id: score(region1.id, studentA.id).id },
+        where: { id: score(region1.id, examStudentA.id).id },
       })
     ).toBeNull()
     expect(
       await testPrisma.questionScore.findUnique({
-        where: { id: score(region2.id, studentA.id).id },
+        where: { id: score(region2.id, examStudentA.id).id },
       })
     ).toBeNull()
   })
 
   it("carry かつページ変化はエラー（DBは不変）", async () => {
-    const { studentA, page1, page2, image } = await buildSimpleExam()
-    const imgP1A = image(page1.id, studentA.id)
+    const { examStudentA, page1, page2, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, examStudentA.id)
 
     const result = await applyStudentAnswerPlacements([
       {
         fileId: imgP1A.id,
-        finalStudentId: studentA.id,
+        finalExamStudentId: examStudentA.id,
         finalExamPageId: page2.id, // ページ変化
         scorePolicy: "carry", // 追従は不可
       },
@@ -336,20 +338,20 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("carry: 移動先生徒の孤立採点は掃除され二重計上しない", async () => {
-    const { studentA, studentB, page1, region1, image } =
+    const { examStudentA, examStudentB, page1, region1, image } =
       await buildSimpleExam()
 
     // B の p1 画像だけを直接削除し、採点を孤立させる（deleteStudentAnswer は採点も
     // 消すので、ここでは孤立状態を作るために低レベル API を使う）。
     // これで移動先 (p1,B) は空マスになり、B は r1 に孤立採点だけを持つ。
     await testPrisma.studentAnswerImage.delete({
-      where: { id: image(page1.id, studentB.id).id },
+      where: { id: image(page1.id, examStudentB.id).id },
     })
 
     const result = await applyStudentAnswerPlacements([
       {
-        fileId: image(page1.id, studentA.id).id,
-        finalStudentId: studentB.id,
+        fileId: image(page1.id, examStudentA.id).id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "carry",
       },
@@ -361,17 +363,17 @@ describe("applyStudentAnswerPlacements", () => {
       where: { cropRegionId: region1.id },
     })
     expect(r1Scores).toHaveLength(1)
-    expect(r1Scores[0].studentId).toBe(studentB.id)
+    expect(r1Scores[0].examStudentId).toBe(examStudentB.id)
   })
 
-  it("finalStudentId=null（削除）は拒否され、画像は残る", async () => {
-    const { studentA, page1, image } = await buildSimpleExam()
-    const imgP1A = image(page1.id, studentA.id)
+  it("finalExamStudentId=null（削除）は拒否され、画像は残る", async () => {
+    const { examStudentA, page1, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, examStudentA.id)
 
     const result = await applyStudentAnswerPlacements([
       {
         fileId: imgP1A.id,
-        finalStudentId: null,
+        finalExamStudentId: null,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
@@ -385,14 +387,14 @@ describe("applyStudentAnswerPlacements", () => {
   })
 
   it("移動先が batch 外の答案で占有されていればエラー（上書きしない）", async () => {
-    const { studentA, studentB, page1, image } = await buildSimpleExam()
-    const imgP1A = image(page1.id, studentA.id)
+    const { examStudentA, examStudentB, page1, image } = await buildSimpleExam()
+    const imgP1A = image(page1.id, examStudentA.id)
 
     // A の p1 を、占有済みの (p1,B) へ単独移動（入れ替えでない）→ 拒否
     const result = await applyStudentAnswerPlacements([
       {
         fileId: imgP1A.id,
-        finalStudentId: studentB.id,
+        finalExamStudentId: examStudentB.id,
         finalExamPageId: page1.id,
         scorePolicy: "discard",
       },
@@ -403,7 +405,7 @@ describe("applyStudentAnswerPlacements", () => {
     const imgAfter = await testPrisma.studentAnswerImage.findUniqueOrThrow({
       where: { id: imgP1A.id },
     })
-    expect(imgAfter.studentId).toBe(studentA.id)
+    expect(imgAfter.examStudentId).toBe(examStudentA.id)
     expect(imgAfter.examPageId).toBe(page1.id)
   })
 })

--- a/__tests__/grade/integration/gradeExamStudentScope.test.ts
+++ b/__tests__/grade/integration/gradeExamStudentScope.test.ts
@@ -1,0 +1,165 @@
+/**
+ * 成績算出が「その試験の受験者」以外の採点を拾わないことの統合テスト（#962 の本丸）。
+ *
+ * 配線変更前、gradeCalculator は CropRegion 起点で採点行を集めており、ExamStudent で
+ * 絞っていなかった。そのため試験から外した生徒の採点データが残っていると、試験側の
+ * 画面・出力（すべて ExamStudent 起点）には一切現れないのに、成績算出でだけ素点として
+ * 算入されていた。採点層を ExamStudent の子にした今は、外した瞬間に採点も消え、
+ * かつ経路上も受験者を必ず1回通るため、この非対称は構造的に起こらない。
+ *
+ * 併せて「見込（expected）は欠測扱いにする」判定が、status を経路上から読むように
+ * なった後も従来どおり効くことを固定する。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { removeStudentsFromExam } from "@/electron-src/lib/prisma/examStudent"
+import { calculateGrades } from "@/electron-src/lib/shared/calculations/gradeCalculator"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+interface Fixture {
+  gradeId: string
+  examId: string
+  studentId: string
+  examStudentId: string
+}
+
+/**
+ * 生徒1名・設問1つ（配点10・正解）の試験を作り、その exam_total を
+ * 参照する成績（評価項目1つ）を組み立てる。
+ */
+async function buildFixture(): Promise<Fixture> {
+  const user = await testPrisma.user.create({
+    data: { username: `grader_${Date.now()}`, name: "採点者" },
+  })
+  const student = await testPrisma.student.create({
+    data: {
+      studentNumber: `S${Date.now()}`,
+      lastName: "山田",
+      firstName: "太郎",
+      lastNameKana: "ヤマダ",
+      firstNameKana: "タロウ",
+    },
+  })
+
+  const exam = await testPrisma.exam.create({ data: { examName: "期末考査" } })
+  const examPage = await testPrisma.examPage.create({
+    data: { examId: exam.id, pageNumber: 1 },
+  })
+  const cropRegion = await testPrisma.cropRegion.create({
+    data: {
+      examPageId: examPage.id,
+      label: "問1",
+      type: "QUESTION_ANSWER",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      points: 10,
+      orderIndex: 0,
+    },
+  })
+  const examStudent = await testPrisma.examStudent.create({
+    data: { examId: exam.id, studentId: student.id, status: "participating" },
+  })
+  await testPrisma.questionScore.create({
+    data: {
+      cropRegionId: cropRegion.id,
+      examStudentId: examStudent.id,
+      status: "correct",
+      userId: user.id,
+    },
+  })
+
+  const grade = await testPrisma.grade.create({ data: { name: "1学期成績" } })
+  await testPrisma.gradeStudent.create({
+    data: { gradeId: grade.id, studentId: student.id },
+  })
+  const gradeItem = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+  })
+  await testPrisma.gradeDataSource.create({
+    data: {
+      gradeItemId: gradeItem.id,
+      type: "exam_total",
+      examId: exam.id,
+      name: "期末考査",
+      weight: 1,
+      order: 0,
+      treatExpectedAsMissing: true,
+    },
+  })
+
+  return {
+    gradeId: grade.id,
+    examId: exam.id,
+    studentId: student.id,
+    examStudentId: examStudent.id,
+  }
+}
+
+/** 対象セル（生徒1名・評価項目1つ）の参照元スコアを取り出す */
+async function readSourceScore(gradeId: string) {
+  const calculation = await calculateGrades(gradeId)
+  expect(calculation.success).toBe(true)
+  return calculation.result!.students[0].gradeItemResults[0].sourceScores[0]
+}
+
+describe("成績算出の受験者スコープ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("受験者として登録されている間は素点が算入される", async () => {
+    const fixture = await buildFixture()
+
+    const source = await readSourceScore(fixture.gradeId)
+    expect(source.rawScore).toBe(10)
+    expect(source.isEstimated).toBe(false)
+  })
+
+  it("試験から外した生徒の得点は算入されない（#962 の非対称の解消）", async () => {
+    const fixture = await buildFixture()
+
+    await removeStudentsFromExam(fixture.examId, [fixture.studentId])
+
+    const source = await readSourceScore(fixture.gradeId)
+    expect(source.rawScore).toBeNull()
+  })
+
+  it("受験状態が見込（expected）なら欠測として扱う", async () => {
+    const fixture = await buildFixture()
+
+    await testPrisma.examStudent.update({
+      where: { id: fixture.examStudentId },
+      data: { status: "expected" },
+    })
+
+    const source = await readSourceScore(fixture.gradeId)
+    expect(source.rawScore).toBeNull()
+  })
+})

--- a/__tests__/helpers/testDataFactory.ts
+++ b/__tests__/helpers/testDataFactory.ts
@@ -221,7 +221,7 @@ export function createArchiveScoresData(
   scores: Array<{
     id?: string
     cropRegionId: string
-    studentId: string
+    examStudentId: string
     status?: string
     partialScore?: string | null
     userId?: string
@@ -231,7 +231,7 @@ export function createArchiveScoresData(
     questionScores: scores.map((score) => ({
       id: score.id ?? generateId(),
       cropRegionId: score.cropRegionId,
-      studentId: score.studentId,
+      examStudentId: score.examStudentId,
       partialScore: score.partialScore ?? null,
       status: score.status ?? "unscored",
       userId: score.userId ?? generateId(),

--- a/__tests__/helpers/testExamBuilder.ts
+++ b/__tests__/helpers/testExamBuilder.ts
@@ -75,7 +75,7 @@ export interface FullTestExam {
   questionScores: Array<{
     id: string
     cropRegionId: string
-    studentId: string
+    examStudentId: string
     userId: string
     status: string
     partialScore: number | null
@@ -93,7 +93,7 @@ export interface FullTestExam {
   studentAnswerImages: Array<{
     id: string
     examPageId: string
-    studentId: string
+    examStudentId: string
     imagePath: string
   }>
   // v1.4.0+
@@ -211,6 +211,8 @@ export async function createFullTestExam(
   const students = []
   const memberships = []
   const examStudents = []
+  /** studentId → その試験の ExamStudent（採点データの親） */
+  const examStudentByStudentId = new Map<string, { id: string }>()
   for (let i = 0; i < studentCount; i++) {
     const student = await prisma.student.create({
       data: {
@@ -246,6 +248,7 @@ export async function createFullTestExam(
       },
     })
     examStudents.push(examStudent)
+    examStudentByStudentId.set(student.id, examStudent)
   }
 
   // 8. ExamClassroom作成
@@ -316,7 +319,7 @@ export async function createFullTestExam(
           data: {
             id: randomUUID(),
             cropRegionId: region.id,
-            studentId: student.id,
+            examStudentId: examStudentByStudentId.get(student.id)!.id,
             userId: user.id,
             status: "correct",
             partialScore: region.points,
@@ -325,7 +328,7 @@ export async function createFullTestExam(
         questionScores.push({
           id: questionScore.id,
           cropRegionId: questionScore.cropRegionId,
-          studentId: questionScore.studentId,
+          examStudentId: questionScore.examStudentId,
           userId: questionScore.userId,
           status: questionScore.status,
           partialScore: questionScore.partialScore
@@ -377,7 +380,7 @@ export async function createFullTestExam(
           data: {
             id: randomUUID(),
             examPageId: page.id,
-            studentId: student.id,
+            examStudentId: examStudentByStudentId.get(student.id)!.id,
             imagePath: `exams/${exam.id}/answer-sheets/${student.studentNumber}_page${page.pageNumber}.png`,
           },
         })
@@ -497,7 +500,7 @@ export async function createFullTestExam(
     studentAnswerImages: studentAnswerImages.map((studentAnswerImage) => ({
       id: studentAnswerImage.id,
       examPageId: studentAnswerImage.examPageId,
-      studentId: studentAnswerImage.studentId,
+      examStudentId: studentAnswerImage.examStudentId,
       imagePath: studentAnswerImage.imagePath,
     })),
     examMarkingFormats: examMarkingFormats.map((examMarkingFormat) => ({

--- a/__tests__/import-export/integration/collectExamData.test.ts
+++ b/__tests__/import-export/integration/collectExamData.test.ts
@@ -102,7 +102,7 @@ describe("collectExamData", () => {
       data: {
         id: generateId(),
         cropRegionId: testExam.cropRegions[0].id,
-        studentId: testExam.students[0].id,
+        examStudentId: testExam.examStudents[0].id,
         userId: otherUser.id,
         status: "incorrect",
         partialScore: 0,

--- a/__tests__/import-export/integration/collectExamDataExportMode.test.ts
+++ b/__tests__/import-export/integration/collectExamDataExportMode.test.ts
@@ -123,8 +123,7 @@ describe("collectExamData - エクスポートモード", () => {
       // 返却版スナップショットを1件作成
       await getTestPrismaClient().returnSnapshot.create({
         data: {
-          examId: testExam.exam.id,
-          studentId: testExam.students[0].id,
+          examStudentId: testExam.examStudents[0].id,
           scoresJson: JSON.stringify({ v: 1, scores: [], annotations: [] }),
           totalScore: 42,
           capturedByUserId: testExam.user.id,
@@ -140,7 +139,7 @@ describe("collectExamData - エクスポートモード", () => {
       expect(result.success).toBe(true)
       const snapshots = result.data!.scoresData.returnSnapshots ?? []
       expect(snapshots).toHaveLength(1)
-      expect(snapshots[0].studentId).toBe(testExam.students[0].id)
+      expect(snapshots[0].examStudentId).toBe(testExam.examStudents[0].id)
       expect(snapshots[0].totalScore).toBe("42")
     })
   })
@@ -200,8 +199,7 @@ describe("collectExamData - エクスポートモード", () => {
     it("EM-T3b: ReturnSnapshot（返却版）もtemplateモードで空になる", async () => {
       await getTestPrismaClient().returnSnapshot.create({
         data: {
-          examId: testExam.exam.id,
-          studentId: testExam.students[0].id,
+          examStudentId: testExam.examStudents[0].id,
           scoresJson: JSON.stringify({ v: 1, scores: [], annotations: [] }),
           totalScore: 42,
           capturedByUserId: testExam.user.id,

--- a/__tests__/import-export/integration/idChangeExecutor.test.ts
+++ b/__tests__/import-export/integration/idChangeExecutor.test.ts
@@ -312,10 +312,11 @@ describe("executeIdChanges", () => {
       expect(warnings).toHaveLength(0)
     })
 
-    it("ScoreDecision/CompoundAnswerScore がカスケード削除されず新IDへ移し替えられる", async () => {
+    it("ScoreDecision/CompoundAnswerScore がカスケード削除されず受験者ごと引き継がれる", async () => {
       const existingStudentId = generateId()
       const newStudentId = generateId()
       const examId = generateId()
+      const examStudentId = generateId()
       const pageId = generateId()
       const regionId = generateId()
       const userId = generateId()
@@ -336,6 +337,14 @@ describe("executeIdChanges", () => {
         },
       })
       await prisma.exam.create({ data: { id: examId, examName: "確定テスト" } })
+      await prisma.examStudent.create({
+        data: {
+          id: examStudentId,
+          examId,
+          studentId: existingStudentId,
+          status: "participating",
+        },
+      })
       await prisma.examPage.create({
         data: { id: pageId, examId, pageNumber: 1 },
       })
@@ -358,7 +367,7 @@ describe("executeIdChanges", () => {
         data: {
           id: decisionId,
           cropRegionId: regionId,
-          studentId: existingStudentId,
+          examStudentId,
           verdict: "correct",
           score: 10,
           decidedByUserId: userId,
@@ -381,7 +390,7 @@ describe("executeIdChanges", () => {
         data: {
           id: compoundAnswerScoreId,
           compoundAnswerId: compoundId,
-          studentId: existingStudentId,
+          examStudentId,
           userId,
           status: "correct",
         },
@@ -401,19 +410,25 @@ describe("executeIdChanges", () => {
         await executeIdChanges(targets, idMappings, warnings, tx)
       })
 
-      // ScoreDecision は削除されず、新IDへ移し替えられている
+      // 受験者（ExamStudent）が新IDへ移し替えられている
+      const examStudent = await prisma.examStudent.findUnique({
+        where: { id: examStudentId },
+      })
+      expect(examStudent).not.toBeNull()
+      expect(examStudent!.studentId).toBe(newStudentId)
+
+      // 採点層は受験者の子なので、id を保ったまま生き残る
       const decision = await prisma.scoreDecision.findUnique({
         where: { id: decisionId },
       })
       expect(decision).not.toBeNull()
-      expect(decision!.studentId).toBe(newStudentId)
+      expect(decision!.examStudentId).toBe(examStudentId)
 
-      // CompoundAnswerScore も同様
       const compoundAnswerScore = await prisma.compoundAnswerScore.findUnique({
         where: { id: compoundAnswerScoreId },
       })
       expect(compoundAnswerScore).not.toBeNull()
-      expect(compoundAnswerScore!.studentId).toBe(newStudentId)
+      expect(compoundAnswerScore!.examStudentId).toBe(examStudentId)
     })
   })
 

--- a/__tests__/import-export/integration/idIntegrationImporter.test.ts
+++ b/__tests__/import-export/integration/idIntegrationImporter.test.ts
@@ -95,9 +95,10 @@ describe("executeIdIntegrationImport", () => {
     })
 
     // ExamStudentを追加
+    const examStudentId = generateId()
     examData.examStudents = [
       {
-        id: generateId(),
+        id: examStudentId,
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -164,7 +165,7 @@ describe("executeIdIntegrationImport", () => {
         {
           id: scoreId,
           cropRegionId: regionId,
-          studentId,
+          examStudentId,
           status: "correct",
           partialScore: "10",
           userId: currentUser.id,
@@ -176,6 +177,7 @@ describe("executeIdIntegrationImport", () => {
       data,
       examId,
       studentId,
+      examStudentId,
       classroomId,
       groupId,
       regionId,
@@ -458,7 +460,7 @@ describe("executeIdIntegrationImport", () => {
 
     // スコアを変更して2回目インポート
     const existingScore = await prisma.questionScore.findFirst({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(existingScore).not.toBeNull()
 
@@ -570,7 +572,7 @@ describe("executeIdIntegrationImport", () => {
     )
 
     const existingScore = await prisma.questionScore.findFirst({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
 
     data.scoresData.questionScores[0].status = "partial"
@@ -678,7 +680,7 @@ describe("executeIdIntegrationImport", () => {
     )
 
     const existingScore = await prisma.questionScore.findFirst({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
 
     data.scoresData.questionScores[0].status = "incorrect"
@@ -1241,7 +1243,7 @@ describe("executeIdIntegrationImport", () => {
 
     // 同じregion+studentのスコアが重複していないことを確認
     const scores = await prisma.questionScore.findMany({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(scores.length).toBe(1)
   })
@@ -1568,7 +1570,8 @@ describe("executeIdIntegrationImport", () => {
 
   // II-21: v1.11.0: 複合解答（CompoundAnswer/Member/Score）が作成される
   it("II-21: 複合解答一式がmerge経路で作成される", async () => {
-    const { data, examId, regionId, studentId } = createBasicTestData()
+    const { data, examId, regionId, studentId, examStudentId } =
+      createBasicTestData()
 
     const pageId = data.examData.examPages[0].id
     const compoundAnswerId = generateId()
@@ -1604,7 +1607,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: generateId(),
         compoundAnswerId: compoundAnswerId,
-        studentId,
+        examStudentId,
         userId: currentUser.id,
         recognizedAnswer: "1/2",
         status: "correct",
@@ -1632,7 +1635,7 @@ describe("executeIdIntegrationImport", () => {
     })
     expect(members.length).toBe(1)
     const scores = await prisma.compoundAnswerScore.findMany({
-      where: { compoundAnswerId: compoundAnswerId, studentId },
+      where: { compoundAnswerId: compoundAnswerId, examStudent: { studentId } },
     })
     expect(scores.length).toBe(1)
     // userIdは現在のユーザーで上書きされる
@@ -1641,7 +1644,8 @@ describe("executeIdIntegrationImport", () => {
 
   // II-22: v1.13.0: ScoreDecisionが作成される
   it("II-22: ScoreDecisionがmerge経路で作成される", async () => {
-    const { data, examId, regionId, studentId } = createBasicTestData()
+    const { data, examId, regionId, studentId, examStudentId } =
+      createBasicTestData()
 
     const scoreDecisionId = generateId()
     const now = new Date().toISOString()
@@ -1649,7 +1653,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: scoreDecisionId,
         cropRegionId: regionId,
-        studentId,
+        examStudentId,
         verdict: "correct",
         score: "10",
         comment: null,
@@ -1671,7 +1675,7 @@ describe("executeIdIntegrationImport", () => {
     expect(result.success).toBe(true)
 
     const decisions = await prisma.scoreDecision.findMany({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(decisions.length).toBe(1)
     expect(decisions[0].verdict).toBe("correct")
@@ -1784,8 +1788,15 @@ describe("executeIdIntegrationImport", () => {
 
   // II-23: ScoreDecisionのLWW競合解決（decidedAtが新しい方を採用）
   it("II-23: ScoreDecision競合はdecidedAtが新しい方を採用する（LWW）", async () => {
-    const { data, examId, studentId, regionId, classroomId, groupId } =
-      createBasicTestData()
+    const {
+      data,
+      examId,
+      studentId,
+      examStudentId,
+      regionId,
+      classroomId,
+      groupId,
+    } = createBasicTestData()
 
     const scoreDecisionId = generateId()
     const oldDate = new Date("2025-06-01T00:00:00.000Z").toISOString()
@@ -1793,7 +1804,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: scoreDecisionId,
         cropRegionId: regionId,
-        studentId,
+        examStudentId,
         verdict: "incorrect",
         score: "0",
         comment: "旧",
@@ -1815,10 +1826,10 @@ describe("executeIdIntegrationImport", () => {
 
     // 2回目: 新しいdecidedAtの確定で同一試験に再インポート
     const newDate = new Date("2025-12-01T00:00:00.000Z").toISOString()
-    data.scoresData.scoreDecisions[0].verdict = "correct"
-    data.scoresData.scoreDecisions[0].score = "10"
-    data.scoresData.scoreDecisions[0].comment = "新"
-    data.scoresData.scoreDecisions[0].decidedAt = newDate
+    data.scoresData.scoreDecisions![0].verdict = "correct"
+    data.scoresData.scoreDecisions![0].score = "10"
+    data.scoresData.scoreDecisions![0].comment = "新"
+    data.scoresData.scoreDecisions![0].decidedAt = newDate
 
     const preMatch2 = createFileOverviewData({
       student: createPreMatchingResult({
@@ -1855,7 +1866,7 @@ describe("executeIdIntegrationImport", () => {
 
     // 確定は1件のまま（重複なし）、新しい方が採用される
     const decisions = await prisma.scoreDecision.findMany({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(decisions.length).toBe(1)
     expect(decisions[0].verdict).toBe("correct")
@@ -1864,8 +1875,15 @@ describe("executeIdIntegrationImport", () => {
 
   // II-24: ScoreDecisionのLWW（既存が新しい場合は上書きしない）
   it("II-24: ScoreDecision競合で既存が新しければ上書きしない（LWW）", async () => {
-    const { data, examId, studentId, regionId, classroomId, groupId } =
-      createBasicTestData()
+    const {
+      data,
+      examId,
+      studentId,
+      examStudentId,
+      regionId,
+      classroomId,
+      groupId,
+    } = createBasicTestData()
 
     const scoreDecisionId = generateId()
     const newDate = new Date("2025-12-01T00:00:00.000Z").toISOString()
@@ -1873,7 +1891,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: scoreDecisionId,
         cropRegionId: regionId,
-        studentId,
+        examStudentId,
         verdict: "correct",
         score: "10",
         comment: "新しい既存",
@@ -1894,9 +1912,9 @@ describe("executeIdIntegrationImport", () => {
 
     // 2回目: 古いdecidedAtの確定 → 上書きされないはず
     const oldDate = new Date("2025-06-01T00:00:00.000Z").toISOString()
-    data.scoresData.scoreDecisions[0].verdict = "incorrect"
-    data.scoresData.scoreDecisions[0].comment = "古い取り込み"
-    data.scoresData.scoreDecisions[0].decidedAt = oldDate
+    data.scoresData.scoreDecisions![0].verdict = "incorrect"
+    data.scoresData.scoreDecisions![0].comment = "古い取り込み"
+    data.scoresData.scoreDecisions![0].decidedAt = oldDate
 
     const preMatch2 = createFileOverviewData({
       student: createPreMatchingResult({
@@ -1932,7 +1950,7 @@ describe("executeIdIntegrationImport", () => {
     expect(result2.success).toBe(true)
 
     const decisions = await prisma.scoreDecision.findMany({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(decisions.length).toBe(1)
     // 既存（新しい方）が維持される
@@ -1943,7 +1961,8 @@ describe("executeIdIntegrationImport", () => {
   // II-25: 新しめモデル全部入りのアーカイブが1回のmergeで全て復元される
   // （merge経路が将来モデルをサイレントに取りこぼさないことの網羅regression）
   it("II-25: OMR・複合解答・確定スコアを含む全モデルがmergeで復元される", async () => {
-    const { data, examId, regionId, studentId } = createBasicTestData()
+    const { data, examId, regionId, studentId, examStudentId } =
+      createBasicTestData()
     const now = new Date().toISOString()
     const pageId = data.examData.examPages[0].id
 
@@ -2027,7 +2046,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: generateId(),
         compoundAnswerId: compoundAnswerId,
-        studentId,
+        examStudentId,
         userId: currentUser.id,
         recognizedAnswer: "1/2",
         status: "correct",
@@ -2042,7 +2061,7 @@ describe("executeIdIntegrationImport", () => {
       {
         id: generateId(),
         cropRegionId: regionId,
-        studentId,
+        examStudentId,
         verdict: "correct",
         score: "10",
         comment: null,
@@ -2092,12 +2111,15 @@ describe("executeIdIntegrationImport", () => {
     ).toBe(1)
     expect(
       await prisma.compoundAnswerScore.count({
-        where: { compoundAnswerId: compoundAnswerId, studentId },
+        where: {
+          compoundAnswerId: compoundAnswerId,
+          examStudent: { studentId },
+        },
       })
     ).toBe(1)
     expect(
       await prisma.scoreDecision.count({
-        where: { cropRegionId: regionId, studentId },
+        where: { cropRegionId: regionId, examStudent: { studentId } },
       })
     ).toBe(1)
   })

--- a/__tests__/import-export/integration/legacyArchiveExtract.test.ts
+++ b/__tests__/import-export/integration/legacyArchiveExtract.test.ts
@@ -151,7 +151,7 @@ describe("extractArchive（旧バージョンアーカイブ）", () => {
 
     // チェーン警告が伝播する
     expect(data.transformWarnings.length).toBeGreaterThan(0)
-    expect(data.manifest.version).toBe("1.20.0")
+    expect(data.manifest.version).toBe("1.21.0")
 
     cleanupTempDir(data.tempDir)
   })
@@ -222,7 +222,7 @@ describe("extractArchive（旧バージョンアーカイブ）", () => {
     const data = result.data!
     createdPaths.push(data.tempDir)
 
-    expect(data.manifest.version).toBe("1.20.0")
+    expect(data.manifest.version).toBe("1.21.0")
     expect(data.examData.exam.id).toBe("exam-1")
     expect(data.examData.examPages).toHaveLength(1)
     expect(data.examData.examClassrooms).toEqual([])
@@ -281,7 +281,7 @@ describe("extractArchive（旧バージョンアーカイブ）", () => {
     createdPaths.push(data.tempDir)
 
     expect(data.transformWarnings).toEqual([])
-    expect(data.manifest.version).toBe("1.20.0")
+    expect(data.manifest.version).toBe("1.21.0")
 
     cleanupTempDir(data.tempDir)
   })

--- a/__tests__/import-export/integration/scoringConflictDetector.test.ts
+++ b/__tests__/import-export/integration/scoringConflictDetector.test.ts
@@ -41,6 +41,37 @@ import {
 const prisma = getTestPrismaClient()
 
 /**
+ * DB に受験者（ExamStudent）を作成し、その id を返す。
+ * 採点行は受験者の子なので、採点を作る前に必ず必要になる。
+ */
+async function createExamStudentRow(
+  examId: string,
+  studentId: string
+): Promise<string> {
+  const examStudent = await prisma.examStudent.create({
+    data: { id: generateId(), examId, studentId, status: "participating" },
+  })
+  return examStudent.id
+}
+
+/** アーカイブ側の受験者行（インポートする採点行の親） */
+function archiveExamStudent(
+  importExamStudentId: string,
+  examId: string,
+  studentId: string
+) {
+  return {
+    id: importExamStudentId,
+    examId,
+    studentId,
+    status: "participating",
+    customOrder: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+/**
  * テスト用の試験・ページ・CropRegionをDBに作成するヘルパー
  */
 async function createExamWithCropRegions(options: {
@@ -124,14 +155,21 @@ describe("detectScoringConflicts", () => {
           enrollmentYear: 2024,
         },
       })
+      await createExamStudentRow(examId, studentId)
+      const importExamStudentId = generateId()
 
       // 既存のQuestionScoreはなし
 
+      const importExamData = createArchiveExamData({ examId })
+      importExamData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, studentId),
+      ]
       const importData = createExtractedArchiveData({
+        examData: importExamData,
         scoresData: createArchiveScoresData([
           {
             cropRegionId: cropRegionId,
-            studentId: studentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,
@@ -186,13 +224,15 @@ describe("detectScoringConflicts", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(examId, studentId)
+      const importExamStudentId = generateId()
 
       // 既存のQuestionScore（incorrect）
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId,
+          examStudentId,
           status: "incorrect",
           partialScore: 0,
           userId: user.id,
@@ -200,11 +240,16 @@ describe("detectScoringConflicts", () => {
       })
 
       // インポートデータ（correct）
+      const importExamData = createArchiveExamData({ examId })
+      importExamData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, studentId),
+      ]
       const importData = createExtractedArchiveData({
+        examData: importExamData,
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,
@@ -265,13 +310,15 @@ describe("detectScoringConflicts", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(examId, studentId)
+      const importExamStudentId = generateId()
 
       // 既存: partial=5
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId,
+          examStudentId,
           status: "partial",
           partialScore: 5,
           userId: user.id,
@@ -279,11 +326,16 @@ describe("detectScoringConflicts", () => {
       })
 
       // インポート: partial=8
+      const importExamData = createArchiveExamData({ examId })
+      importExamData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, studentId),
+      ]
       const importData = createExtractedArchiveData({
+        examData: importExamData,
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId,
+            examStudentId: importExamStudentId,
             status: "partial",
             partialScore: "8",
             userId: user.id,
@@ -330,24 +382,31 @@ describe("detectScoringConflicts", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(examId, studentId)
+      const importExamStudentId = generateId()
 
       // 既存と同じスコア
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId,
+          examStudentId,
           status: "correct",
           partialScore: 10,
           userId: user.id,
         },
       })
 
+      const importExamData = createArchiveExamData({ examId })
+      importExamData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, studentId),
+      ]
       const importData = createExtractedArchiveData({
+        examData: importExamData,
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,
@@ -376,7 +435,7 @@ describe("detectScoringConflicts", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId: generateId(),
-            studentId: generateId(),
+            examStudentId: generateId(),
             status: "correct",
             partialScore: "10",
           },
@@ -394,7 +453,7 @@ describe("detectScoringConflicts", () => {
       const user = await createTestUser()
       const examId = generateId()
       const cropRegionId = generateId()
-      const unmappedStudentId = generateId()
+      const unmappedExamStudentId = generateId()
 
       await createExamWithCropRegions({
         examId,
@@ -406,7 +465,7 @@ describe("detectScoringConflicts", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId: unmappedStudentId,
+            examStudentId: unmappedExamStudentId,
             status: "correct",
             partialScore: "10",
           },
@@ -459,13 +518,17 @@ describe("detectScoringConflicts", () => {
           },
         })
       }
+      const examStudent1 = await createExamStudentRow(examId, student1)
+      await createExamStudentRow(examId, student2)
+      const importExamStudent1 = generateId()
+      const importExamStudent2 = generateId()
 
       // 既存スコア: student1+cropRegion1=correct, student1+cropRegion2=incorrect
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId: cropRegion1,
-          studentId: student1,
+          examStudentId: examStudent1,
           status: "correct",
           partialScore: 10,
           userId: user.id,
@@ -475,7 +538,7 @@ describe("detectScoringConflicts", () => {
         data: {
           id: generateId(),
           cropRegionId: cropRegion2,
-          studentId: student1,
+          examStudentId: examStudent1,
           status: "incorrect",
           partialScore: 0,
           userId: user.id,
@@ -486,23 +549,29 @@ describe("detectScoringConflicts", () => {
       // student1+cropRegion1=correct (同一 -> unchanged)
       // student1+cropRegion2=correct (異なる -> conflict)
       // student2+cropRegion3=correct (新規 -> new)
+      const importExamData = createArchiveExamData({ examId })
+      importExamData.examStudents = [
+        archiveExamStudent(importExamStudent1, examId, student1),
+        archiveExamStudent(importExamStudent2, examId, student2),
+      ]
       const importData = createExtractedArchiveData({
+        examData: importExamData,
         scoresData: createArchiveScoresData([
           {
             cropRegionId: cropRegion1,
-            studentId: student1,
+            examStudentId: importExamStudent1,
             status: "correct",
             partialScore: "10",
           },
           {
             cropRegionId: cropRegion2,
-            studentId: student1,
+            examStudentId: importExamStudent1,
             status: "correct",
             partialScore: "10",
           },
           {
             cropRegionId: cropRegion3,
-            studentId: student2,
+            examStudentId: importExamStudent2,
             status: "correct",
             partialScore: "10",
           },
@@ -550,7 +619,7 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId: generateId(),
-            studentId: generateId(),
+            examStudentId: generateId(),
             status: "correct",
             partialScore: "10",
           },
@@ -608,13 +677,15 @@ describe("detectScoringConflictsWithUserDecisions", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(examId, studentId)
+      const importExamStudentId = generateId()
 
       // 既存スコア
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId,
+          examStudentId,
           status: "incorrect",
           partialScore: 0,
           userId: user.id,
@@ -643,6 +714,9 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         },
       ]
 
+      examData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, studentId),
+      ]
       const importData = createExtractedArchiveData({
         examData,
         studentsData: createArchiveStudentsData([
@@ -656,7 +730,7 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,
@@ -725,13 +799,18 @@ describe("detectScoringConflictsWithUserDecisions", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(
+        examId,
+        existingStudentId
+      )
+      const importExamStudentId = generateId()
 
       // 既存スコア
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId: existingStudentId,
+          examStudentId,
           status: "incorrect",
           partialScore: 0,
           userId: user.id,
@@ -759,6 +838,9 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         },
       ]
 
+      examData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, importStudentId),
+      ]
       const importData = createExtractedArchiveData({
         examData,
         studentsData: createArchiveStudentsData([
@@ -772,7 +854,7 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId: importStudentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,
@@ -844,12 +926,17 @@ describe("detectScoringConflictsWithUserDecisions", () => {
           enrollmentYear: 2024,
         },
       })
+      const examStudentId = await createExamStudentRow(
+        examId,
+        existingStudentId
+      )
+      const importExamStudentId = generateId()
 
       await prisma.questionScore.create({
         data: {
           id: generateId(),
           cropRegionId,
-          studentId: existingStudentId,
+          examStudentId,
           status: "incorrect",
           partialScore: 0,
           userId: user.id,
@@ -877,6 +964,9 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         },
       ]
 
+      examData.examStudents = [
+        archiveExamStudent(importExamStudentId, examId, importStudentId),
+      ]
       const importData = createExtractedArchiveData({
         examData,
         studentsData: createArchiveStudentsData([
@@ -890,7 +980,7 @@ describe("detectScoringConflictsWithUserDecisions", () => {
         scoresData: createArchiveScoresData([
           {
             cropRegionId,
-            studentId: importStudentId,
+            examStudentId: importExamStudentId,
             status: "correct",
             partialScore: "10",
             userId: user.id,

--- a/__tests__/import-export/scenarios/edgeCases.test.ts
+++ b/__tests__/import-export/scenarios/edgeCases.test.ts
@@ -181,9 +181,10 @@ describe("edgeCases", () => {
       cropRegionsPerPage: 1,
     })
 
+    const examStudentId = generateId()
     examData.examStudents = [
       {
-        id: generateId(),
+        id: examStudentId,
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -203,7 +204,7 @@ describe("edgeCases", () => {
       scoresData: createArchiveScoresData([
         {
           cropRegionId: regionId,
-          studentId,
+          examStudentId,
           status: "unscored",
           partialScore: null,
           userId: currentUser.id,
@@ -260,9 +261,10 @@ describe("edgeCases", () => {
       cropRegionsPerPage: 1,
     })
 
+    const examStudentId = generateId()
     examData.examStudents = [
       {
-        id: generateId(),
+        id: examStudentId,
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -284,7 +286,7 @@ describe("edgeCases", () => {
           {
             id: scoreId,
             cropRegionId: regionId,
-            studentId,
+            examStudentId,
             status: "correct",
             partialScore: "10",
             userId: currentUser.id,
@@ -449,9 +451,10 @@ describe("edgeCases", () => {
       cropRegionsPerPage: 1,
     })
 
+    const examStudentId = generateId()
     examData.examStudents = [
       {
-        id: generateId(),
+        id: examStudentId,
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -501,7 +504,7 @@ describe("edgeCases", () => {
       scoresData: createArchiveScoresData([
         {
           cropRegionId: regionId,
-          studentId,
+          examStudentId,
           status: "correct",
           partialScore: "10",
           userId: currentUser.id,
@@ -588,7 +591,7 @@ describe("edgeCases", () => {
     expect(examCount).toBe(1)
 
     const scoreCount = await prisma.questionScore.count({
-      where: { cropRegionId: regionId, studentId },
+      where: { cropRegionId: regionId, examStudent: { studentId } },
     })
     expect(scoreCount).toBe(1)
   })
@@ -690,11 +693,15 @@ describe("edgeCases", () => {
       },
     })
 
+    const existingExamStudent = await prisma.examStudent.findUniqueOrThrow({
+      where: { examId_studentId: { examId, studentId } },
+      select: { id: true },
+    })
     const existingScore = await prisma.questionScore.create({
       data: {
         id: generateId(),
         cropRegionId: region.id,
-        studentId,
+        examStudentId: existingExamStudent.id,
         userId: currentUser.id,
         status: "correct",
         partialScore: 10,
@@ -712,9 +719,10 @@ describe("edgeCases", () => {
     examData.cropRegions[0].id = region.id
     examData.cropRegions[0].examPageId = page.id
 
+    const examStudentId = generateId()
     examData.examStudents = [
       {
-        id: generateId(),
+        id: examStudentId,
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -733,7 +741,7 @@ describe("edgeCases", () => {
         {
           id: scoreId,
           cropRegionId: region.id,
-          studentId,
+          examStudentId,
           status: "incorrect",
           partialScore: "0",
           userId: currentUser.id,

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -78,3 +78,33 @@ describe("ID変更時のカスケード網羅性（schema.prisma駆動）", () =
     )
   })
 })
+
+/**
+ * 試験の採点層が「その試験の受験者」の子であることの固定（#962）。
+ *
+ * かつて採点層は Student 直結で、ExamStudent を参照する子テーブルが1つも無かった。
+ * そのため「試験から生徒を外す」操作では DB の cascade が働かず、削除経路が手書きで
+ * 消し忘れた行が孤児として残り、試験側の画面・出力には現れないのに成績算出でだけ
+ * 算入されていた。新しい採点系テーブルを Student 直結で足すとこの穴が再発するため、
+ * 親が ExamStudent であることを schema 駆動で固定する。
+ */
+describe("採点層の親は ExamStudent（#962 の再発防止）", () => {
+  const SCORING_TABLES = [
+    "CompoundAnswerScore",
+    "QuestionScore",
+    "ReturnSnapshot",
+    "ScoreDecision",
+    "StudentAnswerImage",
+  ]
+
+  it("採点系5テーブルは ExamStudent の onDelete:Cascade 子である", () => {
+    expect(cascadeChildrenFromSchema("ExamStudent")).toEqual(SCORING_TABLES)
+  })
+
+  it("採点系5テーブルは Student 直結ではない", () => {
+    const studentChildren = cascadeChildrenFromSchema("Student")
+    for (const table of SCORING_TABLES) {
+      expect(studentChildren).not.toContain(table)
+    }
+  })
+})

--- a/__tests__/import-export/unit/dataCollector.test.ts
+++ b/__tests__/import-export/unit/dataCollector.test.ts
@@ -128,11 +128,11 @@ describe("アーカイブデータ構造", () => {
   describe("ArchiveScoresData", () => {
     it("採点データが正しい形式で生成される", () => {
       const cropRegionId = generateId()
-      const studentId = generateId()
+      const examStudentId = generateId()
       const data = createArchiveScoresData([
         {
           cropRegionId,
-          studentId,
+          examStudentId,
           status: "correct",
           partialScore: "10",
         },
@@ -140,7 +140,7 @@ describe("アーカイブデータ構造", () => {
 
       expect(data.questionScores).toHaveLength(1)
       expect(data.questionScores[0].cropRegionId).toBe(cropRegionId)
-      expect(data.questionScores[0].studentId).toBe(studentId)
+      expect(data.questionScores[0].examStudentId).toBe(examStudentId)
       expect(data.questionScores[0].status).toBe("correct")
       expect(data.questionScores[0].partialScore).toBe("10")
       expect(data.drawingAnnotations).toEqual([])
@@ -150,7 +150,7 @@ describe("アーカイブデータ構造", () => {
       const data = createArchiveScoresData([
         {
           cropRegionId: generateId(),
-          studentId: generateId(),
+          examStudentId: generateId(),
           status: "unscored",
           partialScore: null,
         },
@@ -214,12 +214,12 @@ describe("データ整合性チェック", () => {
     const scores = createArchiveScoresData([
       {
         cropRegionId: generateId(),
-        studentId: generateId(),
+        examStudentId: generateId(),
         partialScore: "5.5",
       },
       {
         cropRegionId: generateId(),
-        studentId: generateId(),
+        examStudentId: generateId(),
         partialScore: null,
       },
     ])

--- a/__tests__/import-export/unit/examTransformerChain.test.ts
+++ b/__tests__/import-export/unit/examTransformerChain.test.ts
@@ -332,10 +332,10 @@ function createV1_15_0_ArchiveData(): ExamArchiveData {
   return raw as unknown as ExamArchiveData
 }
 
-/** 現行 (v1.19.0) 最小形状 */
+/** 現行 (v1.21.0) 最小形状 */
 function createCurrentArchiveData(): ExamArchiveData {
   const raw = {
-    manifest: createManifest("1.20.0"),
+    manifest: createManifest("1.21.0"),
     examData: {
       exam: {
         id: "exam-1",
@@ -374,14 +374,25 @@ function createCurrentArchiveData(): ExamArchiveData {
   return raw as unknown as ExamArchiveData
 }
 
+/**
+ * 旧形状（1.21.0 未満）の行を差し込む。`ExamArchiveData` は最新版の形しか表せないため、
+ * 旧キーの行は型の外から入れる（`Object.assign` で足りるので `as` は使わない）。
+ */
+const putLegacyRows = (
+  target: object,
+  rows: Record<string, unknown[]>
+): void => {
+  Object.assign(target, rows)
+}
+
 describe("transformExamArchiveToLatest", () => {
-  test("v1.0.0 実形状（project系キー）が全20変換を経て最新形式になる", () => {
+  test("v1.0.0 実形状（project系キー）が全21変換を経て最新形式になる", () => {
     const result = transformExamArchiveToLatest(createV1_0_0_ArchiveData())
 
     expect(result.originalVersion).toBe("1.0.0")
-    expect(result.finalVersion).toBe("1.20.0")
-    expect(result.appliedTransformations).toHaveLength(20)
-    expect(result.data.manifest.version).toBe("1.20.0")
+    expect(result.finalVersion).toBe("1.21.0")
+    expect(result.appliedTransformations).toHaveLength(21)
+    expect(result.data.manifest.version).toBe("1.21.0")
 
     const examData = result.data.examData
     const examDataRecord = examData as unknown as Record<string, unknown>
@@ -400,7 +411,7 @@ describe("transformExamArchiveToLatest", () => {
       expect.objectContaining({
         id: "img-2",
         examPageId: "page-1",
-        studentId: "student-1",
+        examStudentId: "examstudent-1",
       }),
     ])
 
@@ -441,7 +452,7 @@ describe("transformExamArchiveToLatest", () => {
     // final 採点行 → ScoreDecision 導出、scoredByUserId → userId
     expect(result.data.scoresData.scoreDecisions).toHaveLength(1)
     expect(result.data.scoresData.scoreDecisions![0]).toMatchObject({
-      studentId: "student-1",
+      examStudentId: "examstudent-1",
       cropRegionId: "region-1",
       verdict: "correct",
       decidedByUserId: "user-1",
@@ -472,6 +483,7 @@ describe("transformExamArchiveToLatest", () => {
       { from: "1.17.0", to: "1.18.0" },
       { from: "1.18.0", to: "1.19.0" },
       { from: "1.19.0", to: "1.20.0" },
+      { from: "1.20.0", to: "1.21.0" },
     ])
 
     const examData = result.data.examData
@@ -590,7 +602,7 @@ describe("transformExamArchiveToLatest", () => {
     ]
 
     const detection = detectExamArchiveVersion(data)
-    expect(detection.version).toBe("1.20.0")
+    expect(detection.version).toBe("1.21.0")
     expect(detection.corrections).toEqual([])
 
     const result = transformExamArchiveToLatest(data)
@@ -632,7 +644,7 @@ describe("transformExamArchiveToLatest", () => {
       expect.objectContaining({ id: "img-1", examPageId: "page-1" }),
     ])
     expect(result.data.examData.studentAnswerImages).toEqual([
-      expect.objectContaining({ id: "img-2", studentId: "student-1" }),
+      expect.objectContaining({ id: "img-2", examStudentId: "examstudent-1" }),
     ])
     expect(result.data.studentsData.students[0].studentNumber).toBe("1001")
   })
@@ -686,6 +698,7 @@ describe("transformExamArchiveToLatest", () => {
       { from: "1.17.0", to: "1.18.0" },
       { from: "1.18.0", to: "1.19.0" },
       { from: "1.19.0", to: "1.20.0" },
+      { from: "1.20.0", to: "1.21.0" },
     ])
     // キーごと落ちる（取り込み先が存在しないため）
     const transformedExamData = result.data.examData as unknown as Record<
@@ -699,13 +712,13 @@ describe("transformExamArchiveToLatest", () => {
     ).toBe(true)
   })
 
-  test("廃止済みキーを持たない v1.17.0 アーカイブは警告なしで 1.20.0 になる", () => {
+  test("廃止済みキーを持たない v1.17.0 アーカイブは警告なしで 1.21.0 になる", () => {
     const data = createCurrentArchiveData()
     data.manifest.version = "1.17.0"
 
     const result = transformExamArchiveToLatest(data)
 
-    expect(result.finalVersion).toBe("1.20.0")
+    expect(result.finalVersion).toBe("1.21.0")
     expect(result.warnings).toEqual([])
   })
 
@@ -732,6 +745,7 @@ describe("transformExamArchiveToLatest", () => {
     expect(result.appliedTransformations).toEqual([
       { from: "1.18.0", to: "1.19.0" },
       { from: "1.19.0", to: "1.20.0" },
+      { from: "1.20.0", to: "1.21.0" },
     ])
     // キーごと落ちる（アーカイブは正本であり復活防止をしないため）
     const transformedRecord = result.data as unknown as Record<string, unknown>
@@ -751,15 +765,152 @@ describe("transformExamArchiveToLatest", () => {
 
     expect(result.appliedTransformations).toEqual([
       { from: "1.19.0", to: "1.20.0" },
+      { from: "1.20.0", to: "1.21.0" },
     ])
     expect(result.data.scoresData.cropRegionAssignments).toEqual([])
+  })
+
+  test("1.20.0 → 1.21.0: 採点層が受験者（examStudentId）へ付け替わる", () => {
+    const data = createCurrentArchiveData()
+    data.manifest.version = "1.20.0"
+    putLegacyRows(data.examData, {
+      examStudents: [
+        {
+          id: "examstudent-1",
+          examId: "exam-1",
+          studentId: "student-1",
+          status: "participating",
+          customOrder: null,
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+      studentAnswerImages: [
+        {
+          id: "image-1",
+          examPageId: "page-1",
+          studentId: "student-1",
+          imagePath: "answer-sheets/1.png",
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+    })
+    putLegacyRows(data.scoresData, {
+      questionScores: [
+        {
+          id: "score-1",
+          cropRegionId: "region-1",
+          studentId: "student-1",
+          partialScore: null,
+          status: "correct",
+          userId: "user-1",
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+      returnSnapshots: [
+        {
+          id: "snapshot-1",
+          examId: "exam-1",
+          studentId: "student-1",
+          scoresJson: "{}",
+          totalScore: null,
+          capturedByUserId: null,
+          capturedAt: TIMESTAMP,
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+    })
+
+    const result = transformExamArchiveToLatest(data)
+
+    expect(result.appliedTransformations).toEqual([
+      { from: "1.20.0", to: "1.21.0" },
+    ])
+    expect(result.data.examData.studentAnswerImages).toEqual([
+      expect.objectContaining({
+        id: "image-1",
+        examStudentId: "examstudent-1",
+      }),
+    ])
+    expect(result.data.scoresData.questionScores).toEqual([
+      expect.objectContaining({
+        id: "score-1",
+        examStudentId: "examstudent-1",
+      }),
+    ])
+    // ReturnSnapshot の examId は ExamStudent から辿れるので落とす
+    const snapshot = result.data.scoresData.returnSnapshots![0]
+    expect(snapshot.examStudentId).toBe("examstudent-1")
+    expect("examId" in snapshot).toBe(false)
+  })
+
+  test("1.20.0 → 1.21.0: 受験者に居ない生徒の採点は破棄され、件数が警告に出る", () => {
+    const data = createCurrentArchiveData()
+    data.manifest.version = "1.20.0"
+    // examStudents は空 ＝ 受験者として登録されていない
+    putLegacyRows(data.examData, { examStudents: [] })
+    putLegacyRows(data.scoresData, {
+      questionScores: [
+        {
+          id: "score-orphan",
+          cropRegionId: "region-1",
+          studentId: "student-orphan",
+          partialScore: null,
+          status: "correct",
+          userId: "user-1",
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+      drawingAnnotations: [
+        {
+          id: "annot-orphan",
+          questionScoreId: "score-orphan",
+          type: "circle",
+          x: 1,
+          y: 1,
+          color: "#ef4444",
+          strokeWidth: 0.5,
+          width: 0,
+          height: 0,
+          endX: 0,
+          endY: 0,
+          lineStyle: "solid",
+          text: "",
+          fontSize: 4,
+          textBoxWidth: 0,
+          textBoxHeight: 0,
+          horizontalAlign: "left",
+          verticalAlign: "top",
+          anchorDirection: "top-left",
+          displayX: 0,
+          displayY: 0,
+          isFavorite: false,
+          userId: "user-1",
+          createdAt: TIMESTAMP,
+          updatedAt: TIMESTAMP,
+        },
+      ],
+    })
+
+    const result = transformExamArchiveToLatest(data)
+
+    expect(result.data.scoresData.questionScores).toEqual([])
+    // 親を失った注釈も道連れ
+    expect(result.data.scoresData.drawingAnnotations).toEqual([])
+    expect(
+      result.warnings.some((warning) => warning.includes("1 件を破棄"))
+    ).toBe(true)
   })
 
   test("現行形式は無変換で素通しされる", () => {
     const data = createCurrentArchiveData()
     const result = transformExamArchiveToLatest(data)
 
-    expect(result.originalVersion).toBe("1.20.0")
+    expect(result.originalVersion).toBe("1.21.0")
     expect(result.appliedTransformations).toEqual([])
     expect(result.warnings).toEqual([])
     expect(result.data).toBe(data)

--- a/__tests__/import-export/unit/scoresDataV1_13Conversion.test.ts
+++ b/__tests__/import-export/unit/scoresDataV1_13Conversion.test.ts
@@ -7,10 +7,15 @@
  */
 import { describe, expect, it } from "vitest"
 
+import type {
+  LegacyQuestionScore,
+  LegacyScoresData,
+} from "../../../electron-src/lib/import/transformers/shared/legacyStudentKeyedScores"
 import { convertScoresDataToV1_13 } from "../../../electron-src/lib/import/transformers/V1_12_0_to_V1_13_0"
 import type { ArchiveScoresData } from "../../../src/types/examArchive.types"
 
-type ArchiveQuestionScore = ArchiveScoresData["questionScores"][number]
+// この変換器が扱うのは 1.13.0 時点の形状（採点層はまだ studentId 直結）
+type ArchiveQuestionScore = LegacyQuestionScore
 type ArchiveAnnotation = ArchiveScoresData["drawingAnnotations"][number]
 
 let seq = 0
@@ -66,7 +71,7 @@ function annotation(questionScoreId: string): ArchiveAnnotation {
 function scoresData(
   questionScores: ArchiveQuestionScore[],
   drawingAnnotations: ArchiveAnnotation[] = []
-): ArchiveScoresData {
+): LegacyScoresData {
   return { questionScores, drawingAnnotations }
 }
 
@@ -162,7 +167,7 @@ describe("convertScoresDataToV1_13", () => {
   })
 
   it("v1.13.0形式（final/proposedなし・scoreDecisionsあり）には冪等", () => {
-    const data: ArchiveScoresData = {
+    const data: LegacyScoresData = {
       questionScores: [makeQuestionScore({ status: "correct" })],
       drawingAnnotations: [],
       scoreDecisions: [],

--- a/__tests__/migration/rewireScoringToExamStudent.test.ts
+++ b/__tests__/migration/rewireScoringToExamStudent.test.ts
@@ -1,0 +1,351 @@
+/**
+ * 20260728000000_rewire_scoring_to_exam_student のデータ移行テスト
+ *
+ * 検証すること:
+ * - 受験者（ExamStudent）に紐づく採点データが examStudentId へ正しく付け替わる
+ * - 受験者として登録されていない生徒の採点データ（孤児）は破棄される
+ * - 孤児 QuestionScore にぶら下がる手書き注釈も道連れになる
+ * - 破棄件数が AuditLog に記録される（0件のときは行を作らない）
+ *
+ * 手順は「本マイグレーションの1つ手前まで適用 → 旧形状のデータを投入 →
+ * 本マイグレーションだけを適用」。全マイグレーションを一括適用してしまうと
+ * 旧形状のデータを差し込む隙が無くなるため、ここだけ手で刻む。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "rewire-scoring-to-exam-student")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations")
+const TARGET_MIGRATION = "20260728000000_rewire_scoring_to_exam_student"
+
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const migrationNames = (): string[] =>
+  fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const applyMigration = (db: SqliteDatabase, name: string): void => {
+  db.exec(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf-8")
+  )
+}
+
+/** init ＋ 本マイグレーションの1つ手前までを適用した DB を用意する */
+async function buildDatabaseBeforeTargetMigration(): Promise<void> {
+  bootstrapSchema(DB_PATH)
+  const prisma = createPrismaClientForPath(DB_PATH)
+  try {
+    await createBaseline(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  const names = migrationNames()
+  const targetIndex = names.indexOf(TARGET_MIGRATION)
+  expect(targetIndex).toBeGreaterThan(0)
+
+  withDatabase((db) => {
+    for (const name of names.slice(0, targetIndex)) {
+      if (name === "20260322232329_init") continue
+      applyMigration(db, name)
+    }
+  })
+}
+
+const ISO = "2026-07-01T00:00:00.000+00:00"
+
+/**
+ * 旧形状（採点層が studentId 直結）のデータを投入する。
+ * 受験者として登録するのは student-kept のみ。student-orphan は
+ * 「試験から外されたのに採点だけ残った生徒」を表す。
+ */
+function seedLegacyData(db: SqliteDatabase): void {
+  const run = (sql: string, params: unknown[]) => db.prepare(sql).run(params)
+
+  run(
+    `INSERT INTO "User" (id, username, name, role, createdAt, updatedAt) VALUES (?,?,?,?,?,?)`,
+    ["user-1", "grader", "採点者", "teacher", ISO, ISO]
+  )
+  run(
+    `INSERT INTO "Exam" (id, examName, createdAt, updatedAt) VALUES (?,?,?,?)`,
+    ["exam-1", "移行テスト", ISO, ISO]
+  )
+  run(
+    `INSERT INTO "ExamPage" (id, examId, pageNumber, createdAt, updatedAt) VALUES (?,?,?,?,?)`,
+    ["page-1", "exam-1", 1, ISO, ISO]
+  )
+  run(
+    `INSERT INTO "CropRegion" (id, examPageId, label, type, x, y, width, height, points, orderIndex, createdAt, updatedAt)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      "region-1",
+      "page-1",
+      "問1",
+      "QUESTION_ANSWER",
+      0,
+      0,
+      10,
+      10,
+      10,
+      0,
+      ISO,
+      ISO,
+    ]
+  )
+  run(
+    `INSERT INTO "CompoundAnswer" (id, examPageId, label, answerFormat, correctAnswer, points, requireReduced, createdAt, updatedAt)
+     VALUES (?,?,?,?,?,?,?,?,?)`,
+    ["compound-1", "page-1", "アイ", "multi-digit", "42", 5, 0, ISO, ISO]
+  )
+
+  for (const [studentId, studentNumber] of [
+    ["student-kept", "S001"],
+    ["student-orphan", "S002"],
+  ]) {
+    run(
+      `INSERT INTO "Student" (id, studentNumber, lastName, firstName, lastNameKana, firstNameKana, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [studentId, studentNumber, "姓", "名", "セイ", "メイ", ISO, ISO]
+    )
+  }
+
+  // 受験者として登録されているのは student-kept だけ
+  run(
+    `INSERT INTO "ExamStudent" (id, examId, studentId, status, createdAt, updatedAt) VALUES (?,?,?,?,?,?)`,
+    ["examstudent-kept", "exam-1", "student-kept", "participating", ISO, ISO]
+  )
+
+  for (const studentId of ["student-kept", "student-orphan"]) {
+    run(
+      `INSERT INTO "StudentAnswerImage" (id, examPageId, studentId, imagePath, createdAt, updatedAt) VALUES (?,?,?,?,?,?)`,
+      [`image-${studentId}`, "page-1", studentId, `${studentId}.png`, ISO, ISO]
+    )
+    run(
+      `INSERT INTO "QuestionScore" (id, cropRegionId, studentId, partialScore, status, userId, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [
+        `score-${studentId}`,
+        "region-1",
+        studentId,
+        null,
+        "correct",
+        "user-1",
+        ISO,
+        ISO,
+      ]
+    )
+    run(
+      `INSERT INTO "DrawingAnnotation" (id, questionScoreId, type, x, y, userId, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [
+        `annot-${studentId}`,
+        `score-${studentId}`,
+        "circle",
+        1,
+        1,
+        "user-1",
+        ISO,
+        ISO,
+      ]
+    )
+    run(
+      `INSERT INTO "ScoreDecision" (id, cropRegionId, studentId, verdict, decidedByUserId, decidedAt, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [
+        `decision-${studentId}`,
+        "region-1",
+        studentId,
+        "correct",
+        "user-1",
+        ISO,
+        ISO,
+        ISO,
+      ]
+    )
+    run(
+      `INSERT INTO "CompoundAnswerScore" (id, compoundAnswerId, studentId, userId, status, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?)`,
+      [
+        `compound-score-${studentId}`,
+        "compound-1",
+        studentId,
+        "user-1",
+        "correct",
+        ISO,
+        ISO,
+      ]
+    )
+    run(
+      `INSERT INTO "ReturnSnapshot" (id, examId, studentId, scoresJson, capturedAt, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?)`,
+      [`snapshot-${studentId}`, "exam-1", studentId, "{}", ISO, ISO, ISO]
+    )
+  }
+}
+
+const idsOf = (db: SqliteDatabase, table: string): string[] =>
+  (
+    db.prepare(`SELECT id FROM "${table}" ORDER BY id`).all() as {
+      id: string
+    }[]
+  ).map((row) => row.id)
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("採点層の ExamStudent 経由への配線変更マイグレーション", () => {
+  it("受験者に紐づく行は付け替わり、孤児は破棄され、件数が監査ログに残る", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      // 受験者のある生徒の行だけが残り、examStudentId へ付け替わっている
+      expect(idsOf(db, "StudentAnswerImage")).toEqual(["image-student-kept"])
+      expect(idsOf(db, "QuestionScore")).toEqual(["score-student-kept"])
+      expect(idsOf(db, "ScoreDecision")).toEqual(["decision-student-kept"])
+      expect(idsOf(db, "CompoundAnswerScore")).toEqual([
+        "compound-score-student-kept",
+      ])
+      expect(idsOf(db, "ReturnSnapshot")).toEqual(["snapshot-student-kept"])
+
+      const score = db
+        .prepare(`SELECT examStudentId FROM "QuestionScore" WHERE id = ?`)
+        .get("score-student-kept") as { examStudentId: string }
+      expect(score.examStudentId).toBe("examstudent-kept")
+
+      // 孤児 QuestionScore の注釈も道連れ。残した方の注釈は生きている
+      expect(idsOf(db, "DrawingAnnotation")).toEqual(["annot-student-kept"])
+
+      // ReturnSnapshot の examId 列は落ちている（ExamStudent から辿れるため）
+      const columns = (
+        db.prepare(`PRAGMA table_info("ReturnSnapshot")`).all() as {
+          name: string
+        }[]
+      ).map((column) => column.name)
+      expect(columns).not.toContain("examId")
+      expect(columns).toContain("examStudentId")
+
+      // 破棄件数が監査ログに残る
+      const auditLogs = db
+        .prepare(
+          `SELECT summary, metadata FROM "AuditLog" WHERE action = 'system.migration.cleanup_orphaned_scores'`
+        )
+        .all() as { summary: string; metadata: string }[]
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0].summary).toContain("5 件")
+      expect(JSON.parse(auditLogs[0].metadata)).toEqual({
+        studentAnswerImage: 1,
+        questionScore: 1,
+        scoreDecision: 1,
+        compoundAnswerScore: 1,
+        returnSnapshot: 1,
+        drawingAnnotation: 1,
+      })
+    })
+  })
+
+  it("孤児が無ければ監査ログの行を作らない", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => {
+      seedLegacyData(db)
+      // 孤児の採点をあらかじめ全て取り除いておく
+      db.exec(
+        `DELETE FROM "StudentAnswerImage" WHERE studentId = 'student-orphan'`
+      )
+      db.exec(
+        `DELETE FROM "DrawingAnnotation" WHERE id = 'annot-student-orphan'`
+      )
+      db.exec(`DELETE FROM "QuestionScore" WHERE studentId = 'student-orphan'`)
+      db.exec(`DELETE FROM "ScoreDecision" WHERE studentId = 'student-orphan'`)
+      db.exec(
+        `DELETE FROM "CompoundAnswerScore" WHERE studentId = 'student-orphan'`
+      )
+      db.exec(`DELETE FROM "ReturnSnapshot" WHERE studentId = 'student-orphan'`)
+    })
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const count = db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM "AuditLog" WHERE action = 'system.migration.cleanup_orphaned_scores'`
+        )
+        .get() as { n: number }
+      expect(count.n).toBe(0)
+      expect(idsOf(db, "QuestionScore")).toEqual(["score-student-kept"])
+    })
+  })
+
+  it("差し替え後も子テーブルのFK参照名が正しい（RENAME TO の取り違え防止）", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const definitions = new Map(
+        (
+          db
+            .prepare(
+              `SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+            )
+            .all() as { name: string; sql: string }[]
+        ).map((row) => [row.name, row.sql])
+      )
+
+      // new_ 接頭辞の一時テーブルが残っていない
+      for (const name of definitions.keys()) {
+        expect(name.startsWith("new_")).toBe(false)
+      }
+
+      // 差し替えた5テーブルは ExamStudent を参照している
+      for (const table of [
+        "StudentAnswerImage",
+        "QuestionScore",
+        "ScoreDecision",
+        "CompoundAnswerScore",
+        "ReturnSnapshot",
+      ]) {
+        expect(definitions.get(table)).toContain('REFERENCES "ExamStudent"')
+      }
+
+      // 子の DrawingAnnotation は差し替え後の QuestionScore を指している
+      expect(definitions.get("DrawingAnnotation")).toContain(
+        'REFERENCES "QuestionScore"'
+      )
+      expect(definitions.get("DrawingAnnotation")).not.toContain("new_")
+
+      // 参照切れが無い
+      expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+    })
+  })
+})

--- a/__tests__/omr/unit/recognitionConsistency.test.ts
+++ b/__tests__/omr/unit/recognitionConsistency.test.ts
@@ -179,7 +179,7 @@ function reevaluate(
 ): OMRCellResult {
   const sheetResult: OMRSheetResult = {
     success: true,
-    studentId: "student-uuid",
+    examStudentId: "student-uuid",
     pageIndex: 0,
     markerDetection: {
       success: true,

--- a/__tests__/omr/unit/reevaluateResults.test.ts
+++ b/__tests__/omr/unit/reevaluateResults.test.ts
@@ -44,12 +44,12 @@ function measurement(
 
 /** 測定値の並びを1枚の答案の認識結果に仕立てる */
 function createSheet(
-  studentId: string,
+  examStudentId: string,
   cells: BubbleMeasurement[][]
 ): OMRSheetResult {
   return {
     success: true,
-    studentId,
+    examStudentId,
     pageIndex: 0,
     markerDetection: {
       success: true,
@@ -69,12 +69,12 @@ function createSheet(
 
 /** 4択のうち1つを塗った設問を questionCount 問ぶん並べた答案 */
 function createAnsweredSheet(
-  studentId: string,
+  examStudentId: string,
   questionCount: number,
   markedInk: Partial<Omit<EllipticalInkStats, "fillRatio">> = {}
 ): OMRSheetResult {
   return createSheet(
-    studentId,
+    examStudentId,
     Array.from({ length: questionCount }, () => [
       measurement(0, 0.02),
       measurement(1, 0.92, markedInk),

--- a/__tests__/renderer/hooks/scoring/helpers/mockDrawingAPI.ts
+++ b/__tests__/renderer/hooks/scoring/helpers/mockDrawingAPI.ts
@@ -80,7 +80,7 @@ export interface MockDrawingAPI {
   update: ReturnType<typeof vi.fn>
   delete: ReturnType<typeof vi.fn>
   getByQuestionScore: ReturnType<typeof vi.fn>
-  getByStudent: ReturnType<typeof vi.fn>
+  getByExamStudent: ReturnType<typeof vi.fn>
   getByExam: ReturnType<typeof vi.fn>
   getByCropRegion: ReturnType<typeof vi.fn>
   batchCreate: ReturnType<typeof vi.fn>
@@ -109,7 +109,7 @@ export function createMockDrawingAPI(): MockDrawingAPI {
       success: true,
       data: [],
     }),
-    getByStudent: vi.fn().mockResolvedValue({
+    getByExamStudent: vi.fn().mockResolvedValue({
       success: true,
       data: [],
     }),

--- a/__tests__/renderer/hooks/scoring/useAllStudentAnnotations.test.ts
+++ b/__tests__/renderer/hooks/scoring/useAllStudentAnnotations.test.ts
@@ -5,7 +5,7 @@
  * 透明度制御用の全設問アノテーション読み込みパターンを検証：
  *
  * [生徒切り替え]
- *   - currentStudentId変更 → getByStudentで全設問のアノテーション再取得
+ *   - currentExamStudentId変更 → getByExamStudentで全設問のアノテーション再取得
  *
  * [設問切り替え]
  *   - currentCropRegion変更（examIdが変わる場合） → 再取得
@@ -15,7 +15,7 @@
  *   - refreshKey変更 → 再取得（キャンバスでのアノテーション変更後）
  *
  * [データなし]
- *   - studentId/cropRegion未設定 → 空配列
+ *   - examStudentId/cropRegion未設定 → 空配列
  */
 
 import { act, renderHook, waitFor } from "@testing-library/react"
@@ -56,20 +56,20 @@ describe("useAllStudentAnnotations", () => {
     vi.restoreAllMocks()
   })
 
-  describe("currentStudentId変更（生徒切り替え）", () => {
+  describe("currentExamStudentId変更（生徒切り替え）", () => {
     it("生徒変更で全設問のアノテーションを再取得する", async () => {
       const annotations = [
         createMockAnnotation({ id: "a1", questionScoreId: "qs-1" }),
         createMockAnnotation({ id: "a2", questionScoreId: "qs-2" }),
       ]
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: annotations,
       })
 
       const { result } = renderHook(() =>
         useAllStudentAnnotations({
-          currentStudentId: "student-1",
+          currentExamStudentId: "student-1",
           currentCropRegion: makeCropRegion(),
           currentUserId: "user-1",
         })
@@ -79,35 +79,34 @@ describe("useAllStudentAnnotations", () => {
         expect(result.current.allStudentAnnotations).toHaveLength(2)
       })
 
-      expect(mockAPI.getByStudent).toHaveBeenCalledWith(
+      expect(mockAPI.getByExamStudent).toHaveBeenCalledWith(
         "student-1",
-        "exam-1",
         undefined,
         "user-1"
       )
     })
 
     it("生徒IDが変更されるとデータが再取得される", async () => {
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [createMockAnnotation({ id: "a1" })],
       })
 
       const { result, rerender } = renderHook(
-        ({ studentId }) =>
+        ({ examStudentId }) =>
           useAllStudentAnnotations({
-            currentStudentId: studentId,
+            currentExamStudentId: examStudentId,
             currentCropRegion: makeCropRegion(),
             currentUserId: "user-1",
           }),
-        { initialProps: { studentId: "student-1" } }
+        { initialProps: { examStudentId: "student-1" } }
       )
 
       await waitFor(() => {
         expect(result.current.allStudentAnnotations).toHaveLength(1)
       })
 
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [
           createMockAnnotation({ id: "b1" }),
@@ -116,7 +115,7 @@ describe("useAllStudentAnnotations", () => {
         ],
       })
 
-      rerender({ studentId: "student-2" })
+      rerender({ examStudentId: "student-2" })
 
       await waitFor(() => {
         expect(result.current.allStudentAnnotations).toHaveLength(3)
@@ -126,7 +125,7 @@ describe("useAllStudentAnnotations", () => {
 
   describe("currentCropRegion変更（設問切り替え）", () => {
     it("cropRegion.idが変わると再取得される", async () => {
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [createMockAnnotation({ id: "a1" })],
       })
@@ -134,7 +133,7 @@ describe("useAllStudentAnnotations", () => {
       const { rerender } = renderHook(
         ({ cropRegion }) =>
           useAllStudentAnnotations({
-            currentStudentId: "student-1",
+            currentExamStudentId: "student-1",
             currentCropRegion: cropRegion,
             currentUserId: "user-1",
           }),
@@ -142,22 +141,22 @@ describe("useAllStudentAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(mockAPI.getByStudent).toHaveBeenCalled()
+        expect(mockAPI.getByExamStudent).toHaveBeenCalled()
       })
 
-      const callCount = mockAPI.getByStudent.mock.calls.length
+      const callCount = mockAPI.getByExamStudent.mock.calls.length
 
       rerender({ cropRegion: makeCropRegion({ id: "cr-2", examId: "exam-1" }) })
 
       await waitFor(() => {
-        expect(mockAPI.getByStudent.mock.calls.length).toBeGreaterThan(
+        expect(mockAPI.getByExamStudent.mock.calls.length).toBeGreaterThan(
           callCount
         )
       })
     })
 
     it("examIdが変わると再取得される", async () => {
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [createMockAnnotation({ id: "a1" })],
       })
@@ -165,7 +164,7 @@ describe("useAllStudentAnnotations", () => {
       const { rerender } = renderHook(
         ({ cropRegion }) =>
           useAllStudentAnnotations({
-            currentStudentId: "student-1",
+            currentExamStudentId: "student-1",
             currentCropRegion: cropRegion,
             currentUserId: "user-1",
           }),
@@ -173,15 +172,15 @@ describe("useAllStudentAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(mockAPI.getByStudent).toHaveBeenCalled()
+        expect(mockAPI.getByExamStudent).toHaveBeenCalled()
       })
 
-      const callCount = mockAPI.getByStudent.mock.calls.length
+      const callCount = mockAPI.getByExamStudent.mock.calls.length
 
       rerender({ cropRegion: makeCropRegion({ examId: "exam-2" }) })
 
       await waitFor(() => {
-        expect(mockAPI.getByStudent.mock.calls.length).toBeGreaterThan(
+        expect(mockAPI.getByExamStudent.mock.calls.length).toBeGreaterThan(
           callCount
         )
       })
@@ -190,7 +189,7 @@ describe("useAllStudentAnnotations", () => {
 
   describe("refreshKey変更（アノテーション変更通知）", () => {
     it("refreshKey変更で再取得される", async () => {
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [createMockAnnotation({ id: "a1" })],
       })
@@ -198,7 +197,7 @@ describe("useAllStudentAnnotations", () => {
       const { result, rerender } = renderHook(
         ({ refreshKey }) =>
           useAllStudentAnnotations({
-            currentStudentId: "student-1",
+            currentExamStudentId: "student-1",
             currentCropRegion: makeCropRegion(),
             currentUserId: "user-1",
             refreshKey,
@@ -210,7 +209,7 @@ describe("useAllStudentAnnotations", () => {
         expect(result.current.allStudentAnnotations).toHaveLength(1)
       })
 
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: true,
         data: [
           createMockAnnotation({ id: "a1" }),
@@ -227,10 +226,10 @@ describe("useAllStudentAnnotations", () => {
   })
 
   describe("パラメータ未設定", () => {
-    it("studentId未設定で空配列を返す", async () => {
+    it("examStudentId未設定で空配列を返す", async () => {
       const { result } = renderHook(() =>
         useAllStudentAnnotations({
-          currentStudentId: undefined,
+          currentExamStudentId: undefined,
           currentCropRegion: makeCropRegion(),
           currentUserId: "user-1",
         })
@@ -241,13 +240,13 @@ describe("useAllStudentAnnotations", () => {
       })
 
       expect(result.current.allStudentAnnotations).toHaveLength(0)
-      expect(mockAPI.getByStudent).not.toHaveBeenCalled()
+      expect(mockAPI.getByExamStudent).not.toHaveBeenCalled()
     })
 
     it("cropRegion未設定で空配列を返す", async () => {
       const { result } = renderHook(() =>
         useAllStudentAnnotations({
-          currentStudentId: "student-1",
+          currentExamStudentId: "student-1",
           currentCropRegion: null,
           currentUserId: "user-1",
         })
@@ -258,27 +257,27 @@ describe("useAllStudentAnnotations", () => {
       })
 
       expect(result.current.allStudentAnnotations).toHaveLength(0)
-      expect(mockAPI.getByStudent).not.toHaveBeenCalled()
+      expect(mockAPI.getByExamStudent).not.toHaveBeenCalled()
     })
   })
 
   describe("API失敗時", () => {
     it("失敗時に空配列を返す", async () => {
-      mockAPI.getByStudent.mockResolvedValue({
+      mockAPI.getByExamStudent.mockResolvedValue({
         success: false,
         error: "取得エラー",
       })
 
       const { result } = renderHook(() =>
         useAllStudentAnnotations({
-          currentStudentId: "student-1",
+          currentExamStudentId: "student-1",
           currentCropRegion: makeCropRegion(),
           currentUserId: "user-1",
         })
       )
 
       await waitFor(() => {
-        expect(mockAPI.getByStudent).toHaveBeenCalled()
+        expect(mockAPI.getByExamStudent).toHaveBeenCalled()
       })
 
       expect(result.current.allStudentAnnotations).toHaveLength(0)

--- a/__tests__/renderer/hooks/scoring/useAnnotationBrowser.test.ts
+++ b/__tests__/renderer/hooks/scoring/useAnnotationBrowser.test.ts
@@ -8,7 +8,7 @@
  *   - loadAnnotations(examId) → getForBrowseで試験全体のアノテーション取得
  *
  * [フィルタ変更]
- *   - cropRegionId / studentId / type / favoritesOnlyフィルタ → displayItemsの再計算
+ *   - cropRegionId / examStudentId / type / favoritesOnlyフィルタ → displayItemsの再計算
  *
  * [重複グルーピング]
  *   - 同一プロパティのアノテーションをグループ化して表示（count + representative）
@@ -49,7 +49,7 @@ function createMockAnnotationWithContext(
     ...base,
     questionScore: {
       id: "qs-1",
-      studentId: "student-1",
+      examStudentId: "student-1",
       cropRegionId: "cr-1",
       cropRegion: { id: "cr-1", label: "問1" },
       student: {
@@ -138,7 +138,7 @@ describe("useAnnotationBrowser", () => {
             id: "a1",
             questionScore: {
               id: "qs-1",
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-1",
               cropRegion: { id: "cr-1", label: "問1" },
             },
@@ -147,7 +147,7 @@ describe("useAnnotationBrowser", () => {
             id: "a2",
             questionScore: {
               id: "qs-2",
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-2",
               cropRegion: { id: "cr-2", label: "問2" },
             },

--- a/__tests__/renderer/hooks/scoring/useGridAnnotations.test.ts
+++ b/__tests__/renderer/hooks/scoring/useGridAnnotations.test.ts
@@ -13,8 +13,8 @@
  * [データなし]
  *   - cropRegionId未指定 → 空のMapを返す
  *
- * [studentIdグループ化]
- *   - 取得結果をstudentIdでグループ化してMapに格納
+ * [examStudentIdグループ化]
+ *   - 取得結果をexamStudentIdでグループ化してMapに格納
  */
 
 import { renderHook, waitFor } from "@testing-library/react"
@@ -42,19 +42,31 @@ describe("useGridAnnotations", () => {
   })
 
   describe("cropRegionId変更（設問切り替え）", () => {
-    it("cropRegionId指定で全学生のアノテーションを取得しstudentIdでグループ化する", async () => {
+    it("cropRegionId指定で全受験者のアノテーションを取得しexamStudentIdでグループ化する", async () => {
       const annotations = [
         {
           ...createMockAnnotation({ id: "a1" }),
-          questionScore: { studentId: "s1", cropRegionId: "cr-1", id: "qs-1" },
+          questionScore: {
+            examStudentId: "s1",
+            cropRegionId: "cr-1",
+            id: "qs-1",
+          },
         },
         {
           ...createMockAnnotation({ id: "a2" }),
-          questionScore: { studentId: "s1", cropRegionId: "cr-1", id: "qs-2" },
+          questionScore: {
+            examStudentId: "s1",
+            cropRegionId: "cr-1",
+            id: "qs-2",
+          },
         },
         {
           ...createMockAnnotation({ id: "a3" }),
-          questionScore: { studentId: "s2", cropRegionId: "cr-1", id: "qs-3" },
+          questionScore: {
+            examStudentId: "s2",
+            cropRegionId: "cr-1",
+            id: "qs-3",
+          },
         },
       ]
       mockAPI.getByCropRegion.mockResolvedValue({
@@ -70,11 +82,11 @@ describe("useGridAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.size).toBe(2)
+        expect(result.current.annotationsByExamStudent.size).toBe(2)
       })
 
-      expect(result.current.annotationsByStudent.get("s1")).toHaveLength(2)
-      expect(result.current.annotationsByStudent.get("s2")).toHaveLength(1)
+      expect(result.current.annotationsByExamStudent.get("s1")).toHaveLength(2)
+      expect(result.current.annotationsByExamStudent.get("s2")).toHaveLength(1)
     })
 
     it("cropRegionIdが変更されると新しいデータを取得する", async () => {
@@ -84,7 +96,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "a1" }),
             questionScore: {
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-1",
               id: "qs-1",
             },
@@ -99,7 +111,7 @@ describe("useGridAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.size).toBe(1)
+        expect(result.current.annotationsByExamStudent.size).toBe(1)
       })
 
       mockAPI.getByCropRegion.mockResolvedValue({
@@ -108,7 +120,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "b1" }),
             questionScore: {
-              studentId: "s2",
+              examStudentId: "s2",
               cropRegionId: "cr-2",
               id: "qs-4",
             },
@@ -116,7 +128,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "b2" }),
             questionScore: {
-              studentId: "s3",
+              examStudentId: "s3",
               cropRegionId: "cr-2",
               id: "qs-5",
             },
@@ -127,11 +139,11 @@ describe("useGridAnnotations", () => {
       rerender({ cropRegionId: "cr-2" })
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.size).toBe(2)
+        expect(result.current.annotationsByExamStudent.size).toBe(2)
       })
 
-      expect(result.current.annotationsByStudent.has("s2")).toBe(true)
-      expect(result.current.annotationsByStudent.has("s3")).toBe(true)
+      expect(result.current.annotationsByExamStudent.has("s2")).toBe(true)
+      expect(result.current.annotationsByExamStudent.has("s3")).toBe(true)
     })
   })
 
@@ -144,7 +156,7 @@ describe("useGridAnnotations", () => {
         })
       )
 
-      expect(result.current.annotationsByStudent.size).toBe(0)
+      expect(result.current.annotationsByExamStudent.size).toBe(0)
       expect(mockAPI.getByCropRegion).not.toHaveBeenCalled()
     })
   })
@@ -157,7 +169,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "a1" }),
             questionScore: {
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-1",
               id: "qs-1",
             },
@@ -176,7 +188,7 @@ describe("useGridAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.size).toBe(1)
+        expect(result.current.annotationsByExamStudent.size).toBe(1)
       })
 
       mockAPI.getByCropRegion.mockResolvedValue({
@@ -185,7 +197,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "a1" }),
             questionScore: {
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-1",
               id: "qs-1",
             },
@@ -193,7 +205,7 @@ describe("useGridAnnotations", () => {
           {
             ...createMockAnnotation({ id: "a2" }),
             questionScore: {
-              studentId: "s1",
+              examStudentId: "s1",
               cropRegionId: "cr-1",
               id: "qs-2",
             },
@@ -204,7 +216,9 @@ describe("useGridAnnotations", () => {
       rerender({ refreshKey: 1 })
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.get("s1")).toHaveLength(2)
+        expect(result.current.annotationsByExamStudent.get("s1")).toHaveLength(
+          2
+        )
       })
     })
   })
@@ -224,7 +238,7 @@ describe("useGridAnnotations", () => {
       )
 
       await waitFor(() => {
-        expect(result.current.annotationsByStudent.size).toBe(0)
+        expect(result.current.annotationsByExamStudent.size).toBe(0)
       })
     })
   })

--- a/__tests__/renderer/hooks/useTableDataGeneration.test.ts
+++ b/__tests__/renderer/hooks/useTableDataGeneration.test.ts
@@ -3,7 +3,7 @@
  * 06-student-answers 答案テーブルの行生成（useTableDataGeneration）の検証。
  *
  * 守りたい不変条件は「行の生徒とマスのページが、そのマスに置かれた答案の
- * 書き込み先（studentId / examPageId）と必ず一致すること」。
+ * 書き込み先（examStudentId / examPageId）と必ず一致すること」。
  * ここがずれると別の生徒の答案として保存されるため、表示ではなく保存の正しさに直結する。
  * 行は ExamStudent 実体、マスは ExamPage 実体を同梱して返るので、添字の一致に依存しない。
  */
@@ -24,7 +24,9 @@ import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 const EXAM_ID = "eeeeeeee-0000-4000-8000-000000000000"
 const EPOCH = new Date("2026-01-01T00:00:00.000Z")
 
+const EXAM_STUDENT_A = "es-a"
 const STUDENT_A = "11111111-1111-4111-8111-111111111111"
+const EXAM_STUDENT_B = "es-b"
 const STUDENT_B = "22222222-2222-4222-8222-222222222222"
 const PAGE_1 = "aaaaaaaa-0001-4001-8001-000000000001"
 const PAGE_2 = "aaaaaaaa-0002-4002-8002-000000000002"
@@ -43,6 +45,7 @@ function makeExamStudent(
     customOrder,
     createdAt: EPOCH,
     updatedAt: EPOCH,
+    _count: { studentAnswerImages: 0 },
     student: {
       id: studentId,
       studentNumber,
@@ -54,7 +57,6 @@ function makeExamStudent(
       createdAt: EPOCH,
       updatedAt: EPOCH,
       memberships: [],
-      _count: { studentAnswerImages: 0 },
     },
   }
 }
@@ -62,7 +64,7 @@ function makeExamStudent(
 function makeUnsavedAnswer(id: string): UnsavedAnswerImage {
   return {
     id,
-    studentId: null,
+    examStudentId: null,
     examPageId: null,
     imagePath: null,
     buffer: new ArrayBuffer(1),
@@ -75,16 +77,23 @@ function makeUnsavedAnswer(id: string): UnsavedAnswerImage {
 
 function makePlacedAnswer(
   id: string,
-  studentId: string | null,
+  examStudentId: string | null,
   examPageId: string | null
 ): UnsavedAnswerImage {
-  return { ...makeUnsavedAnswer(id), studentId, examPageId }
+  return { ...makeUnsavedAnswer(id), examStudentId, examPageId }
 }
 
 /** 指定マスだけ「既存答案あり」とするルックアップ */
-function existingAnswerAt(studentId: string, examPageId: string): CellLookup {
+function existingAnswerAt(
+  examStudentId: string,
+  examPageId: string
+): CellLookup {
   const lookup: CellLookup = new Map()
-  addCellToLookup(lookup, studentId, examPageId)
+  addCellToLookup(
+    lookup,
+    { id: examStudentId, studentId: `student-of-${examStudentId}` },
+    { id: examPageId, pageNumber: 1 }
+  )
   return lookup
 }
 
@@ -109,7 +118,7 @@ function summarize(
   >["tableRows"]
 ) {
   return tableRows.map((row) => ({
-    studentId: row.examStudent.studentId,
+    examStudentId: row.examStudent.id,
     cells: row.cells.map((cell) => ({
       examPageId: cell.examPage.id,
       type: cell.type,
@@ -121,8 +130,8 @@ function summarize(
 describe("useTableDataGeneration", () => {
   // 生徒の並びは customOrder 順（B が先）。行の実体がその並びに追随することを見る。
   const sortedStudents = [
-    makeExamStudent("es-b", STUDENT_B, "002", 1),
-    makeExamStudent("es-a", STUDENT_A, "001", 2),
+    makeExamStudent(EXAM_STUDENT_B, STUDENT_B, "002", 1),
+    makeExamStudent(EXAM_STUDENT_A, STUDENT_A, "001", 2),
   ]
 
   it("upload: 自動配置された答案は、その行の生徒とマスのページに対応する", () => {
@@ -144,14 +153,14 @@ describe("useTableDataGeneration", () => {
     // student-first なので先頭生徒（customOrder 1 の B）の p1・p2 から順に埋まる
     expect(summarize(result.current.tableRows)).toEqual([
       {
-        studentId: STUDENT_B,
+        examStudentId: EXAM_STUDENT_B,
         cells: [
           { examPageId: PAGE_1, type: "file", fileId: "f1" },
           { examPageId: PAGE_2, type: "file", fileId: "f2" },
         ],
       },
       {
-        studentId: STUDENT_A,
+        examStudentId: EXAM_STUDENT_A,
         cells: [
           { examPageId: PAGE_1, type: "empty", fileId: null },
           { examPageId: PAGE_2, type: "empty", fileId: null },
@@ -177,13 +186,13 @@ describe("useTableDataGeneration", () => {
     )
 
     const rows = summarize(result.current.tableRows)
-    expect(rows[0].studentId).toBe(STUDENT_B)
+    expect(rows[0].examStudentId).toBe(EXAM_STUDENT_B)
     expect(rows[0].cells[0]).toEqual({
       examPageId: PAGE_1,
       type: "file",
       fileId: "f1",
     })
-    expect(rows[1].studentId).toBe(STUDENT_A)
+    expect(rows[1].examStudentId).toBe(EXAM_STUDENT_A)
     expect(rows[1].cells[0]).toEqual({
       examPageId: PAGE_1,
       type: "file",
@@ -191,10 +200,10 @@ describe("useTableDataGeneration", () => {
     })
   })
 
-  it("view: 答案は自身の (studentId, examPageId) のマスに載る", () => {
+  it("view: 答案は自身の (examStudentId, examPageId) のマスに載る", () => {
     const files = [
-      makePlacedAnswer("f1", STUDENT_A, PAGE_2),
-      makePlacedAnswer("f2", STUDENT_B, PAGE_1),
+      makePlacedAnswer("f1", EXAM_STUDENT_A, PAGE_2),
+      makePlacedAnswer("f2", EXAM_STUDENT_B, PAGE_1),
     ]
 
     const { result } = renderHook(() =>
@@ -213,14 +222,14 @@ describe("useTableDataGeneration", () => {
     expect(result.current.orphanItems).toHaveLength(0)
     expect(summarize(result.current.tableRows)).toEqual([
       {
-        studentId: STUDENT_B,
+        examStudentId: EXAM_STUDENT_B,
         cells: [
           { examPageId: PAGE_1, type: "file", fileId: "f2" },
           { examPageId: PAGE_2, type: "disabled", fileId: null },
         ],
       },
       {
-        studentId: STUDENT_A,
+        examStudentId: EXAM_STUDENT_A,
         cells: [
           { examPageId: PAGE_1, type: "disabled", fileId: null },
           { examPageId: PAGE_2, type: "file", fileId: "f1" },
@@ -234,7 +243,7 @@ describe("useTableDataGeneration", () => {
     const removedPage = "aaaaaaaa-0009-4009-8009-000000000009"
     const files = [
       makePlacedAnswer("f1", withdrawn, PAGE_1),
-      makePlacedAnswer("f2", STUDENT_A, removedPage),
+      makePlacedAnswer("f2", EXAM_STUDENT_A, removedPage),
     ]
 
     const { result } = renderHook(() =>
@@ -322,7 +331,7 @@ describe("useTableDataGeneration", () => {
         enhancedIsCellDisabled: () => false,
         allowOverwrite: false,
         // 先頭マス（生徒B・p1）は既に DB 答案が居る
-        cellsWithExistingAnswers: existingAnswerAt(STUDENT_B, PAGE_1),
+        cellsWithExistingAnswers: existingAnswerAt(EXAM_STUDENT_B, PAGE_1),
       })
     )
 

--- a/__tests__/renderer/utils/dragDropUtils.test.ts
+++ b/__tests__/renderer/utils/dragDropUtils.test.ts
@@ -22,10 +22,10 @@ import type { AnswerImageIdentity } from "@/components/exams/06-student-answers/
 
 function makeFile(
   id: string,
-  studentId: string | null,
+  examStudentId: string | null,
   examPageId: string | null
 ): AnswerImageIdentity {
-  return { id, studentId, examPageId }
+  return { id, examStudentId, examPageId }
 }
 
 const STUDENT_A = "11111111-1111-4111-8111-111111111111"
@@ -34,12 +34,19 @@ const PAGE_1 = "aaaaaaaa-0001-4001-8001-000000000001"
 const PAGE_2 = "aaaaaaaa-0002-4002-8002-000000000002"
 const PAGE_3 = "aaaaaaaa-0003-4003-8003-000000000003"
 
+/**
+ * セルの行・列は実体で渡す（id を呼び出し側で選ばない＝本番と同じ呼び方）。
+ * 行は studentId、列は pageNumber を必須にしてあるので、転置するとコンパイルが通らない。
+ */
+const row = (id: string) => ({ id, studentId: `student-of-${id}` })
+const column = (id: string, pageNumber = 1) => ({ id, pageNumber })
+
 describe("encodeCellDroppableId / decodeCellDroppableId", () => {
   it("エンコードとデコードが往復で一致する", () => {
-    const encoded = encodeCellDroppableId(STUDENT_A, PAGE_1)
+    const encoded = encodeCellDroppableId(row(STUDENT_A), column(PAGE_1))
     expect(encoded).toBe(`cell:${STUDENT_A}:${PAGE_1}`)
     expect(decodeCellDroppableId(encoded)).toEqual({
-      studentId: STUDENT_A,
+      examStudentId: STUDENT_A,
       examPageId: PAGE_1,
     })
   })
@@ -58,13 +65,13 @@ describe("applyCellMoveOrSwap", () => {
   it("空セルへの移動: ドラッグした答案の座標だけが更新される", () => {
     const files = [makeFile("f1", STUDENT_A, PAGE_1)]
     const result = applyCellMoveOrSwap(files, "f1", {
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_2,
     })
 
     expect(result).not.toBe(files)
     expect(result.find((file) => file.id === "f1")).toMatchObject({
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_2,
     })
   })
@@ -76,16 +83,16 @@ describe("applyCellMoveOrSwap", () => {
     ]
     // f1 を studentB, page1（f2 の居場所）へ → swap
     const result = applyCellMoveOrSwap(files, "f1", {
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_1,
     })
 
     expect(result.find((file) => file.id === "f1")).toMatchObject({
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_1,
     })
     expect(result.find((file) => file.id === "f2")).toMatchObject({
-      studentId: STUDENT_A,
+      examStudentId: STUDENT_A,
       examPageId: PAGE_1,
     })
   })
@@ -96,16 +103,16 @@ describe("applyCellMoveOrSwap", () => {
       makeFile("f2", STUDENT_B, PAGE_2),
     ]
     const result = applyCellMoveOrSwap(files, "f1", {
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_2,
     })
 
     expect(result.find((file) => file.id === "f1")).toMatchObject({
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_2,
     })
     expect(result.find((file) => file.id === "f2")).toMatchObject({
-      studentId: STUDENT_A,
+      examStudentId: STUDENT_A,
       examPageId: PAGE_1,
     })
   })
@@ -113,7 +120,7 @@ describe("applyCellMoveOrSwap", () => {
   it("同一セルへのドロップは変更なし（同じ配列参照を返す）", () => {
     const files = [makeFile("f1", STUDENT_A, PAGE_1)]
     const result = applyCellMoveOrSwap(files, "f1", {
-      studentId: STUDENT_A,
+      examStudentId: STUDENT_A,
       examPageId: PAGE_1,
     })
     expect(result).toBe(files)
@@ -122,7 +129,7 @@ describe("applyCellMoveOrSwap", () => {
   it("存在しない activeFileId は変更なし", () => {
     const files = [makeFile("f1", STUDENT_A, PAGE_1)]
     const result = applyCellMoveOrSwap(files, "missing", {
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_2,
     })
     expect(result).toBe(files)
@@ -138,7 +145,7 @@ describe("applyCellMoveOrSwap", () => {
     const result = applyCellMoveOrSwap(
       files,
       "orphan",
-      { studentId: STUDENT_A, examPageId: PAGE_1 },
+      { examStudentId: STUDENT_A, examPageId: PAGE_1 },
       new Set(["orphan", "valid"]),
       false // isSourcePlaceable
     )
@@ -151,13 +158,13 @@ describe("applyCellMoveOrSwap", () => {
     const result = applyCellMoveOrSwap(
       files,
       "orphan",
-      { studentId: STUDENT_A, examPageId: PAGE_2 },
+      { examStudentId: STUDENT_A, examPageId: PAGE_2 },
       new Set(["orphan"]),
       false
     )
     expect(result).not.toBe(files)
     expect(result.find((file) => file.id === "orphan")).toMatchObject({
-      studentId: STUDENT_A,
+      examStudentId: STUDENT_A,
       examPageId: PAGE_2,
     })
   })
@@ -171,16 +178,16 @@ describe("applyCellMoveOrSwap", () => {
     const result = applyCellMoveOrSwap(
       files,
       "f1",
-      { studentId: STUDENT_B, examPageId: PAGE_1 },
+      { examStudentId: STUDENT_B, examPageId: PAGE_1 },
       new Set(["f1"]) // f2 は対象外
     )
     expect(result.find((file) => file.id === "f1")).toMatchObject({
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_1,
     })
     // f2 は動かない（隠れて座標を書き換えられない）
     expect(result.find((file) => file.id === "f2")).toMatchObject({
-      studentId: STUDENT_B,
+      examStudentId: STUDENT_B,
       examPageId: PAGE_1,
     })
   })
@@ -188,8 +195,8 @@ describe("applyCellMoveOrSwap", () => {
 
 describe("diffFilesAgainstBaseline", () => {
   const baseline = [
-    { id: "f1", studentId: STUDENT_A, examPageId: PAGE_1 },
-    { id: "f2", studentId: STUDENT_B, examPageId: PAGE_1 },
+    { id: "f1", examStudentId: STUDENT_A, examPageId: PAGE_1 },
+    { id: "f2", examStudentId: STUDENT_B, examPageId: PAGE_1 },
   ]
 
   it("DB 基準から座標が変わったファイルだけを from(DB)/to(現在) で返す", () => {
@@ -203,8 +210,8 @@ describe("diffFilesAgainstBaseline", () => {
     expect(diff).toHaveLength(1)
     expect(diff[0]).toMatchObject({
       fileId: "f1",
-      fromState: { studentId: STUDENT_A, examPageId: PAGE_1 },
-      toState: { studentId: STUDENT_B, examPageId: PAGE_2 },
+      fromState: { examStudentId: STUDENT_A, examPageId: PAGE_1 },
+      toState: { examStudentId: STUDENT_B, examPageId: PAGE_2 },
     })
   })
 
@@ -234,8 +241,8 @@ describe("diffFilesAgainstBaseline", () => {
 })
 
 describe("partitionAnswerItemsByPlacement（孤立答案 [4]/[5]）", () => {
-  const roster = [STUDENT_A, STUDENT_B]
-  const examPageIds = [PAGE_1, PAGE_2]
+  const roster = [row(STUDENT_A), row(STUDENT_B)]
+  const examPageIds = [column(PAGE_1), column(PAGE_2)]
 
   it("ロスター内かつ列にある examPageId の答案はマスに配置される", () => {
     const items = [
@@ -248,12 +255,16 @@ describe("partitionAnswerItemsByPlacement（孤立答案 [4]/[5]）", () => {
       examPageIds
     )
     expect(orphans).toHaveLength(0)
-    // 配置は (studentId, examPageId) で引く（序数キーではない）
-    expect(getCellValue(placedByCell, STUDENT_A, PAGE_1)?.id).toBe("f1")
-    expect(getCellValue(placedByCell, STUDENT_B, PAGE_2)?.id).toBe("f2")
+    // 配置は (examStudentId, examPageId) で引く（序数キーではない）
+    expect(getCellValue(placedByCell, row(STUDENT_A), column(PAGE_1))?.id).toBe(
+      "f1"
+    )
+    expect(getCellValue(placedByCell, row(STUDENT_B), column(PAGE_2))?.id).toBe(
+      "f2"
+    )
   })
 
-  it("[4] studentId が現ロスターに無い答案（除籍）は孤立答案になる", () => {
+  it("[4] examStudentId が現ロスターに無い答案（除籍）は孤立答案になる", () => {
     const withdrawn = "99999999-9999-4999-8999-999999999999"
     const items = [makeFile("f1", withdrawn, PAGE_1)]
     const { placedByCell, orphans } = partitionAnswerItemsByPlacement(
@@ -276,7 +287,7 @@ describe("partitionAnswerItemsByPlacement（孤立答案 [4]/[5]）", () => {
     expect(orphans.map((item) => item.id)).toEqual(["f1"])
   })
 
-  it("studentId 未設定の答案も孤立答案になる", () => {
+  it("examStudentId 未設定の答案も孤立答案になる", () => {
     const items = [makeFile("f1", null, PAGE_1)]
     const { orphans } = partitionAnswerItemsByPlacement(
       items,

--- a/__tests__/renderer/utils/examStatusProgress.test.ts
+++ b/__tests__/renderer/utils/examStatusProgress.test.ts
@@ -1,0 +1,83 @@
+/**
+ * 試験一覧の進捗計算が「受験者ID」で答案・採点を突き合わせることの固定。
+ *
+ * 採点層を ExamStudent 経由へ配線変更した際、main 側 `getExamsForList` の
+ * `select` が examStudents の主キー（id）を落としたままだったため、
+ * participatingExamStudentIds が [undefined, ...] になり、答案枚数も採点件数も
+ * 常に 0 になっていた。IPC ハンドラは `(...args: any[]) => any` で型検査が効かず、
+ * 一覧が「全試験が未着手」に見えるまで誰も気付けない。
+ *
+ * ここでは計算関数そのものに「受験者IDで突き合わせる」ことを固定し、
+ * Student.id を渡すと 0 になることも併せて示す（取り違えの再発検知）。
+ */
+import { describe, expect, it } from "vitest"
+
+import { getExamProgress } from "@/lib/examStatus"
+
+const EXAM_STUDENT_A = "es-a"
+const EXAM_STUDENT_B = "es-b"
+
+/** 1ページ・1設問・受験者2名。答案は2枚、採点は1件だけ入っている */
+function buildExam(examStudents: { id: string; status: string }[]) {
+  return {
+    examPages: [{ id: "page-1" }],
+    answerImages: [
+      { examStudentId: EXAM_STUDENT_A },
+      { examStudentId: EXAM_STUDENT_B },
+    ],
+    cropRegions: [
+      {
+        type: "QUESTION_ANSWER",
+        questionScores: [
+          {
+            examStudentId: EXAM_STUDENT_A,
+            status: "correct",
+            partialScore: null,
+          },
+        ],
+      },
+    ],
+    examStudents,
+    examSubtotalGroups: [],
+  }
+}
+
+describe("getExamProgress の受験者スコープ", () => {
+  it("受験者IDで答案・採点を突き合わせる", () => {
+    const progress = getExamProgress(
+      buildExam([
+        { id: EXAM_STUDENT_A, status: "participating" },
+        { id: EXAM_STUDENT_B, status: "participating" },
+      ])
+    )
+
+    expect(progress.answerSheetCount).toBe(2)
+    // 受験者2名 × 設問1 = 2 マスのうち 1 マスが採点済み
+    expect(progress.expectedScoringCount).toBe(2)
+    expect(progress.actualScoringCount).toBe(1)
+  })
+
+  it("欠席者は分母から外れる", () => {
+    const progress = getExamProgress(
+      buildExam([
+        { id: EXAM_STUDENT_A, status: "participating" },
+        { id: EXAM_STUDENT_B, status: "absent" },
+      ])
+    )
+
+    expect(progress.answerSheetCount).toBe(1)
+  })
+
+  it("受験者IDでない値を渡すと何も突き合わない（取り違えの検知）", () => {
+    const progress = getExamProgress(
+      buildExam([
+        { id: "student-a", status: "participating" },
+        { id: "student-b", status: "participating" },
+      ])
+    )
+
+    expect(progress.answerSheetCount).toBe(0)
+    expect(progress.expectedScoringCount).toBe(0)
+    expect(progress.actualScoringCount).toBe(0)
+  })
+})

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -505,9 +505,10 @@ export async function seedExamWithScoring(
     allScores.push(generateStudentScores(i, REGION_DEFINITIONS))
   }
 
+  const examStudentIds: string[] = []
   for (let i = 0; i < studentIds.length; i++) {
     const studentId = studentIds[i]
-    await db.examStudent.create({
+    const examStudent = await db.examStudent.create({
       data: {
         id: randomUUID(),
         examId,
@@ -516,6 +517,7 @@ export async function seedExamWithScoring(
         customOrder: i + 1,
       },
     })
+    examStudentIds.push(examStudent.id)
     // 手書き風の解答をオーバーレイした答案画像を生成
     await generateStudentAnswerImage(
       answerDir,
@@ -533,7 +535,7 @@ export async function seedExamWithScoring(
       data: {
         id: randomUUID(),
         examPageId: examPage.id,
-        studentId,
+        examStudentId: examStudent.id,
         imagePath: relAnswerPath,
       },
     })
@@ -547,7 +549,7 @@ export async function seedExamWithScoring(
         data: {
           id: randomUUID(),
           cropRegionId: cropRegionIds[scoreEntry.regionIndex],
-          studentId: studentIds[i],
+          examStudentId: examStudentIds[i],
           partialScore: scoreEntry.score,
           status: scoreEntry.status,
           userId,

--- a/docs/membership-key-rewiring-plan.md
+++ b/docs/membership-key-rewiring-plan.md
@@ -1,0 +1,389 @@
+# メンバーシップ経由への配線変更 実装計画（#962）
+
+## 1. 背景
+
+グリッドのセルは概念的に「その試験の受験者 × 設問」であり、DB もそう表現すべきである。しかし現在は
+`QuestionScore.studentId` のように **Student へ直結**しており、`ExamStudent` を経由しない。
+
+調査の結果、これは #962 が指摘した `StudentAnswerImage` 単独の問題ではなく、**3 つのサブシステムに共通する
+同一パターン**であることが判明した。
+
+> 「メンバーシップテーブルが存在するのに、その子データが Student 直結」
+
+| 親（メンバーシップ）                                       | Student 直結の子テーブル                                                                            | 数  |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --- |
+| `ExamStudent`（`@@unique[examId, studentId]`）             | `StudentAnswerImage` / `QuestionScore` / `ScoreDecision` / `CompoundAnswerScore` / `ReturnSnapshot` | 5   |
+| `CourseworkStudent`（`@@unique[courseworkId, studentId]`） | `CourseworkScore`                                                                                   | 1   |
+| `GradeStudent`（`@@unique[gradeId, studentId]`）           | `GradeOverride` / `GradeFrozenScore` / `GradeItemExclusion`                                         | 3   |
+
+**対象は計 9 テーブル。**
+
+なお `StudentClassroomMembership` は「人の学級所属」そのものであり対象外。`Student` を主語とする
+`/students`・`/classrooms`・student-import 系も対象外。
+
+## 2. 現状の実害
+
+### 2.1 削除経路が子データを取りこぼす
+
+親を消す唯一の経路が手書きで子を削除しており、いずれも網羅できていない。
+
+| 削除関数                                         | 消しているもの                  | 取りこぼし                                                                                   |
+| ------------------------------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------- |
+| `examStudent.ts:150 removeStudentsFromExam`      | ExamStudent, StudentAnswerImage | **QuestionScore / ScoreDecision / CompoundAnswerScore / ReturnSnapshot / DrawingAnnotation** |
+| `coursework.ts:808 removeStudentsFromCoursework` | CourseworkStudent のみ          | **CourseworkScore（全部）**                                                                  |
+| `gradeStudent.ts:235 removeClassroomAndStudents` | GradeStudent, GradeClassroom    | **GradeOverride / GradeFrozenScore / GradeItemExclusion（全部）**                            |
+
+`ExamStudent` を参照する子テーブルが 1 つも無いため、DB の `onDelete: Cascade` では何も消せない。
+Student 軸・Exam 軸の cascade は正しく張られているが、**メンバーシップ軸だけ cascade が構造的に存在しない**。
+
+対して「答案 1 枚を削除する」経路（`studentAnswer/crud.ts:596-629`）は QuestionScore・ScoreDecision・
+CompoundAnswerScore・DrawingAnnotation まで正しく消している。同じ意味の削除に 2 実装があり、片方だけが
+不完全という状態になっている。
+
+さらに `gradingData.ts:93 deleteAllGradingDataForStudent`（「生徒の採点データを完全に削除」）が実装されて
+いるが、**コードベースのどこからも呼ばれていない**。仕様は書かれ、実装も用意され、配線だけが落ちている。
+（この関数自体も ScoreDecision 等を消さないので、配線しても不十分。DB の cascade に委ねるのが正解。）
+
+### 2.2 破棄は既存仕様である（仕様変更ではない）
+
+`StudentRemovalConfirmModal.tsx:90-100` は、採点データがある生徒を試験から外すとき既にこう表示している。
+
+> 生徒を削除すると、以下のデータも連動して削除されます：
+> ・答案シート情報 ・採点結果・コメント ・設問別得点記録 ・最終成績情報
+> ※ この操作は取り消すことができません
+
+ユーザーはこれに同意して削除している。本計画は仕様変更ではなく **仕様への適合** である。
+
+### 2.3 表示は隠すのに成績算出だけが孤児を算入する
+
+試験側は全経路が ExamStudent 起点のため、孤児は画面にも出力にも現れない。
+
+- Excel: `excel/dataFetcher.ts:8` が `getStudentsForExam`（ExamStudent 軸）を起点とする。学級平均
+  （`averageRows.ts:102-106`）の母集団にも入らない
+- 05/07/08 の画面: ExamStudent 行で描画される
+
+一方、成績算出は孤児を拾う。
+
+- `gradeCalculator.ts:144`: `where: { cropRegion: { examPage: { examId } } }` のみ。**ExamStudent の
+  絞り込みが無い**。ScoreDecision（`:155`）も同様
+- 本体ループは GradeStudent 軸（`:83`。変数名は `examStudents` だが中身は `gradeStudent.findMany`）。
+  `examScoreCalculator.ts:22` が `questionScore.studentId === studentId` で引くため、ExamStudent に居ない
+  生徒でも GradeStudent に居ればヒットする
+- `:196-204` で ExamStudent の status を読むが用途は「見込→欠測」だけ。**存在しない生徒は
+  `statusMap.get()` が `undefined` を返して特別扱いを受けず、孤児の素点がそのまま採用される**（`:253`）
+
+Coursework も同型。`rawScoreCalculator.ts:116` の
+`item.scores.find((score) => score.studentId === studentId)` は CourseworkStudent を経由しない。
+
+**帰結**: 試験・資料のどこにも姿を見せない孤児が、成績算出でだけ「点が増える」方向に効く。
+
+Grade の 3 テーブルはループが GradeStudent 軸のため孤児が直接算入されることはないが、**生徒を外して
+再度追加すると過去の上書き値・確定値・除外設定が復活する**。特に `GradeFrozenScore` は確定（凍結）した
+成績値であり、これが蘇るのは実害が大きい。
+
+## 3. 設計方針
+
+### 3.1 3 層モデル
+
+```
+Student            ← 人。試験横断で同一人物を追う主語（成績算出のループ軸はここ）
+  ↓ × examId / courseworkId / gradeId
+ExamStudent / CourseworkStudent / GradeStudent   ← その試験・資料・成績における対象者
+  ↓
+採点・点数・上書き・確定・除外などの子データ
+```
+
+成績算出の **軸は Student のまま**とする。メンバーシップの id は親ごとに別物であり、複数試験をまたぐと
+繋がらないため。変わるのは「各親のデータを引く瞬間」で、そこで `Student × parentId → メンバーシップ` の
+解決が 1 回入る。Coursework 昇格で採用した 3 層モデルと同じ構造。
+
+### 3.2 これが再発を型で防ぐ
+
+メンバーシップ経由を強制すると:
+
+- **その試験の受験者でない生徒は構造的にスコアを引けなくなる。** 解決に失敗した＝受験していない＝欠測
+- **`status` が必ず経路上に現れる**ため、`gradeCalculator.ts:196-204` の `statusMap` プリロードが不要になる。
+  あれは ExamStudent を別途引いておきながら「存在しない」を見逃していた箇所であり、経路に組み込まれれば
+  見逃しようがなくなる
+- 列名が変わること自体が型の安全網になる。`where: { studentId }` と書いた瞬間に Prisma の型がエラーにする
+
+### 3.3 Map は症状であって原因ではない
+
+`Map<studentId, Map<dataSourceId, number|null>>` が必要になったのは、DB に「その生徒のその試験での成績」を
+表す実体が無く、2 つの id を突き合わせるしかなかったためである。実体ができれば Prisma の include が
+そのまま構造を表すので Map は不要になる。
+
+**Map の解消は本計画の成果物であり、別途の棚卸し作業ではない。** 対象:
+
+| 箇所                                                | 現状                                                  | 変更後                         |
+| --------------------------------------------------- | ----------------------------------------------------- | ------------------------------ |
+| `gradeCalculator.ts:194` `examExamStudentStatusMap` | `Map<examId, Map<studentId, string>>`                 | 経路上に status があるため消滅 |
+| `gradeCalculator.ts:200` `statusMap`                | `Map<studentId, string>`                              | 同上                           |
+| `gradeCalculator.ts:234` `rawScoreMap`              | `Map<studentId, Map<dataSourceId, number\|null>>`     | セルが実体を持つ形へ           |
+| `absentEstimation.ts`（9 箇所が引数で受ける）       | 同上                                                  | 同上                           |
+| `scoringInitializer.ts:48` `existingSet`            | `` `${studentId}#${cropRegionId}` `` の文字列連結キー | 実体で判定                     |
+| `returnSnapshot.ts:130,132,158,192`                 | `Map<studentId, ...>`                                 | 要棚卸し                       |
+| `statisticsCalculator.ts:311` `scoreByStudentId`    | `Map<studentId, number\|null>`                        | 要棚卸し                       |
+
+branded type は導入しない。Prisma 拡張型を使う既存の型規約がその役割を果たしており、Map で裸の `string` に
+射影した時点で守りが外れていたのが問題だった。規約は既に正しい。
+
+### 3.4 renderer へ渡す主語
+
+判断基準は `prismaExtensions.ts:69-78` に既に明文化されている（`ExamStudentWithMemberships`）。
+**`examId` / `courseworkId` / `gradeId` が文脈にあるならメンバーシップが主語、無ければ Student が主語。**
+
+| 主語              | 対象                                                          |
+| ----------------- | ------------------------------------------------------------- |
+| ExamStudent       | 05 受験生徒 / 06 答案 / 07 採点 / 08 出力、および採点データ行 |
+| CourseworkStudent | coursework の名簿・点数                                       |
+| GradeStudent      | grades の行                                                   |
+| Student           | `/students` 生徒マスタ、`/classrooms` 学級、student-import    |
+
+射影しない規約はそのまま。スコア行の include が 1 段深くなるだけである。
+
+```ts
+// 現在: questionScore.ts:175
+include: { student: true, cropRegion: {...}, user: true }
+// 変更後
+include: { examStudent: { include: { student: true } }, cropRegion: {...}, user: true }
+```
+
+renderer は `questionScore.student.lastName` → `questionScore.examStudent.student.lastName` になる。
+「氏名は表示時に計算」も変わらない。
+
+**規約違反として同時に是正するもの**: `excel/dataFetcher.ts:43,224` の
+`(Student & { examStudent?: ExamStudent })[]` は Student 主語に ExamStudent を optional で後付けした
+合成型で主従が逆。`examStudent` が optional なため「受験者かどうか不明な生徒」を型が許してしまっている。
+`ExamStudentWithMemberships` に寄せる。
+
+## 4. 影響範囲（実測）
+
+- **影響ファイル: 321 / 全 1,104（29%）** — `studentId` に触れるファイルと 9 テーブルに触れるファイルの和集合
+- `studentId` 参照 1,949 行 / 256 ファイル（`examStudentId` は現状 13 行）
+- テスト: 44 ファイルが 9 テーブルのいずれかに触れる（全 100 テストファイル）
+
+比較参考: Class→Classroom 全面リネームは本体コミット `e904914f` が 145 ファイル、期間合計 588 ファイル /
++15,716 行（10 日・51 コミット）。本計画の影響範囲はその 2 倍以上に及ぶ。
+
+**さらにあれとは質が違う。** Class→Classroom は機械的置換で、名前が変わるだけで値は不変・型も同じ・
+置換漏れはコンパイルエラーで出た。本計画は値が変わり、`studentId` と `examStudentId` はどちらも `string`
+であるため、**取り違えてもコンパイルが通り、実行時に別人の答案・別人の点数になる**。段階を分けて各段階で
+実データ検証を行う理由はここにある。
+
+## 5. Phase 分割
+
+依存が下流（grade）← 上流（exam / coursework）であるため、上流から着手する。
+
+| Phase | 対象                                                  | 併せて直す集計経路                                      | アーカイブ                                      |
+| ----- | ----------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------- |
+| **A** | ExamStudent 系 5 テーブル                             | `gradeCalculator.ts:144` の exam 経路、`statusMap` 撤去 | exam 1.20.0 → 1.21.0                            |
+| **B** | CourseworkScore                                       | `rawScoreCalculator.ts:116` の coursework 経路          | coursework 1.0.0 → 1.1.0、grade 1.11.0 → 1.12.0 |
+| **C** | GradeOverride / GradeFrozenScore / GradeItemExclusion | grade 内部の参照、セル実体化                            | grade 1.12.0 → 1.13.0                           |
+
+Phase B で grade アーカイブも上がるのは、`.grade` が Coursework を内包し、収集・生成を coursework-archive
+モジュールへ委譲しているため（v1.5.0 の設計）。
+
+### 5.1 再編集を最小化する取り決め（重要）
+
+Phase A で exam の列名が変われば `gradeCalculator` はコンパイルエラーになるため、grade を触らない選択肢は
+ない。したがって **Phase A / B では grade に対して「機械的な型追随のみ」を行い、設計判断を伴う変更
+（Map の解消・セル実体化）は Phase C で一度に行う**。
+
+この線引きを守らないと、Phase A で grade の Map を中途半端に直し、Phase C で再び考え直すことになる。
+
+| ファイル                | Phase A                   | Phase B                 | Phase C                             |
+| ----------------------- | ------------------------- | ----------------------- | ----------------------------------- |
+| `gradeCalculator.ts`    | exam 経路・statusMap 撤去 | coursework 経路         | override/frozen/exclusion、Map 解消 |
+| `rawScoreCalculator.ts` | exam 呼び出しの追随       | `getCourseworkRawScore` | —                                   |
+| grade の renderer       | 型追随のみ                | 型追随のみ              | セル実体化                          |
+
+## 6. マイグレーション設計
+
+### 6.1 共通手順（各テーブル）
+
+Prisma 7 は datasource に url を持たず `migrate dev` を実行できないため、`migration.sql` は手書きし、
+起動時に `migrationDeployer` が適用する。SQLite のため列の入れ替えは RedefineTables（テーブル再作成）
+となる。`20260725000000_restore_asb_manuscript_divider_columns/migration.sql` を雛形とする。
+
+1. `PRAGMA defer_foreign_keys=ON; PRAGMA foreign_keys=OFF;`
+2. `CREATE TABLE "new_X"`（`studentId` を `examStudentId` に置換、FK を ExamStudent へ）
+3. `INSERT INTO "new_X" SELECT ... JOIN ExamStudent`（バックフィル。孤児は JOIN で落ちる）
+4. **孤児件数を AuditLog へ記録**（後述）
+5. `DROP TABLE "X"; ALTER TABLE "new_X" RENAME TO "X";`
+6. インデックス・UNIQUE を再作成
+7. `PRAGMA foreign_keys=ON;`
+
+**注意**: `RENAME TO` は `PRAGMA foreign_keys=ON` で囲まないと子テーブルの FK 参照が旧名のまま残る
+（deployer は FK 既定 OFF・非トランザクション）。検証は空 DB の `foreign_key_check` では不十分で、
+`sqlite_master` の定義文を目視すること。
+
+### 6.2 親 id への到達経路（バックフィル JOIN）
+
+| テーブル               | 経路                               |
+| ---------------------- | ---------------------------------- |
+| `StudentAnswerImage`   | `ExamPage.examId`                  |
+| `QuestionScore`        | `CropRegion → ExamPage.examId`     |
+| `ScoreDecision`        | `CropRegion → ExamPage.examId`     |
+| `CompoundAnswerScore`  | `CompoundAnswer → ExamPage.examId` |
+| `ReturnSnapshot`       | `examId` を直接保持                |
+| `CourseworkScore`      | `CourseworkItem.courseworkId`      |
+| `GradeOverride` ほか 2 | `gradeId` を直接保持               |
+
+### 6.3 孤児の扱い
+
+**破棄する。** 削除確認モーダルが既に破棄を約束しており（§2.2）、孤児は「本来存在しないはずだったもの」
+であるため。救済すると不具合の産物を正当化することになる。
+
+### 6.4 起動時に通知しない — 監査ログに残す
+
+実運用は data フォルダの手動コピーであり、起動時のマイグレーションに通知を割り込ませても
+「最初にそのコピーを開いた人にだけ出る」ため機能しない。起動シーケンス中のモーダルは単純に邪魔でもある。
+
+代わりに **migration SQL の中から直接 `AuditLog` へ INSERT する**（`AuditLog.userId` は FK を張らない
+設計のため素の SQL で書ける）。0 件なら行を作らない。
+
+```sql
+INSERT INTO AuditLog (id, createdAt, updatedAt, userId, action, category,
+                      entityType, entityId, summary, metadata)
+SELECT ..., NULL, 'system.migration.cleanup_orphaned_scores', 'system', ...
+WHERE (孤児が 1 件以上ある場合のみ)
+```
+
+- 起動フローに割り込まない
+- `AuditLog` は同期対象（`deleteProtected: true`）のため、共有 DB でもコピー運用でも記録が残る
+- 必要になった人が監査ログ画面で後から取りに行ける
+
+### 6.5 fresh-install replay との整合
+
+新規 DB は init baseline（`migrationSql.ts`）＋ post-init の全 migration replay で構築される。
+**新しい migration を `MIGRATION_CHECKSUMS` に足してはならない**（足すと replay されず DB に反映されない）。
+検証は空 DB へ全 SQL を昇順適用し、`freshInstallChain.test.ts` のドリフト検知を通すこと。
+
+## 7. アーカイブ設計
+
+`idRemapper` は既に `examStudent: Record<string, string>` のマッピングを持ち（`merge/types.ts:19`、
+`exam-archive/idRemapper.ts:28`）、アーカイブは `examStudents` を同梱している（`examArchive.types.ts`）。
+したがって transformer はアーカイブ内で `examStudents` を引いて `studentId → examStudentId` を解決できる。
+
+ただしこれは **これまでのデフォルト値埋め型ではなく「解決型」transformer** であり、当該アーカイブ初の形式になる。
+
+### 7.1 各 Phase の対応
+
+- **型定義**: `ArchiveScoresData.questionScores[].studentId` → `examStudentId`。`scoreDecisions` /
+  `returnSnapshots` / `compoundAnswerScores` / `studentAnswerImages` も同様
+- **Export**: `exam-archive/dataCollector.ts`（`:108-113` の studentIds 収集、`:254-370` の各行生成）
+- **Import**: `exam-archive/dataCreator.ts`（`:511-620` の remap + create）、`idRemapper.ts`、`archiveExtractor.ts`
+- **merge**: `scoringConflictDetector.ts` / `importScoring.ts` / `idChangeExecutor.ts` / `imageImporter.ts` /
+  `idIntegrationImporter.ts` / `decisionMergePolicy.ts`
+- **transformer**: `V1_20_0_to_V1_21_0.ts` を新設し `transformers/index.ts` の `EXAM_TRANSFORMERS` に登録
+
+### 7.2 旧アーカイブ内の孤児
+
+アーカイブ内にも `examStudents` に載っていない生徒の採点行が存在しうる。**DB 側と同じく破棄**し、
+transformer の `warnings` に件数を載せる（2026-07-28 確定）。
+
+アーカイブには「正本・存在について忠実復元」という裁定があるが、孤児は「本来存在しないはずだったもの」で
+あり忠実復元の対象外とする。復元すべき正本の姿は、削除確認モーダルが約束したとおりの状態である。
+
+### 7.3 idChangeExecutor のカスケード
+
+`changeStudentId` は delete + 再作成方式のため、Student に cascade 子を足すと道連れになる罠がある。
+配線変更後は子が ExamStudent 側へ移るため、`STUDENT_CASCADE_MOVERS` の内容が変わる。
+`cascadeCoverage.test.ts` が schema.prisma 駆動で網羅を強制しているため、登録漏れは自動検出される。
+
+## 8. テスト戦略
+
+### 8.1 新規に必要なもの
+
+- **削除経路の網羅テスト**: 試験・資料・成績から生徒を外したとき、子データが全て消えること（現状の
+  取りこぼしを再現→是正を確認）
+- **孤児バックフィルテスト**: 孤児を含む DB に migration を適用し、孤児が破棄され AuditLog に記録されること
+- **成績算出の結果一致テスト**: 移行前後で、孤児を含まない生徒の算出結果が完全に一致すること
+- **`cascadeCoverage.test.ts` の拡張**: ターゲットに ExamStudent / CourseworkStudent / GradeStudent を追加
+
+### 8.2 既存で更新が必要なもの
+
+44 ファイル。特に `helpers/testDataFactory.ts`・`helpers/testExamBuilder.ts`・
+`screenshots/helpers/seed-in-test.ts` はファクトリのため全テストに波及する。
+
+### 8.3 migration 検証
+
+- 空 DB へ全 migration を昇順適用（`freshInstallChain.test.ts`）
+- 実 DB のコピーへ適用してのリハーサル
+- `normalizeDatetime.test.ts` の `POST_MIGRATION_TABLES` 更新（新テーブルではないが列構成が変わるため確認）
+- `sqlite_master` の定義文で FK 参照名を目視
+
+## 9. 周知
+
+仕様変更ではなく **不具合修正**として告知する（§2.2）。ただし実質的に変わる点が 2 つある。
+
+> **修正**: 試験・資料・成績から生徒を削除したとき、採点結果や点数が削除されずに残る不具合を修正しました。
+> 削除確認画面の説明どおりに削除されるようになります。
+>
+> **ご注意 1**: これまで、削除した生徒を再度追加すると以前の採点結果・成績が残っている場合がありましたが、
+> 今後は復元されません。
+>
+> **ご注意 2**: 該当する生徒がいる場合、**修正後は成績算出の結果が変わります**（これまでは、削除したはずの
+> 得点が算入されていました）。試験の受験者として登録されていない生徒は「データなし」として扱われます。
+
+## 10. 確定事項と残る変動要因
+
+本計画は 2026-07-28 に確定した。設計上の未決事項は残っていない。
+
+**確定した判断**:
+
+1. **スコープは 9 テーブル・3 サブシステム**を一括で対象とし、Phase A → B → C の順に実施する（§5）
+2. **Phase A / B では grade に機械的な型追随のみを行う。** 設計判断を伴う変更（Map の解消・セル実体化）は
+   Phase C に集約する（§5.1）
+3. **孤児は DB・アーカイブとも破棄する**（§6.3、§7.2）
+4. **移行時に起動時通知を出さず、AuditLog に記録する**（§6.4）
+5. **branded type は導入しない。** Prisma 拡張型の既存規約で足りる（§3.3）
+6. **#1071（採点範囲と権限）は本計画の完了後に着手する。** Phase A 期間中に `ScoringMainView` や採点画面の
+   フックが衝突するため
+
+**残る変動要因**: 321 ファイルのうち、`Map<string, ...>` のキーとして `studentId` が流れているだけで
+変数名に現れない箇所は、着手するまで正確に数えられない。Phase A を実際に通してから Phase B / C の
+作業量を見積もり直す。
+
+## 11. Phase A の実施結果（2026-07-28）
+
+**完了。** ExamStudent 系 5 テーブル（`StudentAnswerImage` / `QuestionScore` / `ScoreDecision` /
+`CompoundAnswerScore` / `ReturnSnapshot`）を `examStudentId` へ配線変更した。実変更は
+**159 ファイル / +2,108 −1,708 行**（見立ての 321 は Phase B / C を含む和集合）。
+
+計画から外れた点・追加で判明した点:
+
+- **`ReturnSnapshot.examId` 列を削除した**（計画では言及なし）。`ExamStudent` が `examId` を持つため
+  両方を残すと `examId ≠ examStudent.examId` が起こりうる。`@@unique([examId, studentId])` は
+  `examStudentId @unique` になった
+- **`gradeCalculator` の試験データ取得を ExamStudent 起点へ組み替えた。** `ExamDataCache` が
+  `examStudents: ExamStudentScores[]`（受験者ごとに解決済みスコアと `status` を持つ）になり、
+  §3.2 のとおり `examExamStudentStatusMap` / `statusMap` は不要になって消えた
+- **`scoringInitializer.ts` の `${studentId}#${cropRegionId}` 文字列連結キーが消えた。** 受験者ごとに
+  子の採点行を include して引くようにしたため、既存判定が受験者の内側で閉じる
+- **`resolveEffectiveScores` の `studentId: string | null` が `string` になった。** 列が NOT NULL に
+  なったので null ガードと `as string` が両方落ちた
+- **`ScoringData`（Excel/PDF 出力の DTO）は `examStudentId` と `studentId` を両方持つ。** 学級所属は
+  Student キーなので、学級平均の突き合わせには人としての id が要る。出力用 DTO であり DB へは書き戻さない
+- **`STUDENT_CASCADE_MOVERS` から 5 件が消えた。** 採点層が Student の cascade 子ではなくなり、
+  `ExamStudent` の移し替えだけで追従する。`cascadeCoverage.test.ts` が schema 駆動で検証している
+- **落とし穴**: IPC ハンドラで DTO を組み立てる箇所（`export:getExcelPreviewData`）は、返り値に
+  文脈型が付かず余剰プロパティ検査が効かないため、`studentId:` のまま残しても **typecheck が通る**。
+  実行時にだけ S-P 表・プレビューが壊れる。同型の箇所（preload の型・`upload-answer-sheets` の引数型）を
+  併せて洗い出して是正した
+
+追加したテスト:
+
+- `__tests__/exam/integration/examStudentRemoval.test.ts` — 試験から生徒を外すと 5 テーブルとも消え、
+  他生徒は巻き添えにならず、再追加しても復元されない
+- `__tests__/migration/rewireScoringToExamStudent.test.ts` — 本マイグレーションの1つ手前まで適用して
+  旧形状データを投入し、付け替え・孤児破棄・AuditLog 記録・`RENAME TO` 後の FK 参照名を検証
+- `__tests__/grade/integration/gradeExamStudentScope.test.ts` — 試験から外した生徒の得点が成績算出に
+  算入されないこと（#962 の非対称の解消）と、見込→欠測が従来どおり効くこと
+- `examTransformerChain.test.ts` に 1.20.0 → 1.21.0 の解決・孤児破棄の2本を追加
+
+**Phase B / C の見積もり**: Phase A の実績（159 ファイル）に対し、Coursework は 1 テーブル・
+経路も `rawScoreCalculator.ts:116` の1本なので小さい（20 ファイル前後）。Phase C は grade 3 テーブルに
+加えて §3.3 の Map 解消（`absentEstimation.ts` の 9 引数を含む）とセル実体化が乗るため、
+Phase A と同等かそれ以上になる。

--- a/electron-src/ipc-handlers/cropRegionHandlers.ts
+++ b/electron-src/ipc-handlers/cropRegionHandlers.ts
@@ -17,17 +17,17 @@ import {
 function serializeQuestionScore(score: {
   id: string
   cropRegionId: string
-  studentId: string | null
+  examStudentId: string
   partialScore: { toNumber(): number } | null
   status: string
-  userId: string | null
+  userId: string
   createdAt: Date
   updatedAt: Date
 }) {
   return {
     id: score.id,
     cropRegionId: score.cropRegionId,
-    studentId: score.studentId,
+    examStudentId: score.examStudentId,
     partialScore: score.partialScore ? score.partialScore.toNumber() : null,
     status: score.status,
     userId: score.userId,
@@ -44,10 +44,10 @@ function serializeCropRegion<
     questionScores?: Array<{
       id: string
       cropRegionId: string
-      studentId: string | null
+      examStudentId: string
       partialScore: { toNumber(): number } | null
       status: string
-      userId: string | null
+      userId: string
       createdAt: Date
       updatedAt: Date
     }>

--- a/electron-src/ipc-handlers/drawingHandlers.ts
+++ b/electron-src/ipc-handlers/drawingHandlers.ts
@@ -42,24 +42,18 @@ export function setupDrawingHandlers() {
     "描画アノテーション取得に失敗しました"
   )
 
-  /** 特定の学生・試験の全描画アノテーション取得（透明度制御用） */
+  /** 特定の受験者の全描画アノテーション取得（透明度制御用） */
   registerSafeHandler(
-    "drawing:getByStudent",
-    async (
-      studentId: string,
-      examId: string,
-      type?: DrawingType,
-      userId?: string
-    ) => {
-      const result = await drawingService.getDrawingAnnotationsByStudent(
-        studentId,
-        examId,
+    "drawing:getByExamStudent",
+    async (examStudentId: string, type?: DrawingType, userId?: string) => {
+      const result = await drawingService.getDrawingAnnotationsByExamStudent(
+        examStudentId,
         type,
         userId
       )
       return { success: true, data: result }
     },
-    "学生別描画アノテーション取得に失敗しました"
+    "受験者別描画アノテーション取得に失敗しました"
   )
 
   /** 試験全体の描画アノテーション取得（PDF出力用） */

--- a/electron-src/ipc-handlers/examHandlers.ts
+++ b/electron-src/ipc-handlers/examHandlers.ts
@@ -18,17 +18,17 @@ import { registerHandler } from "./ipcHandlerUtils"
 function serializeQuestionScore(score: {
   id: string
   cropRegionId: string
-  studentId: string | null
+  examStudentId: string
   partialScore: { toNumber(): number } | null
   status: string
-  userId: string | null
+  userId: string
   createdAt: Date
   updatedAt: Date
 }) {
   return {
     id: score.id,
     cropRegionId: score.cropRegionId,
-    studentId: score.studentId,
+    examStudentId: score.examStudentId,
     partialScore: score.partialScore ? score.partialScore.toNumber() : null,
     status: score.status,
     userId: score.userId,
@@ -58,14 +58,16 @@ export function setupExamHandlers(): void {
           type: region.type,
           questionScores: region.questionScores.map((score) => ({
             status: score.status,
-            studentId: score.studentId,
+            examStudentId: score.examStudentId,
             partialScore:
               score.partialScore == null ? null : Number(score.partialScore),
           })),
         }))
       ),
       answerImages: exam.examPages.flatMap((page) =>
-        page.studentAnswerImages.map((img) => ({ studentId: img.studentId }))
+        page.studentAnswerImages.map((img) => ({
+          examStudentId: img.examStudentId,
+        }))
       ),
       examStudents: exam.examStudents,
       examSubtotalGroups: exam.examSubtotalGroups,

--- a/electron-src/ipc-handlers/exportHandlers.ts
+++ b/electron-src/ipc-handlers/exportHandlers.ts
@@ -250,12 +250,12 @@ export function setupExportHandlers(): void {
     "export:validateScoringData",
     async (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       userId: string
     }) => {
       const result = await fetchExportData(
         options.examId,
-        options.selectedStudentIds
+        options.selectedExamStudentIds
       )
       if (!result.success || !result.scoringData) {
         return {
@@ -275,7 +275,7 @@ export function setupExportHandlers(): void {
             result.scoringData,
             buildConflictWarnings(
               decisionSummary.summary,
-              options.selectedStudentIds
+              options.selectedExamStudentIds
             )
           )
         : // 検査できなかったことを空配列（＝食い違いなし）に化けさせない
@@ -321,7 +321,7 @@ export function setupExportHandlers(): void {
     "export-grading-data-excel",
     async (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       outputPath?: string
       studentPlacements?: Record<string, StudentExportPlacement>
     }) => {
@@ -339,12 +339,12 @@ export function setupExportHandlers(): void {
     "export:getExcelPreviewData",
     async (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       studentPlacements?: Record<string, StudentExportPlacement>
     }) => {
       const result = await fetchExportData(
         options.examId,
-        options.selectedStudentIds,
+        options.selectedExamStudentIds,
         options.studentPlacements
       )
       if (!result.success) {
@@ -364,7 +364,7 @@ export function setupExportHandlers(): void {
       }))
 
       const scoringData = result.scoringData?.map((studentScoring) => ({
-        studentId: studentScoring.studentId,
+        examStudentId: studentScoring.examStudentId,
         studentName: studentScoring.studentName,
         studentNumber: studentScoring.studentNumber,
         grade: studentScoring.grade,
@@ -407,7 +407,7 @@ export function setupExportHandlers(): void {
   // Canvas描画用PDF出力データ取得
   registerSafeHandler(
     "export:getPdfExportData",
-    async (options: { examId: string; selectedStudentIds: string[] }) => {
+    async (options: { examId: string; selectedExamStudentIds: string[] }) => {
       return await getPdfExportData(options)
     }
   )
@@ -418,7 +418,7 @@ export function setupExportHandlers(): void {
     async (options: {
       examId: string
       renderedPages: Array<{
-        studentId: string
+        examStudentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }>
@@ -910,10 +910,10 @@ export function setupExportHandlers(): void {
   // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録する
   registerSafeHandler(
     "export:captureReturnSnapshot",
-    async (options: { examId: string; studentIds: string[] }) => {
+    async (options: { examId: string; examStudentIds: string[] }) => {
       return await captureReturnSnapshot({
         examId: options.examId,
-        studentIds: options.studentIds,
+        examStudentIds: options.examStudentIds,
       })
     }
   )

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -100,7 +100,7 @@ export function setupMiscHandlers(): void {
         name: string
         type: string
         buffer: ArrayBuffer
-        studentId?: string
+        examStudentId?: string
         examPageId: string
         overwrite?: boolean
         correctWithMarkers?: boolean
@@ -151,8 +151,11 @@ export function setupMiscHandlers(): void {
 
   registerHandler(
     "associate-answer-sheet-with-student",
-    async (answerSheetId: string, studentId: string) => {
-      return await associateStudentAnswerWithStudent(answerSheetId, studentId)
+    async (answerSheetId: string, examStudentId: string) => {
+      return await associateStudentAnswerWithStudent(
+        answerSheetId,
+        examStudentId
+      )
     }
   )
 

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -101,7 +101,7 @@ export function setupOMRHandlers(): void {
         ]
         params: OMRRecognitionParams
         pageIndex?: number
-        studentId?: string
+        examStudentId?: string
       }
     ): Promise<OMRSheetResult> => {
       try {
@@ -156,7 +156,7 @@ export function setupOMRHandlers(): void {
 
         return {
           success: true,
-          studentId: args.studentId,
+          examStudentId: args.examStudentId,
           pageIndex: args.pageIndex ?? 0,
           markerDetection: markerResult,
           cellResults,
@@ -190,7 +190,11 @@ export function setupOMRHandlers(): void {
     async (
       _event,
       args: {
-        imagePaths: { path: string; studentId?: string; studentName?: string }[]
+        imagePaths: {
+          path: string
+          examStudentId?: string
+          studentName?: string
+        }[]
         cells: ComputedCell[]
         cellConfigs: Record<string, OMRCellConfig>
         expectedCorners: [
@@ -237,7 +241,7 @@ export function setupOMRHandlers(): void {
           if (!markerResult.success) {
             results.push({
               success: false,
-              studentId: entry.studentId,
+              examStudentId: entry.examStudentId,
               pageIndex: args.pageIndex ?? 0,
               markerDetection: markerResult,
               cellResults: [],
@@ -283,7 +287,7 @@ export function setupOMRHandlers(): void {
 
             results.push({
               success: true,
-              studentId: entry.studentId,
+              examStudentId: entry.examStudentId,
               pageIndex: args.pageIndex ?? 0,
               markerDetection: markerResult,
               cellResults,
@@ -293,7 +297,7 @@ export function setupOMRHandlers(): void {
         } catch (error) {
           results.push({
             success: false,
-            studentId: entry.studentId,
+            examStudentId: entry.examStudentId,
             pageIndex: args.pageIndex ?? 0,
             markerDetection: {
               success: false,

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -24,7 +24,7 @@ import {
   getExamProgress,
   getQuestionScoreById,
   getQuestionScoresForExam,
-  getQuestionScoresForStudent,
+  getQuestionScoresForExamStudent,
   updateQuestionScore,
   UpdateQuestionScoreData,
 } from "../lib/prisma/questionScore"
@@ -41,7 +41,7 @@ import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 function serializeScore(score: {
   id: string
   cropRegionId: string
-  studentId: string
+  examStudentId: string
   partialScore: { toNumber(): number } | null
   status: string
   userId: string
@@ -51,7 +51,7 @@ function serializeScore(score: {
   return {
     id: score.id,
     cropRegionId: score.cropRegionId,
-    studentId: score.studentId,
+    examStudentId: score.examStudentId,
     partialScore: score.partialScore ? score.partialScore.toNumber() : null,
     status: toScoringStatus(score.status),
     userId: score.userId,
@@ -78,9 +78,12 @@ export function setupScoringHandlers(): void {
   )
 
   registerHandler(
-    "get-question-scores-for-student",
-    async (studentId: string, userId?: string) => {
-      const result = await getQuestionScoresForStudent(studentId, userId)
+    "get-question-scores-for-exam-student",
+    async (examStudentId: string, userId?: string) => {
+      const result = await getQuestionScoresForExamStudent(
+        examStudentId,
+        userId
+      )
 
       if (!result.success) {
         return result
@@ -138,7 +141,7 @@ export function setupScoringHandlers(): void {
   registerHandler(
     "finalize-question-score",
     async (
-      studentId: string,
+      examStudentId: string,
       cropRegionId: string,
       userId: string,
       scoreData: {
@@ -159,7 +162,7 @@ export function setupScoringHandlers(): void {
 
       const result = await upsertScoreDecision({
         cropRegionId,
-        studentId,
+        examStudentId,
         verdict,
         score: scoreData.partialScore ?? null,
         comment: scoreData.comment ?? null,

--- a/electron-src/lib/export/exam-archive/dataCollector.ts
+++ b/electron-src/lib/export/exam-archive/dataCollector.ts
@@ -104,16 +104,8 @@ export async function collectExamData(
       for (const examStudent of exam.examStudents) {
         studentIds.add(examStudent.studentId)
       }
-      for (const page of exam.examPages) {
-        for (const studentAnswerImage of page.studentAnswerImages) {
-          studentIds.add(studentAnswerImage.studentId)
-        }
-        for (const region of page.cropRegions) {
-          for (const questionScore of region.questionScores) {
-            studentIds.add(questionScore.studentId)
-          }
-        }
-      }
+      // 採点層は ExamStudent の子なので、受験者を集めれば生徒も網羅される
+      // （受験者に紐づかない採点行はそもそも存在しえない）
     }
 
     // 3. 生徒データを取得（templateモードでは空）
@@ -269,7 +261,7 @@ export async function collectExamData(
             questionScores.push({
               id: questionScore.id,
               cropRegionId: questionScore.cropRegionId,
-              studentId: questionScore.studentId,
+              examStudentId: questionScore.examStudentId,
               partialScore: questionScore.partialScore?.toString() ?? null,
               status: questionScore.status,
               userId: questionScore.userId,
@@ -324,7 +316,7 @@ export async function collectExamData(
         scoreDecisions.push({
           id: decision.id,
           cropRegionId: decision.cropRegionId,
-          studentId: decision.studentId,
+          examStudentId: decision.examStudentId,
           verdict: decision.verdict,
           score: decision.score?.toString() ?? null,
           comment: decision.comment,
@@ -354,15 +346,14 @@ export async function collectExamData(
       }
 
       // 9.6. ReturnSnapshot（返却版スナップショット）を収集 (v1.14.0+)
-      // 返却版は試験ごとに1セット（生徒×試験で1行）なので採点者フィルタはしない
+      // 返却版は試験ごとに1セット（受験者ごとに1行）なので採点者フィルタはしない
       const snapshots = await prisma.returnSnapshot.findMany({
-        where: { examId },
+        where: { examStudent: { examId } },
       })
       for (const snapshot of snapshots) {
         returnSnapshots.push({
           id: snapshot.id,
-          examId: snapshot.examId,
-          studentId: snapshot.studentId,
+          examStudentId: snapshot.examStudentId,
           scoresJson: snapshot.scoresJson,
           totalScore: snapshot.totalScore?.toString() ?? null,
           capturedByUserId: snapshot.capturedByUserId,
@@ -501,7 +492,7 @@ export async function collectExamData(
                 .map((score) => ({
                   id: score.id,
                   compoundAnswerId: score.compoundAnswerId,
-                  studentId: score.studentId,
+                  examStudentId: score.examStudentId,
                   userId: score.userId,
                   recognizedAnswer: score.recognizedAnswer,
                   status: score.status,
@@ -530,7 +521,7 @@ export async function collectExamData(
             page.studentAnswerImages.map((studentAnswerImage) => ({
               id: studentAnswerImage.id,
               examPageId: studentAnswerImage.examPageId,
-              studentId: studentAnswerImage.studentId,
+              examStudentId: studentAnswerImage.examStudentId,
               imagePath: studentAnswerImage.imagePath,
               createdAt: studentAnswerImage.createdAt.toISOString(),
               updatedAt: studentAnswerImage.updatedAt.toISOString(),

--- a/electron-src/lib/export/excel/dataFetcher.ts
+++ b/electron-src/lib/export/excel/dataFetcher.ts
@@ -1,6 +1,6 @@
-import type { CropRegion, Exam, ExamStudent, Student } from "@prisma/client"
+import type { CropRegion, Exam } from "@prisma/client"
 
-import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
+import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 import type { ScoringStatus } from "@/types/scoringStatus.types"
 
 import { getCropRegionsByExamId } from "../../prisma/cropRegion"
@@ -27,6 +27,20 @@ import {
   SubtotalScore,
 } from "../../shared/types"
 
+/**
+ * 出力対象の受験者（ExamStudent 実体 ＋ 表示学級の解決結果）。
+ *
+ * 主語は Student ではなく ExamStudent。採点データは受験者に紐づくため、
+ * 生徒を主語にすると「その試験の受験者かどうか」が型から落ちる。
+ * grade / className / attendanceNumber は renderer が採番解決した表示値で、
+ * 書き出し専用のため DB のスキーマには対応しない（export は型制限の対象外）。
+ */
+export type ExportExamStudent = ExamStudentWithMemberships & {
+  grade?: string
+  className?: string
+  attendanceNumber?: number | null
+}
+
 /** SubtotalGroupから構築した小計列情報（Excel出力用） */
 export interface SubtotalColumn {
   subtotalId: string
@@ -40,7 +54,7 @@ export interface ExportDataResult {
   success: boolean
   error?: string
   exam?: Exam
-  selectedStudents?: (Student & { examStudent?: ExamStudent })[]
+  selectedExamStudents?: ExportExamStudent[]
   questionRegions?: CropRegion[]
   subtotalRegions?: CropRegion[]
   subtotalColumns?: SubtotalColumn[]
@@ -53,12 +67,12 @@ export interface ExportDataResult {
  * 出力用データを取得する
  *
  * @param examId - 試験ID
- * @param selectedStudentIds - 選択された生徒のID配列
+ * @param selectedExamStudentIds - 選択された受験者のID配列（ExamStudent.id）
  * @returns 出力用データまたはエラー情報
  */
 export async function fetchExportData(
   examId: string,
-  selectedStudentIds: string[],
+  selectedExamStudentIds: string[],
   studentPlacements?: Record<string, StudentExportPlacement>
 ): Promise<ExportDataResult> {
   try {
@@ -77,7 +91,7 @@ export async function fetchExportData(
     const questionScoresResult = await getQuestionScoresForExam(examId)
     const decisionsResult = await getScoreDecisionsForExam(examId)
 
-    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+    // 受験者×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
     const { resolved: questionScores, conflicts: scoreConflicts } =
       resolveEffectiveScores(
         questionScoresResult.success ? (questionScoresResult.scores ?? []) : [],
@@ -90,26 +104,27 @@ export async function fetchExportData(
       )
     }
 
-    // 選択された生徒のフィルタリングとソート
-    // 空配列の場合は全生徒を取得（統計計算用）
-    // Excel 出力層は内部で flat な Student 射影（student.id = 生徒ID）を消費するため、
-    // IPC/renderer 契約の nested な ExamStudentWithMemberships をここで境界フラット化する。
-    // customOrder / status は ExamStudent 実列を平坦に畳み、表示学級（grade/className/
-    // attendanceNumber）は renderer が採番解決して渡した studentPlacements を優先する。
-    const selectedStudents = (studentsResult.students || [])
+    // 選択された受験者のフィルタリングとソート
+    // 空配列の場合は全受験者を取得（統計計算用）
+    // ExamStudent 実体をそのまま保持し、表示学級（grade/className/attendanceNumber）だけを
+    // renderer が採番解決して渡した studentPlacements から graft する（採番学級の SSOT は renderer）。
+    const selectedExamStudents: ExportExamStudent[] = (
+      studentsResult.students || []
+    )
       .filter(
         (examStudent) =>
-          selectedStudentIds.length === 0 ||
-          selectedStudentIds.includes(examStudent.studentId)
+          selectedExamStudentIds.length === 0 ||
+          selectedExamStudentIds.includes(examStudent.id)
       )
       .map((examStudent) => {
-        const student = examStudent.student
-
-        // renderer が採番解決して渡した表示学級情報を優先（採番学級の SSOT は renderer）
-        const resolved = studentPlacements?.[examStudent.studentId]
+        // studentPlacements のキーは Student.id（学級所属は人に紐づくため、
+        // 採番学級を解決する resolveExamClassroomPlacement も Student キー）。
+        // ここで examStudent.id を使うと全件 undefined になり、黙って
+        // memberships[0] へフォールバックする（＝学級名・出席番号が誤る）。
+        const resolved = studentPlacements?.[examStudent.student.id]
 
         // 未指定（administered学級に未所属等）は memberships[0] へフォールバック
-        const fallbackMembership = student.memberships?.[0]
+        const fallbackMembership = examStudent.student.memberships?.[0]
         const fallbackClassroom = fallbackMembership?.classroom
 
         const grade = resolved?.grade ?? fallbackClassroom?.grade ?? null
@@ -118,21 +133,19 @@ export async function fetchExportData(
           resolved?.attendanceNumber ?? fallbackMembership?.attendanceNumber
 
         return {
-          ...student,
-          customOrder: examStudent.customOrder,
-          status: examStudent.status,
+          ...examStudent,
           grade: grade != null ? grade.toString() : undefined,
           className: className ?? undefined,
           attendanceNumber: attendanceNumber ?? undefined,
         }
       })
-      .sort((studentA, studentB) => {
-        const aOrder = studentA.customOrder ?? 999999
-        const bOrder = studentB.customOrder ?? 999999
+      .sort((examStudentA, examStudentB) => {
+        const aOrder = examStudentA.customOrder ?? 999999
+        const bOrder = examStudentB.customOrder ?? 999999
         return aOrder - bOrder
       })
 
-    if (selectedStudents.length === 0) {
+    if (selectedExamStudents.length === 0) {
       return { success: false, error: "選択された生徒が見つかりません" }
     }
 
@@ -185,7 +198,7 @@ export async function fetchExportData(
 
     // 採点データの構造化
     const scoringData = await buildScoringData(
-      selectedStudents,
+      selectedExamStudents,
       questionRegions,
       subtotalGroupsData,
       questionScores
@@ -194,7 +207,7 @@ export async function fetchExportData(
     return {
       success: true,
       exam,
-      selectedStudents,
+      selectedExamStudents,
       questionRegions,
       subtotalRegions,
       subtotalColumns,
@@ -214,33 +227,27 @@ export async function fetchExportData(
 /**
  * 採点データを構造化する
  *
- * @param selectedStudents - 選択された生徒配列
+ * @param selectedExamStudents - 選択された受験者配列
  * @param questionRegions - 設問領域配列
  * @param subtotalGroups - 小計点グループ配列
  * @param questionScores - 設問スコア
  * @returns 構造化された採点データ
  */
 async function buildScoringData(
-  selectedStudents: (Student & {
-    customOrder?: number | null
-    grade?: string
-    className?: string
-    attendanceNumber?: number | null
-    status?: ExamStudentStatus
-  })[],
+  selectedExamStudents: ExportExamStudent[],
   questionRegions: CropRegion[],
   subtotalGroups: SubtotalGroupData[],
   questionScores: EffectiveScore[]
 ): Promise<ScoringData[]> {
   return Promise.all(
-    selectedStudents.map(async (student) => {
-      const studentScores = questionScores.filter(
-        (score) => score.studentId === student.id
+    selectedExamStudents.map(async (examStudent) => {
+      const examStudentScores = questionScores.filter(
+        (score) => score.examStudentId === examStudent.id
       )
 
-      const scores = buildScoreDetails(studentScores, questionRegions)
+      const scores = buildScoreDetails(examStudentScores, questionRegions)
       const subtotalScores = await buildSubtotalScores(
-        student.id,
+        examStudent.id,
         subtotalGroups,
         questionRegions,
         questionScores
@@ -255,14 +262,16 @@ async function buildScoringData(
         0
       )
 
+      const { student } = examStudent
       return {
+        examStudentId: examStudent.id,
         studentId: student.id,
         studentName: `${student.lastName} ${student.firstName}`,
         studentNumber: student.studentNumber,
-        grade: student.grade,
-        className: student.className,
-        attendanceNumber: student.attendanceNumber,
-        status: student.status,
+        grade: examStudent.grade,
+        className: examStudent.className,
+        attendanceNumber: examStudent.attendanceNumber,
+        status: examStudent.status,
         scores,
         totalScore,
         totalMaxScore,
@@ -275,16 +284,16 @@ async function buildScoringData(
 /**
  * 設問別スコア詳細を構築する
  *
- * @param studentScores - 生徒の設問スコア配列
+ * @param examStudentScores - 受験者の設問スコア配列
  * @param questionRegions - 設問領域配列
  * @returns 設問別スコア詳細配列
  */
 function buildScoreDetails(
-  studentScores: EffectiveScore[],
+  examStudentScores: EffectiveScore[],
   questionRegions: CropRegion[]
 ): ScoreDetail[] {
   return questionRegions.map((region: CropRegion) => {
-    const scoreRecord = studentScores.find(
+    const scoreRecord = examStudentScores.find(
       (score) => score.cropRegionId === region.id
     )
     const actualScore = scoreRecord
@@ -304,14 +313,14 @@ function buildScoreDetails(
 /**
  * 小計スコアを構築する（Subtotal単位）
  *
- * @param studentId - 生徒ID
+ * @param examStudentId - 受験者ID（ExamStudent.id）
  * @param subtotalGroups - 小計点グループ配列
  * @param questionRegions - 設問領域配列
- * @param allQuestionScores - 全生徒の設問スコア配列
+ * @param allQuestionScores - 全受験者の設問スコア配列
  * @returns 小計スコア配列
  */
 async function buildSubtotalScores(
-  studentId: string,
+  examStudentId: string,
   subtotalGroups: SubtotalGroupData[],
   questionRegions: CropRegion[],
   allQuestionScores: EffectiveScore[]
@@ -319,7 +328,7 @@ async function buildSubtotalScores(
   // 設問スコアデータを変換
   const questionScoreData: QuestionScoreForSubtotal[] = allQuestionScores.map(
     (score) => ({
-      studentId: score.studentId,
+      examStudentId: score.examStudentId,
       cropRegionId: score.cropRegionId,
       status: score.status,
       partialScore: score.partialScore,
@@ -331,7 +340,7 @@ async function buildSubtotalScores(
   for (const group of subtotalGroups) {
     for (const subtotal of group.subtotals) {
       const scoreResult = await calculateSubtotalScoreBySubtotalId(
-        studentId,
+        examStudentId,
         subtotal.id,
         questionScoreData,
         questionRegions

--- a/electron-src/lib/export/excel/excelExportMain.ts
+++ b/electron-src/lib/export/excel/excelExportMain.ts
@@ -20,7 +20,7 @@ export async function exportGradingDataExcel(
   options: ExportGradingDataOptions
 ): Promise<ExportResult> {
   try {
-    const { examId, selectedStudentIds } = options
+    const { examId, selectedExamStudentIds } = options
 
     // 学級平均行の母集団は「試験全体」（生徒選択に無関係）なので、全受験生徒データを
     // 1回だけ取得し、選択生徒分は in-memory で絞る（部分出力時の二重フェッチを回避）。
@@ -44,12 +44,12 @@ export async function exportGradingDataExcel(
     }
 
     const allScoringData = dataResult.scoringData
-    const selectedSet = new Set(selectedStudentIds)
+    const selectedSet = new Set(selectedExamStudentIds)
     const scoringData =
-      selectedStudentIds.length === 0
+      selectedExamStudentIds.length === 0
         ? allScoringData
         : allScoringData.filter((studentScoringData) =>
-            selectedSet.has(studentScoringData.studentId)
+            selectedSet.has(studentScoringData.examStudentId)
           )
     if (scoringData.length === 0) {
       return { success: false, error: "選択された生徒が見つかりません" }

--- a/electron-src/lib/export/excel/spTableSheetCreator.ts
+++ b/electron-src/lib/export/excel/spTableSheetCreator.ts
@@ -13,7 +13,7 @@ import {
 /** ScoringData を S-P表入力（二値）へ正規化 */
 function toSpInput(scoringData: ScoringData[]): SpInputStudent[] {
   return scoringData.map((student) => ({
-    studentId: student.studentId,
+    examStudentId: student.examStudentId,
     studentName: student.studentName,
     items: student.scores.map((score) => ({
       questionId: score.questionId,

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -47,7 +47,7 @@ export async function fetchIndividualReportData(
 ): Promise<GetIndividualReportDataResult> {
   const {
     examId,
-    selectedStudentIds,
+    selectedExamStudentIds,
     options: reportOptions,
     studentPlacements,
   } = options
@@ -65,7 +65,7 @@ export async function fetchIndividualReportData(
     // 選択された生徒のデータを取得
     const selectedDataResult = await fetchExportData(
       examId,
-      selectedStudentIds,
+      selectedExamStudentIds,
       studentPlacements
     )
     if (!selectedDataResult.success || !selectedDataResult.scoringData) {
@@ -102,7 +102,7 @@ export async function fetchIndividualReportData(
     )
     const questionScoresResult = await getQuestionScoresForExam(examId)
     const decisionsResult = await getScoreDecisionsForExam(examId)
-    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+    // 受験者×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
     const { resolved: allQuestionScores } = resolveEffectiveScores(
       questionScoresResult.success ? (questionScoresResult.scores ?? []) : [],
       decisionsResult.success ? (decisionsResult.decisions ?? []) : []
@@ -112,7 +112,7 @@ export async function fetchIndividualReportData(
     const allScoringData = await Promise.all(
       allScoringDataFromExcel.map(async (scoringData) => {
         const subtotalScores = await buildSubtotalScoresFromGroups(
-          scoringData.studentId,
+          scoringData.examStudentId,
           subtotalGroupsData,
           allQuestionScores,
           questionRegions
@@ -125,7 +125,7 @@ export async function fetchIndividualReportData(
     const selectedScoringData = await Promise.all(
       selectedScoringDataFromExcel.map(async (scoringData) => {
         const subtotalScores = await buildSubtotalScoresFromGroups(
-          scoringData.studentId,
+          scoringData.examStudentId,
           subtotalGroupsData,
           allQuestionScores,
           questionRegions
@@ -264,7 +264,7 @@ async function getSubtotalGroupsWithSubtotals(
  * CropRegion（SUBTOTAL_SCORE）を使わず、Subtotalから直接計算
  */
 async function buildSubtotalScoresFromGroups(
-  studentId: string,
+  examStudentId: string,
   subtotalGroups: SubtotalGroupData[],
   allQuestionScores: EffectiveScore[],
   questionRegions: CropRegion[]
@@ -272,7 +272,7 @@ async function buildSubtotalScoresFromGroups(
   // 採点データを変換
   const questionScoreData: QuestionScoreForSubtotal[] = allQuestionScores.map(
     (score) => ({
-      studentId: score.studentId,
+      examStudentId: score.examStudentId,
       cropRegionId: score.cropRegionId,
       status: score.status,
       partialScore: score.partialScore,
@@ -284,7 +284,7 @@ async function buildSubtotalScoresFromGroups(
   for (const group of subtotalGroups) {
     for (const subtotal of group.subtotals) {
       const scoreResult = await calculateSubtotalScoreBySubtotalId(
-        studentId,
+        examStudentId,
         subtotal.id,
         questionScoreData,
         questionRegions

--- a/electron-src/lib/export/individual-report/types.ts
+++ b/electron-src/lib/export/individual-report/types.ts
@@ -269,9 +269,9 @@ export interface IndividualReportData {
 /** 個人成績表データ取得オプション */
 export interface GetIndividualReportDataOptions {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   options: IndividualReportOptions
-  /** renderer が採番解決して渡す表示学級情報（studentId キー） */
+  /** renderer が採番解決して渡す表示学級情報（**Student.id キー**。学級所属は人に紐づく） */
   studentPlacements?: Record<string, StudentExportPlacement>
 }
 

--- a/electron-src/lib/export/r-exametrika/rDataExporter.ts
+++ b/electron-src/lib/export/r-exametrika/rDataExporter.ts
@@ -13,7 +13,7 @@ import { fetchExportData } from "../excel/dataFetcher"
 
 export interface ExportRDataOptions {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   format: "csv" | "json"
   outputPath?: string
 }
@@ -50,9 +50,9 @@ export async function exportRData(
   options: ExportRDataOptions
 ): Promise<ExportResult> {
   try {
-    const { examId, selectedStudentIds, format } = options
+    const { examId, selectedExamStudentIds, format } = options
 
-    const dataResult = await fetchExportData(examId, selectedStudentIds)
+    const dataResult = await fetchExportData(examId, selectedExamStudentIds)
     if (!dataResult.success || !dataResult.scoringData) {
       return {
         success: false,

--- a/electron-src/lib/import/exam-archive/dataCreator.ts
+++ b/electron-src/lib/import/exam-archive/dataCreator.ts
@@ -347,19 +347,50 @@ export async function createImportedData(
       }
 
       // 10. ExamStudentを作成
+      //
+      // 生徒を解決できないアーカイブ行は受験者を作れない。採点層は受験者の子なので、
+      // 「実際に作った受験者」を控えておき、後段の採点行はこの集合で絞る。
+      // mappings.examStudent は全行分の uuid が先に振られており、作成の有無を表さない
+      // （それを作成済みとみなすと、存在しない親を指す行を作って FK 違反で全体が落ちる）。
+      const createdExamStudentIds = new Set<string>()
       for (const examStudent of data.examData.examStudents) {
         const newStudentId = remapId(examStudent.studentId, mappings.student)
         if (newStudentId) {
+          const newExamStudentId = remapIdRequired(
+            examStudent.id,
+            mappings.examStudent
+          )
           await tx.examStudent.create({
             data: {
-              id: remapIdRequired(examStudent.id, mappings.examStudent),
+              id: newExamStudentId,
               examId: newExamId,
               studentId: newStudentId,
               status: examStudent.status,
               customOrder: examStudent.customOrder,
             },
           })
+          createdExamStudentIds.add(newExamStudentId)
         }
+      }
+
+      /**
+       * 実際に作成した QuestionScore の id。手書き注釈はこの子なので、
+       * 受験者が解決できず採点行を飛ばした分の注釈も落とす必要がある
+       * （mappings.questionScore は全行分の uuid を先に振るだけで作成を表さない）。
+       */
+      const createdQuestionScoreIds = new Set<string>()
+
+      /** 受験者が実際に作られている採点行だけを通す */
+      const resolveCreatedExamStudentId = (
+        archiveExamStudentId: string
+      ): string | null => {
+        const newExamStudentId = remapId(
+          archiveExamStudentId,
+          mappings.examStudent
+        )
+        return newExamStudentId && createdExamStudentIds.has(newExamStudentId)
+          ? newExamStudentId
+          : null
       }
 
       // 11. ExamPageを作成
@@ -514,11 +545,10 @@ export async function createImportedData(
           compoundAnswerScore.compoundAnswerId,
           mappings.compoundAnswer
         )
-        const newStudentId = remapId(
-          compoundAnswerScore.studentId,
-          mappings.student
+        const newExamStudentId = resolveCreatedExamStudentId(
+          compoundAnswerScore.examStudentId
         )
-        if (newCompoundAnswerId && newStudentId) {
+        if (newCompoundAnswerId && newExamStudentId) {
           await tx.compoundAnswerScore.create({
             data: {
               id: remapIdRequired(
@@ -526,7 +556,7 @@ export async function createImportedData(
                 mappings.compoundAnswerScore
               ),
               compoundAnswerId: newCompoundAnswerId,
-              studentId: newStudentId,
+              examStudentId: newExamStudentId,
               userId: currentUserId,
               recognizedAnswer: compoundAnswerScore.recognizedAnswer,
               status: compoundAnswerScore.status,
@@ -562,21 +592,27 @@ export async function createImportedData(
 
       // 14. QuestionScoreを作成
       // v0.3.0以降: userIdを現在のログインユーザーで上書き
-      // v0.4.0以降: studentIdは必須フィールド
+      // v1.21.0以降: 採点行は受験者（ExamStudent）に紐づく
       for (const questionScore of data.scoresData.questionScores) {
         const newCropRegionId = remapId(
           questionScore.cropRegionId,
           mappings.cropRegion
         )
-        const newStudentId = remapId(questionScore.studentId, mappings.student)
+        const newExamStudentId = resolveCreatedExamStudentId(
+          questionScore.examStudentId
+        )
 
-        // studentIdは必須フィールド
-        if (newCropRegionId && newStudentId) {
+        if (newCropRegionId && newExamStudentId) {
+          const newQuestionScoreId = remapIdRequired(
+            questionScore.id,
+            mappings.questionScore
+          )
+          createdQuestionScoreIds.add(newQuestionScoreId)
           await tx.questionScore.create({
             data: {
-              id: remapIdRequired(questionScore.id, mappings.questionScore),
+              id: newQuestionScoreId,
               cropRegionId: newCropRegionId,
-              studentId: newStudentId,
+              examStudentId: newExamStudentId,
               partialScore: questionScore.partialScore
                 ? parseFloat(questionScore.partialScore)
                 : null,
@@ -594,14 +630,16 @@ export async function createImportedData(
           scoreDecision.cropRegionId,
           mappings.cropRegion
         )
-        const newStudentId = remapId(scoreDecision.studentId, mappings.student)
+        const newExamStudentId = resolveCreatedExamStudentId(
+          scoreDecision.examStudentId
+        )
 
-        if (newCropRegionId && newStudentId) {
+        if (newCropRegionId && newExamStudentId) {
           await tx.scoreDecision.create({
             data: {
               id: remapIdRequired(scoreDecision.id, mappings.scoreDecision),
               cropRegionId: newCropRegionId,
-              studentId: newStudentId,
+              examStudentId: newExamStudentId,
               verdict: scoreDecision.verdict,
               score: scoreDecision.score
                 ? parseFloat(scoreDecision.score)
@@ -674,15 +712,15 @@ export async function createImportedData(
       // 14.6. ReturnSnapshot（返却版スナップショット）を作成 (v1.14.0+)
       // capturedByUserId は現在のログインユーザーで上書き
       for (const returnSnapshot of data.scoresData.returnSnapshots || []) {
-        const newExamId = remapId(returnSnapshot.examId, mappings.exam)
-        const newStudentId = remapId(returnSnapshot.studentId, mappings.student)
+        const newExamStudentId = resolveCreatedExamStudentId(
+          returnSnapshot.examStudentId
+        )
 
-        if (newExamId && newStudentId) {
+        if (newExamStudentId) {
           await tx.returnSnapshot.create({
             data: {
               id: remapIdRequired(returnSnapshot.id, mappings.returnSnapshot),
-              examId: newExamId,
-              studentId: newStudentId,
+              examStudentId: newExamStudentId,
               scoresJson: returnSnapshot.scoresJson,
               totalScore: returnSnapshot.totalScore
                 ? parseFloat(returnSnapshot.totalScore)
@@ -696,11 +734,18 @@ export async function createImportedData(
 
       // 15. DrawingAnnotationを作成
       // v0.3.0以降: userIdを現在のログインユーザーで上書き
+      // 親の QuestionScore を作れなかった注釈は落とす（存在しない親を指すと
+      // FK 違反でインポート全体がロールバックする）。
       for (const drawingAnnotation of data.scoresData.drawingAnnotations) {
-        const newQuestionScoreId = remapId(
+        const remappedQuestionScoreId = remapId(
           drawingAnnotation.questionScoreId,
           mappings.questionScore
         )
+        const newQuestionScoreId =
+          remappedQuestionScoreId &&
+          createdQuestionScoreIds.has(remappedQuestionScoreId)
+            ? remappedQuestionScoreId
+            : null
 
         if (newQuestionScoreId) {
           await tx.drawingAnnotation.create({

--- a/electron-src/lib/import/exam-archive/imageHandler.ts
+++ b/electron-src/lib/import/exam-archive/imageHandler.ts
@@ -95,17 +95,26 @@ export async function createImageRecords(
         studentAnswerImage.examPageId,
         mappings.examPage
       )
-      const newStudentId = remapId(
-        studentAnswerImage.studentId,
-        mappings.student
+      const newExamStudentId = remapId(
+        studentAnswerImage.examStudentId,
+        mappings.examStudent
       )
-      if (!newExamPageId || !newStudentId) continue
+      if (!newExamPageId || !newExamStudentId) continue
 
-      // 同一(examPageId, studentId)の重複チェック
+      // mappings.examStudent は全行分の uuid を先に振るだけで、受験者が実際に
+      // 作られたかは表さない（生徒を解決できないアーカイブ行は作られない）。
+      // 存在しない親を指すと FK 違反でインポート全体が落ちるので、ここで確かめる。
+      const parentExamStudent = await prisma.examStudent.findUnique({
+        where: { id: newExamStudentId },
+        select: { id: true },
+      })
+      if (!parentExamStudent) continue
+
+      // 同一(examPageId, examStudentId)の重複チェック
       const existing = await prisma.studentAnswerImage.findFirst({
         where: {
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: newExamStudentId,
         },
       })
       if (existing) continue
@@ -125,7 +134,7 @@ export async function createImageRecords(
             mappings.studentAnswerImage
           ),
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: newExamStudentId,
           imagePath: newImagePath,
         },
       })
@@ -158,11 +167,21 @@ export async function createImageRecords(
       const newStudentId = remapId(pageImage.studentId, mappings.student)
       if (!newStudentId) continue
 
-      // 同一(examPageId, studentId)の重複チェック
+      // 旧 pageImages は生徒直結だったので、受験者へ解決する
+      // （受験者に居ない生徒の答案は取り込まない）
+      const examStudent = await prisma.examStudent.findUnique({
+        where: {
+          examId_studentId: { examId: newExamId, studentId: newStudentId },
+        },
+        select: { id: true },
+      })
+      if (!examStudent) continue
+
+      // 同一(examPageId, examStudentId)の重複チェック
       const existing = await prisma.studentAnswerImage.findFirst({
         where: {
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: examStudent.id,
         },
       })
       if (existing) continue
@@ -179,7 +198,7 @@ export async function createImageRecords(
         data: {
           id: remapIdRequired(pageImage.id, mappings.pageImage),
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: examStudent.id,
           imagePath: newImagePath,
         },
       })

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -56,74 +56,8 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
       }),
   },
   {
-    // UNIQUE([examPageId, studentId]) があるため移行先の重複を回避しつつ更新する
-    model: "StudentAnswerImage",
-    move: async (tx, from, to) => {
-      const images = await tx.studentAnswerImage.findMany({
-        where: { studentId: from },
-      })
-      for (const image of images) {
-        const duplicate = await tx.studentAnswerImage.findFirst({
-          where: { examPageId: image.examPageId, studentId: to },
-        })
-        if (duplicate) {
-          await tx.studentAnswerImage.delete({ where: { id: image.id } })
-        } else {
-          await tx.studentAnswerImage.update({
-            where: { id: image.id },
-            data: { studentId: to },
-          })
-        }
-      }
-    },
-  },
-  {
-    model: "QuestionScore",
-    move: (tx, from, to) =>
-      tx.questionScore.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
-  {
-    model: "ScoreDecision",
-    move: (tx, from, to) =>
-      tx.scoreDecision.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
-  {
-    model: "CompoundAnswerScore",
-    move: (tx, from, to) =>
-      tx.compoundAnswerScore.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
-  {
-    // UNIQUE([examId, studentId]) があるため移行先の重複を回避しつつ更新する
-    model: "ReturnSnapshot",
-    move: async (tx, from, to) => {
-      const snapshots = await tx.returnSnapshot.findMany({
-        where: { studentId: from },
-      })
-      for (const snapshot of snapshots) {
-        const duplicate = await tx.returnSnapshot.findFirst({
-          where: { examId: snapshot.examId, studentId: to },
-        })
-        if (duplicate) {
-          await tx.returnSnapshot.delete({ where: { id: snapshot.id } })
-        } else {
-          await tx.returnSnapshot.update({
-            where: { id: snapshot.id },
-            data: { studentId: to },
-          })
-        }
-      }
-    },
-  },
-  {
+    // 答案・採点・確定・複合回答・返却版は ExamStudent の子であり、
+    // ExamStudent.id は変わらないので移し替えは要らない（上の ExamStudent で追従する）。
     model: "GradeStudent",
     move: (tx, from, to) =>
       tx.gradeStudent.updateMany({

--- a/electron-src/lib/import/merge/imageImporter.ts
+++ b/electron-src/lib/import/merge/imageImporter.ts
@@ -125,14 +125,15 @@ async function createStudentAnswerImageRecords(
 ): Promise<void> {
   for (const studentAnswerImage of data.examData.studentAnswerImages!) {
     const newExamPageId = idMappings.examPage[studentAnswerImage.examPageId]
-    const newStudentId = idMappings.student[studentAnswerImage.studentId]
-    if (!newExamPageId || !newStudentId) continue
+    const newExamStudentId =
+      idMappings.examStudent[studentAnswerImage.examStudentId]
+    if (!newExamPageId || !newExamStudentId) continue
 
     // 既存のStudentAnswerImageレコードをチェック
     const existing = await tx.studentAnswerImage.findFirst({
       where: {
         examPageId: newExamPageId,
-        studentId: newStudentId,
+        examStudentId: newExamStudentId,
       },
     })
     if (existing) continue
@@ -153,7 +154,7 @@ async function createStudentAnswerImageRecords(
         data: {
           id: studentAnswerImage.id,
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: newExamStudentId,
           imagePath: newImagePath,
         },
       })
@@ -204,11 +205,20 @@ async function createLegacyImageRecords(
       const newStudentId = idMappings.student[pageImage.studentId]
       if (!newStudentId) continue
 
+      // 旧 pageImages は生徒直結だったので、受験者へ解決する
+      const examStudent = await tx.examStudent.findUnique({
+        where: {
+          examId_studentId: { examId: newExamId, studentId: newStudentId },
+        },
+        select: { id: true },
+      })
+      if (!examStudent) continue
+
       // 既存のStudentAnswerImageレコードをチェック
       const existingAnswer = await tx.studentAnswerImage.findFirst({
         where: {
           examPageId: newExamPageId,
-          studentId: newStudentId,
+          examStudentId: examStudent.id,
         },
       })
       if (existingAnswer) continue
@@ -229,7 +239,7 @@ async function createLegacyImageRecords(
           data: {
             id: pageImage.id,
             examPageId: newExamPageId,
-            studentId: newStudentId,
+            examStudentId: examStudent.id,
             imagePath: newImagePath,
           },
         })

--- a/electron-src/lib/import/merge/importScoring.ts
+++ b/electron-src/lib/import/merge/importScoring.ts
@@ -33,11 +33,11 @@ export async function processQuestionScores(
 
   for (const questionScore of data.scoresData.questionScores) {
     const newRegionId = idMappings.cropRegion[questionScore.cropRegionId]
-    const newStudentId = questionScore.studentId
-      ? idMappings.student[questionScore.studentId]
+    const newExamStudentId = questionScore.examStudentId
+      ? idMappings.examStudent[questionScore.examStudentId]
       : null
 
-    if (newRegionId && newStudentId) {
+    if (newRegionId && newExamStudentId) {
       const conflict = conflictMap.get(questionScore.id)
 
       if (conflict) {
@@ -81,7 +81,7 @@ export async function processQuestionScores(
         const existingByComposite = await tx.questionScore.findFirst({
           where: {
             cropRegionId: newRegionId,
-            studentId: newStudentId,
+            examStudentId: newExamStudentId,
           },
         })
         if (existingByComposite) {
@@ -99,7 +99,7 @@ export async function processQuestionScores(
               data: {
                 id: questionScore.id,
                 cropRegionId: newRegionId,
-                studentId: newStudentId,
+                examStudentId: newExamStudentId,
                 partialScore: questionScore.partialScore
                   ? parseFloat(questionScore.partialScore)
                   : null,
@@ -131,8 +131,8 @@ export async function processScoreDecisions(
 ): Promise<void> {
   for (const scoreDecision of data.scoresData.scoreDecisions ?? []) {
     const newRegionId = idMappings.cropRegion[scoreDecision.cropRegionId]
-    const newStudentId = idMappings.student[scoreDecision.studentId]
-    if (!newRegionId || !newStudentId) continue
+    const newExamStudentId = idMappings.examStudent[scoreDecision.examStudentId]
+    if (!newRegionId || !newExamStudentId) continue
 
     const newSourceQsId = scoreDecision.sourceQuestionScoreId
       ? (idMappings.questionScore[scoreDecision.sourceQuestionScoreId] ?? null)
@@ -141,9 +141,9 @@ export async function processScoreDecisions(
 
     const existing = await tx.scoreDecision.findUnique({
       where: {
-        cropRegionId_studentId: {
+        cropRegionId_examStudentId: {
           cropRegionId: newRegionId,
-          studentId: newStudentId,
+          examStudentId: newExamStudentId,
         },
       },
     })
@@ -183,7 +183,7 @@ export async function processScoreDecisions(
       data: {
         id: scoreDecision.id,
         cropRegionId: newRegionId,
-        studentId: newStudentId,
+        examStudentId: newExamStudentId,
         verdict: scoreDecision.verdict,
         score: scoreDecision.score ? parseFloat(scoreDecision.score) : null,
         comment: scoreDecision.comment,
@@ -213,16 +213,17 @@ export async function processCompoundAnswerScores(
   for (const compoundAnswerScore of data.examData.compoundAnswerScores ?? []) {
     const newCompoundAnswerId =
       idMappings.compoundAnswer[compoundAnswerScore.compoundAnswerId]
-    const newStudentId = idMappings.student[compoundAnswerScore.studentId]
-    if (!newCompoundAnswerId || !newStudentId) continue
+    const newExamStudentId =
+      idMappings.examStudent[compoundAnswerScore.examStudentId]
+    if (!newCompoundAnswerId || !newExamStudentId) continue
 
     const incomingUpdatedAt = new Date(compoundAnswerScore.updatedAt)
 
     const existing = await tx.compoundAnswerScore.findUnique({
       where: {
-        compoundAnswerId_studentId: {
+        compoundAnswerId_examStudentId: {
           compoundAnswerId: newCompoundAnswerId,
-          studentId: newStudentId,
+          examStudentId: newExamStudentId,
         },
       },
     })
@@ -263,7 +264,7 @@ export async function processCompoundAnswerScores(
       data: {
         id: compoundAnswerScore.id,
         compoundAnswerId: newCompoundAnswerId,
-        studentId: newStudentId,
+        examStudentId: newExamStudentId,
         userId: currentUserId,
         recognizedAnswer: compoundAnswerScore.recognizedAnswer,
         status: compoundAnswerScore.status,

--- a/electron-src/lib/import/merge/scoringConflictDetector.ts
+++ b/electron-src/lib/import/merge/scoringConflictDetector.ts
@@ -50,46 +50,72 @@ export async function detectScoringConflicts(
     },
     include: {
       cropRegion: true,
-      student: true,
+      examStudent: { include: { student: true } },
     },
   })
 
-  // 既存スコアをキー（studentId + cropRegionId）でインデックス化
+  // 既存スコアをキー（examStudentId + cropRegionId）でインデックス化
   const existingScoreMap = new Map<string, (typeof existingScores)[0]>()
   for (const score of existingScores) {
-    const key = `${score.studentId}:${score.cropRegionId}`
+    const key = `${score.examStudentId}:${score.cropRegionId}`
     existingScoreMap.set(key, score)
   }
 
-  // CropRegionのラベル・配点を取得
+  // CropRegionのラベル・配点を取得（試験の同定にも使う）
   const cropRegions = await prisma.cropRegion.findMany({
     where: { id: { in: existingCropRegionIds } },
+    include: { examPage: { select: { examId: true } } },
   })
   const cropRegionMap = new Map(
     cropRegions.map((cropRegion) => [cropRegion.id, cropRegion])
   )
+  const existingExamId = cropRegions[0]?.examPage.examId
 
-  // 生徒情報を取得
-  const studentIds = Object.values(studentIdMapping)
-  const students = await prisma.student.findMany({
-    where: { id: { in: studentIds } },
-  })
-  const studentMap = new Map(students.map((student) => [student.id, student]))
+  // 採点行は受験者に紐づくので、アーカイブ側の受験者→生徒を引けるようにする
+  const importStudentIdByExamStudentId = new Map(
+    importData.examData.examStudents.map((examStudent) => [
+      examStudent.id,
+      examStudent.studentId,
+    ])
+  )
+
+  // 既存DBの受験者を生徒IDで引けるようにする（氏名表示もここから取る）
+  const existingExamStudents = existingExamId
+    ? await prisma.examStudent.findMany({
+        where: {
+          examId: existingExamId,
+          studentId: { in: Object.values(studentIdMapping) },
+        },
+        include: { student: true },
+      })
+    : []
+  const existingExamStudentByStudentId = new Map(
+    existingExamStudents.map((examStudent) => [
+      examStudent.studentId,
+      examStudent,
+    ])
+  )
 
   // インポートデータの各QuestionScoreについて競合をチェック
   for (const importScore of importData.scoresData.questionScores) {
-    const mappedStudentId = importScore.studentId
-      ? studentIdMapping[importScore.studentId]
+    const importStudentId = importStudentIdByExamStudentId.get(
+      importScore.examStudentId
+    )
+    const mappedStudentId = importStudentId
+      ? studentIdMapping[importStudentId]
       : null
     const mappedCropRegionId = cropRegionIdMapping[importScore.cropRegionId]
+    const existingExamStudent = mappedStudentId
+      ? existingExamStudentByStudentId.get(mappedStudentId)
+      : undefined
 
-    if (!mappedStudentId || !mappedCropRegionId) {
+    if (!mappedStudentId || !mappedCropRegionId || !existingExamStudent) {
       // マッピングがない場合は新規
       newCount++
       continue
     }
 
-    const key = `${mappedStudentId}:${mappedCropRegionId}`
+    const key = `${existingExamStudent.id}:${mappedCropRegionId}`
     const existingScore = existingScoreMap.get(key)
 
     if (!existingScore) {
@@ -115,15 +141,13 @@ export async function detectScoringConflicts(
       unchangedCount++
     } else {
       // データが異なる — 競合として記録
-      const student = studentMap.get(mappedStudentId)
+      const { student } = existingExamStudent
       const cropRegion = cropRegionMap.get(mappedCropRegionId)
 
       conflicts.push({
         importScoreId: importScore.id,
         existingScoreId: existingScore.id,
-        studentName: student
-          ? `${student.lastName}${student.firstName}`
-          : "不明",
+        studentName: `${student.lastName}${student.firstName}`,
         studentId: mappedStudentId,
         questionLabel: cropRegion?.label ?? "不明",
         cropRegionId: mappedCropRegionId,

--- a/electron-src/lib/import/transformers/V1_12_0_to_V1_13_0.ts
+++ b/electron-src/lib/import/transformers/V1_12_0_to_V1_13_0.ts
@@ -14,14 +14,19 @@
  */
 
 import type {
-  ArchiveScoresData,
   ExamArchiveData,
   ExamArchiveVersion,
   ExamTransformResult,
   ExamVersionTransformer,
 } from "../../../../src/types/examArchive.types"
+import type {
+  LegacyQuestionScore,
+  LegacyScoresData,
+} from "./shared/legacyStudentKeyedScores"
 
-type ArchiveQuestionScore = ArchiveScoresData["questionScores"][number]
+// この変換器が扱うのは 1.13.0 時点の形状（採点層はまだ studentId 直結）。
+// examStudentId への付け替えは V1_20_0_to_V1_21_0 が行う。
+type ArchiveQuestionScore = LegacyQuestionScore
 
 const cellKey = (questionScore: ArchiveQuestionScore): string =>
   `${questionScore.studentId} ${questionScore.cropRegionId}`
@@ -43,8 +48,8 @@ const pickLatest = (rows: ArchiveQuestionScore[]): ArchiveQuestionScore =>
  *
  * v1.13.0 アーカイブ（final/proposed 行なし・scoreDecisions あり）には無変更で冪等。
  */
-export function convertScoresDataToV1_13(scoresData: ArchiveScoresData): {
-  scoresData: ArchiveScoresData
+export function convertScoresDataToV1_13(scoresData: LegacyScoresData): {
+  scoresData: LegacyScoresData
   warnings: string[]
 } {
   const warnings: string[] = []
@@ -168,12 +173,14 @@ export class V1_12_0_to_V1_13_0_Transformer implements ExamVersionTransformer {
   readonly toVersion: ExamArchiveVersion = "1.13.0"
 
   transform(data: ExamArchiveData): ExamTransformResult {
-    const { scoresData, warnings } = convertScoresDataToV1_13(data.scoresData)
+    const { scoresData, warnings } = convertScoresDataToV1_13(
+      data.scoresData as unknown as LegacyScoresData
+    )
     return {
       data: {
         ...data,
         manifest: { ...data.manifest, version: this.toVersion },
-        scoresData,
+        scoresData: scoresData as unknown as ExamArchiveData["scoresData"],
       },
       warnings: warnings.map((warning) => `1.12.0→1.13.0: ${warning}`),
     }

--- a/electron-src/lib/import/transformers/V1_1_0_to_V1_2_0.ts
+++ b/electron-src/lib/import/transformers/V1_1_0_to_V1_2_0.ts
@@ -9,7 +9,9 @@
  * - DrawingAnnotation: createdByUserId → userId (非NULL化)
  * - studentId の非NULL化
  *
- * @see docs/schema-history/README.md
+ * 当時のDBスキーマ: `git show v0.3.2-beta.0:prisma/schema.prisma`
+ * （ただし本変換器が扱うのはアーカイブJSONの形状であり、DBスキーマとは一致しない。
+ *   旧形状は下の V1_1_0_* 型が正）
  */
 
 import type {
@@ -182,20 +184,22 @@ export class V1_1_0_to_V1_2_0_Transformer implements ExamVersionTransformer {
         examData: {
           ...data.examData,
           // 既に分離済み（現行形式）のデータは保持する（冪等）。
-          // 分離前の実アーカイブには masterImages/studentAnswerImages キー自体が無い
+          // 分離前の実アーカイブには masterImages/studentAnswerImages キー自体が無い。
+          // この時点の答案・採点はまだ studentId 直結（examStudentId への
+          // 付け替えは V1_20_0_to_V1_21_0 が行う）ので、最新版の型とは形が違う。
           masterImages:
             data.examData.masterImages ??
             masterImages.map((masterImage) => ({ ...masterImage })),
           studentAnswerImages:
             data.examData.studentAnswerImages ??
-            studentAnswerImages.map((studentAnswerImage) => ({
+            (studentAnswerImages.map((studentAnswerImage) => ({
               ...studentAnswerImage,
-            })),
+            })) as unknown as ExamArchiveData["examData"]["studentAnswerImages"]),
         },
         scoresData: {
           questionScores: questionScores.map((questionScore) => ({
             ...questionScore,
-          })),
+          })) as unknown as ExamArchiveData["scoresData"]["questionScores"],
           drawingAnnotations: drawingAnnotations.map((drawingAnnotation) => ({
             ...drawingAnnotation,
             isFavorite: drawingAnnotation.isFavorite ?? false,

--- a/electron-src/lib/import/transformers/V1_20_0_to_V1_21_0.ts
+++ b/electron-src/lib/import/transformers/V1_20_0_to_V1_21_0.ts
@@ -1,0 +1,173 @@
+/**
+ * v1.20.0 → v1.21.0 変換器
+ *
+ * 主な変更点:
+ * - 採点層を Student 直結から ExamStudent（試験の受験者）経由へ配線変更。
+ *   `studentAnswerImages` / `questionScores` / `scoreDecisions` /
+ *   `compoundAnswerScores` / `returnSnapshots` の `studentId` を `examStudentId` にする。
+ * - `ReturnSnapshot.examId` は ExamStudent が持つため削除する。
+ *
+ * これまでの「新規フィールドをデフォルト値で埋める」型ではなく、アーカイブ内の
+ * `examStudents` を引いて studentId → examStudentId を解決する型の変換器である。
+ *
+ * 受験者として登録されていない生徒の採点行（孤児）は解決できない。これは DB 側の
+ * マイグレーションと同じく**破棄**し、件数を警告に載せる。孤児は「本来存在しないはず
+ * だったもの」であり、復元すべき正本の姿は削除確認ダイアログが約束したとおりの状態
+ * （生徒を試験から外せば採点も消える）である。
+ */
+
+import type {
+  ExamArchiveData,
+  ExamArchiveVersion,
+  ExamTransformResult,
+  ExamVersionTransformer,
+} from "../../../../src/types/examArchive.types"
+
+/** 旧行から studentId を取り出す（`in` と typeof の型ガードで、`as` を使わない） */
+const legacyStudentIdOf = (row: object): string | null =>
+  "studentId" in row && typeof row.studentId === "string" ? row.studentId : null
+
+/**
+ * studentId / examId（ReturnSnapshot のみが持つ）を落とした残りを返す。
+ * これらは ExamStudent が持つので、付け替え後の行には残さない。
+ */
+const withoutLegacyKeys = (row: object): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(row).filter(
+      ([key]) => key !== "studentId" && key !== "examId"
+    )
+  )
+
+/**
+ * studentId で引ける旧レコードから examStudentId 付きの新レコードを作る。
+ *
+ * 入力は「到達時点の実形状」（旧キー）、返り値は最新版の行型。同じ配列の別バージョンの
+ * 姿であり TypeScript では両立を表現できないため、**この 1 行だけ**が版の境界になる。
+ * ここを型で追えないぶん、変換結果は examTransformerChain.test.ts で固定している。
+ *
+ * 既に examStudentId を持つ行はそのまま通す（冪等）。版数を過少申告するアーカイブが
+ * 届いても、変換済みの採点行を孤児として全部捨てないため
+ * （transformers/index.ts の「引き下げ先以降の変換器は可能な限り冪等に」に従う）。
+ */
+const rekey = <T>(
+  rows: readonly object[] | undefined,
+  examStudentIdByStudentId: Map<string, string>
+): { rekeyed: T[]; dropped: number } => {
+  const rekeyed: T[] = []
+  let dropped = 0
+  for (const row of rows ?? []) {
+    // 変換済みの行は触らない（旧キーが無いだけで孤児ではない）
+    if ("examStudentId" in row) {
+      rekeyed.push(row as T)
+      continue
+    }
+    const studentId = legacyStudentIdOf(row)
+    const examStudentId = studentId
+      ? examStudentIdByStudentId.get(studentId)
+      : undefined
+    if (!examStudentId) {
+      dropped++
+      continue
+    }
+    rekeyed.push({ ...withoutLegacyKeys(row), examStudentId } as T)
+  }
+  return { rekeyed, dropped }
+}
+
+type ExamDataOf = ExamArchiveData["examData"]
+type ScoresDataOf = ExamArchiveData["scoresData"]
+
+export class V1_20_0_to_V1_21_0_Transformer implements ExamVersionTransformer {
+  readonly fromVersion: ExamArchiveVersion = "1.20.0"
+  readonly toVersion: ExamArchiveVersion = "1.21.0"
+
+  transform(data: ExamArchiveData): ExamTransformResult {
+    // アーカイブ内の受験者一覧から studentId → examStudentId を引けるようにする。
+    // examStudents は 1.0.0 から同梱されており、(examId, studentId) は一意。
+    const examStudentIdByStudentId = new Map<string, string>()
+    for (const examStudent of data.examData.examStudents ?? []) {
+      examStudentIdByStudentId.set(examStudent.studentId, examStudent.id)
+    }
+
+    const answerImages = rekey<
+      NonNullable<ExamDataOf["studentAnswerImages"]>[number]
+    >(data.examData.studentAnswerImages, examStudentIdByStudentId)
+    const compoundScores = rekey<
+      NonNullable<ExamDataOf["compoundAnswerScores"]>[number]
+    >(data.examData.compoundAnswerScores, examStudentIdByStudentId)
+    const questionScores = rekey<ScoresDataOf["questionScores"][number]>(
+      data.scoresData.questionScores,
+      examStudentIdByStudentId
+    )
+    const scoreDecisions = rekey<
+      NonNullable<ScoresDataOf["scoreDecisions"]>[number]
+    >(data.scoresData.scoreDecisions, examStudentIdByStudentId)
+    // ReturnSnapshot は examId も持っていたが、ExamStudent 経由で辿れるので落とす
+    const returnSnapshots = rekey<
+      NonNullable<ScoresDataOf["returnSnapshots"]>[number]
+    >(data.scoresData.returnSnapshots, examStudentIdByStudentId)
+
+    // 破棄された採点行に紐づく手書き注釈も道連れにする（親を失った注釈は復元できない）
+    const survivingQuestionScoreIds = new Set(
+      questionScores.rekeyed.map((questionScore) => questionScore.id)
+    )
+    const drawingAnnotations = (
+      data.scoresData.drawingAnnotations ?? []
+    ).filter((annotation) =>
+      survivingQuestionScoreIds.has(annotation.questionScoreId)
+    )
+    const droppedAnnotations =
+      (data.scoresData.drawingAnnotations ?? []).length -
+      drawingAnnotations.length
+
+    const droppedTotal =
+      answerImages.dropped +
+      compoundScores.dropped +
+      questionScores.dropped +
+      scoreDecisions.dropped +
+      returnSnapshots.dropped
+
+    // 採点データが1行も無いアーカイブでは実質何も起きないので黙って通す
+    const rekeyedTotal =
+      answerImages.rekeyed.length +
+      compoundScores.rekeyed.length +
+      questionScores.rekeyed.length +
+      scoreDecisions.rekeyed.length +
+      returnSnapshots.rekeyed.length
+
+    const warnings: string[] = []
+    if (rekeyedTotal > 0) {
+      warnings.push(
+        `1.20.0→1.21.0: 採点データ ${rekeyedTotal} 件を受験者（ExamStudent）経由へ付け替えました。`
+      )
+    }
+    if (droppedTotal > 0) {
+      warnings.push(
+        `1.20.0→1.21.0: 受験者として登録されていない生徒の採点データ ${droppedTotal} 件を破棄しました` +
+          `（答案 ${answerImages.dropped} / 採点 ${questionScores.dropped} / 確定 ${scoreDecisions.dropped} /` +
+          ` 複合回答 ${compoundScores.dropped} / 返却版 ${returnSnapshots.dropped}` +
+          `${droppedAnnotations > 0 ? ` / 手書き注釈 ${droppedAnnotations}` : ""}）。`
+      )
+    }
+
+    return {
+      data: {
+        ...data,
+        manifest: { ...data.manifest, version: this.toVersion },
+        examData: {
+          ...data.examData,
+          studentAnswerImages: answerImages.rekeyed,
+          compoundAnswerScores: compoundScores.rekeyed,
+        },
+        scoresData: {
+          ...data.scoresData,
+          questionScores: questionScores.rekeyed,
+          drawingAnnotations,
+          scoreDecisions: scoreDecisions.rekeyed,
+          returnSnapshots: returnSnapshots.rekeyed,
+        },
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/transformers/index.ts
+++ b/electron-src/lib/import/transformers/index.ts
@@ -57,6 +57,7 @@ import { V1_16_0_to_V1_17_0_Transformer } from "./V1_16_0_to_V1_17_0"
 import { V1_17_0_to_V1_18_0_Transformer } from "./V1_17_0_to_V1_18_0"
 import { V1_18_0_to_V1_19_0_Transformer } from "./V1_18_0_to_V1_19_0"
 import { V1_19_0_to_V1_20_0_Transformer } from "./V1_19_0_to_V1_20_0"
+import { V1_20_0_to_V1_21_0_Transformer } from "./V1_20_0_to_V1_21_0"
 
 const EXAM_TRANSFORMERS: ExamVersionTransformer[] = [
   new V1_0_0_to_V1_1_0_Transformer(),
@@ -79,6 +80,7 @@ const EXAM_TRANSFORMERS: ExamVersionTransformer[] = [
   new V1_17_0_to_V1_18_0_Transformer(),
   new V1_18_0_to_V1_19_0_Transformer(),
   new V1_19_0_to_V1_20_0_Transformer(),
+  new V1_20_0_to_V1_21_0_Transformer(),
 ]
 
 /** マニフェストのバージョン文字列からサポート対象バージョンを判定する */
@@ -105,6 +107,13 @@ function rawExamClassroomRecords(
  * 現行データに旧キーの残骸が併存するだけでは発火しない（過剰引き下げは
  * 非冪等変換器 — px→mm・pageImages 分割 — によるデータ破壊を招くため）。
  */
+/**
+ * 採点層の行が「旧キー studentId を持ち、現行キー examStudentId を持たない」か。
+ * `in` 演算子で判定するので、行の型を Record へ潰す必要が無い（`as` を使わない）。
+ */
+const hasLegacyStudentKey = (rows: readonly object[] | undefined): boolean =>
+  (rows ?? []).some((row) => "studentId" in row && !("examStudentId" in row))
+
 const SHAPE_VERSION_FLOORS: {
   maxVersion: ExamArchiveVersion
   marker: string
@@ -203,6 +212,21 @@ const SHAPE_VERSION_FLOORS: {
           typeof examStudent.status === "string" &&
           examStudent.status !== examStudent.status.toLowerCase()
       ),
+  },
+  {
+    // 採点層が ExamStudent 経由になる前の studentId キー（V1_20_0_to_V1_21_0 が処理）。
+    // 現行キー examStudentId が併存する場合は発火しない（変換は非冪等で、
+    // 2度目は解決できず全行を孤児として破棄してしまうため）。
+    maxVersion: "1.20.0",
+    marker: "採点層の studentId キー",
+    applies: (data) =>
+      [
+        data.scoresData.questionScores,
+        data.scoresData.scoreDecisions,
+        data.scoresData.returnSnapshots,
+        data.examData.studentAnswerImages,
+        data.examData.compoundAnswerScores,
+      ].some(hasLegacyStudentKey),
   },
 ]
 

--- a/electron-src/lib/import/transformers/shared/legacyStudentKeyedScores.ts
+++ b/electron-src/lib/import/transformers/shared/legacyStudentKeyedScores.ts
@@ -1,0 +1,36 @@
+/**
+ * 1.21.0 より前のアーカイブ形状（採点層が Student 直結）の型。
+ *
+ * `ArchiveScoresData` / `ArchiveExamData` は常に**最新版**の形を表すため、
+ * 1.21.0 で `studentId` → `examStudentId` へ配線変更した後は、それ以前を扱う
+ * 変換器（V1_1_0_to_V1_2_0 / V1_12_0_to_V1_13_0）が最新版の型では書けなくなる。
+ * そこで「その変換器が実際に触るデータの形」をここに明示して使う。
+ *
+ * 最新版へ揃えるのは V1_20_0_to_V1_21_0 の仕事であり、それより手前の変換器は
+ * この旧形状のまま次の変換器へ渡してよい（チェーンが順に適用される）。
+ */
+
+import type { ArchiveScoresData } from "../../../../../src/types/examArchive.types"
+
+/** examStudentId を studentId に差し替える（1.21.0 より前の形） */
+type StudentKeyed<T extends { examStudentId: string }> = Omit<
+  T,
+  "examStudentId"
+> & { studentId: string }
+
+export type LegacyQuestionScore = StudentKeyed<
+  ArchiveScoresData["questionScores"][number]
+>
+
+export type LegacyScoreDecision = StudentKeyed<
+  NonNullable<ArchiveScoresData["scoreDecisions"]>[number]
+>
+
+/** 1.21.0 より前の scores.json */
+export type LegacyScoresData = Omit<
+  ArchiveScoresData,
+  "questionScores" | "scoreDecisions"
+> & {
+  questionScores: LegacyQuestionScore[]
+  scoreDecisions?: LegacyScoreDecision[]
+}

--- a/electron-src/lib/prisma/auditActions.ts
+++ b/electron-src/lib/prisma/auditActions.ts
@@ -601,6 +601,17 @@ export const AUDIT_ACTIONS = {
     verb: "delete",
     label: "ユーザー「{target}」を削除しました",
   },
+
+  // ── システム（system） ───────────────────────────────────────
+  /**
+   * データベース移行時に、試験の受験者として登録されていない生徒の採点データ
+   * （孤児）を破棄したことの記録。migration SQL から直接 INSERT される。
+   */
+  "system.migration.cleanup_orphaned_scores": {
+    category: "system",
+    verb: "delete",
+    label: "{target}",
+  },
 } as const satisfies Record<string, AuditActionDef>
 
 /** 定義済みアクションキーの型 */

--- a/electron-src/lib/prisma/auditScope.ts
+++ b/electron-src/lib/prisma/auditScope.ts
@@ -199,6 +199,23 @@ export async function resolveStudentLabel(
   }
 }
 
+/** examStudentId から「姓 名」ラベルを解決 */
+export async function resolveExamStudentLabel(
+  examStudentId: string
+): Promise<string | null> {
+  try {
+    const examStudent = await prisma.examStudent.findUnique({
+      where: { id: examStudentId },
+      select: { student: { select: { lastName: true, firstName: true } } },
+    })
+    if (!examStudent) return null
+    const { lastName, firstName } = examStudent.student
+    return `${lastName} ${firstName}`.trim()
+  } catch {
+    return null
+  }
+}
+
 /** userId から表示名を解決 */
 export async function resolveUserLabel(userId: string): Promise<string | null> {
   try {

--- a/electron-src/lib/prisma/compoundAnswer.ts
+++ b/electron-src/lib/prisma/compoundAnswer.ts
@@ -160,7 +160,7 @@ export async function getCompoundAnswersByExamId(
  */
 export async function upsertCompoundAnswerScore(data: {
   compoundAnswerId: string
-  studentId: string
+  examStudentId: string
   userId: string
   recognizedAnswer?: string | null
   status: string
@@ -168,14 +168,14 @@ export async function upsertCompoundAnswerScore(data: {
 }): Promise<CompoundAnswerScore> {
   const result = await prisma.compoundAnswerScore.upsert({
     where: {
-      compoundAnswerId_studentId: {
+      compoundAnswerId_examStudentId: {
         compoundAnswerId: data.compoundAnswerId,
-        studentId: data.studentId,
+        examStudentId: data.examStudentId,
       },
     },
     create: {
       compoundAnswerId: data.compoundAnswerId,
-      studentId: data.studentId,
+      examStudentId: data.examStudentId,
       userId: data.userId,
       recognizedAnswer: data.recognizedAnswer ?? null,
       status: data.status,

--- a/electron-src/lib/prisma/drawingAnnotation.ts
+++ b/electron-src/lib/prisma/drawingAnnotation.ts
@@ -11,6 +11,7 @@ import type {
   DrawingType,
   DrawingUpdateData,
 } from "../../../src/types/drawingAnnotation.types"
+import { narrowAnnotationUnions } from "../../../src/types/drawingAnnotation.types"
 import { recordAuditLog } from "./auditLog"
 import { resolveExamScope, resolveExamScopeByQuestionScore } from "./auditScope"
 import prisma from "./client"
@@ -224,16 +225,14 @@ export async function getDrawingAnnotationsByQuestionScore(
 }
 
 /**
- * 特定の学生・試験の全描画アノテーションを取得する（透明度制御用）
- * @param studentId 学生ID
- * @param examId 試験ID
+ * 特定の受験者の全描画アノテーションを取得する（透明度制御用）
+ * @param examStudentId 試験の受験者ID（ExamStudent.id）
  * @param type フィルタする描画タイプ（オプション）
  * @param userId 作成者のユーザーID（指定時はそのユーザーのアノテーションのみ取得）
  * @returns Promise<DrawingAnnotationWithQuestionScore[]> 描画アノテーション配列（設問情報付き）
  */
-export async function getDrawingAnnotationsByStudent(
-  studentId: string,
-  examId: string,
+export async function getDrawingAnnotationsByExamStudent(
+  examStudentId: string,
   type?: DrawingType,
   userId?: string
 ): Promise<DrawingAnnotation[]> {
@@ -241,12 +240,7 @@ export async function getDrawingAnnotationsByStudent(
     const result = await prisma.drawingAnnotation.findMany({
       where: {
         questionScore: {
-          studentId: studentId,
-          cropRegion: {
-            examPage: {
-              examId: examId,
-            },
-          },
+          examStudentId,
         },
         ...(type && { type }),
         // userIdが指定されている場合、そのユーザーのアノテーション、または作成者不明（null）のものを取得
@@ -314,7 +308,7 @@ export async function getDrawingAnnotationsByExam(
         }),
       },
       orderBy: [
-        { questionScore: { studentId: "asc" } },
+        { questionScore: { examStudentId: "asc" } },
         { questionScore: { cropRegionId: "asc" } },
         { createdAt: "asc" },
       ],
@@ -329,7 +323,7 @@ export async function getDrawingAnnotationsByExam(
         questionScore: {
           select: {
             id: true,
-            studentId: true,
+            examStudentId: true,
             cropRegionId: true,
             cropRegion: {
               select: {
@@ -337,12 +331,17 @@ export async function getDrawingAnnotationsByExam(
                 label: true,
               },
             },
-            student: {
+            examStudent: {
               select: {
                 id: true,
-                studentNumber: true,
-                lastName: true,
-                firstName: true,
+                student: {
+                  select: {
+                    id: true,
+                    studentNumber: true,
+                    lastName: true,
+                    firstName: true,
+                  },
+                },
               },
             },
           },
@@ -361,12 +360,16 @@ export async function getDrawingAnnotationsByExam(
  * CropRegion（設問）に紐づく全学生の描画アノテーションを取得する（Grid表示用）
  * @param cropRegionId CropRegionのID
  * @param userId 作成者のユーザーID（オプション）
- * @returns Promise<DrawingAnnotation[]> 描画アノテーション配列（studentId付き）
+ * @returns Promise<AnnotationWithContext[]> 描画アノテーション配列（questionScore 同梱）
+ *
+ * 返り値を `DrawingAnnotation[]` と名乗って `as` で潰すと、下の `select` から
+ * examStudentId を落としても型検査が通り、グリッドの注釈が実行時に消える。
+ * include した形をそのまま型で表明する。
  */
 export async function getDrawingAnnotationsByCropRegion(
   cropRegionId: string,
   userId?: string
-): Promise<DrawingAnnotation[]> {
+): Promise<AnnotationWithContext[]> {
   try {
     const result = await prisma.drawingAnnotation.findMany({
       where: {
@@ -387,7 +390,7 @@ export async function getDrawingAnnotationsByCropRegion(
         questionScore: {
           select: {
             id: true,
-            studentId: true,
+            examStudentId: true,
             cropRegionId: true,
             cropRegion: {
               select: {
@@ -400,7 +403,8 @@ export async function getDrawingAnnotationsByCropRegion(
       },
     })
 
-    return result as DrawingAnnotation[]
+    // status 同様、DB 上 String の union 列を境界で literal union へ絞る
+    return result.map(narrowAnnotationUnions)
   } catch (error) {
     console.error("設問別描画アノテーション取得エラー:", error)
     throw error
@@ -732,7 +736,7 @@ export async function toggleAnnotationFavorite(
         questionScore: {
           select: {
             id: true,
-            studentId: true,
+            examStudentId: true,
             cropRegionId: true,
             cropRegion: {
               select: {
@@ -740,12 +744,17 @@ export async function toggleAnnotationFavorite(
                 label: true,
               },
             },
-            student: {
+            examStudent: {
               select: {
                 id: true,
-                studentNumber: true,
-                lastName: true,
-                firstName: true,
+                student: {
+                  select: {
+                    id: true,
+                    studentNumber: true,
+                    lastName: true,
+                    firstName: true,
+                  },
+                },
               },
             },
           },
@@ -791,7 +800,7 @@ export async function getAnnotationsForBrowse(
         questionScore: {
           select: {
             id: true,
-            studentId: true,
+            examStudentId: true,
             cropRegionId: true,
             cropRegion: {
               select: {
@@ -799,12 +808,17 @@ export async function getAnnotationsForBrowse(
                 label: true,
               },
             },
-            student: {
+            examStudent: {
               select: {
                 id: true,
-                studentNumber: true,
-                lastName: true,
-                firstName: true,
+                student: {
+                  select: {
+                    id: true,
+                    studentNumber: true,
+                    lastName: true,
+                    firstName: true,
+                  },
+                },
               },
             },
           },
@@ -812,7 +826,10 @@ export async function getAnnotationsForBrowse(
       },
     })
 
-    return result as AnnotationWithContext[]
+    // getDrawingAnnotationsByCropRegion と同じく、include した形を型で表明する
+    // （`as` で潰すと select から examStudent を落としても型検査が通り、
+    //  注釈ブラウザの氏名表示と生徒フィルタが実行時に壊れる）
+    return result.map(narrowAnnotationUnions)
   } catch (error) {
     console.error("ブラウズ用アノテーション取得エラー:", error)
     throw error

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -35,7 +35,7 @@ export const getExamsForList = async (userId: string) => {
         select: {
           id: true,
           studentAnswerImages: {
-            select: { studentId: true },
+            select: { examStudentId: true },
           },
           cropRegions: {
             select: {
@@ -43,7 +43,7 @@ export const getExamsForList = async (userId: string) => {
               questionScores: {
                 select: {
                   status: true,
-                  studentId: true,
+                  examStudentId: true,
                   partialScore: true,
                 },
               },
@@ -55,7 +55,9 @@ export const getExamsForList = async (userId: string) => {
         select: { id: true },
       },
       examStudents: {
-        select: { studentId: true, status: true },
+        // 進捗計算（renderer の getExamProgress）は受験者IDで答案・採点を突き合わせるので
+        // id が要る。select で主キーを落とすとこの突き合わせが黙って全滅する。
+        select: { id: true, status: true },
       },
     },
     orderBy: {
@@ -84,11 +86,11 @@ export const getExamById = async (id: string) => {
           masterImages: true,
           studentAnswerImages: {
             include: {
-              student: true,
+              examStudent: { include: { student: true } },
             },
           },
           cropRegions: {
-            // 進捗計算は questionScores のスカラーのみ読むため student/user は join しない
+            // 進捗計算は questionScores のスカラーのみ読むため examStudent/user は join しない
             include: {
               questionScores: true,
             },

--- a/electron-src/lib/prisma/examPage.ts
+++ b/electron-src/lib/prisma/examPage.ts
@@ -12,13 +12,13 @@ export const examPageWithContentInclude = {
   masterImages: true,
   studentAnswerImages: {
     include: {
-      student: true,
+      examStudent: { include: { student: true } },
     },
   },
   cropRegions: true,
 } satisfies Prisma.ExamPageInclude
 
-/** masterImages・studentAnswerImages.student・cropRegions を含む ExamPage */
+/** masterImages・studentAnswerImages.examStudent.student・cropRegions を含む ExamPage */
 export type ExamPageWithContent = Prisma.ExamPageGetPayload<{
   include: typeof examPageWithContentInclude
 }>
@@ -108,7 +108,7 @@ export const deleteExamPage = async (id: string) => {
   return page
 }
 
-/** 試験IDで全ページを取得する（masterImages・studentAnswerImages.student・cropRegions リレーション含む、ページ番号順） */
+/** 試験IDで全ページを取得する（masterImages・studentAnswerImages.examStudent.student・cropRegions リレーション含む、ページ番号順） */
 export const getExamPagesByExamId = async (examId: string) => {
   return prisma.examPage.findMany({
     where: { examId },
@@ -117,7 +117,7 @@ export const getExamPagesByExamId = async (examId: string) => {
   })
 }
 
-/** IDで試験ページを取得する（masterImages・studentAnswerImages.student・cropRegions リレーション含む） */
+/** IDで試験ページを取得する（masterImages・studentAnswerImages.examStudent.student・cropRegions リレーション含む） */
 export const getExamPageById = async (id: string) => {
   return prisma.examPage.findUnique({
     where: { id },

--- a/electron-src/lib/prisma/examStudent.ts
+++ b/electron-src/lib/prisma/examStudent.ts
@@ -45,15 +45,10 @@ export async function getStudentsForExam(examId: string) {
                 startDate: "desc",
               },
             },
-            _count: {
-              select: {
-                studentAnswerImages: {
-                  where: { examPage: { examId } },
-                },
-              },
-            },
           },
         },
+        // 答案は ExamStudent の子なので、この試験の枚数がそのまま得られる
+        _count: { select: { studentAnswerImages: true } },
       },
     })
 
@@ -146,29 +141,20 @@ export async function addStudentsToExam(examId: string, studentIds: string[]) {
 
 /**
  * 試験から生徒を削除
+ *
+ * 答案画像・採点・確定・複合回答・返却スナップショットは ExamStudent の子なので、
+ * この 1 回の deleteMany が DB の cascade でまとめて消す
+ * （手書きで子テーブルを列挙すると、テーブルが増えたときに必ず取りこぼす）。
  */
 export async function removeStudentsFromExam(
   examId: string,
   studentIds: string[]
 ) {
   try {
-    // 試験から生徒を削除
     await prisma.examStudent.deleteMany({
       where: {
         examId,
         studentId: { in: studentIds },
-      },
-    })
-
-    // 関連するAnswerSheetを削除 (StudentAnswerImageから)
-    await prisma.studentAnswerImage.deleteMany({
-      where: {
-        studentId: {
-          in: studentIds,
-        },
-        examPage: {
-          examId: examId,
-        },
       },
     })
 

--- a/electron-src/lib/prisma/gradingData.ts
+++ b/electron-src/lib/prisma/gradingData.ts
@@ -4,46 +4,55 @@ export interface GradingDataInfo {
   hasData: boolean
   answerSheetCount: number
   questionScoreCount: number
+  scoreDecisionCount: number
+  compoundAnswerScoreCount: number
+  returnSnapshotCount: number
   totalGradingItems: number
 }
 
 /**
- * 指定された生徒が特定の試験で採点データを持っているかチェック
+ * 指定された生徒が特定の試験で採点データを持っているかチェック。
+ *
+ * **数える範囲は削除で消える範囲と一致させること。** 生徒を試験から外すと
+ * ExamStudent の cascade で採点層5テーブルがすべて消えるので、ここで数え漏らすと
+ * 削除確認モーダルが「採点データがないため安全に削除できます」と表示したまま
+ * 取り消せない破棄を実行してしまう（例: OMR の複合回答だけが入っている生徒）。
  */
 export const checkGradingDataForStudent = async (
   examId: string,
   studentId: string
 ): Promise<GradingDataInfo> => {
   try {
-    // 答案シート数をカウント
-    const answerSheetCount = await prisma.studentAnswerImage.count({
-      where: {
-        studentId,
-        examPage: {
-          examId,
-        },
-      },
-    })
+    const examStudent = { examId, studentId }
+    const [
+      answerSheetCount,
+      questionScoreCount,
+      scoreDecisionCount,
+      compoundAnswerScoreCount,
+      returnSnapshotCount,
+    ] = await Promise.all([
+      prisma.studentAnswerImage.count({ where: { examStudent } }),
+      prisma.questionScore.count({ where: { examStudent } }),
+      prisma.scoreDecision.count({ where: { examStudent } }),
+      prisma.compoundAnswerScore.count({ where: { examStudent } }),
+      prisma.returnSnapshot.count({ where: { examStudent } }),
+    ])
 
-    // 設問別採点結果数をカウント
-    const questionScoreCount = await prisma.questionScore.count({
-      where: {
-        studentId,
-        cropRegion: {
-          examPage: {
-            examId,
-          },
-        },
-      },
-    })
-
-    const totalGradingItems = answerSheetCount + questionScoreCount
+    const totalGradingItems =
+      answerSheetCount +
+      questionScoreCount +
+      scoreDecisionCount +
+      compoundAnswerScoreCount +
+      returnSnapshotCount
     const hasData = totalGradingItems > 0
 
     return {
       hasData,
       answerSheetCount,
       questionScoreCount,
+      scoreDecisionCount,
+      compoundAnswerScoreCount,
+      returnSnapshotCount,
       totalGradingItems,
     }
   } catch (error) {
@@ -83,43 +92,6 @@ export const checkGradingDataForStudents = async (
     }
   } catch (error) {
     console.error("Failed to check grading data for students:", error)
-    throw error
-  }
-}
-
-/**
- * 生徒の採点データを完全に削除
- */
-export const deleteAllGradingDataForStudent = async (
-  examId: string,
-  studentId: string
-): Promise<void> => {
-  try {
-    await prisma.$transaction(async (tx) => {
-      // 1. 設問別採点結果を削除（DrawingAnnotationはcascadeで道連れ）
-      await tx.questionScore.deleteMany({
-        where: {
-          studentId,
-          cropRegion: {
-            examPage: {
-              examId,
-            },
-          },
-        },
-      })
-
-      // 2. 答案シートを削除
-      await tx.studentAnswerImage.deleteMany({
-        where: {
-          studentId,
-          examPage: {
-            examId,
-          },
-        },
-      })
-    })
-  } catch (error) {
-    console.error("Failed to delete grading data for student:", error)
     throw error
   }
 }

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -26,26 +26,16 @@ function sanitizeFileName(name: string): string {
 }
 
 /**
- * getStudentAnswersByExamIdの戻り値の型
- * studentのフィールドはPrismaのスキーマに合わせてnullableを許容
+ * getStudentAnswersByExamId の戻り値から、PDF 出力が使う分だけを取り出した形。
  */
 interface StudentAnswerData {
   id: string
-  studentId: string | null
+  examStudentId: string
   pageNumber: number
   examPageId: string
   imagePath: string
   originalImagePath: string
   isAbsent: boolean
-  student: {
-    id: string
-    lastName: string
-    firstName: string
-    lastNameKana: string | null
-    firstNameKana: string | null
-    studentNumber: string | null
-    examStudents: Array<{ customOrder: number | null; status: string }>
-  } | null
   examId: string
   status: "ready"
 }
@@ -58,7 +48,7 @@ interface StudentAnswerData {
  * PDF出力に必要なデータを取得する型定義
  */
 export interface PdfExportPageData {
-  studentId: string
+  examStudentId: string
   studentName: string
   pageNumber: number
   imagePath: string
@@ -140,9 +130,9 @@ export interface PdfExportData {
  */
 export async function getPdfExportData(options: {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
 }): Promise<PdfExportData> {
-  const { examId, selectedStudentIds } = options
+  const { examId, selectedExamStudentIds } = options
 
   try {
     // 試験情報を取得
@@ -166,7 +156,7 @@ export async function getPdfExportData(options: {
     // 採点領域を取得
     const cropRegions = await getCropRegionsByExamId(examId)
 
-    // 採点スコアと確定を取得し、生徒×設問ごとに有効スコア1件へ解決
+    // 採点スコアと確定を取得し、受験者×設問ごとに有効スコア1件へ解決
     const scoresResult = await getQuestionScoresForExam(examId)
     const decisionsResult = await getScoreDecisionsForExam(examId)
     const { resolved: allScores } = resolveEffectiveScores(
@@ -174,14 +164,9 @@ export async function getPdfExportData(options: {
       decisionsResult.success ? (decisionsResult.decisions ?? []) : []
     )
 
-    // 生徒情報を取得。PDF 出力層は内部で flat な Student 射影（student.id = 生徒ID）を
-    // 消費するため、IPC 契約の nested な ExamStudentWithMemberships をここで境界フラット化する。
+    // 受験者を取得（ExamStudent 実体のまま保持する）
     const studentsResult = await getStudentsForExam(examId)
-    const allStudents = (studentsResult.students || []).map((examStudent) => ({
-      ...examStudent.student,
-      customOrder: examStudent.customOrder,
-      status: examStudent.status,
-    }))
+    const allExamStudents = studentsResult.students || []
 
     // 答案画像を取得
     const studentAnswersResult = await getStudentAnswersByExamId(examId)
@@ -195,39 +180,28 @@ export async function getPdfExportData(options: {
     const studentAnswers: StudentAnswerData[] =
       studentAnswersResult.studentAnswerImages.map((image) => ({
         id: image.id,
-        studentId: image.studentId,
+        examStudentId: image.examStudentId,
         pageNumber: image.examPage.pageNumber,
         examPageId: image.examPageId,
         imagePath: image.imagePath,
         originalImagePath: image.imagePath,
-        isAbsent:
-          image.student?.examStudents?.[0]?.status === "absent" || false,
-        student: image.student
-          ? {
-              id: image.student.id,
-              lastName: image.student.lastName,
-              firstName: image.student.firstName,
-              lastNameKana: image.student.lastNameKana,
-              firstNameKana: image.student.firstNameKana,
-              studentNumber: image.student.studentNumber,
-              examStudents: image.student.examStudents,
-            }
-          : null,
+        isAbsent: image.examStudent.status === "absent",
         examId: image.examPage.examId,
         status: "ready" as const,
       }))
 
-    // 選択された生徒のみフィルタリング
-    const selectedStudents = allStudents.filter((student) =>
-      selectedStudentIds.includes(student.id)
+    // 選択された受験者のみフィルタリング
+    const selectedExamStudents = allExamStudents.filter((examStudent) =>
+      selectedExamStudentIds.includes(examStudent.id)
     )
 
     const pages: PdfExportPageData[] = []
 
-    for (const student of selectedStudents) {
-      // この生徒の答案画像を取得
+    for (const examStudent of selectedExamStudents) {
+      const { student } = examStudent
+      // この受験者の答案画像を取得
       const studentAnswerList = studentAnswers.filter(
-        (studentAnswer) => studentAnswer.studentId === student.id
+        (studentAnswer) => studentAnswer.examStudentId === examStudent.id
       )
 
       if (studentAnswerList.length === 0) continue
@@ -258,7 +232,7 @@ export async function getPdfExportData(options: {
             const score = allScores.find(
               (resolvedScore) =>
                 resolvedScore.cropRegionId === region.id &&
-                resolvedScore.studentId === student.id
+                resolvedScore.examStudentId === examStudent.id
             )
             return {
               questionScoreId: score?.questionScoreId || "",
@@ -344,10 +318,10 @@ export async function getPdfExportData(options: {
 
           // 小計点を計算
           const subtotalResult = await calculateSubtotalScoreForStudent(
-            student.id,
+            examStudent.id,
             subtotalRegion.id,
             allScores.map((score) => ({
-              studentId: score.studentId,
+              examStudentId: score.examStudentId,
               cropRegionId: score.cropRegionId,
               status: score.status,
               partialScore: score.partialScore,
@@ -378,7 +352,7 @@ export async function getPdfExportData(options: {
           const score = allScores.find(
             (resolvedScore) =>
               resolvedScore.cropRegionId === region.id &&
-              resolvedScore.studentId === student.id
+              resolvedScore.examStudentId === examStudent.id
           )
           if (score) {
             const maxScore = region.points !== null ? Number(region.points) : 0
@@ -424,7 +398,7 @@ export async function getPdfExportData(options: {
         }
 
         pages.push({
-          studentId: student.id,
+          examStudentId: examStudent.id,
           studentName: `${student.lastName} ${student.firstName}`,
           pageNumber,
           imagePath,
@@ -440,14 +414,16 @@ export async function getPdfExportData(options: {
       }
     }
 
-    // ページを生徒順（customOrder順）・ページ番号順でソート
-    // selectedStudents は getStudentsForExam が customOrder 順で返すため、
-    // その順序を生徒の並び順として使う（選択操作の順序には依存させない）
-    const orderedStudentIds = selectedStudents.map((student) => student.id)
+    // ページを受験者順（customOrder順）・ページ番号順でソート
+    // selectedExamStudents は getStudentsForExam が customOrder 順で返すため、
+    // その順序を受験者の並び順として使う（選択操作の順序には依存させない）
+    const orderedExamStudentIds = selectedExamStudents.map(
+      (examStudent) => examStudent.id
+    )
     pages.sort((pageA, pageB) => {
       const studentCompare =
-        orderedStudentIds.indexOf(pageA.studentId) -
-        orderedStudentIds.indexOf(pageB.studentId)
+        orderedExamStudentIds.indexOf(pageA.examStudentId) -
+        orderedExamStudentIds.indexOf(pageB.examStudentId)
       if (studentCompare !== 0) return studentCompare
       return pageA.pageNumber - pageB.pageNumber
     })
@@ -472,7 +448,7 @@ export async function getPdfExportData(options: {
 export async function createPdfFromRenderedImages(options: {
   examId: string
   renderedPages: Array<{
-    studentId: string
+    examStudentId: string
     pageNumber: number
     imageData: ArrayBuffer
   }>

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -1,7 +1,10 @@
 import { Decimal } from "@prisma/client/runtime/client"
 
 import { type AuditChange, recordAuditLog } from "./auditLog"
-import { resolveExamScopeByCropRegion, resolveStudentLabel } from "./auditScope"
+import {
+  resolveExamScopeByCropRegion,
+  resolveExamStudentLabel,
+} from "./auditScope"
 import prisma from "./client"
 
 /**
@@ -54,12 +57,12 @@ async function recordScoreAudit(opts: {
   action: "exam.score.propose" | "exam.score.update" | "exam.score.delete"
   scoreId: string
   cropRegionId: string
-  studentId: string
+  examStudentId: string
   userId: string
   changes?: AuditChange[]
 }): Promise<void> {
   const scope = await resolveExamScopeByCropRegion(opts.cropRegionId)
-  const studentLabel = await resolveStudentLabel(opts.studentId)
+  const studentLabel = await resolveExamStudentLabel(opts.examStudentId)
   const verb =
     opts.action === "exam.score.propose"
       ? "提案しました"
@@ -122,7 +125,7 @@ export const calculateActualScore = (
 // 注: "proposed"/"final" は廃止済み。QuestionScoreは常に採点者ごとの「提案」であり、
 // 確定はScoreDecision（scoreDecision.ts）で表現する。
 export interface CreateQuestionScoreData {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   partialScore?: number // 部分点・保留時のみ使用
   status:
@@ -172,7 +175,7 @@ export const getQuestionScoresForExam = async (
         ...(userId && { userId: userId }),
       },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         cropRegion: {
           include: {
             examPage: true,
@@ -181,8 +184,8 @@ export const getQuestionScoresForExam = async (
         user: true,
       },
       orderBy: [
-        { student: { lastName: "asc" } },
-        { student: { firstName: "asc" } },
+        { examStudent: { student: { lastName: "asc" } } },
+        { examStudent: { student: { firstName: "asc" } } },
         { cropRegion: { orderIndex: "asc" } },
       ],
     })
@@ -198,18 +201,18 @@ export const getQuestionScoresForExam = async (
 }
 
 /**
- * 特定の生徒の採点データを取得
- * @param studentId 生徒ID
+ * 特定の受験者の採点データを取得
+ * @param examStudentId 試験の受験者ID（ExamStudent.id）
  * @param userId 採点者のユーザーID（指定時はそのユーザーの採点データのみ取得）
  */
-export const getQuestionScoresForStudent = async (
-  studentId: string,
+export const getQuestionScoresForExamStudent = async (
+  examStudentId: string,
   userId?: string
 ) => {
   try {
     const scores = await prisma.questionScore.findMany({
       where: {
-        studentId: studentId,
+        examStudentId,
         // userIdが指定されている場合、そのユーザーの採点データのみ取得
         ...(userId && { userId: userId }),
       },
@@ -241,7 +244,7 @@ export const getQuestionScoreById = async (id: string) => {
     const score = await prisma.questionScore.findUnique({
       where: { id },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         cropRegion: true,
         user: true,
       },
@@ -269,7 +272,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
     // 同じ生徒・設問・採点者の組み合わせで既存レコードをチェック
     const existing = await prisma.questionScore.findFirst({
       where: {
-        studentId: data.studentId,
+        examStudentId: data.examStudentId,
         cropRegionId: data.cropRegionId,
         userId: data.userId,
       },
@@ -287,7 +290,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
           status: data.status,
         },
         include: {
-          student: true,
+          examStudent: { include: { student: true } },
           cropRegion: true,
           user: true,
         },
@@ -297,7 +300,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
         action: "exam.score.update",
         scoreId: updated.id,
         cropRegionId: data.cropRegionId,
-        studentId: data.studentId,
+        examStudentId: data.examStudentId,
         userId: data.userId,
         changes: [
           {
@@ -326,7 +329,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
       // 新規作成
       const created = await prisma.questionScore.create({
         data: {
-          studentId: data.studentId,
+          examStudentId: data.examStudentId,
           cropRegionId: data.cropRegionId,
           partialScore:
             data.partialScore !== null && data.partialScore !== undefined
@@ -336,7 +339,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
           userId: data.userId,
         },
         include: {
-          student: true,
+          examStudent: { include: { student: true } },
           cropRegion: true,
           user: true,
         },
@@ -346,7 +349,7 @@ export const createQuestionScore = async (data: CreateQuestionScoreData) => {
         action: "exam.score.propose",
         scoreId: created.id,
         cropRegionId: data.cropRegionId,
-        studentId: data.studentId,
+        examStudentId: data.examStudentId,
         userId: data.userId,
         changes: [
           {
@@ -431,7 +434,7 @@ export const updateQuestionScore = async (
         status: data.status,
       },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         cropRegion: true,
         user: true,
       },
@@ -441,7 +444,7 @@ export const updateQuestionScore = async (
       action: "exam.score.update",
       scoreId: updated.id,
       cropRegionId: updated.cropRegionId,
-      studentId: updated.studentId,
+      examStudentId: updated.examStudentId,
       userId: updated.userId,
       changes: [
         {
@@ -489,7 +492,7 @@ export const deleteQuestionScore = async (id: string) => {
       where: { id },
       select: {
         cropRegionId: true,
-        studentId: true,
+        examStudentId: true,
         userId: true,
         status: true,
       },
@@ -504,7 +507,7 @@ export const deleteQuestionScore = async (id: string) => {
         action: "exam.score.delete",
         scoreId: id,
         cropRegionId: before.cropRegionId,
-        studentId: before.studentId,
+        examStudentId: before.examStudentId,
         userId: before.userId,
         changes: [
           {
@@ -549,8 +552,8 @@ export const getExamProgress = async (examId: string) => {
       where: {
         examPage: { examId },
       },
-      select: { studentId: true },
-      distinct: ["studentId"],
+      select: { examStudentId: true },
+      distinct: ["examStudentId"],
     })
     const totalStudents = studentsWithAnswers.length
 
@@ -651,7 +654,7 @@ export const getExamProgress = async (examId: string) => {
 }
 
 export interface BatchScoreEntry {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   status: string
   partialScore: number | null
@@ -671,7 +674,7 @@ export async function batchUpdateQuestionScores(
         // 既存レコードを検索
         const existing = await tx.questionScore.findFirst({
           where: {
-            studentId: entry.studentId,
+            examStudentId: entry.examStudentId,
             cropRegionId: entry.cropRegionId,
             userId: entry.userId,
           },
@@ -691,7 +694,7 @@ export async function batchUpdateQuestionScores(
         } else {
           await tx.questionScore.create({
             data: {
-              studentId: entry.studentId,
+              examStudentId: entry.examStudentId,
               cropRegionId: entry.cropRegionId,
               userId: entry.userId,
               status: entry.status,

--- a/electron-src/lib/prisma/returnSnapshot.ts
+++ b/electron-src/lib/prisma/returnSnapshot.ts
@@ -85,7 +85,7 @@ export interface ReturnScoreChange {
 }
 
 export interface ReturnStudentDiff {
-  studentId: string
+  examStudentId: string
   /** この生徒に返却版スナップショットが存在するか */
   hasSnapshot: boolean
   /** スコアまたは注釈に変更があったか（hasSnapshot が false の場合は常に false） */
@@ -126,10 +126,10 @@ const round = (value: number): number => Math.round(value * 1e4) / 1e4
 interface ExamState {
   /** cropRegionId -> { label, maxScore } */
   regions: Map<string, { label: string | null; maxScore: number | null }>
-  /** studentId -> 有効スコア配列 */
-  effectiveByStudent: Map<string, EffectiveScore[]>
-  /** studentId -> 正規化済み注釈配列（印刷対象のみ） */
-  annotationsByStudent: Map<string, SnapshotAnnotation[]>
+  /** examStudentId -> 有効スコア配列 */
+  effectiveByExamStudent: Map<string, EffectiveScore[]>
+  /** examStudentId -> 正規化済み注釈配列（印刷対象のみ） */
+  annotationsByExamStudent: Map<string, SnapshotAnnotation[]>
 }
 
 const loadExamState = async (examId: string): Promise<ExamState> => {
@@ -155,12 +155,13 @@ const loadExamState = async (examId: string): Promise<ExamState> => {
     decisionsResult.success ? (decisionsResult.decisions ?? []) : []
   )
 
-  const effectiveByStudent = new Map<string, EffectiveScore[]>()
+  const effectiveByExamStudent = new Map<string, EffectiveScore[]>()
   const effectiveQsIds = new Set<string>()
   for (const effectiveScore of resolved) {
-    const list = effectiveByStudent.get(effectiveScore.studentId)
+    const list = effectiveByExamStudent.get(effectiveScore.examStudentId)
     if (list) list.push(effectiveScore)
-    else effectiveByStudent.set(effectiveScore.studentId, [effectiveScore])
+    else
+      effectiveByExamStudent.set(effectiveScore.examStudentId, [effectiveScore])
     if (effectiveScore.questionScoreId)
       effectiveQsIds.add(effectiveScore.questionScoreId)
   }
@@ -185,11 +186,11 @@ const loadExamState = async (examId: string): Promise<ExamState> => {
       displayX: true,
       displayY: true,
       anchorDirection: true,
-      questionScore: { select: { studentId: true, cropRegionId: true } },
+      questionScore: { select: { examStudentId: true, cropRegionId: true } },
     },
   })
 
-  const annotationsByStudent = new Map<string, SnapshotAnnotation[]>()
+  const annotationsByExamStudent = new Map<string, SnapshotAnnotation[]>()
   for (const annotationRow of annotationRows) {
     if (!effectiveQsIds.has(annotationRow.questionScoreId)) continue // 印刷されない注釈は除外
     const normalized: SnapshotAnnotation = {
@@ -210,13 +211,13 @@ const loadExamState = async (examId: string): Promise<ExamState> => {
       dy: round(annotationRow.displayY),
       ad: annotationRow.anchorDirection,
     }
-    const studentId = annotationRow.questionScore.studentId
-    const list = annotationsByStudent.get(studentId)
+    const examStudentId = annotationRow.questionScore.examStudentId
+    const list = annotationsByExamStudent.get(examStudentId)
     if (list) list.push(normalized)
-    else annotationsByStudent.set(studentId, [normalized])
+    else annotationsByExamStudent.set(examStudentId, [normalized])
   }
 
-  return { regions, effectiveByStudent, annotationsByStudent }
+  return { regions, effectiveByExamStudent, annotationsByExamStudent }
 }
 
 /** 1生徒分の正規化済みスナップショット内容を構築する */
@@ -276,28 +277,41 @@ const computeTotal = (
  */
 export const captureReturnSnapshot = async (options: {
   examId: string
-  studentIds: string[]
+  examStudentIds: string[]
   capturedByUserId?: string | null
 }): Promise<CaptureReturnSnapshotResult> => {
-  const { examId, studentIds, capturedByUserId = null } = options
+  const { examId, examStudentIds, capturedByUserId = null } = options
   try {
     const state = await loadExamState(examId)
     const now = new Date()
 
+    // 渡された受験者が本当にこの試験のものかを確かめる。
+    // 旧スキーマは @@unique([examId, studentId]) で構造的に保証していたが、
+    // examStudentId 単独キーになった今は自分で確かめないと、他の試験の
+    // 返却版を空スコアで上書きしうる（08 で試験を切り替えた直後の stale な選択など）。
+    const scopedExamStudents = await prisma.examStudent.findMany({
+      where: { examId, id: { in: examStudentIds } },
+      select: { id: true },
+    })
+    const scopedExamStudentIds = new Set(
+      scopedExamStudents.map((examStudent) => examStudent.id)
+    )
+
     let capturedCount = 0
-    for (const studentId of studentIds) {
-      const effective = state.effectiveByStudent.get(studentId) ?? []
-      const annotations = state.annotationsByStudent.get(studentId) ?? []
+    for (const examStudentId of examStudentIds) {
+      if (!scopedExamStudentIds.has(examStudentId)) continue
+      const effective = state.effectiveByExamStudent.get(examStudentId) ?? []
+      const annotations =
+        state.annotationsByExamStudent.get(examStudentId) ?? []
       const content = buildContent(effective, annotations)
       const scoresJson = serializeContent(content)
       const total = computeTotal(effective, state.regions)
       const totalScore = total !== null ? new Decimal(total) : null
 
       await prisma.returnSnapshot.upsert({
-        where: { examId_studentId: { examId, studentId } },
+        where: { examStudentId },
         create: {
-          examId,
-          studentId,
+          examStudentId,
           scoresJson,
           totalScore,
           capturedByUserId,
@@ -363,35 +377,36 @@ export const getReturnDiff = async (
     const state = await loadExamState(examId)
 
     const snapshots = await prisma.returnSnapshot.findMany({
-      where: { examId },
+      where: { examStudent: { examId } },
       select: {
-        studentId: true,
+        examStudentId: true,
         scoresJson: true,
         totalScore: true,
         capturedAt: true,
       },
     })
-    const snapshotByStudent = new Map(
-      snapshots.map((snapshot) => [snapshot.studentId, snapshot])
+    const snapshotByExamStudent = new Map(
+      snapshots.map((snapshot) => [snapshot.examStudentId, snapshot])
     )
 
     // スナップショットを持つ生徒 ∪ 現在の採点データを持つ生徒
-    const studentIds = new Set<string>([
-      ...snapshotByStudent.keys(),
-      ...state.effectiveByStudent.keys(),
+    const examStudentIds = new Set<string>([
+      ...snapshotByExamStudent.keys(),
+      ...state.effectiveByExamStudent.keys(),
     ])
 
     const diffs: ReturnStudentDiff[] = []
-    for (const studentId of studentIds) {
-      const effective = state.effectiveByStudent.get(studentId) ?? []
-      const annotations = state.annotationsByStudent.get(studentId) ?? []
+    for (const examStudentId of examStudentIds) {
+      const effective = state.effectiveByExamStudent.get(examStudentId) ?? []
+      const annotations =
+        state.annotationsByExamStudent.get(examStudentId) ?? []
       const currentContent = buildContent(effective, annotations)
       const currentTotal = computeTotal(effective, state.regions)
 
-      const snapshot = snapshotByStudent.get(studentId)
+      const snapshot = snapshotByExamStudent.get(examStudentId)
       if (!snapshot) {
         diffs.push({
-          studentId,
+          examStudentId,
           hasSnapshot: false,
           changed: false,
           capturedAt: null,
@@ -409,7 +424,7 @@ export const getReturnDiff = async (
       } catch {
         // 壊れたスナップショットは差分不能 → 変更扱いで安全側に倒す
         diffs.push({
-          studentId,
+          examStudentId,
           hasSnapshot: true,
           changed: true,
           capturedAt: toIso(snapshot.capturedAt),
@@ -455,7 +470,7 @@ export const getReturnDiff = async (
         JSON.stringify(currentContent.annotations)
 
       diffs.push({
-        studentId,
+        examStudentId,
         hasSnapshot: true,
         changed: scoreChanges.length > 0 || annotationChanged,
         capturedAt: toIso(snapshot.capturedAt),

--- a/electron-src/lib/prisma/scoreDecision.ts
+++ b/electron-src/lib/prisma/scoreDecision.ts
@@ -1,7 +1,10 @@
 import { Decimal } from "@prisma/client/runtime/client"
 
 import { recordAuditLog } from "./auditLog"
-import { resolveExamScopeByCropRegion, resolveStudentLabel } from "./auditScope"
+import {
+  resolveExamScopeByCropRegion,
+  resolveExamStudentLabel,
+} from "./auditScope"
 import prisma from "./client"
 
 /** verdict コードを日本語表示に変換（監査ログ差分用） */
@@ -26,7 +29,7 @@ const verdictLabel = (verdict: string | null | undefined): string => {
 
 export interface UpsertScoreDecisionData {
   cropRegionId: string
-  studentId: string
+  examStudentId: string
   verdict: string
   score?: number | null
   comment?: string | null
@@ -103,9 +106,9 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
     // 差分記録用に変更前の確定を取得
     const previous = await prisma.scoreDecision.findUnique({
       where: {
-        cropRegionId_studentId: {
+        cropRegionId_examStudentId: {
           cropRegionId: data.cropRegionId,
-          studentId: data.studentId,
+          examStudentId: data.examStudentId,
         },
       },
       select: { verdict: true, score: true },
@@ -113,14 +116,14 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
 
     const decision = await prisma.scoreDecision.upsert({
       where: {
-        cropRegionId_studentId: {
+        cropRegionId_examStudentId: {
           cropRegionId: data.cropRegionId,
-          studentId: data.studentId,
+          examStudentId: data.examStudentId,
         },
       },
       create: {
         cropRegionId: data.cropRegionId,
-        studentId: data.studentId,
+        examStudentId: data.examStudentId,
         verdict: data.verdict,
         score,
         comment: data.comment ?? null,
@@ -143,7 +146,7 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
 
     // 監査ログ: 採点確定（OWNERによる確定。提案連打は記録しない）
     const scope = await resolveExamScopeByCropRegion(data.cropRegionId)
-    const studentLabel = await resolveStudentLabel(data.studentId)
+    const studentLabel = await resolveExamStudentLabel(data.examStudentId)
     const prevScore = previous?.score != null ? Number(previous.score) : null
     const newScore = score != null ? Number(score) : null
     await recordAuditLog({
@@ -200,15 +203,15 @@ export const getScoreDecisionsForExam = async (examId: string) => {
   }
 }
 
-/** 特定の生徒×設問の確定スコアを取得する */
+/** 特定の受験者×設問の確定スコアを取得する */
 export const getScoreDecision = async (
-  studentId: string,
+  examStudentId: string,
   cropRegionId: string
 ) => {
   try {
     const decision = await prisma.scoreDecision.findUnique({
       where: {
-        cropRegionId_studentId: { cropRegionId, studentId },
+        cropRegionId_examStudentId: { cropRegionId, examStudentId },
       },
       include: {
         decidedBy: true,

--- a/electron-src/lib/prisma/scoreDecisionSummary.ts
+++ b/electron-src/lib/prisma/scoreDecisionSummary.ts
@@ -19,8 +19,8 @@ import prisma from "./client"
 import { calculateActualScore } from "./questionScore"
 import { canDecideExamScores } from "./scoreDecision"
 
-const cellKey = (studentId: string, cropRegionId: string): string =>
-  `${studentId} ${cropRegionId}`
+const cellKey = (examStudentId: string, cropRegionId: string): string =>
+  `${examStudentId} ${cropRegionId}`
 
 export const getExamDecisionSummary = async (
   examId: string,
@@ -53,7 +53,7 @@ export const getExamDecisionSummary = async (
         select: {
           id: true,
           cropRegionId: true,
-          studentId: true,
+          examStudentId: true,
           userId: true,
           status: true,
           partialScore: true,
@@ -68,7 +68,7 @@ export const getExamDecisionSummary = async (
       }),
       prisma.examStudent.findMany({
         where: { examId },
-        select: { studentId: true, customOrder: true },
+        select: { id: true, customOrder: true },
       }),
       canDecideExamScores(examId, userId),
       // 担当は「現在この試験のメンバーである人」に限る。非メンバーを担当として
@@ -85,11 +85,11 @@ export const getExamDecisionSummary = async (
         where: { examId },
         include: { user: { select: { id: true, name: true } } },
       }),
-      // 設問の分母は「答案画像がある生徒数」（getExamProgress と同じ数え方）
+      // 設問の分母は「答案画像がある受験者数」（getExamProgress と同じ数え方）
       prisma.studentAnswerImage.findMany({
         where: { examPage: { examId } },
-        select: { studentId: true },
-        distinct: ["studentId"],
+        select: { examStudentId: true },
+        distinct: ["examStudentId"],
       }),
     ])
 
@@ -97,12 +97,12 @@ export const getExamDecisionSummary = async (
 
     // 裁定対象セル: 解決できなかった競合と、確定後に新しい提案が入ったもの
     const targets: Array<{
-      studentId: string
+      examStudentId: string
       cropRegionId: string
       reason: "conflict" | "stale"
     }> = [
       ...conflicts.map((conflict) => ({
-        studentId: conflict.studentId,
+        examStudentId: conflict.examStudentId,
         cropRegionId: conflict.cropRegionId,
         reason: "conflict" as const,
       })),
@@ -111,7 +111,7 @@ export const getExamDecisionSummary = async (
           (effective) => effective.source === "decision" && effective.isStale
         )
         .map((effective) => ({
-          studentId: effective.studentId,
+          examStudentId: effective.examStudentId,
           cropRegionId: effective.cropRegionId,
           reason: "stale" as const,
         })),
@@ -122,13 +122,13 @@ export const getExamDecisionSummary = async (
     )
     const decisionByCell = new Map(
       decisions.map((decision) => [
-        cellKey(decision.studentId, decision.cropRegionId),
+        cellKey(decision.examStudentId, decision.cropRegionId),
         decision,
       ])
     )
-    const customOrderByStudent = new Map(
+    const customOrderByExamStudent = new Map(
       examStudents.map((examStudent) => [
-        examStudent.studentId,
+        examStudent.id,
         examStudent.customOrder ?? Number.MAX_SAFE_INTEGER,
       ])
     )
@@ -146,7 +146,7 @@ export const getExamDecisionSummary = async (
       if (score.status === "unscored") continue
       gradedUserIds.add(score.userId)
 
-      const key = cellKey(score.studentId, score.cropRegionId)
+      const key = cellKey(score.examStudentId, score.cropRegionId)
       const group = proposalsByCell.get(key)
       if (group) {
         group.push(score)
@@ -183,20 +183,26 @@ export const getExamDecisionSummary = async (
     }, new Map<string, AssignedGrader[]>())
 
     // 氏名は裁定対象セルの分だけ引く（全採点行に join を効かせない）
-    const targetStudentIds = [
-      ...new Set(targets.map((target) => target.studentId)),
+    const targetExamStudentIds = [
+      ...new Set(targets.map((target) => target.examStudentId)),
     ]
-    const [students, users] = await Promise.all([
-      prisma.student.findMany({
-        where: { id: { in: targetStudentIds } },
-        select: { id: true, lastName: true, firstName: true },
+    const [targetExamStudents, users] = await Promise.all([
+      prisma.examStudent.findMany({
+        where: { id: { in: targetExamStudentIds } },
+        select: {
+          id: true,
+          student: { select: { lastName: true, firstName: true } },
+        },
       }),
-      targetStudentIds.length > 0
+      targetExamStudentIds.length > 0
         ? prisma.user.findMany({ select: { id: true, name: true } })
         : Promise.resolve([]),
     ])
-    const studentById = new Map(
-      students.map((student) => [student.id, student])
+    const studentByExamStudentId = new Map(
+      targetExamStudents.map((examStudent) => [
+        examStudent.id,
+        examStudent.student,
+      ])
     )
     const userNameById = new Map(users.map((user) => [user.id, user.name]))
 
@@ -224,7 +230,7 @@ export const getExamDecisionSummary = async (
     let totalScoreImpact = 0
 
     for (const target of targets) {
-      const key = cellKey(target.studentId, target.cropRegionId)
+      const key = cellKey(target.examStudentId, target.cropRegionId)
       const group = proposalsByCell.get(key)
       if (!group || group.length === 0) continue
 
@@ -249,13 +255,13 @@ export const getExamDecisionSummary = async (
       totalScoreImpact += scoreImpact
 
       const decision = decisionByCell.get(key)
-      const student = studentById.get(target.studentId)
+      const student = studentByExamStudentId.get(target.examStudentId)
 
       const cell: ScoreDecisionCell = {
-        studentId: target.studentId,
+        examStudentId: target.examStudentId,
         studentName: student
           ? `${student.lastName} ${student.firstName}`
-          : target.studentId,
+          : target.examStudentId,
         cropRegionId: target.cropRegionId,
         reason: target.reason,
         proposals,
@@ -300,9 +306,9 @@ export const getExamDecisionSummary = async (
         scoredCount: scoredCellsByRegion.get(cropRegion.id)?.size ?? 0,
         cells: (cellsByRegion.get(cropRegion.id) ?? []).sort(
           (cellA, cellB) =>
-            (customOrderByStudent.get(cellA.studentId) ??
+            (customOrderByExamStudent.get(cellA.examStudentId) ??
               Number.MAX_SAFE_INTEGER) -
-            (customOrderByStudent.get(cellB.studentId) ??
+            (customOrderByExamStudent.get(cellB.examStudentId) ??
               Number.MAX_SAFE_INTEGER)
         ),
         decidedCount: decidedCountByRegion.get(cropRegion.id) ?? 0,

--- a/electron-src/lib/prisma/scoringInitializer.ts
+++ b/electron-src/lib/prisma/scoringInitializer.ts
@@ -7,12 +7,6 @@ import prisma from "./client"
 export const initializeScoringRecords = async (examId: string) => {
   try {
     return await prisma.$transaction(async (tx) => {
-      // 試験の全ての生徒を取得
-      const examStudents = await tx.examStudent.findMany({
-        where: { examId },
-        select: { studentId: true },
-      })
-
       // 試験の全ての採点領域を取得
       const questionRegions = await tx.cropRegion.findMany({
         where: {
@@ -30,35 +24,38 @@ export const initializeScoringRecords = async (examId: string) => {
         throw new Error("No default user found for scoring initialization")
       }
 
-      const studentIds = examStudents.map(
-        (examStudent) => examStudent.studentId
-      )
       const regionIds = questionRegions.map((region) => region.id)
 
-      // 既存レコードを一括取得してSetで管理
-      const existingScores = await tx.questionScore.findMany({
-        where: {
-          studentId: { in: studentIds },
-          cropRegionId: { in: regionIds },
-          userId: defaultUser.id,
+      // 受験者ごとに、その受験者が既に持つ採点行を子として同梱して引く。
+      // 採点行は ExamStudent の子なので、受験者の内側だけで既存判定が閉じる
+      // （生徒IDと設問IDを連結した文字列キーで突き合わせる必要が無い）。
+      const examStudents = await tx.examStudent.findMany({
+        where: { examId },
+        select: {
+          id: true,
+          questionScores: {
+            where: {
+              cropRegionId: { in: regionIds },
+              userId: defaultUser.id,
+            },
+            select: { cropRegionId: true },
+          },
         },
-        select: { studentId: true, cropRegionId: true },
       })
-      const existingSet = new Set(
-        existingScores.map(
-          (score) => `${score.studentId}#${score.cropRegionId}`
-        )
-      )
 
       const scoringRecords = []
 
-      // 全ての生徒×採点領域の組み合わせを作成
+      // 全ての受験者×採点領域の組み合わせを作成
       for (const examStudent of examStudents) {
+        const scoredRegionIds = new Set(
+          examStudent.questionScores.map(
+            (questionScore) => questionScore.cropRegionId
+          )
+        )
         for (const region of questionRegions) {
-          const key = `${examStudent.studentId}#${region.id}`
-          if (!existingSet.has(key)) {
+          if (!scoredRegionIds.has(region.id)) {
             scoringRecords.push({
-              studentId: examStudent.studentId,
+              examStudentId: examStudent.id,
               cropRegionId: region.id,
               partialScore: null,
               status: "unscored",

--- a/electron-src/lib/prisma/student.ts
+++ b/electron-src/lib/prisma/student.ts
@@ -217,7 +217,8 @@ export const getStudentExamResults = async (
                   where: { type: "QUESTION_ANSWER" },
                   include: {
                     questionScores: {
-                      where: { studentId },
+                      // 同一試験の受験者は1人だけなので、生徒での絞り込みと同値
+                      where: { examStudent: { studentId } },
                     },
                     cropSubtotals: {
                       where: { assignmentType: "QUESTION_ASSIGNMENT" },

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -82,7 +82,7 @@ export async function uploadStudentAnswers(
     name: string
     type: string
     buffer: ArrayBuffer
-    studentId?: string
+    examStudentId?: string
     examPageId: string
     overwrite?: boolean
     correctWithMarkers?: boolean
@@ -189,8 +189,8 @@ export async function uploadStudentAnswers(
       correctionStatus,
       correctionError,
     } of correctedFiles) {
-      if (!fileData.studentId) {
-        throw new Error(`Student ID is required for file: ${fileData.name}`)
+      if (!fileData.examStudentId) {
+        throw new Error(`ExamStudent ID is required for file: ${fileData.name}`)
       }
 
       // 配置先 ExamPage は id 直指定（列＝ExamPage 実体から供給される）。
@@ -198,7 +198,7 @@ export async function uploadStudentAnswers(
       const existingRecord = await prisma.studentAnswerImage.findFirst({
         where: {
           examPageId: fileData.examPageId,
-          studentId: fileData.studentId,
+          examStudentId: fileData.examStudentId,
         },
       })
 
@@ -245,7 +245,7 @@ export async function uploadStudentAnswers(
         const answerSheet = await prisma.studentAnswerImage.create({
           data: {
             examPageId: fileData.examPageId,
-            studentId: fileData.studentId,
+            examStudentId: fileData.examStudentId,
             imagePath: relativePath,
           },
         })
@@ -298,22 +298,16 @@ export async function getStudentAnswersByExamId(examId: string) {
         },
       },
       include: {
-        student: {
-          include: {
-            examStudents: {
-              where: { examId },
-            },
-          },
-        },
+        examStudent: { include: { student: true } },
         examPage: true,
       },
-      orderBy: [{ studentId: "asc" }, { examPage: { pageNumber: "asc" } }],
+      orderBy: [{ examStudentId: "asc" }, { examPage: { pageNumber: "asc" } }],
     })
 
     // 重複除去フォールバック（@@unique制約適用前のデータ対策）
     const seen = new Map<string, (typeof studentAnswerImages)[0]>()
     for (const studentAnswerImage of studentAnswerImages) {
-      const key = `${studentAnswerImage.studentId}-${studentAnswerImage.examPageId}`
+      const key = `${studentAnswerImage.examStudentId}-${studentAnswerImage.examPageId}`
       const existing = seen.get(key)
       if (
         !existing ||
@@ -358,15 +352,17 @@ export async function getStudentAnswersDataset(examId: string) {
             student: {
               include: {
                 memberships: { include: { classroom: true } },
-                _count: { select: { studentAnswerImages: true } },
               },
             },
+            _count: { select: { studentAnswerImages: true } },
           },
         },
         examPages: {
           orderBy: { pageNumber: "asc" },
           include: {
-            studentAnswerImages: { include: { student: true } },
+            studentAnswerImages: {
+              include: { examStudent: { include: { student: true } } },
+            },
           },
         },
       },
@@ -377,25 +373,25 @@ export async function getStudentAnswersDataset(examId: string) {
     }
 
     // 重複除去フォールバック（@@unique 適用前データ・NAS sync 由来の重複対策）。
-    // getStudentAnswersByExamId と同じ (studentId, examPageId) 単位で updatedAt 最新のみ残す。
+    // getStudentAnswersByExamId と同じ (examStudentId, examPageId) 単位で updatedAt 最新のみ残す。
     // 05/07/08（getStudentAnswersByExamId 経由）と 06 で表示が食い違わないようにする。
     const examPages = exam.examPages.map((examPage) => {
-      const latestByStudentId = new Map<
+      const latestByExamStudentId = new Map<
         string,
         (typeof examPage.studentAnswerImages)[number]
       >()
       for (const answerImage of examPage.studentAnswerImages) {
-        const existing = latestByStudentId.get(answerImage.studentId)
+        const existing = latestByExamStudentId.get(answerImage.examStudentId)
         if (
           !existing ||
           new Date(answerImage.updatedAt) > new Date(existing.updatedAt)
         ) {
-          latestByStudentId.set(answerImage.studentId, answerImage)
+          latestByExamStudentId.set(answerImage.examStudentId, answerImage)
         }
       }
       return {
         ...examPage,
-        studentAnswerImages: Array.from(latestByStudentId.values()),
+        studentAnswerImages: Array.from(latestByExamStudentId.values()),
       }
     })
 
@@ -460,7 +456,7 @@ const SCORED_COMPOUND_ANSWER_SCORE_FILTER = {
 async function countStudentAnswerScoreData(
   client: typeof prisma | Tx,
   scope: PageScoreScope,
-  studentId: string
+  examStudentId: string
 ): Promise<StudentAnswerScoreSummary> {
   const { cropRegionIds, compoundAnswerIds } = scope
 
@@ -474,7 +470,7 @@ async function countStudentAnswerScoreData(
       ? []
       : client.questionScore.findMany({
           where: {
-            studentId,
+            examStudentId,
             cropRegionId: { in: cropRegionIds },
             ...SCORED_QUESTION_SCORE_FILTER,
           },
@@ -484,20 +480,23 @@ async function countStudentAnswerScoreData(
     cropRegionIds.length === 0
       ? 0
       : client.scoreDecision.count({
-          where: { studentId, cropRegionId: { in: cropRegionIds } },
+          where: { examStudentId, cropRegionId: { in: cropRegionIds } },
         }),
     cropRegionIds.length === 0
       ? 0
       : client.drawingAnnotation.count({
           where: {
-            questionScore: { studentId, cropRegionId: { in: cropRegionIds } },
+            questionScore: {
+              examStudentId,
+              cropRegionId: { in: cropRegionIds },
+            },
           },
         }),
     compoundAnswerIds.length === 0
       ? 0
       : client.compoundAnswerScore.count({
           where: {
-            studentId,
+            examStudentId,
             compoundAnswerId: { in: compoundAnswerIds },
             ...SCORED_COMPOUND_ANSWER_SCORE_FILTER,
           },
@@ -526,7 +525,7 @@ export async function getStudentAnswerScoreSummary(answerSheetId: string) {
   try {
     const answerSheet = await prisma.studentAnswerImage.findUnique({
       where: { id: answerSheetId },
-      select: { examPageId: true, studentId: true },
+      select: { examPageId: true, examStudentId: true },
     })
 
     if (!answerSheet) {
@@ -537,7 +536,7 @@ export async function getStudentAnswerScoreSummary(answerSheetId: string) {
     const summary = await countStudentAnswerScoreData(
       prisma,
       scope,
-      answerSheet.studentId
+      answerSheet.examStudentId
     )
 
     return { success: true as const, summary }
@@ -577,7 +576,7 @@ export async function deleteStudentAnswer(answerSheetId: string) {
     const { summary, removedRows } = await prisma.$transaction(
       async (tx) => {
         const scope = await getPageScoreScope(tx, answerSheet.examPageId)
-        const studentId = answerSheet.studentId
+        const { examStudentId } = answerSheet
         const { cropRegionIds, compoundAnswerIds } = scope
 
         // 削除前に「利用者から見た採点実績」を数えておく（モーダルの表示と同じ定義）。
@@ -585,7 +584,7 @@ export async function deleteStudentAnswer(answerSheetId: string) {
         const scoreSummary = await countStudentAnswerScoreData(
           tx,
           scope,
-          studentId
+          examStudentId
         )
 
         let questionScoreRows = 0
@@ -596,7 +595,7 @@ export async function deleteStudentAnswer(answerSheetId: string) {
         if (cropRegionIds.length > 0) {
           // QuestionScore を削除（子の DrawingAnnotation は cascade で道連れ）
           const questionScores = await tx.questionScore.findMany({
-            where: { studentId, cropRegionId: { in: cropRegionIds } },
+            where: { examStudentId, cropRegionId: { in: cropRegionIds } },
             select: { id: true },
           })
           const questionScoreIds = questionScores.map(
@@ -614,14 +613,17 @@ export async function deleteStudentAnswer(answerSheetId: string) {
           }
 
           const removedDecisions = await tx.scoreDecision.deleteMany({
-            where: { studentId, cropRegionId: { in: cropRegionIds } },
+            where: { examStudentId, cropRegionId: { in: cropRegionIds } },
           })
           scoreDecisionRows = removedDecisions.count
         }
 
         if (compoundAnswerIds.length > 0) {
           const removedCompound = await tx.compoundAnswerScore.deleteMany({
-            where: { studentId, compoundAnswerId: { in: compoundAnswerIds } },
+            where: {
+              examStudentId,
+              compoundAnswerId: { in: compoundAnswerIds },
+            },
           })
           compoundAnswerScoreRows = removedCompound.count
         }
@@ -679,14 +681,14 @@ export async function deleteStudentAnswer(answerSheetId: string) {
  */
 export async function associateStudentAnswerWithStudent(
   answerSheetId: string,
-  studentId: string
+  examStudentId: string
 ) {
   try {
     const answerSheet = await prisma.studentAnswerImage.update({
       where: { id: answerSheetId },
-      data: { studentId },
+      data: { examStudentId },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         examPage: {
           include: {
             exam: true,
@@ -695,9 +697,9 @@ export async function associateStudentAnswerWithStudent(
       },
     })
 
-    const studentName = answerSheet.student
-      ? `${answerSheet.student.lastName} ${answerSheet.student.firstName}`.trim()
-      : null
+    const { student } = answerSheet.examStudent
+    const studentName =
+      `${student.lastName} ${student.firstName}`.trim() || null
     await recordAuditLog({
       action: "exam.answer.assign",
       entityType: "StudentAnswerImage",
@@ -728,7 +730,7 @@ export async function getStudentAnswerById(answerSheetId: string) {
     const answerSheet = await prisma.studentAnswerImage.findUnique({
       where: { id: answerSheetId },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         examPage: {
           include: {
             exam: {

--- a/electron-src/lib/prisma/studentAnswer/placementApply.ts
+++ b/electron-src/lib/prisma/studentAnswer/placementApply.ts
@@ -1,26 +1,37 @@
 /**
  * 答案配置の採点安全な一括適用（view の方式B: 任意マスへ移動・衝突swap）
  *
- * 設計（docs/06-student-answers-entity-first-plan.md §5）:
- * - 2軸移動: studentId だけでなく examPageId も更新する（移動先 ExamPage は id 直指定で受ける）。
+ * 設計:
+ * - 2軸移動: examStudentId だけでなく examPageId も更新する（移動先 ExamPage は id 直指定で受ける）。
  * - 採点はページ scoped: 移動元ページの CropRegion / CompoundAnswer × 現生徒の
  *   QuestionScore / ScoreDecision / CompoundAnswerScore のみ対象。
  * - carry（追従・同一ページのみ）:
- *   - QuestionScore は unique が無いので **id 指定の updateMany で studentId 付け替え**（id 保持 →
+ *   - QuestionScore は unique が無いので **id 指定の updateMany で examStudentId 付け替え**（id 保持 →
  *     子の DrawingAnnotation を温存。swap も id 指定なので途中衝突なし）。
- *   - ScoreDecision は `@@unique([cropRegionId, studentId])` があるため **delete → 最終位置へ再作成**。
- *   - CompoundAnswerScore も `@@unique([compoundAnswerId, studentId])` があるため同じく再作成方式。
+ *   - ScoreDecision は `@@unique([cropRegionId, examStudentId])` があるため **delete → 最終位置へ再作成**。
+ *   - CompoundAnswerScore も `@@unique([compoundAnswerId, examStudentId])` があるため同じく再作成方式。
  * - discard: 各スコア表（QuestionScore / ScoreDecision / CompoundAnswerScore）を削除。
  *   DrawingAnnotation は QuestionScore の cascade で道連れになる。
- * - **移動先セルの残存採点を掃除**: 移動先 (finalStudentId, 移動先ページの CropRegion /
+ * - **移動先セルの残存採点を掃除**: 移動先 (finalExamStudentId, 移動先ページの CropRegion /
  *   CompoundAnswer) に既存の採点があり、それが「移動してくる採点（moving 集合）」でない場合は
  *   stale として削除する（さもないと carry で QuestionScore が二重計上、ScoreDecision と
  *   CompoundAnswerScore は unique 違反になる）。
- * - 画像は `@@unique([examPageId, studentId])` の 2-cycle を避けるため **delete → 同一 id で再作成**。
- * - ガード: carry かつページ変化はエラー。finalStudentId=null（削除）は不可（削除は別操作）。
+ * - 画像は `@@unique([examPageId, examStudentId])` の 2-cycle を避けるため **delete → 同一 id で再作成**。
+ * - ガード: carry かつページ変化はエラー。finalExamStudentId=null（削除）は不可（削除は別操作）。
  *   移動先が batch 外の答案で占有されている場合もエラー（上書きはしない）。
  *
  * いずれも基本的な Prisma 操作のみ（findMany/updateMany/deleteMany/createMany）。
+ *
+ * ## 前提（実コードで確認済み・崩すと壊れる）
+ *
+ * - **FK は実行時強制**。衝突回避のために偽IDの一時レコードを挟む方式は FK 違反で壊れる
+ *   （旧 `batchUpdateStudentAnswerPlacements`/`swap*` がそれで破綻していた）。
+ *   本APIが一時IDを使わず delete → 再作成で表現しているのはこのため。
+ * - **delete → 同一 id での再作成は sqlite-nas-sync 上で安全**。`sync.ts` の tombstone-ignore が
+ *   「現存すれば再作成とみなす」ため、削除が同期先で復活を潰さない。**必ず id を保持すること**
+ *   （新しい id を振ると別レコードとして増える）。
+ * - 二次 `@@unique`（`[cropRegionId, examStudentId]` 等）の衝突は `conflict.ts` ケース2 が
+ *   LWW で単一行に収束させる。全表汎用なので個別対応は不要。
  */
 import type { Prisma } from "@prisma/client"
 
@@ -36,7 +47,7 @@ export type PlacementScorePolicy = "carry" | "discard"
 
 export interface StudentAnswerPlacementMove {
   fileId: string
-  finalStudentId: string | null // null は不可（本APIは削除を扱わない）
+  finalExamStudentId: string | null // null は不可（本APIは削除を扱わない）
   finalExamPageId: string
   scorePolicy: PlacementScorePolicy
 }
@@ -51,7 +62,7 @@ export async function applyStudentAnswerPlacements(
   if (moves.length === 0) return { success: true }
 
   // 本APIは配置の移動/入れ替え専用。削除は deleteStudentAnswer（ファイル削除・監査込み）を使う。
-  const nullMove = moves.find((move) => move.finalStudentId === null)
+  const nullMove = moves.find((move) => move.finalExamStudentId === null)
   if (nullMove) {
     return {
       success: false,
@@ -70,7 +81,7 @@ export async function applyStudentAnswerPlacements(
               where: { id: move.fileId },
               select: {
                 id: true,
-                studentId: true,
+                examStudentId: true,
                 examPageId: true,
                 imagePath: true,
                 createdAt: true,
@@ -90,14 +101,14 @@ export async function applyStudentAnswerPlacements(
         type PlacementPlan = {
           move: StudentAnswerPlacementMove
           current: NonNullable<(typeof currentAnswers)[number]>
-          finalStudentId: string
+          finalExamStudentId: string
           targetExamPageId: string
         }
         const plans: PlacementPlan[] = []
         for (let index = 0; index < moves.length; index++) {
           const move = moves[index]
           const current = currentAnswers[index]!
-          const finalStudentId = move.finalStudentId! // null は上で除外済み
+          const finalExamStudentId = move.finalExamStudentId! // null は上で除外済み
 
           // 移動先 ExamPage は id 直指定。同一試験のページであることのみ検証する
           // （pageNumber 序数への解決はしない＝id 一次同定）。
@@ -124,7 +135,7 @@ export async function applyStudentAnswerPlacements(
           plans.push({
             move,
             current,
-            finalStudentId,
+            finalExamStudentId,
             targetExamPageId: targetPage.id,
           })
         }
@@ -135,7 +146,7 @@ export async function applyStudentAnswerPlacements(
           const occupant = await tx.studentAnswerImage.findFirst({
             where: {
               examPageId: plan.targetExamPageId,
-              studentId: plan.finalStudentId,
+              examStudentId: plan.finalExamStudentId,
               id: { notIn: batchFileIds },
             },
             select: { id: true },
@@ -152,11 +163,11 @@ export async function applyStudentAnswerPlacements(
         const scoreDecisionIdsToDelete: string[] = [] // discard/carry source + stale destination
         const questionScoreCarryUpdates: Array<{
           ids: string[]
-          finalStudentId: string
+          finalExamStudentId: string
         }> = []
         const scoreDecisionsToRecreate: Prisma.ScoreDecisionCreateManyInput[] =
           []
-        // 複合回答も CropRegion と同じくページ scoped。`@@unique([compoundAnswerId, studentId])`
+        // 複合回答も CropRegion と同じくページ scoped。`@@unique([compoundAnswerId, examStudentId])`
         // があるため ScoreDecision と同様 delete → 再作成で付け替える。
         const compoundAnswerScoreIdsToDelete: string[] = []
         const compoundAnswerScoresToRecreate: Prisma.CompoundAnswerScoreCreateManyInput[] =
@@ -164,9 +175,9 @@ export async function applyStudentAnswerPlacements(
         const movingQuestionScoreIds = new Set<string>()
         const movingScoreDecisionIds = new Set<string>()
         const movingCompoundAnswerScoreIds = new Set<string>()
-        // 移動先掃除のための (finalStudentId, 移動先ページの cropRegionIds/compoundAnswerIds)
+        // 移動先掃除のための (finalExamStudentId, 移動先ページの cropRegionIds/compoundAnswerIds)
         const destinationScopes: Array<{
-          finalStudentId: string
+          finalExamStudentId: string
           cropRegionIds: string[]
           compoundAnswerIds: string[]
         }> = []
@@ -188,7 +199,7 @@ export async function applyStudentAnswerPlacements(
           const sourceCropRegionIds = sourceScope.cropRegionIds
           const sourceCompoundAnswerIds = sourceScope.compoundAnswerIds
           destinationScopes.push({
-            finalStudentId: plan.finalStudentId,
+            finalExamStudentId: plan.finalExamStudentId,
             cropRegionIds: targetScope.cropRegionIds,
             compoundAnswerIds: targetScope.compoundAnswerIds,
           })
@@ -197,7 +208,7 @@ export async function applyStudentAnswerPlacements(
           if (sourceCompoundAnswerIds.length > 0) {
             const compoundAnswerScores = await tx.compoundAnswerScore.findMany({
               where: {
-                studentId: plan.current.studentId,
+                examStudentId: plan.current.examStudentId,
                 compoundAnswerId: { in: sourceCompoundAnswerIds },
               },
             })
@@ -214,7 +225,7 @@ export async function applyStudentAnswerPlacements(
                 ...compoundAnswerScores.map((compoundAnswerScore) => ({
                   id: compoundAnswerScore.id,
                   compoundAnswerId: compoundAnswerScore.compoundAnswerId,
-                  studentId: plan.finalStudentId,
+                  examStudentId: plan.finalExamStudentId,
                   userId: compoundAnswerScore.userId,
                   recognizedAnswer: compoundAnswerScore.recognizedAnswer,
                   status: compoundAnswerScore.status,
@@ -229,14 +240,14 @@ export async function applyStudentAnswerPlacements(
 
           const questionScores = await tx.questionScore.findMany({
             where: {
-              studentId: plan.current.studentId,
+              examStudentId: plan.current.examStudentId,
               cropRegionId: { in: sourceCropRegionIds },
             },
             select: { id: true },
           })
           const scoreDecisions = await tx.scoreDecision.findMany({
             where: {
-              studentId: plan.current.studentId,
+              examStudentId: plan.current.examStudentId,
               cropRegionId: { in: sourceCropRegionIds },
             },
           })
@@ -255,11 +266,11 @@ export async function applyStudentAnswerPlacements(
               ...scoreDecisions.map((scoreDecision) => scoreDecision.id)
             )
           } else {
-            // carry: QuestionScore は id 指定で studentId 付け替え（注釈を温存）
+            // carry: QuestionScore は id 指定で examStudentId 付け替え（注釈を温存）
             if (questionScores.length > 0) {
               questionScoreCarryUpdates.push({
                 ids: questionScores.map((questionScore) => questionScore.id),
-                finalStudentId: plan.finalStudentId,
+                finalExamStudentId: plan.finalExamStudentId,
               })
             }
             // ScoreDecision は unique 回避のため delete → id 保持で最終位置へ再作成
@@ -270,7 +281,7 @@ export async function applyStudentAnswerPlacements(
               ...scoreDecisions.map((scoreDecision) => ({
                 id: scoreDecision.id,
                 cropRegionId: scoreDecision.cropRegionId,
-                studentId: plan.finalStudentId,
+                examStudentId: plan.finalExamStudentId,
                 verdict: scoreDecision.verdict,
                 score: scoreDecision.score,
                 comment: scoreDecision.comment,
@@ -289,7 +300,7 @@ export async function applyStudentAnswerPlacements(
             const staleCompoundAnswerScores =
               await tx.compoundAnswerScore.findMany({
                 where: {
-                  studentId: scope.finalStudentId,
+                  examStudentId: scope.finalExamStudentId,
                   compoundAnswerId: { in: scope.compoundAnswerIds },
                 },
                 select: { id: true },
@@ -304,14 +315,14 @@ export async function applyStudentAnswerPlacements(
           if (scope.cropRegionIds.length === 0) continue
           const staleQuestionScores = await tx.questionScore.findMany({
             where: {
-              studentId: scope.finalStudentId,
+              examStudentId: scope.finalExamStudentId,
               cropRegionId: { in: scope.cropRegionIds },
             },
             select: { id: true },
           })
           const staleScoreDecisions = await tx.scoreDecision.findMany({
             where: {
-              studentId: scope.finalStudentId,
+              examStudentId: scope.finalExamStudentId,
               cropRegionId: { in: scope.cropRegionIds },
             },
             select: { id: true },
@@ -335,11 +346,11 @@ export async function applyStudentAnswerPlacements(
           })
         }
 
-        // 5. carry の QuestionScore: id 指定で studentId 付け替え（行=注釈を保持）
+        // 5. carry の QuestionScore: id 指定で examStudentId 付け替え（行=注釈を保持）
         for (const carryUpdate of questionScoreCarryUpdates) {
           await tx.questionScore.updateMany({
             where: { id: { in: carryUpdate.ids } },
-            data: { studentId: carryUpdate.finalStudentId },
+            data: { examStudentId: carryUpdate.finalExamStudentId },
           })
         }
 
@@ -373,7 +384,7 @@ export async function applyStudentAnswerPlacements(
           data: plans.map((plan) => ({
             id: plan.move.fileId,
             examPageId: plan.targetExamPageId,
-            studentId: plan.finalStudentId,
+            examStudentId: plan.finalExamStudentId,
             imagePath: plan.current.imagePath,
             createdAt: plan.current.createdAt,
           })),

--- a/electron-src/lib/prisma/studentAnswer/status.ts
+++ b/electron-src/lib/prisma/studentAnswer/status.ts
@@ -25,7 +25,7 @@ export async function setStudentAnswerAbsent(
     const answerSheet = await prisma.studentAnswerImage.findUnique({
       where: { id: answerSheetId },
       include: {
-        student: true,
+        examStudent: { include: { student: true } },
         examPage: {
           include: {
             exam: true,

--- a/electron-src/lib/shared/calculations/examScoreCalculator.ts
+++ b/electron-src/lib/shared/calculations/examScoreCalculator.ts
@@ -2,10 +2,30 @@
  * 試験（Exam）由来のrawScore算出
  * - exam_total: 全QUESTION_ANSWER CropRegionスコア合計
  * - crop_region: 単一CropRegionのスコア
+ *
+ * 生徒からスコアへ到達する経路は必ず「その試験の受験者（ExamStudent）」を1回通す。
+ * 受験者として登録されていない生徒はスコアを引けず、データなし（null）になる。
  */
 
 import { calculateActualScore } from "../../prisma/questionScore"
-import type { ExamDataCache } from "./gradeCalculatorTypes"
+import type { ExamDataCache, ExamStudentScores } from "./gradeCalculatorTypes"
+
+/**
+ * 生徒をその試験の受験者へ解決する。受験していなければ null。
+ */
+export function findExamStudentScores(
+  studentId: string,
+  examId: string,
+  examDataCache: Map<string, ExamDataCache>
+): ExamStudentScores | null {
+  const examData = examDataCache.get(examId)
+  if (!examData) return null
+  return (
+    examData.examStudents.find(
+      (examStudent) => examStudent.studentId === studentId
+    ) ?? null
+  )
+}
 
 /**
  * exam_total: 試験の全QUESTION_ANSWER CropRegionスコア合計
@@ -18,9 +38,9 @@ export function calculateExamTotalScore(
   const examData = examDataCache.get(examId)
   if (!examData) return null
 
-  const studentScores = examData.questionScores.filter(
-    (questionScore) => questionScore.studentId === studentId
-  )
+  const examStudent = findExamStudentScores(studentId, examId, examDataCache)
+  if (!examStudent) return null
+
   const questionRegions = examData.cropRegions.filter(
     (cropRegion) => cropRegion.type === "QUESTION_ANSWER"
   )
@@ -29,7 +49,7 @@ export function calculateExamTotalScore(
   let hasScored = false
 
   for (const cropRegion of questionRegions) {
-    const scoreData = studentScores.find(
+    const scoreData = examStudent.questionScores.find(
       (questionScore) => questionScore.cropRegionId === cropRegion.id
     )
     if (scoreData) {
@@ -64,10 +84,11 @@ export function calculateCropRegionScore(
   )
   if (!cropRegion) return null
 
-  const scoreData = examData.questionScores.find(
-    (questionScore) =>
-      questionScore.studentId === studentId &&
-      questionScore.cropRegionId === cropRegionId
+  const examStudent = findExamStudentScores(studentId, examId, examDataCache)
+  if (!examStudent) return null
+
+  const scoreData = examStudent.questionScores.find(
+    (questionScore) => questionScore.cropRegionId === cropRegionId
   )
   if (!scoreData) return null
 

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -22,6 +22,7 @@ import {
   computeSourceFit,
   estimateAbsentScore,
 } from "./absentEstimation"
+import { findExamStudentScores } from "./examScoreCalculator"
 import type { DataSourceInfo, ExamDataCache } from "./gradeCalculatorTypes"
 import { determineGradeLabel } from "./gradeLabel"
 import { getRawScore } from "./rawScoreCalculator"
@@ -136,31 +137,43 @@ async function buildGradeCalcContext(gradeId: string) {
     ),
   ]
 
-  // 5. 試験試験のスコアデータを事前取得
+  // 5. 試験のスコアデータを事前取得
+  //
+  // 起点は ExamStudent（その試験の受験者）で、採点行はその子として引く。
+  // 「試験から外した生徒の採点行」は受験者が居ないので構造的に集まらない
+  // （以前は CropRegion 起点で引いており、外したはずの生徒の得点が
+  //  成績算出でだけ算入されていた）。受験状態も同じ行から取れるので、
+  //  見込→欠測の判定に別途 status のプリロードを持たない。
   const examDataCache = new Map<string, ExamDataCache>()
 
   for (const examId of examIds) {
-    const [questionScores, scoreDecisions, examPages] = await Promise.all([
-      prisma.questionScore.findMany({
-        where: { cropRegion: { examPage: { examId: examId } } },
+    const [examStudentRows, examPages] = await Promise.all([
+      prisma.examStudent.findMany({
+        where: { examId },
         select: {
           id: true,
           studentId: true,
-          cropRegionId: true,
           status: true,
-          partialScore: true,
-          updatedAt: true,
-        },
-      }),
-      prisma.scoreDecision.findMany({
-        where: { cropRegion: { examPage: { examId: examId } } },
-        select: {
-          studentId: true,
-          cropRegionId: true,
-          verdict: true,
-          score: true,
-          decidedAt: true,
-          sourceQuestionScoreId: true,
+          questionScores: {
+            select: {
+              id: true,
+              examStudentId: true,
+              cropRegionId: true,
+              status: true,
+              partialScore: true,
+              updatedAt: true,
+            },
+          },
+          scoreDecisions: {
+            select: {
+              examStudentId: true,
+              cropRegionId: true,
+              verdict: true,
+              score: true,
+              decidedAt: true,
+              sourceQuestionScoreId: true,
+            },
+          },
         },
       }),
       prisma.examPage.findMany({
@@ -169,39 +182,32 @@ async function buildGradeCalcContext(gradeId: string) {
       }),
     ])
     const cropRegions = examPages.flatMap((examPage) => examPage.cropRegions)
-    // 生徒×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
-    const { resolved: resolvedScores } = resolveEffectiveScores(
-      questionScores,
-      scoreDecisions
-    )
+
     examDataCache.set(examId, {
-      questionScores: resolvedScores.map((resolvedScore) => ({
-        studentId: resolvedScore.studentId,
-        cropRegionId: resolvedScore.cropRegionId,
-        status: resolvedScore.status,
-        partialScore: resolvedScore.partialScore,
-      })),
+      examStudents: examStudentRows.map((examStudentRow) => {
+        // 受験者×設問ごとに有効スコア1件へ解決（確定 > 提案合意 > 競合）
+        const { resolved: resolvedScores } = resolveEffectiveScores(
+          examStudentRow.questionScores,
+          examStudentRow.scoreDecisions
+        )
+        return {
+          examStudentId: examStudentRow.id,
+          studentId: examStudentRow.studentId,
+          status: examStudentRow.status,
+          questionScores: resolvedScores.map((resolvedScore) => ({
+            examStudentId: resolvedScore.examStudentId,
+            cropRegionId: resolvedScore.cropRegionId,
+            status: resolvedScore.status,
+            partialScore: resolvedScore.partialScore,
+          })),
+        }
+      }),
       cropRegions: cropRegions.map((cropRegion) => ({
         id: cropRegion.id,
         type: cropRegion.type,
         points: cropRegion.points,
       })),
     })
-  }
-
-  // 5.5. 見込→欠測対応: examIdごとのExamStudent状態をプリロード
-  // Map<examId, Map<studentId, status>>
-  const examExamStudentStatusMap = new Map<string, Map<string, string>>()
-  for (const examId of examIds) {
-    const examStudentStatuses = await prisma.examStudent.findMany({
-      where: { examId: examId },
-      select: { studentId: true, status: true },
-    })
-    const statusMap = new Map<string, string>()
-    for (const examStudent of examStudentStatuses) {
-      statusMap.set(examStudent.studentId, examStudent.status)
-    }
-    examExamStudentStatusMap.set(examId, statusMap)
   }
 
   // 満点は元データ（設問配点 / 評価項目満点）からライブ算出する。
@@ -243,14 +249,18 @@ async function buildGradeCalcContext(gradeId: string) {
       )
 
       // 見込→欠測対応: treatExpectedAsMissing が true かつ
-      // 試験試験の ExamStudent.status === "expected" → null扱い
+      // その試験の ExamStudent.status === "expected" → null扱い
       if (
         raw !== null &&
         dataSource.treatExpectedAsMissing &&
         dataSource.examId
       ) {
-        const statusMap = examExamStudentStatusMap.get(dataSource.examId)
-        if (statusMap?.get(examStudent.student.id) === "expected") {
+        const examStudentScores = findExamStudentScores(
+          examStudent.student.id,
+          dataSource.examId,
+          examDataCache
+        )
+        if (examStudentScores?.status === "expected") {
           raw = null
         }
       }

--- a/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
@@ -7,10 +7,26 @@ import type { AbsentMethod } from "../../../../src/types/grade.types"
 import type { QuestionScoreForSubtotal } from "./subtotalCalculator"
 
 /**
+ * 試験の受験者1人分の解決済みスコア。
+ *
+ * 成績算出のループ軸は Student（試験横断で同一人物を追う）なので、この行が
+ * 「その人がその試験を受験しているか」の解決結果そのものになる。
+ * ここに現れない生徒はその試験を受験していない＝データなしであり、
+ * 採点データだけが残っている孤児を拾うことは構造的に起こらない。
+ */
+export interface ExamStudentScores {
+  examStudentId: string
+  studentId: string
+  /** 受験状態（participating | expected | absent）。見込→欠測の判定に使う */
+  status: string
+  questionScores: QuestionScoreForSubtotal[]
+}
+
+/**
  * 試験ごとに事前取得したスコア・領域データ（生徒ループ外で1回だけ構築）
  */
 export interface ExamDataCache {
-  questionScores: QuestionScoreForSubtotal[]
+  examStudents: ExamStudentScores[]
   cropRegions: { id: string; type: string; points: number | null }[]
 }
 

--- a/electron-src/lib/shared/calculations/rawScoreCalculator.ts
+++ b/electron-src/lib/shared/calculations/rawScoreCalculator.ts
@@ -7,6 +7,7 @@
 import {
   calculateCropRegionScore,
   calculateExamTotalScore,
+  findExamStudentScores,
 } from "./examScoreCalculator"
 import type { ExamDataCache } from "./gradeCalculatorTypes"
 import { calculateSubtotalScoreBySubtotalId } from "./subtotalCalculator"
@@ -51,11 +52,16 @@ export async function getRawScore(
     dataSource.examId
   ) {
     const examData = examDataCache.get(dataSource.examId)
-    if (examData) {
+    const examStudent = findExamStudentScores(
+      studentId,
+      dataSource.examId,
+      examDataCache
+    )
+    if (examData && examStudent) {
       const result = await calculateSubtotalScoreBySubtotalId(
-        studentId,
+        examStudent.examStudentId,
         dataSource.subtotalId,
-        examData.questionScores,
+        examStudent.questionScores,
         examData.cropRegions as Parameters<
           typeof calculateSubtotalScoreBySubtotalId
         >[3]

--- a/electron-src/lib/shared/calculations/scoreResolution.ts
+++ b/electron-src/lib/shared/calculations/scoreResolution.ts
@@ -2,8 +2,8 @@
  * 有効スコアの解決（リゾルバ）
  *
  * 採点データは2層で保持される:
- * - QuestionScore: 採点者ごとの「提案」（生徒×設問×採点者）
- * - ScoreDecision: 試験OWNERによる「確定」（生徒×設問ごとに高々1行）
+ * - QuestionScore: 採点者ごとの「提案」（受験者×設問×採点者）
+ * - ScoreDecision: 試験OWNERによる「確定」（受験者×設問ごとに高々1行）
  *
  * 集計・出力系（Excel出力・個人レポート・PDF出力・小計・成績連携）は
  * 必ずこのモジュールで生徒×設問ごとに1つの有効スコアへ解決してから処理する。
@@ -21,7 +21,7 @@
  */
 
 export interface ResolvableScore {
-  studentId: string | null
+  examStudentId: string
   cropRegionId: string
   status: string
   partialScore: number | string | { toString(): string } | null
@@ -30,7 +30,7 @@ export interface ResolvableScore {
 }
 
 export interface ResolvableDecision {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   verdict: string
   score: number | string | { toString(): string } | null
@@ -38,9 +38,9 @@ export interface ResolvableDecision {
   sourceQuestionScoreId?: string | null
 }
 
-/** 生徒×設問ごとに解決された有効スコア */
+/** 受験者×設問ごとに解決された有効スコア */
 export interface EffectiveScore {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   /** 採点判定（correct | incorrect | partial | pending | no_answer | double_mark | unscored） */
   status: string
@@ -57,7 +57,7 @@ export interface EffectiveScore {
 }
 
 export interface ScoreConflict {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   /** 競合した採点行の数（unscored を除く） */
   candidateCount: number
@@ -90,14 +90,14 @@ const pickLatest = <T extends ResolvableScore>(group: T[]): T =>
     return (current.id ?? "") > (latest.id ?? "") ? current : latest
   })
 
-const cellKey = (studentId: string, cropRegionId: string): string =>
-  `${studentId} ${cropRegionId}`
+const cellKey = (examStudentId: string, cropRegionId: string): string =>
+  `${examStudentId} ${cropRegionId}`
 
 const proposalToEffective = (
   proposal: ResolvableScore,
   isStale = false
 ): EffectiveScore => ({
-  studentId: proposal.studentId as string,
+  examStudentId: proposal.examStudentId,
   cropRegionId: proposal.cropRegionId,
   status: proposal.status,
   partialScore: normalizeScore(proposal.partialScore),
@@ -112,8 +112,7 @@ export function resolveEffectiveScores(
 ): ResolveResult {
   const groups = new Map<string, ResolvableScore[]>()
   for (const score of scores) {
-    if (!score.studentId) continue
-    const key = cellKey(score.studentId, score.cropRegionId)
+    const key = cellKey(score.examStudentId, score.cropRegionId)
     const group = groups.get(key)
     if (group) {
       group.push(score)
@@ -128,7 +127,7 @@ export function resolveEffectiveScores(
 
   // 1) 明示的な確定（ScoreDecision）が最優先
   for (const decision of decisions) {
-    const key = cellKey(decision.studentId, decision.cropRegionId)
+    const key = cellKey(decision.examStudentId, decision.cropRegionId)
     if (decidedCells.has(key)) continue // 不正データ耐性（uniqueにより通常は発生しない）
     decidedCells.add(key)
 
@@ -140,7 +139,7 @@ export function resolveEffectiveScores(
     )
 
     resolved.push({
-      studentId: decision.studentId,
+      examStudentId: decision.examStudentId,
       cropRegionId: decision.cropRegionId,
       status: decision.verdict,
       partialScore: normalizeScore(decision.score),
@@ -179,7 +178,7 @@ export function resolveEffectiveScores(
       resolved.push(proposalToEffective(pickLatest(candidates)))
     } else {
       conflicts.push({
-        studentId: first.studentId as string,
+        examStudentId: first.examStudentId,
         cropRegionId: first.cropRegionId,
         candidateCount: candidates.length,
       })

--- a/electron-src/lib/shared/calculations/spAnalysis.ts
+++ b/electron-src/lib/shared/calculations/spAnalysis.ts
@@ -20,14 +20,14 @@ export interface SpInputItem {
 
 /** 生徒1人分の入力 */
 export interface SpInputStudent {
-  studentId: string
+  examStudentId: string
   studentName: string
   items: SpInputItem[]
 }
 
 /** S-P表の生徒行（合計正答数の降順に並ぶ） */
 export interface SpStudentRow {
-  studentId: string
+  examStudentId: string
   studentName: string
   /** 正答数（行和 n_i） */
   correctCount: number
@@ -134,7 +134,7 @@ export function computeSpTable(input: SpInputStudent[]): SpTableResult | null {
   }))
 
   const studentRows: SpStudentRow[] = studentOrder.map((i) => ({
-    studentId: students[i].studentId,
+    examStudentId: students[i].examStudentId,
     studentName: students[i].studentName,
     correctCount: rowSum[i],
     cautionIndex: studentCaution(i),

--- a/electron-src/lib/shared/calculations/subtotalCalculator.ts
+++ b/electron-src/lib/shared/calculations/subtotalCalculator.ts
@@ -40,15 +40,15 @@ export interface SubtotalScoreResult {
  * @returns スコアと最大点の両方を返す
  */
 export async function calculateSubtotalScoreForStudent(
-  studentId: string,
+  examStudentId: string,
   subtotalRegionId: string,
   allQuestionScores: QuestionScoreForSubtotal[],
   cropRegions: CropRegion[]
 ): Promise<SubtotalScoreResult> {
   try {
     // この生徒の全採点データを取得
-    const studentScores = allQuestionScores.filter(
-      (score) => score.studentId === studentId
+    const examStudentScores = allQuestionScores.filter(
+      (score) => score.examStudentId === examStudentId
     )
 
     // 小計点領域に関連付けられたグループ項目を取得
@@ -57,7 +57,7 @@ export async function calculateSubtotalScoreForStudent(
     // グループ定義がない場合は、この生徒の全設問の合計点を返す（フォールバック）
     if (!cropSubtotals || cropSubtotals.length === 0) {
       return calculateStudentTotalScoreWithMax(
-        studentId,
+        examStudentId,
         allQuestionScores,
         cropRegions
       )
@@ -80,7 +80,7 @@ export async function calculateSubtotalScoreForStudent(
 
     if (groupMap.size === 0) {
       return calculateStudentTotalScoreWithMax(
-        studentId,
+        examStudentId,
         allQuestionScores,
         cropRegions
       )
@@ -139,7 +139,7 @@ export async function calculateSubtotalScoreForStudent(
     let hasScoredQuestion = false
 
     for (const questionId of finalQuestionIds) {
-      const scoreData = studentScores.find(
+      const scoreData = examStudentScores.find(
         (questionScore) => questionScore.cropRegionId === questionId
       )
       if (scoreData) {
@@ -163,7 +163,7 @@ export async function calculateSubtotalScoreForStudent(
     }
   } catch (error) {
     console.error(
-      `Error calculating subtotal score for student ${studentId}, region ${subtotalRegionId}:`,
+      `Error calculating subtotal score for student ${examStudentId}, region ${subtotalRegionId}:`,
       error
     )
     return { score: null, maxScore: 0, hasQuestionAssignments: false }
@@ -174,12 +174,12 @@ export async function calculateSubtotalScoreForStudent(
  * 生徒の全設問合計点とその最大点を計算する（フォールバック用）
  */
 function calculateStudentTotalScoreWithMax(
-  studentId: string,
+  examStudentId: string,
   allQuestionScores: QuestionScoreForSubtotal[],
   cropRegions: CropRegion[]
 ): SubtotalScoreResult {
-  const studentScores = allQuestionScores.filter(
-    (score) => score.studentId === studentId
+  const examStudentScores = allQuestionScores.filter(
+    (score) => score.examStudentId === examStudentId
   )
 
   let totalScore = 0
@@ -194,7 +194,7 @@ function calculateStudentTotalScoreWithMax(
   }
 
   // 採点データがある設問の得点を合計
-  for (const scoreData of studentScores) {
+  for (const scoreData of examStudentScores) {
     const cropRegion = cropRegions.find(
       (cropRegion) => cropRegion.id === scoreData.cropRegionId
     )
@@ -219,22 +219,22 @@ function calculateStudentTotalScoreWithMax(
  * Subtotal IDから直接小計点を計算する関数（個人成績表用）
  * SUBTOTAL_SCORE CropRegionを介さず、Subtotalから直接計算
  *
- * @param studentId 生徒ID
+ * @param examStudentId 生徒ID
  * @param subtotalId Subtotal ID
  * @param allQuestionScores 全採点データ
  * @param cropRegions 全CropRegion（QUESTION_ANSWER用）
  * @returns 小計点と最大点
  */
 export async function calculateSubtotalScoreBySubtotalId(
-  studentId: string,
+  examStudentId: string,
   subtotalId: string,
   allQuestionScores: QuestionScoreForSubtotal[],
   cropRegions: CropRegion[]
 ): Promise<SubtotalScoreResult> {
   try {
     // この生徒の全採点データを取得
-    const studentScores = allQuestionScores.filter(
-      (score) => score.studentId === studentId
+    const examStudentScores = allQuestionScores.filter(
+      (score) => score.examStudentId === examStudentId
     )
 
     // SubtotalからQUESTION_ASSIGNMENTのCropSubtotalを直接取得
@@ -281,7 +281,7 @@ export async function calculateSubtotalScoreBySubtotalId(
       const questionMaxScore = cropRegion.points || 0
       totalMaxScore += questionMaxScore
 
-      const scoreData = studentScores.find(
+      const scoreData = examStudentScores.find(
         (questionScore) => questionScore.cropRegionId === questionId
       )
       if (scoreData) {
@@ -300,7 +300,7 @@ export async function calculateSubtotalScoreBySubtotalId(
     }
   } catch (error) {
     console.error(
-      `Error calculating subtotal score for student ${studentId}, subtotal ${subtotalId}:`,
+      `Error calculating subtotal score for student ${examStudentId}, subtotal ${subtotalId}:`,
       error
     )
     return { score: null, maxScore: 0, hasQuestionAssignments: false }

--- a/electron-src/lib/shared/types.ts
+++ b/electron-src/lib/shared/types.ts
@@ -22,14 +22,21 @@ export interface StudentExportPlacement {
 
 export interface ExportGradingDataOptions {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   outputPath?: string
   forceExport?: boolean // 警告を無視して強制実行
-  /** renderer が採番解決して渡す表示学級情報（studentId キー）。Excel 出力で使用 */
+  /**
+   * renderer が採番解決して渡す表示学級情報。**キーは Student.id**
+   * （学級所属は人に紐づくので、採番学級の解決も Student キーになる）。
+   * 受験者IDではないことに注意 — 両方 string なので取り違えても型検査は通る。
+   */
   studentPlacements?: Record<string, StudentExportPlacement>
 }
 
 export interface ScoringData {
+  /** 採点データの同定に使う受験者ID（ExamStudent.id） */
+  examStudentId: string
+  /** 人としての生徒ID。学級所属（Student キー）との突き合わせに使う */
   studentId: string
   studentName: string
   studentNumber: string

--- a/electron-src/lib/shared/utilities/validateScoringData.ts
+++ b/electron-src/lib/shared/utilities/validateScoringData.ts
@@ -15,13 +15,13 @@ import type { ScoringData } from "../types"
  */
 export function buildConflictWarnings(
   summary: ExamDecisionSummary,
-  selectedStudentIds: string[] = []
+  selectedExamStudentIds: string[] = []
 ): ConflictWarning[] {
-  const selected = new Set(selectedStudentIds)
+  const selected = new Set(selectedExamStudentIds)
   return summary.questions.flatMap((question) =>
     question.cells
       .filter((cell) => cell.reason === "conflict")
-      .filter((cell) => selected.size === 0 || selected.has(cell.studentId))
+      .filter((cell) => selected.size === 0 || selected.has(cell.examStudentId))
       .map((cell) => ({
         ...cell,
         questionLabel: question.questionLabel,

--- a/electron-src/preload-apis/answerSheetApi.ts
+++ b/electron-src/preload-apis/answerSheetApi.ts
@@ -10,7 +10,7 @@ export function createAnswerSheetApi() {
         name: string
         type: string
         buffer: ArrayBuffer
-        studentId?: string
+        examStudentId?: string
         examPageId: string
         overwrite?: boolean
         correctWithMarkers?: boolean
@@ -26,12 +26,12 @@ export function createAnswerSheetApi() {
       ipcRenderer.invoke("delete-answer-sheet", answerSheetId),
     associateStudentAnswerWithStudent: (
       answerSheetId: string,
-      studentId: string
+      examStudentId: string
     ) =>
       ipcRenderer.invoke(
         "associate-answer-sheet-with-student",
         answerSheetId,
-        studentId
+        examStudentId
       ),
     setStudentAnswerAbsent: (answerSheetId: string, isAbsent: boolean) =>
       ipcRenderer.invoke("set-answer-sheet-absent", answerSheetId, isAbsent),
@@ -40,7 +40,7 @@ export function createAnswerSheetApi() {
     applyStudentAnswerPlacements: (
       moves: Array<{
         fileId: string
-        finalStudentId: string | null
+        finalExamStudentId: string | null
         finalExamPageId: string
         scorePolicy: "carry" | "discard"
       }>

--- a/electron-src/preload-apis/drawingApi.ts
+++ b/electron-src/preload-apis/drawingApi.ts
@@ -19,16 +19,14 @@ export function createDrawingApi() {
           type,
           userId
         ),
-      getByStudent: (
-        studentId: string,
-        examId: string,
+      getByExamStudent: (
+        examStudentId: string,
         type?: string,
         userId?: string
       ) =>
         ipcRenderer.invoke(
-          "drawing:getByStudent",
-          studentId,
-          examId,
+          "drawing:getByExamStudent",
+          examStudentId,
           type,
           userId
         ),

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -9,7 +9,7 @@ export function createExportApi() {
     export: {
       validateScoringData: (options: {
         examId: string
-        selectedStudentIds: string[]
+        selectedExamStudentIds: string[]
         userId: string
       }) => ipcRenderer.invoke("export:validateScoringData", options),
       recordUnresolvedConflicts: (options: {
@@ -21,12 +21,12 @@ export function createExportApi() {
       }) => ipcRenderer.invoke("export:recordUnresolvedConflicts", options),
       getPdfExportData: (options: {
         examId: string
-        selectedStudentIds: string[]
+        selectedExamStudentIds: string[]
       }) => ipcRenderer.invoke("export:getPdfExportData", options),
       createPdfFromRenderedImages: (options: {
         examId: string
         renderedPages: Array<{
-          studentId: string
+          examStudentId: string
           pageNumber: number
           imageData: ArrayBuffer
         }>
@@ -59,7 +59,7 @@ export function createExportApi() {
       // 個人成績表PDF API
       getIndividualReportData: (options: {
         examId: string
-        selectedStudentIds: string[]
+        selectedExamStudentIds: string[]
         options: import("../lib/export/individual-report").IndividualReportOptions
         studentPlacements?: Record<
           string,
@@ -96,7 +96,7 @@ export function createExportApi() {
       // Excelプレビューデータ取得
       getExcelPreviewData: (options: {
         examId: string
-        selectedStudentIds: string[]
+        selectedExamStudentIds: string[]
         studentPlacements?: Record<
           string,
           import("../lib/shared/types").StudentExportPlacement
@@ -112,7 +112,7 @@ export function createExportApi() {
       // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録
       captureReturnSnapshot: (options: {
         examId: string
-        studentIds: string[]
+        examStudentIds: string[]
       }) => ipcRenderer.invoke("export:captureReturnSnapshot", options),
       // 返却版と現在状態の差分（変更があった生徒の検出）
       getReturnDiff: (examId: string) =>
@@ -122,7 +122,7 @@ export function createExportApi() {
     // Excel Export related
     exportGradingDataExcel: (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       outputPath?: string
       studentPlacements?: Record<
         string,

--- a/electron-src/preload-apis/omrApi.ts
+++ b/electron-src/preload-apis/omrApi.ts
@@ -19,12 +19,12 @@ export function createOmrApi() {
         ]
         params: { colorThreshold: number; areaThreshold: number }
         pageIndex?: number
-        studentId?: string
+        examStudentId?: string
       }) => ipcRenderer.invoke("omr:recognize-sheet", args),
       batchRecognize: (args: {
         imagePaths: {
           path: string
-          studentId?: string
+          examStudentId?: string
           studentName?: string
         }[]
         cells: unknown[]

--- a/electron-src/preload-apis/scoringApi.ts
+++ b/electron-src/preload-apis/scoringApi.ts
@@ -75,7 +75,7 @@ export function createScoringApi() {
       ipcRenderer.invoke("initialize-scoring-records", examId),
     batchUpdateQuestionScores: (
       entries: Array<{
-        studentId: string
+        examStudentId: string
         cropRegionId: string
         status: string
         partialScore: number | null

--- a/prisma/migrations/20260728000000_rewire_scoring_to_exam_student/migration.sql
+++ b/prisma/migrations/20260728000000_rewire_scoring_to_exam_student/migration.sql
@@ -1,0 +1,193 @@
+-- 採点層の5テーブルを Student 直結から ExamStudent（試験の受験者）経由へ配線し直す。
+--
+-- これまで StudentAnswerImage / QuestionScore / ScoreDecision / CompoundAnswerScore /
+-- ReturnSnapshot は studentId で Student を直接参照していた。ExamStudent を参照する
+-- 子テーブルが1つも無かったため「試験から生徒を外す」操作では DB の cascade が働かず、
+-- 削除経路の手書き DELETE が取りこぼした行が孤児として残り続けていた。
+-- 孤児は試験側の画面・出力（すべて ExamStudent 起点）には現れないのに、成績算出
+-- （gradeCalculator は ExamStudent で絞っていなかった）でだけ素点として算入されていた。
+--
+-- バックフィルは ExamStudent との INNER JOIN で行うため、孤児は自然に落ちる。
+-- 破棄は削除確認ダイアログが以前から約束していた挙動であり、仕様変更ではなく仕様への適合。
+-- 破棄件数は AuditLog に記録する（起動時のモーダルは data フォルダの手動コピー運用では
+-- 最初にそのコピーを開いた人にしか出ず、周知手段として機能しないため）。
+--
+-- ReturnSnapshot の examId 列は ExamStudent が examId を持つため削除する
+-- （両方を保持すると examId と examStudent.examId が食い違いうる）。
+--
+-- 注: 孤児 StudentAnswerImage が指していた画像ファイルはディスク上に残る。
+--     参照が無くなるだけで、実害は使用済み容量のみ。
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+-- ── 1. 新テーブルの作成とバックフィル ───────────────────────────
+
+-- StudentAnswerImage: ExamPage.examId 経由で ExamStudent に到達する
+CREATE TABLE "new_StudentAnswerImage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "examPageId" TEXT NOT NULL,
+    "examStudentId" TEXT NOT NULL,
+    "imagePath" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "StudentAnswerImage_examPageId_fkey" FOREIGN KEY ("examPageId") REFERENCES "ExamPage" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "StudentAnswerImage_examStudentId_fkey" FOREIGN KEY ("examStudentId") REFERENCES "ExamStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_StudentAnswerImage" ("id", "examPageId", "examStudentId", "imagePath", "createdAt", "updatedAt")
+SELECT sai."id", sai."examPageId", es."id", sai."imagePath", sai."createdAt", sai."updatedAt"
+FROM "StudentAnswerImage" sai
+JOIN "ExamPage" ep ON ep."id" = sai."examPageId"
+JOIN "ExamStudent" es ON es."examId" = ep."examId" AND es."studentId" = sai."studentId";
+
+-- QuestionScore: CropRegion → ExamPage.examId 経由
+CREATE TABLE "new_QuestionScore" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "cropRegionId" TEXT NOT NULL,
+    "examStudentId" TEXT NOT NULL,
+    "partialScore" DECIMAL,
+    "status" TEXT NOT NULL DEFAULT 'unscored',
+    "userId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "QuestionScore_cropRegionId_fkey" FOREIGN KEY ("cropRegionId") REFERENCES "CropRegion" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "QuestionScore_examStudentId_fkey" FOREIGN KEY ("examStudentId") REFERENCES "ExamStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "QuestionScore_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+INSERT INTO "new_QuestionScore" ("id", "cropRegionId", "examStudentId", "partialScore", "status", "userId", "createdAt", "updatedAt")
+SELECT qs."id", qs."cropRegionId", es."id", qs."partialScore", qs."status", qs."userId", qs."createdAt", qs."updatedAt"
+FROM "QuestionScore" qs
+JOIN "CropRegion" cr ON cr."id" = qs."cropRegionId"
+JOIN "ExamPage" ep ON ep."id" = cr."examPageId"
+JOIN "ExamStudent" es ON es."examId" = ep."examId" AND es."studentId" = qs."studentId";
+
+-- ScoreDecision: CropRegion → ExamPage.examId 経由
+CREATE TABLE "new_ScoreDecision" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "cropRegionId" TEXT NOT NULL,
+    "examStudentId" TEXT NOT NULL,
+    "verdict" TEXT NOT NULL,
+    "score" DECIMAL,
+    "comment" TEXT,
+    "decidedByUserId" TEXT NOT NULL,
+    "decidedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sourceQuestionScoreId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ScoreDecision_cropRegionId_fkey" FOREIGN KEY ("cropRegionId") REFERENCES "CropRegion" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ScoreDecision_examStudentId_fkey" FOREIGN KEY ("examStudentId") REFERENCES "ExamStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ScoreDecision_decidedByUserId_fkey" FOREIGN KEY ("decidedByUserId") REFERENCES "User" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+INSERT INTO "new_ScoreDecision" ("id", "cropRegionId", "examStudentId", "verdict", "score", "comment", "decidedByUserId", "decidedAt", "sourceQuestionScoreId", "createdAt", "updatedAt")
+SELECT sd."id", sd."cropRegionId", es."id", sd."verdict", sd."score", sd."comment", sd."decidedByUserId", sd."decidedAt", sd."sourceQuestionScoreId", sd."createdAt", sd."updatedAt"
+FROM "ScoreDecision" sd
+JOIN "CropRegion" cr ON cr."id" = sd."cropRegionId"
+JOIN "ExamPage" ep ON ep."id" = cr."examPageId"
+JOIN "ExamStudent" es ON es."examId" = ep."examId" AND es."studentId" = sd."studentId";
+
+-- CompoundAnswerScore: CompoundAnswer → ExamPage.examId 経由
+CREATE TABLE "new_CompoundAnswerScore" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "compoundAnswerId" TEXT NOT NULL,
+    "examStudentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "recognizedAnswer" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'unscored',
+    "partialScore" DECIMAL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CompoundAnswerScore_compoundAnswerId_fkey" FOREIGN KEY ("compoundAnswerId") REFERENCES "CompoundAnswer" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "CompoundAnswerScore_examStudentId_fkey" FOREIGN KEY ("examStudentId") REFERENCES "ExamStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "CompoundAnswerScore_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+INSERT INTO "new_CompoundAnswerScore" ("id", "compoundAnswerId", "examStudentId", "userId", "recognizedAnswer", "status", "partialScore", "createdAt", "updatedAt")
+SELECT cas."id", cas."compoundAnswerId", es."id", cas."userId", cas."recognizedAnswer", cas."status", cas."partialScore", cas."createdAt", cas."updatedAt"
+FROM "CompoundAnswerScore" cas
+JOIN "CompoundAnswer" ca ON ca."id" = cas."compoundAnswerId"
+JOIN "ExamPage" ep ON ep."id" = ca."examPageId"
+JOIN "ExamStudent" es ON es."examId" = ep."examId" AND es."studentId" = cas."studentId";
+
+-- ReturnSnapshot: examId を直接保持していたので ExamStudent へ即到達できる。examId 列は落とす
+CREATE TABLE "new_ReturnSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "examStudentId" TEXT NOT NULL,
+    "scoresJson" TEXT NOT NULL,
+    "totalScore" DECIMAL,
+    "capturedByUserId" TEXT,
+    "capturedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReturnSnapshot_examStudentId_fkey" FOREIGN KEY ("examStudentId") REFERENCES "ExamStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_ReturnSnapshot" ("id", "examStudentId", "scoresJson", "totalScore", "capturedByUserId", "capturedAt", "createdAt", "updatedAt")
+SELECT rs."id", es."id", rs."scoresJson", rs."totalScore", rs."capturedByUserId", rs."capturedAt", rs."createdAt", rs."updatedAt"
+FROM "ReturnSnapshot" rs
+JOIN "ExamStudent" es ON es."examId" = rs."examId" AND es."studentId" = rs."studentId";
+
+-- ── 2. 破棄した孤児の件数を監査ログへ記録（1件以上あるときだけ） ──
+INSERT INTO "AuditLog" ("id", "createdAt", "updatedAt", "userId", "action", "category", "scopeId", "scopeLabel", "entityType", "entityId", "summary", "metadata")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (abs(random()) % 4) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    NULL,
+    'system.migration.cleanup_orphaned_scores',
+    'system',
+    NULL,
+    NULL,
+    'System',
+    '20260728000000_rewire_scoring_to_exam_student',
+    '試験の受験者として登録されていない生徒の採点データ ' ||
+        ((SELECT COUNT(*) FROM "StudentAnswerImage") - (SELECT COUNT(*) FROM "new_StudentAnswerImage")
+       + (SELECT COUNT(*) FROM "QuestionScore") - (SELECT COUNT(*) FROM "new_QuestionScore")
+       + (SELECT COUNT(*) FROM "ScoreDecision") - (SELECT COUNT(*) FROM "new_ScoreDecision")
+       + (SELECT COUNT(*) FROM "CompoundAnswerScore") - (SELECT COUNT(*) FROM "new_CompoundAnswerScore")
+       + (SELECT COUNT(*) FROM "ReturnSnapshot") - (SELECT COUNT(*) FROM "new_ReturnSnapshot")) ||
+        ' 件を、データ移行時に破棄しました。該当する試験では成績算出の結果が変わります。',
+    json_object(
+        'studentAnswerImage', (SELECT COUNT(*) FROM "StudentAnswerImage") - (SELECT COUNT(*) FROM "new_StudentAnswerImage"),
+        'questionScore', (SELECT COUNT(*) FROM "QuestionScore") - (SELECT COUNT(*) FROM "new_QuestionScore"),
+        'scoreDecision', (SELECT COUNT(*) FROM "ScoreDecision") - (SELECT COUNT(*) FROM "new_ScoreDecision"),
+        'compoundAnswerScore', (SELECT COUNT(*) FROM "CompoundAnswerScore") - (SELECT COUNT(*) FROM "new_CompoundAnswerScore"),
+        'returnSnapshot', (SELECT COUNT(*) FROM "ReturnSnapshot") - (SELECT COUNT(*) FROM "new_ReturnSnapshot"),
+        'drawingAnnotation', (SELECT COUNT(*) FROM "DrawingAnnotation" WHERE "questionScoreId" NOT IN (SELECT "id" FROM "new_QuestionScore"))
+    )
+WHERE ((SELECT COUNT(*) FROM "StudentAnswerImage") - (SELECT COUNT(*) FROM "new_StudentAnswerImage")
+     + (SELECT COUNT(*) FROM "QuestionScore") - (SELECT COUNT(*) FROM "new_QuestionScore")
+     + (SELECT COUNT(*) FROM "ScoreDecision") - (SELECT COUNT(*) FROM "new_ScoreDecision")
+     + (SELECT COUNT(*) FROM "CompoundAnswerScore") - (SELECT COUNT(*) FROM "new_CompoundAnswerScore")
+     + (SELECT COUNT(*) FROM "ReturnSnapshot") - (SELECT COUNT(*) FROM "new_ReturnSnapshot")) > 0;
+
+-- ── 3. 孤児 QuestionScore にぶら下がる手書き注釈を破棄 ──────────
+-- foreign_keys=OFF のため DROP TABLE では cascade しない。明示的に消す。
+DELETE FROM "DrawingAnnotation" WHERE "questionScoreId" NOT IN (SELECT "id" FROM "new_QuestionScore");
+
+-- ── 4. 差し替えとインデックス再作成 ──────────────────────────────
+
+DROP TABLE "StudentAnswerImage";
+ALTER TABLE "new_StudentAnswerImage" RENAME TO "StudentAnswerImage";
+CREATE UNIQUE INDEX "StudentAnswerImage_examPageId_examStudentId_key" ON "StudentAnswerImage"("examPageId", "examStudentId");
+CREATE INDEX "StudentAnswerImage_examPageId_idx" ON "StudentAnswerImage"("examPageId");
+CREATE INDEX "StudentAnswerImage_examStudentId_idx" ON "StudentAnswerImage"("examStudentId");
+
+DROP TABLE "QuestionScore";
+ALTER TABLE "new_QuestionScore" RENAME TO "QuestionScore";
+CREATE INDEX "QuestionScore_examStudentId_idx" ON "QuestionScore"("examStudentId");
+
+DROP TABLE "ScoreDecision";
+ALTER TABLE "new_ScoreDecision" RENAME TO "ScoreDecision";
+CREATE UNIQUE INDEX "ScoreDecision_cropRegionId_examStudentId_key" ON "ScoreDecision"("cropRegionId", "examStudentId");
+CREATE INDEX "ScoreDecision_examStudentId_idx" ON "ScoreDecision"("examStudentId");
+
+DROP TABLE "CompoundAnswerScore";
+ALTER TABLE "new_CompoundAnswerScore" RENAME TO "CompoundAnswerScore";
+CREATE UNIQUE INDEX "CompoundAnswerScore_compoundAnswerId_examStudentId_key" ON "CompoundAnswerScore"("compoundAnswerId", "examStudentId");
+CREATE INDEX "CompoundAnswerScore_compoundAnswerId_idx" ON "CompoundAnswerScore"("compoundAnswerId");
+CREATE INDEX "CompoundAnswerScore_examStudentId_idx" ON "CompoundAnswerScore"("examStudentId");
+
+DROP TABLE "ReturnSnapshot";
+ALTER TABLE "new_ReturnSnapshot" RENAME TO "ReturnSnapshot";
+CREATE UNIQUE INDEX "ReturnSnapshot_examStudentId_key" ON "ReturnSnapshot"("examStudentId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,28 +46,23 @@ model Classroom {
 }
 
 model Student {
-  id                   String                       @id @default(uuid())
-  studentNumber        String                       @unique
-  lastName             String
-  firstName            String
-  lastNameKana         String
-  firstNameKana        String
-  enrollmentYear       Int?
-  createdAt            DateTime                     @default(now())
-  updatedAt            DateTime                     @updatedAt
-  studentAnswerImages  StudentAnswerImage[]
-  examStudents         ExamStudent[]
-  questionScores       QuestionScore[]
-  memberships          StudentClassroomMembership[]
-  gradeStudents        GradeStudent[]
-  gradeOverrides       GradeOverride[]
-  gradeFrozenScores    GradeFrozenScore[]
-  gradeItemExclusions  GradeItemExclusion[]
-  compoundAnswerScores CompoundAnswerScore[]
-  scoreDecisions       ScoreDecision[]
-  returnSnapshots      ReturnSnapshot[]
-  courseworkStudents   CourseworkStudent[]
-  courseworkScores     CourseworkScore[]
+  id                  String                       @id @default(uuid())
+  studentNumber       String                       @unique
+  lastName            String
+  firstName           String
+  lastNameKana        String
+  firstNameKana       String
+  enrollmentYear      Int?
+  createdAt           DateTime                     @default(now())
+  updatedAt           DateTime                     @updatedAt
+  examStudents        ExamStudent[]
+  memberships         StudentClassroomMembership[]
+  gradeStudents       GradeStudent[]
+  gradeOverrides      GradeOverride[]
+  gradeFrozenScores   GradeFrozenScore[]
+  gradeItemExclusions GradeItemExclusion[]
+  courseworkStudents  CourseworkStudent[]
+  courseworkScores    CourseworkScore[]
 }
 
 model StudentClassroomMembership {
@@ -107,19 +102,26 @@ model Exam {
   exportSettings          ExamExportSettings?
   gradeDataSources        GradeDataSource[]
   examTags                ExamTag[]
-  returnSnapshots         ReturnSnapshot[]
 }
 
+/// 試験の受験対象者。答案・採点・確定・返却スナップショットはすべてこの行を親とする
+/// （Student 直結にすると、試験から外した生徒の採点データが孤児として残り、
+/// 試験側には現れないのに成績算出でだけ算入されてしまうため）。
 model ExamStudent {
-  id          String   @id @default(uuid())
-  examId      String
-  studentId   String
-  status      String
-  customOrder Int?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  exam        Exam     @relation(fields: [examId], references: [id], onDelete: Cascade)
-  student     Student  @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  id                   String                @id @default(uuid())
+  examId               String
+  studentId            String
+  status               String
+  customOrder          Int?
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  exam                 Exam                  @relation(fields: [examId], references: [id], onDelete: Cascade)
+  student              Student               @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  studentAnswerImages  StudentAnswerImage[]
+  questionScores       QuestionScore[]
+  scoreDecisions       ScoreDecision[]
+  compoundAnswerScores CompoundAnswerScore[]
+  returnSnapshots      ReturnSnapshot[]
 
   @@unique([examId, studentId])
   @@index([examId])
@@ -153,18 +155,18 @@ model MasterImage {
 
 /// 答案画像
 model StudentAnswerImage {
-  id         String   @id @default(uuid())
-  examPageId String
-  studentId  String
-  imagePath  String
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @default(now()) @updatedAt
-  examPage   ExamPage @relation(fields: [examPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  student    Student  @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id            String      @id @default(uuid())
+  examPageId    String
+  examStudentId String
+  imagePath     String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @default(now()) @updatedAt
+  examPage      ExamPage    @relation(fields: [examPageId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  examStudent   ExamStudent @relation(fields: [examStudentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
-  @@unique([examPageId, studentId])
+  @@unique([examPageId, examStudentId])
   @@index([examPageId])
-  @@index([studentId])
+  @@index([examStudentId])
 }
 
 model CropRegion {
@@ -282,7 +284,7 @@ model ExamSubtotalGroup {
 model QuestionScore {
   id                 String              @id @default(uuid())
   cropRegionId       String
-  studentId          String
+  examStudentId      String
   partialScore       Decimal?
   status             String              @default("unscored")
   userId             String
@@ -290,34 +292,36 @@ model QuestionScore {
   updatedAt          DateTime            @default(now()) @updatedAt
   drawingAnnotations DrawingAnnotation[]
   cropRegion         CropRegion          @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  student            Student             @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  examStudent        ExamStudent         @relation(fields: [examStudentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   user               User                @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@index([examStudentId])
 }
 
 /// 生徒×設問ごとの確定スコア（試験OWNERによる裁定）。
 /// QuestionScore（採点者ごとの提案）とは別に1セル1行で保持し、upsertのみで運用する
 /// （削除・再作成しない — LWW同期でセカンダリUNIQUEにより単一行へ収束させるため）。
 model ScoreDecision {
-  id                    String     @id @default(uuid())
+  id                    String      @id @default(uuid())
   cropRegionId          String
-  studentId             String
+  examStudentId         String
   /// 確定した採点判定（correct | incorrect | partial | pending | no_answer | double_mark）
   verdict               String
   /// 確定点。correct等のverdict自体が点数を決める場合はnull可
   score                 Decimal?
   comment               String?
   decidedByUserId       String
-  decidedAt             DateTime   @default(now())
+  decidedAt             DateTime    @default(now())
   /// 採用元の提案（QuestionScore）のID。手入力で確定した場合はnull
   sourceQuestionScoreId String?
-  createdAt             DateTime   @default(now())
-  updatedAt             DateTime   @default(now()) @updatedAt
-  cropRegion            CropRegion @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  student               Student    @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  decidedBy             User       @relation(fields: [decidedByUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  createdAt             DateTime    @default(now())
+  updatedAt             DateTime    @default(now()) @updatedAt
+  cropRegion            CropRegion  @relation(fields: [cropRegionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  examStudent           ExamStudent @relation(fields: [examStudentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  decidedBy             User        @relation(fields: [decidedByUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@unique([cropRegionId, studentId])
-  @@index([studentId])
+  @@unique([cropRegionId, examStudentId])
+  @@index([examStudentId])
 }
 
 model DrawingAnnotation {
@@ -361,9 +365,8 @@ model DrawingAnnotation {
 /// 変更があった生徒だけを絞り込む。scoresJson は resolveEffectiveScores() の出力と
 /// 印刷対象の DrawingAnnotation を正規化シリアライズした文字列。
 model ReturnSnapshot {
-  id               String   @id @default(uuid())
-  examId           String
-  studentId        String
+  id               String      @id @default(uuid())
+  examStudentId    String      @unique
   /// 有効スコア＋注釈の正規化JSON（直接比較で差分判定する）
   scoresJson       String
   /// 返却時点の合計点（表示用。null可）
@@ -371,14 +374,10 @@ model ReturnSnapshot {
   /// 返却操作を行った操作者。システム操作はnull
   capturedByUserId String?
   /// 返却版として記録した日時（ISO text）
-  capturedAt       DateTime @default(now())
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @default(now()) @updatedAt
-  exam             Exam     @relation(fields: [examId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  student          Student  @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-
-  @@unique([examId, studentId])
-  @@index([studentId])
+  capturedAt       DateTime    @default(now())
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @default(now()) @updatedAt
+  examStudent      ExamStudent @relation(fields: [examStudentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 }
 
 /// 監査ログ（Discord風の操作履歴）。
@@ -646,7 +645,7 @@ model CompoundAnswerMember {
 model CompoundAnswerScore {
   id               String   @id @default(uuid())
   compoundAnswerId String
-  studentId        String
+  examStudentId    String
   userId           String
   recognizedAnswer String? // 組み立てた回答文字列
   status           String   @default("unscored")
@@ -655,12 +654,12 @@ model CompoundAnswerScore {
   updatedAt        DateTime @default(now()) @updatedAt
 
   compoundAnswer CompoundAnswer @relation(fields: [compoundAnswerId], references: [id], onDelete: Cascade)
-  student        Student        @relation(fields: [studentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  examStudent    ExamStudent    @relation(fields: [examStudentId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   user           User           @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@unique([compoundAnswerId, studentId])
+  @@unique([compoundAnswerId, examStudentId])
   @@index([compoundAnswerId])
-  @@index([studentId])
+  @@index([examStudentId])
 }
 
 /// 成績算出プロジェクト

--- a/scripts/importTempSaiten.ts
+++ b/scripts/importTempSaiten.ts
@@ -440,9 +440,11 @@ async function importExam(
     return ai.attendance - bi.attendance
   })
 
+  /** studentId → ExamStudent.id（採点データの親） */
+  const examStudentIdByStudentId = new Map<string, string>()
   for (let i = 0; i < sortedAllStudents.length; i++) {
     const sid = sortedAllStudents[i]
-    await prisma.examStudent.create({
+    const examStudent = await prisma.examStudent.create({
       data: {
         id: crypto.randomUUID(),
         examId,
@@ -453,6 +455,7 @@ async function importExam(
         updatedAt: now,
       },
     })
+    examStudentIdByStudentId.set(sid, examStudent.id)
   }
 
   console.log(
@@ -499,12 +502,13 @@ async function importExam(
       const answerRows = [...mm.entries()]
         .map(([idx, sid]) => {
           const rp = answerRelPaths.get(`${pi}-${idx}`)
-          if (!rp || seenStudents.has(sid)) return null
+          const examStudentId = examStudentIdByStudentId.get(sid)
+          if (!rp || !examStudentId || seenStudents.has(sid)) return null
           seenStudents.add(sid)
           return {
             id: crypto.randomUUID(),
             examPageId,
-            studentId: sid,
+            examStudentId,
             imagePath: rp,
             createdAt: now,
             updatedAt: now,
@@ -559,7 +563,7 @@ async function importExam(
       const scoreRows: Array<{
         id: string
         cropRegionId: string
-        studentId: string
+        examStudentId: string
         partialScore: number | null
         status: string
         userId: string
@@ -570,6 +574,8 @@ async function importExam(
       for (let mi = 0; mi < question.score.length; mi++) {
         const sid = mm.get(mi)
         if (!sid) continue
+        const examStudentId = examStudentIdByStudentId.get(sid)
+        if (!examStudentId) continue
         const scoreEntry = question.score[mi]
         if (scoreEntry.status === "unscored") continue
 
@@ -581,7 +587,7 @@ async function importExam(
         scoreRows.push({
           id: crypto.randomUUID(),
           cropRegionId,
-          studentId: sid,
+          examStudentId,
           partialScore: ps,
           status: scoreEntry.status,
           userId: USER_ID,

--- a/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
+++ b/src/app/exams/[examId]/06-student-answers/hooks/index.tsx
@@ -90,27 +90,27 @@ export function usePendingChanges(
         ({ fileId, fromState, toState }) => {
           // 生徒名を解決（表示用）
           const fromStudent = students?.find(
-            (examStudent) => examStudent.studentId === fromState.studentId
+            (examStudent) => examStudent.id === fromState.examStudentId
           )
           const toStudent = students?.find(
-            (examStudent) => examStudent.studentId === toState.studentId
+            (examStudent) => examStudent.id === toState.examStudentId
           )
 
-          // 移動先にある既存ファイルを特定（(studentId, examPageId) で同定）
+          // 移動先にある既存ファイルを特定（(examStudentId, examPageId) で同定）
           const targetFile = placedAnswers.find(
             (answer) =>
-              answer.studentId === toState.studentId &&
+              answer.examStudentId === toState.examStudentId &&
               answer.examPageId === toState.examPageId &&
               answer.id !== fileId // 移動されたファイル自体は除外
           )
 
           const change: PendingChange = {
-            id: `${fileId}-change-${Date.now()}-${fromState.studentId}-${fromState.examPageId}-${toState.studentId}-${toState.examPageId}`,
+            id: `${fileId}-change-${Date.now()}-${fromState.examStudentId}-${fromState.examPageId}-${toState.examStudentId}-${toState.examPageId}`,
             movedFileId: fileId,
             targetFileId: targetFile?.id || null, // 移動先にファイルがない場合はnull
             timestamp: new Date(),
             fromPosition: {
-              studentId: fromState.studentId,
+              examStudentId: fromState.examStudentId,
               examPageId: fromState.examPageId ?? "",
               pageNumber: fromState.examPageId
                 ? (pageNumberByExamPageId.get(fromState.examPageId) ?? 0)
@@ -120,7 +120,7 @@ export function usePendingChanges(
                 : undefined,
             },
             toPosition: {
-              studentId: toState.studentId,
+              examStudentId: toState.examStudentId,
               examPageId: toState.examPageId ?? "",
               pageNumber: toState.examPageId
                 ? (pageNumberByExamPageId.get(toState.examPageId) ?? 0)
@@ -155,7 +155,7 @@ export function usePendingChanges(
             : requested
           return {
             fileId: change.movedFileId,
-            finalStudentId: change.toPosition.studentId,
+            finalExamStudentId: change.toPosition.examStudentId,
             finalExamPageId: change.toPosition.examPageId,
             scorePolicy,
           }

--- a/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
+++ b/src/components/exams/05-students/components/sortable-student-table/components/SortableStudentTableContainer.tsx
@@ -152,8 +152,7 @@ export function SortableStudentTableContainer(
         cellClassName: "text-center",
         cell: (row) => {
           const count =
-            examStudentByStudentId.get(row.id)?.student._count
-              .studentAnswerImages ?? 0
+            examStudentByStudentId.get(row.id)?._count.studentAnswerImages ?? 0
           return count > 0 ? (
             <Badge variant="secondary" className="tabular-nums">
               {count}枚

--- a/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
+++ b/src/components/exams/06-student-answers/student-answer-management/hooks/useStudentAnswerUpload.ts
@@ -88,7 +88,7 @@ export function useStudentAnswerUpload(
 
                 results.push({
                   id: crypto.randomUUID(),
-                  studentId: null,
+                  examStudentId: null,
                   examPageId: null,
                   imagePath: null,
                   name: image.name,
@@ -106,7 +106,7 @@ export function useStudentAnswerUpload(
             const buffer = await file.arrayBuffer()
             results.push({
               id: crypto.randomUUID(),
-              studentId: null,
+              examStudentId: null,
               examPageId: null,
               imagePath: null,
               name: file.name,
@@ -262,15 +262,15 @@ export function useStudentAnswerUpload(
       setIsUploading(true)
 
       try {
-        // クライアント側補正結果からマップ構築（キーは (studentId, examPageId)＝セル同定）
+        // クライアント側補正結果からマップ構築（キーは (examStudentId, examPageId)＝セル同定）
         const correctionMap = new Map<string, "corrected" | "skipped">()
         for (const uploadItem of uploadData) {
           if (
             uploadItem.correctionStatus &&
             uploadItem.correctionStatus !== "not_requested" &&
-            uploadItem.studentId
+            uploadItem.examStudentId
           ) {
-            const key = `${uploadItem.studentId}-${uploadItem.examPageId}`
+            const key = `${uploadItem.examStudentId}-${uploadItem.examPageId}`
             correctionMap.set(
               key,
               uploadItem.correctionStatus as "corrected" | "skipped"

--- a/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/AnswerTableShell.tsx
@@ -29,7 +29,11 @@ import type {
   FilePreviewSource,
   PreviewMode,
 } from "@/components/exams/06-student-answers/student-answer-table/types"
-import type { CellLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import type {
+  CellColumn,
+  CellLookup,
+  CellRow,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
   AnswerImageIdentity,
   ExamPageColumn,
@@ -84,7 +88,7 @@ interface AnswerTableShellProps {
   toggleRowDisabled: (examStudentId: string) => void
   toggleColDisabled: (examPageId: string) => void
   bulkDisabling?: BulkDisablingHandlers
-  toggleCellDisabled: (studentId: string, examPageId: string) => void
+  toggleCellDisabled: (examStudent: CellRow, examPage: CellColumn) => void
   toggleFileDisabled: (fileId: string) => void
   onDeleteAnswerSheet?: (fileId: string) => void
 
@@ -164,13 +168,14 @@ export function AnswerTableShell({
   const orphanCards =
     mode === "view" && orphanItems.length > 0
       ? (() => {
-          const rosterStudentIds = new Set(
-            tableRows.map((row) => row.examStudent.studentId)
+          const rosterExamStudentIds = new Set(
+            tableRows.map((row) => row.examStudent.id)
           )
           return orphanItems.map((orphan) => ({
             orphan,
             reasonLabel:
-              orphan.studentId && rosterStudentIds.has(orphan.studentId)
+              orphan.examStudentId &&
+              rosterExamStudentIds.has(orphan.examStudentId)
                 ? "ページ削除などで配置先の列がありません"
                 : "配置先の生徒が名簿にありません",
           }))

--- a/src/components/exams/06-student-answers/student-answer-table/components/DraggableAnswerCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/DraggableAnswerCell.tsx
@@ -45,7 +45,7 @@ export function DraggableAnswerCell({
 
   // マス（ドロップ受け皿）: 占有マスも空マスと同じ座標 droppable（examPageId）にする
   const { setNodeRef: setDropRef, isOver } = useDroppable({
-    id: encodeCellDroppableId(examStudent.studentId, examPage.id),
+    id: encodeCellDroppableId(examStudent, examPage),
   })
 
   // 答案（掴む対象）

--- a/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/EmptyTableCell.tsx
@@ -60,10 +60,10 @@ export function EmptyTableCell({
   // 欠席生徒のマスは「答案なし」表示だが、欠席者に答案を割り当てないようドロップ不可にする。
   const isAbsentStudent = examStudent?.status === "absent"
   const { setNodeRef, isOver } = useDroppable({
-    id: encodeCellDroppableId(
-      examStudent?.studentId ?? "none",
-      examPage?.id ?? "none"
-    ),
+    id:
+      examStudent && examPage
+        ? encodeCellDroppableId(examStudent, examPage)
+        : "cell:none:none",
     disabled: mode !== "view" || !examStudent || isAbsentStudent,
   })
   const isDropTarget = mode === "view" && isOver

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -8,7 +8,11 @@ import type {
   PreviewMode,
 } from "@/components/exams/06-student-answers/student-answer-table/types"
 import type { DisabledReason } from "@/components/exams/06-student-answers/student-answer-table/types"
-import type { CellLookup } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
+import type {
+  CellColumn,
+  CellLookup,
+  CellRow,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import { lookupHasCell } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type {
   AnswerImageIdentity,
@@ -93,7 +97,7 @@ interface TableContentProps {
   toggleColDisabled: (examPageId: string) => void
   // 行・列の一括無効化（upload のみ。view は行・列無効が配置に効かないので渡さない）
   bulkDisabling?: BulkDisablingHandlers
-  toggleCellDisabled: (studentId: string, examPageId: string) => void
+  toggleCellDisabled: (examStudent: CellRow, examPage: CellColumn) => void
   toggleFileDisabled: (fileId: string) => void
   onDeleteAnswerSheet?: (fileId: string) => void
   // DnD ラッパー（モード別に注入）
@@ -238,11 +242,7 @@ export function TableContent({
                 // 既存答案があるか（オーバーレイ用・upload のみ）
                 const hasExistingAnswerForEmpty =
                   mode === "upload" &&
-                  lookupHasCell(
-                    cellsWithExistingAnswers,
-                    examStudent.studentId,
-                    examPage.id
-                  )
+                  lookupHasCell(cellsWithExistingAnswers, examStudent, examPage)
 
                 return (
                   <ClientCell key={examPage.id}>
@@ -253,7 +253,7 @@ export function TableContent({
                       hasExistingAnswer: hasExistingAnswerForEmpty,
                       disabledReason: cellData.disabledReason,
                       onTogglePosition: () =>
-                        toggleCellDisabled(examStudent.studentId, examPage.id),
+                        toggleCellDisabled(examStudent, examPage),
                     })}
                   </ClientCell>
                 )
@@ -264,11 +264,7 @@ export function TableContent({
               const isFileDisabled = disabledState.files.has(file.id)
               const hasExistingAnswer =
                 mode === "upload" &&
-                lookupHasCell(
-                  cellsWithExistingAnswers,
-                  examStudent.studentId,
-                  examPage.id
-                )
+                lookupHasCell(cellsWithExistingAnswers, examStudent, examPage)
               // 上書き無効時で既存答案がある場合はドラッグ無効
               const isDragDisabledByOverwrite =
                 hasExistingAnswer && !allowOverwrite
@@ -284,7 +280,7 @@ export function TableContent({
                     isDragDisabled: isDragDisabledByOverwrite,
                     isFileDisabled,
                     onTogglePosition: () =>
-                      toggleCellDisabled(examStudent.studentId, examPage.id),
+                      toggleCellDisabled(examStudent, examPage),
                     onToggleFileDisabled: () => toggleFileDisabled(file.id),
                     onDelete: () => onDeleteAnswerSheet?.(file.id),
                     children: (

--- a/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/UploadAnswerTable.tsx
@@ -75,7 +75,7 @@ export function UploadAnswerTable(props: UploadAnswerTableProps) {
           originalFileName: cell.file.originalFileName,
           type: cell.file.fileType,
           buffer: cell.file.buffer,
-          studentId: examStudent.studentId,
+          examStudentId: examStudent.id,
           examPageId: cell.examPage.id,
           overwrite: core.allowOverwrite,
           correctWithMarkers: false, // クライアント側で補正済み

--- a/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/ViewAnswerTable.tsx
@@ -12,7 +12,7 @@ import type { PlacedAnswerImage } from "@/types/prismaExtensions"
 const EMPTY_CORRECTING: Set<string> = new Set()
 
 interface ViewAnswerTableExtraProps {
-  // 直近アップロードのマーカー補正結果（(studentId, examPageId) → status）。表示オーバーレイ専用。
+  // 直近アップロードのマーカー補正結果（(examStudentId, examPageId) → status）。表示オーバーレイ専用。
   correctionStatusMap?: Map<string, "corrected" | "skipped">
 }
 
@@ -42,13 +42,11 @@ export function ViewAnswerTable(
     const map = new Map<string, FilePreviewSource>()
     for (const answer of props.files) {
       const correctionStatus = correctionStatusMap?.get(
-        `${answer.studentId}-${answer.examPageId}`
+        `${answer.examStudentId}-${answer.examPageId}`
       )
       map.set(answer.id, {
         imagePath: answer.imagePath,
-        altName: answer.student
-          ? `${answer.student.lastName} ${answer.student.firstName}`
-          : answer.id,
+        altName: `${answer.examStudent.student.lastName} ${answer.examStudent.student.firstName}`,
         correctionStatus,
       })
     }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDisabledState.ts
@@ -1,6 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { ExtendedDisabledState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  CellColumn,
+  CellRow,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import { manualDisabledReason } from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type { ExamPageColumn } from "@/components/exams/06-student-answers/types"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
@@ -8,7 +12,7 @@ import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 /**
  * 答案テーブルの行・列・セル単位の無効化状態と上書きモードを管理するフック。
  * 同一性でキーする: 行 = examStudentId[]、列 = examPageId[]、
- * セル = {studentId, examPageId}[]（いずれも少数なので配列）、
+ * セル = {examStudentId, examPageId}[]（いずれも少数なので配列）、
  * files = Set<fileId>（アップロードで多数になりうるので O(1)）。
  * 一括操作は名簿・ページ一覧を要するので、行・列の実体をフックが受け取る。
  */
@@ -96,12 +100,17 @@ export function useDisabledState({
     setDisabledState((prev) => ({ ...prev, cols: [] }))
   }, [])
 
+  // 実体で受ける（id を呼び出し側で選ばせない）。ExamStudent.id と Student.id は
+  // どちらも string なので、id 引数だと取り違えても型検査が通ってしまう。
   const toggleCellDisabled = useCallback(
-    (studentId: string, examPageId: string) => {
+    (examStudent: CellRow, examPage: CellColumn) => {
+      const examStudentId = examStudent.id
+      const examPageId = examPage.id
       setDisabledState((prev) => {
         const alreadyDisabled = prev.cells.some(
           (cell) =>
-            cell.studentId === studentId && cell.examPageId === examPageId
+            cell.examStudentId === examStudentId &&
+            cell.examPageId === examPageId
         )
         return {
           ...prev,
@@ -109,11 +118,11 @@ export function useDisabledState({
             ? prev.cells.filter(
                 (cell) =>
                   !(
-                    cell.studentId === studentId &&
+                    cell.examStudentId === examStudentId &&
                     cell.examPageId === examPageId
                   )
               )
-            : [...prev.cells, { studentId, examPageId }],
+            : [...prev.cells, { examStudentId, examPageId }],
         }
       })
     },
@@ -133,10 +142,9 @@ export function useDisabledState({
   }, [])
 
   const isCellDisabled = useCallback(
-    (examStudent: ExamStudentWithMemberships, examPageId: string) => {
+    (examStudent: ExamStudentWithMemberships, examPage: CellColumn) => {
       return (
-        manualDisabledReason(disabledState, examStudent, examPageId) !==
-        undefined
+        manualDisabledReason(disabledState, examStudent, examPage) !== undefined
       )
     },
     [disabledState]

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useDragDropHandlers.ts
@@ -86,7 +86,7 @@ export function useDragDropHandlers<TItem extends AnswerImageIdentity>({
 
       // 確認モード（方式B）: 対象セル座標へ move、占有セルなら swap。
       // over は空セルの droppable（cell:...）か、占有セルのファイル（fileId）。
-      // どちらでも対象セルの (studentId, examPageId) を求め、座標だけ更新する。
+      // どちらでも対象セルの (examStudentId, examPageId) を求め、座標だけ更新する。
       if (mode === "view") {
         // 差分は DB baseline（existingAnswers）と突き合わせて毎回算出する。
         // これが無いと配置変更を pending として記録できない＝黙って取りこぼすので、
@@ -107,25 +107,25 @@ export function useDragDropHandlers<TItem extends AnswerImageIdentity>({
 
         // 「そのマスに配置できる座標か」（除籍生徒＝名簿外／列に無い examPageId を弾く）。
         // 移動元が孤立答案（配置不能座標）なら占有マスへの swap を拒否するために使う。
-        const rosterStudentIds = new Set(
-          (students ?? []).map((examStudent) => examStudent.studentId)
+        const rosterExamStudentIds = new Set(
+          (students ?? []).map((examStudent) => examStudent.id)
         )
         const columnExamPageIds = new Set(
           (examPages ?? []).map((examPage) => examPage.id)
         )
         const isPlaceable = (
-          studentId: string | null,
+          examStudentId: string | null,
           examPageId: string | null
         ): boolean =>
-          !!studentId &&
+          !!examStudentId &&
           !!examPageId &&
-          rosterStudentIds.has(studentId) &&
+          rosterExamStudentIds.has(examStudentId) &&
           columnExamPageIds.has(examPageId)
 
         // 移動元（ドラッグした答案）が配置可能座標か。孤立答案なら false → 占有セルへの swap を拒否。
         const activeItem = files.find((file) => file.id === activeId)
         const isSourcePlaceable = activeItem
-          ? isPlaceable(activeItem.studentId, activeItem.examPageId)
+          ? isPlaceable(activeItem.examStudentId, activeItem.examPageId)
           : false
 
         // 占有判定は「表に見えている答案」だけに限定する（trash 等の隠れ答案を巻き込まない）
@@ -186,12 +186,12 @@ export function useDragDropHandlers<TItem extends AnswerImageIdentity>({
       const activeContainer = findContainer(activeId)
       const overContainer = findContainer(overId)
 
-      // アップロードモード（方式A）: arrayMove で並べ替え、各位置の studentId/examPageId は固定。
+      // アップロードモード（方式A）: arrayMove で並べ替え、各位置の examStudentId/examPageId は固定。
       // 新規ファイルの自動配置順を手で入れ替えるための経路（view の座標 move/swap とは別物）。
       if (activeContainer === overContainer && activeId !== overId) {
         // 同一コンテナ内のファイル（main=有効 / trash=無効）だけを並べ替え対象にする。
         // 全 files を arrayMove すると、old〜new index 間に挟まった trash スロットへ
-        // 隣接スロットの studentId/examPageId が誤って再代入される（#964）。
+        // 隣接スロットの examStudentId/examPageId が誤って再代入される（#964）。
         const containerFiles =
           activeContainer === "main" ? getEnabledFiles() : getDisabledFiles()
         const oldIndex = containerFiles.findIndex(
@@ -200,7 +200,7 @@ export function useDragDropHandlers<TItem extends AnswerImageIdentity>({
         const newIndex = containerFiles.findIndex((file) => file.id === overId)
 
         if (oldIndex !== -1 && newIndex !== -1) {
-          // fileId のみを入れ替え、各スロット（元の位置）の studentId/examPageId は固定
+          // fileId のみを入れ替え、各スロット（元の位置）の examStudentId/examPageId は固定
           const reorderedFileIds = arrayMove(
             containerFiles.map((file) => file.id),
             oldIndex,
@@ -213,7 +213,7 @@ export function useDragDropHandlers<TItem extends AnswerImageIdentity>({
               slot.id,
               {
                 ...files.find((file) => file.id === reorderedFileIds[index])!,
-                studentId: slot.studentId,
+                examStudentId: slot.examStudentId,
                 examPageId: slot.examPageId,
               },
             ])

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableData.ts
@@ -25,7 +25,7 @@ interface UseTableDataParams<TItem extends AnswerImageIdentity> {
   disabledState: ExtendedDisabledState
   isCellDisabled: (
     examStudent: ExamStudentWithMemberships,
-    examPageId: string
+    examPage: ExamPageColumn
   ) => boolean
   mode?: "upload" | "view"
   existingAnswers?: AnswerImageIdentity[]
@@ -65,16 +65,12 @@ export function useTableData<TItem extends AnswerImageIdentity>({
 
   // 手動無効化 + 動的無効化を合わせたセル無効判定
   const enhancedIsCellDisabled = useCallback(
-    (examStudent: ExamStudentWithMemberships, examPageId: string) => {
+    (examStudent: ExamStudentWithMemberships, examPage: ExamPageColumn) => {
       // 元の無効化チェック
-      if (isCellDisabled(examStudent, examPageId)) return true
+      if (isCellDisabled(examStudent, examPage)) return true
 
       // 動的無効化チェック
-      return lookupHasCell(
-        dynamicDisabledCells,
-        examStudent.studentId,
-        examPageId
-      )
+      return lookupHasCell(dynamicDisabledCells, examStudent, examPage)
     },
     [isCellDisabled, dynamicDisabledCells]
   )

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useTableDataGeneration.ts
@@ -33,7 +33,7 @@ interface UseTableDataGenerationParams<TItem extends AnswerImageIdentity> {
   mode?: "upload" | "view"
   enhancedIsCellDisabled: (
     examStudent: ExamStudentWithMemberships,
-    examPageId: string
+    examPage: ExamPageColumn
   ) => boolean
   allowOverwrite?: boolean
   // 既存答案（DB答案の占有信号）があるマス。呼び出し側が導出済みのものを受け取り、
@@ -69,31 +69,23 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
     const unplaced: TItem[] = []
 
     if (mode === "view") {
-      // 確認モード（方式B）: 各答案を自身の実セル座標 (studentId, examPageId) に配置する。
+      // 確認モード（方式B）: 各答案を自身の実セル座標 (受験者, ページ) に配置する。
       // 配列順ではなく id 対を基準にすることで、DnD の move/swap が座標更新だけで完結し、
       // 任意マスへの移動・占有マスとの入れ替えが素直に描画へ反映される。
       // 配置できない答案（除籍・列に無い examPageId）は placeable にならず orphans に落ちる。
       const { placedByCell, orphans: orphanItems } =
-        partitionAnswerItemsByPlacement(
-          enabledFiles,
-          sortedStudents.map((examStudent) => examStudent.studentId),
-          examPages.map((examPage) => examPage.id)
-        )
+        partitionAnswerItemsByPlacement(enabledFiles, sortedStudents, examPages)
       orphans.push(...orphanItems)
 
       for (const examStudent of sortedStudents) {
         const cells = examPages.map<AnswerTableCell<TItem>>((examPage) => {
-          const file = getCellValue(
-            placedByCell,
-            examStudent.studentId,
-            examPage.id
-          )
+          const file = getCellValue(placedByCell, examStudent, examPage)
 
           // 答案が居るセルは常にファイルセル（動的無効化は答案なしセルにのみ効く）
           if (file) return { examPage, type: "file", file }
 
           // 答案なしセル。確認モードは表示上「答案なし」
-          if (enhancedIsCellDisabled(examStudent, examPage.id)) {
+          if (enhancedIsCellDisabled(examStudent, examPage)) {
             return { examPage, type: "disabled" }
           }
 
@@ -119,15 +111,11 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
         examPage: ExamPageColumn
       ) => {
         const isManuallyDisabled =
-          manualDisabledReason(disabledState, examStudent, examPage.id) !==
+          manualDisabledReason(disabledState, examStudent, examPage) !==
           undefined
         const shouldSkipExisting =
           skipsExistingAnswers &&
-          lookupHasCell(
-            cellsWithExistingAnswers,
-            examStudent.studentId,
-            examPage.id
-          )
+          lookupHasCell(cellsWithExistingAnswers, examStudent, examPage)
 
         if (!isManuallyDisabled && !shouldSkipExisting) {
           validPositions.push({ examStudent, examPage })
@@ -156,8 +144,8 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
         if (file) {
           setCellValue(
             filePlacement,
-            position.examStudent.studentId,
-            position.examPage.id,
+            position.examStudent,
+            position.examPage,
             file
           )
         }
@@ -173,7 +161,7 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
           const manualReason = manualDisabledReason(
             disabledState,
             examStudent,
-            examPage.id
+            examPage
           )
           if (manualReason) {
             // 手動無効化セル（無効理由も権威的にここで確定）
@@ -181,21 +169,13 @@ export function useTableDataGeneration<TItem extends AnswerImageIdentity>({
           }
 
           // 有効セル: ファイルがマッピングされていればファイルセル、なければ空セル
-          const file = getCellValue(
-            filePlacement,
-            examStudent.studentId,
-            examPage.id
-          )
+          const file = getCellValue(filePlacement, examStudent, examPage)
           if (file) return { examPage, type: "file", file }
 
           // 既存答案があり上書き無効の場合は無効セルとして表示
           if (
             skipsExistingAnswers &&
-            lookupHasCell(
-              cellsWithExistingAnswers,
-              examStudent.studentId,
-              examPage.id
-            )
+            lookupHasCell(cellsWithExistingAnswers, examStudent, examPage)
           ) {
             return {
               examPage,

--- a/src/components/exams/06-student-answers/student-answer-table/types.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/types.ts
@@ -20,9 +20,9 @@ import type {
 // Preview mode for different display options
 export type PreviewMode = "full" | "name-only"
 
-// セル同一性 = (studentId, examPageId)。序数 pageNumber は key にしない。
+// セル同一性 = (examStudentId, examPageId)。序数 pageNumber は key にしない。
 export interface DisabledCell {
-  studentId: string
+  examStudentId: string
   examPageId: string
 }
 
@@ -32,7 +32,7 @@ export interface DisabledCell {
 export interface ExtendedDisabledState {
   rows: string[] // examStudentId（ExamStudent.id）— 無効行は少数なので配列
   cols: string[] // examPageId（ExamPage.id）— 無効列は少数なので配列
-  cells: DisabledCell[] // (studentId, examPageId) — 個別無効セルは少数なので配列
+  cells: DisabledCell[] // (examStudentId, examPageId) — 個別無効セルは少数なので配列
   files: Set<string> // fileId — アップロードで多数になりうるので Set（O(1)）
 }
 
@@ -150,10 +150,10 @@ export interface PreviewModeToggleProps {
 }
 
 // ファイル状態管理用の型定義。DnD の移動 from/to はセル座標（移動先は空マス＝実体が
-// 無いこともある）なので、実体ではなく id（studentId, examPageId）で持つ。
+// 無いこともある）なので、実体ではなく id（examStudentId, examPageId）で持つ。
 export interface FileState {
   fileId: string
-  studentId: string | null
+  examStudentId: string | null
   examPageId: string | null
 }
 

--- a/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/dragDropUtils.ts
@@ -1,35 +1,43 @@
 import type { FileState } from "@/components/exams/06-student-answers/student-answer-table/types"
+import type {
+  CellColumn,
+  CellRow,
+} from "@/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils"
 import type { AnswerImageIdentity } from "@/components/exams/06-student-answers/types"
 
 /**
- * view 方式B のセル droppable ID を (studentId, examPageId) から生成する。
- * studentId・examPageId はいずれも uuid（コロンを含まない）前提。ファイルID（uuid）と
+ * view 方式B のセル droppable ID を (受験者, ページ) から生成する。
+ *
+ * dnd-kit の droppable id は文字列でなければならない（技術的制約）ので、ここだけは
+ * id を連結する。ただし**実体を引数に取る**ことで、呼び出し側が `examStudent.studentId`
+ * のような別の id を渡せないようにする（両方 `string` なので型検査では守れないため）。
+ * examStudentId・examPageId はいずれも uuid（コロンを含まない）前提。ファイルID（uuid）と
  * 衝突しないよう `cell:` 接頭辞で名前空間を分ける。
  */
 export function encodeCellDroppableId(
-  studentId: string,
-  examPageId: string
+  examStudent: CellRow,
+  examPage: CellColumn
 ): string {
-  return `cell:${studentId}:${examPageId}`
+  return `cell:${examStudent.id}:${examPage.id}`
 }
 
-/** セル droppable ID を (studentId, examPageId) に復号する。cell: 接頭辞でなければ null */
+/** セル droppable ID を (examStudentId, examPageId) に復号する。cell: 接頭辞でなければ null */
 export function decodeCellDroppableId(
   droppableId: string
-): { studentId: string; examPageId: string } | null {
+): { examStudentId: string; examPageId: string } | null {
   const prefix = "cell:"
   if (!droppableId.startsWith(prefix)) return null
   const rest = droppableId.slice(prefix.length)
   const lastColon = rest.lastIndexOf(":")
   if (lastColon <= 0) return null
-  const studentId = rest.slice(0, lastColon)
+  const examStudentId = rest.slice(0, lastColon)
   const examPageId = rest.slice(lastColon + 1)
-  if (!studentId || !examPageId) return null
-  return { studentId, examPageId }
+  if (!examStudentId || !examPageId) return null
+  return { examStudentId, examPageId }
 }
 
 /**
- * view 方式B: ドラッグした答案を対象セル (studentId, examPageId) へ配置する。
+ * view 方式B: ドラッグした答案を対象セル (examStudentId, examPageId) へ配置する。
  * 対象セルに別の答案が既にある場合は 2 セルの座標を入れ替える（swap）。
  * 採点データの追従/破棄は後段の確認モーダル（PlacementScorePolicy）で解決するため、
  * ここでは座標だけを更新する（新しい配列を返す。変更が無ければ元の配列を返す）。
@@ -42,7 +50,7 @@ export function decodeCellDroppableId(
 export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
   files: T[],
   activeFileId: string,
-  target: { studentId: string; examPageId: string },
+  target: { examStudentId: string; examPageId: string },
   // 占有判定を「表に見えている答案」に限定するための任意フィルタ。
   // trash 等で非表示の答案を隠れて swap しないため（view は無効ファイル無しだが防御的に受ける）。
   occupantEligibleIds?: Set<string>,
@@ -52,12 +60,12 @@ export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
   const activeFile = files.find((file) => file.id === activeFileId)
   if (!activeFile) return files
 
-  const sourceStudentId = activeFile.studentId
+  const sourceExamStudentId = activeFile.examStudentId
   const sourceExamPageId = activeFile.examPageId
 
   // 同一セルへのドロップは変更なし
   if (
-    sourceStudentId === target.studentId &&
+    sourceExamStudentId === target.examStudentId &&
     sourceExamPageId === target.examPageId
   ) {
     return files
@@ -66,7 +74,7 @@ export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
   const occupant = files.find(
     (file) =>
       file.id !== activeFileId &&
-      file.studentId === target.studentId &&
+      file.examStudentId === target.examStudentId &&
       file.examPageId === target.examPageId &&
       (occupantEligibleIds ? occupantEligibleIds.has(file.id) : true)
   )
@@ -81,7 +89,7 @@ export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
     if (file.id === activeFileId) {
       return {
         ...file,
-        studentId: target.studentId,
+        examStudentId: target.examStudentId,
         examPageId: target.examPageId,
       }
     }
@@ -90,7 +98,7 @@ export function applyCellMoveOrSwap<T extends AnswerImageIdentity>(
       // 占有セルなら元の答案を移動元へ入れ替える。
       return {
         ...file,
-        studentId: sourceStudentId,
+        examStudentId: sourceExamStudentId,
         examPageId: sourceExamPageId,
       }
     }
@@ -120,22 +128,22 @@ export function diffFilesAgainstBaseline<T extends AnswerImageIdentity>(
   for (const file of files) {
     const base = baselineById.get(file.id)
     if (!base) continue
-    const currentStudentId = file.studentId ?? null
+    const currentExamStudentId = file.examStudentId ?? null
     const currentExamPageId = file.examPageId ?? null
     if (
-      base.studentId !== currentStudentId ||
+      base.examStudentId !== currentExamStudentId ||
       base.examPageId !== currentExamPageId
     ) {
       changedFiles.push({
         fileId: file.id,
         fromState: {
           fileId: file.id,
-          studentId: base.studentId,
+          examStudentId: base.examStudentId,
           examPageId: base.examPageId,
         },
         toState: {
           fileId: file.id,
-          studentId: currentStudentId,
+          examStudentId: currentExamStudentId,
           examPageId: currentExamPageId,
         },
       })

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -10,47 +10,63 @@ import type {
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
 
 /**
- * セルレコード配列に (studentId, examPageId) が含まれるかを判定する。
+ * セルレコード配列に (受験者, ページ) が含まれるかを判定する。
  * 文字列合成キーを使わず identity のフィールド比較で照合する（DnD の FileState と同流儀）。
  * ユーザートグル由来の小さな配列（disabledState.cells）専用。
  */
 export function hasCell(
   cells: DisabledCell[],
-  studentId: string,
-  examPageId: string
+  examStudent: CellRow,
+  examPage: CellColumn
 ): boolean {
   return cells.some(
-    (cell) => cell.studentId === studentId && cell.examPageId === examPageId
+    (cell) =>
+      cell.examStudentId === examStudent.id && cell.examPageId === examPage.id
   )
 }
 
 /**
- * (studentId, examPageId) → 値 を O(1) で引く入れ子マップ。
- * 文字列合成キー（`${a}:${b}`）も序数も使わず、studentId → examPageId → 値 で持つ。
+ * セルの行＝受験者、列＝ページ。**実体をそのまま受け取る**（呼び出し側に
+ * `examStudent.id` を書かせない）。
+ *
+ * `ExamStudent.id` と `Student.id` はどちらも `string` なので、id を引数に取ると
+ * 取り違えても型検査が通ってしまう（実際にそれで表が全滅した）。実体を要求すれば
+ * `examStudent.studentId` を渡した時点でコンパイルエラーになる。
+ *
+ * さらに、行と列で**必須フィールドを重ならせない**（行は `studentId`、列は `pageNumber`）。
+ * 両方を `{ id: string }` にすると互いに代入可能で、引数を転置しても
+ * コンパイルが通ってしまう（＝表が全滅するのに気付けない）。
+ */
+export type CellRow = Pick<ExamStudentWithMemberships, "id" | "studentId">
+export type CellColumn = ExamPageColumn
+
+/**
+ * (受験者, ページ) → 値 を O(1) で引く入れ子マップ。
+ * 文字列合成キー（`${a}:${b}`）も序数も使わず、examStudentId → examPageId → 値 で持つ。
  * グリッド全体分に膨らみうる派生（既存答案・動的無効・配置解決）向け。
  */
 export type CellValueMap<T> = Map<string, Map<string, T>>
 
 export function setCellValue<T>(
   cellValues: CellValueMap<T>,
-  studentId: string,
-  examPageId: string,
+  examStudent: CellRow,
+  examPage: CellColumn,
   value: T
 ): void {
-  const pages = cellValues.get(studentId)
+  const pages = cellValues.get(examStudent.id)
   if (pages) {
-    pages.set(examPageId, value)
+    pages.set(examPage.id, value)
   } else {
-    cellValues.set(studentId, new Map([[examPageId, value]]))
+    cellValues.set(examStudent.id, new Map([[examPage.id, value]]))
   }
 }
 
 export function getCellValue<T>(
   cellValues: CellValueMap<T>,
-  studentId: string,
-  examPageId: string
+  examStudent: CellRow,
+  examPage: CellColumn
 ): T | undefined {
-  return cellValues.get(studentId)?.get(examPageId)
+  return cellValues.get(examStudent.id)?.get(examPage.id)
 }
 
 /** 値を持たず所属だけを表すセル集合（CellValueMap の存在判定専用の姿）。 */
@@ -58,18 +74,18 @@ export type CellLookup = CellValueMap<true>
 
 export function addCellToLookup(
   lookup: CellLookup,
-  studentId: string,
-  examPageId: string
+  examStudent: CellRow,
+  examPage: CellColumn
 ): void {
-  setCellValue(lookup, studentId, examPageId, true)
+  setCellValue(lookup, examStudent, examPage, true)
 }
 
 export function lookupHasCell(
   lookup: CellLookup,
-  studentId: string,
-  examPageId: string
+  examStudent: CellRow,
+  examPage: CellColumn
 ): boolean {
-  return getCellValue(lookup, studentId, examPageId) ?? false
+  return getCellValue(lookup, examStudent, examPage) ?? false
 }
 
 /**
@@ -80,13 +96,13 @@ export function lookupHasCell(
 export function manualDisabledReason(
   disabledState: ExtendedDisabledState,
   examStudent: ExamStudentWithMemberships,
-  examPageId: string
+  examPage: CellColumn
 ): DisabledReason {
   if (disabledState.rows.includes(examStudent.id)) {
     return examStudent.status === "absent" ? "absent_student" : "row"
   }
-  if (disabledState.cols.includes(examPageId)) return "column"
-  if (hasCell(disabledState.cells, examStudent.studentId, examPageId)) {
+  if (disabledState.cols.includes(examPage.id)) return "column"
+  if (hasCell(disabledState.cells, examStudent, examPage)) {
     return "position"
   }
   return undefined
@@ -118,21 +134,21 @@ export function calculateDynamicDisabledCells<T extends AnswerImageIdentity>(
     for (const examStudent of sortedStudents) {
       for (const examPage of examPages) {
         // 手動無効化済みのセルはスキップ
-        if (manualDisabledReason(disabledState, examStudent, examPage.id)) {
+        if (manualDisabledReason(disabledState, examStudent, examPage)) {
           continue
         }
 
         // そのセルに対応する答案があるかチェック
         const hasAnswerForCell = files.some(
           (file) =>
-            file.studentId === examStudent.studentId &&
+            file.examStudentId === examStudent.id &&
             file.examPageId === examPage.id &&
             !disabledState.files.has(file.id)
         )
 
         // 答案がない場合は動的無効化
         if (!hasAnswerForCell) {
-          addCellToLookup(dynamicDisabled, examStudent.studentId, examPage.id)
+          addCellToLookup(dynamicDisabled, examStudent, examPage)
         }
       }
     }
@@ -164,21 +180,21 @@ export function calculateCellsWithExistingAnswers<
         // アップロードモード: existingAnswers（DB答案の占有信号）から判定
         hasAnswerForCell = existingAnswers.some(
           (answer) =>
-            answer.studentId === examStudent.studentId &&
+            answer.examStudentId === examStudent.id &&
             answer.examPageId === examPage.id
         )
       } else {
         // 確認モード: files から判定
         hasAnswerForCell = files.some(
           (file) =>
-            file.studentId === examStudent.studentId &&
+            file.examStudentId === examStudent.id &&
             file.examPageId === examPage.id &&
             !disabledState.files.has(file.id)
         )
       }
 
       if (hasAnswerForCell) {
-        addCellToLookup(cells, examStudent.studentId, examPage.id)
+        addCellToLookup(cells, examStudent, examPage)
       }
     }
   }
@@ -205,42 +221,50 @@ export function getDisabledFiles<T extends AnswerImageIdentity>(
 /**
  * 確認モード（方式B）: 答案アイテムを「表のマスに置けるもの」と「置けない孤立答案」に分ける。
  *
- * マスに置ける条件は (1) studentId が現在の受験生徒（ロスター）に居る かつ
- * (2) examPageId が現在の列（examPages）に含まれる、の両方。どちらかを満たさない答案は
- * 除籍（studentId が現ロスターに無い）・ページ削除（列に無い examPageId）などで座標配置できず、
- * 表からは不可視になる（＝孤立答案）。呼び出し側で専用枠に描画して再配置できるようにする。
+ * マスに置ける条件は (1) 答案の受験者が現在のロスター（sortedStudents）に居る かつ
+ * (2) 答案のページが現在の列（examPages）に含まれる、の両方。どちらかを満たさない答案は
+ * 試験から外された・ページ削除などで座標配置できず、表からは不可視になる（＝孤立答案）。
+ * 呼び出し側で専用枠に描画して再配置できるようにする。
  *
- * placedByCell は (studentId, examPageId) で引く CellValueMap（序数キーは使わない）。
+ * ロスターと列は **実体の配列**で受け取る（呼び出し側が id を選ばない）。
+ * placedByCell は (受験者, ページ) で引く CellValueMap（序数キーは使わない）。
  * 同一セルに複数の配置可能答案が解決された場合は先着のみを配置し、後続は孤立扱いに
  * する（黙って上書きして消さない＝表からも孤立枠からも見えなくなる事故を防ぐ。
- * 実データは @@unique([examPageId, studentId]) によりセル衝突は構造的に起きないが、
+ * 実データは @@unique([examPageId, examStudentId]) によりセル衝突は構造的に起きないが、
  * 「解決不能な画像を黙って落とさない」原則をここで担保する）。
  */
 export function partitionAnswerItemsByPlacement<T extends AnswerImageIdentity>(
   items: T[],
-  rosterStudentIds: string[],
-  examPageIds: string[]
+  sortedStudents: CellRow[],
+  examPages: CellColumn[]
 ): { placedByCell: CellValueMap<T>; orphans: T[] } {
-  const rosterStudentIdSet = new Set(rosterStudentIds)
-  const columnPageIdSet = new Set(examPageIds)
+  const rosterByExamStudentId = new Map(
+    sortedStudents.map((examStudent) => [examStudent.id, examStudent])
+  )
+  const columnByExamPageId = new Map(
+    examPages.map((examPage) => [examPage.id, examPage])
+  )
 
   const placedByCell: CellValueMap<T> = new Map()
   const orphans: T[] = []
 
   for (const answerItem of items) {
-    const { studentId, examPageId } = answerItem
-    const isPlaceable =
-      studentId !== null &&
-      examPageId !== null &&
-      rosterStudentIdSet.has(studentId) &&
-      columnPageIdSet.has(examPageId)
+    const { examStudentId, examPageId } = answerItem
+    // 答案が持つ id をロスター・列の実体へ解決する。解決できない＝置き場が無い
+    const examStudent =
+      examStudentId !== null
+        ? rosterByExamStudentId.get(examStudentId)
+        : undefined
+    const examPage =
+      examPageId !== null ? columnByExamPageId.get(examPageId) : undefined
 
     // 配置可能でも同一セルが既に埋まっていれば孤立へ退避する（上書きで消さない）
     if (
-      isPlaceable &&
-      getCellValue(placedByCell, studentId, examPageId) === undefined
+      examStudent &&
+      examPage &&
+      getCellValue(placedByCell, examStudent, examPage) === undefined
     ) {
-      setCellValue(placedByCell, studentId, examPageId, answerItem)
+      setCellValue(placedByCell, examStudent, examPage, answerItem)
     } else {
       orphans.push(answerItem)
     }

--- a/src/components/exams/06-student-answers/types.ts
+++ b/src/components/exams/06-student-answers/types.ts
@@ -7,7 +7,7 @@
  * 未保存答案（upload）だけは DB レコードが存在しないため、同定フィールド＋未永続バイトを持つ
  * 投射型（`UnsavedAnswerImage`）で扱う（アップロード前に限り許容される投射）。
  *
- * 同定・key は必ず id（`studentAnswerImage.id` / `studentId` / `examPageId`）。
+ * 同定・key は必ず id（`studentAnswerImage.id` / `examStudentId` / `examPageId`）。
  * sqlite-nas-sync では id 以外の unique が同期違反となるため、pageNumber 等の序数は
  * 恒久的に key になり得ない。
  */
@@ -18,11 +18,11 @@
 
 /**
  * 表・DnD が扱うセル要素の同定。保存済み（`PlacedAnswerImage`）・未保存
- * （`UnsavedAnswerImage`）の両方が満たす。座標は id のみ（examPageId・studentId）。
+ * （`UnsavedAnswerImage`）の両方が満たす。座標は id のみ（examPageId・examStudentId）。
  */
 export interface AnswerImageIdentity {
   id: string
-  studentId: string | null // 配置済みの生徒（= Student.id）。未配置は null
+  examStudentId: string | null // 配置済みの受験者（= ExamStudent.id）。未配置は null
   examPageId: string | null // 配置済みの ExamPage.id。未配置は null
 }
 
@@ -41,9 +41,9 @@ export interface ExamPageColumn {
 
 /**
  * 未保存答案（アップロード源）。ドロップ→変換した画像で、DB にはまだ無い。
- * `PlacedAnswerImage` と同じ同定フィールド（id/studentId/examPageId）を満たしつつ、
+ * `PlacedAnswerImage` と同じ同定フィールド（id/examStudentId/examPageId）を満たしつつ、
  * バイトは state 上の `buffer`（`imagePath` は保存まで null）で持つ。
- * upload の配置は「配列順＋配置戦略」で決まるため studentId/examPageId は未使用
+ * upload の配置は「配列順＋配置戦略」で決まるため examStudentId/examPageId は未使用
  * （型統一のため保持し、確定時は列＝ExamPage 実体・行＝ExamStudent 実体から導出する）。
  */
 export interface UnsavedAnswerImage extends AnswerImageIdentity {
@@ -83,7 +83,7 @@ export interface UploadData {
   originalFileName: string
   type: string
   buffer: ArrayBuffer
-  studentId: string // 受験生徒ID（= Student.id）
+  examStudentId: string // 受験者ID（= ExamStudent.id）
   examPageId: string // 配置先 ExamPage.id
   overwrite: boolean // 上書きフラグ
   correctWithMarkers?: boolean // マーカー補正フラグ
@@ -96,7 +96,7 @@ export interface UploadData {
 
 /**
  * 保留中の変更データ（view 方式B の move/swap を確認モーダルへ渡す view-model）。
- * 同定は id（examPageId/studentId）。studentName・pageNumber は確認モーダル表示用に
+ * 同定は id（examPageId/examStudentId）。studentName・pageNumber は確認モーダル表示用に
  * 生成時点でエンティティから導出して持つ（DBデータの射影ではなく UI 差分の表示補助）。
  */
 export interface PendingChange {
@@ -108,9 +108,9 @@ export interface PendingChange {
   toPosition: PendingChangePosition // 移動先の位置
 }
 
-/** 変更の移動元/移動先の位置。同定は examPageId/studentId、表示は導出値。 */
+/** 変更の移動元/移動先の位置。同定は examPageId/examStudentId、表示は導出値。 */
 export interface PendingChangePosition {
-  studentId: string | null
+  examStudentId: string | null
   examPageId: string
   pageNumber: number // 表示用（列 ExamPage から導出）
   studentName?: string // 表示用（行 ExamStudent から導出）

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOMRRecognition.ts
@@ -24,7 +24,7 @@ interface OMRRecognitionState {
   /** シートごとの認識結果 */
   sheetResults: OMRSheetResult[]
   /** 全セル結果のフラットリスト */
-  allCellResults: Array<OMRCellResult & { studentId?: string }>
+  allCellResults: Array<OMRCellResult & { examStudentId?: string }>
   /** エラーメッセージ */
   error: string | null
 }
@@ -41,11 +41,11 @@ interface UseOMRRecognitionReturn extends OMRRecognitionState {
   /** 単一画像の認識を実行 */
   recognizeSingle: (
     imagePath: string,
-    studentId?: string
+    examStudentId?: string
   ) => Promise<OMRSheetResult | null>
   /** バッチ認識を実行 */
   recognizeBatch: (
-    entries: { path: string; studentId?: string; studentName?: string }[]
+    entries: { path: string; examStudentId?: string; studentName?: string }[]
   ) => Promise<void>
   /** 結果をクリア */
   clearResults: () => void
@@ -98,7 +98,7 @@ export function useOMRRecognition(
   const recognizeSingle = useCallback(
     async (
       imagePath: string,
-      studentId?: string
+      examStudentId?: string
     ): Promise<OMRSheetResult | null> => {
       if (!window.electronAPI?.omr) {
         setState((prev) => ({
@@ -122,7 +122,7 @@ export function useOMRRecognition(
           expectedCorners,
           params: currentParams,
           pageIndex,
-          studentId,
+          examStudentId,
         })
 
         setState((prev) => ({
@@ -133,7 +133,7 @@ export function useOMRRecognition(
             ...prev.allCellResults,
             ...result.cellResults.map((cellResult) => ({
               ...cellResult,
-              studentId: result.studentId,
+              examStudentId: result.examStudentId,
             })),
           ],
         }))
@@ -153,7 +153,7 @@ export function useOMRRecognition(
 
   const recognizeBatch = useCallback(
     async (
-      entries: { path: string; studentId?: string; studentName?: string }[]
+      entries: { path: string; examStudentId?: string; studentName?: string }[]
     ) => {
       if (!window.electronAPI?.omr) {
         setState((prev) => ({
@@ -186,10 +186,13 @@ export function useOMRRecognition(
           pageIndex,
         })
 
-        const allCells: Array<OMRCellResult & { studentId?: string }> = []
+        const allCells: Array<OMRCellResult & { examStudentId?: string }> = []
         for (const result of results) {
           for (const cellResult of result.cellResults) {
-            allCells.push({ ...cellResult, studentId: result.studentId })
+            allCells.push({
+              ...cellResult,
+              examStudentId: result.examStudentId,
+            })
           }
         }
 

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -263,10 +263,8 @@ export function useOmrAutoScoring(examId: string) {
       // 画像パス（DB相対パス）を収集 — メインプロセス側で絶対パスに解決
       const imagePaths = answerImages.map((answerImage) => ({
         path: answerImage.imagePath,
-        studentId: answerImage.studentId,
-        studentName: answerImage.student
-          ? `${answerImage.student.lastName} ${answerImage.student.firstName}`
-          : undefined,
+        examStudentId: answerImage.examStudentId,
+        studentName: `${answerImage.examStudent.student.lastName} ${answerImage.examStudent.student.firstName}`,
       }))
 
       // 6. バッチ認識実行
@@ -296,7 +294,7 @@ export function useOmrAutoScoring(examId: string) {
         console.warn(
           `OMR: ${failedSheets.length}/${results.length} 枚でマーカー検出失敗`,
           failedSheets.map((sheet) => ({
-            studentId: sheet.studentId,
+            examStudentId: sheet.examStudentId,
             error: sheet.error,
           }))
         )
@@ -365,17 +363,17 @@ export function useOmrAutoScoring(examId: string) {
       setState((prev) => ({ ...prev, isApplying: true, error: null }))
       try {
         const entries: Array<{
-          studentId: string
+          examStudentId: string
           cropRegionId: string
           status: ScoringStatus
           partialScore: number | null
           userId: string
         }> = []
 
-        for (const [studentId, scoreEntries] of state.scoreEntries) {
+        for (const [examStudentId, scoreEntries] of state.scoreEntries) {
           for (const entry of scoreEntries) {
             entries.push({
-              studentId,
+              examStudentId,
               cropRegionId: entry.cropRegionId!,
               status: entry.status,
               partialScore: entry.status === "partial" ? entry.score : null,

--- a/src/components/exams/07-score-at-once/OMRRecognition/utils/reevaluateResults.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/utils/reevaluateResults.ts
@@ -83,7 +83,7 @@ export function reevaluateWithThreshold(
   const updatedSheetResults: OMRSheetResult[] = []
 
   for (const sheet of sheetResults) {
-    if (!sheet.success || !sheet.studentId) {
+    if (!sheet.success || !sheet.examStudentId) {
       updatedSheetResults.push(sheet)
       continue
     }
@@ -135,7 +135,7 @@ export function reevaluateWithThreshold(
     }
 
     updatedSheetResults.push({ ...sheet, cellResults: updatedCellResults })
-    allEntries.set(sheet.studentId, entries)
+    allEntries.set(sheet.examStudentId, entries)
   }
 
   // サマリーはエントリのstatusから集計

--- a/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -159,12 +159,12 @@ export function useBatchScoring({
         )
         if (!studentAnswerImage) continue
 
-        if (!studentAnswerImage.studentId) continue
+        if (!studentAnswerImage.examStudentId) continue
 
         // refから最新のquestionScoresを取得
         const currentScore = findQuestionScore(
           questionScoresRef.current,
-          studentAnswerImage.studentId,
+          studentAnswerImage.examStudentId,
           currentCropRegion.id
         )
 
@@ -279,7 +279,7 @@ export function useBatchScoring({
           const optimisticScore: QuestionScore = {
             id: tempId,
             cropRegionId: currentCropRegion.id,
-            studentId: studentAnswerImage.studentId,
+            examStudentId: studentAnswerImage.examStudentId,
             partialScore:
               newScore !== null
                 ? (newScore as unknown as QuestionScore["partialScore"])
@@ -298,7 +298,7 @@ export function useBatchScoring({
 
           // DB保存をfire-and-forget
           const scoreData = {
-            studentId: studentAnswerImage.studentId,
+            examStudentId: studentAnswerImage.examStudentId,
             cropRegionId: currentCropRegion.id,
             partialScore: newScore !== null ? newScore : undefined,
             status: scoringStatus,

--- a/src/components/exams/07-score-at-once/ScoringData/types.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/types.ts
@@ -27,7 +27,7 @@ export interface ScoreUpdateData {
 }
 
 export interface ScoreCreateData {
-  studentId: string
+  examStudentId: string
   cropRegionId: string
   partialScore?: number
   status: ScoringStatus

--- a/src/components/exams/07-score-at-once/ScoringData/utils/progressCalculator.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/utils/progressCalculator.ts
@@ -32,20 +32,16 @@ export function calculateQuestionProgress(
       (pageImage) => pageImage.examPageId === cropRegion.examPageId
     )
 
-    // studentIdフィルタリング
-    const relevantPageImages = samePageImages.filter(
-      (pageImage) => pageImage.studentId
-    )
+    // 答案は必ず受験者に紐づくので、ここでの絞り込みは不要
+    const relevantPageImages = samePageImages
 
     const totalAnswers = relevantPageImages.length
     let gradedAnswers = 0
 
-    relevantPageImages.forEach((pageImage, _index) => {
-      if (!pageImage.studentId) return // studentIdがnullの場合はスキップ
-
+    relevantPageImages.forEach((pageImage) => {
       const score = findQuestionScore(
         questionScores,
-        pageImage.studentId,
+        pageImage.examStudentId,
         cropRegion.id
       )
       const isGraded =

--- a/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/AnswerGridView.tsx
@@ -148,7 +148,7 @@ export default function AnswerGridView({
   const scoringColors = useScoringStatusColors()
 
   /** アノテーション取得（設問ごとに全学生分を一括取得） */
-  const { annotationsByStudent } = useGridAnnotations({
+  const { annotationsByExamStudent } = useGridAnnotations({
     cropRegionId: currentCropRegion?.id,
     currentUserId,
     refreshKey: annotationRefreshKey,
@@ -358,7 +358,7 @@ export default function AnswerGridView({
               selectionBorderColor={selectionBorderColor}
               scoringColors={scoringColors}
               expandMargin={expandMargin}
-              annotations={annotationsByStudent.get(answer.studentId)}
+              annotations={annotationsByExamStudent.get(answer.examStudentId)}
               pageSize={pageSize}
               onMouseDown={onCellMouseDown}
             />

--- a/src/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
+++ b/src/components/exams/07-score-at-once/ScoringGrid/GridCell.tsx
@@ -57,7 +57,7 @@ export function GridCell({
   const config = statusConfig[statusKey]
   const Icon = config.icon
   const isMaster =
-    answer.studentId === "MASTER" || answer.studentName === "模範解答"
+    answer.examStudentId === "MASTER" || answer.studentName === "模範解答"
 
   // 基本のセルクラス
   const cellClasses = ["flex shrink-0 flex-col gap-1 p-2 border-2"]

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridAnnotations.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridAnnotations.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
-import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
+import type { AnnotationWithContext } from "@/types/drawingAnnotation.types"
 
 interface UseGridAnnotationsProps {
   cropRegionId: string | undefined
@@ -10,27 +10,28 @@ interface UseGridAnnotationsProps {
 }
 
 interface UseGridAnnotationsReturn {
-  /** studentId → DrawingAnnotation[] のマップ */
-  annotationsByStudent: Map<string, DrawingAnnotation[]>
+  /** examStudentId（ExamStudent.id）→ その受験者の注釈 */
+  annotationsByExamStudent: Map<string, AnnotationWithContext[]>
 }
 
 /**
- * Grid表示用アノテーション取得フック
- * 指定されたcropRegionの全学生のアノテーションを一括取得し、studentIdでグループ化する
+ * Grid表示用アノテーション取得フック。
+ * 指定 cropRegion の全受験者の注釈を一括取得し、examStudentId でグループ化する。
+ * グリッドの行は受験者なので、キーは Student.id ではない。
  */
 export function useGridAnnotations({
   cropRegionId,
   currentUserId,
   refreshKey,
 }: UseGridAnnotationsProps): UseGridAnnotationsReturn {
-  const [annotationsByStudent, setAnnotationsByStudent] = useState<
-    Map<string, DrawingAnnotation[]>
+  const [annotationsByExamStudent, setAnnotationsByExamStudent] = useState<
+    Map<string, AnnotationWithContext[]>
   >(new Map())
   const lastFetchedRef = useRef<string>("")
 
   const fetchAnnotations = useCallback(async () => {
     if (!cropRegionId) {
-      setAnnotationsByStudent(new Map())
+      setAnnotationsByExamStudent(new Map())
       return
     }
 
@@ -47,27 +48,23 @@ export function useGridAnnotations({
       if (result.success && result.data) {
         // フェッチ成功後にキーを設定（失敗時のリトライを阻害しない）
         lastFetchedRef.current = fetchKey
-        const grouped = new Map<string, DrawingAnnotation[]>()
+        const grouped = new Map<string, AnnotationWithContext[]>()
         for (const annotation of result.data) {
-          // questionScore.studentId を使用してグループ化
-          const studentId = (
-            annotation as DrawingAnnotation & {
-              questionScore?: { studentId?: string }
-            }
-          ).questionScore?.studentId
-          if (!studentId) continue
+          // グリッドの行は受験者なので questionScore.examStudentId でまとめる
+          const examStudentId = annotation.questionScore?.examStudentId
+          if (!examStudentId) continue
 
-          const existing = grouped.get(studentId) || []
+          const existing = grouped.get(examStudentId) || []
           existing.push(annotation)
-          grouped.set(studentId, existing)
+          grouped.set(examStudentId, existing)
         }
-        setAnnotationsByStudent(grouped)
+        setAnnotationsByExamStudent(grouped)
       } else {
-        setAnnotationsByStudent(new Map())
+        setAnnotationsByExamStudent(new Map())
       }
     } catch (error) {
       console.error("Grid用アノテーション取得エラー:", error)
-      setAnnotationsByStudent(new Map())
+      setAnnotationsByExamStudent(new Map())
     }
   }, [cropRegionId, currentUserId])
 
@@ -77,5 +74,5 @@ export function useGridAnnotations({
     fetchAnnotations()
   }, [fetchAnnotations, refreshKey])
 
-  return { annotationsByStudent }
+  return { annotationsByExamStudent }
 }

--- a/src/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -39,7 +39,7 @@ export default function AnswerIndividualView({
   studentAnswerImages,
   showMultiplePages = true, // 常に複数ページ表示
   pageSpacing = 20,
-  currentStudentId,
+  currentExamStudentId,
   currentUserId,
   questionScores,
   onQuestionScoreCreated,
@@ -100,16 +100,16 @@ export default function AnswerIndividualView({
   // 全設問の採点ステータスと点数を計算（全設問マーク・点数描画用）
   const allCropRegionsWithStatus = useMemo(() => {
     if (!cropRegions || !questionScores || !currentScoringData) return []
-    const studentId = currentScoringData.studentId
+    const examStudentId = currentScoringData.examStudentId
     return cropRegions.map((cropRegion) => {
       const status = getScoringStatusFromArray(
         questionScores,
-        studentId,
+        examStudentId,
         cropRegion.id
       )
       const questionScore = questionScores.find(
         (candidateQuestionScore) =>
-          candidateQuestionScore.studentId === studentId &&
+          candidateQuestionScore.examStudentId === examStudentId &&
           candidateQuestionScore.cropRegionId === cropRegion.id
       )
       const maxScore = cropRegion.points ?? 0
@@ -136,7 +136,7 @@ export default function AnswerIndividualView({
 
   // QuestionScore自動作成フック（設問表示時にQuestionScoreが存在しない場合は自動作成）
   const { currentQuestionScoreId } = useAutoCreateQuestionScore({
-    currentStudentId,
+    currentExamStudentId,
     currentCropRegionId: currentCropRegion?.id,
     currentUserId,
     questionScores,
@@ -148,7 +148,7 @@ export default function AnswerIndividualView({
     currentQuestionScoreId,
     true, // データベース永続化を有効化
     {
-      currentStudentId,
+      currentExamStudentId,
       currentCropRegionId: currentCropRegion?.id,
       currentUserId,
     },
@@ -172,7 +172,7 @@ export default function AnswerIndividualView({
   // 透明度制御用：全設問のアノテーション読み込み
   // currentUserIdを渡してログインユーザーのアノテーションのみ取得
   const { allStudentAnnotations } = useAllStudentAnnotations({
-    currentStudentId,
+    currentExamStudentId,
     currentCropRegion,
     currentUserId,
     refreshKey: annotationRefreshKey,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/IndividualModePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/IndividualModePanel.tsx
@@ -22,7 +22,7 @@ interface IndividualModePanelProps {
   students: Student[]
   selectedAnswers?: Set<string> // TODO: selectedPageImageIdsに統一予定
   studentAnswerImages?: StudentAnswerImageWithExamStudents[]
-  onStudentChange: (studentId: string) => void
+  onStudentChange: (examStudentId: string) => void
   scoringBehavior: ScoringBehavior
   onScoringBehaviorChange: (behavior: ScoringBehavior) => void
 }
@@ -36,13 +36,13 @@ export function IndividualModePanel({
   onScoringBehaviorChange,
 }: IndividualModePanelProps) {
   // selectedAnswersから現在の生徒IDを取得
-  const currentStudentId = useMemo(() => {
+  const currentExamStudentId = useMemo(() => {
     if (selectedAnswers && selectedAnswers.size > 0) {
       const selectedAnswerId = Array.from(selectedAnswers)[0]
       const selectedAnswer = studentAnswerImages?.find(
         (studentAnswerImage) => studentAnswerImage.id === selectedAnswerId
       )
-      return selectedAnswer?.student?.id || ""
+      return selectedAnswer?.examStudentId || ""
     }
     return ""
   }, [selectedAnswers, studentAnswerImages])
@@ -50,7 +50,7 @@ export function IndividualModePanel({
     <>
       <StudentAnswerPanel
         students={students}
-        currentStudentId={currentStudentId}
+        currentExamStudentId={currentExamStudentId}
         onStudentChange={onStudentChange}
       />
 

--- a/src/components/exams/07-score-at-once/ScoringIndividual/StudentAnswerPanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/StudentAnswerPanel.tsx
@@ -22,13 +22,13 @@ interface Student {
 
 interface StudentAnswerPanelProps {
   students: Student[]
-  currentStudentId: string
+  currentExamStudentId: string
   onStudentChange: (studentId: string) => void
 }
 
 export function StudentAnswerPanel({
   students,
-  currentStudentId,
+  currentExamStudentId,
   onStudentChange,
 }: StudentAnswerPanelProps) {
   // 受験生徒順にソート
@@ -36,12 +36,12 @@ export function StudentAnswerPanel({
     (studentA, studentB) => studentA.customOrder - studentB.customOrder
   )
   const currentStudent = sortedStudents.find(
-    (student) => student.id === currentStudentId
+    (student) => student.id === currentExamStudentId
   )
 
   const handlePrevStudent = () => {
     const currentIndex = sortedStudents.findIndex(
-      (student) => student.id === currentStudentId
+      (student) => student.id === currentExamStudentId
     )
     if (currentIndex > 0) {
       onStudentChange(sortedStudents[currentIndex - 1].id)
@@ -50,7 +50,7 @@ export function StudentAnswerPanel({
 
   const handleNextStudent = () => {
     const currentIndex = sortedStudents.findIndex(
-      (student) => student.id === currentStudentId
+      (student) => student.id === currentExamStudentId
     )
     if (currentIndex < sortedStudents.length - 1) {
       onStudentChange(sortedStudents[currentIndex + 1].id)
@@ -67,13 +67,13 @@ export function StudentAnswerPanel({
           onClick={handlePrevStudent}
           disabled={
             sortedStudents.findIndex(
-              (student) => student.id === currentStudentId
+              (student) => student.id === currentExamStudentId
             ) === 0
           }
         >
           ←
         </Button>
-        <Select value={currentStudentId} onValueChange={onStudentChange}>
+        <Select value={currentExamStudentId} onValueChange={onStudentChange}>
           <SelectTrigger className="flex-1">
             <SelectValue>
               {currentStudent
@@ -95,7 +95,7 @@ export function StudentAnswerPanel({
           onClick={handleNextStudent}
           disabled={
             sortedStudents.findIndex(
-              (student) => student.id === currentStudentId
+              (student) => student.id === currentExamStudentId
             ) ===
             sortedStudents.length - 1
           }
@@ -107,7 +107,7 @@ export function StudentAnswerPanel({
       {/* 現在の位置表示 */}
       <div className="text-center text-xs text-gray-500">
         {sortedStudents.findIndex(
-          (student) => student.id === currentStudentId
+          (student) => student.id === currentExamStudentId
         ) + 1}{" "}
         / {sortedStudents.length}
       </div>

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingAnnotations.ts
@@ -17,7 +17,7 @@ import type { DrawingElement } from "../../types"
 
 // QuestionScore自動作成用のコンテキスト情報
 interface DrawingContext {
-  currentStudentId?: string
+  currentExamStudentId?: string
   currentCropRegionId?: string
   currentUserId?: string
 }

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useDrawingState.ts
@@ -32,7 +32,7 @@ export function useDrawingState(
   questionScoreId?: string | null,
   enablePersistence: boolean = true,
   context?: {
-    currentStudentId?: string
+    currentExamStudentId?: string
     currentCropRegionId?: string
     currentUserId?: string
   },

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
@@ -46,7 +46,9 @@ export function useImageLoader({
       if (showMultiplePages && studentAnswerImages) {
         // 複数ページ表示：同一生徒の全ページを取得
         const studentAnswerSheets = studentAnswerImages
-          .filter((sheet) => sheet.studentId === currentScoringData.studentId)
+          .filter(
+            (sheet) => sheet.examStudentId === currentScoringData.examStudentId
+          )
           .sort(
             (sheetA, sheetB) =>
               (sheetA.examPage?.pageNumber || 1) -

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAllStudentAnnotations.ts
@@ -10,7 +10,7 @@ import type { DrawingAnnotation } from "@/types/drawingAnnotation.types"
 /** 全設問アノテーション読み込みフックのパラメータ */
 export interface UseAllStudentAnnotationsParams {
   /** 現在の学生ID */
-  currentStudentId?: string
+  currentExamStudentId?: string
   /** 現在の設問領域（試験ID取得用） */
   currentCropRegion?: CropRegionWithExamPage | null
   /** 現在のユーザーID（アノテーション取得のフィルタリング用） */
@@ -37,7 +37,7 @@ export interface UseAllStudentAnnotationsReturn {
  * @returns 全設問のアノテーション
  */
 export function useAllStudentAnnotations({
-  currentStudentId,
+  currentExamStudentId,
   currentCropRegion,
   currentUserId,
   refreshKey,
@@ -48,23 +48,22 @@ export function useAllStudentAnnotations({
 
   useEffect(() => {
     const loadAllAnnotations = async () => {
-      if (!currentStudentId || !currentCropRegion?.examPage?.examId) {
+      if (!currentExamStudentId || !currentCropRegion?.examPage?.examId) {
         setAllStudentAnnotations([])
         return
       }
 
       try {
         console.log("🎨 透明度制御: 全設問アノテーション読み込み開始", {
-          studentId: currentStudentId,
+          studentId: currentExamStudentId,
           examId: currentCropRegion.examPage.examId,
           userId: currentUserId,
         })
 
         // ElectronAPIを直接呼び出してフック依存関係を回避
         // currentUserIdを渡してログインユーザーのアノテーションのみ取得
-        const result = await window.electronAPI.drawing.getByStudent(
-          currentStudentId,
-          currentCropRegion.examPage.examId,
+        const result = await window.electronAPI.drawing.getByExamStudent(
+          currentExamStudentId,
           undefined, // type
           currentUserId
         )
@@ -87,7 +86,7 @@ export function useAllStudentAnnotations({
 
     loadAllAnnotations()
   }, [
-    currentStudentId,
+    currentExamStudentId,
     currentCropRegion?.examPage?.examId,
     currentCropRegion?.id,
     currentUserId,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAutoCreateQuestionScore.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/view/useAutoCreateQuestionScore.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef } from "react"
 
 export interface UseAutoCreateQuestionScoreParams {
   /** 現在の生徒ID */
-  currentStudentId?: string
+  currentExamStudentId?: string
   /** 現在の設問領域ID */
   currentCropRegionId?: string
   /** 現在のユーザーID */
@@ -15,7 +15,7 @@ export interface UseAutoCreateQuestionScoreParams {
   /** QuestionScore配列（既存のスコアを検索用） */
   questionScores?: Array<{
     id: string
-    studentId: string
+    examStudentId: string
     cropRegionId: string
   }>
   /** QuestionScore作成後のコールバック（リストの更新用） */
@@ -31,7 +31,7 @@ export interface UseAutoCreateQuestionScoreReturn {
  * 設問表示時にQuestionScoreを自動作成するフック
  */
 export function useAutoCreateQuestionScore({
-  currentStudentId,
+  currentExamStudentId,
   currentCropRegionId,
   currentUserId,
   questionScores,
@@ -44,17 +44,17 @@ export function useAutoCreateQuestionScore({
   const currentQuestionScoreId =
     questionScores?.find(
       (questionScore) =>
-        questionScore.studentId === currentStudentId &&
+        questionScore.examStudentId === currentExamStudentId &&
         questionScore.cropRegionId === currentCropRegionId
     )?.id ?? null
 
   // QuestionScore作成関数
   const createQuestionScore = useCallback(async () => {
-    if (!currentStudentId || !currentCropRegionId || !currentUserId) {
+    if (!currentExamStudentId || !currentCropRegionId || !currentUserId) {
       return
     }
 
-    const key = `${currentStudentId}-${currentCropRegionId}-${currentUserId}`
+    const key = `${currentExamStudentId}-${currentCropRegionId}-${currentUserId}`
 
     // 既に作成中の場合はスキップ
     if (creatingRef.current === key) {
@@ -65,7 +65,7 @@ export function useAutoCreateQuestionScore({
 
     try {
       const result = await window.electronAPI.createQuestionScore({
-        studentId: currentStudentId,
+        examStudentId: currentExamStudentId,
         cropRegionId: currentCropRegionId,
         userId: currentUserId,
         status: "unscored",
@@ -87,7 +87,7 @@ export function useAutoCreateQuestionScore({
       }
     }
   }, [
-    currentStudentId,
+    currentExamStudentId,
     currentCropRegionId,
     currentUserId,
     onQuestionScoreCreated,
@@ -96,7 +96,7 @@ export function useAutoCreateQuestionScore({
   // 設問表示時にQuestionScoreが存在しない場合は自動作成
   useEffect(() => {
     if (
-      currentStudentId &&
+      currentExamStudentId &&
       currentCropRegionId &&
       currentUserId &&
       currentQuestionScoreId === null
@@ -104,7 +104,7 @@ export function useAutoCreateQuestionScore({
       createQuestionScore()
     }
   }, [
-    currentStudentId,
+    currentExamStudentId,
     currentCropRegionId,
     currentUserId,
     currentQuestionScoreId,

--- a/src/components/exams/07-score-at-once/ScoringIndividual/types.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/types.ts
@@ -56,7 +56,7 @@ export interface AnswerIndividualViewProps {
   cropRegions?: CropRegionWithExamPage[] // 全採点領域（全設問マーク描画用）
 
   // QuestionScore自動作成用のコンテキスト情報
-  currentStudentId?: string
+  currentExamStudentId?: string
   currentUserId?: string
 
   // アノテーション用: QuestionScore配列（正しいquestionScoreIdを取得するため）

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/QuestionAssignmentRow.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/QuestionAssignmentRow.tsx
@@ -198,11 +198,11 @@ export function QuestionAssignmentRow({
       {isExpanded &&
         question.cells.map((cell) => (
           <button
-            key={`${cell.cropRegionId}:${cell.studentId}`}
+            key={`${cell.cropRegionId}:${cell.examStudentId}`}
             onClick={() => onSelectCell(cell)}
             className={`flex w-full items-center justify-between gap-2 py-1.5 pr-3 pl-9 text-left text-sm hover:bg-blue-50 ${
               selectedCell?.cropRegionId === cell.cropRegionId &&
-              selectedCell?.studentId === cell.studentId
+              selectedCell?.examStudentId === cell.examStudentId
                 ? "bg-blue-50 font-medium"
                 : ""
             }`}

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionForm.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionForm.tsx
@@ -93,7 +93,7 @@ export function ScoreDecisionForm({
     setDeciding(true)
     try {
       const result = await window.electronAPI.finalizeQuestionScore(
-        cell.studentId,
+        cell.examStudentId,
         cell.cropRegionId,
         user.id,
         {

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionPanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionPanel.tsx
@@ -31,7 +31,7 @@ interface ScoreDecisionPanelProps {
 /** 選択中セルの所在（設問とセルは必ずペアで持つ — 添字では引かない） */
 interface SelectedCell {
   cropRegionId: string
-  studentId: string
+  examStudentId: string
 }
 
 /**
@@ -64,7 +64,7 @@ export function ScoreDecisionPanel({
       cellEntries.find(
         (entry) =>
           entry.cell.cropRegionId === selected?.cropRegionId &&
-          entry.cell.studentId === selected?.studentId
+          entry.cell.examStudentId === selected?.examStudentId
       ) ?? null,
     [cellEntries, selected]
   )
@@ -78,7 +78,7 @@ export function ScoreDecisionPanel({
       first
         ? {
             cropRegionId: first.cell.cropRegionId,
-            studentId: first.cell.studentId,
+            examStudentId: first.cell.examStudentId,
           }
         : null
     )
@@ -129,7 +129,7 @@ export function ScoreDecisionPanel({
                 onSelectCell={(cell) =>
                   setSelected({
                     cropRegionId: cell.cropRegionId,
-                    studentId: cell.studentId,
+                    examStudentId: cell.examStudentId,
                   })
                 }
                 onAssignmentChanged={onAssignmentChanged}
@@ -141,7 +141,7 @@ export function ScoreDecisionPanel({
           <div className="min-w-0 flex-1">
             {selectedEntry ? (
               <ScoreDecisionForm
-                key={`${selectedEntry.cell.cropRegionId}:${selectedEntry.cell.studentId}`}
+                key={`${selectedEntry.cell.cropRegionId}:${selectedEntry.cell.examStudentId}`}
                 cell={selectedEntry.cell}
                 questionLabel={selectedEntry.question.questionLabel}
                 maxScore={selectedEntry.question.maxScore}

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringContentArea.tsx
@@ -34,7 +34,7 @@ interface ScoringContentAreaProps {
   showStudentNames: boolean
   expandMargin?: number
   studentAnswerImages?: StudentAnswerImageWithExamStudents[]
-  currentStudentId?: string
+  currentExamStudentId?: string
   currentUserId?: string
   questionScores?: QuestionScore[]
   onQuestionScoreCreated?: () => void
@@ -73,7 +73,7 @@ export function ScoringContentArea({
   showStudentNames,
   expandMargin,
   studentAnswerImages,
-  currentStudentId,
+  currentExamStudentId,
   currentUserId,
   questionScores,
   onQuestionScoreCreated,
@@ -244,7 +244,7 @@ export function ScoringContentArea({
       currentCropRegion={currentCropRegion}
       cropRegions={cropRegions}
       studentAnswerImages={studentAnswerImages}
-      currentStudentId={currentStudentId}
+      currentExamStudentId={currentExamStudentId}
       currentUserId={currentUserId}
       questionScores={questionScores}
       onQuestionScoreCreated={onQuestionScoreCreated}

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoringMainView.tsx
@@ -696,13 +696,13 @@ function ScoringMainViewContent() {
     scoringOperationMode: effectiveMode,
   })
 
-  const currentStudentId = useMemo(() => {
+  const currentExamStudentId = useMemo(() => {
     if (selectedStudentAnswerImageIds.size > 0) {
       const selectedAnswerId = Array.from(selectedStudentAnswerImageIds)[0]
       const selectedAnswer = studentAnswerImages.find(
         (answerImage) => answerImage.id === selectedAnswerId
       )
-      return selectedAnswer?.student?.id || ""
+      return selectedAnswer?.examStudentId || ""
     }
     return ""
   }, [selectedStudentAnswerImageIds, studentAnswerImages])
@@ -771,7 +771,7 @@ function ScoringMainViewContent() {
             itemsPerLine={itemsPerLine}
             autoScroll={autoScroll}
             showStudentNames={showStudentNames}
-            currentStudentId={currentStudentId || undefined}
+            currentExamStudentId={currentExamStudentId || undefined}
             currentUserId={currentUserId || undefined}
             questionScores={questionScores}
             onQuestionScoreCreated={handleQuestionScoreCreated}

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringEffects.ts
@@ -125,17 +125,17 @@ export function useScoringEffects(params: UseScoringEffectsParams): void {
         const currentAnswer = currentPageImages.find(
           (pageImage) => pageImage.id === currentAnswerId
         )
-        if (currentAnswer?.student?.id) {
+        if (currentAnswer?.examStudentId) {
           // 新しい設問のcropRegionを取得
           const newCropRegion = currentCropRegions.find(
             (cropRegion) => cropRegion.id === currentCropRegionId
           )
           if (newCropRegion) {
             // 同じ生徒の新しいページに対応するpageImageを探す
-            const studentId = currentAnswer.student?.id
+            const examStudentId = currentAnswer.examStudentId
             const newPageImage = currentPageImages.find(
               (pageImage) =>
-                pageImage.student?.id === studentId &&
+                pageImage.examStudentId === examStudentId &&
                 pageImage.examPageId === newCropRegion.examPageId
             )
             if (newPageImage) {

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useScoringFilter.ts
@@ -125,55 +125,34 @@ export function useScoringFilter({
 
     const sortedAnswerSheets = [...pageFilteredSheets].sort(
       (sheetA, sheetB) => {
-        const aOrder =
-          sheetA.student?.examStudents?.[0]?.customOrder !== undefined
-            ? sheetA.student.examStudents[0].customOrder
-            : 999999
-        const bOrder =
-          sheetB.student?.examStudents?.[0]?.customOrder !== undefined
-            ? sheetB.student.examStudents[0].customOrder
-            : 999999
+        const aOrder = sheetA.examStudent.customOrder ?? 999999
+        const bOrder = sheetB.examStudent.customOrder ?? 999999
 
         if (aOrder === bOrder) {
-          const aName = `${sheetA.student?.lastName ?? ""}${sheetA.student?.firstName ?? ""}`
-          const bName = `${sheetB.student?.lastName ?? ""}${sheetB.student?.firstName ?? ""}`
+          const studentA = sheetA.examStudent.student
+          const studentB = sheetB.examStudent.student
+          const aName = `${studentA.lastName}${studentA.firstName}`
+          const bName = `${studentB.lastName}${studentB.firstName}`
           return aName.localeCompare(bName, "ja")
         }
 
-        const sortResult = (aOrder || 0) - (bOrder || 0)
-
-        return sortResult
+        return aOrder - bOrder
       }
     )
 
     const studentScoringData: ScoringData[] = sortedAnswerSheets.map(
       (pageImage) => {
-        if (!pageImage.studentId) {
-          return {
-            id: pageImage.id,
-            studentId: "",
-            studentName: "不明",
-            imageUrl: pageImage.imagePath
-              ? `appimg:///${pageImage.imagePath}`
-              : "",
-            currentScore: undefined,
-            maxScore: currentCropRegion.points ?? 0,
-            status: "unscored",
-            questionRegion: currentCropRegion,
-            customOrder: 999999,
-          }
-        }
-
         const score = findQuestionScore(
           questionScores,
-          pageImage.studentId,
+          pageImage.examStudentId,
           currentCropRegion.id
         )
+        const { student } = pageImage.examStudent
 
         return {
           id: pageImage.id,
-          studentId: pageImage.studentId,
-          studentName: `${pageImage.student?.lastName ?? ""} ${pageImage.student?.firstName ?? ""}`,
+          examStudentId: pageImage.examStudentId,
+          studentName: `${student.lastName} ${student.firstName}`,
           imageUrl: pageImage.imagePath
             ? `appimg:///${pageImage.imagePath}`
             : "",
@@ -184,8 +163,7 @@ export function useScoringFilter({
           maxScore: currentCropRegion.points ?? 0,
           status: toScoringStatus(score?.status),
           questionRegion: currentCropRegion,
-          customOrder:
-            pageImage.student?.examStudents?.[0]?.customOrder || 999999,
+          customOrder: pageImage.examStudent.customOrder ?? 999999,
         }
       }
     )
@@ -578,7 +556,7 @@ export function useScoringFilter({
 
     return {
       id: `master-${currentCropRegion.id}`,
-      studentId: "MASTER",
+      examStudentId: "MASTER",
       studentName: "模範解答",
       imageUrl: masterImagePath ? `appimg:///${masterImagePath}` : "",
       maxScore: currentCropRegion.points || 0,

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useStudentAnswerManagement.ts
@@ -17,7 +17,7 @@ import type {
  * 生徒データの型定義（UIコンポーネント用）
  */
 export interface AnswerManagementStudent {
-  /** 生徒ID (UUID) */
+  /** 受験者ID（ExamStudent.id / UUID） */
   id: string
   /** 学籍番号 */
   studentNumber: string
@@ -54,7 +54,7 @@ interface UseStudentAnswerManagementReturn {
   /** 生徒一覧（ソート済み） */
   students: AnswerManagementStudent[]
   /** 生徒変更ハンドラー */
-  handleStudentChange: (studentId: string) => void
+  handleStudentChange: (examStudentId: string) => void
   /** 次の生徒へ移動（個別表示用） */
   handleIndividualNextStudent: () => void
   /** 前の生徒へ移動（個別表示用） */
@@ -88,16 +88,15 @@ export function useStudentAnswerManagement(
     const uniqueStudents = new Map<string, AnswerManagementStudent>()
 
     studentAnswerImages.forEach((sheet) => {
-      if (sheet.student && !uniqueStudents.has(sheet.student.id)) {
-        const studentData: AnswerManagementStudent = {
-          id: sheet.student.id,
-          studentNumber: sheet.student.studentNumber,
-          lastName: sheet.student.lastName,
-          firstName: sheet.student.firstName,
-          customOrder: sheet.student.examStudents?.[0]?.customOrder || 0,
-        }
-        uniqueStudents.set(sheet.student.id, studentData)
-      }
+      if (uniqueStudents.has(sheet.examStudentId)) return
+      const { student } = sheet.examStudent
+      uniqueStudents.set(sheet.examStudentId, {
+        id: sheet.examStudentId,
+        studentNumber: student.studentNumber,
+        lastName: student.lastName,
+        firstName: student.firstName,
+        customOrder: sheet.examStudent.customOrder ?? 0,
+      })
     })
 
     const sortedStudents = Array.from(uniqueStudents.values()).sort(
@@ -110,9 +109,9 @@ export function useStudentAnswerManagement(
    * 個別表示用のナビゲーション関数
    */
   const handleStudentChange = useCallback(
-    (studentId: string) => {
+    (examStudentId: string) => {
       const studentSheets = studentAnswerImages.filter(
-        (sheet) => sheet.student?.id === studentId
+        (sheet) => sheet.examStudentId === examStudentId
       )
       if (studentSheets.length > 0) {
         // 現在の設問ページに対応するpageImageを優先選択
@@ -179,13 +178,13 @@ export function useStudentAnswerManagement(
       (answerA, answerB) => answerA.customOrder - answerB.customOrder
     )
     const currentIndex = sortedStudents.findIndex(
-      (student) => student.id === currentAnswer.student?.id
+      (student) => student.id === currentAnswer.examStudentId
     )
     if (currentIndex < sortedStudents.length - 1) {
       const nextStudent = sortedStudents[currentIndex + 1]
       // 現在の設問ページに対応するpageImageを優先選択
       const nextStudentSheets = studentAnswerImages.filter(
-        (sheet) => sheet.student?.id === nextStudent.id
+        (sheet) => sheet.examStudentId === nextStudent.id
       )
       const nextStudentAnswer = currentCropRegion
         ? nextStudentSheets.find(
@@ -220,12 +219,12 @@ export function useStudentAnswerManagement(
       (answerA, answerB) => answerA.customOrder - answerB.customOrder
     )
     const currentIndex = sortedStudents.findIndex(
-      (student) => student.id === currentAnswer.student?.id
+      (student) => student.id === currentAnswer.examStudentId
     )
     if (currentIndex > 0) {
       const prevStudent = sortedStudents[currentIndex - 1]
       const prevStudentSheets = studentAnswerImages.filter(
-        (sheet) => sheet.student?.id === prevStudent.id
+        (sheet) => sheet.examStudentId === prevStudent.id
       )
       const prevStudentAnswer = currentCropRegion
         ? prevStudentSheets.find(

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/AnnotationBrowserPanel.tsx
@@ -41,7 +41,7 @@ interface AnnotationBrowserPanelProps {
   examId: string
   currentUserId?: string
   currentCropRegionId?: string
-  currentStudentId?: string
+  currentExamStudentId?: string
   cropRegions: CropRegionWithExamPage[]
   gradingMode: "grid" | "individual"
   // ブラウザーhookから
@@ -55,16 +55,16 @@ interface AnnotationBrowserPanelProps {
   // QuestionScore確保用
   questionScores: Array<{
     id: string
-    studentId: string
+    examStudentId: string
     cropRegionId: string
   }>
   selectedScoringDataIds: string[]
-  allScoringData: Array<{ id: string; studentId: string }>
+  allScoringData: Array<{ id: string; examStudentId: string }>
   onQuestionScoreCreated?: () => void
   /** ブラウザの+ボタンでアノテーション追加後のコールバック（キャンバスリロード用） */
   onAnnotationAddedFromBrowser?: () => void
   /** アノテーションの生徒・設問に移動 */
-  onNavigateTo?: (studentId: string, cropRegionId: string) => void
+  onNavigateTo?: (examStudentId: string, cropRegionId: string) => void
   /** グループ内全アノテーション参照用 */
   allAnnotations?: AnnotationWithContext[]
 }
@@ -105,8 +105,8 @@ function getSourceInfo(annotation: AnnotationWithContext): string {
   if (annotation.questionScore?.cropRegion?.label) {
     parts.push(annotation.questionScore.cropRegion.label)
   }
-  if (annotation.questionScore?.student) {
-    const student = annotation.questionScore.student
+  if (annotation.questionScore?.examStudent?.student) {
+    const { student } = annotation.questionScore.examStudent
     parts.push(`${student.lastName}${student.firstName}`)
   }
   return parts.join(" / ") || "—"
@@ -116,7 +116,7 @@ export function AnnotationBrowserPanel({
   examId,
   currentUserId,
   currentCropRegionId,
-  currentStudentId,
+  currentExamStudentId,
   cropRegions,
   gradingMode,
   displayItems,
@@ -139,36 +139,42 @@ export function AnnotationBrowserPanel({
     onLoadAnnotations(examId)
   }, [examId, onLoadAnnotations])
 
-  // ユニークな生徒リスト
-  const uniqueStudents = useMemo(() => {
-    const studentMap = new Map<
+  // 絞り込み候補の受験者一覧。フィルタは questionScore.examStudentId と突き合わせるので、
+  // 実体（examStudent）をそのまま持ち、氏名は表示時に student から導出する
+  // （ここで Student.id へ畳むと、同じ string 型ゆえフィルタが永久に一致しなくなる）。
+  const uniqueExamStudents = useMemo(() => {
+    const examStudentMap = new Map<
       string,
-      { id: string; studentNumber: string; name: string }
+      NonNullable<
+        NonNullable<AnnotationWithContext["questionScore"]>["examStudent"]
+      >
     >()
     for (const item of displayItems) {
-      const student = item.representative.questionScore?.student
-      if (student && !studentMap.has(student.id)) {
-        studentMap.set(student.id, {
-          id: student.id,
-          studentNumber: student.studentNumber,
-          name: `${student.lastName}${student.firstName}`,
-        })
+      const examStudent = item.representative.questionScore?.examStudent
+      if (examStudent && !examStudentMap.has(examStudent.id)) {
+        examStudentMap.set(examStudent.id, examStudent)
       }
     }
-    return Array.from(studentMap.values()).sort((studentA, studentB) =>
-      studentA.studentNumber.localeCompare(studentB.studentNumber, "ja", {
-        numeric: true,
-      })
+    return Array.from(examStudentMap.values()).sort(
+      (examStudentA, examStudentB) =>
+        examStudentA.student.studentNumber.localeCompare(
+          examStudentB.student.studentNumber,
+          "ja",
+          { numeric: true }
+        )
     )
   }, [displayItems])
 
   // QuestionScoreを確保または取得する
   const ensureQuestionScore = useCallback(
-    async (studentId: string, cropRegionId: string): Promise<string | null> => {
+    async (
+      examStudentId: string,
+      cropRegionId: string
+    ): Promise<string | null> => {
       // 既存のQuestionScoreを探す
       const existing = questionScores.find(
         (questionScore) =>
-          questionScore.studentId === studentId &&
+          questionScore.examStudentId === examStudentId &&
           questionScore.cropRegionId === cropRegionId
       )
       if (existing) return existing.id
@@ -178,7 +184,7 @@ export function AnnotationBrowserPanel({
       try {
         const result = await window.electronAPI.createQuestionScore({
           cropRegionId,
-          studentId,
+          examStudentId,
           userId: currentUserId,
           status: "unscored",
         })
@@ -212,9 +218,9 @@ export function AnnotationBrowserPanel({
 
         if (gradingMode === "individual") {
           // 個別モード: 現在の生徒+設問に追加
-          if (!currentStudentId || !currentCropRegionId) return
+          if (!currentExamStudentId || !currentCropRegionId) return
           const qsId = await ensureQuestionScore(
-            currentStudentId,
+            currentExamStudentId,
             currentCropRegionId
           )
           if (!qsId) return
@@ -231,21 +237,21 @@ export function AnnotationBrowserPanel({
           if (selectedScoringDataIds.length === 0 || !currentCropRegionId)
             return
 
-          // selectedScoringDataIdsからstudentIdをマッピング
+          // selectedScoringDataIdsからexamStudentIdをマッピング
           const targetStudentIds = selectedScoringDataIds
             .map((scoringDataId) => {
               const scoringData = allScoringData.find(
                 (candidate) => candidate.id === scoringDataId
               )
-              return scoringData?.studentId
+              return scoringData?.examStudentId
             })
             .filter((id): id is string => !!id)
 
           // 各生徒のQuestionScoreを確保
           const targetQsIds: string[] = []
-          for (const studentId of targetStudentIds) {
+          for (const examStudentId of targetStudentIds) {
             const qsId = await ensureQuestionScore(
-              studentId,
+              examStudentId,
               currentCropRegionId
             )
             if (qsId) targetQsIds.push(qsId)
@@ -278,7 +284,7 @@ export function AnnotationBrowserPanel({
     },
     [
       currentUserId,
-      currentStudentId,
+      currentExamStudentId,
       currentCropRegionId,
       gradingMode,
       selectedScoringDataIds,
@@ -318,9 +324,9 @@ export function AnnotationBrowserPanel({
 
           {/* 生徒フィルタ */}
           <Select
-            value={filters.studentId ?? "all"}
+            value={filters.examStudentId ?? "all"}
             onValueChange={(v) =>
-              onFiltersChange({ studentId: v === "all" ? null : v })
+              onFiltersChange({ examStudentId: v === "all" ? null : v })
             }
           >
             <SelectTrigger className="h-8 text-xs">
@@ -328,9 +334,11 @@ export function AnnotationBrowserPanel({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">全生徒</SelectItem>
-              {uniqueStudents.map((student) => (
-                <SelectItem key={student.id} value={student.id}>
-                  {student.studentNumber} {student.name}
+              {uniqueExamStudents.map((examStudent) => (
+                <SelectItem key={examStudent.id} value={examStudent.id}>
+                  {examStudent.student.studentNumber}{" "}
+                  {examStudent.student.lastName}
+                  {examStudent.student.firstName}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -443,7 +451,7 @@ export function AnnotationBrowserPanel({
 
                 {/* 移動ボタン（左クリック: 代表に移動, 右クリック: 生徒選択メニュー） */}
                 {onNavigateTo &&
-                  item.representative.questionScore?.studentId &&
+                  item.representative.questionScore?.examStudentId &&
                   item.representative.questionScore?.cropRegionId &&
                   (item.count > 1 ? (
                     <ContextMenu>
@@ -455,7 +463,7 @@ export function AnnotationBrowserPanel({
                           title="クリック: 移動 / 右クリック: 生徒選択"
                           onClick={() =>
                             onNavigateTo(
-                              item.representative.questionScore!.studentId!,
+                              item.representative.questionScore!.examStudentId!,
                               item.representative.questionScore!.cropRegionId!
                             )
                           }
@@ -472,14 +480,18 @@ export function AnnotationBrowserPanel({
                           )
                           .filter(
                             (annotation): annotation is AnnotationWithContext =>
-                              !!annotation?.questionScore?.studentId &&
+                              !!annotation?.questionScore?.examStudentId &&
                               !!annotation?.questionScore?.cropRegionId
                           )
                           .map((annotation) => {
-                            const student = annotation.questionScore!.student
+                            const student =
+                              annotation.questionScore!.examStudent?.student
                             const label = student
                               ? `${student.studentNumber} ${student.lastName}${student.firstName}`
-                              : annotation.questionScore!.studentId!.slice(0, 8)
+                              : annotation.questionScore!.examStudentId!.slice(
+                                  0,
+                                  8
+                                )
                             const question =
                               annotation.questionScore!.cropRegion?.label ?? ""
                             return (
@@ -487,7 +499,7 @@ export function AnnotationBrowserPanel({
                                 key={annotation.id}
                                 onClick={() =>
                                   onNavigateTo(
-                                    annotation.questionScore!.studentId!,
+                                    annotation.questionScore!.examStudentId!,
                                     annotation.questionScore!.cropRegionId!
                                   )
                                 }
@@ -511,7 +523,7 @@ export function AnnotationBrowserPanel({
                       title="この生徒・設問に移動"
                       onClick={() =>
                         onNavigateTo(
-                          item.representative.questionScore!.studentId!,
+                          item.representative.questionScore!.examStudentId!,
                           item.representative.questionScore!.cropRegionId!
                         )
                       }

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -140,7 +140,7 @@ interface ScoringSidePanelProps {
     firstName: string
     customOrder: number
   }[]
-  onStudentChange?: (studentId: string) => void
+  onStudentChange?: (examStudentId: string) => void
   selectedStudentAnswerImageIds?: Set<string>
   studentAnswerImages?: StudentAnswerImageWithExamStudents[]
   scoringBehavior?: "next-student" | "next-question" | "stay"
@@ -152,10 +152,10 @@ interface ScoringSidePanelProps {
   selectedScoringDataIds?: string[]
   questionScores?: Array<{
     id: string
-    studentId: string
+    examStudentId: string
     cropRegionId: string
   }>
-  allScoringData?: Array<{ id: string; studentId: string }>
+  allScoringData?: Array<{ id: string; examStudentId: string }>
   onQuestionScoreCreated?: () => void
   /** キャンバスでアノテーション変更時にブラウザ一覧をリロードするキー */
   annotationRefreshKey?: number
@@ -272,7 +272,7 @@ export function ScoringSidePanel({
 
   // アノテーションの生徒・設問に移動
   const handleNavigateTo = useCallback(
-    (studentId: string, cropRegionId: string) => {
+    (examStudentId: string, cropRegionId: string) => {
       const targetCropRegion = cropRegions.find(
         (cropRegion) => cropRegion.id === cropRegionId
       )
@@ -280,20 +280,20 @@ export function ScoringSidePanel({
         onCropRegionChange(targetCropRegion)
       }
       if (onStudentChange) {
-        onStudentChange(studentId)
+        onStudentChange(examStudentId)
       }
     },
     [cropRegions, onCropRegionChange, onStudentChange]
   )
 
-  // 現在のstudentIdを取得
-  const currentStudentId = (() => {
+  // 現在のexamStudentIdを取得
+  const currentExamStudentId = (() => {
     if (!selectedStudentAnswerImageIds || !studentAnswerImages) return undefined
     const selectedId = Array.from(selectedStudentAnswerImageIds)[0]
     const selectedAnswer = studentAnswerImages.find(
       (studentAnswerImage) => studentAnswerImage.id === selectedId
     )
-    return selectedAnswer?.student?.id
+    return selectedAnswer?.examStudentId
   })()
 
   return (
@@ -527,7 +527,7 @@ export function ScoringSidePanel({
             examId={examId}
             currentUserId={currentUserId}
             currentCropRegionId={currentCropRegion?.id}
-            currentStudentId={currentStudentId}
+            currentExamStudentId={currentExamStudentId}
             cropRegions={cropRegions}
             gradingMode={gradingMode}
             displayItems={annotationBrowser.displayItems}

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/hooks/useAnnotationBrowser.ts
@@ -23,7 +23,7 @@ export interface AnnotationDisplayItem {
 // フィルタ設定
 export interface AnnotationFilters {
   cropRegionId: string | null
-  studentId: string | null
+  examStudentId: string | null
   type: DrawingType | null
   favoritesOnly: boolean
 }
@@ -117,7 +117,7 @@ export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
   const [isLoading, setIsLoading] = useState(false)
   const [filters, setFiltersState] = useState<AnnotationFilters>({
     cropRegionId: null,
-    studentId: null,
+    examStudentId: null,
     type: null,
     favoritesOnly: false,
   })
@@ -150,10 +150,10 @@ export function useAnnotationBrowser(): UseAnnotationBrowserReturn {
           annotation.questionScore?.cropRegionId === filters.cropRegionId
       )
     }
-    if (filters.studentId) {
+    if (filters.examStudentId) {
       filtered = filtered.filter(
         (annotation) =>
-          annotation.questionScore?.studentId === filters.studentId
+          annotation.questionScore?.examStudentId === filters.examStudentId
       )
     }
     if (filters.type) {

--- a/src/components/exams/07-score-at-once/types.ts
+++ b/src/components/exams/07-score-at-once/types.ts
@@ -105,8 +105,8 @@ export function calculateActualScore(
 export interface ScoringData {
   /** StudentAnswerImage.id */
   id: string
-  /** Student.id (UUID) */
-  studentId: string
+  /** ExamStudent.id (UUID) */
+  examStudentId: string
   /** 生徒氏名 */
   studentName: string
   /** 画像URL (appimg://...) */
@@ -154,7 +154,7 @@ export type MasterStatus = "master"
 
 export interface MasterGridItem {
   id: string
-  studentId: "MASTER"
+  examStudentId: "MASTER"
   studentName: string
   imageUrl: string
   maxScore: number
@@ -170,12 +170,13 @@ export interface MasterGridItem {
  */
 export function findQuestionScore(
   questionScores: QuestionScore[],
-  studentId: string,
+  examStudentId: string,
   cropRegionId: string
 ): QuestionScore | undefined {
   return questionScores.find(
     (score) =>
-      score.studentId === studentId && score.cropRegionId === cropRegionId
+      score.examStudentId === examStudentId &&
+      score.cropRegionId === cropRegionId
   )
 }
 
@@ -184,12 +185,12 @@ export function findQuestionScore(
  */
 export function getScoringStatusFromArray(
   questionScores: QuestionScore[],
-  studentId: string,
+  examStudentId: string,
   cropRegionId?: string
 ): ScoringStatus {
   if (!cropRegionId) return "unscored"
 
-  const score = findQuestionScore(questionScores, studentId, cropRegionId)
+  const score = findQuestionScore(questionScores, examStudentId, cropRegionId)
   return toScoringStatus(score?.status)
 }
 

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -84,15 +84,15 @@ export default function ExportMainView() {
   } = useExportPage()
 
   // プレビュー用のデータ取得
-  const selectedStudentIds = useMemo(
+  const selectedExamStudentIds = useMemo(
     () => Array.from(selectedStudents),
     [selectedStudents]
   )
 
   // 答案返却・差分（左カードのパネルと右カードの記録ボタンで状態を共有）
   const {
-    diffByStudent,
-    changedStudentIds,
+    diffByExamStudent,
+    changedExamStudentIds,
     hasAnySnapshot,
     capturing: capturingReturn,
     capture: captureReturn,
@@ -106,7 +106,7 @@ export default function ExportMainView() {
     setPreviewStudentId,
   } = useIndividualReportPreview({
     examId: exam?.id || "",
-    selectedStudentIds,
+    selectedExamStudentIds,
     options: individualReportOptions,
     enabled: !!exam?.id && selectedStudents.size > 0,
   })
@@ -118,7 +118,7 @@ export default function ExportMainView() {
     error: excelPreviewError,
   } = useExcelPreview({
     examId: exam?.id || "",
-    selectedStudentIds,
+    selectedExamStudentIds,
     enabled:
       !!exam?.id && selectedStudents.size > 0 && exportTab === "grading-data",
   })
@@ -126,9 +126,9 @@ export default function ExportMainView() {
   // プレビュー用の生徒リスト
   const previewStudentList = useMemo(() => {
     return students
-      .filter((examStudent) => selectedStudents.has(examStudent.studentId))
+      .filter((examStudent) => selectedStudents.has(examStudent.id))
       .map((examStudent) => ({
-        id: examStudent.studentId,
+        id: examStudent.id,
         name: `${examStudent.student.lastName} ${examStudent.student.firstName}`,
       }))
   }, [students, selectedStudents])
@@ -148,7 +148,7 @@ export default function ExportMainView() {
     setPreviewStudentId: setScoredAnswerPreviewStudentId,
   } = useScoredAnswerPreview({
     examId: exam?.id || "",
-    selectedStudentIds,
+    selectedExamStudentIds,
     scoringMarkConfig: scoringMarkConfigForPdf,
     enabled:
       !!exam?.id && selectedStudents.size > 0 && exportTab === "scored-answers",
@@ -234,10 +234,10 @@ export default function ExportMainView() {
         "ログイン情報を取得できませんでした。再ログインしてから出力してください"
       )
     }
-    const selectedStudentIds = Array.from(selectedStudents)
+    const selectedExamStudentIds = Array.from(selectedStudents)
     const result = await window.electronAPI.export.validateScoringData({
       examId: exam.id,
-      selectedStudentIds,
+      selectedExamStudentIds,
       userId: user.id,
     })
 
@@ -367,10 +367,10 @@ export default function ExportMainView() {
               // 答案返却・差分（生徒選択タブ内に表示）
               // 差分の件数・詳細は表示フィルタと独立させるため未フィルタの全生徒を渡す
               allStudents={allStudents}
-              selectedStudentIds={selectedStudentIds}
-              onSelectStudentIds={replaceSelection}
-              diffByStudent={diffByStudent}
-              changedStudentIds={changedStudentIds}
+              selectedExamStudentIds={selectedExamStudentIds}
+              onSelectExamStudentIds={replaceSelection}
+              diffByExamStudent={diffByExamStudent}
+              changedExamStudentIds={changedExamStudentIds}
               hasAnySnapshot={hasAnySnapshot}
               capturingReturn={capturingReturn}
               captureReturn={captureReturn}

--- a/src/components/exams/08-export/components/CaptureReturnVersionButton.tsx
+++ b/src/components/exams/08-export/components/CaptureReturnVersionButton.tsx
@@ -6,11 +6,11 @@ import { Button } from "@/components/ui/button"
 
 interface CaptureReturnVersionButtonProps {
   /** 記録対象（現在の選択） */
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   /** 返却版記録の実行中フラグ */
   capturing: boolean
   /** 指定生徒を返却版として記録する */
-  capture: (studentIds: string[]) => Promise<boolean>
+  capture: (examStudentIds: string[]) => Promise<boolean>
   /** ボタンのラベル（件数を含めるかは呼び出し側が決める） */
   label: string
   /** サイズ（既定 sm） */
@@ -25,7 +25,7 @@ interface CaptureReturnVersionButtonProps {
  * ラベルとサイズ・幅のみを呼び出し側で差し替える。処理・無効化条件は一箇所に集約。
  */
 export function CaptureReturnVersionButton({
-  selectedStudentIds,
+  selectedExamStudentIds,
   capturing,
   capture,
   label,
@@ -37,8 +37,8 @@ export function CaptureReturnVersionButton({
       variant="outline"
       size={size}
       className={className}
-      onClick={() => capture(selectedStudentIds)}
-      disabled={capturing || selectedStudentIds.length === 0}
+      onClick={() => capture(selectedExamStudentIds)}
+      disabled={capturing || selectedExamStudentIds.length === 0}
     >
       <FileCheck className="mr-1 h-4 w-4" />
       {label}

--- a/src/components/exams/08-export/components/ExcelPreview.tsx
+++ b/src/components/exams/08-export/components/ExcelPreview.tsx
@@ -110,7 +110,7 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
             </thead>
             <tbody>
               {data.rows.map((row, rowIdx) => (
-                <tr key={row.studentId} className="hover:bg-muted/50">
+                <tr key={row.examStudentId} className="hover:bg-muted/50">
                   <td className="border px-1 py-0.5 text-center">
                     {rowIdx + 1}
                   </td>
@@ -168,7 +168,7 @@ export function ExcelPreview({ data }: ExcelPreviewProps) {
             </thead>
             <tbody>
               {data.rows.map((row, rowIdx) => (
-                <tr key={row.studentId} className="hover:bg-muted/50">
+                <tr key={row.examStudentId} className="hover:bg-muted/50">
                   <td className="border px-1 py-0.5 text-center">
                     {rowIdx + 1}
                   </td>

--- a/src/components/exams/08-export/components/ExportOptionsCard.tsx
+++ b/src/components/exams/08-export/components/ExportOptionsCard.tsx
@@ -35,7 +35,7 @@ interface ExportOptionsCardProps {
   onExportRData: (format: "csv" | "json") => void
   onExportIndividualReports: () => void
   /** 指定生徒を返却版として記録する */
-  captureReturn: (studentIds: string[]) => Promise<boolean>
+  captureReturn: (examStudentIds: string[]) => Promise<boolean>
   /** 返却版記録の実行中フラグ */
   capturingReturn: boolean
   activeTab: ExportTabType
@@ -107,7 +107,7 @@ export function ExportOptionsCard({
   // 記録ボタンは全タブ共通（左カードの ReturnDiffPanel と同一コンポーネント）
   const captureButton = (
     <CaptureReturnVersionButton
-      selectedStudentIds={Array.from(selectedStudents)}
+      selectedExamStudentIds={Array.from(selectedStudents)}
       capturing={capturingReturn}
       capture={captureReturn}
       label="返却版として記録"

--- a/src/components/exams/08-export/components/ExportWarningModal.tsx
+++ b/src/components/exams/08-export/components/ExportWarningModal.tsx
@@ -182,7 +182,7 @@ export default function ExportWarningModal({
                 <div className="mb-3 space-y-0.5 text-sm">
                   {conflicted.map((conflict) => (
                     <ConflictRow
-                      key={`${conflict.cropRegionId}:${conflict.studentId}`}
+                      key={`${conflict.cropRegionId}:${conflict.examStudentId}`}
                       conflict={conflict}
                     />
                   ))}

--- a/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -44,7 +44,7 @@ interface PdfCanvasRendererProps {
   /** 全ページのレンダリング完了時のコールバック */
   onComplete?: (
     renderedPages: Array<{
-      studentId: string
+      examStudentId: string
       pageNumber: number
       imageData: ArrayBuffer
     }>
@@ -285,7 +285,7 @@ export function PdfCanvasRenderer({
 
       return {
         pageIndex,
-        studentId: page.studentId,
+        examStudentId: page.examStudentId,
         pageNumber: page.pageNumber,
         imageData: arrayBuffer,
       }
@@ -397,7 +397,7 @@ export function PdfCanvasRenderer({
 
       // 結果を順序通りに並べて返す
       const orderedResults: Array<{
-        studentId: string
+        examStudentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }> = []
@@ -405,7 +405,7 @@ export function PdfCanvasRenderer({
         const result = renderedPages.get(i)
         if (result) {
           orderedResults.push({
-            studentId: result.studentId,
+            examStudentId: result.examStudentId,
             pageNumber: result.pageNumber,
             imageData: result.imageData,
           })

--- a/src/components/exams/08-export/components/ReturnDiffPanel.tsx
+++ b/src/components/exams/08-export/components/ReturnDiffPanel.tsx
@@ -62,19 +62,19 @@ interface ReturnDiffPanelProps {
   /** 表示名解決用の生徒一覧（フィルタ前の全件が望ましい） */
   students: Student[]
   /** 現在の選択（「返却版として記録」対象・件数表示に使う） */
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   /** 選択を差し替える（「変更があった生徒のみ選択」） */
-  onSelectStudentIds: (studentIds: string[]) => void
+  onSelectExamStudentIds: (examStudentIds: string[]) => void
   /** 生徒ID → 返却版との差分 */
-  diffByStudent: Map<string, ReturnStudentDiff>
+  diffByExamStudent: Map<string, ReturnStudentDiff>
   /** 返却版から変更があった生徒IDの集合 */
-  changedStudentIds: Set<string>
+  changedExamStudentIds: Set<string>
   /** 返却版スナップショットが1件でも存在するか */
   hasAnySnapshot: boolean
   /** 返却版記録の実行中フラグ */
   capturing: boolean
   /** 指定生徒を返却版として記録する */
-  capture: (studentIds: string[]) => Promise<boolean>
+  capture: (examStudentIds: string[]) => Promise<boolean>
 }
 
 /**
@@ -84,10 +84,10 @@ interface ReturnDiffPanelProps {
  */
 export function ReturnDiffPanel({
   students,
-  selectedStudentIds,
-  onSelectStudentIds,
-  diffByStudent,
-  changedStudentIds,
+  selectedExamStudentIds,
+  onSelectExamStudentIds,
+  diffByExamStudent,
+  changedExamStudentIds,
   hasAnySnapshot,
   capturing,
   capture,
@@ -98,7 +98,7 @@ export function ReturnDiffPanel({
   const changedDiffs = students
     .map((examStudent) => ({
       examStudent,
-      diff: diffByStudent.get(examStudent.studentId),
+      diff: diffByExamStudent.get(examStudent.id),
     }))
     .filter(
       (pair): pair is { examStudent: Student; diff: ReturnStudentDiff } =>
@@ -106,17 +106,17 @@ export function ReturnDiffPanel({
     )
 
   const selectChangedOnly = () => {
-    onSelectStudentIds(Array.from(changedStudentIds))
+    onSelectExamStudentIds(Array.from(changedExamStudentIds))
   }
 
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <CaptureReturnVersionButton
-          selectedStudentIds={selectedStudentIds}
+          selectedExamStudentIds={selectedExamStudentIds}
           capturing={capturing}
           capture={capture}
-          label={`選択中の${selectedStudentIds.length}名を返却版として記録`}
+          label={`選択中の${selectedExamStudentIds.length}名を返却版として記録`}
         />
 
         {hasAnySnapshot && (
@@ -124,10 +124,10 @@ export function ReturnDiffPanel({
             variant="outline"
             size="sm"
             onClick={selectChangedOnly}
-            disabled={changedStudentIds.size === 0}
+            disabled={changedExamStudentIds.size === 0}
           >
             <Filter className="mr-1 h-4 w-4" />
-            変更があった生徒のみ選択（{changedStudentIds.size}名）
+            変更があった生徒のみ選択（{changedExamStudentIds.size}名）
           </Button>
         )}
 
@@ -168,7 +168,7 @@ export function ReturnDiffPanel({
             <CollapsibleContent className="mt-2 max-h-64 space-y-3 overflow-y-auto pr-1">
               {changedDiffs.map(({ examStudent, diff }) => (
                 <div
-                  key={diff.studentId}
+                  key={diff.examStudentId}
                   className="border-border rounded-md border p-3 text-sm"
                 >
                   <div className="mb-1 flex items-center gap-2 font-medium">

--- a/src/components/exams/08-export/components/SpTablePreview.tsx
+++ b/src/components/exams/08-export/components/SpTablePreview.tsx
@@ -42,7 +42,7 @@ export function SpTablePreview({ data }: SpTablePreviewProps) {
         </thead>
         <tbody>
           {students.map((student, rowIdx) => (
-            <tr key={student.studentId} className="hover:bg-muted/50">
+            <tr key={student.examStudentId} className="hover:bg-muted/50">
               <td className="border px-1 py-0.5 whitespace-nowrap">
                 {student.studentName}
               </td>

--- a/src/components/exams/08-export/components/StudentSelectionCard.tsx
+++ b/src/components/exams/08-export/components/StudentSelectionCard.tsx
@@ -56,26 +56,26 @@ interface StudentSelectionCardProps {
   selectedStatuses: string[]
   setSelectedStatuses: (statuses: string[]) => void
   selectedStudents: Set<string>
-  toggleStudent: (studentId: string) => void
-  addStudents: (studentIds: string[]) => void
-  removeStudents: (studentIds: string[]) => void
+  toggleStudent: (examStudentId: string) => void
+  addStudents: (examStudentIds: string[]) => void
+  removeStudents: (examStudentIds: string[]) => void
   // 答案返却・差分（生徒選択タブ内に表示）
   /** 表示フィルタ前の全生徒（差分の件数・詳細を表示フィルタと独立させるため） */
   allStudents: Student[]
-  selectedStudentIds: string[]
-  onSelectStudentIds: (studentIds: string[]) => void
-  diffByStudent: Map<string, ReturnStudentDiff>
-  changedStudentIds: Set<string>
+  selectedExamStudentIds: string[]
+  onSelectExamStudentIds: (examStudentIds: string[]) => void
+  diffByExamStudent: Map<string, ReturnStudentDiff>
+  changedExamStudentIds: Set<string>
   hasAnySnapshot: boolean
   capturingReturn: boolean
-  captureReturn: (studentIds: string[]) => Promise<boolean>
+  captureReturn: (examStudentIds: string[]) => Promise<boolean>
   // プレビュー関連
   exportTab?: ExportTabType
   previewData?: IndividualReportData | null
   isPreviewLoading?: boolean
   previewError?: string | null
   previewStudentId?: string
-  onPreviewStudentChange?: (studentId: string) => void
+  onPreviewStudentChange?: (examStudentId: string) => void
   previewStudentList?: Array<{ id: string; name: string }>
   individualReportOptions?: IndividualReportOptions
   // 採点済み答案プレビュー
@@ -83,7 +83,7 @@ interface StudentSelectionCardProps {
   isScoredAnswerPreviewLoading?: boolean
   scoredAnswerPreviewError?: string | null
   scoredAnswerPreviewStudentId?: string | null
-  onScoredAnswerPreviewStudentChange?: (studentId: string) => void
+  onScoredAnswerPreviewStudentChange?: (examStudentId: string) => void
   // Excelプレビュー
   excelPreviewData?: ExcelPreviewData | null
   isExcelPreviewLoading?: boolean
@@ -105,10 +105,10 @@ export function StudentSelectionCard({
   addStudents,
   removeStudents,
   allStudents,
-  selectedStudentIds,
-  onSelectStudentIds,
-  diffByStudent,
-  changedStudentIds,
+  selectedExamStudentIds,
+  onSelectExamStudentIds,
+  diffByExamStudent,
+  changedExamStudentIds,
   hasAnySnapshot,
   capturingReturn,
   captureReturn,
@@ -142,11 +142,11 @@ export function StudentSelectionCard({
         : "scored-answers"
 
   const selectAllFiltered = () => {
-    addStudents(students.map((examStudent) => examStudent.studentId))
+    addStudents(students.map((examStudent) => examStudent.id))
   }
 
   const deselectAllFiltered = () => {
-    removeStudents(students.map((examStudent) => examStudent.studentId))
+    removeStudents(students.map((examStudent) => examStudent.id))
   }
 
   const toggleClassroomFilter = (classroomId: string) => {
@@ -316,10 +316,10 @@ export function StudentSelectionCard({
         <div className="mb-2 shrink-0">
           <ReturnDiffPanel
             students={allStudents}
-            selectedStudentIds={selectedStudentIds}
-            onSelectStudentIds={onSelectStudentIds}
-            diffByStudent={diffByStudent}
-            changedStudentIds={changedStudentIds}
+            selectedExamStudentIds={selectedExamStudentIds}
+            onSelectExamStudentIds={onSelectExamStudentIds}
+            diffByExamStudent={diffByExamStudent}
+            changedExamStudentIds={changedExamStudentIds}
             hasAnySnapshot={hasAnySnapshot}
             capturing={capturingReturn}
             capture={captureReturn}
@@ -337,17 +337,17 @@ export function StudentSelectionCard({
           <div className="relative flex-1 space-y-0.5 overflow-y-auto rounded-md border p-1.5">
             {students.map((examStudent) => (
               <div
-                key={examStudent.studentId}
+                key={examStudent.id}
                 className="hover:bg-muted flex items-center space-x-2 rounded p-1"
               >
                 <Checkbox
-                  id={`student-${examStudent.studentId}`}
-                  checked={selectedStudents.has(examStudent.studentId)}
-                  onCheckedChange={() => toggleStudent(examStudent.studentId)}
+                  id={`student-${examStudent.id}`}
+                  checked={selectedStudents.has(examStudent.id)}
+                  onCheckedChange={() => toggleStudent(examStudent.id)}
                   className="h-4 w-4"
                 />
                 <Label
-                  htmlFor={`student-${examStudent.studentId}`}
+                  htmlFor={`student-${examStudent.id}`}
                   className="flex-1 cursor-pointer"
                 >
                   <div className="flex items-center justify-between">

--- a/src/components/exams/08-export/hooks/useDataFileExports.ts
+++ b/src/components/exams/08-export/hooks/useDataFileExports.ts
@@ -33,12 +33,12 @@ export function useDataFileExports({
     setIsExporting(true)
 
     try {
-      const selectedStudentIds = Array.from(selectedStudents)
+      const selectedExamStudentIds = Array.from(selectedStudents)
       const studentPlacements = await loadStudentExportPlacements(exam.id)
 
       const result = await window.electronAPI.exportGradingDataExcel({
         examId: exam.id,
-        selectedStudentIds,
+        selectedExamStudentIds,
         forceExport: true,
         studentPlacements,
       })
@@ -64,10 +64,10 @@ export function useDataFileExports({
     if (!exam) return
     setIsExporting(true)
     try {
-      const selectedStudentIds = Array.from(selectedStudents)
+      const selectedExamStudentIds = Array.from(selectedStudents)
       const result = await window.electronAPI.exportRData({
         examId: exam.id,
-        selectedStudentIds,
+        selectedExamStudentIds,
         format,
       })
       if (result.success) {
@@ -89,14 +89,14 @@ export function useDataFileExports({
     setIsExporting(true)
 
     try {
-      const selectedStudentIds = Array.from(selectedStudents)
+      const selectedExamStudentIds = Array.from(selectedStudents)
       const studentPlacements = await loadStudentExportPlacements(exam.id)
 
       // 1. データ取得（統計・アドバイス含む）
       const dataResult =
         await window.electronAPI.export.getIndividualReportData({
           examId: exam.id,
-          selectedStudentIds,
+          selectedExamStudentIds,
           options: individualReportOptions,
           studentPlacements,
         })

--- a/src/components/exams/08-export/hooks/useExcelPreview.ts
+++ b/src/components/exams/08-export/hooks/useExcelPreview.ts
@@ -22,7 +22,7 @@ interface ExcelPreviewSubtotalScore {
 }
 
 export interface ExcelPreviewRow {
-  studentId: string
+  examStudentId: string
   studentName: string
   studentNumber: string
   grade?: string
@@ -48,25 +48,25 @@ export interface ExcelPreviewData {
 
 interface UseExcelPreviewProps {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   enabled: boolean
 }
 
 /** Excel出力用のプレビューデータ（設問別得点・小計・合計）をデバウンス付きで取得するフック */
 export function useExcelPreview({
   examId,
-  selectedStudentIds,
+  selectedExamStudentIds,
   enabled,
 }: UseExcelPreviewProps) {
   const [previewData, setPreviewData] = useState<ExcelPreviewData | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // selectedStudentIdsのJSON文字列でオブジェクト参照変化を無視
-  const selectedStudentIdsKey = JSON.stringify(selectedStudentIds)
+  // selectedExamStudentIdsのJSON文字列でオブジェクト参照変化を無視
+  const selectedExamStudentIdsKey = JSON.stringify(selectedExamStudentIds)
 
   useEffect(() => {
-    if (!enabled || !examId || selectedStudentIds.length === 0) {
+    if (!enabled || !examId || selectedExamStudentIds.length === 0) {
       setPreviewData(null)
       setError(null)
       setIsLoading(false)
@@ -87,7 +87,7 @@ export function useExcelPreview({
         const studentPlacements = await loadStudentExportPlacements(examId)
         const result = await window.electronAPI.export.getExcelPreviewData({
           examId,
-          selectedStudentIds,
+          selectedExamStudentIds,
           studentPlacements,
         })
 
@@ -115,7 +115,7 @@ export function useExcelPreview({
         }
 
         const rows: ExcelPreviewRow[] = result.scoringData.map((data) => ({
-          studentId: data.studentId,
+          examStudentId: data.examStudentId,
           studentName: data.studentName,
           studentNumber: data.studentNumber,
           grade: data.grade,
@@ -146,7 +146,7 @@ export function useExcelPreview({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [examId, selectedStudentIdsKey, enabled])
+  }, [examId, selectedExamStudentIdsKey, enabled])
 
   return { previewData, isLoading, error }
 }

--- a/src/components/exams/08-export/hooks/useExportPage.ts
+++ b/src/components/exams/08-export/hooks/useExportPage.ts
@@ -35,7 +35,7 @@ export function useExportPage() {
 
   // 選択状態（Set の変異は useStudentSelection のインテントメソッドに閉じ込める）
   const {
-    selectedStudentIds,
+    selectedExamStudentIds,
     replaceSelection,
     toggleStudent,
     addStudents,
@@ -269,11 +269,11 @@ export function useExportPage() {
         )
 
         setStudents(sortedStudents)
-        // デフォルトで参加中の学生を選択
-        const participatingStudents = sortedStudents
+        // デフォルトで参加中の受験者を選択（選択集合は ExamStudent.id で持つ）
+        const participatingExamStudentIds = sortedStudents
           .filter((examStudent) => examStudent.status === "participating")
-          .map((examStudent) => examStudent.studentId)
-        replaceSelection(participatingStudents)
+          .map((examStudent) => examStudent.id)
+        replaceSelection(participatingExamStudentIds)
       }
     } catch (error) {
       console.error("Failed to load data:", error)
@@ -350,7 +350,7 @@ export function useExportPage() {
     setSelectedStatuses,
 
     // 選択
-    selectedStudents: selectedStudentIds,
+    selectedStudents: selectedExamStudentIds,
     replaceSelection,
     toggleStudent,
     addStudents,

--- a/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
+++ b/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
@@ -8,7 +8,7 @@ import type { IndividualReportData } from "@/electron-src/lib/export/individual-
 
 interface UseIndividualReportPreviewOptions {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   options: IndividualReportOptions
   enabled?: boolean
 }
@@ -28,7 +28,7 @@ interface UseIndividualReportPreviewResult {
  */
 export function useIndividualReportPreview({
   examId,
-  selectedStudentIds,
+  selectedExamStudentIds,
   options,
   enabled = true,
 }: UseIndividualReportPreviewOptions): UseIndividualReportPreviewResult {
@@ -46,16 +46,19 @@ export function useIndividualReportPreview({
 
   // 選択された生徒が変わったらプレビュー対象をリセット
   useEffect(() => {
-    if (selectedStudentIds.length > 0) {
+    if (selectedExamStudentIds.length > 0) {
       // 現在のプレビュー対象が選択リストにない場合、最初の生徒にリセット
-      if (!previewStudentId || !selectedStudentIds.includes(previewStudentId)) {
-        setPreviewStudentId(selectedStudentIds[0])
+      if (
+        !previewStudentId ||
+        !selectedExamStudentIds.includes(previewStudentId)
+      ) {
+        setPreviewStudentId(selectedExamStudentIds[0])
       }
     } else {
       setPreviewStudentId(null)
       setPreviewData(null)
     }
-  }, [selectedStudentIds, previewStudentId])
+  }, [selectedExamStudentIds, previewStudentId])
 
   const fetchPreviewData = useCallback(async () => {
     if (!enabled || !examId || !previewStudentId) {
@@ -70,7 +73,7 @@ export function useIndividualReportPreview({
       const studentPlacements = await loadStudentExportPlacements(examId)
       const result = await window.electronAPI.export.getIndividualReportData({
         examId,
-        selectedStudentIds: [previewStudentId],
+        selectedExamStudentIds: [previewStudentId],
         options: optionsRef.current,
         studentPlacements,
       })

--- a/src/components/exams/08-export/hooks/useReturnDiff.ts
+++ b/src/components/exams/08-export/hooks/useReturnDiff.ts
@@ -12,11 +12,11 @@ import type {
  * 答案返却スナップショットの記録と差分検出を管理するフック。
  *
  * - capture: 選択中の生徒を「返却版」として記録する
- * - diffByStudent: 生徒ID → 差分（返却版との比較結果）
- * - changedStudentIds: 返却版から変更があった生徒IDの集合
+ * - diffByExamStudent: 生徒ID → 差分（返却版との比較結果）
+ * - changedExamStudentIds: 返却版から変更があった生徒IDの集合
  */
 export function useReturnDiff(examId: string) {
-  const [diffByStudent, setDiffByStudent] = useState<
+  const [diffByExamStudent, setDiffByStudent] = useState<
     Map<string, ReturnStudentDiff>
   >(new Map())
   const [hasAnySnapshot, setHasAnySnapshot] = useState(false)
@@ -31,7 +31,7 @@ export function useReturnDiff(examId: string) {
         await window.electronAPI.export.getReturnDiff(examId)
       if (result.success) {
         setDiffByStudent(
-          new Map(result.diffs.map((diff) => [diff.studentId, diff]))
+          new Map(result.diffs.map((diff) => [diff.examStudentId, diff]))
         )
         setHasAnySnapshot(result.hasAnySnapshot)
       } else {
@@ -50,13 +50,13 @@ export function useReturnDiff(examId: string) {
 
   /** 指定生徒を返却版として記録する */
   const capture = useCallback(
-    async (studentIds: string[]): Promise<boolean> => {
-      if (!examId || studentIds.length === 0) return false
+    async (examStudentIds: string[]): Promise<boolean> => {
+      if (!examId || examStudentIds.length === 0) return false
       setCapturing(true)
       try {
         const result = await window.electronAPI.export.captureReturnSnapshot({
           examId,
-          studentIds,
+          examStudentIds,
         })
         if (result.success) {
           toast.success(`${result.capturedCount}名を返却版として記録しました`)
@@ -76,17 +76,17 @@ export function useReturnDiff(examId: string) {
     [examId, refresh]
   )
 
-  const changedStudentIds = useMemo(() => {
+  const changedExamStudentIds = useMemo(() => {
     const ids = new Set<string>()
-    for (const diff of diffByStudent.values()) {
-      if (diff.changed) ids.add(diff.studentId)
+    for (const diff of diffByExamStudent.values()) {
+      if (diff.changed) ids.add(diff.examStudentId)
     }
     return ids
-  }, [diffByStudent])
+  }, [diffByExamStudent])
 
   return {
-    diffByStudent,
-    changedStudentIds,
+    diffByExamStudent,
+    changedExamStudentIds,
     hasAnySnapshot,
     loading,
     capturing,

--- a/src/components/exams/08-export/hooks/useScoredAnswerPdfExport.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPdfExport.ts
@@ -85,12 +85,12 @@ export function useScoredAnswerPdfExport({
       savePathResultRef.current = null
       isExportCancelledRef.current = false
 
-      const selectedStudentIds = Array.from(selectedStudents)
+      const selectedExamStudentIds = Array.from(selectedStudents)
 
       // 1. データ取得
       const dataResult = await window.electronAPI.export.getPdfExportData({
         examId: exam.id,
-        selectedStudentIds,
+        selectedExamStudentIds,
       })
 
       if (!dataResult.success || !dataResult.pages) {
@@ -256,7 +256,7 @@ export function useScoredAnswerPdfExport({
   const handleCanvasComplete = useCallback(
     async (
       _renderedPages: Array<{
-        studentId: string
+        examStudentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }>

--- a/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
@@ -16,7 +16,7 @@ import {
 
 interface UseScoredAnswerPreviewProps {
   examId: string
-  selectedStudentIds: string[]
+  selectedExamStudentIds: string[]
   scoringMarkConfig: ScoringMarkConfigForPdf
   enabled: boolean
 }
@@ -46,7 +46,7 @@ const RENDER_DEBOUNCE_MS = 150
  */
 export function useScoredAnswerPreview({
   examId,
-  selectedStudentIds,
+  selectedExamStudentIds,
   scoringMarkConfig,
   enabled,
 }: UseScoredAnswerPreviewProps) {
@@ -67,15 +67,18 @@ export function useScoredAnswerPreview({
 
   // 選択生徒が変更されたときにpreviewStudentIdを初期化
   useEffect(() => {
-    if (selectedStudentIds.length > 0) {
-      if (!previewStudentId || !selectedStudentIds.includes(previewStudentId)) {
-        setPreviewStudentId(selectedStudentIds[0])
+    if (selectedExamStudentIds.length > 0) {
+      if (
+        !previewStudentId ||
+        !selectedExamStudentIds.includes(previewStudentId)
+      ) {
+        setPreviewStudentId(selectedExamStudentIds[0])
       }
     } else {
       setPreviewStudentId(null)
       setPreviewImageUrls([])
     }
-  }, [selectedStudentIds, previewStudentId])
+  }, [selectedExamStudentIds, previewStudentId])
 
   // enabled が false になったらリセット
   useEffect(() => {
@@ -110,7 +113,7 @@ export function useScoredAnswerPreview({
       try {
         const dataResult = await window.electronAPI.export.getPdfExportData({
           examId,
-          selectedStudentIds: [previewStudentId],
+          selectedExamStudentIds: [previewStudentId],
         })
 
         if (cancelled) return

--- a/src/components/exams/08-export/hooks/useSpAnalysis.ts
+++ b/src/components/exams/08-export/hooks/useSpAnalysis.ts
@@ -25,7 +25,7 @@ export function useSpAnalysis(
     if (!data || data.rows.length === 0) return null
 
     const input: SpInputStudent[] = data.rows.map((row) => ({
-      studentId: row.studentId,
+      examStudentId: row.examStudentId,
       studentName: row.studentName,
       items: row.scores.map((questionScore) => ({
         questionId: questionScore.questionId,

--- a/src/components/exams/08-export/hooks/useStudentSelection.ts
+++ b/src/components/exams/08-export/hooks/useStudentSelection.ts
@@ -5,61 +5,63 @@ import { useCallback, useState } from "react"
 /**
  * 出力対象の生徒選択を一元管理するフック。
  *
- * 選択集合は `Set<string>`（studentId）で保持する（`.has()` が O(1)・`.size` が安価で、
+ * 選択集合は `Set<string>`（examStudentId = ExamStudent.id）で保持する（`.has()` が O(1)・`.size` が安価で、
  * チェックボックス描画に最適）。ただし集合の変異は本フックのインテントメソッドに閉じ込め、
  * 生の setState を prop 境界へ渡さない。各画面（StudentSelectionCard / ReturnDiffPanel 等）は
  * 「トグルする」「まとめて追加する」といった意図だけを呼び、Set の複製ロジックを重複させない。
  */
 export interface StudentSelection {
   /** 選択中の生徒ID集合（描画時の `.has()` / `.size` 参照用。書き込みは各メソッド経由） */
-  selectedStudentIds: Set<string>
+  selectedExamStudentIds: Set<string>
   /** 選択集合を丸ごと差し替える（初期化・「変更があった生徒のみ」等） */
-  replaceSelection: (studentIds: Iterable<string>) => void
+  replaceSelection: (examStudentIds: Iterable<string>) => void
   /** 1名の選択をトグルする */
-  toggleStudent: (studentId: string) => void
+  toggleStudent: (examStudentId: string) => void
   /** 指定生徒を選択へ追加する（和集合） */
-  addStudents: (studentIds: Iterable<string>) => void
+  addStudents: (examStudentIds: Iterable<string>) => void
   /** 指定生徒を選択から除外する（差集合） */
-  removeStudents: (studentIds: Iterable<string>) => void
+  removeStudents: (examStudentIds: Iterable<string>) => void
 }
 
 export function useStudentSelection(): StudentSelection {
-  const [selectedStudentIds, setSelectedStudentIds] = useState<Set<string>>(
+  const [selectedExamStudentIds, setSelectedStudentIds] = useState<Set<string>>(
     () => new Set()
   )
 
-  const replaceSelection = useCallback((studentIds: Iterable<string>) => {
-    setSelectedStudentIds(new Set(studentIds))
+  const replaceSelection = useCallback((examStudentIds: Iterable<string>) => {
+    setSelectedStudentIds(new Set(examStudentIds))
   }, [])
 
-  const toggleStudent = useCallback((studentId: string) => {
+  const toggleStudent = useCallback((examStudentId: string) => {
     setSelectedStudentIds((prev) => {
       const next = new Set(prev)
-      if (next.has(studentId)) {
-        next.delete(studentId)
+      if (next.has(examStudentId)) {
+        next.delete(examStudentId)
       } else {
-        next.add(studentId)
+        next.add(examStudentId)
       }
       return next
     })
   }, [])
 
-  const addStudents = useCallback((studentIds: Iterable<string>) => {
-    setSelectedStudentIds((prev) => new Set([...prev, ...studentIds]))
+  const addStudents = useCallback((examStudentIds: Iterable<string>) => {
+    setSelectedStudentIds((prev) => new Set([...prev, ...examStudentIds]))
   }, [])
 
-  const removeStudents = useCallback((studentIds: Iterable<string>) => {
-    const removal = new Set(studentIds)
+  const removeStudents = useCallback((examStudentIds: Iterable<string>) => {
+    const removal = new Set(examStudentIds)
     setSelectedStudentIds(
       (prev) =>
-        new Set([...prev].filter((studentId) => !removal.has(studentId)))
+        new Set(
+          [...prev].filter((examStudentId) => !removal.has(examStudentId))
+        )
     )
   }, [])
 
   // メソッドは useCallback で安定、集合の変化時のみ再描画したいので、
   // オブジェクトはそのまま返す（唯一の消費者は即座に分解代入するため同一性は不問）。
   return {
-    selectedStudentIds,
+    selectedExamStudentIds,
     replaceSelection,
     toggleStudent,
     addStudents,

--- a/src/components/exams/08-export/types.ts
+++ b/src/components/exams/08-export/types.ts
@@ -61,7 +61,7 @@ export interface DetailedProgressState {
 // レンダリングされたページデータ
 export interface RenderedPageData {
   pageIndex: number
-  studentId: string
+  examStudentId: string
   pageNumber: number
   imageData: ArrayBuffer
 }

--- a/src/components/exams/08-export/utils/loadStudentExportPlacements.ts
+++ b/src/components/exams/08-export/utils/loadStudentExportPlacements.ts
@@ -7,6 +7,9 @@ import { resolveExamClassroomPlacement } from "@/lib/examClassroomPlacement"
  * 採番学級の解決は renderer が単一ソースで担い（`resolveExamClassroomPlacement`）、
  * main へは書き出しに必要な値だけ（学級名・学年・出席番号）を lean な形で渡す。
  * main 側は placement を解決せず、渡された値をそのまま出力に使う（export は型制限の対象外）。
+ *
+ * **返り値のキーは Student.id**。学級所属（StudentClassroomMembership）は人に紐づくので、
+ * 受験者ID（ExamStudent.id）ではない。main 側の引き当ても Student.id で行うこと。
  */
 export async function loadStudentExportPlacements(
   examId: string

--- a/src/lib/examStatus.ts
+++ b/src/lib/examStatus.ts
@@ -20,13 +20,13 @@ export interface ExamProgressSource {
     type: string
     questionScores: {
       status: string
-      studentId: string | null
+      examStudentId: string
       partialScore: number | null
     }[]
   }[]
   /** 平坦化済み答案画像 */
-  answerImages?: { studentId: string | null }[]
-  examStudents: { studentId: string; status: string }[]
+  answerImages?: { examStudentId: string }[]
+  examStudents: { id: string; status: string }[]
   examSubtotalGroups: { id: string }[]
 }
 
@@ -93,23 +93,22 @@ export function getExamProgress(exam: ExamProgressSource): ExamProgress {
       .length || 0
 
   // 受験・見込み生徒のIDリストを取得（欠席生徒を除外）
-  const participatingStudentIds =
+  const participatingExamStudentIds =
     exam.examStudents
       ?.filter(
         (examStudent) =>
           examStudent.status === "participating" ||
           examStudent.status === "expected"
       )
-      ?.map((examStudent) => examStudent.studentId) || []
+      ?.map((examStudent) => examStudent.id) || []
 
   // 受験・見込み生徒の数をカウント（複数ページの答案でも1人1回のみ）
   const answerSheetCount = new Set(
     exam.answerImages
-      ?.filter(
-        (img) =>
-          img.studentId && participatingStudentIds.includes(img.studentId)
+      ?.filter((answerImage) =>
+        participatingExamStudentIds.includes(answerImage.examStudentId)
       )
-      ?.map((img) => img.studentId)
+      ?.map((answerImage) => answerImage.examStudentId)
   ).size
 
   const expectedScoringCount = questionAnswerCount * answerSheetCount
@@ -122,8 +121,7 @@ export function getExamProgress(exam: ExamProgressSource): ExamProgress {
         const validQuestionScores = region.questionScores.filter(
           (score) =>
             score.status !== "unscored" &&
-            score.studentId !== null &&
-            participatingStudentIds.includes(score.studentId) &&
+            participatingExamStudentIds.includes(score.examStudentId) &&
             // partial/pending は partialScore が入力済みの場合のみ採点済みとする
             !(
               (score.status === "partial" || score.status === "pending") &&

--- a/src/types/drawingAnnotation.types.ts
+++ b/src/types/drawingAnnotation.types.ts
@@ -2,24 +2,93 @@
  * @fileoverview 描画アノテーション型定義
  * @description 全描画ツール（テキスト・直線・長方形・楕円）の統合型定義
  */
+import { defineStringUnion } from "./stringUnion"
 
 // 基本型定義
-export type DrawingType = "text" | "line" | "rectangle" | "ellipse"
+/**
+ * 描画種別。SQLite に enum が無いため DB 上は String 列で、境界で `toDrawingType`
+ * を通して literal union へ絞り込む（Decimal→number / ScoringStatus と同じ型注入）。
+ */
+export const DRAWING_TYPES = ["text", "line", "rectangle", "ellipse"] as const
+export type DrawingType = (typeof DRAWING_TYPES)[number]
+
+export const { is: isDrawingType, to: toDrawingType } = defineStringUnion(
+  DRAWING_TYPES,
+  "line"
+)
 export type DrawingTool = "select" | "text" | "line" | "rectangle" | "ellipse"
-export type LineStyle =
-  "solid" | "wave" | "zigzag" | "double" | "arrow" | "both_arrow"
-export type AnnotationHorizontalAlign = "left" | "center" | "right"
-export type AnnotationVerticalAlign = "top" | "center" | "bottom"
-export type AnchorDirection =
-  | "top-left"
-  | "top"
-  | "top-right"
-  | "left"
-  | "center"
-  | "right"
-  | "bottom-left"
-  | "bottom"
-  | "bottom-right"
+
+export const LINE_STYLES = [
+  "solid",
+  "wave",
+  "zigzag",
+  "double",
+  "arrow",
+  "both_arrow",
+] as const
+export type LineStyle = (typeof LINE_STYLES)[number]
+
+export const ANNOTATION_HORIZONTAL_ALIGNS = ["left", "center", "right"] as const
+export type AnnotationHorizontalAlign =
+  (typeof ANNOTATION_HORIZONTAL_ALIGNS)[number]
+
+export const ANNOTATION_VERTICAL_ALIGNS = ["top", "center", "bottom"] as const
+export type AnnotationVerticalAlign =
+  (typeof ANNOTATION_VERTICAL_ALIGNS)[number]
+
+export const ANCHOR_DIRECTIONS = [
+  "top-left",
+  "top",
+  "top-right",
+  "left",
+  "center",
+  "right",
+  "bottom-left",
+  "bottom",
+  "bottom-right",
+] as const
+export type AnchorDirection = (typeof ANCHOR_DIRECTIONS)[number]
+
+/**
+ * 型ガードと境界コンバータ。想定外値は既定へ倒す（DB 直書き・旧データへの耐性）。
+ * scoringStatus.types.ts / cropRegionAreaType.types.ts と同じ factory から生成する。
+ */
+export const { is: isLineStyle, to: toLineStyle } = defineStringUnion(
+  LINE_STYLES,
+  "solid"
+)
+export const {
+  is: isAnnotationHorizontalAlign,
+  to: toAnnotationHorizontalAlign,
+} = defineStringUnion(ANNOTATION_HORIZONTAL_ALIGNS, "left")
+export const { is: isAnnotationVerticalAlign, to: toAnnotationVerticalAlign } =
+  defineStringUnion(ANNOTATION_VERTICAL_ALIGNS, "top")
+export const { is: isAnchorDirection, to: toAnchorDirection } =
+  defineStringUnion(ANCHOR_DIRECTIONS, "top-left")
+
+/**
+ * DB 行（union 列がすべて String）を境界で 1 回だけ絞り込む。
+ * SQLite に enum が無いための型注入で、`as` で潰さずここを通すことで
+ * include の形が変わったときに型検査が効く。
+ */
+export const narrowAnnotationUnions = <
+  T extends {
+    type: string
+    lineStyle: string
+    horizontalAlign: string
+    verticalAlign: string
+    anchorDirection: string
+  },
+>(
+  row: T
+) => ({
+  ...row,
+  type: toDrawingType(row.type),
+  lineStyle: toLineStyle(row.lineStyle),
+  horizontalAlign: toAnnotationHorizontalAlign(row.horizontalAlign),
+  verticalAlign: toAnnotationVerticalAlign(row.verticalAlign),
+  anchorDirection: toAnchorDirection(row.anchorDirection),
+})
 
 // データベース対応統合インターフェース
 export interface DrawingAnnotation {
@@ -77,7 +146,7 @@ export interface DrawingCreateData {
   strokeWidth?: number
 
   // コンテキスト情報（参照用、自動作成には使用しない）
-  studentId?: string
+  examStudentId?: string
   cropRegionId?: string
 
   // 全プロパティ（デフォルト値はデータベース側で設定）
@@ -131,14 +200,17 @@ export interface DrawingAnnotationStats {
 export interface AnnotationWithContext extends DrawingAnnotation {
   questionScore?: {
     id: string
-    studentId: string
+    examStudentId: string
     cropRegionId: string
     cropRegion?: { id: string; label: string }
-    student?: {
+    examStudent?: {
       id: string
-      studentNumber: string
-      lastName: string
-      firstName: string
+      student: {
+        id: string
+        studentNumber: string
+        lastName: string
+        firstName: string
+      }
     }
   } | null
   user?: {

--- a/src/types/electron/drawingApi.d.ts
+++ b/src/types/electron/drawingApi.d.ts
@@ -4,54 +4,56 @@
 export interface DrawingAPI {
   drawing: {
     create: (
-      data: import("../drawing-annotation.types").DrawingCreateData
+      data: import("../drawingAnnotation.types").DrawingCreateData
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation
+      data?: import("../drawingAnnotation.types").DrawingAnnotation
       error?: string
     }>
     getByQuestionScore: (
       questionScoreId: string,
-      type?: import("../drawing-annotation.types").DrawingType,
+      type?: import("../drawingAnnotation.types").DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
       error?: string
     }>
-    getByStudent: (
-      studentId: string,
-      examId: string,
-      type?: import("../drawing-annotation.types").DrawingType,
+    getByExamStudent: (
+      examStudentId: string,
+      type?: import("../drawingAnnotation.types").DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
       error?: string
     }>
     getByExam: (
       examId: string,
-      type?: import("../drawing-annotation.types").DrawingType,
+      type?: import("../drawingAnnotation.types").DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
       error?: string
     }>
+    // main 側は questionScore（examStudentId / cropRegion）を include して返すので、
+    // 契約もそれを表す型にする。DrawingAnnotation[] にすると受け手が `as` で
+    // 補うことになり、main の select から列が消えても型検査が効かなくなる。
     getByCropRegion: (
       cropRegionId: string,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").AnnotationWithContext[]
       error?: string
     }>
     update: (
       id: string,
-      data: import("../drawing-annotation.types").DrawingUpdateData
+      data: import("../drawingAnnotation.types").DrawingUpdateData
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation
+      data?: import("../drawingAnnotation.types").DrawingAnnotation
       error?: string
     }>
     delete: (id: string) => Promise<{
@@ -60,36 +62,36 @@ export interface DrawingAPI {
     }>
     deleteByQuestionScore: (
       questionScoreId: string,
-      type?: import("../drawing-annotation.types").DrawingType
+      type?: import("../drawingAnnotation.types").DrawingType
     ) => Promise<{
       success: boolean
       error?: string
     }>
     batchCreate: (
-      annotations: import("../drawing-annotation.types").DrawingCreateData[]
+      annotations: import("../drawingAnnotation.types").DrawingCreateData[]
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
       error?: string
     }>
     batchUpdate: (
       updates: Array<{
         id: string
-        data: import("../drawing-annotation.types").DrawingUpdateData
+        data: import("../drawingAnnotation.types").DrawingUpdateData
       }>
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation[]
+      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
       error?: string
     }>
     getStats: (questionScoreId: string) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotationStats
+      data?: import("../drawingAnnotation.types").DrawingAnnotationStats
       error?: string
     }>
     getById: (id: string) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation | null
+      data?: import("../drawingAnnotation.types").DrawingAnnotation | null
       error?: string
     }>
     toggleFavorite: (
@@ -97,12 +99,12 @@ export interface DrawingAPI {
       isFavorite: boolean
     ) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").DrawingAnnotation
+      data?: import("../drawingAnnotation.types").DrawingAnnotation
       error?: string
     }>
     getForBrowse: (examId: string) => Promise<{
       success: boolean
-      data?: import("../drawing-annotation.types").AnnotationWithContext[]
+      data?: import("../drawingAnnotation.types").AnnotationWithContext[]
       error?: string
     }>
   }

--- a/src/types/electron/examApi.d.ts
+++ b/src/types/electron/examApi.d.ts
@@ -85,14 +85,11 @@ export interface ExamAPI {
     success: boolean
     hasAnyData?: boolean
     totalGradingItems?: number
+    // main 側の SSOT をそのまま参照する（手書きで写すと今回のように
+    // フィールド名と数える範囲がずれ、削除確認の表示が実態とずれる）
     studentData?: Record<
       string,
-      {
-        hasData: boolean
-        studentAnswerCount: number
-        questionScoreCount: number
-        totalGradingItems: number
-      }
+      import("@/electron-src/lib/prisma/gradingData").GradingDataInfo
     >
     error?: string
   }>

--- a/src/types/electron/exportApi.d.ts
+++ b/src/types/electron/exportApi.d.ts
@@ -23,7 +23,7 @@ export interface ExportAPI {
     // 採点データバリデーション（全エクスポート共通）
     validateScoringData: (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       userId: string
     }) => Promise<
       | { success: false; error: string }
@@ -42,7 +42,7 @@ export interface ExportAPI {
     // PDF出力に必要なデータを取得
     getPdfExportData: (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
     }) => Promise<{
       success: boolean
       examName?: string
@@ -54,7 +54,7 @@ export interface ExportAPI {
     createPdfFromRenderedImages: (options: {
       examId: string
       renderedPages: Array<{
-        studentId: string
+        examStudentId: string
         pageNumber: number
         imageData: ArrayBuffer
       }>
@@ -133,7 +133,7 @@ export interface ExportAPI {
     // 個人成績表用データ取得
     getIndividualReportData: (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       options: IndividualReportOptions
       studentPlacements?: Record<string, StudentExportPlacement>
     }) => Promise<GetIndividualReportDataResult>
@@ -192,7 +192,7 @@ export interface ExportAPI {
     // Excelプレビューデータ取得
     getExcelPreviewData: (options: {
       examId: string
-      selectedStudentIds: string[]
+      selectedExamStudentIds: string[]
       studentPlacements?: Record<string, StudentExportPlacement>
     }) => Promise<{
       success: boolean
@@ -207,7 +207,7 @@ export interface ExportAPI {
         label: string
       }>
       scoringData?: Array<{
-        studentId: string
+        examStudentId: string
         studentName: string
         studentNumber: string
         grade?: string
@@ -247,7 +247,7 @@ export interface ExportAPI {
     // 答案返却スナップショット: 現在の有効スコア＋注釈を返却版として記録
     captureReturnSnapshot: (options: {
       examId: string
-      studentIds: string[]
+      examStudentIds: string[]
     }) => Promise<CaptureReturnSnapshotResult>
 
     // 返却版と現在状態の差分（変更があった生徒の検出）
@@ -257,7 +257,7 @@ export interface ExportAPI {
   // Excel Export related
   exportGradingDataExcel: (options: {
     examId: string
-    selectedStudentIds: string[]
+    selectedExamStudentIds: string[]
     outputPath?: string
     forceExport?: boolean
     studentPlacements?: Record<string, StudentExportPlacement>

--- a/src/types/electron/omrApi.d.ts
+++ b/src/types/electron/omrApi.d.ts
@@ -19,10 +19,14 @@ export interface OmrAPI {
       ]
       params: import("../omr.types").OMRRecognitionParams
       pageIndex?: number
-      studentId?: string
+      examStudentId?: string
     }) => Promise<import("../omr.types").OMRSheetResult>
     batchRecognize: (args: {
-      imagePaths: { path: string; studentId?: string; studentName?: string }[]
+      imagePaths: {
+        path: string
+        examStudentId?: string
+        studentName?: string
+      }[]
       cells: import("../answerSheetBuilder.types").ComputedCell[]
       cellConfigs: Record<string, import("../omr.types").OMRCellConfig>
       expectedCorners: [

--- a/src/types/electron/scoringApi.d.ts
+++ b/src/types/electron/scoringApi.d.ts
@@ -34,7 +34,7 @@ export type UpdateQuestionScoreArgs = Partial<
 export interface ScoreDecisionForComparison {
   id: string
   cropRegionId: string
-  studentId: string
+  examStudentId: string
   verdict: string
   score: number | null
   comment: string | null
@@ -78,7 +78,7 @@ export interface ScoringAPI {
   }>
   createQuestionScore: (data: {
     cropRegionId: string
-    studentId: string // v0.4.0+: required
+    examStudentId: string
     partialScore?: number
     status: ScoringStatus
     userId: string // v0.4.0+: required
@@ -96,7 +96,7 @@ export interface ScoringAPI {
   ) => Promise<QuestionScoreOperationResult>
   deleteQuestionScore: (id: string) => Promise<QuestionScore | void>
   finalizeQuestionScore: (
-    studentId: string,
+    examStudentId: string,
     cropRegionId: string,
     userId: string,
     scoreData: {
@@ -165,7 +165,7 @@ export interface ScoringAPI {
   }>
   batchUpdateQuestionScores: (
     entries: Array<{
-      studentId: string
+      examStudentId: string
       cropRegionId: string
       status: ScoringStatus
       partialScore: number | null

--- a/src/types/electron/studentAnswerApi.d.ts
+++ b/src/types/electron/studentAnswerApi.d.ts
@@ -12,7 +12,7 @@ export interface UploadStudentAnswerFileData {
   originalFileName: string
   type: string
   buffer: ArrayBuffer
-  studentId: string
+  examStudentId: string
   examPageId: string
   overwrite: boolean
   correctWithMarkers?: boolean
@@ -62,7 +62,7 @@ export interface StudentAnswerAPI {
   }>
   associateStudentAnswerWithStudent: (
     studentAnswerId: string,
-    studentId: string
+    examStudentId: string
   ) => Promise<{
     success: boolean
     answerSheet?: StudentAnswerImageWithExamPageAndStudent
@@ -84,7 +84,7 @@ export interface StudentAnswerAPI {
   applyStudentAnswerPlacements: (
     moves: Array<{
       fileId: string
-      finalStudentId: string | null
+      finalExamStudentId: string | null
       finalExamPageId: string
       scorePolicy: PlacementScorePolicy | "discard"
     }>

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -78,6 +78,7 @@ export interface ArchiveDataCounts {
  * - 1.18.0: v0.16.x (CropRegionMarkingOverride 廃止 — UI・出力反映が無いまま入出力のみ維持されていたため削除)
  * - 1.19.0: v0.16.x (DeletedRecord tombstone 廃止 — アーカイブは正本であり import は忠実に復元する。削除の伝搬は sqlite-nas-sync の `_tombstone` に一本化)
  * - 1.20.0: v0.16.x (CropRegionAssignment 追加 — 設問ごとの採点担当。ユーザーはアーカイブを越えないため username で照合する)
+ * - 1.21.0: v0.16.x (採点層を ExamStudent 経由へ配線変更 — studentAnswerImages / questionScores / scoreDecisions / compoundAnswerScores / returnSnapshots の studentId を examStudentId へ。ReturnSnapshot.examId は ExamStudent が持つため削除)
  */
 export type ExamArchiveVersion =
   | "1.0.0"
@@ -101,9 +102,10 @@ export type ExamArchiveVersion =
   | "1.18.0"
   | "1.19.0"
   | "1.20.0"
+  | "1.21.0"
 
 /** 現在の最新バージョン */
-export const EXAM_CURRENT_VERSION: ExamArchiveVersion = "1.20.0"
+export const EXAM_CURRENT_VERSION: ExamArchiveVersion = "1.21.0"
 
 /** サポートされている全バージョン（古い順） */
 export const EXAM_SUPPORTED_VERSIONS: readonly ExamArchiveVersion[] = [
@@ -128,6 +130,7 @@ export const EXAM_SUPPORTED_VERSIONS: readonly ExamArchiveVersion[] = [
   "1.18.0",
   "1.19.0",
   "1.20.0",
+  "1.21.0",
 ] as const
 
 /**
@@ -781,7 +784,8 @@ export interface ArchiveExamData {
   compoundAnswerScores?: Array<{
     id: string
     compoundAnswerId: string
-    studentId: string
+    /** v1.21.0+ 受験者ID（ExamStudent.id）。それ以前は studentId */
+    examStudentId: string
     userId: string
     recognizedAnswer: string | null
     status: string
@@ -813,7 +817,8 @@ export interface ArchiveExamData {
   studentAnswerImages?: Array<{
     id: string
     examPageId: string
-    studentId: string
+    /** v1.21.0+ 受験者ID（ExamStudent.id）。それ以前は studentId */
+    examStudentId: string
     imagePath: string
     createdAt: string
     updatedAt: string
@@ -982,7 +987,8 @@ export interface ArchiveScoresData {
   questionScores: Array<{
     id: string
     cropRegionId: string
-    studentId: string
+    /** v1.21.0+ 受験者ID（ExamStudent.id）。それ以前は studentId */
+    examStudentId: string
     partialScore: string | null // Decimal as string
     status: string
     userId: string
@@ -1020,7 +1026,8 @@ export interface ArchiveScoresData {
   scoreDecisions?: Array<{
     id: string
     cropRegionId: string
-    studentId: string
+    /** v1.21.0+ 受験者ID（ExamStudent.id）。それ以前は studentId */
+    examStudentId: string
     verdict: string
     score: string | null // Decimal as string
     comment: string | null
@@ -1044,11 +1051,11 @@ export interface ArchiveScoresData {
     createdAt: string
     updatedAt: string
   }>
-  /** v1.14.0+ 答案返却版スナップショット（生徒×試験で1行）。旧バージョンのアーカイブには存在しない */
+  /** v1.14.0+ 答案返却版スナップショット（受験者ごとに1行）。旧バージョンのアーカイブには存在しない */
   returnSnapshots?: Array<{
     id: string
-    examId: string
-    studentId: string
+    /** v1.21.0+ 受験者ID（ExamStudent.id）。それ以前は examId + studentId */
+    examStudentId: string
     scoresJson: string
     totalScore: string | null // Decimal as string
     capturedByUserId: string | null

--- a/src/types/omr.types.ts
+++ b/src/types/omr.types.ts
@@ -171,7 +171,7 @@ export interface OMRCellResult {
 
 export interface OMRSheetResult {
   success: boolean
-  studentId?: string
+  examStudentId?: string
   pageIndex: number
   markerDetection: MarkerDetectionResult
   cellResults: OMRCellResult[]

--- a/src/types/prismaExtensions.ts
+++ b/src/types/prismaExtensions.ts
@@ -72,7 +72,8 @@ export type StudentWithMemberships = Prisma.StudentGetPayload<{
  * 実体は Exam×Student×Classroom の結合を生徒1人へ畳んだもので、基底は Student ではなく
  * **ExamStudent**。受験状態（status）・並び順（customOrder）は ExamStudent の実列、
  * 生徒識別・学級所属は `examStudent.student(.memberships.classroom)`、答案枚数は
- * `examStudent.student._count.studentAnswerImages` として Prisma スキーマに完全追随する。
+ * `examStudent._count.studentAnswerImages` として Prisma スキーマに完全追随する
+ * （答案は ExamStudent の子なので、試験での絞り込みは不要）。
  * 機能ごとに手書きで重複宣言せず、05/06/08・electron 出力すべてがこの型を参照する。
  *
  * status のみ ExamStudentStatus へ narrowing する（DB 上は string。Prisma+SQLite が enum を
@@ -85,9 +86,9 @@ export type ExamStudentWithMemberships = Omit<
       student: {
         include: {
           memberships: { include: { classroom: true } }
-          _count: { select: { studentAnswerImages: true } }
         }
       }
+      _count: { select: { studentAnswerImages: true } }
     }
   }>,
   "status"
@@ -156,10 +157,12 @@ export type ExamForDetail = Prisma.ExamGetPayload<{
     examPages: {
       include: {
         masterImages: true
-        studentAnswerImages: { include: { student: true } }
+        studentAnswerImages: {
+          include: { examStudent: { include: { student: true } } }
+        }
         cropRegions: {
-          // 進捗計算は questionScores のスカラー（status/studentId/partialScore）のみ読むため
-          // student/user は join しない（over-fetch 排除）
+          // 進捗計算は questionScores のスカラー（status/examStudentId/partialScore）のみ読むため
+          // examStudent/user は join しない（over-fetch 排除）
           include: { questionScores: true }
         }
       }
@@ -185,7 +188,7 @@ export type ExamForDetail = Prisma.ExamGetPayload<{
   })[]
   /** IPCハンドラーで抽出されるanswerImages */
   answerImages?: (Prisma.StudentAnswerImageGetPayload<{
-    include: { student: true }
+    include: { examStudent: { include: { student: true } } }
   }> & {
     pageNumber: number
   })[]
@@ -203,9 +206,9 @@ export type StudentAnswerImageWithExamPageAndStudent =
   Prisma.StudentAnswerImageGetPayload<{
     include: {
       examPage: true
-      student: {
+      examStudent: {
         include: {
-          examStudents: true
+          student: true
         }
       }
     }
@@ -215,17 +218,21 @@ export type StudentAnswerImageWithExamPageAndStudent =
  * 保存済み答案（配置済み）を Prisma include のまま持つ実体型（06 entity-first）。
  * 列＝ExamPage 実体から供給されるため、答案は自身の examPage を再同梱しない
  * （examPageId で列に照合し、pageNumber は列の ExamPage から表示時に導出する）。
- * 孤立答案の氏名表示のため student は同梱する。
+ * 氏名表示のため受験者（と生徒）は同梱する。
  */
 export type PlacedAnswerImage = Prisma.StudentAnswerImageGetPayload<{
-  include: { student: true }
+  include: { examStudent: { include: { student: true } } }
 }>
 
 /**
  * 06 データセットの列となる ExamPage 実体（配置済み答案を子に持つ）。
  */
 export type StudentAnswerDatasetExamPage = Prisma.ExamPageGetPayload<{
-  include: { studentAnswerImages: { include: { student: true } } }
+  include: {
+    studentAnswerImages: {
+      include: { examStudent: { include: { student: true } } }
+    }
+  }
 }>
 
 /**

--- a/src/types/scoreDecision.types.ts
+++ b/src/types/scoreDecision.types.ts
@@ -36,9 +36,9 @@ export type ScoreDecisionReason =
   /** 確定済みだが、その後に新しい提案が入った（再確認が必要） */
   | "stale"
 
-/** 裁定対象の生徒×設問セル */
+/** 裁定対象の受験者×設問セル */
 export interface ScoreDecisionCell {
-  studentId: string
+  examStudentId: string
   studentName: string
   cropRegionId: string
   reason: ScoreDecisionReason
@@ -72,7 +72,7 @@ export interface ScoreDecisionQuestion {
    * 担当者ごとの進捗もここに畳む（設問×担当者を添字で突き合わせない）。
    */
   assignees: AssignedGrader[]
-  /** 答案がある生徒数（この設問の分母） */
+  /** 答案がある受験者数（この設問の分母） */
   totalStudents: number
   /** 誰か1人でも採点したセル数 */
   scoredCount: number


### PR DESCRIPTION
Closes #1075

## 何をしたか

採点層の5テーブル（`StudentAnswerImage` / `QuestionScore` / `ScoreDecision` / `CompoundAnswerScore` / `ReturnSnapshot`）を `Student` 直結から `ExamStudent` 経由へ配線変更しました。

これにより「試験から生徒を外す」操作が DB の cascade で子データを巻き取るようになり、孤児が構造的に発生しなくなります。成績算出も受験者を必ず1回通すため、外した生徒の得点を拾えません。

178 ファイル / +4,314 −1,929。

## 主な変更

### スキーマ・マイグレーション

- 5テーブルの `studentId` を `examStudentId` へ。FK は `ExamStudent` に張り、cascade 子にする
- `ReturnSnapshot.examId` を削除。`ExamStudent` が `examId` を持つため、両方を残すと `examId` と `examStudent.examId` が食い違いうる。`@@unique([examId, studentId])` は `examStudentId @unique` になる
- `20260728000000_rewire_scoring_to_exam_student`（手書き）: RedefineTables × 5。バックフィルは `ExamStudent` との INNER JOIN なので孤児は自然に落ちる。孤児 `QuestionScore` にぶら下がる手書き注釈も明示削除（`foreign_keys=OFF` では cascade しないため）
- 破棄件数は migration SQL から `AuditLog` へ直接 INSERT（0件なら行を作らない）

### 削除経路

- `removeStudentsFromExam` の手書き削除を撤去し cascade に委ねる
- **削除確認の件数も5テーブル全部を数える**。答案と採点行しか数えないと、確定・複合回答・返却版だけが残っている生徒（OMR で複合回答だけ採点した場合など）で「採点データがないため安全に削除できます」と表示したまま破棄してしまう
- 呼ばれていなかった `deleteAllGradingDataForStudent` を削除

### 成績算出

- `ExamDataCache` を受験者起点へ組み替え（`examStudents: ExamStudentScores[]`）。`status` が経路上に現れるため、見込→欠測用の `statusMap` プリロードが不要になり消滅
- `scoringInitializer` の `${studentId}#${cropRegionId}` 文字列連結キーが消滅（受験者の子として引くため、既存判定が受験者の内側で閉じる）

### アーカイブ 1.21.0

- `V1_20_0_to_V1_21_0`: 初の「解決型」トランスフォーマー。アーカイブ内の `examStudents` を引いて `studentId → examStudentId` を解決する
- 受験者に紐づかない行は DB 側と同じく破棄し、件数を `warnings` に載せる
- 変換済みの行はそのまま通す（冪等）。版数を過少申告するアーカイブで全行を捨てないため

## 型の扱い

`ExamStudent.id` と `Student.id` はどちらも `string` なので、**取り違えてもコンパイルが通り実行時に別人の答案になります**。そこで renderer が id を持ち回らず実体を渡す形へ寄せました。

```ts
// 変更前: どちらの id でも通る
getCellValue(placedByCell, examStudent.studentId, examPage.id)

// 変更後: 実体を要求する（studentId を渡すとコンパイルエラー）
getCellValue(placedByCell, examStudent, examPage)
```

行と列は必須フィールドを重ならせてあるため（行は `studentId`、列は `pageNumber`）、引数の**転置**もコンパイルエラーになります。

あわせて既存の規約へ寄せ直した箇所があります。

- `drawing.getByCropRegion` の `as` を外し、include した形を型で表明する
- 描画注釈の union は手書きせず `defineStringUnion`（既存 factory）から生成する
- `src/types/electron/drawingApi.d.ts` が存在しないモジュールパスを参照しており、`skipLibCheck` に握り潰されて全体が `any` になっていたのを修正

## テスト

1139 件全通過。新規に固定したもの:

- 試験から生徒を外すと5テーブルとも消え、他生徒は巻き添えにならず、再追加しても復元されない
- 削除確認の件数が cascade 範囲と一致する（「安全」と誤表示しない）
- migration の付け替え・孤児破棄・AuditLog 記録・`RENAME TO` 後の FK 参照名
- 外した生徒の得点が成績算出に算入されないこと、見込→欠測が従来どおり効くこと
- 進捗計算・出力の採番学級が正しいキーで引けること
- 採点系5テーブルが `ExamStudent` の cascade 子であり `Student` 直結でないこと（schema 駆動）

## 注意

該当する生徒がいる場合、**このマージ後は成績算出の結果が変わります**。これまでは削除したはずの得点が算入されていたためです。

## 残作業

- 実 DB のコピーへ migration を当てるリハーサル（実データが必要）
- Phase B（`CourseworkScore`）・Phase C（Grade 系3テーブル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EgMLK6Yo2B2RCMTNsB45D