### PR TITLE
feat(coursework): 資料の点数を CourseworkStudent 経由へ配線変更する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,11 +200,12 @@ export class V1_9_0_to_V1_10_0_Transformer implements ExamVersionTransformer {
 | 1.17.0     | v0.15.x    | ExamStudent.status小文字統一                  |
 | 1.19.0     | v0.16.x    | DeletedRecord tombstone廃止（1.9.0を撤回）    |
 
-**試験外成績資料アーカイブ（.coursework）** — exam-archive と同型の独立アーカイブ。`electron-src/lib/export|import/coursework-archive/`。id一次照合 + 名前マッチング（付加）+ スコア LWW。トランスフォーマー機構あり（`COURSEWORK_CURRENT_VERSION`、初版 1.0.0 は変換器ゼロ）。
+**試験外成績資料アーカイブ（.coursework）** — exam-archive と同型の独立アーカイブ。`electron-src/lib/export|import/coursework-archive/`。id一次照合 + 名前マッチング（付加）+ スコア LWW。トランスフォーマー機構あり（`COURSEWORK_CURRENT_VERSION`）。**版ごとの「アーカイブ全体の型」と旧版の形は `import/coursework-transformers/types.ts` / `legacyShape.ts` が持ち、`src/types/courseworkArchive.types.ts` は現行の形だけを宣言する。**
 
-| バージョン | 変更内容                                          |
-| ---------- | ------------------------------------------------- |
-| 1.0.0      | 初版（独立化）。UUID参照 + full生徒/学級/タグ同梱 |
+| バージョン | 変更内容                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------ |
+| 1.0.0      | 初版（独立化）。UUID参照 + full生徒/学級/タグ同梱。資料1件を入れ子ツリーへ射影             |
+| 1.1.0      | テーブルごとの平坦なセクションへ。Prisma の行をそのまま持つ。点数が courseworkStudentId へ |
 
 **成績アーカイブ（.grade）の Coursework 内包** — 収集・生成は coursework-archive モジュールへ委譲（二重実装の解消）。
 
@@ -212,6 +213,7 @@ export class V1_9_0_to_V1_10_0_Transformer implements ExamVersionTransformer {
 | ---------- | ----------------------------------------------------------------------------- |
 | 1.4.0      | Coursework を名前ベースで `courseworks.json` に埋め込み（読込互換のみ）       |
 | 1.5.0      | `courseworks.json` を coursework-archive 形式（UUIDベース）へ。旧版は読込互換 |
+| 1.12.0     | 内包資料を coursework 1.1.0（平坦なセクション）へ。旧入れ子形式は読込互換     |
 
 #### 🔄 多対多関係の強化（2025年7月29日更新）
 

--- a/__tests__/coursework/courseworkCrud.test.ts
+++ b/__tests__/coursework/courseworkCrud.test.ts
@@ -127,21 +127,36 @@ describe("Coursework CRUD", () => {
   it("点数を一括 upsert・部分更新・取得できる", async () => {
     const { student1, student2 } = await createStudents()
     const courseworkResult = await createCoursework({ name: "資料" })
+    const courseworkId = courseworkResult.coursework!.id
     const item = await createCourseworkItem({
-      courseworkId: courseworkResult.coursework!.id,
+      courseworkId,
       name: "知識",
       maxScore: 100,
     })
     const itemId = item.item!.id
 
+    // 点数は資料の対象者にぶら下がるため、先に名簿へ載せる
+    await addStudentsToCoursework(courseworkId, [student1.id, student2.id])
+    const roster = await getCourseworkStudents(courseworkId)
+    const courseworkStudent1 = roster.students!.find(
+      (courseworkStudent) => courseworkStudent.studentId === student1.id
+    )!
+    const courseworkStudent2 = roster.students!.find(
+      (courseworkStudent) => courseworkStudent.studentId === student2.id
+    )!
+
     await batchUpsertCourseworkScores([
       {
         courseworkItemId: itemId,
-        studentId: student1.id,
+        courseworkStudentId: courseworkStudent1.id,
         score: 85,
         comment: "良い",
       },
-      { courseworkItemId: itemId, studentId: student2.id, score: 70 },
+      {
+        courseworkItemId: itemId,
+        courseworkStudentId: courseworkStudent2.id,
+        score: 70,
+      },
     ])
 
     let scores = await getCourseworkScoresByItemId(itemId)
@@ -149,15 +164,93 @@ describe("Coursework CRUD", () => {
 
     // 部分更新（adjustment のみ。score/comment は保持）
     await batchUpsertCourseworkScores([
-      { courseworkItemId: itemId, studentId: student1.id, adjustment: -5 },
+      {
+        courseworkItemId: itemId,
+        courseworkStudentId: courseworkStudent1.id,
+        adjustment: -5,
+      },
     ])
     scores = await getCourseworkScoresByItemId(itemId)
     const student1Score = scores.scores!.find(
-      (score) => score.studentId === student1.id
+      (score) => score.courseworkStudentId === courseworkStudent1.id
     )!
     expect(Number(student1Score.score)).toBe(85)
     expect(Number(student1Score.adjustment)).toBe(-5)
     expect(student1Score.comment).toBe("良い")
+  })
+
+  it("資料から生徒を外すと、その生徒の点数も消える（#962）", async () => {
+    const { student1, student2 } = await createStudents()
+    const courseworkResult = await createCoursework({ name: "資料" })
+    const courseworkId = courseworkResult.coursework!.id
+    const item = await createCourseworkItem({
+      courseworkId,
+      name: "知識",
+      maxScore: 100,
+    })
+    const itemId = item.item!.id
+
+    await addStudentsToCoursework(courseworkId, [student1.id, student2.id])
+    const roster = await getCourseworkStudents(courseworkId)
+    const courseworkStudent1 = roster.students!.find(
+      (courseworkStudent) => courseworkStudent.studentId === student1.id
+    )!
+    const courseworkStudent2 = roster.students!.find(
+      (courseworkStudent) => courseworkStudent.studentId === student2.id
+    )!
+
+    await batchUpsertCourseworkScores([
+      {
+        courseworkItemId: itemId,
+        courseworkStudentId: courseworkStudent1.id,
+        score: 85,
+      },
+      {
+        courseworkItemId: itemId,
+        courseworkStudentId: courseworkStudent2.id,
+        score: 70,
+      },
+    ])
+
+    await removeStudentsFromCoursework(courseworkId, [student1.id])
+
+    // 外した生徒の点数だけが消え、残った生徒は巻き添えにならない
+    const remaining = await getCourseworkScoresByItemId(itemId)
+    expect(remaining.scores).toHaveLength(1)
+    expect(remaining.scores![0].courseworkStudentId).toBe(courseworkStudent2.id)
+
+    // 同じ生徒を追加し直しても、以前の点数は復活しない
+    await addStudentsToCoursework(courseworkId, [student1.id])
+    const afterReadd = await getCourseworkScoresByItemId(itemId)
+    expect(afterReadd.scores).toHaveLength(1)
+  })
+
+  it("別の資料の対象者に点数を書こうとすると拒否される", async () => {
+    const { student1 } = await createStudents()
+    const courseworkA = await createCoursework({ name: "資料A" })
+    const courseworkB = await createCoursework({ name: "資料B" })
+    const itemA = await createCourseworkItem({
+      courseworkId: courseworkA.coursework!.id,
+      name: "知識",
+      maxScore: 100,
+    })
+
+    // 生徒は資料Bの名簿にだけ載せる
+    await addStudentsToCoursework(courseworkB.coursework!.id, [student1.id])
+    const rosterB = await getCourseworkStudents(courseworkB.coursework!.id)
+
+    // 資料Aの評価項目 × 資料Bの対象者。FK は両方の実在しか見ないので通ってしまう
+    const result = await batchUpsertCourseworkScores([
+      {
+        courseworkItemId: itemA.item!.id,
+        courseworkStudentId: rosterB.students![0].id,
+        score: 85,
+      },
+    ])
+
+    expect(result.success).toBe(false)
+    const written = await getCourseworkScoresByItemId(itemA.item!.id)
+    expect(written.scores).toHaveLength(0)
   })
 
   it("名簿に生徒を追加・並べ替え・削除できる", async () => {

--- a/__tests__/exam/integration/examScopeGuard.test.ts
+++ b/__tests__/exam/integration/examScopeGuard.test.ts
@@ -1,0 +1,178 @@
+/**
+ * 採点対象と受験者が別々の試験に属する書き込みを弾くことの検証（#962）。
+ *
+ * 採点層は「採点対象（採点領域・複合回答・ページ）」と「受験者（ExamStudent）」の
+ * 2つを参照する。FK が保証するのはそれぞれが実在することだけで、両者が同じ試験に
+ * 属することは強制されない。どちらの id も string なので取り違えてもコンパイルは通り、
+ * 書けてしまうと「試験Aの受験者一覧に居ない生徒の得点」が成績算出に算入される
+ * — Phase B で Coursework に対して塞いだのと同じ穴が試験側にも残っていた。
+ */
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { upsertCompoundAnswerScore } from "@/electron-src/lib/prisma/compoundAnswer"
+import {
+  batchUpdateQuestionScores,
+  createQuestionScore,
+} from "@/electron-src/lib/prisma/questionScore"
+import { upsertScoreDecision } from "@/electron-src/lib/prisma/scoreDecision"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 別々の試験を2つ作り、Aの採点領域とBの受験者を取り出す */
+async function buildTwoExams() {
+  const examA = await createFullTestExam(testPrisma, {
+    studentCount: 1,
+    pageCount: 1,
+    cropRegionsPerPage: 1,
+    examName: "試験A",
+    className: "学級A",
+    includeScores: false,
+  })
+  const examB = await createFullTestExam(testPrisma, {
+    studentCount: 1,
+    pageCount: 1,
+    cropRegionsPerPage: 1,
+    examName: "試験B",
+    className: "学級B",
+    includeScores: false,
+  })
+
+  const cropRegionA = await testPrisma.cropRegion.findFirstOrThrow({
+    where: { examPage: { examId: examA.exam.id } },
+  })
+  const examStudentA = await testPrisma.examStudent.findFirstOrThrow({
+    where: { examId: examA.exam.id },
+  })
+  const examStudentB = await testPrisma.examStudent.findFirstOrThrow({
+    where: { examId: examB.exam.id },
+  })
+
+  return { examA, examB, cropRegionA, examStudentA, examStudentB }
+}
+
+describe("採点対象と受験者の試験スコープ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("同じ試験の採点領域と受験者なら採点できる", async () => {
+    const { examA, cropRegionA, examStudentA } = await buildTwoExams()
+
+    const result = await createQuestionScore({
+      cropRegionId: cropRegionA.id,
+      examStudentId: examStudentA.id,
+      status: "correct",
+      userId: examA.user.id,
+    })
+
+    expect(result.success).toBe(true)
+    expect(await testPrisma.questionScore.count()).toBe(1)
+  })
+
+  it("別の試験の受験者への採点は拒否され、行も残らない", async () => {
+    const { examA, cropRegionA, examStudentB } = await buildTwoExams()
+
+    const result = await createQuestionScore({
+      cropRegionId: cropRegionA.id,
+      examStudentId: examStudentB.id,
+      status: "correct",
+      userId: examA.user.id,
+    })
+
+    expect(result.success).toBe(false)
+    expect(await testPrisma.questionScore.count()).toBe(0)
+  })
+
+  it("一括採点（OMR反映）でも別の試験の受験者は拒否される", async () => {
+    const { examA, cropRegionA, examStudentA, examStudentB } =
+      await buildTwoExams()
+
+    const result = await batchUpdateQuestionScores([
+      {
+        cropRegionId: cropRegionA.id,
+        examStudentId: examStudentA.id,
+        status: "correct",
+        partialScore: null,
+        userId: examA.user.id,
+      },
+      {
+        cropRegionId: cropRegionA.id,
+        examStudentId: examStudentB.id,
+        status: "correct",
+        partialScore: null,
+        userId: examA.user.id,
+      },
+    ])
+
+    expect(result.success).toBe(false)
+    // 正しい1件も書かれない（検査は書き込み前に全件分を見る）
+    expect(await testPrisma.questionScore.count()).toBe(0)
+  })
+
+  it("確定（ScoreDecision）でも別の試験の受験者は拒否される", async () => {
+    const { examA, cropRegionA, examStudentB } = await buildTwoExams()
+
+    const result = await upsertScoreDecision({
+      cropRegionId: cropRegionA.id,
+      examStudentId: examStudentB.id,
+      verdict: "correct",
+      score: null,
+      comment: null,
+      decidedByUserId: examA.user.id,
+    })
+
+    expect(result.success).toBe(false)
+    expect(await testPrisma.scoreDecision.count()).toBe(0)
+  })
+
+  it("複合回答の採点でも別の試験の受験者は拒否される", async () => {
+    const { examA, examStudentB } = await buildTwoExams()
+
+    const examPageA = await testPrisma.examPage.findFirstOrThrow({
+      where: { examId: examA.exam.id },
+    })
+    const compoundAnswerA = await testPrisma.compoundAnswer.create({
+      data: {
+        examPageId: examPageA.id,
+        label: "アイ",
+        answerFormat: "multi-digit",
+        correctAnswer: "42",
+        points: 5,
+      },
+    })
+
+    await expect(
+      upsertCompoundAnswerScore({
+        compoundAnswerId: compoundAnswerA.id,
+        examStudentId: examStudentB.id,
+        userId: examA.user.id,
+        status: "correct",
+      })
+    ).rejects.toThrow(/別の試験/)
+    expect(await testPrisma.compoundAnswerScore.count()).toBe(0)
+  })
+})

--- a/__tests__/grade/integration/gradeCourseworkStudentScope.test.ts
+++ b/__tests__/grade/integration/gradeCourseworkStudentScope.test.ts
@@ -1,0 +1,155 @@
+/**
+ * 成績算出が「その資料の対象者」以外の点数を拾わないことの統合テスト（#962 Phase B）。
+ *
+ * 配線変更前、CourseworkScore は Student 直結で、rawScoreCalculator も
+ * `score.studentId === studentId` で引いていた。そのため資料の名簿から外した生徒の
+ * 点数が残っていると、資料の画面（すべて CourseworkStudent 起点）には一切現れないのに、
+ * 成績算出でだけ素点として算入されていた。点数を CourseworkStudent の子にした今は、
+ * 外した瞬間に点数も消え、かつ経路上も対象者を必ず1回通るため構造的に起こらない。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { removeStudentsFromCoursework } from "@/electron-src/lib/prisma/coursework"
+import { calculateGrades } from "@/electron-src/lib/shared/calculations/gradeCalculator"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+interface Fixture {
+  gradeId: string
+  courseworkId: string
+  studentId: string
+  courseworkStudentId: string
+}
+
+/**
+ * 生徒1名・評価項目1つ（満点100・素点80）の資料を作り、その coursework 型
+ * データソースを参照する成績（評価項目1つ）を組み立てる。
+ */
+async function buildFixture(): Promise<Fixture> {
+  const student = await testPrisma.student.create({
+    data: {
+      studentNumber: `S${Date.now()}`,
+      lastName: "山田",
+      firstName: "太郎",
+      lastNameKana: "ヤマダ",
+      firstNameKana: "タロウ",
+    },
+  })
+
+  const coursework = await testPrisma.coursework.create({
+    data: { name: "第1回レポート" },
+  })
+  const courseworkItem = await testPrisma.courseworkItem.create({
+    data: {
+      courseworkId: coursework.id,
+      name: "提出物",
+      maxScore: 100,
+      inputMode: "numeric",
+      order: 0,
+    },
+  })
+  const courseworkStudent = await testPrisma.courseworkStudent.create({
+    data: { courseworkId: coursework.id, studentId: student.id },
+  })
+  await testPrisma.courseworkScore.create({
+    data: {
+      courseworkItemId: courseworkItem.id,
+      courseworkStudentId: courseworkStudent.id,
+      score: 80,
+    },
+  })
+
+  const grade = await testPrisma.grade.create({ data: { name: "1学期成績" } })
+  await testPrisma.gradeStudent.create({
+    data: { gradeId: grade.id, studentId: student.id },
+  })
+  const gradeItem = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "主体的態度", order: 0 },
+  })
+  await testPrisma.gradeDataSource.create({
+    data: {
+      gradeItemId: gradeItem.id,
+      type: "coursework",
+      courseworkItemId: courseworkItem.id,
+      name: "提出物",
+      weight: 1,
+      order: 0,
+    },
+  })
+
+  return {
+    gradeId: grade.id,
+    courseworkId: coursework.id,
+    studentId: student.id,
+    courseworkStudentId: courseworkStudent.id,
+  }
+}
+
+/** 対象セル（生徒1名・評価項目1つ）の参照元スコアを取り出す */
+async function readSourceScore(gradeId: string) {
+  const calculation = await calculateGrades(gradeId)
+  expect(calculation.success).toBe(true)
+  return calculation.result!.students[0].gradeItemResults[0].sourceScores[0]
+}
+
+describe("成績算出の資料対象者スコープ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("対象者として登録されている間は素点が算入される", async () => {
+    const fixture = await buildFixture()
+
+    const source = await readSourceScore(fixture.gradeId)
+    expect(source.rawScore).toBe(80)
+    expect(source.isEstimated).toBe(false)
+  })
+
+  it("資料から外した生徒の点数は算入されない（#962 の非対称の解消）", async () => {
+    const fixture = await buildFixture()
+
+    await removeStudentsFromCoursework(fixture.courseworkId, [
+      fixture.studentId,
+    ])
+
+    const source = await readSourceScore(fixture.gradeId)
+    expect(source.rawScore).toBeNull()
+  })
+
+  it("資料から外しても、点数そのものが DB から消えている", async () => {
+    const fixture = await buildFixture()
+
+    await removeStudentsFromCoursework(fixture.courseworkId, [
+      fixture.studentId,
+    ])
+
+    const remaining = await testPrisma.courseworkScore.count({
+      where: { courseworkStudentId: fixture.courseworkStudentId },
+    })
+    expect(remaining).toBe(0)
+  })
+})

--- a/__tests__/grade/integration/gradeFrozenScore.test.ts
+++ b/__tests__/grade/integration/gradeFrozenScore.test.ts
@@ -70,10 +70,13 @@ async function buildFixture(): Promise<Fixture> {
       order: 0,
     },
   })
+  const courseworkStudent = await testPrisma.courseworkStudent.create({
+    data: { courseworkId: coursework.id, studentId: student.id },
+  })
   await testPrisma.courseworkScore.create({
     data: {
       courseworkItemId: courseworkItem.id,
-      studentId: student.id,
+      courseworkStudentId: courseworkStudent.id,
       score: 80,
     },
   })
@@ -146,7 +149,7 @@ async function updateSourceScore(
   await testPrisma.courseworkScore.updateMany({
     where: {
       courseworkItemId: fixture.courseworkItemId,
-      studentId: fixture.studentId,
+      courseworkStudent: { studentId: fixture.studentId },
     },
     data: { score },
   })

--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -178,7 +178,12 @@ function buildGrade(
         courseworkItem: {
           maxScore: dataSource.maxScore,
           inputMode: dataSource.inputMode ?? "numeric",
-          scores: dataSource.manualScores ?? [],
+          // 点数は資料の対象者（CourseworkStudent）にぶら下がる。テストケースは
+          // 生徒idで書けるようにし、ここで対象者を1段かませた形へ寄せる。
+          scores: (dataSource.manualScores ?? []).map((manualScore) => ({
+            ...manualScore,
+            courseworkStudent: { studentId: manualScore.studentId },
+          })),
           letterScales: dataSource.letterScales ?? [],
         },
       }
@@ -1116,13 +1121,23 @@ describe("calculateGrades", () => {
                   {
                     maxScore: 50,
                     inputMode: "numeric",
-                    scores: [{ studentId: "s1", score: 40 }],
+                    scores: [
+                      {
+                        courseworkStudent: { studentId: "s1" },
+                        score: 40,
+                      },
+                    ],
                     letterScales: [],
                   },
                   {
                     maxScore: 30,
                     inputMode: "numeric",
-                    scores: [{ studentId: "s1", score: 30 }],
+                    scores: [
+                      {
+                        courseworkStudent: { studentId: "s1" },
+                        score: 30,
+                      },
+                    ],
                     letterScales: [],
                   },
                 ],

--- a/__tests__/import-export/integration/courseworkArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/courseworkArchiveRoundTrip.test.ts
@@ -47,6 +47,12 @@ function toArchive(collected: CollectedCourseworkData): CourseworkArchiveData {
       counts: collected.counts,
     },
     courseworks: collected.courseworks,
+    courseworkClassrooms: collected.courseworkClassrooms,
+    courseworkTags: collected.courseworkTags,
+    courseworkStudents: collected.courseworkStudents,
+    courseworkItems: collected.courseworkItems,
+    courseworkLetterScales: collected.courseworkLetterScales,
+    courseworkScores: collected.courseworkScores,
     studentsData: collected.studentsData,
     classesData: collected.classesData,
     membershipsData: collected.membershipsData,
@@ -93,10 +99,18 @@ async function seedCoursework(suffix: number) {
       inputMode: "numeric",
     },
   })
+  const courseworkStudent = await prisma.courseworkStudent.findUniqueOrThrow({
+    where: {
+      courseworkId_studentId: {
+        courseworkId: coursework.id,
+        studentId: student.id,
+      },
+    },
+  })
   const score = await prisma.courseworkScore.create({
     data: {
       courseworkItemId: item.id,
-      studentId: student.id,
+      courseworkStudentId: courseworkStudent.id,
       score: 85,
       adjustment: -5,
       adjustmentReason: "提出遅延",
@@ -121,9 +135,11 @@ describe("coursework-archive ラウンドトリップ", () => {
 
     const collected = await collectCourseworkArchiveData([seeded.coursework.id])
     expect(collected.courseworks).toHaveLength(1)
-    const coursework = collected.courseworks[0]
-    expect(coursework.items).toHaveLength(1)
-    expect(coursework.items[0].scores[0].updatedAt).toBeDefined()
+    expect(collected.courseworkItems).toHaveLength(1)
+    expect(collected.courseworkScores[0].updatedAt).toBeDefined()
+    expect(collected.courseworkScores[0].courseworkStudentId).toBe(
+      collected.courseworkStudents[0].id
+    )
     expect(collected.studentsData[0].studentNumber).toBe(`CW_${suffix}`)
     expect(collected.tagsData[0].name).toBe(`タグ_${suffix}`)
 
@@ -152,13 +168,19 @@ describe("coursework-archive ラウンドトリップ", () => {
 
     const item = await prisma.courseworkItem.findFirst({
       where: { name: "提出物" },
-      include: { scores: { include: { student: true } } },
+      include: {
+        scores: {
+          include: { courseworkStudent: { include: { student: true } } },
+        },
+      },
     })
     expect(item).not.toBeNull()
     expect(item!.scores).toHaveLength(1)
     expect(Number(item!.scores[0].score)).toBe(85)
     expect(Number(item!.scores[0].adjustment)).toBe(-5)
-    expect(item!.scores[0].student.studentNumber).toBe(`CW_${suffix}`)
+    expect(item!.scores[0].courseworkStudent.student.studentNumber).toBe(
+      `CW_${suffix}`
+    )
 
     const classroom = await prisma.classroom.findUnique({
       where: { name: `学級_${suffix}` },
@@ -205,7 +227,7 @@ describe("coursework-archive ラウンドトリップ", () => {
     expect(students[0].id).toBe(reborn.id)
 
     const score = await prisma.courseworkScore.findFirst({
-      where: { studentId: reborn.id },
+      where: { courseworkStudent: { studentId: reborn.id } },
     })
     expect(score).not.toBeNull()
     expect(Number(score!.score)).toBe(85)
@@ -224,7 +246,7 @@ describe("coursework-archive ラウンドトリップ", () => {
 
     // アーカイブ側 updatedAt を過去にして再インポート → 既存(50)を維持
     const archive = toArchive(collected)
-    archive.courseworks[0].items[0].scores[0].updatedAt = new Date(
+    archive.courseworkScores[0].updatedAt = new Date(
       "2000-01-01T00:00:00.000Z"
     ).toISOString()
     const oldResult = await importCourseworkArchive(archive)
@@ -235,7 +257,7 @@ describe("coursework-archive ラウンドトリップ", () => {
     expect(Number(afterOld!.score)).toBe(50)
 
     // アーカイブ側 updatedAt を未来にして再インポート → アーカイブ(85)で上書き
-    archive.courseworks[0].items[0].scores[0].updatedAt = new Date(
+    archive.courseworkScores[0].updatedAt = new Date(
       "2099-01-01T00:00:00.000Z"
     ).toISOString()
     const newResult = await importCourseworkArchive(archive)
@@ -244,6 +266,31 @@ describe("coursework-archive ラウンドトリップ", () => {
       where: { id: seeded.score.id },
     })
     expect(Number(afterNew!.score)).toBe(85)
+  })
+
+  it("取り込み先に生徒が居ない場合は、孤児とは別の警告になる", async () => {
+    const suffix = Date.now()
+    const seeded = await seedCoursework(suffix)
+    const collected = await collectCourseworkArchiveData([seeded.coursework.id])
+
+    // 別環境想定。生徒を作らせない設定（grade-archive 内包と同じ allowCreate:false）
+    await cleanupTestDatabase()
+
+    const result = await importCourseworkArchive(toArchive(collected), {
+      allowCreate: false,
+    })
+    expect(result.success).toBe(true)
+
+    const warnings = result.warnings ?? []
+    // 名簿には載っているが取り込み先に居ない ＝ アーカイブの不整合ではない
+    expect(
+      warnings.some((warning) => warning.includes("この環境に存在しない生徒"))
+    ).toBe(true)
+    expect(
+      warnings.some((warning) =>
+        warning.includes("対象生徒として登録されていない生徒")
+      )
+    ).toBe(false)
   })
 
   it("previewCourseworkImport が UUID一致と名前候補を返す", async () => {

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -168,10 +168,18 @@ describe("grade-archive ラウンドトリップ", () => {
         },
       },
     })
+    const courseworkStudent = await prisma.courseworkStudent.findUniqueOrThrow({
+      where: {
+        courseworkId_studentId: {
+          courseworkId: coursework.id,
+          studentId: student.id,
+        },
+      },
+    })
     await prisma.courseworkScore.create({
       data: {
         courseworkItemId: numItem.id,
-        studentId: student.id,
+        courseworkStudentId: courseworkStudent.id,
         score: 85,
         adjustment: -5,
         adjustmentReason: "提出遅延",
@@ -181,7 +189,7 @@ describe("grade-archive ラウンドトリップ", () => {
     await prisma.courseworkScore.create({
       data: {
         courseworkItemId: letterItem.id,
-        studentId: student.id,
+        courseworkStudentId: courseworkStudent.id,
         letterValue: "B",
         comment: "発表が活発でした",
       },
@@ -218,9 +226,8 @@ describe("grade-archive ラウンドトリップ", () => {
     // 収集（export）
     const collected = await collectGradeArchiveData(grade.id)
     expect(collected.courseworkArchive.courseworks).toHaveLength(1)
-    const archivedCoursework = collected.courseworkArchive.courseworks[0]
-    expect(archivedCoursework.items).toHaveLength(2)
-    expect(archivedCoursework.classrooms).toHaveLength(1)
+    expect(collected.courseworkArchive.courseworkItems).toHaveLength(2)
+    expect(collected.courseworkArchive.courseworkClassrooms).toHaveLength(1)
     expect(collected.courseworkArchive.tagsData[0].name).toBe(`タグ_${suffix}`)
     expect(collected.courseworkArchive.studentsData[0].studentNumber).toBe(
       `CW_${suffix}`
@@ -248,7 +255,9 @@ describe("grade-archive ラウンドトリップ", () => {
         courseworkItem: {
           include: {
             coursework: true,
-            scores: { include: { student: true } },
+            scores: {
+              include: { courseworkStudent: { include: { student: true } } },
+            },
           },
         },
       },
@@ -366,12 +375,18 @@ describe("grade-archive ラウンドトリップ", () => {
 
     const importedItem = await prisma.courseworkItem.findFirst({
       where: { coursework: { name: `埋込資料_${suffix}` }, name: "課題1" },
-      include: { scores: { include: { student: true } } },
+      include: {
+        scores: {
+          include: { courseworkStudent: { include: { student: true } } },
+        },
+      },
     })
     expect(importedItem).not.toBeNull()
     expect(importedItem!.scores).toHaveLength(1)
     expect(Number(importedItem!.scores[0].score)).toBe(72)
-    expect(importedItem!.scores[0].student.studentNumber).toBe(`CW2_${suffix}`)
+    expect(
+      importedItem!.scores[0].courseworkStudent.student.studentNumber
+    ).toBe(`CW2_${suffix}`)
 
     const dataSource = await prisma.gradeDataSource.findFirst({
       where: { gradeItem: { gradeId: result.gradeId! }, name: "資料参照" },
@@ -1655,7 +1670,7 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // 旧形式でも Coursework と点数が復元され、DataSource が解決される
     const score = await prisma.courseworkScore.findFirst({
-      where: { studentId: student.id },
+      where: { courseworkStudent: { studentId: student.id } },
       include: { item: { include: { coursework: true } } },
     })
     expect(score).not.toBeNull()

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -108,3 +108,23 @@ describe("採点層の親は ExamStudent（#962 の再発防止）", () => {
     }
   })
 })
+
+/**
+ * 試験外成績資料の点数が「その資料の対象者」の子であることの固定（#962 Phase B）。
+ *
+ * 採点層（ExamStudent）と同じ穴が Coursework にもあった。名簿から生徒を外しても
+ * 点数は消えず、資料の画面には現れないのに成績算出でだけ算入されていた。
+ */
+describe("資料の点数の親は CourseworkStudent（#962 の再発防止）", () => {
+  it("CourseworkScore は CourseworkStudent の onDelete:Cascade 子である", () => {
+    expect(cascadeChildrenFromSchema("CourseworkStudent")).toEqual([
+      "CourseworkScore",
+    ])
+  })
+
+  it("CourseworkScore は Student 直結ではない", () => {
+    expect(cascadeChildrenFromSchema("Student")).not.toContain(
+      "CourseworkScore"
+    )
+  })
+})

--- a/__tests__/import-export/unit/courseworkTransformerChain.test.ts
+++ b/__tests__/import-export/unit/courseworkTransformerChain.test.ts
@@ -1,0 +1,224 @@
+/**
+ * coursework-archive のバージョン変換チェーン
+ *
+ * 1.0.0（資料1件の入れ子ツリー）→ 1.1.0（テーブルごとの平坦なセクション）の展開と、
+ * 点数の参照が人（Student）から資料の対象者（CourseworkStudent）へ移ること、
+ * 名簿に載っていない生徒の点数が破棄されることを固定する（#962 Phase B）。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { transformCourseworkToLatest } from "../../../electron-src/lib/import/coursework-transformers"
+import type { LegacyArchiveCourseworkRef } from "../../../electron-src/lib/import/coursework-transformers/legacyShape"
+import type { CourseworkArchiveDataV1_0_0 } from "../../../electron-src/lib/import/coursework-transformers/types"
+import {
+  COURSEWORK_CURRENT_VERSION,
+  type CourseworkArchiveData,
+} from "../../../src/types/courseworkArchive.types"
+
+/** 1.0.0 が実際に書き出していた形（version は名乗りどおりに書く） */
+function buildLegacyArchive(
+  courseworks: LegacyArchiveCourseworkRef[]
+): CourseworkArchiveDataV1_0_0 {
+  return {
+    manifest: {
+      version: "1.0.0",
+      appVersion: "test",
+      exportedAt: "2026-06-29T00:00:00.000Z",
+      counts: {
+        courseworks: courseworks.length,
+        items: 0,
+        scores: 0,
+        students: 0,
+        classrooms: 0,
+      },
+    },
+    courseworks,
+    studentsData: [],
+    classesData: [],
+    membershipsData: [],
+    tagsData: [],
+  }
+}
+
+/** 1.1.0（現行）の空アーカイブ */
+function buildCurrentArchive(): CourseworkArchiveData {
+  return {
+    manifest: {
+      version: COURSEWORK_CURRENT_VERSION,
+      appVersion: "test",
+      exportedAt: "2026-06-29T00:00:00.000Z",
+      counts: {
+        courseworks: 0,
+        items: 0,
+        scores: 0,
+        students: 0,
+        classrooms: 0,
+      },
+    },
+    courseworks: [],
+    courseworkClassrooms: [],
+    courseworkTags: [],
+    courseworkStudents: [],
+    courseworkItems: [],
+    courseworkLetterScales: [],
+    courseworkScores: [],
+    studentsData: [],
+    classesData: [],
+    membershipsData: [],
+    tagsData: [],
+  }
+}
+
+const LEGACY_COURSEWORK: LegacyArchiveCourseworkRef = {
+  id: "cw-1",
+  name: "第1回レポート",
+  description: null,
+  date: null,
+  classrooms: [{ classroomId: "classroom-1", order: 0 }],
+  tags: [{ tagId: "tag-1" }],
+  students: [{ studentId: "student-kept", customOrder: 0 }],
+  items: [
+    {
+      id: "item-1",
+      name: "提出物",
+      order: 0,
+      maxScore: 100,
+      inputMode: "letter",
+      letterScales: [{ label: "A", score: 100, order: 0 }],
+      scores: [
+        {
+          studentId: "student-kept",
+          score: 85,
+          letterValue: "A",
+          adjustment: -5,
+          adjustmentReason: "提出遅延",
+          comment: "良い",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ],
+    },
+  ],
+}
+
+describe("coursework-archive 1.0.0 → 1.1.0", () => {
+  it("入れ子ツリーをテーブルごとの平坦なセクションへ展開する", () => {
+    const result = transformCourseworkToLatest(
+      buildLegacyArchive([LEGACY_COURSEWORK])
+    )
+
+    expect(result.originalVersion).toBe("1.0.0")
+    expect(result.finalVersion).toBe(COURSEWORK_CURRENT_VERSION)
+
+    expect(result.data.courseworks).toEqual([
+      expect.objectContaining({ id: "cw-1", name: "第1回レポート" }),
+    ])
+    expect(result.data.courseworkClassrooms).toEqual([
+      expect.objectContaining({
+        courseworkId: "cw-1",
+        classroomId: "classroom-1",
+      }),
+    ])
+    expect(result.data.courseworkTags).toEqual([
+      expect.objectContaining({ courseworkId: "cw-1", tagId: "tag-1" }),
+    ])
+    expect(result.data.courseworkItems).toEqual([
+      expect.objectContaining({ id: "item-1", courseworkId: "cw-1" }),
+    ])
+    expect(result.data.courseworkLetterScales).toEqual([
+      expect.objectContaining({ courseworkItemId: "item-1", label: "A" }),
+    ])
+  })
+
+  it("点数の参照が人から資料の対象者へ付け替わる", () => {
+    const result = transformCourseworkToLatest(
+      buildLegacyArchive([LEGACY_COURSEWORK])
+    )
+
+    const courseworkStudent = result.data.courseworkStudents[0]
+    expect(courseworkStudent.studentId).toBe("student-kept")
+
+    expect(result.data.courseworkScores).toHaveLength(1)
+    const score = result.data.courseworkScores[0]
+    expect(score.courseworkStudentId).toBe(courseworkStudent.id)
+    // Decimal は JSON.stringify と同じ文字列表現で持つ
+    expect(score.score).toBe("85")
+    expect(score.adjustment).toBe("-5")
+    expect(score.updatedAt).toBe("2026-06-01T00:00:00.000Z")
+  })
+
+  it("名簿に載っていない生徒の点数は破棄し、件数を警告に載せる", () => {
+    const withOrphan: LegacyArchiveCourseworkRef = {
+      ...LEGACY_COURSEWORK,
+      items: [
+        {
+          ...LEGACY_COURSEWORK.items[0],
+          scores: [
+            ...LEGACY_COURSEWORK.items[0].scores,
+            {
+              studentId: "student-orphan",
+              score: 40,
+              letterValue: null,
+              adjustment: null,
+              adjustmentReason: null,
+              comment: null,
+              updatedAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = transformCourseworkToLatest(buildLegacyArchive([withOrphan]))
+
+    expect(result.data.courseworkScores).toHaveLength(1)
+    expect(result.data.courseworkScores[0].courseworkStudentId).toBe(
+      result.data.courseworkStudents[0].id
+    )
+    expect(
+      result.warnings.some((warning) => warning.includes("1 件を破棄"))
+    ).toBe(true)
+  })
+
+  it("同じアーカイブを2度通しても同じ id になる（変換が冪等）", () => {
+    const first = transformCourseworkToLatest(
+      buildLegacyArchive([LEGACY_COURSEWORK])
+    )
+    const second = transformCourseworkToLatest(
+      buildLegacyArchive([LEGACY_COURSEWORK])
+    )
+    expect(second.data.courseworkStudents).toEqual(
+      first.data.courseworkStudents
+    )
+    expect(second.data.courseworkScores).toEqual(first.data.courseworkScores)
+  })
+
+  it("1.1.0 を名乗っていても中身が入れ子なら 1.0.0 として変換する", () => {
+    const lying = buildLegacyArchive([LEGACY_COURSEWORK])
+    lying.manifest.version = "1.1.0"
+
+    const result = transformCourseworkToLatest(lying)
+
+    expect(result.originalVersion).toBe("1.0.0")
+    expect(result.data.courseworkScores).toHaveLength(1)
+  })
+
+  it("既に平坦なアーカイブは素通しする", () => {
+    const flat = buildCurrentArchive()
+    flat.courseworks = [
+      {
+        id: "cw-1",
+        name: "第1回レポート",
+        description: null,
+        date: null,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:00:00.000Z",
+      },
+    ]
+
+    const result = transformCourseworkToLatest(flat)
+
+    expect(result.appliedTransformations).toEqual([])
+    expect(result.data.courseworks).toEqual(flat.courseworks)
+  })
+})

--- a/__tests__/import-export/unit/gradeTransformerChain.test.ts
+++ b/__tests__/import-export/unit/gradeTransformerChain.test.ts
@@ -11,6 +11,10 @@
 
 import { describe, expect, it } from "vitest"
 
+import {
+  isCurrentCollectedCourseworkData,
+  isLegacyCollectedCourseworkData,
+} from "../../../electron-src/lib/import/coursework-transformers/legacyShape"
 import { transformGradeToLatest } from "../../../electron-src/lib/import/grade-transformers"
 import type {
   GradeArchiveData,
@@ -65,6 +69,12 @@ function buildV1_9_0Archive(): GradeArchiveData {
     },
     courseworkArchive: {
       courseworks: [],
+      courseworkClassrooms: [],
+      courseworkTags: [],
+      courseworkStudents: [],
+      courseworkItems: [],
+      courseworkLetterScales: [],
+      courseworkScores: [],
       studentsData: [],
       classesData: [],
       membershipsData: [],
@@ -330,5 +340,161 @@ describe("transformGradeToLatest: 1.10.0 → 1.11.0（制約ルールの設定JS
       )
     ).toBe(false)
     expect(originalVersion).toBe(GRADE_CURRENT_VERSION)
+  })
+})
+
+/**
+ * v1.11.0 までが実際に書き出していた内包資料の形（入れ子・射影ツリー）。
+ * 点数は人（Student）の uuid を指していた。
+ */
+function buildV1_11_0Archive(): GradeArchiveData {
+  const archive = buildV1_9_0Archive()
+  archive.manifest = { ...manifest, version: "1.11.0" }
+  // 1.9.0 の名残（総合エントリ）を取り除き、内包資料だけが旧形の状態にする
+  archive.boundariesData.boundarySets = []
+  archive.gradeData.gradeOverrides = []
+  archive.courseworkArchive = undefined
+  archive.legacyCourseworkArchive = {
+    courseworks: [
+      {
+        id: "cw-1",
+        name: "第1回レポート",
+        description: null,
+        date: null,
+        classrooms: [],
+        tags: [],
+        students: [{ studentId: "student-kept", customOrder: 0 }],
+        items: [
+          {
+            id: "item-1",
+            name: "提出物",
+            order: 0,
+            maxScore: 100,
+            inputMode: "numeric",
+            letterScales: [],
+            scores: [
+              {
+                studentId: "student-kept",
+                score: 85,
+                letterValue: null,
+                adjustment: null,
+                adjustmentReason: null,
+                comment: null,
+                updatedAt: "2026-06-01T00:00:00.000Z",
+              },
+              {
+                studentId: "student-orphan",
+                score: 40,
+                letterValue: null,
+                adjustment: null,
+                adjustmentReason: null,
+                comment: null,
+                updatedAt: "2026-06-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    studentsData: [],
+    classesData: [],
+    membershipsData: [],
+    tagsData: [],
+    counts: {
+      courseworks: 1,
+      items: 1,
+      scores: 2,
+      students: 0,
+      classrooms: 0,
+    },
+  }
+  return archive
+}
+
+describe("transformGradeToLatest: 1.11.0 → 1.12.0（内包資料の平坦化）", () => {
+  it("入れ子の内包資料をテーブルごとのセクションへ展開する", () => {
+    const { data } = transformGradeToLatest(buildV1_11_0Archive())
+
+    expect(data.legacyCourseworkArchive).toBeUndefined()
+    expect(data.courseworkArchive!.courseworks).toHaveLength(1)
+    expect(data.courseworkArchive!.courseworkItems).toHaveLength(1)
+    expect(data.courseworkArchive!.courseworkStudents).toHaveLength(1)
+  })
+
+  it("点数が資料の対象者を指し、名簿外の点数は破棄される", () => {
+    const { data, warnings } = transformGradeToLatest(buildV1_11_0Archive())
+
+    const scores = data.courseworkArchive!.courseworkScores
+    expect(scores).toHaveLength(1)
+    expect(scores[0].courseworkStudentId).toBe(
+      data.courseworkArchive!.courseworkStudents[0].id
+    )
+    expect(scores[0].score).toBe("85")
+    expect(warnings.some((warning) => warning.includes("1 件を破棄"))).toBe(
+      true
+    )
+  })
+
+  it("元バージョンを 1.11.0 と報告し、適用した変換と矛盾しない", () => {
+    const { originalVersion, appliedTransformations } = transformGradeToLatest(
+      buildV1_11_0Archive()
+    )
+
+    expect(originalVersion).toBe("1.11.0")
+    expect(appliedTransformations).toContainEqual({
+      from: "1.11.0",
+      to: "1.12.0",
+    })
+  })
+})
+
+/**
+ * 資料を1件も参照していない成績。収集器は内包資料を「空だが形はある」オブジェクトとして
+ * 必ず書き出すので、旧アーカイブの大多数がこの形になる。
+ * 中身（courseworks の要素）で新旧を見分けようとすると空配列で判別できず、
+ * 旧アーカイブが現行の形と誤認されて取り込みが落ちていた。
+ */
+const EMPTY_LEGACY_EMBEDDED = {
+  courseworks: [],
+  studentsData: [],
+  classesData: [],
+  membershipsData: [],
+  tagsData: [],
+  counts: { courseworks: 0, items: 0, scores: 0, students: 0, classrooms: 0 },
+}
+
+describe("内包資料が空の旧アーカイブ", () => {
+  it("現行の形と誤認せず、旧形式として扱う", () => {
+    expect(isLegacyCollectedCourseworkData(EMPTY_LEGACY_EMBEDDED)).toBe(true)
+    expect(isCurrentCollectedCourseworkData(EMPTY_LEGACY_EMBEDDED)).toBe(false)
+  })
+
+  it("現行の形（全セクションが揃っている）は旧形式と誤認しない", () => {
+    const current = {
+      ...EMPTY_LEGACY_EMBEDDED,
+      courseworkClassrooms: [],
+      courseworkTags: [],
+      courseworkStudents: [],
+      courseworkItems: [],
+      courseworkLetterScales: [],
+      courseworkScores: [],
+    }
+    expect(isCurrentCollectedCourseworkData(current)).toBe(true)
+    expect(isLegacyCollectedCourseworkData(current)).toBe(false)
+  })
+
+  it("変換後は全セクションが揃い、取り込み側が undefined を踏まない", () => {
+    const archive = buildV1_11_0Archive()
+    archive.legacyCourseworkArchive = EMPTY_LEGACY_EMBEDDED
+
+    const { data } = transformGradeToLatest(archive)
+
+    expect(data.courseworkArchive!.courseworks).toEqual([])
+    expect(data.courseworkArchive!.courseworkClassrooms).toEqual([])
+    expect(data.courseworkArchive!.courseworkTags).toEqual([])
+    expect(data.courseworkArchive!.courseworkStudents).toEqual([])
+    expect(data.courseworkArchive!.courseworkItems).toEqual([])
+    expect(data.courseworkArchive!.courseworkLetterScales).toEqual([])
+    expect(data.courseworkArchive!.courseworkScores).toEqual([])
   })
 })

--- a/__tests__/migration/rewireCourseworkScoreToCourseworkStudent.test.ts
+++ b/__tests__/migration/rewireCourseworkScoreToCourseworkStudent.test.ts
@@ -1,0 +1,230 @@
+/**
+ * 20260729000000_rewire_coursework_score_to_coursework_student のデータ移行テスト
+ *
+ * 検証すること:
+ * - 資料の対象者（CourseworkStudent）に紐づく点数が courseworkStudentId へ正しく付け替わる
+ * - 対象者として登録されていない生徒の点数（孤児）は破棄される
+ * - 破棄件数が AuditLog に記録される（0件のときは行を作らない）
+ * - RENAME TO 後の FK 参照名が正しい
+ *
+ * 手順は「本マイグレーションの1つ手前まで適用 → 旧形状のデータを投入 →
+ * 本マイグレーションだけを適用」。全マイグレーションを一括適用してしまうと
+ * 旧形状のデータを差し込む隙が無くなるため、ここだけ手で刻む。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "rewire-coursework-score")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations")
+const TARGET_MIGRATION =
+  "20260729000000_rewire_coursework_score_to_coursework_student"
+
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const migrationNames = (): string[] =>
+  fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const applyMigration = (db: SqliteDatabase, name: string): void => {
+  db.exec(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf-8")
+  )
+}
+
+/** init ＋ 本マイグレーションの1つ手前までを適用した DB を用意する */
+async function buildDatabaseBeforeTargetMigration(): Promise<void> {
+  bootstrapSchema(DB_PATH)
+  const prisma = createPrismaClientForPath(DB_PATH)
+  try {
+    await createBaseline(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  const names = migrationNames()
+  const targetIndex = names.indexOf(TARGET_MIGRATION)
+  expect(targetIndex).toBeGreaterThan(0)
+
+  withDatabase((db) => {
+    for (const name of names.slice(0, targetIndex)) {
+      if (name === "20260322232329_init") continue
+      applyMigration(db, name)
+    }
+  })
+}
+
+const ISO = "2026-07-01T00:00:00.000+00:00"
+
+/**
+ * 旧形状（点数が studentId 直結）のデータを投入する。
+ * 対象者として登録するのは student-kept のみ。student-orphan は
+ * 「資料から外されたのに点数だけ残った生徒」を表す。
+ */
+function seedLegacyData(db: SqliteDatabase): void {
+  const run = (sql: string, params: unknown[]) => db.prepare(sql).run(params)
+
+  run(
+    `INSERT INTO "Coursework" (id, name, createdAt, updatedAt) VALUES (?,?,?,?)`,
+    ["coursework-1", "第1回レポート", ISO, ISO]
+  )
+  run(
+    `INSERT INTO "CourseworkItem" (id, courseworkId, name, "order", maxScore, inputMode, createdAt, updatedAt)
+     VALUES (?,?,?,?,?,?,?,?)`,
+    ["item-1", "coursework-1", "提出物", 0, 100, "numeric", ISO, ISO]
+  )
+
+  for (const [studentId, studentNumber] of [
+    ["student-kept", "S001"],
+    ["student-orphan", "S002"],
+  ]) {
+    run(
+      `INSERT INTO "Student" (id, studentNumber, lastName, firstName, lastNameKana, firstNameKana, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [studentId, studentNumber, "姓", "名", "セイ", "メイ", ISO, ISO]
+    )
+  }
+
+  // 対象者として登録されているのは student-kept だけ
+  run(
+    `INSERT INTO "CourseworkStudent" (id, courseworkId, studentId, createdAt, updatedAt) VALUES (?,?,?,?,?)`,
+    ["cwstudent-kept", "coursework-1", "student-kept", ISO, ISO]
+  )
+
+  for (const studentId of ["student-kept", "student-orphan"]) {
+    run(
+      `INSERT INTO "CourseworkScore" (id, courseworkItemId, studentId, score, adjustment, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?)`,
+      [`cwscore-${studentId}`, "item-1", studentId, 85, 0, ISO, ISO]
+    )
+  }
+}
+
+const idsOf = (db: SqliteDatabase, table: string): string[] =>
+  (
+    db.prepare(`SELECT id FROM "${table}" ORDER BY id`).all() as {
+      id: string
+    }[]
+  ).map((row) => row.id)
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("資料の点数の CourseworkStudent 経由への配線変更マイグレーション", () => {
+  it("対象者のある行は付け替わり、孤児は破棄され、件数が監査ログに残る", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      expect(idsOf(db, "CourseworkScore")).toEqual(["cwscore-student-kept"])
+
+      const score = db
+        .prepare(
+          `SELECT courseworkStudentId FROM "CourseworkScore" WHERE id = ?`
+        )
+        .get("cwscore-student-kept") as { courseworkStudentId: string }
+      expect(score.courseworkStudentId).toBe("cwstudent-kept")
+
+      // studentId 列は落ちている（CourseworkStudent から辿れるため）
+      const columns = (
+        db.prepare(`PRAGMA table_info("CourseworkScore")`).all() as {
+          name: string
+        }[]
+      ).map((column) => column.name)
+      expect(columns).not.toContain("studentId")
+      expect(columns).toContain("courseworkStudentId")
+
+      const auditLogs = db
+        .prepare(
+          `SELECT summary, metadata FROM "AuditLog" WHERE action = 'system.migration.cleanup_orphaned_scores'`
+        )
+        .all() as { summary: string; metadata: string }[]
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0].summary).toContain("1 件")
+      expect(JSON.parse(auditLogs[0].metadata)).toEqual({ courseworkScore: 1 })
+    })
+  })
+
+  it("孤児が無ければ監査ログの行を作らない", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => {
+      seedLegacyData(db)
+      db.exec(
+        `DELETE FROM "CourseworkScore" WHERE studentId = 'student-orphan'`
+      )
+    })
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const count = db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM "AuditLog" WHERE action = 'system.migration.cleanup_orphaned_scores'`
+        )
+        .get() as { n: number }
+      expect(count.n).toBe(0)
+      expect(idsOf(db, "CourseworkScore")).toEqual(["cwscore-student-kept"])
+    })
+  })
+
+  it("差し替え後も FK 参照名が正しい（RENAME TO の取り違え防止）", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const definitions = new Map(
+        (
+          db
+            .prepare(
+              `SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+            )
+            .all() as { name: string; sql: string }[]
+        ).map((row) => [row.name, row.sql])
+      )
+
+      for (const name of definitions.keys()) {
+        expect(name.startsWith("new_")).toBe(false)
+      }
+
+      expect(definitions.get("CourseworkScore")).toContain(
+        'REFERENCES "CourseworkStudent"'
+      )
+      expect(definitions.get("CourseworkScore")).toContain(
+        'REFERENCES "CourseworkItem"'
+      )
+      expect(definitions.get("CourseworkScore")).not.toContain("new_")
+
+      expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+    })
+  })
+})

--- a/docs/membership-key-rewiring-plan.md
+++ b/docs/membership-key-rewiring-plan.md
@@ -387,3 +387,73 @@ transformer の `warnings` に件数を載せる（2026-07-28 確定）。
 経路も `rawScoreCalculator.ts:116` の1本なので小さい（20 ファイル前後）。Phase C は grade 3 テーブルに
 加えて §3.3 の Map 解消（`absentEstimation.ts` の 9 引数を含む）とセル実体化が乗るため、
 Phase A と同等かそれ以上になる。
+
+## 12. Phase B の実施結果（2026-07-29）
+
+**完了。** `CourseworkScore` を `courseworkStudentId` へ配線変更した。見立てどおり小さく収まった。
+
+計画から外れた点・追加で判明した点:
+
+- **`.coursework` を入れ子の射影ツリーから、テーブルごとの平坦なセクションへ作り直した**
+  （coursework 1.1.0 / grade 1.12.0）。当初は「名簿に id が無いので点数の参照だけ変えると
+  変換器が id を作る羽目になる」として形状据え置きを提案したが、OWNER 裁定により
+  **exam-archive と揃え、Prisma のクエリが返した行をそのまま JSON に持つ**方針とした。
+  - 収集は射影しない。JSON に載らない型だけを `JSON.stringify` と同じ規則で文字列にする
+    （DateTime → ISO 文字列、Decimal → 文字列。exam-archive の `partialScore` と同じ）
+  - 旧 1.0.0 の結合行（学級・タグ・名簿・点数・変換表）は id を持たないが、いずれも
+    `@@unique` を持つ中間テーブルなので **自然キーから id を組み立てる**
+    （`deterministicId.ts` と同じ規則。同じアーカイブを何度読んでも同じ id ＝冪等）。
+    組み立てた id はアーカイブ内の結合キーとしてのみ使い、DB へは書き込まない
+  - 旧形式に無い `createdAt`/`updatedAt` は復元できないため下限値を入れ、warning で伝える
+- **旧版の形の知識は変換器ディレクトリへ閉じ込めた。** `src/types/courseworkArchive.types.ts`
+  は現行の形だけを宣言し、`coursework-transformers/types.ts` が版ごとの
+  「アーカイブ全体の型」（`CourseworkArchiveDataV1_0_0`）と変換器・チェーンの型を持つ。
+  変換器は `V1_0_0 → V1_1_0` として型付けされ、`unknown` もキャストも使っていない
+  （版が変わらない外部参照セクションは共有し、実際に変わった部分だけ版ごとに書く）
+- **旧アーカイブ内の孤児は破棄し、資料ごとに1本の警告へまとめた。** 従来は点数1件ごとに
+  警告を積んでいたため、孤児が多いアーカイブでは警告が溢れていた
+- **`idChangeExecutor` の `CourseworkStudent` mover が data-loss 経路になっていた。**
+  `CourseworkScore` mover は Student 直結ではなくなったので消えるが、`CourseworkStudent` の
+  重複行を `delete` する既存分岐が cascade で点数を道連れにする。移行先に同じ評価項目の
+  点数が無いものを先に付け替えてから delete するようにして、旧来の
+  「移行先の点数を残し、衝突した元の点数を捨てる」挙動を保った（`project_idchange_cascade_hazard`）
+- **IPC の点数 upsert 入力が 4 層（renderer / preload / handler / DB 層）で同じ形を
+  重複定義していた。** Phase A で踏んだ「余剰プロパティ検査が効かず 1 層直し忘れても
+  typecheck が通る」型の罠なので、`CourseworkScoreUpsertInput` として 1 箇所に集約した
+- **`prisma.updateMany` の `where` は余剰プロパティ検査が効かない。**
+  `gradeFrozenScore.test.ts` の `where: { studentId }` は typecheck を通り、実行時にだけ
+  `PrismaClientValidationError` で落ちた。`findMany`/`create` は捕まえるので油断しやすい
+
+追加したテスト:
+
+- `__tests__/coursework/courseworkCrud.test.ts` — 資料から生徒を外すと点数も消え、
+  他生徒は巻き添えにならず、再追加しても復元されない
+- `__tests__/migration/rewireCourseworkScoreToCourseworkStudent.test.ts` — 付け替え・
+  孤児破棄・AuditLog 記録・`RENAME TO` 後の FK 参照名
+- `__tests__/grade/integration/gradeCourseworkStudentScope.test.ts` — 資料から外した生徒の
+  点数が成績算出に算入されないこと
+- `cascadeCoverage.test.ts` に「`CourseworkScore` の親は `CourseworkStudent`・Student 直結ではない」
+- `__tests__/import-export/unit/courseworkTransformerChain.test.ts` — 1.0.0 → 1.1.0 の展開・
+  点数の付け替え・孤児破棄・冪等性・version 偽装時の形状ベース下方補正
+- `gradeTransformerChain.test.ts` に 1.11.0 → 1.12.0（内包資料の平坦化）の3本
+
+- **採点対象と受験者・対象者が同じ親に属することを、書き込みの入口で検査するようにした。**
+  FK は「それぞれが実在すること」しか保証せず、両者が同じ Exam / Coursework に属することは
+  強制されない。id はどちらも string なので取り違えてもコンパイルが通り、書けてしまうと
+  「その試験の受験者一覧に居ない生徒の得点」が成績算出に算入される — §2.3 の非対称が
+  別の入口から復活する。`examScopeGuard.ts` に集約し、Phase A で残していた試験側
+  （`QuestionScore` / `ScoreDecision` / `CompoundAnswerScore` / `StudentAnswerImage`）も
+  併せて塞いだ。`initializeScoringRecords` だけは採点領域も受験者も同じ `examId` から
+  引くため構造的に安全で、検査を足していない（その旨を doc コメントに明記）
+  - **守れるのはアプリのコードが書く経路だけ。** NAS 同期はライブラリから DB へ直接書く。
+    ただし同期は行単位で運ぶため食い違ったペアを新たに作ることは無い（`cropRegionId` と
+    `examStudentId` は同じ 1 行にあり、列ごとのマージはしていない）。同期で起こりうるのは
+    参照先が消えた行が残ること
+
+**未着手のまま残した項目**:
+
+- **資料・成績の名簿からの生徒削除には確認ダイアログが無い。** 試験（05）は
+  `StudentRemovalConfirmModal` で破棄を明示しているが、`RosterTable` の `enableRemove` は
+  無確認で削除する（`slots.onBeforeRemove` は用意されているだけで利用者ゼロ）。
+  Phase B で削除が破壊的になったため、確認の必要性が上がった。ただし grade の名簿も
+  同じ形なので、Phase C でまとめて入れる方が一貫する

--- a/electron-src/ipc-handlers/courseworkHandlers.ts
+++ b/electron-src/ipc-handlers/courseworkHandlers.ts
@@ -4,6 +4,7 @@
 
 import { dialog, ipcMain } from "electron"
 
+import type { CourseworkScoreUpsertInput } from "../../src/types/coursework.types"
 import type {
   CourseworkImportDecisions,
   CourseworkMatchingMethod,
@@ -131,17 +132,7 @@ export function setupCourseworkHandlers(): void {
 
   registerHandler(
     "coursework:batchUpsertScores",
-    async (
-      scores: {
-        courseworkItemId: string
-        studentId: string
-        score?: number | null
-        letterValue?: string | null
-        adjustment?: number | null
-        adjustmentReason?: string | null
-        comment?: string | null
-      }[]
-    ) => {
+    async (scores: CourseworkScoreUpsertInput[]) => {
       return batchUpsertCourseworkScores(scores)
     }
   )

--- a/electron-src/lib/export/coursework-archive/archiveCreator.ts
+++ b/electron-src/lib/export/coursework-archive/archiveCreator.ts
@@ -69,8 +69,28 @@ export async function createCourseworkArchive(
       archive.append(JSON.stringify(manifest, null, 2), {
         name: "manifest.json",
       })
+      // テーブルごとに1ファイル（v1.1.0）。旧 v1.0.0 は courseworks.json に
+      // 入れ子ツリーを1本だけ書いていた
       archive.append(JSON.stringify(data.courseworks, null, 2), {
         name: "courseworks.json",
+      })
+      archive.append(JSON.stringify(data.courseworkClassrooms, null, 2), {
+        name: "coursework-classrooms.json",
+      })
+      archive.append(JSON.stringify(data.courseworkTags, null, 2), {
+        name: "coursework-tags.json",
+      })
+      archive.append(JSON.stringify(data.courseworkStudents, null, 2), {
+        name: "coursework-students.json",
+      })
+      archive.append(JSON.stringify(data.courseworkItems, null, 2), {
+        name: "coursework-items.json",
+      })
+      archive.append(JSON.stringify(data.courseworkLetterScales, null, 2), {
+        name: "coursework-letter-scales.json",
+      })
+      archive.append(JSON.stringify(data.courseworkScores, null, 2), {
+        name: "coursework-scores.json",
       })
       archive.append(JSON.stringify(data.studentsData, null, 2), {
         name: "students.json",

--- a/electron-src/lib/export/coursework-archive/dataCollector.ts
+++ b/electron-src/lib/export/coursework-archive/dataCollector.ts
@@ -3,10 +3,22 @@
  *
  * 指定した coursework を、生徒・学級・タグの full レコード（元 UUID 付き）込みで
  * 自己完結に収集する。grade-archive の内包収集もこの関数へ委譲する。
+ *
+ * 【原則】Prisma のクエリが返した行をそのまま JSON として持つ。射影・詰め替えはしない。
+ * JSON に載らない型だけを JSON.stringify と同じ規則で文字列にする
+ * （DateTime → ISO 文字列、Decimal → decimal.js の toJSON と同じ文字列）。
  */
 
+import type { Prisma } from "@prisma/client"
+
 import type {
-  ArchiveCourseworkRef,
+  ArchiveCourseworkClassroomRow,
+  ArchiveCourseworkItemRow,
+  ArchiveCourseworkLetterScaleRow,
+  ArchiveCourseworkRow,
+  ArchiveCourseworkScoreRow,
+  ArchiveCourseworkStudentRow,
+  ArchiveCourseworkTagRow,
   ArchiveCwClass,
   ArchiveCwMembership,
   ArchiveCwStudent,
@@ -14,6 +26,11 @@ import type {
   CollectedCourseworkData,
 } from "../../../../src/types/courseworkArchive.types"
 import prisma from "../../prisma/client"
+
+/** Decimal を JSON.stringify と同じ文字列表現にする */
+const decimalToJson = (value: Prisma.Decimal): string => value.toString()
+const nullableDecimalToJson = (value: Prisma.Decimal | null): string | null =>
+  value === null ? null : value.toString()
 
 /**
  * 指定 coursework 群を full レコード込みで収集する。
@@ -24,75 +41,134 @@ import prisma from "../../prisma/client"
 export async function collectCourseworkArchiveData(
   courseworkIds: string[]
 ): Promise<CollectedCourseworkData> {
-  const rows = await prisma.coursework.findMany({
-    where: { id: { in: courseworkIds } },
-    include: {
-      classrooms: { orderBy: { order: "asc" } },
-      tags: true,
-      students: {
-        orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
-      },
-      items: {
-        include: {
-          letterScales: { orderBy: { order: "asc" } },
-          scores: true,
-        },
-        orderBy: { order: "asc" },
-      },
-    },
-  })
+  const [
+    courseworkRows,
+    classroomJoinRows,
+    tagJoinRows,
+    studentJoinRows,
+    itemRows,
+  ] = await Promise.all([
+    prisma.coursework.findMany({ where: { id: { in: courseworkIds } } }),
+    prisma.courseworkClassroom.findMany({
+      where: { courseworkId: { in: courseworkIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.courseworkTag.findMany({
+      where: { courseworkId: { in: courseworkIds } },
+    }),
+    prisma.courseworkStudent.findMany({
+      where: { courseworkId: { in: courseworkIds } },
+      orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
+    }),
+    prisma.courseworkItem.findMany({
+      where: { courseworkId: { in: courseworkIds } },
+      orderBy: { order: "asc" },
+    }),
+  ])
 
-  const courseworks: ArchiveCourseworkRef[] = rows.map((coursework) => ({
-    id: coursework.id,
-    name: coursework.name,
-    description: coursework.description,
-    date: coursework.date?.toISOString() ?? null,
-    classrooms: coursework.classrooms.map((classroom) => ({
-      classroomId: classroom.classroomId,
-      order: classroom.order,
-    })),
-    tags: coursework.tags.map((tag) => ({ tagId: tag.tagId })),
-    students: coursework.students.map((student) => ({
-      studentId: student.studentId,
-      customOrder: student.customOrder,
-    })),
-    items: coursework.items.map((item) => ({
-      id: item.id,
-      name: item.name,
-      order: item.order,
-      maxScore: Number(item.maxScore),
-      inputMode: item.inputMode,
-      letterScales: item.letterScales.map((letterScale) => ({
-        label: letterScale.label,
-        score: Number(letterScale.score),
-        order: letterScale.order,
-      })),
-      scores: item.scores.map((score) => ({
-        studentId: score.studentId,
-        score: score.score !== null ? Number(score.score) : null,
-        letterValue: score.letterValue,
-        adjustment: score.adjustment !== null ? Number(score.adjustment) : null,
-        adjustmentReason: score.adjustmentReason,
-        comment: score.comment,
-        updatedAt: score.updatedAt.toISOString(),
-      })),
-    })),
+  const itemIds = itemRows.map((item) => item.id)
+  const [letterScaleRows, scoreRows] = await Promise.all([
+    prisma.courseworkLetterScale.findMany({
+      where: { courseworkItemId: { in: itemIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.courseworkScore.findMany({
+      where: { courseworkItemId: { in: itemIds } },
+    }),
+  ])
+
+  const courseworks: ArchiveCourseworkRow[] = courseworkRows.map(
+    (coursework) => ({
+      id: coursework.id,
+      name: coursework.name,
+      description: coursework.description,
+      date: coursework.date?.toISOString() ?? null,
+      createdAt: coursework.createdAt.toISOString(),
+      updatedAt: coursework.updatedAt.toISOString(),
+    })
+  )
+
+  const courseworkClassrooms: ArchiveCourseworkClassroomRow[] =
+    classroomJoinRows.map((courseworkClassroom) => ({
+      id: courseworkClassroom.id,
+      courseworkId: courseworkClassroom.courseworkId,
+      classroomId: courseworkClassroom.classroomId,
+      order: courseworkClassroom.order,
+      createdAt: courseworkClassroom.createdAt.toISOString(),
+      updatedAt: courseworkClassroom.updatedAt.toISOString(),
+    }))
+
+  const courseworkTags: ArchiveCourseworkTagRow[] = tagJoinRows.map(
+    (courseworkTag) => ({
+      id: courseworkTag.id,
+      courseworkId: courseworkTag.courseworkId,
+      tagId: courseworkTag.tagId,
+      createdAt: courseworkTag.createdAt.toISOString(),
+      updatedAt: courseworkTag.updatedAt.toISOString(),
+    })
+  )
+
+  const courseworkStudents: ArchiveCourseworkStudentRow[] = studentJoinRows.map(
+    (courseworkStudent) => ({
+      id: courseworkStudent.id,
+      courseworkId: courseworkStudent.courseworkId,
+      studentId: courseworkStudent.studentId,
+      customOrder: courseworkStudent.customOrder,
+      createdAt: courseworkStudent.createdAt.toISOString(),
+      updatedAt: courseworkStudent.updatedAt.toISOString(),
+    })
+  )
+
+  const courseworkItems: ArchiveCourseworkItemRow[] = itemRows.map((item) => ({
+    id: item.id,
+    courseworkId: item.courseworkId,
+    name: item.name,
+    order: item.order,
+    maxScore: decimalToJson(item.maxScore),
+    inputMode: item.inputMode,
+    createdAt: item.createdAt.toISOString(),
+    updatedAt: item.updatedAt.toISOString(),
   }))
 
-  // 参照されている生徒・学級・タグの UUID を集約
-  const studentIds = new Set<string>()
-  const classroomIds = new Set<string>()
-  const tagIds = new Set<string>()
-  for (const coursework of rows) {
-    coursework.students.forEach((student) => studentIds.add(student.studentId))
-    coursework.classrooms.forEach((classroom) =>
-      classroomIds.add(classroom.classroomId)
+  const courseworkLetterScales: ArchiveCourseworkLetterScaleRow[] =
+    letterScaleRows.map((letterScale) => ({
+      id: letterScale.id,
+      courseworkItemId: letterScale.courseworkItemId,
+      label: letterScale.label,
+      score: decimalToJson(letterScale.score),
+      order: letterScale.order,
+      createdAt: letterScale.createdAt.toISOString(),
+      updatedAt: letterScale.updatedAt.toISOString(),
+    }))
+
+  const courseworkScores: ArchiveCourseworkScoreRow[] = scoreRows.map(
+    (score) => ({
+      id: score.id,
+      courseworkItemId: score.courseworkItemId,
+      courseworkStudentId: score.courseworkStudentId,
+      score: nullableDecimalToJson(score.score),
+      letterValue: score.letterValue,
+      adjustment: nullableDecimalToJson(score.adjustment),
+      adjustmentReason: score.adjustmentReason,
+      comment: score.comment,
+      createdAt: score.createdAt.toISOString(),
+      updatedAt: score.updatedAt.toISOString(),
+    })
+  )
+
+  // 参照されている生徒・学級・タグの UUID を集約。
+  // 点数は対象者の子なので、名簿を集めれば生徒は網羅される。
+  const studentIds = new Set(
+    courseworkStudents.map((courseworkStudent) => courseworkStudent.studentId)
+  )
+  const classroomIds = new Set(
+    courseworkClassrooms.map(
+      (courseworkClassroom) => courseworkClassroom.classroomId
     )
-    coursework.tags.forEach((tag) => tagIds.add(tag.tagId))
-    coursework.items.forEach((item) =>
-      item.scores.forEach((score) => studentIds.add(score.studentId))
-    )
-  }
+  )
+  const tagIds = new Set(
+    courseworkTags.map((courseworkTag) => courseworkTag.tagId)
+  )
 
   const studentRows = await prisma.student.findMany({
     where: { id: { in: [...studentIds] } },
@@ -149,27 +225,22 @@ export async function collectCourseworkArchiveData(
     color: tag.color,
   }))
 
-  const itemCount = courseworks.reduce(
-    (sum, coursework) => sum + coursework.items.length,
-    0
-  )
-  const scoreCount = courseworks.reduce(
-    (sum, coursework) =>
-      sum +
-      coursework.items.reduce((total, item) => total + item.scores.length, 0),
-    0
-  )
-
   return {
     courseworks,
+    courseworkClassrooms,
+    courseworkTags,
+    courseworkStudents,
+    courseworkItems,
+    courseworkLetterScales,
+    courseworkScores,
     studentsData,
     classesData,
     membershipsData,
     tagsData,
     counts: {
       courseworks: courseworks.length,
-      items: itemCount,
-      scores: scoreCount,
+      items: courseworkItems.length,
+      scores: courseworkScores.length,
       students: studentsData.length,
       classrooms: classesData.length,
     },

--- a/electron-src/lib/import/coursework-archive/archiveExtractor.ts
+++ b/electron-src/lib/import/coursework-archive/archiveExtractor.ts
@@ -8,19 +8,27 @@ import * as os from "os"
 import * as path from "path"
 
 import type {
-  ArchiveCourseworkRef,
+  ArchiveCourseworkClassroomRow,
+  ArchiveCourseworkItemRow,
+  ArchiveCourseworkLetterScaleRow,
+  ArchiveCourseworkRow,
+  ArchiveCourseworkScoreRow,
+  ArchiveCourseworkStudentRow,
+  ArchiveCourseworkTagRow,
   ArchiveCwClass,
   ArchiveCwMembership,
   ArchiveCwStudent,
   ArchiveCwTag,
-  CourseworkArchiveData,
   CourseworkArchiveManifest,
 } from "../../../../src/types/courseworkArchive.types"
+import { isLegacyCourseworkTree } from "../coursework-transformers/legacyShape"
+import type { AnyCourseworkArchiveData } from "../coursework-transformers/types"
 import { normalizeLegacyClassroomKeys } from "../shared/legacyClassroomKeys"
 
 export interface ExtractedCourseworkArchive {
   manifest: CourseworkArchiveManifest
-  data: CourseworkArchiveData
+  /** 版が確定していない生データ。現行の形への正規化は変換チェーンが行う */
+  data: AnyCourseworkArchiveData
   tempDir: string
 }
 
@@ -28,6 +36,18 @@ function readJsonFile<T>(dir: string, name: string): T | null {
   const filePath = path.join(dir, name)
   if (!fs.existsSync(filePath)) return null
   return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T
+}
+
+/**
+ * 版の判定に使う配列を、型を主張せずに読む。
+ *
+ * `readJsonFile<T>` は中身を確かめずに T を名乗らせるので、まだ版が判っていない
+ * courseworks.json には使わない。ここでは配列であることだけを実際に確かめ、
+ * 要素の形の判定は型ガード（isLegacyCourseworkTree）に委ねる。
+ */
+function readJsonArray(dir: string, name: string): unknown[] {
+  const parsed = readJsonFile<unknown>(dir, name)
+  return Array.isArray(parsed) ? parsed : []
 }
 
 /**
@@ -62,8 +82,8 @@ export async function extractCourseworkArchive(archivePath: string): Promise<{
     }
 
     // 学級リネーム前の旧キー（classId/classes/className/classCode）は読取り時に現行キー（classroom*）へ正規化
-    const courseworks = normalizeLegacyClassroomKeys(
-      readJsonFile<ArchiveCourseworkRef[]>(tempDir, "courseworks.json") ?? []
+    const courseworksJson = normalizeLegacyClassroomKeys(
+      readJsonArray(tempDir, "courseworks.json")
     )
     const studentsData =
       readJsonFile<ArchiveCwStudent[]>(tempDir, "students.json") ?? []
@@ -75,13 +95,55 @@ export async function extractCourseworkArchive(archivePath: string): Promise<{
     )
     const tagsData = readJsonFile<ArchiveCwTag[]>(tempDir, "tags.json") ?? []
 
+    // 現行の形でなければ旧版の形のまま変換器へ渡す（旧版の知識は変換器が持つ）。
+    // 現行と判った側は、その版の型で読み直す（JSON の型付けは readJsonFile に集約する）。
+    const sections = isLegacyCourseworkTree(courseworksJson)
+      ? { courseworks: courseworksJson }
+      : {
+          courseworks: normalizeLegacyClassroomKeys(
+            readJsonFile<ArchiveCourseworkRow[]>(tempDir, "courseworks.json") ??
+              []
+          ),
+          courseworkClassrooms: normalizeLegacyClassroomKeys(
+            readJsonFile<ArchiveCourseworkClassroomRow[]>(
+              tempDir,
+              "coursework-classrooms.json"
+            ) ?? []
+          ),
+          courseworkTags:
+            readJsonFile<ArchiveCourseworkTagRow[]>(
+              tempDir,
+              "coursework-tags.json"
+            ) ?? [],
+          courseworkStudents:
+            readJsonFile<ArchiveCourseworkStudentRow[]>(
+              tempDir,
+              "coursework-students.json"
+            ) ?? [],
+          courseworkItems:
+            readJsonFile<ArchiveCourseworkItemRow[]>(
+              tempDir,
+              "coursework-items.json"
+            ) ?? [],
+          courseworkLetterScales:
+            readJsonFile<ArchiveCourseworkLetterScaleRow[]>(
+              tempDir,
+              "coursework-letter-scales.json"
+            ) ?? [],
+          courseworkScores:
+            readJsonFile<ArchiveCourseworkScoreRow[]>(
+              tempDir,
+              "coursework-scores.json"
+            ) ?? [],
+        }
+
     return {
       success: true,
       data: {
         manifest,
         data: {
           manifest,
-          courseworks,
+          ...sections,
           studentsData,
           classesData,
           membershipsData,

--- a/electron-src/lib/import/coursework-archive/dataCreator.ts
+++ b/electron-src/lib/import/coursework-archive/dataCreator.ts
@@ -3,7 +3,10 @@
  *
  * - 外部参照（生徒/学級/タグ）は idRemapper で UUID 一次 + 名前マッチング解決。
  * - 資料本体は UUID 一次照合（decision 未指定）/ ユーザー判断（reuse/new）で流用 or 新規。
- * - 点数は @@unique([courseworkItemId, studentId]) を updatedAt の LWW で upsert。
+ * - 点数は @@unique([courseworkItemId, courseworkStudentId]) を updatedAt の LWW で upsert。
+ *
+ * アーカイブはテーブルごとの平坦なセクションで来るので、courseworkId / courseworkItemId で
+ * 束ね直してから資料単位に処理する。
  *
  * grade-archive はこの importCourseworkData をトランザクション内で呼び出して内包する。
  */
@@ -11,8 +14,8 @@
 import { randomUUID } from "crypto"
 
 import type {
-  ArchiveCourseworkItemRef,
-  ArchiveCourseworkRef,
+  ArchiveCourseworkItemRow,
+  ArchiveCourseworkRow,
   CourseworkArchiveData,
   CourseworkImportOptions,
 } from "../../../../src/types/courseworkArchive.types"
@@ -37,11 +40,39 @@ export interface ImportCourseworkResult {
 export type CourseworkImportSections = Pick<
   CourseworkArchiveData,
   | "courseworks"
+  | "courseworkClassrooms"
+  | "courseworkTags"
+  | "courseworkStudents"
+  | "courseworkItems"
+  | "courseworkLetterScales"
+  | "courseworkScores"
   | "studentsData"
   | "classesData"
   | "membershipsData"
   | "tagsData"
 >
+
+/**
+ * 点数の書き込み先となる名簿。
+ * アーカイブの CourseworkStudent.id → 取り込み先の CourseworkStudent.id と、
+ * 「名簿には居るが取り込み先にその生徒が居ない」対象者の集合を持つ。
+ */
+interface CourseworkRoster {
+  byArchiveId: Map<string, string>
+  unresolvedArchiveIds: Set<string>
+}
+
+/** 行の配列を親 id で束ねる */
+function groupBy<T>(rows: T[], keyOf: (row: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const row of rows) {
+    const key = keyOf(row)
+    const bucket = grouped.get(key)
+    if (bucket) bucket.push(row)
+    else grouped.set(key, [row])
+  }
+  return grouped
+}
 
 /**
  * 試験外成績資料をトランザクション内で DB へ反映する。
@@ -57,6 +88,31 @@ export async function importCourseworkData(
   const warnings: string[] = []
   const createdCourseworkIds: string[] = []
   const itemIdMap = new Map<string, string>()
+
+  const classroomsByCoursework = groupBy(
+    data.courseworkClassrooms,
+    (courseworkClassroom) => courseworkClassroom.courseworkId
+  )
+  const tagsByCoursework = groupBy(
+    data.courseworkTags,
+    (courseworkTag) => courseworkTag.courseworkId
+  )
+  const studentsByCoursework = groupBy(
+    data.courseworkStudents,
+    (courseworkStudent) => courseworkStudent.courseworkId
+  )
+  const itemsByCoursework = groupBy(
+    data.courseworkItems,
+    (item) => item.courseworkId
+  )
+  const letterScalesByItem = groupBy(
+    data.courseworkLetterScales,
+    (letterScale) => letterScale.courseworkItemId
+  )
+  const scoresByItem = groupBy(
+    data.courseworkScores,
+    (score) => score.courseworkItemId
+  )
 
   // 1. 外部参照の解決
   const students = await resolveStudents(tx, data.studentsData, {
@@ -76,35 +132,79 @@ export async function importCourseworkData(
     )
   }
 
-  /** 点数を LWW で upsert する */
+  /**
+   * 書き込めなかった点数の件数。原因を分けて数える。
+   *
+   * - orphaned: アーカイブの名簿にそもそも載っていない生徒の点数（アーカイブ側の不整合）
+   * - unresolved: 名簿には居るが、取り込み先にその生徒が居ない（取り込み先の不足）
+   *
+   * どちらも結果は「点数が入らない」だが、利用者が取るべき行動が違う。
+   * 一緒くたにすると「アーカイブが壊れている」と誤解させる。
+   */
+  interface SkippedScoreCounts {
+    orphaned: number
+    unresolved: number
+  }
+
+  const warnSkippedScores = (
+    courseworkName: string,
+    skipped: SkippedScoreCounts
+  ) => {
+    if (skipped.orphaned > 0) {
+      warnings.push(
+        `試験外成績資料「${courseworkName}」: 対象生徒として登録されていない生徒の点数 ${skipped.orphaned} 件を破棄しました`
+      )
+    }
+    if (skipped.unresolved > 0) {
+      warnings.push(
+        `試験外成績資料「${courseworkName}」: この環境に存在しない生徒の点数 ${skipped.unresolved} 件を取り込めませんでした`
+      )
+    }
+  }
+
+  /**
+   * 点数を LWW で upsert する。
+   *
+   * 点数の主語は資料の対象者（CourseworkStudent）。取り込み先では名簿行の id が
+   * 別物になるため、アーカイブの対象者 id を roster で引き直す。名簿に対応行が
+   * 無い点数（旧アーカイブに残りうる孤児）は破棄する。
+   */
   const upsertScores = async (
+    archiveItemId: string,
     courseworkItemId: string,
-    item: ArchiveCourseworkItemRef,
-    courseworkName: string
-  ): Promise<void> => {
-    for (const courseworkScore of item.scores) {
-      const studentId = students.map.get(courseworkScore.studentId)
-      if (!studentId) {
-        warnings.push(
-          `試験外成績資料「${courseworkName}」評価項目「${item.name}」: 生徒の点数を解決できずスキップしました`
-        )
+    roster: CourseworkRoster
+  ): Promise<SkippedScoreCounts> => {
+    const skipped: SkippedScoreCounts = { orphaned: 0, unresolved: 0 }
+    for (const archiveScore of scoresByItem.get(archiveItemId) ?? []) {
+      const courseworkStudentId = roster.byArchiveId.get(
+        archiveScore.courseworkStudentId
+      )
+      if (!courseworkStudentId) {
+        if (roster.unresolvedArchiveIds.has(archiveScore.courseworkStudentId)) {
+          skipped.unresolved++
+        } else {
+          skipped.orphaned++
+        }
         continue
       }
       const existing = await tx.courseworkScore.findUnique({
         where: {
-          courseworkItemId_studentId: { courseworkItemId, studentId },
+          courseworkItemId_courseworkStudentId: {
+            courseworkItemId,
+            courseworkStudentId,
+          },
         },
       })
       const payload = {
-        score: courseworkScore.score,
-        letterValue: courseworkScore.letterValue,
-        adjustment: courseworkScore.adjustment ?? 0,
-        adjustmentReason: courseworkScore.adjustmentReason,
-        comment: courseworkScore.comment,
+        score: archiveScore.score,
+        letterValue: archiveScore.letterValue,
+        adjustment: archiveScore.adjustment ?? 0,
+        adjustmentReason: archiveScore.adjustmentReason,
+        comment: archiveScore.comment,
       }
       if (existing) {
         if (
-          isNewerByLww(new Date(courseworkScore.updatedAt), existing.updatedAt)
+          isNewerByLww(new Date(archiveScore.updatedAt), existing.updatedAt)
         ) {
           await tx.courseworkScore.update({
             where: { id: existing.id },
@@ -113,18 +213,20 @@ export async function importCourseworkData(
         }
       } else {
         await tx.courseworkScore.create({
-          data: { courseworkItemId, studentId, ...payload },
+          data: { courseworkItemId, courseworkStudentId, ...payload },
         })
       }
     }
+    return skipped
   }
 
   /** 評価項目を作成（変換表も投入）し実 ID を返す */
   const createItem = async (
     courseworkId: string,
     itemId: string | undefined,
-    item: ArchiveCourseworkItemRef
+    item: ArchiveCourseworkItemRow
   ): Promise<string> => {
+    const letterScales = letterScalesByItem.get(item.id) ?? []
     const created = await tx.courseworkItem.create({
       data: {
         ...(itemId ? { id: itemId } : {}),
@@ -133,9 +235,9 @@ export async function importCourseworkData(
         order: item.order,
         maxScore: item.maxScore,
         inputMode: item.inputMode || "numeric",
-        ...(item.letterScales.length > 0 && {
+        ...(letterScales.length > 0 && {
           letterScales: {
-            create: item.letterScales.map((letterScale) => ({
+            create: letterScales.map((letterScale) => ({
               label: letterScale.label,
               score: letterScale.score,
               order: letterScale.order,
@@ -147,12 +249,20 @@ export async function importCourseworkData(
     return created.id
   }
 
-  /** 学級・タグ・名簿の join を冪等に張る */
+  /**
+   * 学級・タグ・名簿の join を冪等に張り、点数の書き込み先となる名簿
+   * （アーカイブの CourseworkStudent.id → 取り込み先の CourseworkStudent.id）を返す。
+   *
+   * 名簿行の id は取り込み先で新しく採番する。結合行そのものに外部から参照される
+   * 意味は無く、旧アーカイブ由来の id は uuid ですらないため。
+   */
   const ensureJoins = async (
     courseworkId: string,
-    coursework: ArchiveCourseworkRef
-  ): Promise<void> => {
-    for (const classroomRef of coursework.classrooms) {
+    archiveCourseworkId: string
+  ): Promise<CourseworkRoster> => {
+    for (const classroomRef of classroomsByCoursework.get(
+      archiveCourseworkId
+    ) ?? []) {
       const classroomId = classes.map.get(classroomRef.classroomId)
       if (!classroomId) continue
       const exists = await tx.courseworkClassroom.findUnique({
@@ -165,7 +275,8 @@ export async function importCourseworkData(
         })
       }
     }
-    for (const tagRef of coursework.tags) {
+
+    for (const tagRef of tagsByCoursework.get(archiveCourseworkId) ?? []) {
       const tagId = tagMap.get(tagRef.tagId)
       if (!tagId) continue
       const exists = await tx.courseworkTag.findUnique({
@@ -176,9 +287,19 @@ export async function importCourseworkData(
         await tx.courseworkTag.create({ data: { courseworkId, tagId } })
       }
     }
-    for (const studentRef of coursework.students) {
+
+    /** アーカイブの対象者 id → 取り込み先の生徒 id（この後 DB の名簿と突き合わせる） */
+    const archiveStudentIdByCourseworkStudent = new Map<string, string>()
+    /** 名簿には居るが、取り込み先にその生徒が居なかった対象者 */
+    const unresolvedArchiveIds = new Set<string>()
+    for (const studentRef of studentsByCoursework.get(archiveCourseworkId) ??
+      []) {
       const studentId = students.map.get(studentRef.studentId)
-      if (!studentId) continue
+      if (!studentId) {
+        unresolvedArchiveIds.add(studentRef.id)
+        continue
+      }
+      archiveStudentIdByCourseworkStudent.set(studentRef.id, studentId)
       const exists = await tx.courseworkStudent.findUnique({
         where: { courseworkId_studentId: { courseworkId, studentId } },
         select: { id: true },
@@ -193,6 +314,58 @@ export async function importCourseworkData(
         })
       }
     }
+
+    // 既存資料への統合では、アーカイブの名簿に載っていない対象者が既に居ることがある。
+    // 点数の宛先は DB の名簿が正なので、張り終えた後に全件を読み直す。
+    const dbRoster = await tx.courseworkStudent.findMany({
+      where: { courseworkId },
+      select: { id: true, studentId: true },
+    })
+    const dbIdByStudent = new Map(
+      dbRoster.map((courseworkStudent) => [
+        courseworkStudent.studentId,
+        courseworkStudent.id,
+      ])
+    )
+    const byArchiveId = new Map<string, string>()
+    for (const [
+      archiveCourseworkStudentId,
+      studentId,
+    ] of archiveStudentIdByCourseworkStudent) {
+      const dbCourseworkStudentId = dbIdByStudent.get(studentId)
+      if (dbCourseworkStudentId) {
+        byArchiveId.set(archiveCourseworkStudentId, dbCourseworkStudentId)
+      } else {
+        unresolvedArchiveIds.add(archiveCourseworkStudentId)
+      }
+    }
+    return { byArchiveId, unresolvedArchiveIds }
+  }
+
+  /** 資料1件の評価項目と点数を取り込む。書き込めなかった点数の件数を返す */
+  const importItems = async (
+    coursework: ArchiveCourseworkRow,
+    courseworkId: string,
+    roster: CourseworkRoster,
+    existingItemIdByName: Map<string, string>,
+    preserveUuids: boolean
+  ): Promise<SkippedScoreCounts> => {
+    const skipped: SkippedScoreCounts = { orphaned: 0, unresolved: 0 }
+    for (const item of itemsByCoursework.get(coursework.id) ?? []) {
+      let actualItemId = existingItemIdByName.get(item.name)
+      if (!actualItemId) {
+        actualItemId = await createItem(
+          courseworkId,
+          preserveUuids ? item.id : randomUUID(),
+          item
+        )
+      }
+      const itemSkipped = await upsertScores(item.id, actualItemId, roster)
+      skipped.orphaned += itemSkipped.orphaned
+      skipped.unresolved += itemSkipped.unresolved
+      itemIdMap.set(item.id, actualItemId)
+    }
+    return skipped
   }
 
   // 2. 資料本体
@@ -221,22 +394,24 @@ export async function importCourseworkData(
 
     if (reuseId) {
       // 既存資料へ統合: 名簿/学級/タグの不足を補い、項目は名前で突合、点数は LWW
-      await ensureJoins(reuseId, coursework)
+      const roster = await ensureJoins(reuseId, coursework.id)
       const existing = await tx.coursework.findUnique({
         where: { id: reuseId },
         include: { items: { select: { id: true, name: true } } },
       })
-      const existingByName = new Map(
+      const existingItemIdByName = new Map(
         (existing?.items ?? []).map((item) => [item.name, item.id])
       )
-      for (const item of coursework.items) {
-        let actualItemId = existingByName.get(item.name)
-        if (!actualItemId) {
-          actualItemId = await createItem(reuseId, randomUUID(), item)
-        }
-        await upsertScores(actualItemId, item, coursework.name)
-        if (item.id) itemIdMap.set(item.id, actualItemId)
-      }
+      warnSkippedScores(
+        coursework.name,
+        await importItems(
+          coursework,
+          reuseId,
+          roster,
+          existingItemIdByName,
+          false
+        )
+      )
       continue
     }
 
@@ -252,16 +427,17 @@ export async function importCourseworkData(
       },
     })
     createdCourseworkIds.push(created.id)
-    await ensureJoins(created.id, coursework)
-    for (const item of coursework.items) {
-      const actualItemId = await createItem(
+    const roster = await ensureJoins(created.id, coursework.id)
+    warnSkippedScores(
+      coursework.name,
+      await importItems(
+        coursework,
         created.id,
-        preserveUuids ? item.id : randomUUID(),
-        item
+        roster,
+        new Map(),
+        preserveUuids
       )
-      await upsertScores(actualItemId, item, coursework.name)
-      if (item.id) itemIdMap.set(item.id, actualItemId)
-    }
+    )
   }
 
   return { createdCourseworkIds, itemIdMap, warnings }

--- a/electron-src/lib/import/coursework-archive/index.ts
+++ b/electron-src/lib/import/coursework-archive/index.ts
@@ -3,7 +3,6 @@
  */
 
 import type {
-  CourseworkArchiveData,
   CourseworkArchiveImportPreview,
   CourseworkArchiveImportResult,
   CourseworkArchiveMatch,
@@ -12,6 +11,7 @@ import type {
 import { recordAuditLog } from "../../prisma/auditLog"
 import prisma from "../../prisma/client"
 import { transformCourseworkToLatest } from "../coursework-transformers"
+import type { AnyCourseworkArchiveData } from "../coursework-transformers/types"
 import { importCourseworkData } from "./dataCreator"
 import { validateCourseworkManifest } from "./manifestValidator"
 
@@ -27,7 +27,7 @@ export { importCourseworkData } from "./dataCreator"
  * インポート前のプレビュー（資料ごとの照合候補）を作る。
  */
 export async function previewCourseworkImport(
-  data: CourseworkArchiveData
+  data: AnyCourseworkArchiveData
 ): Promise<{
   success: boolean
   preview?: CourseworkArchiveImportPreview
@@ -53,8 +53,12 @@ export async function previewCourseworkImport(
     matches.push({
       archiveId: coursework.id,
       name: coursework.name,
-      itemCount: coursework.items.length,
-      studentCount: coursework.students.length,
+      itemCount: normalized.courseworkItems.filter(
+        (item) => item.courseworkId === coursework.id
+      ).length,
+      studentCount: normalized.courseworkStudents.filter(
+        (courseworkStudent) => courseworkStudent.courseworkId === coursework.id
+      ).length,
       uuidMatch: uuidMatch ?? null,
       nameCandidates,
     })
@@ -74,7 +78,7 @@ export async function previewCourseworkImport(
  * 試験外成績資料アーカイブをインポートする（単体・新規トランザクション）。
  */
 export async function importCourseworkArchive(
-  data: CourseworkArchiveData,
+  data: AnyCourseworkArchiveData,
   options: CourseworkImportOptions = {}
 ): Promise<CourseworkArchiveImportResult> {
   try {

--- a/electron-src/lib/import/coursework-transformers/V1_0_0_to_V1_1_0.ts
+++ b/electron-src/lib/import/coursework-transformers/V1_0_0_to_V1_1_0.ts
@@ -1,0 +1,61 @@
+/**
+ * coursework-archive 1.0.0 → 1.1.0
+ *
+ * 入れ子・射影形式（資料1件のツリー）を、テーブルごとの平坦なセクションへ展開する。
+ * 併せて点数の参照を人（Student）から資料の対象者（CourseworkStudent）へ付け替え、
+ * 名簿に載っていない生徒の点数（孤児）を破棄する（#962 Phase B）。
+ *
+ * 展開の実体は legacyShape に置き、.grade が内包する資料の変換と共有する。
+ */
+
+import type { CourseworkArchiveVersion } from "../../../../src/types/courseworkArchive.types"
+import { flattenLegacyCourseworks } from "./legacyShape"
+import {
+  type AnyCourseworkArchiveData,
+  type CourseworkTransformResult,
+  type CourseworkVersionTransformer,
+  isCourseworkArchiveV1_0_0,
+} from "./types"
+
+export class V1_0_0_to_V1_1_0_Transformer implements CourseworkVersionTransformer {
+  readonly fromVersion: CourseworkArchiveVersion = "1.0.0"
+  readonly toVersion: CourseworkArchiveVersion = "1.1.0"
+
+  transform(data: AnyCourseworkArchiveData): CourseworkTransformResult {
+    // 既に平坦なら通す（チェーンの冪等性）
+    if (!isCourseworkArchiveV1_0_0(data)) {
+      return {
+        data: {
+          ...data,
+          manifest: { ...data.manifest, version: this.toVersion },
+        },
+        warnings: [],
+      }
+    }
+
+    const { sections, discardedScoreCount } = flattenLegacyCourseworks(
+      data.courseworks
+    )
+
+    const warnings = [
+      "1.0.0→1.1.0: 資料データをテーブルごとの形式へ変換しました（作成・更新時刻は旧形式に無いため復元できません）",
+    ]
+    if (discardedScoreCount > 0) {
+      warnings.push(
+        `1.0.0→1.1.0: 対象生徒として登録されていない生徒の点数 ${discardedScoreCount} 件を破棄しました`
+      )
+    }
+
+    return {
+      data: {
+        manifest: { ...data.manifest, version: this.toVersion },
+        ...sections,
+        studentsData: data.studentsData,
+        classesData: data.classesData,
+        membershipsData: data.membershipsData,
+        tagsData: data.tagsData,
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/coursework-transformers/index.ts
+++ b/electron-src/lib/import/coursework-transformers/index.ts
@@ -1,17 +1,15 @@
 /**
  * 試験外成績資料アーカイブ（.coursework）バージョン変換器
  *
- * 初版（1.0.0）では変換器は空。将来バージョン追加時に V<FROM>_to_V<TO> を作成し
- * COURSEWORK_TRANSFORMERS へ登録する（exam/asb の transformers に倣う）。
+ * バージョンを追加したら types.ts に「その版のアーカイブ全体の形」を宣言し、
+ * V<FROM>_to_V<TO> を作成して COURSEWORK_TRANSFORMERS へ登録する
+ * （exam/asb の transformers に倣う）。
  * チェーン実行は shared/transformChain の共通実装を使う。
  */
 
 import type {
-  CourseworkArchiveData,
   CourseworkArchiveManifest,
   CourseworkArchiveVersion,
-  CourseworkChainTransformResult,
-  CourseworkVersionTransformer,
 } from "../../../../src/types/courseworkArchive.types"
 import {
   COURSEWORK_CURRENT_VERSION,
@@ -21,35 +19,64 @@ import {
   detectVersionInRange,
   runTransformChain,
 } from "../shared/transformChain"
+import {
+  type AnyCourseworkArchiveData,
+  type CourseworkChainTransformResult,
+  type CourseworkVersionTransformer,
+  isCourseworkArchiveV1_0_0,
+} from "./types"
+import { V1_0_0_to_V1_1_0_Transformer } from "./V1_0_0_to_V1_1_0"
 
-const COURSEWORK_TRANSFORMERS: CourseworkVersionTransformer[] = []
+const COURSEWORK_TRANSFORMERS: CourseworkVersionTransformer[] = [
+  new V1_0_0_to_V1_1_0_Transformer(),
+]
 
-/** マニフェストのバージョン文字列からサポート対象バージョンを判定する */
+/**
+ * マニフェストのバージョン文字列からサポート対象バージョンを判定する。
+ *
+ * 実データの形が manifest より古ければそちらへ下方補正する（version が実態と
+ * ずれたアーカイブが実在したため。exam の形状ベース検出と同じ理由）。
+ */
 export function detectCourseworkVersion(
-  manifest: CourseworkArchiveManifest
+  manifest: CourseworkArchiveManifest,
+  data?: AnyCourseworkArchiveData
 ): CourseworkArchiveVersion | "unknown" {
-  return detectVersionInRange(manifest.version, COURSEWORK_SUPPORTED_VERSIONS)
+  const declared = detectVersionInRange(
+    manifest.version,
+    COURSEWORK_SUPPORTED_VERSIONS
+  )
+  if (declared === "unknown") return declared
+  // 旧版の形なら、名乗りに関わらず 1.0.0 として変換を通す
+  if (data && isCourseworkArchiveV1_0_0(data)) return "1.0.0"
+  return declared
 }
 
 /** アーカイブデータを変換チェーンを通じて最新バージョンへ変換する */
 export function transformCourseworkToLatest(
-  data: CourseworkArchiveData,
+  data: AnyCourseworkArchiveData,
   targetVersion: CourseworkArchiveVersion = COURSEWORK_CURRENT_VERSION
 ): CourseworkChainTransformResult {
-  const originalVersion = detectCourseworkVersion(data.manifest)
+  const originalVersion = detectCourseworkVersion(data.manifest, data)
   if (originalVersion === "unknown") {
     throw new Error(
       `Unknown coursework archive version: ${data.manifest.version}. ` +
         `Supported versions: ${COURSEWORK_SUPPORTED_VERSIONS.join(", ")}`
     )
   }
-  return runTransformChain({
+  const outcome = runTransformChain({
     data,
     originalVersion,
     targetVersion,
     transformers: COURSEWORK_TRANSFORMERS,
     archiveLabel: "coursework",
   })
+  if (isCourseworkArchiveV1_0_0(outcome.data)) {
+    // 変換器の実装バグ（旧版の形のまま抜けてきた）。取り込みへ進めてはいけない
+    throw new Error(
+      "coursework archive is still in the 1.0.0 shape after transformation"
+    )
+  }
+  return { ...outcome, data: outcome.data }
 }
 
 export { COURSEWORK_CURRENT_VERSION, COURSEWORK_SUPPORTED_VERSIONS }

--- a/electron-src/lib/import/coursework-transformers/legacyShape.ts
+++ b/electron-src/lib/import/coursework-transformers/legacyShape.ts
@@ -1,0 +1,282 @@
+/**
+ * v1.0.0（入れ子・射影形式）の資料データを、v1.1.0 の平坦なセクションへ展開する。
+ *
+ * .coursework 単体と、.grade が内包する資料の両方から使う（二重実装の回避）。
+ *
+ * 旧形式は結合行（学級・タグ・名簿・点数・変換表）の id を持たない。これらはいずれも
+ * `@@unique` を持つ中間テーブルなので、自然キーから id を組み立てる
+ * （`deterministicId.ts` と同じ方針。同じアーカイブを何度読んでも同じ id になる＝冪等）。
+ * 組み立てた id はアーカイブ内の結合キーとしてのみ使い、DB へは書き込まない
+ * （import は名簿行を新しい uuid で作る）。
+ */
+
+import type {
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+  ArchiveCwTag,
+  CollectedCourseworkData,
+  CourseworkArchiveManifest,
+  CourseworkExternalSections,
+  CourseworkSections,
+} from "../../../../src/types/courseworkArchive.types"
+
+// =============================================================================
+// v1.0.0 の形状定義（ここだけが知っていればよい負債）
+// =============================================================================
+
+/** v1.0.0 の資料1件（入れ子ツリー） */
+export interface LegacyArchiveCourseworkRef {
+  id: string
+  name: string
+  description: string | null
+  date: string | null
+  classrooms: { classroomId: string; order: number }[]
+  tags: { tagId: string }[]
+  students: { studentId: string; customOrder: number | null }[]
+  items: LegacyArchiveCourseworkItemRef[]
+}
+
+/** v1.0.0 の評価項目（変換表・点数を内包） */
+export interface LegacyArchiveCourseworkItemRef {
+  id: string
+  name: string
+  order: number
+  maxScore: number
+  inputMode: string
+  letterScales: { label: string; score: number; order: number }[]
+  scores: LegacyArchiveCourseworkScoreRef[]
+}
+
+/** v1.0.0 の点数（人＝Student の uuid を指していた） */
+export interface LegacyArchiveCourseworkScoreRef {
+  studentId: string
+  score: number | null
+  letterValue: string | null
+  adjustment: number | null
+  adjustmentReason: string | null
+  comment: string | null
+  updatedAt: string
+}
+
+/** grade-archive v1.5.0〜1.11.0 が内包していた入れ子形式の資料データ */
+export interface LegacyCollectedCourseworkData {
+  courseworks: LegacyArchiveCourseworkRef[]
+  studentsData: ArchiveCwStudent[]
+  classesData: ArchiveCwClass[]
+  membershipsData: ArchiveCwMembership[]
+  tagsData: ArchiveCwTag[]
+  counts: CourseworkArchiveManifest["counts"]
+}
+
+/** 旧形式に無い作成・更新時刻の代わり。実際の値は失われているので下限値を使う */
+const UNKNOWN_TIMESTAMP = new Date(0).toISOString()
+
+/** 中間テーブルの id を自然キーから組み立てる（deterministicId.ts と同じ規則） */
+const joinIds = (parentId: string, childKey: string) =>
+  `${parentId}:${childKey}`
+
+/**
+ * courseworks.json が v1.0.0 の入れ子ツリーかどうかを形で判定する。
+ * v1.1.0 の Coursework 行は `items` を持たない。
+ *
+ * manifest.version は信用しない（version が実態とずれたアーカイブが実在したため。
+ * exam の形状ベース検出と同じ理由）。
+ */
+export function isLegacyCourseworkTree(
+  courseworksJson: unknown[]
+): courseworksJson is LegacyArchiveCourseworkRef[] {
+  const first = courseworksJson[0]
+  return (
+    typeof first === "object" &&
+    first !== null &&
+    "items" in first &&
+    Array.isArray((first as { items: unknown }).items)
+  )
+}
+
+/**
+ * grade が内包する資料データが v1.5.0〜1.11.0 の入れ子形式かどうかを形で判定する。
+ *
+ * 判定は「現行のセクションが揃っているか」で行い、揃っていなければ旧形式とみなす。
+ * 中身（`courseworks` の要素）で見分けようとすると、**資料を1件も参照していない成績**
+ * — 収集器が常に空の内包資料を書き出すので、旧アーカイブの大多数がこれ — で
+ * 空配列になり、新旧どちらとも判別できなくなる。
+ */
+export function isLegacyCollectedCourseworkData(
+  value: unknown
+): value is LegacyCollectedCourseworkData {
+  if (typeof value !== "object" || value === null) return false
+  if (!Array.isArray((value as { courseworks?: unknown }).courseworks)) {
+    return false
+  }
+  return !isCurrentCollectedCourseworkData(value)
+}
+
+/** 現行（v1.1.0）の形で内包されているか。全セクションが揃っていることを実際に確かめる */
+export function isCurrentCollectedCourseworkData(
+  value: unknown
+): value is CollectedCourseworkData {
+  if (typeof value !== "object" || value === null) return false
+  const sections = value as Record<string, unknown>
+  const sectionKeys: (
+    keyof CourseworkSections | keyof CourseworkExternalSections
+  )[] = [
+    "courseworks",
+    "courseworkClassrooms",
+    "courseworkTags",
+    "courseworkStudents",
+    "courseworkItems",
+    "courseworkLetterScales",
+    "courseworkScores",
+    "studentsData",
+    "classesData",
+    "membershipsData",
+    "tagsData",
+  ]
+  return (
+    sectionKeys.every((key) => Array.isArray(sections[key])) &&
+    typeof sections.counts === "object" &&
+    sections.counts !== null
+  )
+}
+
+export interface FlattenedLegacyCourseworks {
+  sections: CourseworkSections
+  /** 名簿に載っていない生徒の点数として破棄した件数 */
+  discardedScoreCount: number
+}
+
+/**
+ * 入れ子ツリーを平坦なセクションへ展開する。
+ *
+ * 点数は旧形式では人（Student）の uuid を指していた。名簿の対応行へ付け替え、
+ * 名簿に載っていない生徒の点数（旧アーカイブに残りうる孤児）は破棄する。
+ */
+export function flattenLegacyCourseworks(
+  legacyCourseworks: LegacyArchiveCourseworkRef[]
+): FlattenedLegacyCourseworks {
+  const sections: CourseworkSections = {
+    courseworks: [],
+    courseworkClassrooms: [],
+    courseworkTags: [],
+    courseworkStudents: [],
+    courseworkItems: [],
+    courseworkLetterScales: [],
+    courseworkScores: [],
+  }
+  let discardedScoreCount = 0
+
+  for (const coursework of legacyCourseworks) {
+    sections.courseworks.push({
+      id: coursework.id,
+      name: coursework.name,
+      description: coursework.description,
+      date: coursework.date,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+
+    for (const classroomRef of coursework.classrooms) {
+      sections.courseworkClassrooms.push({
+        id: joinIds(coursework.id, classroomRef.classroomId),
+        courseworkId: coursework.id,
+        classroomId: classroomRef.classroomId,
+        order: classroomRef.order,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    }
+
+    for (const tagRef of coursework.tags) {
+      sections.courseworkTags.push({
+        id: joinIds(coursework.id, tagRef.tagId),
+        courseworkId: coursework.id,
+        tagId: tagRef.tagId,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    }
+
+    /** 旧形式の点数が指していた studentId → 展開後の対象者 id */
+    const courseworkStudentIdByStudent = new Map<string, string>()
+    for (const studentRef of coursework.students) {
+      const courseworkStudentId = joinIds(coursework.id, studentRef.studentId)
+      courseworkStudentIdByStudent.set(
+        studentRef.studentId,
+        courseworkStudentId
+      )
+      sections.courseworkStudents.push({
+        id: courseworkStudentId,
+        courseworkId: coursework.id,
+        studentId: studentRef.studentId,
+        customOrder: studentRef.customOrder,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    }
+
+    for (const item of coursework.items) {
+      sections.courseworkItems.push({
+        id: item.id,
+        courseworkId: coursework.id,
+        name: item.name,
+        order: item.order,
+        maxScore: String(item.maxScore),
+        inputMode: item.inputMode || "numeric",
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+      discardedScoreCount += flattenLegacyItemChildren(
+        sections,
+        item,
+        courseworkStudentIdByStudent
+      )
+    }
+  }
+
+  return { sections, discardedScoreCount }
+}
+
+/** 評価項目の変換表・点数を展開し、破棄した点数の件数を返す */
+function flattenLegacyItemChildren(
+  sections: CourseworkSections,
+  item: LegacyArchiveCourseworkItemRef,
+  courseworkStudentIdByStudent: Map<string, string>
+): number {
+  for (const letterScale of item.letterScales) {
+    sections.courseworkLetterScales.push({
+      id: joinIds(item.id, letterScale.label),
+      courseworkItemId: item.id,
+      label: letterScale.label,
+      score: String(letterScale.score),
+      order: letterScale.order,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+  }
+
+  let discarded = 0
+  for (const score of item.scores) {
+    const courseworkStudentId = courseworkStudentIdByStudent.get(
+      score.studentId
+    )
+    if (!courseworkStudentId) {
+      discarded++
+      continue
+    }
+    sections.courseworkScores.push({
+      id: joinIds(item.id, courseworkStudentId),
+      courseworkItemId: item.id,
+      courseworkStudentId,
+      score: score.score === null ? null : String(score.score),
+      letterValue: score.letterValue,
+      adjustment: score.adjustment === null ? null : String(score.adjustment),
+      adjustmentReason: score.adjustmentReason,
+      comment: score.comment,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: score.updatedAt,
+    })
+  }
+  return discarded
+}

--- a/electron-src/lib/import/coursework-transformers/types.ts
+++ b/electron-src/lib/import/coursework-transformers/types.ts
@@ -1,0 +1,64 @@
+/**
+ * coursework-archive のバージョン変換の型
+ *
+ * バージョンごとに「アーカイブ全体の形」を宣言し、変換器を V<FROM> → V<TO> として
+ * 型付けする。旧バージョンの形の知識はこのディレクトリの中だけに閉じ込め、
+ * src/types 側は現行の形（CourseworkArchiveData）だけを持つ。
+ *
+ * 版が変わらないセクション（外部参照＝生徒・学級・所属・タグ）は共有し、
+ * 実際に変わった部分だけを版ごとに書く。
+ */
+
+import type {
+  CourseworkArchiveData,
+  CourseworkArchiveManifest,
+  CourseworkArchiveVersion,
+  CourseworkExternalSections,
+} from "../../../../src/types/courseworkArchive.types"
+import {
+  isLegacyCourseworkTree,
+  type LegacyArchiveCourseworkRef,
+} from "./legacyShape"
+
+/** v1.0.0 のアーカイブ全体。資料1件を入れ子ツリーへ射影して持っていた */
+export interface CourseworkArchiveDataV1_0_0 extends CourseworkExternalSections {
+  manifest: CourseworkArchiveManifest
+  courseworks: LegacyArchiveCourseworkRef[]
+}
+
+/** v1.1.0 のアーカイブ全体（現行） */
+export type CourseworkArchiveDataV1_1_0 = CourseworkArchiveData
+
+/** 読み込み時点では版が確定していないので、扱いうる版の総和で受ける */
+export type AnyCourseworkArchiveData =
+  CourseworkArchiveDataV1_0_0 | CourseworkArchiveDataV1_1_0
+
+/** どの版の形かを判定する（manifest.version ではなく実データの形で決める） */
+export function isCourseworkArchiveV1_0_0(
+  data: AnyCourseworkArchiveData
+): data is CourseworkArchiveDataV1_0_0 {
+  return isLegacyCourseworkTree(data.courseworks)
+}
+
+export interface CourseworkTransformResult {
+  data: AnyCourseworkArchiveData
+  warnings: string[]
+}
+
+export interface CourseworkVersionTransformer {
+  readonly fromVersion: CourseworkArchiveVersion
+  readonly toVersion: CourseworkArchiveVersion
+  transform(data: AnyCourseworkArchiveData): CourseworkTransformResult
+}
+
+/** チェーン完了後は現行の形であることが保証される */
+export interface CourseworkChainTransformResult {
+  data: CourseworkArchiveDataV1_1_0
+  originalVersion: CourseworkArchiveVersion
+  finalVersion: CourseworkArchiveVersion
+  appliedTransformations: {
+    from: CourseworkArchiveVersion
+    to: CourseworkArchiveVersion
+  }[]
+  warnings: string[]
+}

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -11,6 +11,11 @@ import type {
   GradeArchiveData,
   GradeArchiveManifest,
 } from "../../../../src/types/gradeArchive.types"
+import {
+  isCurrentCollectedCourseworkData,
+  isLegacyCollectedCourseworkData,
+  type LegacyCollectedCourseworkData,
+} from "../coursework-transformers/legacyShape"
 import { normalizeLegacyClassroomKeys } from "../shared/legacyClassroomKeys"
 
 // archiver で作った ZIP を展開するために unzipper を使用
@@ -53,18 +58,25 @@ export async function extractGradeArchive(
       files["boundaries.json"] ?? '{"boundarySets":[]}'
     )
     // 試験外成績資料の埋め込み。
-    //   v1.5.0+: courseworks.json は coursework-archive 形式のオブジェクト（UUID ベース）。
+    //   v1.12.0+: courseworks.json は coursework-archive 形式（テーブルごとの平坦なセクション）。
+    //   v1.5.0〜1.11.0: 同じくオブジェクトだが入れ子・射影形式。変換器が展開する。
     //   v1.4.0 : courseworks.json は名前ベースの ArchiveCoursework[] 配列。
     let courseworks: ArchiveCoursework[] | undefined
     let courseworkArchive: CollectedCourseworkData | undefined
+    let legacyCourseworkArchive: LegacyCollectedCourseworkData | undefined
     if (files["courseworks.json"]) {
       const parsed = normalizeLegacyClassroomKeys(
         JSON.parse(files["courseworks.json"])
       )
+      // 現行の形は「全セクションが揃っていること」を実際に確かめてから名乗らせる。
+      // 中身で新旧を見分けようとすると、資料を1件も参照していない成績（内包資料が
+      // 空で書き出される。旧アーカイブの大多数がこれ）を判別できない。
       if (Array.isArray(parsed)) {
         courseworks = parsed
-      } else if (parsed && typeof parsed === "object") {
+      } else if (isCurrentCollectedCourseworkData(parsed)) {
         courseworkArchive = parsed
+      } else if (isLegacyCollectedCourseworkData(parsed)) {
+        legacyCourseworkArchive = parsed
       }
     }
     // 旧 v1.3.0 以前: manual-scores.json があれば後方互換用に読む
@@ -82,6 +94,7 @@ export async function extractGradeArchive(
         boundariesData,
         courseworks,
         courseworkArchive,
+        legacyCourseworkArchive,
         manualScoresData,
       },
     }

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -94,8 +94,12 @@ export async function previewGradeArchiveImport(
     (coursework) => ({
       id: coursework.id,
       name: coursework.name,
-      itemCount: coursework.items.length,
-      studentCount: coursework.students.length,
+      itemCount: (courseworkArchive?.courseworkItems ?? []).filter(
+        (item) => item.courseworkId === coursework.id
+      ).length,
+      studentCount: (courseworkArchive?.courseworkStudents ?? []).filter(
+        (courseworkStudent) => courseworkStudent.courseworkId === coursework.id
+      ).length,
     })
   )
 
@@ -329,11 +333,17 @@ export async function importGradeArchive(
           for (const [archiveItemId, actualId] of cwResult.itemIdMap) {
             itemIdToActual.set(archiveItemId, actualId)
           }
-          for (const coursework of data.courseworkArchive.courseworks) {
-            for (const item of coursework.items) {
-              const actual = cwResult.itemIdMap.get(item.id)
-              if (actual)
-                itemNameToActual.set(`${coursework.name}:${item.name}`, actual)
+          const courseworkNameById = new Map(
+            data.courseworkArchive.courseworks.map((coursework) => [
+              coursework.id,
+              coursework.name,
+            ])
+          )
+          for (const item of data.courseworkArchive.courseworkItems) {
+            const actual = cwResult.itemIdMap.get(item.id)
+            const courseworkName = courseworkNameById.get(item.courseworkId)
+            if (actual && courseworkName) {
+              itemNameToActual.set(`${courseworkName}:${item.name}`, actual)
             }
           }
         }

--- a/electron-src/lib/import/grade-transformers/V1_11_0_to_V1_12_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_11_0_to_V1_12_0.ts
@@ -1,0 +1,67 @@
+/**
+ * grade-archive 1.11.0 → 1.12.0
+ *
+ * 内包している試験外成績資料を、入れ子・射影形式からテーブルごとの平坦なセクションへ
+ * 展開する（coursework-archive 1.0.0 → 1.1.0 と同じ変換）。併せて点数の参照が
+ * 人（Student）から資料の対象者（CourseworkStudent）へ移り、名簿に載っていない
+ * 生徒の点数は破棄される（#962 Phase B）。
+ *
+ * 展開の実体は coursework-transformers/legacyShape が持つ（二重実装の回避）。
+ */
+
+import type {
+  GradeArchiveData,
+  GradeTransformResult,
+  GradeVersionTransformer,
+} from "../../../../src/types/gradeArchive.types"
+import {
+  flattenLegacyCourseworks,
+  isLegacyCollectedCourseworkData,
+} from "../coursework-transformers/legacyShape"
+
+export class V1_11_0_to_V1_12_0_Transformer implements GradeVersionTransformer {
+  readonly fromVersion = "1.11.0" as const
+  readonly toVersion = "1.12.0" as const
+
+  transform(data: GradeArchiveData): GradeTransformResult {
+    const legacy = data.legacyCourseworkArchive
+    if (!isLegacyCollectedCourseworkData(legacy)) {
+      return { data, warnings: [] }
+    }
+
+    const { sections, discardedScoreCount } = flattenLegacyCourseworks(
+      legacy.courseworks
+    )
+
+    const warnings = [
+      "1.11.0→1.12.0: 内包する試験外成績資料をテーブルごとの形式へ変換しました（作成・更新時刻は旧形式に無いため復元できません）",
+    ]
+    if (discardedScoreCount > 0) {
+      warnings.push(
+        `1.11.0→1.12.0: 対象生徒として登録されていない生徒の点数 ${discardedScoreCount} 件を破棄しました`
+      )
+    }
+
+    return {
+      data: {
+        ...data,
+        legacyCourseworkArchive: undefined,
+        courseworkArchive: {
+          ...sections,
+          studentsData: legacy.studentsData,
+          classesData: legacy.classesData,
+          membershipsData: legacy.membershipsData,
+          tagsData: legacy.tagsData,
+          counts: {
+            courseworks: sections.courseworks.length,
+            items: sections.courseworkItems.length,
+            scores: sections.courseworkScores.length,
+            students: legacy.studentsData.length,
+            classrooms: legacy.classesData.length,
+          },
+        },
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/grade-transformers/V1_4_0_to_V1_5_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_4_0_to_V1_5_0.ts
@@ -11,17 +11,19 @@
  */
 
 import type {
-  ArchiveCourseworkRef,
   ArchiveCwClass,
   ArchiveCwStudent,
   ArchiveCwTag,
-  CollectedCourseworkData,
 } from "../../../../src/types/courseworkArchive.types"
 import type {
   GradeArchiveData,
   GradeTransformResult,
   GradeVersionTransformer,
 } from "../../../../src/types/gradeArchive.types"
+import type {
+  LegacyArchiveCourseworkRef,
+  LegacyCollectedCourseworkData,
+} from "../coursework-transformers/legacyShape"
 
 /** LWW で既存を上書きしないための過去日時 */
 const EPOCH = new Date(0).toISOString()
@@ -82,38 +84,42 @@ export class V1_4_0_to_V1_5_0_Transformer implements GradeVersionTransformer {
       color: null,
     }))
 
-    const courseworks: ArchiveCourseworkRef[] = legacy.map((coursework) => ({
-      id: coursework.id,
-      name: coursework.name,
-      description: coursework.description,
-      date: coursework.date,
-      classrooms: coursework.classrooms.map((classroom) => ({
-        classroomId: synthClassroomId(classroom.classroomName),
-        order: classroom.order,
-      })),
-      tags: coursework.tags.map((tag) => ({ tagId: synthTagId(tag.tagName) })),
-      students: coursework.students.map((student) => ({
-        studentId: synthStudentId(student.studentNumber),
-        customOrder: student.customOrder,
-      })),
-      items: coursework.items.map((item) => ({
-        id: item.id,
-        name: item.name,
-        order: item.order,
-        maxScore: item.maxScore,
-        inputMode: item.inputMode,
-        letterScales: item.letterScales,
-        scores: item.scores.map((score) => ({
-          studentId: synthStudentId(score.studentNumber),
-          score: score.score,
-          letterValue: score.letterValue,
-          adjustment: score.adjustment,
-          adjustmentReason: score.adjustmentReason,
-          comment: score.comment,
-          updatedAt: EPOCH,
+    const courseworks: LegacyArchiveCourseworkRef[] = legacy.map(
+      (coursework) => ({
+        id: coursework.id,
+        name: coursework.name,
+        description: coursework.description,
+        date: coursework.date,
+        classrooms: coursework.classrooms.map((classroom) => ({
+          classroomId: synthClassroomId(classroom.classroomName),
+          order: classroom.order,
         })),
-      })),
-    }))
+        tags: coursework.tags.map((tag) => ({
+          tagId: synthTagId(tag.tagName),
+        })),
+        students: coursework.students.map((student) => ({
+          studentId: synthStudentId(student.studentNumber),
+          customOrder: student.customOrder,
+        })),
+        items: coursework.items.map((item) => ({
+          id: item.id,
+          name: item.name,
+          order: item.order,
+          maxScore: item.maxScore,
+          inputMode: item.inputMode,
+          letterScales: item.letterScales,
+          scores: item.scores.map((score) => ({
+            studentId: synthStudentId(score.studentNumber),
+            score: score.score,
+            letterValue: score.letterValue,
+            adjustment: score.adjustment,
+            adjustmentReason: score.adjustmentReason,
+            comment: score.comment,
+            updatedAt: EPOCH,
+          })),
+        })),
+      })
+    )
 
     const itemCount = courseworks.reduce(
       (total, coursework) => total + coursework.items.length,
@@ -128,7 +134,8 @@ export class V1_4_0_to_V1_5_0_Transformer implements GradeVersionTransformer {
         ),
       0
     )
-    const courseworkArchive: CollectedCourseworkData = {
+    // 1.5.0 時点の入れ子形式。平坦化は後段の 1.11.0 → 1.12.0 が行う
+    const legacyCourseworkArchive: LegacyCollectedCourseworkData = {
       courseworks,
       studentsData,
       classesData,
@@ -148,7 +155,7 @@ export class V1_4_0_to_V1_5_0_Transformer implements GradeVersionTransformer {
         ...data,
         manifest: { ...data.manifest, version: this.toVersion },
         courseworks: undefined,
-        courseworkArchive,
+        legacyCourseworkArchive,
       },
       warnings: [],
     }

--- a/electron-src/lib/import/grade-transformers/index.ts
+++ b/electron-src/lib/import/grade-transformers/index.ts
@@ -23,13 +23,21 @@ import type {
   GradeChainTransformResult,
 } from "../../../../src/types/gradeArchive.types"
 import { GRADE_CURRENT_VERSION } from "../../../../src/types/gradeArchive.types"
+import { isLegacyCollectedCourseworkData } from "../coursework-transformers/legacyShape"
 import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 import { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
 import { V1_9_0_to_V1_10_0_Transformer } from "./V1_9_0_to_V1_10_0"
 import { V1_10_0_to_V1_11_0_Transformer } from "./V1_10_0_to_V1_11_0"
+import { V1_11_0_to_V1_12_0_Transformer } from "./V1_11_0_to_V1_12_0"
 
 const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
   courseworks: [],
+  courseworkClassrooms: [],
+  courseworkTags: [],
+  courseworkStudents: [],
+  courseworkItems: [],
+  courseworkLetterScales: [],
+  courseworkScores: [],
   studentsData: [],
   classesData: [],
   membershipsData: [],
@@ -41,6 +49,7 @@ const v1_3_0 = new V1_3_0_to_V1_4_0_Transformer()
 const v1_4_0 = new V1_4_0_to_V1_5_0_Transformer()
 const v1_9_0 = new V1_9_0_to_V1_10_0_Transformer()
 const v1_10_0 = new V1_10_0_to_V1_11_0_Transformer()
+const v1_11_0 = new V1_11_0_to_V1_12_0_Transformer()
 
 /**
  * 総合（overall）の名残を持つか。境界セット・手動上書きのどちらかに targetType があるか、
@@ -84,6 +93,11 @@ function detectOriginalVersion(data: GradeArchiveData): GradeArchiveVersion {
   if (hasManualDataSource(data) || data.manualScoresData) return "1.3.0"
   if (hasOverallResidue(data)) return "1.9.0"
   if (hasLegacyConstraintConfig(data)) return "1.10.0"
+  // 内包資料が入れ子形式なら 1.5.0〜1.11.0 のいずれか。この形だけでは区別できないので
+  // 上限の 1.11.0 と報告する（既存の粒度と同じ）
+  if (isLegacyCollectedCourseworkData(data.legacyCourseworkArchive)) {
+    return "1.11.0"
+  }
   return GRADE_CURRENT_VERSION
 }
 
@@ -100,26 +114,24 @@ export function transformGradeToLatest(
   const appliedTransformations: GradeChainTransformResult["appliedTransformations"] =
     []
 
+  const hasCoursework = (candidate: GradeArchiveData) =>
+    Boolean(candidate.courseworkArchive || candidate.legacyCourseworkArchive)
+
   // 1.3.0 → 1.4.0: manual 型の外部成績を名前ベース資料へ
   //   点数の有無に関わらず、manual 型 DataSource が残らないよう変換する。
-  if (!current.courseworkArchive && hasManualDataSource(current)) {
+  if (!hasCoursework(current) && hasManualDataSource(current)) {
     const result = v1_3_0.transform(current)
     current = result.data
     warnings.push(...result.warnings)
     appliedTransformations.push({ from: "1.3.0", to: "1.4.0" })
   }
 
-  // 1.4.0 → 1.5.0: 名前ベース資料を courseworkArchive 形式へ（空配列でも変換して統一）
-  if (!current.courseworkArchive && current.courseworks !== undefined) {
+  // 1.4.0 → 1.5.0: 名前ベース資料を入れ子形式の内包資料へ（空配列でも変換して統一）
+  if (!hasCoursework(current) && current.courseworks !== undefined) {
     const result = v1_4_0.transform(current)
     current = result.data
     warnings.push(...result.warnings)
     appliedTransformations.push({ from: "1.4.0", to: "1.5.0" })
-  }
-
-  // 外部成績を持たない旧アーカイブは空の courseworkArchive を補う
-  if (!current.courseworkArchive) {
-    current = { ...current, courseworkArchive: EMPTY_COURSEWORK_ARCHIVE }
   }
 
   // 1.9.0 → 1.10.0: 総合（overall）の撤去。移し先が無いので破棄し warning で知らせる
@@ -136,6 +148,19 @@ export function transformGradeToLatest(
     current = result.data
     warnings.push(...result.warnings)
     appliedTransformations.push({ from: "1.10.0", to: "1.11.0" })
+  }
+
+  // 1.11.0 → 1.12.0: 内包資料をテーブルごとの平坦なセクションへ展開
+  if (isLegacyCollectedCourseworkData(current.legacyCourseworkArchive)) {
+    const result = v1_11_0.transform(current)
+    current = result.data
+    warnings.push(...result.warnings)
+    appliedTransformations.push({ from: "1.11.0", to: "1.12.0" })
+  }
+
+  // 外部成績を持たない旧アーカイブは空の courseworkArchive を補う
+  if (!current.courseworkArchive) {
+    current = { ...current, courseworkArchive: EMPTY_COURSEWORK_ARCHIVE }
   }
 
   // マニフェストを現行バージョンへ

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -66,7 +66,11 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
       }),
   },
   {
-    // UNIQUE([courseworkId, studentId]) があるため移行先の重複を回避しつつ更新する
+    // UNIQUE([courseworkId, studentId]) があるため移行先の重複を回避しつつ更新する。
+    //
+    // 点数（CourseworkScore）は CourseworkStudent の onDelete:Cascade 子なので、
+    // 重複行をそのまま delete すると点数が道連れになる。移行先に同じ評価項目の点数が
+    // 無いものは先に付け替え、衝突するものだけを（移行先の値を残して）捨てる。
     model: "CourseworkStudent",
     move: async (tx, from, to) => {
       const rows = await tx.courseworkStudent.findMany({
@@ -79,43 +83,34 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
             studentId: to,
           },
         })
-        if (duplicate) {
-          await tx.courseworkStudent.delete({
-            where: { id: courseworkStudent.id },
-          })
-        } else {
+        if (!duplicate) {
           await tx.courseworkStudent.update({
             where: { id: courseworkStudent.id },
             data: { studentId: to },
           })
+          continue
         }
-      }
-    },
-  },
-  {
-    // UNIQUE([courseworkItemId, studentId]) があるため移行先の重複を回避しつつ更新する
-    model: "CourseworkScore",
-    move: async (tx, from, to) => {
-      const rows = await tx.courseworkScore.findMany({
-        where: { studentId: from },
-      })
-      for (const courseworkScore of rows) {
-        const duplicate = await tx.courseworkScore.findFirst({
-          where: {
-            courseworkItemId: courseworkScore.courseworkItemId,
-            studentId: to,
-          },
+
+        const scores = await tx.courseworkScore.findMany({
+          where: { courseworkStudentId: courseworkStudent.id },
         })
-        if (duplicate) {
-          await tx.courseworkScore.delete({
-            where: { id: courseworkScore.id },
+        for (const courseworkScore of scores) {
+          const conflicting = await tx.courseworkScore.findFirst({
+            where: {
+              courseworkItemId: courseworkScore.courseworkItemId,
+              courseworkStudentId: duplicate.id,
+            },
           })
-        } else {
+          if (conflicting) continue // 移行先の点数を残す（衝突分は下の delete で cascade 削除）
           await tx.courseworkScore.update({
             where: { id: courseworkScore.id },
-            data: { studentId: to },
+            data: { courseworkStudentId: duplicate.id },
           })
         }
+
+        await tx.courseworkStudent.delete({
+          where: { id: courseworkStudent.id },
+        })
       }
     },
   },

--- a/electron-src/lib/prisma/compoundAnswer.ts
+++ b/electron-src/lib/prisma/compoundAnswer.ts
@@ -13,6 +13,7 @@ import type {
 import { recordAuditLog } from "./auditLog"
 import { resolveExamScopeByPage } from "./auditScope"
 import prisma from "./client"
+import { assertCompoundAnswersInSameExam } from "./examScopeGuard"
 
 export type CompoundAnswerWithMembers = CompoundAnswer & {
   members: (CompoundAnswerMember & {
@@ -166,6 +167,14 @@ export async function upsertCompoundAnswerScore(data: {
   status: string
   partialScore?: Prisma.Decimal | null
 }): Promise<CompoundAnswerScore> {
+  // 複合回答と受験者が同じ試験のものであること（FK は片方ずつしか見ない）
+  await assertCompoundAnswersInSameExam([
+    {
+      compoundAnswerId: data.compoundAnswerId,
+      examStudentId: data.examStudentId,
+    },
+  ])
+
   const result = await prisma.compoundAnswerScore.upsert({
     where: {
       compoundAnswerId_examStudentId: {

--- a/electron-src/lib/prisma/coursework.ts
+++ b/electron-src/lib/prisma/coursework.ts
@@ -6,6 +6,7 @@
  * courseworkItemId で項目単位に参照される（点数そのものを共有・再利用）。
  */
 
+import type { CourseworkScoreUpsertInput } from "../../../src/types/coursework.types"
 import { recordAuditLog } from "./auditLog"
 import {
   resolveCourseworkScope,
@@ -438,22 +439,26 @@ export async function reorderCourseworkItems(
 // CourseworkScore（点数）
 // =============================================================================
 
-/** 評価項目の全点数（生徒情報付き）を取得 */
+/** 評価項目の全点数（資料の対象者・生徒情報付き）を取得 */
 export async function getCourseworkScoresByItemId(courseworkItemId: string) {
   try {
     const scores = await prisma.courseworkScore.findMany({
       where: { courseworkItemId },
       include: {
-        student: {
-          select: {
-            id: true,
-            studentNumber: true,
-            lastName: true,
-            firstName: true,
+        courseworkStudent: {
+          include: {
+            student: {
+              select: {
+                id: true,
+                studentNumber: true,
+                lastName: true,
+                firstName: true,
+              },
+            },
           },
         },
       },
-      orderBy: { student: { studentNumber: "asc" } },
+      orderBy: { courseworkStudent: { student: { studentNumber: "asc" } } },
     })
     return { success: true, scores: serializePrisma(scores) }
   } catch (error) {
@@ -466,20 +471,66 @@ export async function getCourseworkScoresByItemId(courseworkItemId: string) {
 }
 
 /**
+ * 評価項目と対象者が同じ資料に属していることを確かめる。
+ *
+ * FK は「CourseworkItem が実在すること」「CourseworkStudent が実在すること」しか
+ * 保証せず、両者が同じ Coursework に属することは強制しない。食い違ったまま書けると、
+ * 資料 A の項目に資料 B の名簿の生徒の点数がぶら下がり、A の名簿に居ない生徒の点数が
+ * 成績算出に算入される — #962 で塞いだのと同じ穴が別の入口から開く。
+ */
+async function assertSameCoursework(
+  scores: CourseworkScoreUpsertInput[]
+): Promise<void> {
+  const [items, courseworkStudents] = await Promise.all([
+    prisma.courseworkItem.findMany({
+      where: {
+        id: { in: [...new Set(scores.map((s) => s.courseworkItemId))] },
+      },
+      select: { id: true, courseworkId: true },
+    }),
+    prisma.courseworkStudent.findMany({
+      where: {
+        id: { in: [...new Set(scores.map((s) => s.courseworkStudentId))] },
+      },
+      select: { id: true, courseworkId: true },
+    }),
+  ])
+  const courseworkIdByItem = new Map(
+    items.map((item) => [item.id, item.courseworkId])
+  )
+  const courseworkIdByStudent = new Map(
+    courseworkStudents.map((courseworkStudent) => [
+      courseworkStudent.id,
+      courseworkStudent.courseworkId,
+    ])
+  )
+
+  for (const score of scores) {
+    const itemCourseworkId = courseworkIdByItem.get(score.courseworkItemId)
+    const studentCourseworkId = courseworkIdByStudent.get(
+      score.courseworkStudentId
+    )
+    if (!itemCourseworkId || !studentCourseworkId) {
+      throw new Error("評価項目または対象生徒が見つかりません")
+    }
+    if (itemCourseworkId !== studentCourseworkId) {
+      throw new Error("評価項目と対象生徒が別の試験外成績資料に属しています")
+    }
+  }
+}
+
+/**
  * 点数を一括更新（upsert）。各フィールドは optional（セル単位編集対応）。
+ *
+ * 点数の主語は「その資料の対象者」（CourseworkStudent）であり、人（Student）ではない。
+ * 名簿に載っていない生徒の点数は書けない（FK が拒否する）。
  */
 export async function batchUpsertCourseworkScores(
-  scores: {
-    courseworkItemId: string
-    studentId: string
-    score?: number | null
-    letterValue?: string | null
-    adjustment?: number | null
-    adjustmentReason?: string | null
-    comment?: string | null
-  }[]
+  scores: CourseworkScoreUpsertInput[]
 ) {
   try {
+    if (scores.length > 0) await assertSameCoursework(scores)
+
     await prisma.$transaction(
       scores.map((score) => {
         const fields: {
@@ -499,14 +550,14 @@ export async function batchUpsertCourseworkScores(
 
         return prisma.courseworkScore.upsert({
           where: {
-            courseworkItemId_studentId: {
+            courseworkItemId_courseworkStudentId: {
               courseworkItemId: score.courseworkItemId,
-              studentId: score.studentId,
+              courseworkStudentId: score.courseworkStudentId,
             },
           },
           create: {
             courseworkItemId: score.courseworkItemId,
-            studentId: score.studentId,
+            courseworkStudentId: score.courseworkStudentId,
             ...fields,
           },
           update: fields,
@@ -743,6 +794,7 @@ const courseworkRosterAdapter: RosterAdapter = {
     })
     return rows.map((courseworkClassroom) => courseworkClassroom.classroomId)
   },
+  // 名簿行を消せば点数は cascade で落ちる（CourseworkScore は CourseworkStudent の子）
   removeClassroomAndStudents: async (targetId, classroomId, studentIds) => {
     await prisma.$transaction([
       prisma.courseworkStudent.deleteMany({
@@ -804,7 +856,13 @@ export function updateCourseworkStudentOrders(
   )
 }
 
-/** 生徒を個別に削除 */
+/**
+ * 生徒を個別に削除。
+ *
+ * 点数（CourseworkScore）は CourseworkStudent の onDelete:Cascade 子なので DB が消す。
+ * ここで手書きの DELETE を足してはいけない（消し忘れが孤児になり、資料の画面には
+ * 現れないのに成績算出でだけ算入される、という #962 の穴が再発する）。
+ */
 export async function removeStudentsFromCoursework(
   courseworkId: string,
   studentIds: string[]

--- a/electron-src/lib/prisma/examScopeGuard.ts
+++ b/electron-src/lib/prisma/examScopeGuard.ts
@@ -1,0 +1,162 @@
+/**
+ * 採点行の親と受験者が同じ試験に属することの検査
+ *
+ * 採点層（QuestionScore / ScoreDecision / CompoundAnswerScore / StudentAnswerImage）は
+ * 「採点対象（採点領域・複合回答・ページ）」と「受験者（ExamStudent）」の2つを参照する。
+ * FK が保証するのは**それぞれが実在すること**だけで、両者が同じ Exam に属することは
+ * 強制されない。食い違ったまま書けると、試験 A の設問に試験 B の受験者の採点が
+ * ぶら下がり、A の受験者一覧に居ない生徒の得点が成績算出に算入される
+ * — #962 で塞いだのと同じ穴が別の入口から開く。
+ *
+ * どちらの id も string なので取り違えてもコンパイルは通る。書き込みの入口で
+ * 実際に試験を突き合わせて弾く。
+ *
+ * 注: これはアプリのコードが書く経路の守りであって、NAS 同期がライブラリから
+ * 直接書く行には効かない（同期は行単位で運ぶため、食い違ったペアを新たに作ることは
+ * 無いが、参照先が消えた行は残りうる）。
+ */
+
+import prisma from "./client"
+import type { Tx } from "./transactionClient"
+
+type PrismaLike = typeof prisma | Tx
+
+/** 検査に失敗したときのエラー。呼び出し側は success:false へ倒す */
+export class ExamScopeMismatchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "ExamScopeMismatchError"
+  }
+}
+
+/** 受験者 id → その試験の id */
+async function resolveExamIdByExamStudent(
+  client: PrismaLike,
+  examStudentIds: string[]
+): Promise<Map<string, string>> {
+  const rows = await client.examStudent.findMany({
+    where: { id: { in: examStudentIds } },
+    select: { id: true, examId: true },
+  })
+  return new Map(
+    rows.map((examStudent) => [examStudent.id, examStudent.examId])
+  )
+}
+
+/**
+ * 「採点対象 id → 試験 id」と「受験者 id → 試験 id」を突き合わせる共通処理。
+ * 解決できない id があればその時点でエラーにする（存在しない親を指す行を作らせない）。
+ */
+function assertPairs(
+  pairs: { targetId: string; examStudentId: string }[],
+  examIdByTarget: Map<string, string>,
+  examIdByExamStudent: Map<string, string>,
+  targetLabel: string
+): void {
+  for (const pair of pairs) {
+    const targetExamId = examIdByTarget.get(pair.targetId)
+    const examStudentExamId = examIdByExamStudent.get(pair.examStudentId)
+    if (!targetExamId || !examStudentExamId) {
+      throw new ExamScopeMismatchError(
+        `${targetLabel}または受験者が見つかりません`
+      )
+    }
+    if (targetExamId !== examStudentExamId) {
+      throw new ExamScopeMismatchError(
+        `${targetLabel}と受験者が別の試験に属しています`
+      )
+    }
+  }
+}
+
+/** 採点領域（CropRegion）と受験者が同じ試験のものか検査する */
+export async function assertCropRegionsInSameExam(
+  pairs: { cropRegionId: string; examStudentId: string }[],
+  client: PrismaLike = prisma
+): Promise<void> {
+  if (pairs.length === 0) return
+  const [cropRegions, examIdByExamStudent] = await Promise.all([
+    client.cropRegion.findMany({
+      where: {
+        id: { in: [...new Set(pairs.map((pair) => pair.cropRegionId))] },
+      },
+      select: { id: true, examPage: { select: { examId: true } } },
+    }),
+    resolveExamIdByExamStudent(client, [
+      ...new Set(pairs.map((pair) => pair.examStudentId)),
+    ]),
+  ])
+  assertPairs(
+    pairs.map((pair) => ({
+      targetId: pair.cropRegionId,
+      examStudentId: pair.examStudentId,
+    })),
+    new Map(
+      cropRegions.map((cropRegion) => [
+        cropRegion.id,
+        cropRegion.examPage.examId,
+      ])
+    ),
+    examIdByExamStudent,
+    "採点領域"
+  )
+}
+
+/** 複合回答（CompoundAnswer）と受験者が同じ試験のものか検査する */
+export async function assertCompoundAnswersInSameExam(
+  pairs: { compoundAnswerId: string; examStudentId: string }[],
+  client: PrismaLike = prisma
+): Promise<void> {
+  if (pairs.length === 0) return
+  const [compoundAnswers, examIdByExamStudent] = await Promise.all([
+    client.compoundAnswer.findMany({
+      where: {
+        id: { in: [...new Set(pairs.map((pair) => pair.compoundAnswerId))] },
+      },
+      select: { id: true, examPage: { select: { examId: true } } },
+    }),
+    resolveExamIdByExamStudent(client, [
+      ...new Set(pairs.map((pair) => pair.examStudentId)),
+    ]),
+  ])
+  assertPairs(
+    pairs.map((pair) => ({
+      targetId: pair.compoundAnswerId,
+      examStudentId: pair.examStudentId,
+    })),
+    new Map(
+      compoundAnswers.map((compoundAnswer) => [
+        compoundAnswer.id,
+        compoundAnswer.examPage.examId,
+      ])
+    ),
+    examIdByExamStudent,
+    "複合回答"
+  )
+}
+
+/** 答案ページ（ExamPage）と受験者が同じ試験のものか検査する */
+export async function assertExamPagesInSameExam(
+  pairs: { examPageId: string; examStudentId: string }[],
+  client: PrismaLike = prisma
+): Promise<void> {
+  if (pairs.length === 0) return
+  const [examPages, examIdByExamStudent] = await Promise.all([
+    client.examPage.findMany({
+      where: { id: { in: [...new Set(pairs.map((pair) => pair.examPageId))] } },
+      select: { id: true, examId: true },
+    }),
+    resolveExamIdByExamStudent(client, [
+      ...new Set(pairs.map((pair) => pair.examStudentId)),
+    ]),
+  ])
+  assertPairs(
+    pairs.map((pair) => ({
+      targetId: pair.examPageId,
+      examStudentId: pair.examStudentId,
+    })),
+    new Map(examPages.map((examPage) => [examPage.id, examPage.examId])),
+    examIdByExamStudent,
+    "答案ページ"
+  )
+}

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -6,6 +6,7 @@ import {
   resolveExamStudentLabel,
 } from "./auditScope"
 import prisma from "./client"
+import { assertCropRegionsInSameExam } from "./examScopeGuard"
 
 /**
  * 採点対象が既に無いことを表す機械可読な理由コード。
@@ -269,6 +270,14 @@ export const getQuestionScoreById = async (id: string) => {
  */
 export const createQuestionScore = async (data: CreateQuestionScoreData) => {
   try {
+    // 採点領域と受験者が同じ試験のものであること（FK は片方ずつしか見ない）
+    await assertCropRegionsInSameExam([
+      {
+        cropRegionId: data.cropRegionId,
+        examStudentId: data.examStudentId,
+      },
+    ])
+
     // 同じ生徒・設問・採点者の組み合わせで既存レコードをチェック
     const existing = await prisma.questionScore.findFirst({
       where: {
@@ -667,6 +676,9 @@ export async function batchUpdateQuestionScores(
 ): Promise<{ success: boolean; updatedCount: number; error?: string }> {
   try {
     let updatedCount = 0
+
+    // 採点領域と受験者が同じ試験のものであること（FK は片方ずつしか見ない）
+    await assertCropRegionsInSameExam(entries)
 
     // トランザクション内で一括処理
     await prisma.$transaction(async (tx) => {

--- a/electron-src/lib/prisma/scoreDecision.ts
+++ b/electron-src/lib/prisma/scoreDecision.ts
@@ -6,6 +6,7 @@ import {
   resolveExamStudentLabel,
 } from "./auditScope"
 import prisma from "./client"
+import { assertCropRegionsInSameExam } from "./examScopeGuard"
 
 /** verdict コードを日本語表示に変換（監査ログ差分用） */
 const verdictLabel = (verdict: string | null | undefined): string => {
@@ -102,6 +103,14 @@ export const upsertScoreDecision = async (data: UpsertScoreDecisionData) => {
       data.score !== null && data.score !== undefined
         ? new Decimal(data.score)
         : null
+
+    // 採点領域と受験者が同じ試験のものであること（FK は片方ずつしか見ない）
+    await assertCropRegionsInSameExam([
+      {
+        cropRegionId: data.cropRegionId,
+        examStudentId: data.examStudentId,
+      },
+    ])
 
     // 差分記録用に変更前の確定を取得
     const previous = await prisma.scoreDecision.findUnique({

--- a/electron-src/lib/prisma/scoringInitializer.ts
+++ b/electron-src/lib/prisma/scoringInitializer.ts
@@ -3,6 +3,9 @@ import prisma from "./client"
 /**
  * 試験の採点レコードを初期化する
  * 全ての答案と採点領域の組み合わせに対して初期の採点レコードを作成
+ *
+ * 採点領域も受験者も同じ examId から引くため、両者が別の試験のものになることは
+ * 構造的に起こらない（examScopeGuard による検査を足す必要が無い唯一の書き込み経路）。
  */
 export const initializeScoringRecords = async (examId: string) => {
   try {

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -112,6 +112,29 @@ export async function uploadStudentAnswers(
       }
     }
 
+    // 受験者も当該試験のものであること。ページと受験者は別々の FK なので、
+    // 片方だけ検証しても「試験Aのページに試験Bの受験者の答案」が書けてしまう。
+    const requestedExamStudentIds = [
+      ...new Set(
+        filesData
+          .map((fileData) => fileData.examStudentId)
+          .filter((examStudentId): examStudentId is string => !!examStudentId)
+      ),
+    ]
+    if (requestedExamStudentIds.length > 0) {
+      const validExamStudents = await prisma.examStudent.findMany({
+        where: { examId, id: { in: requestedExamStudentIds } },
+        select: { id: true },
+      })
+      if (validExamStudents.length !== requestedExamStudentIds.length) {
+        return {
+          success: false,
+          error:
+            "配置先の受験者が見つかりません（他の教員が受験生徒を変更した可能性があります）。再読み込みしてください。",
+        }
+      }
+    }
+
     const examDir = getAnswerSheetsDirectory(examId)
 
     // 試験ディレクトリを作成

--- a/electron-src/lib/prisma/studentAnswer/placementApply.ts
+++ b/electron-src/lib/prisma/studentAnswer/placementApply.ts
@@ -125,6 +125,21 @@ export async function applyStudentAnswerPlacements(
             )
           }
 
+          // 移動先の受験者も同一試験のものであること。ページと受験者は別々の FK なので、
+          // ページだけ検証しても「試験Aのページに試験Bの受験者の答案」が作れてしまう。
+          const targetExamStudent = await tx.examStudent.findFirst({
+            where: {
+              id: finalExamStudentId,
+              examId: current.examPage.examId,
+            },
+            select: { id: true },
+          })
+          if (!targetExamStudent) {
+            throw new Error(
+              `移動先の受験者が見つかりません: ${finalExamStudentId}`
+            )
+          }
+
           const pageChanged = current.examPageId !== targetPage.id
           if (move.scorePolicy === "carry" && pageChanged) {
             throw new Error(

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -25,7 +25,7 @@ import {
 import { findExamStudentScores } from "./examScoreCalculator"
 import type { DataSourceInfo, ExamDataCache } from "./gradeCalculatorTypes"
 import { determineGradeLabel } from "./gradeLabel"
-import { getRawScore } from "./rawScoreCalculator"
+import { findCourseworkStudentScore, getRawScore } from "./rawScoreCalculator"
 import { resolveEffectiveScores } from "./scoreResolution"
 
 /**
@@ -50,9 +50,11 @@ async function buildGradeCalcContext(gradeId: string) {
               subtotal: true,
               cropRegion: true,
               estimationSources: { orderBy: { order: "asc" } },
+              // 点数は資料の対象者（CourseworkStudent）経由でのみ引ける。
+              // 名簿から外された生徒の点数は存在しえないため算出に混ざらない（#962）。
               courseworkItem: {
                 include: {
-                  scores: true,
+                  scores: { include: { courseworkStudent: true } },
                   letterScales: { orderBy: { order: "asc" } },
                 },
               },
@@ -60,7 +62,7 @@ async function buildGradeCalcContext(gradeId: string) {
                 include: {
                   items: {
                     include: {
-                      scores: true,
+                      scores: { include: { courseworkStudent: true } },
                       letterScales: { orderBy: { order: "asc" } },
                     },
                   },
@@ -568,9 +570,10 @@ export async function calculateGrades(
 
           // coursework型: 入力された評価記号・加減点・コメントを結果に添付
           const courseworkScore =
-            dataSource.type === "coursework"
-              ? dataSource.courseworkItem?.scores.find(
-                  (score) => score.studentId === student.id
+            dataSource.type === "coursework" && dataSource.courseworkItem
+              ? findCourseworkStudentScore(
+                  student.id,
+                  dataSource.courseworkItem
                 )
               : undefined
 

--- a/electron-src/lib/shared/calculations/rawScoreCalculator.ts
+++ b/electron-src/lib/shared/calculations/rawScoreCalculator.ts
@@ -14,17 +14,31 @@ import { calculateSubtotalScoreBySubtotalId } from "./subtotalCalculator"
 
 /**
  * coursework / coursework_total で参照する評価項目の構造（Prisma include のサブセット）
+ *
+ * 点数は資料の対象者（CourseworkStudent）にぶら下がるため、生徒から点数へ到達する経路は
+ * 必ず対象者を1回通る。名簿から外された生徒は点数を引けず、データなし（null）になる。
  */
 interface CourseworkItemForRawScore {
   maxScore: unknown
   inputMode: string
   scores: {
-    studentId: string
+    courseworkStudent: { studentId: string }
     score: unknown
     letterValue?: string | null
     adjustment?: unknown
   }[]
   letterScales: { label: string; score: unknown }[]
+}
+
+/**
+ * 生徒をその資料の対象者の点数へ解決する。名簿に載っていなければ undefined。
+ */
+export function findCourseworkStudentScore<
+  T extends { courseworkStudent: { studentId: string } },
+>(studentId: string, item: { scores: T[] }): T | undefined {
+  return item.scores.find(
+    (score) => score.courseworkStudent.studentId === studentId
+  )
 }
 
 /**
@@ -122,9 +136,7 @@ function getCourseworkRawScore(
   studentId: string,
   item: CourseworkItemForRawScore
 ): number | null {
-  const courseworkScore = item.scores.find(
-    (score) => score.studentId === studentId
-  )
+  const courseworkScore = findCourseworkStudentScore(studentId, item)
   if (!courseworkScore) return null
 
   // 基準スコア（変換前・加減点前）を決定

--- a/electron-src/preload-apis/courseworkApi.ts
+++ b/electron-src/preload-apis/courseworkApi.ts
@@ -1,5 +1,7 @@
 import { ipcRenderer } from "electron"
 
+import type { CourseworkScoreUpsertInput } from "../../src/types/coursework.types"
+
 /** 試験外成績資料（Coursework）の IPC API（資料・評価項目・点数・名簿・タグ） */
 export function createCourseworkApi() {
   return {
@@ -48,17 +50,8 @@ export function createCourseworkApi() {
       // 点数
       getScores: (courseworkItemId: string) =>
         ipcRenderer.invoke("coursework:getScores", courseworkItemId),
-      batchUpsertScores: (
-        scores: {
-          courseworkItemId: string
-          studentId: string
-          score?: number | null
-          letterValue?: string | null
-          adjustment?: number | null
-          adjustmentReason?: string | null
-          comment?: string | null
-        }[]
-      ) => ipcRenderer.invoke("coursework:batchUpsertScores", scores),
+      batchUpsertScores: (scores: CourseworkScoreUpsertInput[]) =>
+        ipcRenderer.invoke("coursework:batchUpsertScores", scores),
 
       // 名簿
       getStudents: (courseworkId: string) =>

--- a/prisma/migrations/20260729000000_rewire_coursework_score_to_coursework_student/migration.sql
+++ b/prisma/migrations/20260729000000_rewire_coursework_score_to_coursework_student/migration.sql
@@ -1,0 +1,71 @@
+-- 試験外成績資料の点数（CourseworkScore）を Student 直結から
+-- CourseworkStudent（資料の対象者）経由へ配線し直す。
+--
+-- これまで CourseworkScore は studentId で Student を直接参照していた。
+-- CourseworkStudent を参照する子テーブルが1つも無かったため「資料から生徒を外す」操作
+-- （removeStudentsFromCoursework / 学級ごとの削除）では DB の cascade が働かず、
+-- 名簿から消えた生徒の点数がそのまま残り続けていた。
+-- 残った点数は資料の画面（すべて CourseworkStudent 起点）には現れないのに、
+-- 成績算出（rawScoreCalculator は CourseworkStudent を経由していなかった）でだけ
+-- 素点として算入されていた。ExamStudent 系（20260728000000）と同型の穴である。
+--
+-- バックフィルは CourseworkStudent との INNER JOIN で行うため、孤児は自然に落ちる。
+-- 破棄は削除確認ダイアログが以前から約束していた挙動であり、仕様変更ではなく仕様への適合。
+-- 破棄件数は AuditLog に記録する（起動時のモーダルは data フォルダの手動コピー運用では
+-- 最初にそのコピーを開いた人にしか出ず、周知手段として機能しないため）。
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+-- ── 1. 新テーブルの作成とバックフィル ───────────────────────────
+-- CourseworkItem.courseworkId 経由で CourseworkStudent に到達する
+CREATE TABLE "new_CourseworkScore" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "courseworkItemId" TEXT NOT NULL,
+    "courseworkStudentId" TEXT NOT NULL,
+    "score" DECIMAL,
+    "letterValue" TEXT,
+    "adjustment" DECIMAL DEFAULT 0,
+    "adjustmentReason" TEXT,
+    "comment" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CourseworkScore_courseworkItemId_fkey" FOREIGN KEY ("courseworkItemId") REFERENCES "CourseworkItem" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "CourseworkScore_courseworkStudentId_fkey" FOREIGN KEY ("courseworkStudentId") REFERENCES "CourseworkStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_CourseworkScore" ("id", "courseworkItemId", "courseworkStudentId", "score", "letterValue", "adjustment", "adjustmentReason", "comment", "createdAt", "updatedAt")
+SELECT cs."id", cs."courseworkItemId", cst."id", cs."score", cs."letterValue", cs."adjustment", cs."adjustmentReason", cs."comment", cs."createdAt", cs."updatedAt"
+FROM "CourseworkScore" cs
+JOIN "CourseworkItem" ci ON ci."id" = cs."courseworkItemId"
+JOIN "CourseworkStudent" cst ON cst."courseworkId" = ci."courseworkId" AND cst."studentId" = cs."studentId";
+
+-- ── 2. 破棄した孤児の件数を監査ログへ記録（1件以上あるときだけ） ──
+INSERT INTO "AuditLog" ("id", "createdAt", "updatedAt", "userId", "action", "category", "scopeId", "scopeLabel", "entityType", "entityId", "summary", "metadata")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (abs(random()) % 4) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    NULL,
+    'system.migration.cleanup_orphaned_scores',
+    'system',
+    NULL,
+    NULL,
+    'System',
+    '20260729000000_rewire_coursework_score_to_coursework_student',
+    '試験外成績資料の対象者として登録されていない生徒の点数 ' ||
+        ((SELECT COUNT(*) FROM "CourseworkScore") - (SELECT COUNT(*) FROM "new_CourseworkScore")) ||
+        ' 件を、データ移行時に破棄しました。該当する資料を参照している成績では算出の結果が変わります。',
+    json_object(
+        'courseworkScore', (SELECT COUNT(*) FROM "CourseworkScore") - (SELECT COUNT(*) FROM "new_CourseworkScore")
+    )
+WHERE ((SELECT COUNT(*) FROM "CourseworkScore") - (SELECT COUNT(*) FROM "new_CourseworkScore")) > 0;
+
+-- ── 3. 差し替えとインデックス再作成 ──────────────────────────────
+DROP TABLE "CourseworkScore";
+ALTER TABLE "new_CourseworkScore" RENAME TO "CourseworkScore";
+CREATE UNIQUE INDEX "CourseworkScore_courseworkItemId_courseworkStudentId_key" ON "CourseworkScore"("courseworkItemId", "courseworkStudentId");
+CREATE INDEX "CourseworkScore_courseworkItemId_idx" ON "CourseworkScore"("courseworkItemId");
+CREATE INDEX "CourseworkScore_courseworkStudentId_idx" ON "CourseworkScore"("courseworkStudentId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,7 +62,6 @@ model Student {
   gradeFrozenScores   GradeFrozenScore[]
   gradeItemExclusions GradeItemExclusion[]
   courseworkStudents  CourseworkStudent[]
-  courseworkScores    CourseworkScore[]
 }
 
 model StudentClassroomMembership {
@@ -1073,8 +1072,9 @@ model CourseworkStudent {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  coursework Coursework @relation(fields: [courseworkId], references: [id], onDelete: Cascade)
-  student    Student    @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  coursework Coursework        @relation(fields: [courseworkId], references: [id], onDelete: Cascade)
+  student    Student           @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  scores     CourseworkScore[]
 
   @@unique([courseworkId, studentId])
   @@index([courseworkId])
@@ -1117,25 +1117,25 @@ model CourseworkItem {
   @@index([courseworkId])
 }
 
-/// 生徒×評価項目の点数（加減点・コメント含む）
+/// 資料の対象者×評価項目の点数（加減点・コメント含む）
 model CourseworkScore {
-  id               String   @id @default(uuid())
-  courseworkItemId String
-  studentId        String
-  score            Decimal?
-  letterValue      String? // 文字モード時の評価記号（"A"/"B"/"C" 等）
-  adjustment       Decimal? @default(0) // 加点・減点（期限超過等）
-  adjustmentReason String? // 加減点の理由
-  comment          String? // 成績通知書に表示するコメント
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  id                  String   @id @default(uuid())
+  courseworkItemId    String
+  courseworkStudentId String
+  score               Decimal?
+  letterValue         String? // 文字モード時の評価記号（"A"/"B"/"C" 等）
+  adjustment          Decimal? @default(0) // 加点・減点（期限超過等）
+  adjustmentReason    String? // 加減点の理由
+  comment             String? // 成績通知書に表示するコメント
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
-  item    CourseworkItem @relation(fields: [courseworkItemId], references: [id], onDelete: Cascade)
-  student Student        @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  item              CourseworkItem    @relation(fields: [courseworkItemId], references: [id], onDelete: Cascade)
+  courseworkStudent CourseworkStudent @relation(fields: [courseworkStudentId], references: [id], onDelete: Cascade)
 
-  @@unique([courseworkItemId, studentId])
+  @@unique([courseworkItemId, courseworkStudentId])
   @@index([courseworkItemId])
-  @@index([studentId])
+  @@index([courseworkStudentId])
 }
 
 /// 文字評価→点数の変換表（評価項目単位。例: A=100, B=80, C=60）

--- a/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
+++ b/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
@@ -18,7 +18,7 @@ interface CourseworkScoresContainerProps {
 }
 
 interface ScoreRow {
-  _studentId: string
+  _courseworkStudentId: string
   attendanceNumber: string
   className: string
   studentName: string
@@ -49,7 +49,7 @@ export function CourseworkScoresContainer({
   const tableData = useMemo(() => {
     const data = studentRows.map((row): ScoreRow => {
       const tableRow: ScoreRow = {
-        _studentId: row.studentId,
+        _courseworkStudentId: row.courseworkStudentId,
         attendanceNumber:
           row.attendanceNumber != null ? String(row.attendanceNumber) : "-",
         className: row.className ?? "-",
@@ -184,16 +184,20 @@ export function CourseworkScoresContainer({
       const prev = prevDataRef.current
       const changes: {
         courseworkItemId: string
-        studentId: string
+        courseworkStudentId: string
         patch: CourseworkCellPatch
       }[] = []
 
       const pushPatch = (
         item: CourseworkItemWithLetterScales,
-        studentId: string,
+        courseworkStudentId: string,
         patch: CourseworkCellPatch
       ) => {
-        changes.push({ courseworkItemId: item.id, studentId, patch })
+        changes.push({
+          courseworkItemId: item.id,
+          courseworkStudentId,
+          patch,
+        })
       }
 
       for (let i = 0; i < newData.length; i++) {
@@ -201,7 +205,7 @@ export function CourseworkScoresContainer({
         const oldRow = prev[i]
         if (!oldRow || !newRow) continue
 
-        const studentId = newRow._studentId
+        const courseworkStudentId = newRow._courseworkStudentId
         for (const item of items) {
           const validLabels = new Set(
             item.letterScales.map((letterScale) => letterScale.label)
@@ -213,14 +217,14 @@ export function CourseworkScoresContainer({
             const trimmed = (newRow[valueColumnId] ?? "").trim()
             if (item.inputMode === "letter") {
               if (trimmed === "") {
-                pushPatch(item, studentId, { letterValue: null })
+                pushPatch(item, courseworkStudentId, { letterValue: null })
               } else if (validLabels.has(trimmed)) {
-                pushPatch(item, studentId, { letterValue: trimmed })
+                pushPatch(item, courseworkStudentId, { letterValue: trimmed })
               }
               // 未定義の評価記号は無視
             } else {
               if (trimmed === "") {
-                pushPatch(item, studentId, { score: null })
+                pushPatch(item, courseworkStudentId, { score: null })
               } else {
                 const parsedValue = Number(trimmed)
                 if (
@@ -228,7 +232,7 @@ export function CourseworkScoresContainer({
                   parsedValue >= 0 &&
                   parsedValue <= item.maxScore
                 ) {
-                  pushPatch(item, studentId, { score: parsedValue })
+                  pushPatch(item, courseworkStudentId, { score: parsedValue })
                 }
                 // 範囲外・無効値は無視
               }
@@ -240,11 +244,13 @@ export function CourseworkScoresContainer({
           if (newRow[adjustmentColumnId] !== oldRow[adjustmentColumnId]) {
             const trimmed = (newRow[adjustmentColumnId] ?? "").trim()
             if (trimmed === "") {
-              pushPatch(item, studentId, { adjustment: null })
+              pushPatch(item, courseworkStudentId, { adjustment: null })
             } else {
               const parsedValue = Number(trimmed)
               if (!isNaN(parsedValue) && isFinite(parsedValue)) {
-                pushPatch(item, studentId, { adjustment: parsedValue })
+                pushPatch(item, courseworkStudentId, {
+                  adjustment: parsedValue,
+                })
               }
               // 無効値は無視
             }
@@ -254,7 +260,7 @@ export function CourseworkScoresContainer({
           const reasonColumnId = reasonColId(item.id)
           if (newRow[reasonColumnId] !== oldRow[reasonColumnId]) {
             const reasonValue = (newRow[reasonColumnId] ?? "").trim()
-            pushPatch(item, studentId, {
+            pushPatch(item, courseworkStudentId, {
               adjustmentReason: reasonValue === "" ? null : reasonValue,
             })
           }
@@ -263,7 +269,7 @@ export function CourseworkScoresContainer({
           const commentColumnId = commentColId(item.id)
           if (newRow[commentColumnId] !== oldRow[commentColumnId]) {
             const commentValue = (newRow[commentColumnId] ?? "").trim()
-            pushPatch(item, studentId, {
+            pushPatch(item, courseworkStudentId, {
               comment: commentValue === "" ? null : commentValue,
             })
           }

--- a/src/components/coursework/04-scores/hooks/useCourseworkScores.ts
+++ b/src/components/coursework/04-scores/hooks/useCourseworkScores.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import type {
   CourseworkItemWithLetterScales,
-  CourseworkScoreWithStudent,
+  CourseworkScoreWithCourseworkStudent,
+  CourseworkStudentWithMemberships,
 } from "@/types/coursework.types"
 
 /** 1セル分の点数（評価項目×生徒） */
@@ -22,9 +23,14 @@ export interface CourseworkCell {
 /** 点数の部分更新（変更されたフィールドのみ） */
 export type CourseworkCellPatch = Partial<CourseworkCell>
 
-/** 名簿1行（生徒情報 + 評価項目ごとのセル値） */
+/**
+ * 名簿1行（対象者の生徒情報 + 評価項目ごとのセル値）
+ *
+ * 行の同定は資料の対象者（CourseworkStudent）の id で行う。点数の書き込み先が
+ * 対象者だからで、人（Student）の id では名簿に載っていない生徒にも書けてしまう。
+ */
 export interface CourseworkStudentRow {
-  studentId: string
+  courseworkStudentId: string
   studentNumber: string
   lastName: string
   firstName: string
@@ -40,6 +46,21 @@ const EMPTY_CELL: CourseworkCell = {
   adjustment: null,
   adjustmentReason: null,
   comment: null,
+}
+
+/**
+ * 評価項目の点数の中から、その対象者の1件を取り出す。
+ *
+ * 引数に対象者の実体を要求することで、呼び出し側が生徒 id（Student.id）を
+ * 渡してしまう取り違えを型で弾く（どちらも string で見分けがつかないため）。
+ */
+function findScoreOf(
+  scores: CourseworkScoreWithCourseworkStudent[] | undefined,
+  courseworkStudent: CourseworkStudentWithMemberships
+): CourseworkScoreWithCourseworkStudent | undefined {
+  return scores?.find(
+    (score) => score.courseworkStudentId === courseworkStudent.id
+  )
 }
 
 /**
@@ -59,7 +80,7 @@ export function useCourseworkScores(courseworkId: string) {
       string,
       {
         courseworkItemId: string
-        studentId: string
+        courseworkStudentId: string
       } & CourseworkCellPatch
     >
   >(new Map())
@@ -91,7 +112,8 @@ export function useCourseworkScores(courseworkId: string) {
       )
 
       // 各評価項目の点数を並列取得（項目間は独立なので逐次にしない）
-      const allScores: Record<string, CourseworkScoreWithStudent[]> = {}
+      const allScores: Record<string, CourseworkScoreWithCourseworkStudent[]> =
+        {}
       const scoreResults = await Promise.all(
         sortedItems.map((item) =>
           window.electronAPI.coursework.getScores(item.id)
@@ -109,9 +131,7 @@ export function useCourseworkScores(courseworkId: string) {
         (courseworkStudent) => {
           const cells: Record<string, CourseworkCell> = {}
           for (const item of sortedItems) {
-            const score = allScores[item.id]?.find(
-              (score) => score.studentId === courseworkStudent.student.id
-            )
+            const score = findScoreOf(allScores[item.id], courseworkStudent)
             cells[item.id] = score
               ? {
                   score: score.score ?? null,
@@ -126,7 +146,7 @@ export function useCourseworkScores(courseworkId: string) {
             (membership) => registeredClassroomIds.has(membership.classroomId)
           )
           return {
-            studentId: courseworkStudent.student.id,
+            courseworkStudentId: courseworkStudent.id,
             studentNumber: courseworkStudent.student.studentNumber,
             lastName: courseworkStudent.student.lastName,
             firstName: courseworkStudent.student.firstName,
@@ -166,7 +186,7 @@ export function useCourseworkScores(courseworkId: string) {
     (
       changes: {
         courseworkItemId: string
-        studentId: string
+        courseworkStudentId: string
         patch: CourseworkCellPatch
       }[]
     ) => {
@@ -176,16 +196,16 @@ export function useCourseworkScores(courseworkId: string) {
       setStudentRows((prev) => {
         const changeMap = new Map<string, Map<string, CourseworkCellPatch>>()
         for (const change of changes) {
-          if (!changeMap.has(change.studentId))
-            changeMap.set(change.studentId, new Map())
-          const studentMap = changeMap.get(change.studentId)!
+          if (!changeMap.has(change.courseworkStudentId))
+            changeMap.set(change.courseworkStudentId, new Map())
+          const studentMap = changeMap.get(change.courseworkStudentId)!
           studentMap.set(change.courseworkItemId, {
             ...studentMap.get(change.courseworkItemId),
             ...change.patch,
           })
         }
         return prev.map((row) => {
-          const rowChanges = changeMap.get(row.studentId)
+          const rowChanges = changeMap.get(row.courseworkStudentId)
           if (!rowChanges) return row
           const newCells = { ...row.cells }
           for (const [itemId, patch] of rowChanges) {
@@ -200,11 +220,11 @@ export function useCourseworkScores(courseworkId: string) {
 
       // pendingChangesにマージ
       for (const change of changes) {
-        const key = `${change.courseworkItemId}:${change.studentId}`
+        const key = `${change.courseworkItemId}:${change.courseworkStudentId}`
         pendingChanges.current.set(key, {
           ...pendingChanges.current.get(key),
           courseworkItemId: change.courseworkItemId,
-          studentId: change.studentId,
+          courseworkStudentId: change.courseworkStudentId,
           ...change.patch,
         })
       }

--- a/src/components/coursework/05-results/CourseworkResultsContainer.tsx
+++ b/src/components/coursework/05-results/CourseworkResultsContainer.tsx
@@ -104,7 +104,7 @@ export function CourseworkResultsContainer({
                 .filter((comment): comment is string => comment != null)
 
               return (
-                <TableRow key={row.studentId}>
+                <TableRow key={row.courseworkStudentId}>
                   <TableCell className="text-center text-sm">
                     {row.attendanceNumber != null ? row.attendanceNumber : "-"}
                   </TableCell>

--- a/src/components/grades/04-manual-scores/ManualScoresContainer.tsx
+++ b/src/components/grades/04-manual-scores/ManualScoresContainer.tsx
@@ -68,8 +68,11 @@ export function ManualScoresContainer({ gradeId }: ManualScoresContainerProps) {
               await window.electronAPI.coursework.getScores(itemId)
             const scores = scoreResult.success ? (scoreResult.scores ?? []) : []
             enteredByItem[itemId] = scores.filter(
+              // 成績の対象生徒は人（Student）で数えるので、対象者から生徒へ1段辿る
               (courseworkScore) =>
-                gradeStudentIds.has(courseworkScore.studentId) &&
+                gradeStudentIds.has(
+                  courseworkScore.courseworkStudent.studentId
+                ) &&
                 (courseworkScore.score !== null ||
                   courseworkScore.letterValue !== null)
             ).length

--- a/src/types/coursework.types.ts
+++ b/src/types/coursework.types.ts
@@ -26,16 +26,25 @@ export type CourseworkLetterScaleData = Omit<
   score: number
 }
 
-/** 生徒×評価項目の点数（生徒情報付き） */
-export type CourseworkScoreWithStudent = Omit<
+/**
+ * 資料の対象者×評価項目の点数（対象者・生徒情報付き）。
+ *
+ * 点数の主語は「その資料の対象者」（CourseworkStudent）であり、人（Student）ではない。
+ * 名簿から外された生徒の点数は存在しえない（#962）。
+ */
+export type CourseworkScoreWithCourseworkStudent = Omit<
   Prisma.CourseworkScoreGetPayload<{
     include: {
-      student: {
-        select: {
-          id: true
-          studentNumber: true
-          lastName: true
-          firstName: true
+      courseworkStudent: {
+        include: {
+          student: {
+            select: {
+              id: true
+              studentNumber: true
+              lastName: true
+              firstName: true
+            }
+          }
         }
       }
     }
@@ -45,6 +54,23 @@ export type CourseworkScoreWithStudent = Omit<
   score: number | null
   /** 加点・減点（期限超過等） */
   adjustment: number | null
+}
+
+/**
+ * 点数のセル単位更新の入力（IPC 境界の唯一の定義）。
+ *
+ * renderer → preload → handler → DB 層の4層が同じ形を書いていたため、
+ * 1層だけ直しても余剰プロパティ検査が効かず typecheck が通ってしまう
+ * （実行時にだけ点数が保存されない）。定義はここ1箇所に集約する。
+ */
+export interface CourseworkScoreUpsertInput {
+  courseworkItemId: string
+  courseworkStudentId: string
+  score?: number | null
+  letterValue?: string | null
+  adjustment?: number | null
+  adjustmentReason?: string | null
+  comment?: string | null
 }
 
 /** 評価項目（リレーション付き） */

--- a/src/types/courseworkArchive.types.ts
+++ b/src/types/courseworkArchive.types.ts
@@ -10,16 +10,22 @@
  * 旧 .grade（v1.4.0、名前ベース埋め込み）の読込互換は grade 側の legacy 経路で維持。
  */
 
-/** アーカイブバージョン（追加時にユニオンへ足す） */
-export type CourseworkArchiveVersion = "1.0.0"
+/**
+ * アーカイブバージョン（追加時にユニオンへ足す）
+ *
+ * - 1.0.0: 初版（独立化）。資料1件を入れ子ツリーへ射影して持っていた
+ * - 1.1.0: テーブルごとの平坦なセクションへ変更し、各行を Prisma の行のまま持つ。
+ *   点数の参照が studentId → courseworkStudentId（#962 Phase B）
+ */
+export type CourseworkArchiveVersion = "1.0.0" | "1.1.0"
 /** 現行アーカイブバージョン */
-export const COURSEWORK_CURRENT_VERSION: CourseworkArchiveVersion = "1.0.0"
+export const COURSEWORK_CURRENT_VERSION: CourseworkArchiveVersion = "1.1.0"
 /** 読込可能な最小バージョン */
 export const COURSEWORK_MIN_SUPPORTED_VERSION: CourseworkArchiveVersion =
   "1.0.0"
 /** サポート対象バージョン（昇順） */
 export const COURSEWORK_SUPPORTED_VERSIONS: readonly CourseworkArchiveVersion[] =
-  ["1.0.0"] as const
+  ["1.0.0", "1.1.0"] as const
 
 export interface CourseworkArchiveManifest {
   version: string
@@ -34,35 +40,96 @@ export interface CourseworkArchiveManifest {
   }
 }
 
-/** 名簿・学級・タグ参照は UUID で持つ（名前は studentsData 等から逆引き可能） */
-export interface ArchiveCourseworkRef {
+// =============================================================================
+// v1.1.0: テーブルごとの平坦なセクション（Prisma の行をそのまま持つ）
+//
+// Prisma の型のうち JSON にそのまま載らないものだけを、JSON.stringify と同じ規則で
+// 文字列にする（DateTime → ISO 文字列、Decimal → decimal.js の toJSON と同じ文字列）。
+// 射影・詰め替えはしない。列を足したらここにも足すこと。
+// =============================================================================
+
+/** Coursework の行 */
+export interface ArchiveCourseworkRow {
   id: string
   name: string
   description: string | null
   date: string | null
-  classrooms: { classroomId: string; order: number }[]
-  tags: { tagId: string }[]
-  students: { studentId: string; customOrder: number | null }[]
-  items: ArchiveCourseworkItemRef[]
+  createdAt: string
+  updatedAt: string
 }
 
-export interface ArchiveCourseworkItemRef {
+/** CourseworkClassroom（資料×学級）の行 */
+export interface ArchiveCourseworkClassroomRow {
   id: string
+  courseworkId: string
+  classroomId: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** CourseworkTag（資料×タグ）の行 */
+export interface ArchiveCourseworkTagRow {
+  id: string
+  courseworkId: string
+  tagId: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** CourseworkStudent（資料の対象者＝名簿）の行 */
+export interface ArchiveCourseworkStudentRow {
+  id: string
+  courseworkId: string
+  studentId: string
+  customOrder: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+/** CourseworkItem（評価項目）の行 */
+export interface ArchiveCourseworkItemRow {
+  id: string
+  courseworkId: string
   name: string
   order: number
-  maxScore: number
+  /** Decimal */
+  maxScore: string
   inputMode: string
-  letterScales: { label: string; score: number; order: number }[]
-  scores: ArchiveCourseworkScoreRef[]
+  createdAt: string
+  updatedAt: string
 }
 
-export interface ArchiveCourseworkScoreRef {
-  studentId: string
-  score: number | null
+/** CourseworkLetterScale（文字評価→点数の変換表）の行 */
+export interface ArchiveCourseworkLetterScaleRow {
+  id: string
+  courseworkItemId: string
+  label: string
+  /** Decimal */
+  score: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** CourseworkScore（対象者×評価項目の点数）の行 */
+export interface ArchiveCourseworkScoreRow {
+  id: string
+  courseworkItemId: string
+  /**
+   * 資料の対象者（CourseworkStudent.id）。取り込み先では名簿行の id が別物になるため、
+   * import 時に「アーカイブの対象者 id → 取り込み先の対象者 id」へ解決する。
+   * 名簿に対応行が無い点数（旧アーカイブに残りうる孤児）は破棄する。
+   */
+  courseworkStudentId: string
+  /** Decimal */
+  score: string | null
   letterValue: string | null
-  adjustment: number | null
+  /** Decimal */
+  adjustment: string | null
   adjustmentReason: string | null
   comment: string | null
+  createdAt: string
   /** LWW 競合解決に使用 */
   updatedAt: string
 }
@@ -107,23 +174,37 @@ export interface ArchiveCwTag {
   color: string | null
 }
 
-/** アーカイブ全体（manifest + 各セクション）。grade-archive へ内包する際もこの形を流用する。 */
-export interface CourseworkArchiveData {
-  manifest: CourseworkArchiveManifest
-  courseworks: ArchiveCourseworkRef[]
+/**
+ * 資料本体のセクション群（テーブルごとに平坦）。
+ * grade-archive へ内包する際もこの形を流用する。
+ */
+export interface CourseworkSections {
+  courseworks: ArchiveCourseworkRow[]
+  courseworkClassrooms: ArchiveCourseworkClassroomRow[]
+  courseworkTags: ArchiveCourseworkTagRow[]
+  courseworkStudents: ArchiveCourseworkStudentRow[]
+  courseworkItems: ArchiveCourseworkItemRow[]
+  courseworkLetterScales: ArchiveCourseworkLetterScaleRow[]
+  courseworkScores: ArchiveCourseworkScoreRow[]
+}
+
+/** 外部参照（生徒・学級・所属・タグ）の full レコード */
+export interface CourseworkExternalSections {
   studentsData: ArchiveCwStudent[]
   classesData: ArchiveCwClass[]
   membershipsData: ArchiveCwMembership[]
   tagsData: ArchiveCwTag[]
 }
 
+/** アーカイブ全体（manifest + 各セクション） */
+export interface CourseworkArchiveData
+  extends CourseworkSections, CourseworkExternalSections {
+  manifest: CourseworkArchiveManifest
+}
+
 /** dataCollector が返す収集結果（manifest を除いた本体 + counts） */
-export interface CollectedCourseworkData {
-  courseworks: ArchiveCourseworkRef[]
-  studentsData: ArchiveCwStudent[]
-  classesData: ArchiveCwClass[]
-  membershipsData: ArchiveCwMembership[]
-  tagsData: ArchiveCwTag[]
+export interface CollectedCourseworkData
+  extends CourseworkSections, CourseworkExternalSections {
   counts: CourseworkArchiveManifest["counts"]
 }
 
@@ -192,28 +273,6 @@ export interface CourseworkArchiveImportResult {
   error?: string
 }
 
-// =============================================================================
-// バージョントランスフォーマー
-// =============================================================================
-
-export interface CourseworkTransformResult {
-  data: CourseworkArchiveData
-  warnings: string[]
-}
-
-export interface CourseworkVersionTransformer {
-  readonly fromVersion: CourseworkArchiveVersion
-  readonly toVersion: CourseworkArchiveVersion
-  transform(data: CourseworkArchiveData): CourseworkTransformResult
-}
-
-export interface CourseworkChainTransformResult {
-  data: CourseworkArchiveData
-  originalVersion: CourseworkArchiveVersion
-  finalVersion: CourseworkArchiveVersion
-  appliedTransformations: {
-    from: CourseworkArchiveVersion
-    to: CourseworkArchiveVersion
-  }[]
-  warnings: string[]
-}
+// バージョン変換の型（旧版の形・変換器・チェーン）は
+// electron-src/lib/import/coursework-transformers/types.ts が持つ。
+// このファイルは現行の形だけを宣言する。

--- a/src/types/electron/courseworkApi.d.ts
+++ b/src/types/electron/courseworkApi.d.ts
@@ -94,19 +94,11 @@ export interface CourseworkAPI {
     // 点数
     getScores: (courseworkItemId: string) => Promise<{
       success: boolean
-      scores?: import("../coursework.types").CourseworkScoreWithStudent[]
+      scores?: import("../coursework.types").CourseworkScoreWithCourseworkStudent[]
       error?: string
     }>
     batchUpsertScores: (
-      scores: {
-        courseworkItemId: string
-        studentId: string
-        score?: number | null
-        letterValue?: string | null
-        adjustment?: number | null
-        adjustmentReason?: string | null
-        comment?: string | null
-      }[]
+      scores: import("../coursework.types").CourseworkScoreUpsertInput[]
     ) => Promise<{ success: boolean; error?: string }>
 
     // 名簿

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -2,6 +2,7 @@
  * 成績算出アーカイブ(.grade)の型定義
  */
 
+import type { LegacyCollectedCourseworkData } from "../../electron-src/lib/import/coursework-transformers/legacyShape"
 import type {
   CollectedCourseworkData,
   CourseworkImportDecisions,
@@ -39,10 +40,16 @@ export interface GradeArchiveData {
    */
   courseworks?: ArchiveCoursework[]
   /**
-   * v1.5.0+: 試験外成績資料を coursework-archive と同じ UUID ベースの形で内包する。
-   * 収集・生成ロジックは独立 coursework モジュールへ委譲（二重実装の解消）。
+   * v1.12.0+: 試験外成績資料を coursework-archive と同じ形（テーブルごとの平坦な
+   * セクション）で内包する。収集・生成ロジックは独立 coursework モジュールへ委譲。
    */
   courseworkArchive?: CollectedCourseworkData
+  /**
+   * v1.5.0〜1.11.0 が内包していた入れ子・射影形式の資料データ。
+   * 形の定義は変換器側（coursework-transformers）が持ち、
+   * V1_11_0_to_V1_12_0 が courseworkArchive へ展開する。
+   */
+  legacyCourseworkArchive?: LegacyCollectedCourseworkData
   boundariesData: ArchiveBoundariesData
 }
 
@@ -385,7 +392,8 @@ export type GradeArchiveVersion =
   | "1.9.0"
   | "1.10.0"
   | "1.11.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.11.0"
+  | "1.12.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.12.0"
 
 export interface GradeTransformResult {
   data: GradeArchiveData


### PR DESCRIPTION
Closes #1078

`CourseworkScore` を `Student` 直結から `CourseworkStudent`（資料の対象者）経由へ配線変更しました。#1075 で試験側に対して塞いだ穴と同型のものが、試験外成績資料側に残っていたものです（#962 Phase B）。

## 実害

資料から生徒を外しても点数が消えず、資料の画面には現れないのに**成績算出でだけ素点として算入されて**いました。`CourseworkStudent` を参照する子テーブルが1つも無く、DB の cascade が構造的に存在しなかったためです。

## 変更

### 配線変更

| 層 | 内容 |
| --- | --- |
| schema | `studentId` → `courseworkStudentId`、UNIQUE も付け替え |
| migration | `20260729000000` RedefineTables。INNER JOIN でバックフィルし、孤児は落として件数を `AuditLog` へ |
| 削除経路 | 手書き DELETE を足さず DB の cascade に委ねる |
| 成績算出 | `findCourseworkStudentScore` で対象者を必ず1回通す。名簿外はデータなし |
| IPC | 4層に重複していた upsert 入力型を `CourseworkScoreUpsertInput` へ集約 |

### アーカイブの作り直し（coursework 1.1.0 / grade 1.12.0）

exam-archive と揃え、**Prisma のクエリが返した行をそのまま JSON に持つ**形にしました。

- 入れ子の射影ツリーからテーブルごとの平坦なセクションへ
- JSON に載らない型のみ `JSON.stringify` と同じ規則で文字列化（DateTime → ISO / Decimal → 文字列）
- 旧 1.0.0 の結合行は id を持たないので、`@@unique` の自然キーから決定論的に組み立てる（`deterministicId.ts` と同じ規則。アーカイブ内の結合キーとしてのみ使い DB へは書かない）
- 版ごとの「アーカイブ全体の型」と旧版の形は `coursework-transformers/` 配下に閉じ込め、`src/types` は現行の形だけを宣言する。変換器は `V1_0_0 → V1_1_0` として型付けし、`unknown` もキャストも使っていない

### 書き込み入口のスコープ検査

FK は「それぞれが実在すること」しか保証せず、採点対象と受験者・対象者が同じ親に属することは強制されません。id はどちらも `string` なので取り違えてもコンパイルが通り、書けてしまうと同じ穴が別の入口から開きます。

`examScopeGuard.ts` へ集約し、**#1075 で残していた試験側の4経路も併せて塞ぎました**。答案アップロードと配置適用はページのみ検証していたので、受験者の検証を追加しています。

守れるのはアプリのコードが書く経路だけです。NAS 同期はライブラリから DB へ直接書くため通りませんが、同期は行単位で運ぶので食い違ったペアを新たに作ることはありません（`cropRegionId` と `examStudentId` は同じ1行にあり、列ごとのマージはしていない）。

### その他

- `idChangeExecutor` の `CourseworkStudent` mover は、重複行の `delete` が cascade で点数を道連れにするようになったため、非衝突分を先に付け替えてから delete する
- 取り込み時の警告を「アーカイブの孤児」と「取り込み先に生徒が居ない」で分けた（利用者が取るべき行動が違うため）

## テスト

114 ファイル / 1,167 件通過。`check-all` green。

- 資料から生徒を外すと点数も消え、他生徒は巻き添えにならず、再追加しても復元されない
- migration の付け替え・孤児破棄・`AuditLog` 記録・`RENAME TO` 後の FK 参照名
- 資料から外した生徒の点数が成績算出に算入されないこと
- アーカイブ 1.0.0 → 1.1.0 の展開・付け替え・孤児破棄・冪等性・version 偽装時の形状ベース下方補正
- grade 1.11.0 → 1.12.0（内包資料の平坦化）。**内包資料が空の旧アーカイブ**が現行形式と誤認されないこと
- 別の資料／別の試験の対象者への書き込みが拒否され、DB に行が残らないこと
- `cascadeCoverage.test.ts` に「`CourseworkScore` の親は `CourseworkStudent`・Student 直結ではない」

## ⚠️ 注意

**該当する生徒がいる場合、このマージ後は成績算出の結果が変わります**（これまでは、資料から外したはずの点数が算入されていました）。仕様変更ではなく不具合修正です。

## 未了

- **実 DB のコピーへ migration を当てるリハーサル**は行っていません（実データが必要）
- 資料・成績の名簿からの生徒削除には確認ダイアログがありません。試験（05）は破棄を明示していますが、`RosterTable` の `enableRemove` は無確認です。grade の名簿も同じ形なので Phase C でまとめて入れるほうが一貫すると判断し、今回は入れていません
- アーカイブ JSON の実行時スキーマ検証は #1077 として別立て

🤖 Generated with [Claude Code](https://claude.com/claude-code)
