### PR TITLE
feat(grade): 成績のセルを GradeStudent 経由へ配線変更しアーカイブを行ベースへ作り直す

### DIFF
--- a/__tests__/calculations/statisticsCalculator.test.ts
+++ b/__tests__/calculations/statisticsCalculator.test.ts
@@ -272,7 +272,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s2",
       null,
       allData,
       classOf(allData),
@@ -293,7 +292,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s1",
       80,
       allData,
       classOf(allData),
@@ -314,7 +312,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s1",
       null,
       allData,
       classOf(allData),
@@ -335,7 +332,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s1",
       0,
       allData,
       classOf(allData),
@@ -356,7 +352,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s1",
       80,
       allData,
       [],
@@ -375,7 +370,6 @@ describe("calculateStatisticsForStudent", () => {
     ]
 
     const result = calculateStatisticsForStudent(
-      "s1",
       80,
       allData,
       [

--- a/__tests__/grade/integration/gradeFrozenScore.test.ts
+++ b/__tests__/grade/integration/gradeFrozenScore.test.ts
@@ -40,6 +40,8 @@ interface Fixture {
   gradeId: string
   gradeItemId: string
   studentId: string
+  /** 成績の対象者。上書き・確定値・除外設定の書き込み先はこちら（人の id ではない） */
+  gradeStudentId: string
   courseworkItemId: string
 }
 
@@ -82,7 +84,7 @@ async function buildFixture(): Promise<Fixture> {
   })
 
   const grade = await testPrisma.grade.create({ data: { name: "1学期成績" } })
-  await testPrisma.gradeStudent.create({
+  const gradeStudent = await testPrisma.gradeStudent.create({
     data: { gradeId: grade.id, studentId: student.id },
   })
   const gradeItem = await testPrisma.gradeItem.create({
@@ -129,6 +131,7 @@ async function buildFixture(): Promise<Fixture> {
     gradeId: grade.id,
     gradeItemId: gradeItem.id,
     studentId: student.id,
+    gradeStudentId: gradeStudent.id,
     courseworkItemId: courseworkItem.id,
   }
 }
@@ -225,8 +228,7 @@ describe("成績値の確定（凍結）", () => {
     // 自動算出は A。教員が B へ調整してから確定する。
     await testPrisma.gradeOverride.create({
       data: {
-        gradeId: fixture.gradeId,
-        studentId: fixture.studentId,
+        gradeStudentId: fixture.gradeStudentId,
         gradeItemId: fixture.gradeItemId,
         overrideLabel: "B",
       },
@@ -235,7 +237,7 @@ describe("成績値の確定（凍結）", () => {
     await freezeGradeScores({ gradeId: fixture.gradeId })
 
     const stored = await testPrisma.gradeFrozenScore.findFirstOrThrow({
-      where: { gradeId: fixture.gradeId },
+      where: { gradeStudent: { gradeId: fixture.gradeId } },
     })
     expect(stored.gradeLabel).toBe("B")
 
@@ -251,8 +253,7 @@ describe("成績値の確定（凍結）", () => {
     // 確定後に上書きを足しても、確定値（A）が採用され続ける
     await testPrisma.gradeOverride.create({
       data: {
-        gradeId: fixture.gradeId,
-        studentId: fixture.studentId,
+        gradeStudentId: fixture.gradeStudentId,
         gradeItemId: fixture.gradeItemId,
         overrideLabel: "C",
       },
@@ -272,7 +273,10 @@ describe("成績値の確定（凍結）", () => {
     await freezeGradeScores({
       gradeId: fixture.gradeId,
       targets: [
-        { studentId: fixture.studentId, gradeItemId: fixture.gradeItemId },
+        {
+          gradeStudentId: fixture.gradeStudentId,
+          gradeItemId: fixture.gradeItemId,
+        },
       ],
     })
 
@@ -282,7 +286,7 @@ describe("成績値の確定（凍結）", () => {
     expect(cell.frozen!.isStale).toBe(false)
     // 再確定は上書きではなく削除→再作成だが、1セル1行のままであること
     const rows = await testPrisma.gradeFrozenScore.findMany({
-      where: { gradeId: fixture.gradeId },
+      where: { gradeStudent: { gradeId: fixture.gradeId } },
     })
     expect(rows).toHaveLength(1)
   })
@@ -306,8 +310,7 @@ describe("成績値の確定（凍結）", () => {
     const fixture = await buildFixture()
     await testPrisma.gradeItemExclusion.create({
       data: {
-        gradeId: fixture.gradeId,
-        studentId: fixture.studentId,
+        gradeStudentId: fixture.gradeStudentId,
         gradeItemId: fixture.gradeItemId,
       },
     })
@@ -328,8 +331,7 @@ describe("成績値の確定（凍結）", () => {
     // 確定後にこの生徒をこの評価項目から除外し、資料も変えたうえで再確定する
     await testPrisma.gradeItemExclusion.create({
       data: {
-        gradeId: fixture.gradeId,
-        studentId: fixture.studentId,
+        gradeStudentId: fixture.gradeStudentId,
         gradeItemId: fixture.gradeItemId,
       },
     })
@@ -339,13 +341,13 @@ describe("成績値の確定（凍結）", () => {
     // 除外セルは確定対象外なので、確定行は残っていてはならない
     expect(
       await testPrisma.gradeFrozenScore.findMany({
-        where: { gradeId: fixture.gradeId },
+        where: { gradeStudent: { gradeId: fixture.gradeId } },
       })
     ).toHaveLength(0)
 
     // 除外を解除すると、古い確定値（80% A）ではなく現在値（30% C）が出る
     await testPrisma.gradeItemExclusion.deleteMany({
-      where: { gradeId: fixture.gradeId },
+      where: { gradeStudent: { gradeId: fixture.gradeId } },
     })
     const cell = await readCell(fixture.gradeId)
     expect(cell.frozen).toBeNull()
@@ -360,7 +362,7 @@ describe("成績値の確定（凍結）", () => {
     await testPrisma.grade.delete({ where: { id: fixture.gradeId } })
 
     const rows = await testPrisma.gradeFrozenScore.findMany({
-      where: { gradeId: fixture.gradeId },
+      where: { gradeStudent: { gradeId: fixture.gradeId } },
     })
     expect(rows).toHaveLength(0)
   })

--- a/__tests__/grade/integration/gradeScopeGuard.test.ts
+++ b/__tests__/grade/integration/gradeScopeGuard.test.ts
@@ -1,0 +1,140 @@
+/**
+ * 成績のセルの書き込み入口でのスコープ検査（#962 Phase C）。
+ *
+ * セルは対象者（GradeStudent）と評価項目（GradeItem）の2つを参照する。FK が保証するのは
+ * それぞれが実在することだけで、両者が同じ Grade に属することは強制されない。どちらの id も
+ * string なので取り違えてもコンパイルは通り、書けてしまうと成績 A の対象者に成績 B の項目の
+ * 上書き・確定値がぶら下がる（どちらの画面にも出ないのに DB には残る）。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { setGradeItemExclusion } from "@/electron-src/lib/prisma/gradeItemExclusion"
+import { upsertGradeOverride } from "@/electron-src/lib/prisma/gradeOverride"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+interface Fixture {
+  /** 成績A の対象者 */
+  gradeStudentId: string
+  /** 成績A の評価項目 */
+  gradeItemId: string
+  /** 成績B（別の成績）の評価項目 */
+  otherGradeItemId: string
+}
+
+async function buildFixture(): Promise<Fixture> {
+  const suffix = Date.now()
+  const student = await testPrisma.student.create({
+    data: {
+      studentNumber: `SG${suffix}`,
+      lastName: "山田",
+      firstName: "太郎",
+      lastNameKana: "ヤマダ",
+      firstNameKana: "タロウ",
+    },
+  })
+
+  const grade = await testPrisma.grade.create({ data: { name: "1学期成績" } })
+  const gradeStudent = await testPrisma.gradeStudent.create({
+    data: { gradeId: grade.id, studentId: student.id },
+  })
+  const gradeItem = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+  })
+
+  const otherGrade = await testPrisma.grade.create({
+    data: { name: "2学期成績" },
+  })
+  const otherGradeItem = await testPrisma.gradeItem.create({
+    data: { gradeId: otherGrade.id, name: "知識・技能", order: 0 },
+  })
+
+  return {
+    gradeStudentId: gradeStudent.id,
+    gradeItemId: gradeItem.id,
+    otherGradeItemId: otherGradeItem.id,
+  }
+}
+
+describe("成績のセルのスコープ検査", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("同じ成績の対象者・評価項目なら書ける", async () => {
+    const fixture = await buildFixture()
+
+    const result = await upsertGradeOverride({
+      gradeStudentId: fixture.gradeStudentId,
+      gradeItemId: fixture.gradeItemId,
+      overrideLabel: "A",
+    })
+
+    expect(result.success).toBe(true)
+    expect(await testPrisma.gradeOverride.count()).toBe(1)
+  })
+
+  it("別の成績の評価項目には上書きを書けない", async () => {
+    const fixture = await buildFixture()
+
+    const result = await upsertGradeOverride({
+      gradeStudentId: fixture.gradeStudentId,
+      gradeItemId: fixture.otherGradeItemId,
+      overrideLabel: "A",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain("別の成績")
+    expect(await testPrisma.gradeOverride.count()).toBe(0)
+  })
+
+  it("別の成績の評価項目には除外設定を書けない", async () => {
+    const fixture = await buildFixture()
+
+    const result = await setGradeItemExclusion({
+      gradeStudentId: fixture.gradeStudentId,
+      gradeItemId: fixture.otherGradeItemId,
+      excluded: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(await testPrisma.gradeItemExclusion.count()).toBe(0)
+  })
+
+  it("存在しない対象者を指した書き込みは弾かれる", async () => {
+    const fixture = await buildFixture()
+
+    const result = await upsertGradeOverride({
+      gradeStudentId: "missing-grade-student",
+      gradeItemId: fixture.gradeItemId,
+      overrideLabel: "A",
+    })
+
+    expect(result.success).toBe(false)
+    expect(await testPrisma.gradeOverride.count()).toBe(0)
+  })
+})

--- a/__tests__/grade/integration/gradeStudentCellRemoval.test.ts
+++ b/__tests__/grade/integration/gradeStudentCellRemoval.test.ts
@@ -1,0 +1,204 @@
+/**
+ * 成績から生徒を外すとセル3種も消えることの統合テスト（#962 Phase C）。
+ *
+ * 配線変更前、上書き・確定値・除外設定は (gradeId, studentId) の2列で人を直に指しており、
+ * GradeStudent を参照する子テーブルが1つも無かった。そのため学級ごと外しても設定は残り、
+ * 同じ生徒を再び追加した瞬間に過去の設定が甦っていた。特に確定（凍結）した成績値が
+ * 教員の知らないうちに復活するのは実害が大きい。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import {
+  addStudentsFromClassroomToGrade,
+  removeClassroomFromGrade,
+} from "@/electron-src/lib/prisma/gradeStudent"
+
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+interface Fixture {
+  gradeId: string
+  gradeItemId: string
+  classroomId: string
+  /** 学級を外すと一緒に消える生徒（その学級にしか所属しない） */
+  removedStudentId: string
+  removedGradeStudentId: string
+  /** 別の学級にも所属していて残る生徒 */
+  keptStudentId: string
+  keptGradeStudentId: string
+}
+
+/**
+ * 生徒2名・評価項目1つの成績を作り、両名にセル3種（上書き・確定値・除外設定）を付ける。
+ * removed 側はこの学級にのみ所属し、kept 側は別学級にも所属する（＝専属でないので残る）。
+ */
+async function buildFixture(): Promise<Fixture> {
+  const suffix = Date.now()
+  const classroom = await testPrisma.classroom.create({
+    data: { name: `3年A組_${suffix}` },
+  })
+  const otherClassroom = await testPrisma.classroom.create({
+    data: { name: `3年B組_${suffix}` },
+  })
+
+  const createStudent = async (studentNumber: string, classroomIds: string[]) =>
+    testPrisma.student.create({
+      data: {
+        studentNumber,
+        lastName: "山田",
+        firstName: "太郎",
+        lastNameKana: "ヤマダ",
+        firstNameKana: "タロウ",
+        memberships: {
+          create: classroomIds.map((classroomId) => ({ classroomId })),
+        },
+      },
+    })
+
+  const removedStudent = await createStudent(`SR${suffix}`, [classroom.id])
+  const keptStudent = await createStudent(`SK${suffix}`, [
+    classroom.id,
+    otherClassroom.id,
+  ])
+
+  const grade = await testPrisma.grade.create({ data: { name: "1学期成績" } })
+  await testPrisma.gradeClassroom.createMany({
+    data: [
+      { gradeId: grade.id, classroomId: classroom.id, order: 0 },
+      { gradeId: grade.id, classroomId: otherClassroom.id, order: 1 },
+    ],
+  })
+  const gradeItem = await testPrisma.gradeItem.create({
+    data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+  })
+
+  const gradeStudents = new Map<string, string>()
+  for (const student of [removedStudent, keptStudent]) {
+    const gradeStudent = await testPrisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    gradeStudents.set(student.id, gradeStudent.id)
+
+    await testPrisma.gradeOverride.create({
+      data: {
+        gradeStudentId: gradeStudent.id,
+        gradeItemId: gradeItem.id,
+        overrideLabel: "A",
+      },
+    })
+    await testPrisma.gradeFrozenScore.create({
+      data: {
+        gradeStudentId: gradeStudent.id,
+        gradeItemId: gradeItem.id,
+        weightedScore: 0.8,
+        weightedMaxScore: 1,
+        percentage: 80,
+        gradeLabel: "A",
+      },
+    })
+    await testPrisma.gradeItemExclusion.create({
+      data: { gradeStudentId: gradeStudent.id, gradeItemId: gradeItem.id },
+    })
+  }
+
+  return {
+    gradeId: grade.id,
+    gradeItemId: gradeItem.id,
+    classroomId: classroom.id,
+    removedStudentId: removedStudent.id,
+    removedGradeStudentId: gradeStudents.get(removedStudent.id)!,
+    keptStudentId: keptStudent.id,
+    keptGradeStudentId: gradeStudents.get(keptStudent.id)!,
+  }
+}
+
+/** その対象者に紐づくセル3種の件数 */
+async function countCells(gradeStudentId: string) {
+  const [overrides, frozenScores, itemExclusions] = await Promise.all([
+    testPrisma.gradeOverride.count({ where: { gradeStudentId } }),
+    testPrisma.gradeFrozenScore.count({ where: { gradeStudentId } }),
+    testPrisma.gradeItemExclusion.count({ where: { gradeStudentId } }),
+  ])
+  return { overrides, frozenScores, itemExclusions }
+}
+
+describe("成績から生徒を外したときのセルの削除", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("学級ごと外すと、その生徒の上書き・確定値・除外設定が全て消える", async () => {
+    const fixture = await buildFixture()
+
+    const result = await removeClassroomFromGrade(
+      fixture.gradeId,
+      fixture.classroomId,
+      true
+    )
+    expect(result.success).toBe(true)
+
+    expect(await countCells(fixture.removedGradeStudentId)).toEqual({
+      overrides: 0,
+      frozenScores: 0,
+      itemExclusions: 0,
+    })
+  })
+
+  it("他の生徒のセルは巻き添えにならない", async () => {
+    const fixture = await buildFixture()
+
+    await removeClassroomFromGrade(fixture.gradeId, fixture.classroomId, true)
+
+    // kept は別学級にも所属するため専属ではなく、対象者として残る
+    expect(await countCells(fixture.keptGradeStudentId)).toEqual({
+      overrides: 1,
+      frozenScores: 1,
+      itemExclusions: 1,
+    })
+  })
+
+  it("外した生徒を再び追加しても、以前の確定値・上書き・除外は復元されない", async () => {
+    const fixture = await buildFixture()
+
+    await removeClassroomFromGrade(fixture.gradeId, fixture.classroomId, true)
+    const added = await addStudentsFromClassroomToGrade(
+      fixture.gradeId,
+      fixture.classroomId
+    )
+    expect(added.success).toBe(true)
+
+    const readded = await testPrisma.gradeStudent.findFirstOrThrow({
+      where: { gradeId: fixture.gradeId, studentId: fixture.removedStudentId },
+    })
+    // 再追加された対象者は別の行（id が違う）で、セルは付いていない
+    expect(readded.id).not.toBe(fixture.removedGradeStudentId)
+    expect(await countCells(readded.id)).toEqual({
+      overrides: 0,
+      frozenScores: 0,
+      itemExclusions: 0,
+    })
+  })
+})

--- a/__tests__/grade/unit/gradeCalculator.test.ts
+++ b/__tests__/grade/unit/gradeCalculator.test.ts
@@ -25,9 +25,6 @@ vi.mock("@/electron-src/lib/prisma/questionScore", () => ({
 // Prisma client
 const mockFindUnique = vi.fn()
 const mockFindMany = vi.fn()
-const mockGradeItemExclusionFindMany = vi.fn().mockResolvedValue([])
-// 成績値の確定（凍結）。既定は「確定なし」で、確定の検証をするテストだけ差し替える。
-const mockGradeFrozenScoreFindMany = vi.fn().mockResolvedValue([])
 
 // computeLiveMaxScore は coursework 型の満点を courseworkItem.findUnique で引く。
 // buildGrade が courseworkItemId → maxScore を登録し、モックはそれを返す。
@@ -55,13 +52,6 @@ vi.mock("@/electron-src/lib/prisma/client", () => ({
     gradeStudent: {
       findMany: (...args: unknown[]) => mockFindMany(...args),
     },
-    gradeOverride: { findMany: vi.fn().mockResolvedValue([]) },
-    gradeFrozenScore: {
-      findMany: (...args: unknown[]) => mockGradeFrozenScoreFindMany(...args),
-    },
-    gradeItemExclusion: {
-      findMany: (...args: unknown[]) => mockGradeItemExclusionFindMany(...args),
-    },
     questionScore: { findMany: vi.fn().mockResolvedValue([]) },
     examPage: { findMany: vi.fn().mockResolvedValue([]) },
     examStudent: { findMany: vi.fn().mockResolvedValue([]) },
@@ -79,6 +69,9 @@ import {
   estimateAbsentScore,
 } from "@/electron-src/lib/shared/calculations/absentEstimation"
 import { calculateGrades } from "@/electron-src/lib/shared/calculations/gradeCalculator"
+import type { DataSourceInfo } from "@/electron-src/lib/shared/calculations/gradeCalculatorTypes"
+import type { RawScoreRowEntity } from "@/electron-src/lib/shared/calculations/rawScoreMatrix"
+import { RawScoreMatrix } from "@/electron-src/lib/shared/calculations/rawScoreMatrix"
 
 // === ヘルパー ===
 
@@ -199,23 +192,60 @@ function buildGrade(
   }
 }
 
+/**
+ * 成績の対象者1行。上書き・確定値・除外設定は対象者の子として同じ行に載る
+ * （calculator は Grade 単位で別途引かず、この include から読む）。
+ */
 function buildStudent(
   overrides: {
     id?: string
     studentNumber?: string
     lastName?: string
     firstName?: string
+    /** 除外する評価項目 */
+    excludedGradeItemIds?: string[]
+    /** 手動上書き（gradeItemId → ラベル） */
+    overrideLabels?: Record<string, string>
+    /** 確定済みセル */
+    frozenScores?: {
+      gradeItemId: string
+      weightedScore: unknown
+      weightedMaxScore: unknown
+      percentage: unknown
+      gradeLabel: string | null
+      frozenAt: Date
+    }[]
   } = {}
 ) {
+  const studentId = overrides.id ?? "s1"
+  // テストでは対象者 id を「gs:生徒id」とし、人の id と取り違えたら露見するようにする
+  const gradeStudentId = `gs:${studentId}`
   return {
+    id: gradeStudentId,
+    gradeId: "gp1",
+    studentId,
     student: {
-      id: overrides.id ?? "s1",
+      id: studentId,
       studentNumber: overrides.studentNumber ?? "S001",
       lastName: overrides.lastName ?? "テスト",
       firstName: overrides.firstName ?? "太郎",
       memberships: [],
     },
     customOrder: 0,
+    itemExclusions: (overrides.excludedGradeItemIds ?? []).map(
+      (gradeItemId) => ({ gradeStudentId, gradeItemId })
+    ),
+    overrides: Object.entries(overrides.overrideLabels ?? {}).map(
+      ([gradeItemId, overrideLabel]) => ({
+        gradeStudentId,
+        gradeItemId,
+        overrideLabel,
+      })
+    ),
+    frozenScores: (overrides.frozenScores ?? []).map((frozenScore) => ({
+      gradeStudentId,
+      ...frozenScore,
+    })),
   }
 }
 
@@ -663,10 +693,9 @@ describe("calculateGrades", () => {
       ],
     })
     mockFindUnique.mockResolvedValue(grade)
-    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
     // s1をgi2から除外
-    mockGradeItemExclusionFindMany.mockResolvedValue([
-      { studentId: "s1", gradeItemId: "gi2" },
+    mockFindMany.mockResolvedValue([
+      buildStudent({ id: "s1", excludedGradeItemIds: ["gi2"] }),
     ])
 
     const result = await calculateGrades("gp1")
@@ -718,10 +747,9 @@ describe("calculateGrades", () => {
       ],
     })
     mockFindUnique.mockResolvedValue(grade)
-    mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
     // 全項目除外
-    mockGradeItemExclusionFindMany.mockResolvedValue([
-      { studentId: "s1", gradeItemId: "gi1" },
+    mockFindMany.mockResolvedValue([
+      buildStudent({ id: "s1", excludedGradeItemIds: ["gi1"] }),
     ])
 
     const result = await calculateGrades("gp1")
@@ -762,7 +790,6 @@ describe("calculateGrades", () => {
     })
     mockFindUnique.mockResolvedValue(grade)
     mockFindMany.mockResolvedValue([buildStudent({ id: "s1" })])
-    mockGradeItemExclusionFindMany.mockResolvedValue([])
 
     const result = await calculateGrades("gp1")
     const student = result.result!.students[0]
@@ -1190,10 +1217,40 @@ describe("estimateAbsentScore", () => {
     estimationSourceIds: [] as string[],
   }
 
+  /**
+   * `studentId → dataSourceId → 素点` の表から素点行列を組むテスト用ヘルパー。
+   * 推定は行を識別して素点を引くだけなので、行の実体は id のみで足りる。
+   */
+  const buildMatrix = (
+    rawScores: Map<string, Map<string, number | null>>,
+    allDataSources: DataSourceInfo[]
+  ) =>
+    new RawScoreMatrix<RawScoreRowEntity>(
+      Array.from(rawScores, ([studentId, scoresBySource]) => ({
+        gradeStudent: { id: studentId },
+        cells: allDataSources.map((dataSource) => ({
+          dataSource,
+          rawScore: scoresBySource.get(dataSource.id) ?? null,
+        })),
+      }))
+    )
+
+  /** 素点行列から対象者の行を取り出す（テスト用の同定は studentId で足りる） */
+  const rowOf = (
+    matrix: RawScoreMatrix<RawScoreRowEntity>,
+    studentId: string
+  ) => {
+    const row = matrix.rows.find(
+      (candidate) => candidate.gradeStudent.id === studentId
+    )
+    if (!row) throw new Error(`row ${studentId} not found`)
+    return row
+  }
+
   it("method='zero' → 0を返す", () => {
     const rawScoreMap = new Map<string, Map<string, number | null>>()
     rawScoreMap.set("s1", new Map([["ds1", null]]))
-    const result = estimateAbsentScore("zero", "s1", "ds1", 100, rawScoreMap, [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1203,7 +1260,15 @@ describe("estimateAbsentScore", () => {
         absentOffset: 0,
         ...dataSourceDefaults,
       },
-    ])
+    ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
+    const result = estimateAbsentScore(
+      "zero",
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
+      allDataSources
+    )
     expect(result?.value).toBe(0)
     expect(result?.effectiveMethod).toBe("zero")
   })
@@ -1221,7 +1286,7 @@ describe("estimateAbsentScore", () => {
         ["ds3", 30],
       ])
     )
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1250,12 +1315,12 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "average",
-      "s1",
-      "ds1",
-      200,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
     expect(result?.value).toBeCloseTo(140)
@@ -1267,7 +1332,7 @@ describe("estimateAbsentScore", () => {
   it("method='average' → 他DataSourceがない場合はnull", () => {
     const rawScoreMap = new Map<string, Map<string, number | null>>()
     rawScoreMap.set("s1", new Map([["ds1", null]]))
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1278,12 +1343,12 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "average",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
     expect(result).toBeNull()
@@ -1324,7 +1389,7 @@ describe("estimateAbsentScore", () => {
       ])
     )
 
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1344,12 +1409,12 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "regression",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
     // 結果はOLS回帰の予測値で、0-100の範囲内であること
@@ -1382,7 +1447,7 @@ describe("estimateAbsentScore", () => {
       ])
     )
 
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1402,12 +1467,12 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "regression",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
     // averageフォールバック: s1のds2比率=60/100=0.6 → 0.6*100=60
@@ -1421,7 +1486,7 @@ describe("estimateAbsentScore", () => {
     rawScoreMap.set("s1", new Map([["ds1", null]]))
     rawScoreMap.set("s2", new Map([["ds1", 80]]))
 
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1432,12 +1497,12 @@ describe("estimateAbsentScore", () => {
         ...dataSourceDefaults,
       },
     ]
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "regression",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
     expect(result).toBeNull()
@@ -1470,7 +1535,7 @@ describe("estimateAbsentScore", () => {
     }
 
     const predictorNames = ["ds2", "ds3", "ds4"]
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1491,12 +1556,12 @@ describe("estimateAbsentScore", () => {
       })),
     ]
 
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "regression",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
 
@@ -1540,7 +1605,7 @@ describe("estimateAbsentScore", () => {
     }
 
     const predictorNames = ["ds2", "ds3", "ds4"]
-    const allDataSources = [
+    const allDataSources: DataSourceInfo[] = [
       {
         id: "ds1",
         name: "ds1",
@@ -1561,12 +1626,12 @@ describe("estimateAbsentScore", () => {
       })),
     ]
 
+    const matrix = buildMatrix(rawScoreMap, allDataSources)
     const result = estimateAbsentScore(
       "regression",
-      "s1",
-      "ds1",
-      100,
-      rawScoreMap,
+      rowOf(matrix, "s1"),
+      allDataSources[0],
+      matrix,
       allDataSources
     )
 

--- a/__tests__/grade/unit/gradeDetailSheet.test.ts
+++ b/__tests__/grade/unit/gradeDetailSheet.test.ts
@@ -90,6 +90,7 @@ function makeStudent(
   excludedItemIds: string[] = []
 ): StudentGradeResult {
   return {
+    gradeStudentId: `gs:${id}`,
     studentId: id,
     studentNumber: id,
     lastName: id,

--- a/__tests__/grades/gradeConstraints.test.ts
+++ b/__tests__/grades/gradeConstraints.test.ts
@@ -29,6 +29,7 @@ function makeStudent(
   labels: [string, string, string]
 ): StudentGradeResult {
   return {
+    gradeStudentId: `gs:${id}`,
     studentId: id,
     studentNumber: id,
     lastName: id,
@@ -63,12 +64,21 @@ function makeResult(students: StudentGradeResult[]): GradeCalculationResult {
   }
 }
 
+/**
+ * 違反した生徒の id 一覧。
+ *
+ * 違反は「その成績の対象者」（GradeStudent）でキーされるので、テストの可読性のため
+ * 人の id へ1段戻す。対象者 id と人の id が食い違っていれば空になり露見する。
+ */
 function violatedIds(
   result: GradeCalculationResult,
   constraints: GradeConstraintData[]
 ): string[] {
   const { violations } = evaluateConstraints(result, constraints)
-  return [...violations.keys()].sort()
+  return result.students
+    .filter((student) => violations.has(student.gradeStudentId))
+    .map((student) => student.studentId)
+    .sort()
 }
 
 const baseConstraint: Omit<GradeConstraintData, "kind" | "expression"> = {
@@ -149,6 +159,7 @@ describe("gradeConstraints: 整合ルール（評定は独立したGradeItem）"
       "gi-h": hyotei,
     }
     return {
+      gradeStudentId: `gs:${id}`,
       studentId: id,
       studentNumber: id,
       lastName: id,
@@ -370,6 +381,7 @@ describe("gradeConstraints: 参照はidで持つ（issue #1063）", () => {
     labels: Record<string, string>
   ): StudentGradeResult {
     return {
+      gradeStudentId: "gs:s1",
       studentId: "s1",
       studentNumber: "s1",
       lastName: "s1",
@@ -487,9 +499,9 @@ describe("gradeConstraints: 参照はidで持つ（issue #1063）", () => {
       viewpoints: [],
     }
 
-    const { violations, errors } = evaluateConstraints(result, [expr])
+    const { errors } = evaluateConstraints(result, [expr])
     expect(errors.size).toBe(0)
-    expect([...violations.keys()]).toEqual(["s1"])
+    expect(violatedIds(result, [expr])).toEqual(["s1"])
   })
 
   it("式ルールの mean() が非数値ラベルを集計できる", () => {
@@ -520,9 +532,9 @@ describe("gradeConstraints: 参照はidで持つ（issue #1063）", () => {
       viewpoints: [],
     }
 
-    const { violations, errors } = evaluateConstraints(result, [expr])
+    const { errors } = evaluateConstraints(result, [expr])
     expect(errors.size).toBe(0)
-    expect([...violations.keys()]).toEqual(["s1"])
+    expect(violatedIds(result, [expr])).toEqual(["s1"])
   })
 
   it("混在禁止ラベルが1つ以下なら無言失火せずエラーになる", () => {

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -13,6 +13,7 @@
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { LegacyGradeArchiveData } from "../../../electron-src/lib/import/grade-transformers/legacyShape"
 import type { GradeArchiveData } from "../../../src/types/gradeArchive.types"
 import {
   cleanupTestDatabase,
@@ -40,18 +41,194 @@ function toArchive(
   gradeId: string,
   collected: Awaited<ReturnType<typeof collectGradeArchiveData>>
 ): GradeArchiveData {
+  const { counts, ...sections } = collected
   return {
     manifest: {
-      version: "1.5.0",
+      version: "1.13.0",
       appVersion: "test",
       exportedAt: new Date("2026-06-23T00:00:00.000Z").toISOString(),
       gradeId,
-      gradeName: collected.gradeData.grade.name,
+      gradeName: collected.grades[0]?.name ?? "",
+      counts,
+    },
+    ...sections,
+  }
+}
+
+/**
+ * 収集結果を v1.12.0 以前の射影形式へ落とす（旧アーカイブの再現用）。
+ * 変換器の逆向きで、旧形式の読込互換を検証するテストだけが使う。
+ */
+function toLegacyArchive(
+  gradeId: string,
+  collected: Awaited<ReturnType<typeof collectGradeArchiveData>>
+): LegacyGradeArchiveData {
+  const gradeItemNameById = new Map(
+    collected.gradeItems.map((gradeItem) => [gradeItem.id, gradeItem.name])
+  )
+  const studentNumberByGradeStudentId = new Map(
+    collected.gradeStudents.map((gradeStudent) => [
+      gradeStudent.id,
+      collected.studentsData.find(
+        (student) => student.id === gradeStudent.studentId
+      )!.studentNumber,
+    ])
+  )
+  const legacyCell = (cell: {
+    gradeStudentId: string
+    gradeItemId: string
+  }) => ({
+    studentNumber: studentNumberByGradeStudentId.get(cell.gradeStudentId)!,
+    gradeItemId: cell.gradeItemId,
+    gradeItemName: gradeItemNameById.get(cell.gradeItemId)!,
+  })
+
+  return {
+    manifest: {
+      version: "1.12.0",
+      appVersion: "test",
+      exportedAt: new Date("2026-06-23T00:00:00.000Z").toISOString(),
+      gradeId,
+      gradeName: collected.grades[0]?.name ?? "",
       counts: collected.counts,
     },
-    gradeData: collected.gradeData,
+    gradeData: {
+      grade: {
+        name: collected.grades[0].name,
+        description: collected.grades[0].description,
+        referenceDate: collected.grades[0].referenceDate,
+      },
+      exportSettings: collected.gradeExportSettings[0]
+        ? { settingsJson: collected.gradeExportSettings[0].settingsJson }
+        : null,
+      gradeItems: collected.gradeItems.map((gradeItem) => ({
+        id: gradeItem.id,
+        name: gradeItem.name,
+        order: gradeItem.order,
+        dataSources: collected.gradeDataSources
+          .filter((dataSource) => dataSource.gradeItemId === gradeItem.id)
+          .map((dataSource) => ({
+            id: dataSource.id,
+            type: dataSource.type,
+            name: dataSource.name,
+            weight: Number(dataSource.weight),
+            order: dataSource.order,
+            examName:
+              collected.examRefs.find(
+                (examRef) => examRef.id === dataSource.examId
+              )?.examName ?? null,
+            subtotalName:
+              collected.subtotalRefs.find(
+                (subtotalRef) => subtotalRef.id === dataSource.subtotalId
+              )?.name ?? null,
+            cropRegionLabel:
+              collected.cropRegionRefs.find(
+                (cropRegionRef) => cropRegionRef.id === dataSource.cropRegionId
+              )?.label ?? null,
+            absentMethod: dataSource.absentMethod,
+            absentRatio: Number(dataSource.absentRatio),
+            absentOffset: Number(dataSource.absentOffset),
+            treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
+            estimationMode: dataSource.estimationMode,
+            estimationSourceIds: collected.gradeDataSourceEstimationSources
+              .filter(
+                (estimationSource) =>
+                  estimationSource.dataSourceId === dataSource.id
+              )
+              .map((estimationSource) => estimationSource.sourceDataSourceId),
+            examId: dataSource.examId,
+            subtotalId: dataSource.subtotalId,
+            cropRegionId: dataSource.cropRegionId,
+            courseworkId: dataSource.courseworkId,
+            courseworkItemId: dataSource.courseworkItemId,
+          })),
+      })),
+      classroomRefs: collected.gradeClassrooms.map((gradeClassroom) => ({
+        id: gradeClassroom.classroomId,
+        name: collected.classesData.find(
+          (classroom) => classroom.id === gradeClassroom.classroomId
+        )!.name,
+      })),
+      examRefs: collected.examRefs.map((examRef) => ({
+        id: examRef.id,
+        examName: examRef.examName,
+        examDate: examRef.examDate,
+        dataSourceName:
+          collected.gradeDataSources.find(
+            (dataSource) => dataSource.examId === examRef.id
+          )?.name ?? "",
+      })),
+      studentRefs: collected.gradeStudents.map((gradeStudent) => ({
+        id: gradeStudent.studentId,
+        studentNumber: studentNumberByGradeStudentId.get(gradeStudent.id)!,
+        classroomName: null,
+        customOrder: gradeStudent.customOrder,
+      })),
+      gradeItemExclusions: collected.gradeItemExclusions.map(legacyCell),
+      gradeOverrides: collected.gradeOverrides.map((override) => ({
+        ...legacyCell(override),
+        overrideLabel: override.overrideLabel,
+      })),
+      gradeFrozenScores: collected.gradeFrozenScores.map((frozenScore) => ({
+        ...legacyCell(frozenScore),
+        weightedScore:
+          frozenScore.weightedScore === null
+            ? null
+            : Number(frozenScore.weightedScore),
+        weightedMaxScore: Number(frozenScore.weightedMaxScore),
+        percentage:
+          frozenScore.percentage === null
+            ? null
+            : Number(frozenScore.percentage),
+        gradeLabel: frozenScore.gradeLabel,
+        frozenAt: frozenScore.frozenAt,
+      })),
+      gradeConstraints: collected.gradeConstraints.map((constraint) => ({
+        name: constraint.name,
+        kind: constraint.kind,
+        targetGradeItemId: constraint.targetGradeItemId,
+        targetGradeItemName: constraint.targetGradeItemId
+          ? (gradeItemNameById.get(constraint.targetGradeItemId) ?? null)
+          : null,
+        aggregate: constraint.aggregate,
+        tolerance: Number(constraint.tolerance),
+        viewpointGradeItemIds: collected.gradeConstraintViewpoints
+          .filter((viewpoint) => viewpoint.constraintId === constraint.id)
+          .map((viewpoint) => viewpoint.gradeItemId),
+        viewpointGradeItemNames: collected.gradeConstraintViewpoints
+          .filter((viewpoint) => viewpoint.constraintId === constraint.id)
+          .map((viewpoint) => gradeItemNameById.get(viewpoint.gradeItemId)!),
+        labelValues: Object.fromEntries(
+          collected.gradeConstraintLabelValues
+            .filter((labelValue) => labelValue.constraintId === constraint.id)
+            .map((labelValue) => [labelValue.label, Number(labelValue.value)])
+        ),
+        exclusionLabels: collected.gradeConstraintExclusionLabels
+          .filter(
+            (exclusionLabel) => exclusionLabel.constraintId === constraint.id
+          )
+          .map((exclusionLabel) => exclusionLabel.label),
+        expression: constraint.expression,
+        color: constraint.color,
+        message: constraint.message,
+        enabled: constraint.enabled,
+        order: constraint.order,
+      })),
+    },
     courseworkArchive: collected.courseworkArchive,
-    boundariesData: collected.boundariesData,
+    boundariesData: {
+      boundarySets: collected.gradeBoundarySets.map((boundarySet) => ({
+        gradeItemId: boundarySet.gradeItemId,
+        gradeItemName: gradeItemNameById.get(boundarySet.gradeItemId)!,
+        boundaries: collected.gradeBoundaries
+          .filter((boundary) => boundary.gradeBoundarySetId === boundarySet.id)
+          .map((boundary) => ({
+            label: boundary.label,
+            minPercentage: Number(boundary.minPercentage),
+            order: boundary.order,
+          })),
+      })),
+    },
   }
 }
 
@@ -85,10 +262,8 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // 収集（export）
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.grade.referenceDate).toBe(
-      referenceDate.toISOString()
-    )
-    expect(collected.gradeData.exportSettings?.settingsJson).toBe(settingsJson)
+    expect(collected.grades[0].referenceDate).toBe(referenceDate.toISOString())
+    expect(collected.gradeExportSettings[0].settingsJson).toBe(settingsJson)
 
     // インポート（新規Gradeとして作成される）
     const result = await importGradeArchive(toArchive(grade.id, collected))
@@ -232,11 +407,21 @@ describe("grade-archive ラウンドトリップ", () => {
     expect(collected.courseworkArchive.studentsData[0].studentNumber).toBe(
       `CW_${suffix}`
     )
-    const collectedNumDs = collected.gradeData.gradeItems[0].dataSources.find(
+    const collectedNumDs = collected.gradeDataSources.find(
       (dataSource) => dataSource.name === "提出物参照"
     )!
-    expect(collectedNumDs.courseworkName).toBe(`第2回レポート_${suffix}`)
-    expect(collectedNumDs.courseworkItemName).toBe("提出物")
+    // 参照先の資料・評価項目は内包する courseworkArchive の行として carry される。
+    // データソースの行は uuid だけを持つ（名前を二重に持たない）
+    expect(collectedNumDs.courseworkItemId).not.toBeNull()
+    const referencedItem = collected.courseworkArchive.courseworkItems.find(
+      (item) => item.id === collectedNumDs.courseworkItemId
+    )!
+    expect(referencedItem.name).toBe("提出物")
+    expect(
+      collected.courseworkArchive.courseworks.find(
+        (coursework) => coursework.id === referencedItem.courseworkId
+      )!.name
+    ).toBe(`第2回レポート_${suffix}`)
 
     // インポート（新規 Grade + Coursework が作成される。同名Courseworkは無い前提）
     // 既存 Coursework と名前衝突しないよう、元の資料は残るが import 時は
@@ -287,7 +472,7 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     // アーカイブを手組み（DBには Coursework を作らず、埋め込みのみ）
-    const archive: GradeArchiveData = {
+    const archive: LegacyGradeArchiveData = {
       manifest: {
         version: "1.4.0",
         appVersion: "test",
@@ -408,7 +593,7 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     // 旧 v1.3.0 アーカイブ JSON を手組み（courseworks 無し、manualScoresData あり）
-    const legacy: GradeArchiveData = {
+    const legacy: LegacyGradeArchiveData = {
       manifest: {
         version: "1.3.0",
         appVersion: "test",
@@ -520,7 +705,7 @@ describe("grade-archive ラウンドトリップ", () => {
       },
     })
 
-    const buildLegacy = (): GradeArchiveData => ({
+    const buildLegacy = (): LegacyGradeArchiveData => ({
       manifest: {
         version: "1.3.0",
         appVersion: "test",
@@ -615,7 +800,7 @@ describe("grade-archive ラウンドトリップ", () => {
   //   無効な "manual" 型のまま永続化されないこと（検出ゲートの回帰防止）
   it("v1.3.0: 点数未入力の manual ソースも coursework 型へ変換される", async () => {
     const suffix = Date.now()
-    const archive: GradeArchiveData = {
+    const archive: LegacyGradeArchiveData = {
       manifest: {
         version: "1.3.0",
         appVersion: "test",
@@ -677,8 +862,8 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.grade.referenceDate).toBeNull()
-    expect(collected.gradeData.exportSettings).toBeNull()
+    expect(collected.grades[0].referenceDate).toBeNull()
+    expect(collected.gradeExportSettings).toHaveLength(0)
     expect(collected.courseworkArchive.courseworks).toHaveLength(0)
 
     const result = await importGradeArchive(toArchive(grade.id, collected))
@@ -710,7 +895,7 @@ describe("grade-archive ラウンドトリップ", () => {
       },
     })
 
-    const buildArchive = (): GradeArchiveData => ({
+    const buildArchive = (): LegacyGradeArchiveData => ({
       manifest: {
         version: "1.4.0",
         appVersion: "test",
@@ -849,7 +1034,7 @@ describe("grade-archive ラウンドトリップ", () => {
       include: { items: true },
     })
 
-    const archive: GradeArchiveData = {
+    const archive: LegacyGradeArchiveData = {
       manifest: {
         version: "1.4.0",
         appVersion: "test",
@@ -1023,25 +1208,38 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // 収集（export）
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.gradeConstraints).toHaveLength(2)
-    const exclusion = collected.gradeData.gradeConstraints!.find(
+    expect(collected.gradeConstraints).toHaveLength(2)
+    const exclusion = collected.gradeConstraints.find(
       (constraint) => constraint.kind === "mutual_exclusion"
     )!
     expect(exclusion.name).toBe("A・C混在禁止")
-    expect(exclusion.exclusionLabels).toEqual(["A", "C"])
-    expect(exclusion.config).toBeUndefined()
+    // 混在禁止ラベルは中間テーブルの行として持つ（配列へ潰さない）
+    expect(
+      collected.gradeConstraintExclusionLabels
+        .filter((row) => row.constraintId === exclusion.id)
+        .map((row) => row.label)
+    ).toEqual(["A", "C"])
 
-    const consistency = collected.gradeData.gradeConstraints!.find(
+    const consistency = collected.gradeConstraints.find(
       (constraint) => constraint.kind === "consistency"
     )!
-    // uuid 一次・名前二次で持ち出す
+    // 参照は行の uuid のまま。観点・ラベル値も中間テーブルの行として持つ
     expect(consistency.targetGradeItemId).toBe(hyoteiItem.id)
-    expect(consistency.targetGradeItemName).toBe("評定")
-    expect(consistency.viewpointGradeItemIds).toEqual([knowledgeItem.id])
-    expect(consistency.viewpointGradeItemNames).toEqual(["知識・技能"])
-    expect(consistency.labelValues).toEqual({ A: 5, C: 1 })
+    expect(
+      collected.gradeConstraintViewpoints
+        .filter((row) => row.constraintId === consistency.id)
+        .map((row) => row.gradeItemId)
+    ).toEqual([knowledgeItem.id])
+    expect(
+      collected.gradeConstraintLabelValues
+        .filter((row) => row.constraintId === consistency.id)
+        .map((row) => [row.label, Number(row.value)])
+    ).toEqual([
+      ["A", 5],
+      ["C", 1],
+    ])
     expect(consistency.aggregate).toBe("sum")
-    expect(consistency.tolerance).toBe(2)
+    expect(Number(consistency.tolerance)).toBe(2)
 
     // インポート（新規Gradeとして作成される）
     const result = await importGradeArchive(toArchive(grade.id, collected))
@@ -1112,7 +1310,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_frozen_${suffix}` },
     })
-    await prisma.gradeStudent.create({
+    const gradeStudent = await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
     const gradeItem = await prisma.gradeItem.create({
@@ -1121,8 +1319,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const frozenAt = new Date("2026-07-20T09:00:00.000Z")
     await prisma.gradeFrozenScore.create({
       data: {
-        gradeId: grade.id,
-        studentId: student.id,
+        gradeStudentId: gradeStudent.id,
         gradeItemId: gradeItem.id,
         weightedScore: 0.8,
         weightedMaxScore: 1,
@@ -1132,31 +1329,37 @@ describe("grade-archive ラウンドトリップ", () => {
       },
     })
 
-    // 収集（export）: 外部参照は学籍番号・評価項目名の名前ベース
+    // 収集（export）: 行をそのまま持つ（Decimal は文字列、参照は uuid）
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.gradeFrozenScores).toHaveLength(1)
-    expect(collected.gradeData.gradeFrozenScores![0]).toMatchObject({
-      studentNumber: `SF${suffix}`,
-      gradeItemName: "知識・技能",
-      weightedScore: 0.8,
-      weightedMaxScore: 1,
-      percentage: 80,
+    expect(collected.gradeFrozenScores).toHaveLength(1)
+    expect(collected.gradeFrozenScores[0]).toMatchObject({
+      gradeStudentId: gradeStudent.id,
+      gradeItemId: gradeItem.id,
+      weightedScore: "0.8",
+      weightedMaxScore: "1",
+      percentage: "80",
       gradeLabel: "A",
     })
+    // 生徒は full レコードとして carry される（uuid が当たらなければ学籍番号で当てる）
+    expect(collected.studentsData[0].studentNumber).toBe(`SF${suffix}`)
 
     // インポート（新規Gradeとして作成される）
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
 
     const imported = await prisma.gradeFrozenScore.findMany({
-      where: { gradeId: result.gradeId! },
+      where: { gradeStudent: { gradeId: result.gradeId! } },
     })
     expect(imported).toHaveLength(1)
     expect(Number(imported[0].percentage)).toBe(80)
     expect(Number(imported[0].weightedScore)).toBe(0.8)
     expect(Number(imported[0].weightedMaxScore)).toBe(1)
     expect(imported[0].gradeLabel).toBe("A")
-    expect(imported[0].studentId).toBe(student.id)
+    // 確定値は「その成績の対象者」にぶら下がる。人へは1段辿って確認する
+    const importedGradeStudent = await prisma.gradeStudent.findUniqueOrThrow({
+      where: { id: imported[0].gradeStudentId },
+    })
+    expect(importedGradeStudent.studentId).toBe(student.id)
     expect(new Date(imported[0].frozenAt).toISOString()).toBe(
       frozenAt.toISOString()
     )
@@ -1180,7 +1383,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_dup_${suffix}` },
     })
-    await prisma.gradeStudent.create({
+    const gradeStudent = await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
     // 同じ名前の評価項目を2つ作る（1つ目は「寄せられる先」になりうる側）
@@ -1193,8 +1396,7 @@ describe("grade-archive ラウンドトリップ", () => {
     // 確定値・上書き・境界はすべて「2つ目」に付ける
     await prisma.gradeFrozenScore.create({
       data: {
-        gradeId: grade.id,
-        studentId: student.id,
+        gradeStudentId: gradeStudent.id,
         gradeItemId: secondItem.id,
         weightedScore: 0.7,
         weightedMaxScore: 1,
@@ -1204,8 +1406,7 @@ describe("grade-archive ラウンドトリップ", () => {
     })
     await prisma.gradeOverride.create({
       data: {
-        gradeId: grade.id,
-        studentId: student.id,
+        gradeStudentId: gradeStudent.id,
         gradeItemId: secondItem.id,
         overrideLabel: "4",
       },
@@ -1224,10 +1425,8 @@ describe("grade-archive ラウンドトリップ", () => {
 
     const collected = await collectGradeArchiveData(grade.id)
     // 参照は uuid を持ち出している
-    expect(collected.gradeData.gradeItems[1].id).toBe(secondItem.id)
-    expect(collected.gradeData.gradeFrozenScores![0].gradeItemId).toBe(
-      secondItem.id
-    )
+    expect(collected.gradeItems[1].id).toBe(secondItem.id)
+    expect(collected.gradeFrozenScores[0].gradeItemId).toBe(secondItem.id)
 
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
@@ -1241,13 +1440,13 @@ describe("grade-archive ラウンドトリップ", () => {
     const importedSecondId = importedItems[1].id
 
     const frozen = await prisma.gradeFrozenScore.findMany({
-      where: { gradeId: result.gradeId! },
+      where: { gradeStudent: { gradeId: result.gradeId! } },
     })
     expect(frozen).toHaveLength(1)
     expect(frozen[0].gradeItemId).toBe(importedSecondId)
 
     const overrides = await prisma.gradeOverride.findMany({
-      where: { gradeId: result.gradeId! },
+      where: { gradeStudent: { gradeId: result.gradeId! } },
     })
     expect(overrides).toHaveLength(1)
     expect(overrides[0].gradeItemId).toBe(importedSecondId)
@@ -1274,7 +1473,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_legacy_${suffix}` },
     })
-    await prisma.gradeStudent.create({
+    const gradeStudent = await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
     await prisma.gradeItem.create({
@@ -1285,7 +1484,7 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     const collected = await collectGradeArchiveData(grade.id)
-    const archive = toArchive(grade.id, collected)
+    const archive = toLegacyArchive(grade.id, collected)
     // uuid を持たない v1.9.0 以前のアーカイブを再現する
     archive.gradeData.gradeItems = archive.gradeData.gradeItems.map(
       (gradeItem) => ({ ...gradeItem, id: undefined })
@@ -1303,7 +1502,7 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // どちらの項目か決められないので取り込まず、その旨を警告する
     const overrides = await prisma.gradeOverride.findMany({
-      where: { gradeId: result.gradeId! },
+      where: { gradeStudent: { gradeId: result.gradeId! } },
     })
     expect(overrides).toHaveLength(0)
     expect(
@@ -1358,11 +1557,9 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.studentRefs[0].id).toBe(student.id)
-    expect(collected.gradeData.classroomRefs[0].id).toBe(classroom.id)
-    expect(collected.gradeData.gradeItems[0].dataSources[0].examId).toBe(
-      exam.id
-    )
+    expect(collected.gradeStudents[0].studentId).toBe(student.id)
+    expect(collected.gradeClassrooms[0].classroomId).toBe(classroom.id)
+    expect(collected.gradeDataSources[0].examId).toBe(exam.id)
 
     // 取り込み前に名前・学籍番号をすべて変える（名前照合なら全滅する状況）
     await prisma.student.update({
@@ -1422,12 +1619,12 @@ describe("grade-archive ラウンドトリップ", () => {
     await prisma.gradeClassroom.create({
       data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
     })
-    await prisma.gradeStudent.create({
+    const gradeStudent = await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
 
     const collected = await collectGradeArchiveData(grade.id)
-    const archive = toArchive(grade.id, collected)
+    const archive = toLegacyArchive(grade.id, collected)
     // v1.9.0 以前を再現: 外部参照から uuid を落とす
     archive.gradeData.studentRefs = archive.gradeData.studentRefs.map(
       (studentRef) => ({ ...studentRef, id: undefined })
@@ -1502,9 +1699,7 @@ describe("grade-archive ラウンドトリップ", () => {
     })
 
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.gradeItems[0].dataSources[0].subtotalId).toBe(
-      targetSubtotal.id
-    )
+    expect(collected.gradeDataSources[0].subtotalId).toBe(targetSubtotal.id)
 
     // uuid あり: 一次照合で対象の小計に当たる
     const withUuid = await importGradeArchive(toArchive(grade.id, collected))
@@ -1516,7 +1711,7 @@ describe("grade-archive ラウンドトリップ", () => {
 
     // uuid なし（v1.9.0 以前）: 名前フォールバックでも試験で絞られ、
     // 無関係な試験の同名小計には当たらない
-    const legacyArchive = toArchive(grade.id, collected)
+    const legacyArchive = toLegacyArchive(grade.id, collected)
     legacyArchive.gradeData.gradeItems = legacyArchive.gradeData.gradeItems.map(
       (item) => ({
         ...item,
@@ -1540,14 +1735,401 @@ describe("grade-archive ラウンドトリップ", () => {
       data: { name: `成績_nofrozen_${Date.now()}` },
     })
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.gradeFrozenScores).toBeUndefined()
+    expect(collected.gradeFrozenScores).toHaveLength(0)
 
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
     const imported = await prisma.gradeFrozenScore.findMany({
-      where: { gradeId: result.gradeId! },
+      where: { gradeStudent: { gradeId: result.gradeId! } },
     })
     expect(imported).toHaveLength(0)
+  })
+
+  it("アーカイブの名簿に無い対象者を指すセルは取り込まず警告する（#962 Phase C）", async () => {
+    const suffix = Date.now()
+    // セルは対象者（GradeStudent）を uuid で指す。その uuid が名簿セクションに
+    // 無ければ、取り込み先で対象者を作れないのでセルも作ってはいけない
+    // （作れてしまうと、どの画面にも出ない孤児が復活する）。
+    const grade = await prisma.grade.create({
+      data: { name: `成績_orphan_${suffix}` },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    const collected = await collectGradeArchiveData(grade.id)
+
+    const EPOCH = new Date(0).toISOString()
+    // 名簿（gradeStudents）は空のまま、そこに載っていない対象者を指すセルを差し込む
+    const cell = {
+      gradeStudentId: `orphan-grade-student-${suffix}`,
+      gradeItemId: gradeItem.id,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+    }
+    collected.gradeOverrides = [
+      { id: "override-1", ...cell, overrideLabel: "A" },
+    ]
+    collected.gradeFrozenScores = [
+      {
+        id: "frozen-1",
+        ...cell,
+        weightedScore: "0.8",
+        weightedMaxScore: "1",
+        percentage: "80",
+        gradeLabel: "A",
+        frozenByUserId: null,
+        frozenAt: new Date("2026-07-20T09:00:00.000Z").toISOString(),
+      },
+    ]
+    collected.gradeItemExclusions = [{ id: "exclusion-1", ...cell }]
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    const [overrides, frozenScores, itemExclusions] = await Promise.all([
+      prisma.gradeOverride.count({
+        where: { gradeStudent: { gradeId: result.gradeId! } },
+      }),
+      prisma.gradeFrozenScore.count({
+        where: { gradeStudent: { gradeId: result.gradeId! } },
+      }),
+      prisma.gradeItemExclusion.count({
+        where: { gradeStudent: { gradeId: result.gradeId! } },
+      }),
+    ])
+    expect(overrides).toBe(0)
+    expect(frozenScores).toBe(0)
+    expect(itemExclusions).toBe(0)
+
+    // 捨てたことは黙らずに伝える
+    expect(
+      result.warnings?.some((warning) =>
+        warning.includes("上書き・確定値・除外設定 3件")
+      )
+    ).toBe(true)
+  })
+
+  it("取り込み先に居ない生徒・学級は作られ、学級所属も復元される (v1.13.0)", async () => {
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SNEW${suffix}`,
+        lastName: "新規",
+        firstName: "太郎",
+        lastNameKana: "シンキ",
+        firstNameKana: "タロウ",
+      },
+    })
+    const classroom = await prisma.classroom.create({
+      data: { name: `新規学級_${suffix}` },
+    })
+    await prisma.studentClassroomMembership.create({
+      data: {
+        studentId: student.id,
+        classroomId: classroom.id,
+        attendanceNumber: 7,
+      },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_new_${suffix}` },
+    })
+    await prisma.gradeClassroom.create({
+      data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
+    })
+    const gradeStudent = await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeOverride.create({
+      data: {
+        gradeStudentId: gradeStudent.id,
+        gradeItemId: gradeItem.id,
+        overrideLabel: "A",
+      },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+
+    // 取り込み先から生徒・学級を消して「別PCへ持って行った」状況を作る
+    await prisma.grade.delete({ where: { id: grade.id } })
+    await prisma.studentClassroomMembership.deleteMany({
+      where: { studentId: student.id },
+    })
+    await prisma.student.delete({ where: { id: student.id } })
+    await prisma.classroom.delete({ where: { id: classroom.id } })
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    // 生徒・学級が作られ、学級所属（出席番号つき）まで戻る
+    const restoredStudent = await prisma.student.findUniqueOrThrow({
+      where: { studentNumber: `SNEW${suffix}` },
+      include: { memberships: { include: { classroom: true } } },
+    })
+    expect(restoredStudent.lastName).toBe("新規")
+    expect(restoredStudent.memberships).toHaveLength(1)
+    expect(restoredStudent.memberships[0].classroom.name).toBe(
+      `新規学級_${suffix}`
+    )
+    expect(restoredStudent.memberships[0].attendanceNumber).toBe(7)
+
+    // 名簿と上書きも復元される（作られなければ両方落ちていた）
+    const restoredOverrides = await prisma.gradeOverride.findMany({
+      where: { gradeStudent: { gradeId: result.gradeId! } },
+      include: { gradeStudent: true },
+    })
+    expect(restoredOverrides).toHaveLength(1)
+    expect(restoredOverrides[0].gradeStudent.studentId).toBe(restoredStudent.id)
+    expect(restoredOverrides[0].overrideLabel).toBe("A")
+  })
+
+  it("収集結果は Prisma の行そのままで、射影した名前を持たない (v1.13.0)", async () => {
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SROW${suffix}`,
+        lastName: "行",
+        firstName: "太郎",
+        lastNameKana: "ギョウ",
+        firstNameKana: "タロウ",
+      },
+    })
+    const classroom = await prisma.classroom.create({
+      data: { name: `行学級_${suffix}` },
+    })
+    await prisma.studentClassroomMembership.create({
+      data: { studentId: student.id, classroomId: classroom.id },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_row_${suffix}` },
+    })
+    await prisma.gradeClassroom.create({
+      data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
+    })
+    const gradeStudent = await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeItemExclusion.create({
+      data: { gradeStudentId: gradeStudent.id, gradeItemId: gradeItem.id },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+
+    // 行は DB の列そのまま。id・作成日時まで持ち、射影した名前を持たない
+    expect(collected.grades[0].id).toBe(grade.id)
+    expect(collected.grades[0].createdAt).toBe(grade.createdAt.toISOString())
+    expect(collected.gradeStudents[0]).toEqual({
+      id: gradeStudent.id,
+      gradeId: grade.id,
+      studentId: student.id,
+      customOrder: null,
+      createdAt: gradeStudent.createdAt.toISOString(),
+      updatedAt: gradeStudent.updatedAt.toISOString(),
+    })
+    expect(collected.gradeStudents[0]).not.toHaveProperty("studentNumber")
+    expect(collected.gradeItemExclusions[0]).not.toHaveProperty("gradeItemName")
+    // 学級所属も carry する（名簿の学級表示の裏付け）
+    expect(collected.membershipsData).toHaveLength(1)
+    expect(collected.membershipsData[0].studentId).toBe(student.id)
+
+    // 往復しても対象者・評価項目の対応が保たれる
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+    const importedExclusions = await prisma.gradeItemExclusion.findMany({
+      where: { gradeStudent: { gradeId: result.gradeId! } },
+      include: {
+        gradeStudent: { include: { student: true } },
+        gradeItem: true,
+      },
+    })
+    expect(importedExclusions).toHaveLength(1)
+    expect(importedExclusions[0].gradeStudent.student.id).toBe(student.id)
+    expect(importedExclusions[0].gradeItem.name).toBe("知識・技能")
+  })
+
+  it("確定操作者は取り込み先に居れば残り、居なければ操作者不明になる (v1.13.0)", async () => {
+    const suffix = Date.now()
+    const user = await prisma.user.create({
+      data: { username: `teacher_${suffix}`, name: "採点 教員" },
+    })
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SFU${suffix}`,
+        lastName: "凍結",
+        firstName: "花子",
+        lastNameKana: "トウケツ",
+        firstNameKana: "ハナコ",
+      },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_frozenby_${suffix}` },
+    })
+    const gradeStudent = await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+    const gradeItem = await prisma.gradeItem.create({
+      data: { gradeId: grade.id, name: "知識・技能", order: 0 },
+    })
+    await prisma.gradeFrozenScore.create({
+      data: {
+        gradeStudentId: gradeStudent.id,
+        gradeItemId: gradeItem.id,
+        weightedScore: 0.8,
+        weightedMaxScore: 1,
+        percentage: 80,
+        gradeLabel: "A",
+        frozenByUserId: user.id,
+      },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    // 行そのままなので確定操作者も持ち出す（旧形式は落としていた）
+    expect(collected.gradeFrozenScores[0].frozenByUserId).toBe(user.id)
+
+    const kept = await importGradeArchive(toArchive(grade.id, collected))
+    expect(
+      (
+        await prisma.gradeFrozenScore.findFirstOrThrow({
+          where: { gradeStudent: { gradeId: kept.gradeId! } },
+        })
+      ).frozenByUserId
+    ).toBe(user.id)
+
+    // 取り込み先に居ない操作者は null（値そのものは残す）
+    collected.gradeFrozenScores[0].frozenByUserId = `missing-user-${suffix}`
+    const dropped = await importGradeArchive(toArchive(grade.id, collected))
+    const restored = await prisma.gradeFrozenScore.findFirstOrThrow({
+      where: { gradeStudent: { gradeId: dropped.gradeId! } },
+    })
+    expect(restored.frozenByUserId).toBeNull()
+    expect(Number(restored.percentage)).toBe(80)
+  })
+
+  it("既存生徒の学級所属は書き換えない（異動先を旧学級で上書きしない）", async () => {
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SMOVE${suffix}`,
+        lastName: "異動",
+        firstName: "太郎",
+        lastNameKana: "イドウ",
+        firstNameKana: "タロウ",
+      },
+    })
+    const oldClassroom = await prisma.classroom.create({
+      data: { name: `旧学級_${suffix}` },
+    })
+    await prisma.studentClassroomMembership.create({
+      data: { studentId: student.id, classroomId: oldClassroom.id },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_move_${suffix}` },
+    })
+    await prisma.gradeClassroom.create({
+      data: { gradeId: grade.id, classroomId: oldClassroom.id, order: 0 },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+
+    // 取り込み先では別学級へ異動済み、という状況を作る
+    await prisma.studentClassroomMembership.deleteMany({
+      where: { studentId: student.id },
+    })
+    const newClassroom = await prisma.classroom.create({
+      data: { name: `新学級_${suffix}` },
+    })
+    await prisma.studentClassroomMembership.create({
+      data: { studentId: student.id, classroomId: newClassroom.id },
+    })
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+    expect(result.success).toBe(true)
+
+    // 既存生徒なので学級所属は触らない。旧学級の在籍が復活してはいけない
+    const memberships = await prisma.studentClassroomMembership.findMany({
+      where: { studentId: student.id },
+      include: { classroom: true },
+    })
+    expect(memberships).toHaveLength(1)
+    expect(memberships[0].classroom.name).toBe(`新学級_${suffix}`)
+  })
+
+  it("アーカイブの別々の生徒が同じ既存生徒へ一致しても取り込みは失敗しない", async () => {
+    const suffix = Date.now()
+    const student = await prisma.student.create({
+      data: {
+        studentNumber: `SDUP${suffix}`,
+        lastName: "重複",
+        firstName: "太郎",
+        lastNameKana: "ジュウフク",
+        firstNameKana: "タロウ",
+      },
+    })
+    const grade = await prisma.grade.create({
+      data: { name: `成績_dupstudent_${suffix}` },
+    })
+    await prisma.gradeStudent.create({
+      data: { gradeId: grade.id, studentId: student.id },
+    })
+
+    const collected = await collectGradeArchiveData(grade.id)
+    const EPOCH = new Date(0).toISOString()
+    // uuid は違うが学籍番号が同じ、という2人目を差し込む（学籍番号の振り直しで起こる）
+    collected.studentsData.push({
+      ...collected.studentsData[0],
+      id: `other-uuid-${suffix}`,
+    })
+    collected.gradeStudents.push({
+      id: `other-grade-student-${suffix}`,
+      gradeId: grade.id,
+      studentId: `other-uuid-${suffix}`,
+      customOrder: 1,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+    })
+
+    const result = await importGradeArchive(toArchive(grade.id, collected))
+
+    // unique 違反で全体がロールバックせず、1名にまとめたことを伝える
+    expect(result.success).toBe(true)
+    expect(
+      await prisma.gradeStudent.count({
+        where: { gradeId: result.gradeId! },
+      })
+    ).toBe(1)
+    expect(
+      result.warnings?.some((warning) => warning.includes("1名にまとめました"))
+    ).toBe(true)
+  })
+
+  it("旧アーカイブから作る学級の id は uuid になる（合成idを主キーにしない）", async () => {
+    const suffix = Date.now()
+    const grade = await prisma.grade.create({
+      data: { name: `成績_clsid_${suffix}` },
+    })
+    const collected = await collectGradeArchiveData(grade.id)
+    const legacy = toLegacyArchive(grade.id, collected)
+    // v1.10.0 未満を再現: 学級参照から uuid を落とす
+    legacy.gradeData.classroomRefs = [{ name: `合成id学級_${suffix}` }]
+
+    const result = await importGradeArchive(legacy)
+    expect(result.success).toBe(true)
+
+    const created = await prisma.classroom.findUniqueOrThrow({
+      where: { name: `合成id学級_${suffix}` },
+    })
+    expect(created.id).not.toContain("legacy-classroom:")
+    expect(created.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    )
   })
 
   it("gradeConstraints が無いGradeも問題なく往復する（後方互換）", async () => {
@@ -1555,7 +2137,7 @@ describe("grade-archive ラウンドトリップ", () => {
       data: { name: `成績_noconstraint_${Date.now()}` },
     })
     const collected = await collectGradeArchiveData(grade.id)
-    expect(collected.gradeData.gradeConstraints).toBeUndefined()
+    expect(collected.gradeConstraints).toHaveLength(0)
 
     const result = await importGradeArchive(toArchive(grade.id, collected))
     expect(result.success).toBe(true)
@@ -1581,7 +2163,7 @@ describe("grade-archive ラウンドトリップ", () => {
 
     const archiveItemId = "00000000-0000-4000-8000-000000000abc"
     // v1.4.0 形式の GradeArchiveData を手組み（courseworks は名前ベース配列）
-    const legacy: GradeArchiveData = {
+    const legacy: LegacyGradeArchiveData = {
       manifest: {
         version: "1.4.0",
         appVersion: "test",

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -72,9 +72,11 @@ describe("ID変更時のカスケード網羅性（schema.prisma駆動）", () =
   }
 
   it("解析が機能していることの保証（Studentは複数のカスケード子を持つ）", () => {
-    // 解析が壊れて空集合になっても上のテストが通ってしまう事故を防ぐ
+    // 解析が壊れて空集合になっても上のテストが通ってしまう事故を防ぐ。
+    // #962 で採点・点数・成績のセルが各メンバーシップの子へ移ったため、
+    // Student 直下に残るのは所属とメンバーシップ4種のみ。
     expect(cascadeChildrenFromSchema("Student").length).toBeGreaterThanOrEqual(
-      5
+      4
     )
   })
 })
@@ -126,5 +128,31 @@ describe("資料の点数の親は CourseworkStudent（#962 の再発防止）",
     expect(cascadeChildrenFromSchema("Student")).not.toContain(
       "CourseworkScore"
     )
+  })
+})
+
+/**
+ * 成績のセルが「その成績の対象者」の子であることの固定（#962 Phase C）。
+ *
+ * 上書き・確定値・除外設定は (gradeId, studentId) の2列で人を直に指していた。
+ * GradeStudent を参照する子テーブルが1つも無いため名簿から外しても消えず、
+ * 同じ生徒を再び追加すると過去の設定が甦っていた（特に確定値は実害が大きい）。
+ */
+describe("成績のセルの親は GradeStudent（#962 の再発防止）", () => {
+  const GRADE_CELL_TABLES = [
+    "GradeFrozenScore",
+    "GradeItemExclusion",
+    "GradeOverride",
+  ]
+
+  it("成績のセル3種は GradeStudent の onDelete:Cascade 子である", () => {
+    expect(cascadeChildrenFromSchema("GradeStudent")).toEqual(GRADE_CELL_TABLES)
+  })
+
+  it("成績のセル3種は Student 直結ではない", () => {
+    const studentChildren = cascadeChildrenFromSchema("Student")
+    for (const table of GRADE_CELL_TABLES) {
+      expect(studentChildren).not.toContain(table)
+    }
   })
 })

--- a/__tests__/import-export/unit/gradeTransformerChain.test.ts
+++ b/__tests__/import-export/unit/gradeTransformerChain.test.ts
@@ -16,10 +16,8 @@ import {
   isLegacyCollectedCourseworkData,
 } from "../../../electron-src/lib/import/coursework-transformers/legacyShape"
 import { transformGradeToLatest } from "../../../electron-src/lib/import/grade-transformers"
-import type {
-  GradeArchiveData,
-  GradeArchiveManifest,
-} from "../../../src/types/gradeArchive.types"
+import type { LegacyGradeArchiveData } from "../../../electron-src/lib/import/grade-transformers/legacyShape"
+import type { GradeArchiveManifest } from "../../../src/types/gradeArchive.types"
 import { GRADE_CURRENT_VERSION } from "../../../src/types/gradeArchive.types"
 
 const manifest: GradeArchiveManifest = {
@@ -43,7 +41,7 @@ const manifest: GradeArchiveManifest = {
  * v1.9.0 が実際に書き出していた形。境界セット・手動上書きが targetType を持ち、
  * 総合は gradeItemName が null。courseworkArchive は 1.5.0 以降の現行形式。
  */
-function buildV1_9_0Archive(): GradeArchiveData {
+function buildV1_9_0Archive(): LegacyGradeArchiveData {
   return {
     manifest,
     gradeData: {
@@ -51,7 +49,13 @@ function buildV1_9_0Archive(): GradeArchiveData {
       gradeItems: [{ name: "知識・技能", order: 0, dataSources: [] }],
       classroomRefs: [],
       examRefs: [],
-      studentRefs: [],
+      studentRefs: [
+        {
+          studentNumber: "S001",
+          classroomName: null,
+          customOrder: 0,
+        },
+      ],
       gradeOverrides: [
         {
           studentNumber: "S001",
@@ -108,11 +112,18 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
   it("総合の境界セット・手動上書きが破棄され、評価項目のものは残る", () => {
     const { data } = transformGradeToLatest(buildV1_9_0Archive())
 
-    expect(data.boundariesData.boundarySets).toHaveLength(1)
-    expect(data.boundariesData.boundarySets[0].gradeItemName).toBe("知識・技能")
-    expect(data.gradeData.gradeOverrides).toHaveLength(1)
-    expect(data.gradeData.gradeOverrides![0].gradeItemName).toBe("知識・技能")
-    expect(data.gradeData.gradeOverrides![0].overrideLabel).toBe("A")
+    const gradeItemNameById = new Map(
+      data.gradeItems.map((gradeItem) => [gradeItem.id, gradeItem.name])
+    )
+    expect(data.gradeBoundarySets).toHaveLength(1)
+    expect(gradeItemNameById.get(data.gradeBoundarySets[0].gradeItemId)).toBe(
+      "知識・技能"
+    )
+    expect(data.gradeOverrides).toHaveLength(1)
+    expect(gradeItemNameById.get(data.gradeOverrides[0].gradeItemId)).toBe(
+      "知識・技能"
+    )
+    expect(data.gradeOverrides[0].overrideLabel).toBe("A")
   })
 
   it("破棄した件数が warning として利用者に伝わる（黙って消さない）", () => {
@@ -128,11 +139,11 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
     expect(warnings.join("\n")).toContain("1 件")
   })
 
-  it("targetType は新形式へ持ち越さない", () => {
+  it("targetType は新形式へ持ち越さない（行に列そのものが無い）", () => {
     const { data } = transformGradeToLatest(buildV1_9_0Archive())
 
-    expect(data.boundariesData.boundarySets[0].targetType).toBeUndefined()
-    expect(data.gradeData.gradeOverrides![0].targetType).toBeUndefined()
+    expect(data.gradeBoundarySets[0]).not.toHaveProperty("targetType")
+    expect(data.gradeOverrides[0]).not.toHaveProperty("targetType")
   })
 
   it("元バージョンを 1.9.0 と報告し、適用した変換と矛盾しない", () => {
@@ -173,9 +184,11 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
     const { warnings, appliedTransformations, originalVersion } =
       transformGradeToLatest(archive)
 
-    expect(warnings).toEqual([])
-    expect(appliedTransformations).toEqual([])
-    expect(originalVersion).toBe(GRADE_CURRENT_VERSION)
+    // 総合の名残が無いので 1.9.0→1.10.0 は当たらない。射影形式である以上
+    // 1.12.0→1.13.0 の平坦化だけは必ず通る
+    expect(warnings.some((warning) => warning.includes("1.9.0"))).toBe(false)
+    expect(appliedTransformations).toEqual([{ from: "1.12.0", to: "1.13.0" }])
+    expect(originalVersion).toBe("1.12.0")
   })
 
   it("gradeOverrides を持たない旧アーカイブでも境界セットだけ正規化できる", () => {
@@ -184,8 +197,8 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
 
     const { data, warnings } = transformGradeToLatest(archive)
 
-    expect(data.boundariesData.boundarySets).toHaveLength(1)
-    expect(data.gradeData.gradeOverrides).toBeUndefined()
+    expect(data.gradeBoundarySets).toHaveLength(1)
+    expect(data.gradeOverrides).toHaveLength(0)
     // 上書きは元々0件なので上書き側の warning は出ない
     expect(warnings.some((warning) => warning.includes("手動上書き"))).toBe(
       false
@@ -197,7 +210,7 @@ describe("transformGradeToLatest: 1.9.0 → 1.10.0（総合の撤去）", () => 
  * v1.10.0 が実際に書き出していた形。制約ルールの設定は kind 別の JSON 文字列
  * （config）で、評価項目を「名前」で参照していた（issue #1063 以前）。
  */
-function buildV1_10_0Archive(): GradeArchiveData {
+function buildV1_10_0Archive(): LegacyGradeArchiveData {
   const archive = buildV1_9_0Archive()
   // 総合の名残を取り除いて 1.10.0 相当の形にする
   archive.boundariesData.boundarySets = [
@@ -263,41 +276,63 @@ describe("transformGradeToLatest: 1.10.0 → 1.11.0（制約ルールの設定JS
       to: "1.11.0",
     })
 
-    const constraints = data.gradeData.gradeConstraints!
-    const consistency = constraints.find(
+    const gradeItemIdByName = new Map(
+      data.gradeItems.map((gradeItem) => [gradeItem.name, gradeItem.id])
+    )
+    const consistency = data.gradeConstraints.find(
       (constraint) => constraint.kind === "consistency"
     )!
-    // uuid は旧アーカイブに無いので名前だけ（importer が名前フォールバックで解決する）
-    expect(consistency.targetGradeItemName).toBe("評定")
-    expect(consistency.targetGradeItemId).toBeUndefined()
-    expect(consistency.viewpointGradeItemNames).toEqual(["知識・技能"])
-    expect(consistency.labelValues).toEqual({ A: 5, B: 3, C: 1 })
+    // 旧 config の名前参照は、平坦化の過程で評価項目の行 id へ解決される
+    expect(consistency.targetGradeItemId).toBe(gradeItemIdByName.get("評定"))
+    expect(
+      data.gradeConstraintViewpoints
+        .filter((viewpoint) => viewpoint.constraintId === consistency.id)
+        .map((viewpoint) => viewpoint.gradeItemId)
+    ).toEqual([gradeItemIdByName.get("知識・技能")])
+    expect(
+      data.gradeConstraintLabelValues
+        .filter((labelValue) => labelValue.constraintId === consistency.id)
+        .map((labelValue) => [labelValue.label, Number(labelValue.value)])
+    ).toEqual([
+      ["A", 5],
+      ["B", 3],
+      ["C", 1],
+    ])
     expect(consistency.aggregate).toBe("sum")
-    expect(consistency.tolerance).toBe(2)
+    expect(Number(consistency.tolerance)).toBe(2)
     // 教員が書いた違反メッセージは触らない
     expect(consistency.message).toBe("観点と評定が合いません")
-    // 展開後は config を残さない
-    expect(consistency.config).toBeUndefined()
+    // 展開後は config を残さない（行に列そのものが無い）
+    expect(consistency).not.toHaveProperty("config")
 
-    const exclusion = constraints.find(
+    const exclusion = data.gradeConstraints.find(
       (constraint) => constraint.kind === "mutual_exclusion"
     )!
-    expect(exclusion.exclusionLabels).toEqual(["A", "C"])
-    expect(exclusion.config).toBeUndefined()
+    expect(
+      data.gradeConstraintExclusionLabels
+        .filter(
+          (exclusionLabel) => exclusionLabel.constraintId === exclusion.id
+        )
+        .map((exclusionLabel) => exclusionLabel.label)
+    ).toEqual(["A", "C"])
   })
 
   it("壊れた config は既定値へ倒して取り込める形にする", () => {
     const { data } = transformGradeToLatest(buildV1_10_0Archive())
 
-    const broken = data.gradeData.gradeConstraints!.find(
+    const broken = data.gradeConstraints.find(
       (constraint) => constraint.name === "壊れたconfig"
     )!
     // 旧 parseConfig の既定値フォールバックと同じ挙動（JSON.parse 失敗で既定値）
-    expect(broken.targetGradeItemName).toBeNull()
+    expect(broken.targetGradeItemId).toBeNull()
     expect(broken.aggregate).toBe("average")
-    expect(broken.tolerance).toBe(1)
-    expect(broken.viewpointGradeItemNames).toEqual([])
-    expect(broken.config).toBeUndefined()
+    expect(Number(broken.tolerance)).toBe(1)
+    expect(
+      data.gradeConstraintViewpoints.filter(
+        (viewpoint) => viewpoint.constraintId === broken.id
+      )
+    ).toEqual([])
+    expect(broken).not.toHaveProperty("config")
   })
 
   it("マニフェストを現行へ上げ、変換した件数を warning で知らせる", () => {
@@ -339,7 +374,7 @@ describe("transformGradeToLatest: 1.10.0 → 1.11.0（制約ルールの設定JS
         (transformation) => transformation.to === "1.11.0"
       )
     ).toBe(false)
-    expect(originalVersion).toBe(GRADE_CURRENT_VERSION)
+    expect(originalVersion).toBe("1.12.0")
   })
 })
 
@@ -347,7 +382,7 @@ describe("transformGradeToLatest: 1.10.0 → 1.11.0（制約ルールの設定JS
  * v1.11.0 までが実際に書き出していた内包資料の形（入れ子・射影ツリー）。
  * 点数は人（Student）の uuid を指していた。
  */
-function buildV1_11_0Archive(): GradeArchiveData {
+function buildV1_11_0Archive(): LegacyGradeArchiveData {
   const archive = buildV1_9_0Archive()
   archive.manifest = { ...manifest, version: "1.11.0" }
   // 1.9.0 の名残（総合エントリ）を取り除き、内包資料だけが旧形の状態にする
@@ -415,19 +450,19 @@ describe("transformGradeToLatest: 1.11.0 → 1.12.0（内包資料の平坦化�
   it("入れ子の内包資料をテーブルごとのセクションへ展開する", () => {
     const { data } = transformGradeToLatest(buildV1_11_0Archive())
 
-    expect(data.legacyCourseworkArchive).toBeUndefined()
-    expect(data.courseworkArchive!.courseworks).toHaveLength(1)
-    expect(data.courseworkArchive!.courseworkItems).toHaveLength(1)
-    expect(data.courseworkArchive!.courseworkStudents).toHaveLength(1)
+    expect(data).not.toHaveProperty("legacyCourseworkArchive")
+    expect(data.courseworkArchive.courseworks).toHaveLength(1)
+    expect(data.courseworkArchive.courseworkItems).toHaveLength(1)
+    expect(data.courseworkArchive.courseworkStudents).toHaveLength(1)
   })
 
   it("点数が資料の対象者を指し、名簿外の点数は破棄される", () => {
     const { data, warnings } = transformGradeToLatest(buildV1_11_0Archive())
 
-    const scores = data.courseworkArchive!.courseworkScores
+    const scores = data.courseworkArchive.courseworkScores
     expect(scores).toHaveLength(1)
     expect(scores[0].courseworkStudentId).toBe(
-      data.courseworkArchive!.courseworkStudents[0].id
+      data.courseworkArchive.courseworkStudents[0].id
     )
     expect(scores[0].score).toBe("85")
     expect(warnings.some((warning) => warning.includes("1 件を破棄"))).toBe(
@@ -489,12 +524,266 @@ describe("内包資料が空の旧アーカイブ", () => {
 
     const { data } = transformGradeToLatest(archive)
 
-    expect(data.courseworkArchive!.courseworks).toEqual([])
-    expect(data.courseworkArchive!.courseworkClassrooms).toEqual([])
-    expect(data.courseworkArchive!.courseworkTags).toEqual([])
-    expect(data.courseworkArchive!.courseworkStudents).toEqual([])
-    expect(data.courseworkArchive!.courseworkItems).toEqual([])
-    expect(data.courseworkArchive!.courseworkLetterScales).toEqual([])
-    expect(data.courseworkArchive!.courseworkScores).toEqual([])
+    expect(data.courseworkArchive.courseworks).toEqual([])
+    expect(data.courseworkArchive.courseworkClassrooms).toEqual([])
+    expect(data.courseworkArchive.courseworkTags).toEqual([])
+    expect(data.courseworkArchive.courseworkStudents).toEqual([])
+    expect(data.courseworkArchive.courseworkItems).toEqual([])
+    expect(data.courseworkArchive.courseworkLetterScales).toEqual([])
+    expect(data.courseworkArchive.courseworkScores).toEqual([])
+  })
+})
+
+describe("transformGradeToLatest: 1.12.0 → 1.13.0（成績本体の平坦化）", () => {
+  it("射影された入れ子をテーブルごとのセクションへ展開する", () => {
+    const { data, appliedTransformations } = transformGradeToLatest(
+      buildV1_11_0Archive()
+    )
+
+    expect(appliedTransformations).toContainEqual({
+      from: "1.12.0",
+      to: "1.13.0",
+    })
+    // 成績本体が入れ子でなく行の配列になっている
+    expect(data).not.toHaveProperty("gradeData")
+    expect(data).not.toHaveProperty("boundariesData")
+    expect(data.grades).toHaveLength(1)
+    expect(data.grades[0].name).toBe("1学期成績")
+    expect(data.gradeItems.length).toBeGreaterThan(0)
+    // 各行が id を持ち、アーカイブ内で結合できる
+    expect(
+      data.gradeDataSources.every((dataSource) =>
+        data.gradeItems.some(
+          (gradeItem) => gradeItem.id === dataSource.gradeItemId
+        )
+      )
+    ).toBe(true)
+  })
+
+  it("生徒・学級は full レコードとして外部参照セクションへ出る", () => {
+    const { data } = transformGradeToLatest(buildV1_9_0Archive())
+
+    expect(data.studentsData.map((student) => student.studentNumber)).toEqual([
+      "S001",
+    ])
+    // 対象者の行は生徒 uuid を指し、その uuid は studentsData に載っている
+    expect(data.gradeStudents[0].studentId).toBe(data.studentsData[0].id)
+  })
+
+  it("旧形式が名前でしか持たない参照を id へ解決する（試験・小計・領域）", () => {
+    const archive = buildV1_9_0Archive()
+    archive.gradeData.gradeItems = [
+      {
+        name: "知識・技能",
+        order: 0,
+        dataSources: [
+          {
+            type: "subtotal",
+            name: "小計参照",
+            weight: 100,
+            order: 0,
+            examName: "1学期中間",
+            subtotalName: "大問1",
+            cropRegionLabel: null,
+          },
+        ],
+      },
+    ]
+
+    const { data } = transformGradeToLatest(archive)
+
+    const dataSource = data.gradeDataSources[0]
+    // 行は uuid だけを持ち、同定情報は refs 側にある
+    expect(dataSource.examId).not.toBeNull()
+    expect(dataSource.subtotalId).not.toBeNull()
+    expect(dataSource).not.toHaveProperty("examName")
+    expect(
+      data.examRefs.find((examRef) => examRef.id === dataSource.examId)
+        ?.examName
+    ).toBe("1学期中間")
+    const subtotalRef = data.subtotalRefs.find(
+      (candidate) => candidate.id === dataSource.subtotalId
+    )!
+    expect(subtotalRef.name).toBe("大問1")
+    // 小計名で当て直すには試験の絞り込みが要るので、試験も併せて持つ
+    expect(subtotalRef.examId).toBe(dataSource.examId)
+  })
+
+  it("旧アーカイブは氏名を持たないので、その旨を警告する（生徒は作れない）", () => {
+    const { data, warnings } = transformGradeToLatest(buildV1_9_0Archive())
+
+    // 学籍番号での照合には使えるが、氏名が無いので取り込み側は生徒を作らない
+    expect(data.studentsData[0].lastName).toBe("")
+    expect(
+      warnings.some((warning) => warning.includes("氏名・学級所属を持ちません"))
+    ).toBe(true)
+    // 在籍期間を捏造しないので学級所属は空
+    expect(data.membershipsData).toEqual([])
+  })
+
+  it("同名の評価項目でもデータソースは片寄せされない（合成idに並び順を混ぜる）", () => {
+    const archive = buildV1_9_0Archive()
+    archive.gradeData.gradeItems = [
+      {
+        name: "観点別評価",
+        order: 0,
+        dataSources: [
+          {
+            type: "exam_total",
+            name: "1つ目",
+            weight: 100,
+            order: 0,
+            examName: null,
+            subtotalName: null,
+            cropRegionLabel: null,
+          },
+        ],
+      },
+      {
+        name: "観点別評価",
+        order: 1,
+        dataSources: [
+          {
+            type: "exam_total",
+            name: "2つ目",
+            weight: 100,
+            order: 0,
+            examName: null,
+            subtotalName: null,
+            cropRegionLabel: null,
+          },
+        ],
+      },
+    ]
+    archive.gradeData.gradeOverrides = []
+    archive.boundariesData.boundarySets = []
+
+    const { data } = transformGradeToLatest(archive)
+
+    // 2項目が別の id を持ち、データソースが1本ずつ付く
+    expect(new Set(data.gradeItems.map((item) => item.id)).size).toBe(2)
+    for (const gradeItem of data.gradeItems) {
+      expect(
+        data.gradeDataSources.filter(
+          (dataSource) => dataSource.gradeItemId === gradeItem.id
+        )
+      ).toHaveLength(1)
+    }
+  })
+
+  it("別試験の同名小計・同ラベル領域は別の参照として扱う", () => {
+    const archive = buildV1_9_0Archive()
+    const buildSource = (
+      name: string,
+      examName: string
+    ): (typeof archive.gradeData.gradeItems)[number]["dataSources"][number] => ({
+      type: "crop_region",
+      name,
+      weight: 100,
+      order: 0,
+      examName,
+      subtotalName: "大問1",
+      cropRegionLabel: "問3",
+    })
+    archive.gradeData.gradeItems = [
+      {
+        name: "知識・技能",
+        order: 0,
+        dataSources: [
+          buildSource("中間の問3", "中間テスト"),
+          buildSource("期末の問3", "期末テスト"),
+        ],
+      },
+    ]
+    archive.gradeData.gradeOverrides = []
+    archive.boundariesData.boundarySets = []
+
+    const { data } = transformGradeToLatest(archive)
+
+    const [midterm, finalExam] = data.gradeDataSources
+    expect(midterm.examId).not.toBe(finalExam.examId)
+    // ラベル・小計名が同じでも、試験が違えば別の参照になる
+    expect(midterm.cropRegionId).not.toBe(finalExam.cropRegionId)
+    expect(midterm.subtotalId).not.toBe(finalExam.subtotalId)
+    // 同定情報も試験ごとに1件ずつ出る
+    expect(data.cropRegionRefs).toHaveLength(2)
+    expect(data.subtotalRefs).toHaveLength(2)
+  })
+
+  it("Project 時代の project_total を exam_total へ直す", () => {
+    const archive = buildV1_9_0Archive()
+    archive.gradeData.gradeItems = [
+      {
+        name: "知識・技能",
+        order: 0,
+        dataSources: [
+          {
+            type: "project_total",
+            name: "試験合計",
+            weight: 100,
+            order: 0,
+            examName: "1学期中間",
+            subtotalName: null,
+            cropRegionLabel: null,
+          },
+        ],
+      },
+    ]
+    archive.gradeData.gradeOverrides = []
+    archive.boundariesData.boundarySets = []
+
+    const { data } = transformGradeToLatest(archive)
+
+    expect(data.gradeDataSources[0].type).toBe("exam_total")
+  })
+
+  it("観点を解決できない制約ルールは無効化して取り込ませる", () => {
+    const archive = buildV1_9_0Archive()
+    archive.gradeData.gradeItems = [
+      { name: "知識・技能", order: 0, dataSources: [] },
+    ]
+    archive.gradeData.gradeConstraints = [
+      {
+        name: "観点と評定の整合",
+        kind: "consistency",
+        targetGradeItemName: "知識・技能",
+        viewpointGradeItemNames: ["知識・技能", "存在しない観点"],
+        expression: "",
+        color: "#fecaca",
+        message: "観点と評定が合いません",
+        enabled: true,
+        order: 0,
+      },
+    ]
+    archive.gradeData.gradeOverrides = []
+    archive.boundariesData.boundarySets = []
+
+    const { data, warnings } = transformGradeToLatest(archive)
+
+    // 集計対象が減った状態で有効のまま通すと、別物のルールとして判定が動く
+    expect(data.gradeConstraints[0].enabled).toBe(false)
+    expect(data.gradeConstraints[0].disabledReason).toContain("集計対象の観点")
+    expect(
+      warnings.some((warning) => warning.includes("観点と評定の整合"))
+    ).toBe(true)
+  })
+
+  it("同名の評価項目を名前でしか指せないセルは破棄して警告する", () => {
+    const archive = buildV1_9_0Archive()
+    archive.gradeData.gradeItems = [
+      { name: "評定", order: 0, dataSources: [] },
+      { name: "評定", order: 1, dataSources: [] },
+    ]
+    archive.gradeData.gradeOverrides = [
+      { studentNumber: "S001", gradeItemName: "評定", overrideLabel: "4" },
+    ]
+    archive.boundariesData.boundarySets = []
+
+    const { data, warnings } = transformGradeToLatest(archive)
+
+    expect(data.gradeOverrides).toHaveLength(0)
+    expect(warnings.some((warning) => warning.includes("同名の評価項目"))).toBe(
+      true
+    )
   })
 })

--- a/__tests__/migration/rewireGradeCellsToGradeStudent.test.ts
+++ b/__tests__/migration/rewireGradeCellsToGradeStudent.test.ts
@@ -1,0 +1,279 @@
+/**
+ * 20260730000000_rewire_grade_cells_to_grade_student のデータ移行テスト
+ *
+ * 検証すること:
+ * - 対象者（GradeStudent）に紐づく上書き・確定値・除外設定が gradeStudentId へ付け替わる
+ * - 対象者として登録されていない生徒の行（孤児）は3種とも破棄される
+ * - 破棄件数が AuditLog に記録される（0件のときは行を作らない）
+ * - RENAME TO 後の FK 参照名が正しい
+ *
+ * 手順は「本マイグレーションの1つ手前まで適用 → 旧形状のデータを投入 →
+ * 本マイグレーションだけを適用」。全マイグレーションを一括適用してしまうと
+ * 旧形状のデータを差し込む隙が無くなるため、ここだけ手で刻む。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "rewire-grade-cells")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations")
+const TARGET_MIGRATION = "20260730000000_rewire_grade_cells_to_grade_student"
+const AUDIT_ACTION = "system.migration.cleanup_orphaned_grade_cells"
+
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const migrationNames = (): string[] =>
+  fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const applyMigration = (db: SqliteDatabase, name: string): void => {
+  db.exec(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf-8")
+  )
+}
+
+/** init ＋ 本マイグレーションの1つ手前までを適用した DB を用意する */
+async function buildDatabaseBeforeTargetMigration(): Promise<void> {
+  bootstrapSchema(DB_PATH)
+  const prisma = createPrismaClientForPath(DB_PATH)
+  try {
+    await createBaseline(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  const names = migrationNames()
+  const targetIndex = names.indexOf(TARGET_MIGRATION)
+  expect(targetIndex).toBeGreaterThan(0)
+
+  withDatabase((db) => {
+    for (const name of names.slice(0, targetIndex)) {
+      if (name === "20260322232329_init") continue
+      applyMigration(db, name)
+    }
+  })
+}
+
+const ISO = "2026-07-01T00:00:00.000+00:00"
+
+/**
+ * 旧形状（(gradeId, studentId) で人を直に指す）のデータを投入する。
+ * 対象者として登録するのは student-kept のみ。student-orphan は
+ * 「成績から外されたのに設定だけ残った生徒」を表す。
+ */
+function seedLegacyData(db: SqliteDatabase): void {
+  const run = (sql: string, params: unknown[]) => db.prepare(sql).run(params)
+
+  run(`INSERT INTO "Grade" (id, name, createdAt, updatedAt) VALUES (?,?,?,?)`, [
+    "grade-1",
+    "1学期成績",
+    ISO,
+    ISO,
+  ])
+  run(
+    `INSERT INTO "GradeItem" (id, gradeId, name, "order", createdAt, updatedAt) VALUES (?,?,?,?,?,?)`,
+    ["item-1", "grade-1", "知識・技能", 0, ISO, ISO]
+  )
+
+  for (const [studentId, studentNumber] of [
+    ["student-kept", "S001"],
+    ["student-orphan", "S002"],
+  ]) {
+    run(
+      `INSERT INTO "Student" (id, studentNumber, lastName, firstName, lastNameKana, firstNameKana, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?)`,
+      [studentId, studentNumber, "姓", "名", "セイ", "メイ", ISO, ISO]
+    )
+  }
+
+  // 対象者として登録されているのは student-kept だけ
+  run(
+    `INSERT INTO "GradeStudent" (id, gradeId, studentId, createdAt, updatedAt) VALUES (?,?,?,?,?)`,
+    ["gradestudent-kept", "grade-1", "student-kept", ISO, ISO]
+  )
+
+  for (const studentId of ["student-kept", "student-orphan"]) {
+    run(
+      `INSERT INTO "GradeOverride" (id, gradeId, studentId, gradeItemId, overrideLabel, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?)`,
+      [`override-${studentId}`, "grade-1", studentId, "item-1", "A", ISO, ISO]
+    )
+    run(
+      `INSERT INTO "GradeFrozenScore" (id, gradeId, studentId, gradeItemId, weightedScore, weightedMaxScore, percentage, gradeLabel, frozenAt, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        `frozen-${studentId}`,
+        "grade-1",
+        studentId,
+        "item-1",
+        0.8,
+        1,
+        80,
+        "A",
+        ISO,
+        ISO,
+        ISO,
+      ]
+    )
+    run(
+      `INSERT INTO "GradeItemExclusion" (id, gradeId, studentId, gradeItemId, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?)`,
+      [`exclusion-${studentId}`, "grade-1", studentId, "item-1", ISO, ISO]
+    )
+  }
+}
+
+const idsOf = (db: SqliteDatabase, table: string): string[] =>
+  (
+    db.prepare(`SELECT id FROM "${table}" ORDER BY id`).all() as {
+      id: string
+    }[]
+  ).map((row) => row.id)
+
+const columnsOf = (db: SqliteDatabase, table: string): string[] =>
+  (db.prepare(`PRAGMA table_info("${table}")`).all() as { name: string }[]).map(
+    (column) => column.name
+  )
+
+const CELL_TABLES = ["GradeOverride", "GradeFrozenScore", "GradeItemExclusion"]
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("成績のセルの GradeStudent 経由への配線変更マイグレーション", () => {
+  it("対象者のある行は付け替わり、孤児は破棄され、件数が監査ログに残る", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      expect(idsOf(db, "GradeOverride")).toEqual(["override-student-kept"])
+      expect(idsOf(db, "GradeFrozenScore")).toEqual(["frozen-student-kept"])
+      expect(idsOf(db, "GradeItemExclusion")).toEqual([
+        "exclusion-student-kept",
+      ])
+
+      for (const table of CELL_TABLES) {
+        const row = db
+          .prepare(`SELECT gradeStudentId FROM "${table}"`)
+          .get() as { gradeStudentId: string }
+        expect(row.gradeStudentId).toBe("gradestudent-kept")
+
+        // gradeId / studentId 列は落ちている（GradeStudent から辿れるため）
+        const columns = columnsOf(db, table)
+        expect(columns).not.toContain("studentId")
+        expect(columns).not.toContain("gradeId")
+        expect(columns).toContain("gradeStudentId")
+      }
+
+      // 確定値の中身が失われていないこと
+      const frozen = db
+        .prepare(
+          `SELECT weightedScore, weightedMaxScore, percentage, gradeLabel FROM "GradeFrozenScore"`
+        )
+        .get() as {
+        weightedScore: number
+        weightedMaxScore: number
+        percentage: number
+        gradeLabel: string
+      }
+      expect(frozen).toMatchObject({
+        weightedScore: 0.8,
+        weightedMaxScore: 1,
+        percentage: 80,
+        gradeLabel: "A",
+      })
+
+      const auditLogs = db
+        .prepare(`SELECT summary, metadata FROM "AuditLog" WHERE action = ?`)
+        .all(AUDIT_ACTION) as { summary: string; metadata: string }[]
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0].summary).toContain("3 件")
+      expect(JSON.parse(auditLogs[0].metadata)).toEqual({
+        gradeOverride: 1,
+        gradeFrozenScore: 1,
+        gradeItemExclusion: 1,
+      })
+    })
+  })
+
+  it("孤児が無ければ監査ログの行を作らない", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => {
+      seedLegacyData(db)
+      for (const table of CELL_TABLES) {
+        db.exec(`DELETE FROM "${table}" WHERE studentId = 'student-orphan'`)
+      }
+    })
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const count = db
+        .prepare(`SELECT COUNT(*) AS n FROM "AuditLog" WHERE action = ?`)
+        .get(AUDIT_ACTION) as { n: number }
+      expect(count.n).toBe(0)
+      expect(idsOf(db, "GradeOverride")).toEqual(["override-student-kept"])
+    })
+  })
+
+  it("差し替え後も FK 参照名が正しい（RENAME TO の取り違え防止）", async () => {
+    await buildDatabaseBeforeTargetMigration()
+    withDatabase((db) => seedLegacyData(db))
+    withDatabase((db) => applyMigration(db, TARGET_MIGRATION))
+
+    withDatabase((db) => {
+      const definitions = new Map(
+        (
+          db
+            .prepare(
+              `SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`
+            )
+            .all() as { name: string; sql: string }[]
+        ).map((row) => [row.name, row.sql])
+      )
+
+      for (const name of definitions.keys()) {
+        expect(name.startsWith("new_")).toBe(false)
+      }
+
+      for (const table of CELL_TABLES) {
+        expect(definitions.get(table)).toContain('REFERENCES "GradeStudent"')
+        expect(definitions.get(table)).toContain('REFERENCES "GradeItem"')
+        expect(definitions.get(table)).not.toContain("new_")
+      }
+      // 確定操作者は SetNull のまま残る
+      expect(definitions.get("GradeFrozenScore")).toContain('REFERENCES "User"')
+
+      expect(db.prepare(`PRAGMA foreign_key_check`).all()).toEqual([])
+    })
+  })
+})

--- a/docs/membership-key-rewiring-plan.md
+++ b/docs/membership-key-rewiring-plan.md
@@ -450,10 +450,195 @@ Phase A と同等かそれ以上になる。
     `examStudentId` は同じ 1 行にあり、列ごとのマージはしていない）。同期で起こりうるのは
     参照先が消えた行が残ること
 
-**未着手のまま残した項目**:
+**未着手のまま残した項目**（Phase C で対応済み）:
 
 - **資料・成績の名簿からの生徒削除には確認ダイアログが無い。** 試験（05）は
   `StudentRemovalConfirmModal` で破棄を明示しているが、`RosterTable` の `enableRemove` は
   無確認で削除する（`slots.onBeforeRemove` は用意されているだけで利用者ゼロ）。
   Phase B で削除が破壊的になったため、確認の必要性が上がった。ただし grade の名簿も
   同じ形なので、Phase C でまとめて入れる方が一貫する
+
+## 13. Phase C の実施結果（2026-07-29）
+
+**完了。** `GradeOverride` / `GradeFrozenScore` / `GradeItemExclusion` を `gradeStudentId` へ
+配線変更し、§3.3 の Map 解消・セル実体化・名簿削除の確認ダイアログまで含めて実施した。
+これで対象 9 テーブル・3 サブシステムがすべて片付き、本計画は完了。
+
+計画から外れた点・追加で判明した点:
+
+- **grade アーカイブを 1.13.0 へ上げ、成績本体もテーブルごとの平坦なセクションへ作り直した。**
+  当初は「3種とも名前ベース外部参照で持ち出しており JSON の形が変わらない」として据え置いたが、
+  OWNER 指摘により **exam / coursework と揃え、Prisma のクエリが返した行をそのまま持つ**方針とした。
+  詳細は §14
+- **`gradeId` / `studentId` の2列は残さず畳んだ。** 両方を残すと
+  `gradeId ≠ gradeStudent.gradeId` が起こりうるため（`ReturnSnapshot.examId` と同じ判断）。
+  `@@unique([gradeId, studentId, gradeItemId])` は `@@unique([gradeStudentId, gradeItemId])` に、
+  `where: { gradeId }` は `where: { gradeStudent: { gradeId } } }` になった
+- **`rawScoreMap` を `RawScoreMatrix` へ実体化した（§3.3 の中心）。**
+  `Map<studentId, Map<dataSourceId, number|null>>` を、行が対象者・セルが列のデータソースを
+  同梱する行列に置き換えた。索引（Map）は実装の内側に閉じ、公開 API は実体しか受け取らない。
+  `absentEstimation` の9関数は `(studentId: string, dataSourceId: string, maxScore: number, map)`
+  から `(targetRow, dataSource, matrix)` になり、**満点は列の実体から取れるので引数が1つ減った**
+  （呼び出し側が別のソースの満点を渡す取り違えが構造的に起こらなくなった）
+- **上書き・確定値・除外設定は対象者の include から読むようになり、3本の findMany が消えた。**
+  `${studentId}:${gradeItemId}` の文字列連結キーで突き合わせていた `overrideMap` /
+  `exclusionSet` / `frozenByCell` は、`gradeStudent.overrides` 等を `find` するだけになった。
+  名簿に居ない生徒の設定を読み込むこと自体が起こらない
+- **`estimateByRegression` に潜在的なクラッシュがあった。** 訓練行が0件のとき
+  `const p = X[0].length` が `undefined` を参照して throw し、成績算出全体が失敗していた
+  （対象生徒の説明変数を全部揃えた他生徒が居ない構成で起こる）。行列化のついでに
+  `insufficient_samples` として average へ落とすガードを入れた
+- **`idChangeExecutor` の `GradeStudent` mover が単純な `updateMany` のままだった。**
+  `@@unique([gradeId, studentId])` があるので移行先が同じ成績に居ると以前から
+  unique 違反で落ちていたが、Phase C で cascade 子が付いたため危険度が上がった。
+  `CourseworkStudent` と同じく「衝突しないセルを先に付け替えてから delete」に揃えた
+- **`duplicateGrade`（成績の複製）が `createMany` で対象者を作っていた。** 新しい対象者の
+  id が要るので1件ずつ作って旧→新の対応を持つ形にした。確定値は元々複製していない
+  （複製は「設定の写し」であって確定という操作の写しではない）ので据え置き
+- **名簿削除の確認ダイアログを共通部品へ入れた。** `RosterTable` に確認を内蔵し、
+  利用者ゼロだった `slots.onBeforeRemove` は `slots.removalLosses`（連動して消えるものの
+  列挙）へ置き換えた。学級ごと外す2段階モーダルにも `deletionLosses` を足し、
+  「その生徒の入力済みデータ」という曖昧な文言を **確定した成績値・上書きした評定・
+  除外設定**（成績）／**点数・加減点・コメント**（資料）と具体的に言うようにした
+- **`statisticsCalculator` の `scoreByStudentId` は人キーのままが正しい**（§3.3 の棚卸し結果）。
+  突き合わせ相手が学級の在籍者一覧（`StudentClassroomMembership` ＝人の所属）なので、
+  受験者キーにすると母集団と噛み合わない。根拠をコメントに残し、未使用だった
+  `_studentId` 引数だけ落とした。`returnSnapshot` の Map は Phase A で受験者キーへ
+  移行済みで、こちらも根拠をコメント化した
+
+追加したテスト:
+
+- `__tests__/migration/rewireGradeCellsToGradeStudent.test.ts` — 付け替え・孤児破棄（3種）・
+  AuditLog 記録・確定値の中身の保存・`RENAME TO` 後の FK 参照名
+- `__tests__/grade/integration/gradeStudentCellRemoval.test.ts` — 学級ごと外すとセル3種が
+  消え、他生徒は巻き添えにならず、再追加しても復元されない
+- `__tests__/grade/integration/gradeScopeGuard.test.ts` — 別の成績の評価項目・存在しない
+  対象者への書き込みが弾かれる
+- `gradeArchiveRoundTrip.test.ts` に「名簿に載らない生徒のセルは取り込まず警告する」
+- `cascadeCoverage.test.ts` に「成績のセル3種の親は `GradeStudent`・Student 直結ではない」
+
+**残る課題**:
+
+- **実 DB のコピーへ migration を当てるリハーサル**は Phase A / B と同様に未実施（実データが要る）
+- **`Student` 直下の cascade 子は所属とメンバーシップ4種だけになった。** 新しい子データを
+  Student 直結で足すと同じ穴が開くが、`cascadeCoverage.test.ts` が schema 駆動で
+  3つのメンバーシップすべての親子関係を固定しているので、追加時には気付ける
+
+## 14. grade アーカイブの作り直し（2026-07-30）
+
+`.grade` を **1.12.0 → 1.13.0** へ上げ、成績本体をテーブルごとの平坦なセクションにして
+各行を Prisma の行のまま持つようにした。exam / coursework と同じ形になり、3つのアーカイブが
+「Prisma のクエリが返した行をそのまま JSON に持つ」という同一の原則に揃った。
+
+### 14.1 何が射影されていたか
+
+1.12.0 までの `.grade` は成績本体を入れ子へ射影し、外部参照を名前で持っていた。
+
+| 対象                                 | 旧（1.12.0）                                                 | 新（1.13.0）                                                         |
+| ------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| セル3種                              | `{ studentNumber, gradeItemName, … }`                        | `GradeOverride` などの行そのまま（`gradeStudentId` / `gradeItemId`） |
+| `GradeItem` / `GradeDataSource`      | 入れ子。`examName` 等の名前を同梱                            | 行そのまま。参照は uuid のみ                                         |
+| `GradeConstraint` の子               | `labelValues` を `Record` へ、観点を **2本の平行配列**へ潰す | `GradeConstraintViewpoint` などの行の配列                            |
+| `GradeBoundarySet` / `GradeBoundary` | 別ファイル `boundaries.json` に射影                          | 行として `grade-exam.json` の一セクション                            |
+| Decimal                              | `Number(...)`（原理的に精度が落ちる）                        | 文字列（`JSON.stringify` と同じ規則。exam / coursework と同一）      |
+| `GradeFrozenScore.frozenByUserId`    | 出力しない                                                   | 行のまま持ち出し、取り込み先に居なければ null にする                 |
+
+観点の平行配列は `project_grid_ordinal_coupling_hazard` で潰したのと同じ添字結合だった。
+展開の過程で1行1参照へ解け、対応が添字に依存しなくなった。
+
+### 14.2 「uuid が当たらない」は据え置きの理由にならなかった
+
+名前ベースにしていた根拠は「別PCで登録された生徒は uuid が違うので当たらない」だったが、
+**coursework-archive の `resolveStudents` が既に uuid 一次 → 学籍番号二次 → 作成の三段で
+解いていた**。grade だけが古い実装のまま名前へ落としていたに過ぎない。
+
+1.13.0 では外部参照をこう解く（解決器は coursework と共有する）。
+
+- 生徒・学級 — full レコードを carry し、uuid 一次 → 学籍番号 / 学級名 二次 → **作成**
+- 試験 — uuid 一次 → ウィザードのマッピング → 試験名
+- 小計・採点領域 — uuid 一次 → **当該試験で絞った**名前・ラベル
+- 資料・評価項目 — 内包する coursework アーカイブの取り込み結果から解決
+
+**未一致の生徒・学級は作る（`allowCreate: true`）。学級所属も復元する。** 当初は
+「`.grade` は生徒マスタの持ち主ではない」として lookup のみに据え置いたが、`.exam`
+（`studentProcessor.ts`）も `.coursework` 単体も作っており、grade だけが古い実装のまま
+だった。内包する資料の取り込みも `allowCreate: true` に揃えた（同じ資料が単体では点数まで
+復元されるのに `.grade` 経由だと空になっていた）。試験・小計・採点領域はアーカイブに
+含められないので作れない。解決できなかった参照はその行ごと落とし、必ず warning で伝える。
+
+**ただし氏名を持たないレコードからは作らない**（`resolveStudents` のガード）。旧 `.grade`
+（v1.12.0 以前）は生徒を学籍番号だけで参照しており氏名を持ち出していないため、作ると
+氏名が空の生徒が名簿に並ぶ。作らずに知らせる方が復旧できる。学級所属も旧形式は
+在籍期間・出席番号を持たないので復元しない（在籍期間を捏造すると受験日スナップショットの
+判定が狂う）。どちらも変換時に warning で伝える。
+
+### 14.3 変換器
+
+`V1_12_0_to_V1_13_0` を新設。旧形式の知識は `grade-transformers/legacyShape.ts` へ閉じ込め、
+`src/types/gradeArchive.types.ts` は現行の形だけを宣言する（coursework と同じ構え）。
+既存5本の変換器は `LegacyGradeArchiveData` に型付けし直した。
+
+展開で解いていること:
+
+- id を持たない行（セル・境界・制約の子・名簿・対象学級）の id を自然キーから組み立てる
+  （`deterministicId.ts` と同じ規則で冪等。アーカイブ内の結合キーにのみ使い DB へは書かない）
+- 名前でしか指せなかった参照（試験・小計・採点領域・資料・評価項目）を id へ解決する。
+  試験・小計・領域は uuid が無ければ名前から決定論的な id を合成し、同定情報を refs へ添える
+  — 行は uuid しか持たないという原則を崩さずに名前フォールバックを残すため
+- **同名の評価項目を名前でしか指せないセルは破棄して警告する。** 旧 importer が持っていた
+  曖昧検出（`ambiguousGradeItemNames`）を展開側へ移した。取り違えるより落とす
+- 復元できない `createdAt`/`updatedAt` は下限値を入れ、warning で伝える
+
+### 14.4 チェーンの出口
+
+変換後に射影形式が残っていたら **throw する**。旧形式のまま importer へ流れると実行時に崩れる
+ので、黙って先へ進ませない（coursework の出口判定と同じ）。
+
+追加したテスト:
+
+- `gradeArchiveRoundTrip.test.ts` — 「収集結果は Prisma の行そのままで、射影した名前を持たない」
+  「確定操作者は取り込み先に居れば残り、居なければ操作者不明になる」。
+  旧形式の読込互換テストは `toLegacyArchive`（平坦→射影の逆変換）で射影形式を組んで維持
+- `gradeTransformerChain.test.ts` — 1.12.0 → 1.13.0 の展開・外部参照セクション・
+  名前でしか持たない参照の id 解決・同名評価項目の破棄と警告・旧アーカイブが氏名と
+  学級所属を持たないことの警告
+- `gradeArchiveRoundTrip.test.ts` — 「取り込み先に居ない生徒・学級は作られ、学級所属も
+  復元される」「アーカイブの名簿に無い対象者を指すセルは取り込まず警告する」
+
+### 14.5 レビュー指摘の反映（2026-07-31）
+
+`/code-review high` で9件（すべて correctness）。作り直しで持ち込んだ退行が中心で、全件修正した。
+
+**旧アーカイブの合成 id が衝突していた（3件）**
+
+- 評価項目の合成 id が `${gradeId}:${name}` だけだったため、同名の2項目が1つの id へ潰れ、
+  両方のデータソースが片方へ寄っていた（重み倍・もう片方は全欠測）。並び順を混ぜて解消
+- 小計・採点領域の合成 id も名前だけだったため、別の試験の同名参照と衝突していた。
+  試験を混ぜて解消（小計名はグループ内、領域ラベルは試験内でしか一意でない）
+- 旧 importer にあった `project_total` → `exam_total` の型正規化が落ちていた。
+  残ると gradeCalculator のどの分岐にも一致せず、試験合計が理由も示されず空欄になる
+
+**生徒・学級を作るようにしたことの副作用（4件）**
+
+- **`restoreMemberships` を「この取り込みで新規作成した生徒」に限定した。** 無条件に呼ぶと、
+  取り込み先で別学級へ異動済みの生徒に旧学級の在籍行が復活し、取り込みと無関係な試験の
+  学級別集計・受験日スナップショットの母集団まで変わっていた。`resolveStudents` が
+  `createdIds` を返すようにして区別する（doc コメントの元々の意図どおり。coursework も同時に直る）
+- **合成された非 uuid の id を主キーにしない。** `legacy-classroom:3年A組` がそのまま
+  Classroom の id になっていた。生徒側にあった氏名ガードと同じ性質の穴で、
+  `isUuid` で判定して uuid でなければ Prisma に生成させる
+- **アーカイブの別々の生徒が同じ既存生徒へ解決すると unique 違反で全体が落ちていた**
+  （uuid で当たる生徒と学籍番号で当たる生徒が同一人物になる場合）。先に作った対象者へ寄せ、
+  まとめたことを警告で伝える
+- **プレビューが lookup-only 時代の表示のままだった。** 「見つかりません」ではなく
+  「生徒 N 名を新規登録」「学級 N 件を新規登録」を出し、生徒マスタ・学級マスタへ
+  書き込むことを取り込み前に明示する。旧アーカイブで作れない生徒は別枠で理由を出す
+
+**その他（2件）**
+
+- 制約ルールの観点を変換器が落としたとき、取り込み側からは見えず有効のまま入っていた。
+  落とした時点で `disabledReason` を書いて無効化する（集計対象が減れば別物のルールになる）
+- `coursework_total` の参照を評価項目経由でしか解決していなかったため、評価項目0件の資料への
+  参照が取り込み先に実在しても失われていた。資料を直接引く経路を戻した
+- **内包資料の取り込みを生徒解決より前へ移した。** 旧 .grade は成績側に氏名を持たないが
+  内包資料側は持っているため、逆順だと「生徒は DB に居るのに成績の名簿だけ空」になっていた

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -4,7 +4,11 @@
 
 import { dialog } from "electron"
 
-import type { GradeConstraintInput } from "../../src/types/grade.types"
+import type {
+  GradeCellTarget,
+  GradeConstraintInput,
+  GradeItemExclusionInput,
+} from "../../src/types/grade.types"
 import { createGradeArchive } from "../lib/export/grade-archive/gradeArchiveCreator"
 import { exportGradeExcel } from "../lib/export/gradeExcel/gradeExcelExportMain"
 import { extractGradeArchive } from "../lib/import/grade-archive/gradeArchiveExtractor"
@@ -45,7 +49,6 @@ import {
 } from "../lib/prisma/gradeDataSource"
 import {
   freezeGradeScores,
-  type GradeFrozenTarget,
   unfreezeGradeScores,
 } from "../lib/prisma/gradeFrozenScore"
 import {
@@ -361,24 +364,15 @@ export function setupGradeHandlers(): void {
 
   registerHandler(
     "grade:upsertGradeOverride",
-    async (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-      overrideLabel: string
-    }) => {
+    async (data: GradeCellTarget & { overrideLabel: string }) => {
       return upsertGradeOverride(data)
     }
   )
 
   registerHandler(
     "grade:deleteGradeOverride",
-    async (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-    }) => {
-      return deleteGradeOverride(data)
+    async (target: GradeCellTarget) => {
+      return deleteGradeOverride(target)
     }
   )
 
@@ -418,23 +412,15 @@ export function setupGradeHandlers(): void {
 
   registerHandler(
     "grade:setGradeItemExclusion",
-    async (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-      excluded: boolean
-    }) => {
-      return setGradeItemExclusion(data)
+    async (input: GradeItemExclusionInput) => {
+      return setGradeItemExclusion(input)
     }
   )
 
   registerHandler(
     "grade:batchUpdateGradeItemExclusions",
-    async (
-      gradeId: string,
-      updates: { studentId: string; gradeItemId: string; excluded: boolean }[]
-    ) => {
-      return batchUpdateGradeItemExclusions(gradeId, updates)
+    async (updates: GradeItemExclusionInput[]) => {
+      return batchUpdateGradeItemExclusions(updates)
     }
   )
 
@@ -459,7 +445,7 @@ export function setupGradeHandlers(): void {
     "grade:freezeGradeScores",
     async (data: {
       gradeId: string
-      targets?: GradeFrozenTarget[]
+      targets?: GradeCellTarget[]
       frozenByUserId?: string | null
     }) => {
       return freezeGradeScores(data)
@@ -470,7 +456,7 @@ export function setupGradeHandlers(): void {
     "grade:unfreezeGradeScores",
     async (data: {
       gradeId: string
-      targets?: GradeFrozenTarget[]
+      targets?: GradeCellTarget[]
       userId?: string | null
     }) => {
       return unfreezeGradeScores(data)

--- a/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveCreator.ts
@@ -34,7 +34,7 @@ export async function createGradeArchive(
       appVersion: getAppVersion(),
       exportedAt: new Date().toISOString(),
       gradeId,
-      gradeName: data.gradeData.grade.name,
+      gradeName: data.grades[0]?.name ?? "",
       counts: data.counts,
     }
 
@@ -49,8 +49,8 @@ export async function createGradeArchive(
           entityType: "Grade",
           entityId: gradeId,
           scopeId: gradeId,
-          scopeLabel: data.gradeData.grade.name,
-          target: data.gradeData.grade.name,
+          scopeLabel: data.grades[0]?.name ?? "",
+          target: data.grades[0]?.name ?? "",
           extra: { outputPath },
         })
         resolve({ success: true })
@@ -65,14 +65,14 @@ export async function createGradeArchive(
       archive.append(JSON.stringify(manifest, null, 2), {
         name: "manifest.json",
       })
-      archive.append(JSON.stringify(data.gradeData, null, 2), {
+      // v1.13.0: 成績本体はテーブルごとの平坦なセクション。境界も同じファイルに入る
+      // （旧 boundaries.json は射影形式の名残で、行として持つ今は分ける理由が無い）
+      const { courseworkArchive, counts: _counts, ...sections } = data
+      archive.append(JSON.stringify(sections, null, 2), {
         name: "grade-exam.json",
       })
-      archive.append(JSON.stringify(data.courseworkArchive, null, 2), {
+      archive.append(JSON.stringify(courseworkArchive, null, 2), {
         name: "courseworks.json",
-      })
-      archive.append(JSON.stringify(data.boundariesData, null, 2), {
-        name: "boundaries.json",
       })
 
       archive.finalize()

--- a/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
+++ b/electron-src/lib/export/grade-archive/gradeArchiveDataCollector.ts
@@ -1,339 +1,545 @@
 /**
- * 成績算出アーカイブ用データ収集
+ * 成績算出アーカイブ（.grade）用データ収集
+ *
+ * 【原則】Prisma のクエリが返した行をそのまま JSON として持つ。射影・詰め替えはしない。
+ * JSON に載らない型だけを JSON.stringify と同じ規則で文字列にする
+ * （DateTime → ISO 文字列、Decimal → decimal.js の toJSON と同じ文字列）。
+ *
+ * アーカイブに含めない実体（生徒・学級・試験・小計・採点領域）への参照は、行が持つ uuid を
+ * 一次キーにしたまま残し、取り込み先で同定するための情報を別セクションで添える。
+ * 生徒・学級は coursework-archive と同形の full レコードを carry する（uuid → 学籍番号 /
+ * 学級名 のフォールバックが効く）。試験・小計・採点領域は carry できないので名前だけ添える。
  */
 
-import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
+import type { Prisma } from "@prisma/client"
+
 import type {
-  ArchiveBoundariesData,
-  ArchiveGradeData,
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+} from "../../../../src/types/courseworkArchive.types"
+import type {
+  ArchiveGradeBoundaryRow,
+  ArchiveGradeBoundarySetRow,
+  ArchiveGradeClassroomRow,
+  ArchiveGradeConstraintExclusionLabelRow,
+  ArchiveGradeConstraintLabelValueRow,
+  ArchiveGradeConstraintRow,
+  ArchiveGradeConstraintViewpointRow,
+  ArchiveGradeCropRegionRef,
+  ArchiveGradeDataSourceEstimationSourceRow,
+  ArchiveGradeDataSourceRow,
+  ArchiveGradeExamRef,
+  ArchiveGradeExportSettingsRow,
+  ArchiveGradeFrozenScoreRow,
+  ArchiveGradeItemExclusionRow,
+  ArchiveGradeItemRow,
+  ArchiveGradeOverrideRow,
+  ArchiveGradeRow,
+  ArchiveGradeStudentRow,
+  ArchiveGradeSubtotalRef,
+  CollectedGradeData,
 } from "../../../../src/types/gradeArchive.types"
 import prisma from "../../prisma/client"
 import { collectCourseworkArchiveData } from "../coursework-archive/dataCollector"
 
-interface CollectedGradeData {
-  gradeData: ArchiveGradeData
-  /**
-   * v1.5.0+: 参照中の試験外成績資料（Coursework）を coursework-archive と同じ
-   * UUID ベースの形で内包する（独立モジュールの収集ロジックへ委譲）。
-   */
-  courseworkArchive: CollectedCourseworkData
-  boundariesData: ArchiveBoundariesData
-  counts: {
-    gradeItems: number
-    dataSources: number
-    manualScores: number
-    boundarySets: number
-    boundaries: number
-    classrooms: number
-    students: number
-  }
-}
+/** Decimal を JSON.stringify と同じ文字列表現にする */
+const decimalToJson = (value: Prisma.Decimal): string => value.toString()
+const nullableDecimalToJson = (value: Prisma.Decimal | null): string | null =>
+  value === null ? null : value.toString()
 
-/** 指定した成績算出IDに関連する全データ（成績項目・手動スコア・境界値・生徒情報）をDBから収集する */
+const dateToJson = (value: Date): string => value.toISOString()
+const nullableDateToJson = (value: Date | null): string | null =>
+  value === null ? null : value.toISOString()
+
+/**
+ * 指定した成績を、参照している試験外成績資料込みで収集する。
+ * @throws Grade が存在しない場合
+ */
 export async function collectGradeArchiveData(
   gradeId: string
 ): Promise<CollectedGradeData> {
-  const grade = await prisma.grade.findUniqueOrThrow({
-    where: { id: gradeId },
-    include: {
-      gradeItems: {
-        include: {
-          dataSources: {
-            include: {
-              exam: { select: { examName: true, examDate: true } },
-              subtotal: true,
-              cropRegion: true,
-              courseworkItem: { include: { coursework: true } },
-              coursework: { select: { id: true, name: true } },
-              estimationSources: { orderBy: { order: "asc" } },
-            },
-            orderBy: { order: "asc" },
-          },
-        },
-        orderBy: { order: "asc" },
-      },
-      gradeClassrooms: {
-        include: { classroom: true },
-        orderBy: { order: "asc" },
-      },
-      gradeStudents: {
-        include: {
-          student: {
-            include: {
-              memberships: {
-                include: { classroom: { select: { name: true } } },
-              },
-            },
-          },
-        },
-        orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
-      },
-      boundarySets: {
-        include: {
-          gradeItem: true,
-          boundaries: { orderBy: { order: "asc" } },
-        },
-      },
-      gradeItemExclusions: {
-        include: {
-          student: { select: { studentNumber: true } },
-          gradeItem: { select: { name: true } },
-        },
-      },
-      gradeOverrides: {
-        include: {
-          student: { select: { studentNumber: true } },
-          gradeItem: { select: { name: true } },
-        },
-      },
-      gradeFrozenScores: {
-        include: {
-          student: { select: { studentNumber: true } },
-          gradeItem: { select: { name: true } },
-        },
-      },
-      gradeConstraints: {
-        include: {
-          targetGradeItem: { select: { name: true } },
-          viewpoints: {
-            include: { gradeItem: { select: { name: true } } },
-            orderBy: { order: "asc" },
-          },
-          labelValues: { orderBy: { order: "asc" } },
-          exclusionLabels: { orderBy: { order: "asc" } },
-        },
-        orderBy: { order: "asc" },
-      },
-      exportSettings: true,
-    },
-  })
+  const gradeRow = await prisma.grade.findUnique({ where: { id: gradeId } })
+  if (!gradeRow) {
+    throw new Error(`Grade ${gradeId} が見つかりません`)
+  }
 
-  const classroomIds = new Set(
-    grade.gradeClassrooms.map((gradeClassroom) => gradeClassroom.classroomId)
-  )
-
-  const gradeItems = grade.gradeItems.map((gradeItem) => ({
-    // 照合の一次キー。名前は unique でないので id を必ず持ち出す
-    id: gradeItem.id,
-    name: gradeItem.name,
-    order: gradeItem.order,
-    dataSources: gradeItem.dataSources.map((dataSource) => ({
-      // 照合の一次キー。estimationSourceIds の解決に使う
-      id: dataSource.id,
-      type: dataSource.type,
-      name: dataSource.name,
-      // v1.6.0: maxScore は廃止（満点は import 後に元データからライブ算出）。出力しない。
-      weight: Number(dataSource.weight),
-      order: dataSource.order,
-      examName: dataSource.exam?.examName ?? null,
-      subtotalName: dataSource.subtotal?.name ?? null,
-      cropRegionLabel: dataSource.cropRegion?.label ?? null,
-      absentMethod: dataSource.absentMethod,
-      absentRatio: Number(dataSource.absentRatio),
-      absentOffset: Number(dataSource.absentOffset),
-      treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
-      estimationMode: dataSource.estimationMode,
-      estimationSourceIds: (() => {
-        return dataSource.estimationSources.map(
-          (estimationSource) => estimationSource.sourceDataSourceId
-        )
-      })(),
-      // coursework: 評価項目参照（courseworkId は親資料 / courseworkItemId は項目）
-      // coursework_total: 資料全体参照（courseworkId のみ・項目参照は null）
-      courseworkId:
-        dataSource.type === "coursework"
-          ? (dataSource.courseworkItem?.coursework?.id ?? null)
-          : dataSource.type === "coursework_total"
-            ? (dataSource.coursework?.id ?? null)
-            : null,
-      courseworkItemId:
-        dataSource.type === "coursework"
-          ? (dataSource.courseworkItem?.id ?? null)
-          : null,
-      courseworkName:
-        dataSource.type === "coursework"
-          ? (dataSource.courseworkItem?.coursework?.name ?? null)
-          : dataSource.type === "coursework_total"
-            ? (dataSource.coursework?.name ?? null)
-            : null,
-      courseworkItemName:
-        dataSource.type === "coursework"
-          ? (dataSource.courseworkItem?.name ?? null)
-          : null,
-      // 参照の一次キー。試験名・小計名・領域ラベルはいずれも同定に足りないので
-      // id を持ち出す（小計名はグループ内でしか一意でない）
-      examId: dataSource.examId,
-      subtotalId: dataSource.subtotalId,
-      cropRegionId: dataSource.cropRegionId,
-    })),
-  }))
-
-  const allDataSources = grade.gradeItems.flatMap(
-    (gradeItem) => gradeItem.dataSources
-  )
-
-  const examRefs = allDataSources
-    .filter(
-      (dataSource) =>
-        (dataSource.type === "exam_total" ||
-          dataSource.type === "subtotal" ||
-          dataSource.type === "crop_region") &&
-        dataSource.exam
-    )
-    .map((dataSource) => ({
-      id: dataSource.examId ?? undefined,
-      examName: dataSource.exam!.examName,
-      examDate: dataSource.exam!.examDate?.toISOString() ?? null,
-      dataSourceName: dataSource.name,
-    }))
-
-  const classroomRefs = grade.gradeClassrooms.map((gradeClassroom) => ({
-    id: gradeClassroom.classroomId,
-    name: gradeClassroom.classroom.name,
-  }))
-
-  const studentRefs = grade.gradeStudents.map((gradeStudent) => {
-    const membership = gradeStudent.student.memberships.find(
-      (studentMembership) => classroomIds.has(studentMembership.classroomId)
-    )
-    return {
-      id: gradeStudent.studentId,
-      studentNumber: gradeStudent.student.studentNumber,
-      classroomName: membership?.classroom.name ?? null,
-      customOrder: gradeStudent.customOrder,
-    }
-  })
-
-  // v1.5.0+: 参照中の試験外成績資料（Coursework）を独立モジュールへ委譲して収集
-  const courseworkIds = new Set(
-    allDataSources
-      .filter(
-        (dataSource) =>
-          dataSource.type === "coursework" && dataSource.courseworkItem
-      )
-      .map((dataSource) => dataSource.courseworkItem!.courseworkId)
-  )
-  const courseworkArchive = await collectCourseworkArchiveData([
-    ...courseworkIds,
+  const [
+    classroomJoinRows,
+    studentJoinRows,
+    itemRows,
+    boundarySetRows,
+    constraintRows,
+    exportSettingsRow,
+  ] = await Promise.all([
+    prisma.gradeClassroom.findMany({
+      where: { gradeId },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeStudent.findMany({
+      where: { gradeId },
+      orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
+    }),
+    prisma.gradeItem.findMany({
+      where: { gradeId },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeBoundarySet.findMany({ where: { gradeId } }),
+    prisma.gradeConstraint.findMany({
+      where: { gradeId },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeExportSettings.findUnique({ where: { gradeId } }),
   ])
-  const manualScoresCount = courseworkArchive.counts.scores
 
-  const boundarySets = grade.boundarySets.map((boundarySet) => ({
-    gradeItemId: boundarySet.gradeItemId,
-    gradeItemName: boundarySet.gradeItem.name,
-    boundaries: boundarySet.boundaries.map((boundary) => ({
-      label: boundary.label,
-      minPercentage: Number(boundary.minPercentage),
-      order: boundary.order,
-    })),
-  }))
+  const gradeItemIds = itemRows.map((gradeItem) => gradeItem.id)
+  const gradeStudentIds = studentJoinRows.map((gradeStudent) => gradeStudent.id)
+  const boundarySetIds = boundarySetRows.map((boundarySet) => boundarySet.id)
+  const constraintIds = constraintRows.map((constraint) => constraint.id)
 
-  const totalBoundaries = boundarySets.reduce(
-    (sum, boundarySet) => sum + boundarySet.boundaries.length,
-    0
-  )
+  const [
+    dataSourceRows,
+    boundaryRows,
+    overrideRows,
+    frozenScoreRows,
+    itemExclusionRows,
+    viewpointRows,
+    labelValueRows,
+    exclusionLabelRows,
+  ] = await Promise.all([
+    prisma.gradeDataSource.findMany({
+      where: { gradeItemId: { in: gradeItemIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeBoundary.findMany({
+      where: { gradeBoundarySetId: { in: boundarySetIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeOverride.findMany({
+      where: { gradeStudentId: { in: gradeStudentIds } },
+    }),
+    prisma.gradeFrozenScore.findMany({
+      where: { gradeStudentId: { in: gradeStudentIds } },
+    }),
+    prisma.gradeItemExclusion.findMany({
+      where: { gradeStudentId: { in: gradeStudentIds } },
+    }),
+    prisma.gradeConstraintViewpoint.findMany({
+      where: { constraintId: { in: constraintIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeConstraintLabelValue.findMany({
+      where: { constraintId: { in: constraintIds } },
+      orderBy: { order: "asc" },
+    }),
+    prisma.gradeConstraintExclusionLabel.findMany({
+      where: { constraintId: { in: constraintIds } },
+      orderBy: { order: "asc" },
+    }),
+  ])
 
-  const totalDataSources = gradeItems.reduce(
-    (sum, gradeItem) => sum + gradeItem.dataSources.length,
-    0
-  )
+  const dataSourceIds = dataSourceRows.map((dataSource) => dataSource.id)
+  const estimationSourceRows =
+    await prisma.gradeDataSourceEstimationSource.findMany({
+      where: { dataSourceId: { in: dataSourceIds } },
+      orderBy: { order: "asc" },
+    })
 
-  const gradeItemExclusions = grade.gradeItemExclusions.map(
-    (gradeItemExclusion) => ({
-      studentNumber: gradeItemExclusion.student.studentNumber,
-      gradeItemId: gradeItemExclusion.gradeItemId,
-      gradeItemName: gradeItemExclusion.gradeItem.name,
+  // ── 成績本体のセクション（行をそのまま持つ） ─────────────────
+  const grades: ArchiveGradeRow[] = [
+    {
+      id: gradeRow.id,
+      name: gradeRow.name,
+      description: gradeRow.description,
+      referenceDate: nullableDateToJson(gradeRow.referenceDate),
+      createdAt: dateToJson(gradeRow.createdAt),
+      updatedAt: dateToJson(gradeRow.updatedAt),
+    },
+  ]
+
+  const gradeClassrooms: ArchiveGradeClassroomRow[] = classroomJoinRows.map(
+    (gradeClassroom) => ({
+      id: gradeClassroom.id,
+      gradeId: gradeClassroom.gradeId,
+      classroomId: gradeClassroom.classroomId,
+      order: gradeClassroom.order,
+      createdAt: dateToJson(gradeClassroom.createdAt),
+      updatedAt: dateToJson(gradeClassroom.updatedAt),
     })
   )
 
-  const gradeOverrides = grade.gradeOverrides.map((gradeOverride) => ({
-    studentNumber: gradeOverride.student.studentNumber,
-    gradeItemId: gradeOverride.gradeItemId,
-    gradeItemName: gradeOverride.gradeItem.name,
-    overrideLabel: gradeOverride.overrideLabel,
+  const gradeStudents: ArchiveGradeStudentRow[] = studentJoinRows.map(
+    (gradeStudent) => ({
+      id: gradeStudent.id,
+      gradeId: gradeStudent.gradeId,
+      studentId: gradeStudent.studentId,
+      customOrder: gradeStudent.customOrder,
+      createdAt: dateToJson(gradeStudent.createdAt),
+      updatedAt: dateToJson(gradeStudent.updatedAt),
+    })
+  )
+
+  const gradeItems: ArchiveGradeItemRow[] = itemRows.map((gradeItem) => ({
+    id: gradeItem.id,
+    gradeId: gradeItem.gradeId,
+    name: gradeItem.name,
+    order: gradeItem.order,
+    createdAt: dateToJson(gradeItem.createdAt),
+    updatedAt: dateToJson(gradeItem.updatedAt),
   }))
 
-  // 確定値は成績そのものなので必ず持ち出す。確定操作者は移動先に同じ User が居る保証が
-  // 無いため出さない（取り込み側で null＝操作者不明になる）。
-  const gradeFrozenScores = grade.gradeFrozenScores.map((gradeFrozenScore) => ({
-    studentNumber: gradeFrozenScore.student.studentNumber,
-    gradeItemId: gradeFrozenScore.gradeItemId,
-    gradeItemName: gradeFrozenScore.gradeItem.name,
-    weightedScore:
-      gradeFrozenScore.weightedScore !== null
-        ? Number(gradeFrozenScore.weightedScore)
-        : null,
-    weightedMaxScore: Number(gradeFrozenScore.weightedMaxScore),
-    percentage:
-      gradeFrozenScore.percentage !== null
-        ? Number(gradeFrozenScore.percentage)
-        : null,
-    gradeLabel: gradeFrozenScore.gradeLabel,
-    frozenAt: gradeFrozenScore.frozenAt.toISOString(),
+  const gradeDataSources: ArchiveGradeDataSourceRow[] = dataSourceRows.map(
+    (dataSource) => ({
+      id: dataSource.id,
+      gradeItemId: dataSource.gradeItemId,
+      type: dataSource.type,
+      examId: dataSource.examId,
+      subtotalId: dataSource.subtotalId,
+      cropRegionId: dataSource.cropRegionId,
+      courseworkItemId: dataSource.courseworkItemId,
+      courseworkId: dataSource.courseworkId,
+      name: dataSource.name,
+      weight: decimalToJson(dataSource.weight),
+      order: dataSource.order,
+      absentMethod: dataSource.absentMethod,
+      absentRatio: decimalToJson(dataSource.absentRatio),
+      absentOffset: decimalToJson(dataSource.absentOffset),
+      treatExpectedAsMissing: dataSource.treatExpectedAsMissing,
+      estimationMode: dataSource.estimationMode,
+      createdAt: dateToJson(dataSource.createdAt),
+      updatedAt: dateToJson(dataSource.updatedAt),
+    })
+  )
+
+  const gradeDataSourceEstimationSources: ArchiveGradeDataSourceEstimationSourceRow[] =
+    estimationSourceRows.map((estimationSource) => ({
+      id: estimationSource.id,
+      dataSourceId: estimationSource.dataSourceId,
+      sourceDataSourceId: estimationSource.sourceDataSourceId,
+      order: estimationSource.order,
+      createdAt: dateToJson(estimationSource.createdAt),
+      updatedAt: dateToJson(estimationSource.updatedAt),
+    }))
+
+  const gradeBoundarySets: ArchiveGradeBoundarySetRow[] = boundarySetRows.map(
+    (boundarySet) => ({
+      id: boundarySet.id,
+      gradeId: boundarySet.gradeId,
+      gradeItemId: boundarySet.gradeItemId,
+      createdAt: dateToJson(boundarySet.createdAt),
+      updatedAt: dateToJson(boundarySet.updatedAt),
+    })
+  )
+
+  const gradeBoundaries: ArchiveGradeBoundaryRow[] = boundaryRows.map(
+    (boundary) => ({
+      id: boundary.id,
+      gradeBoundarySetId: boundary.gradeBoundarySetId,
+      label: boundary.label,
+      minPercentage: decimalToJson(boundary.minPercentage),
+      order: boundary.order,
+      createdAt: dateToJson(boundary.createdAt),
+      updatedAt: dateToJson(boundary.updatedAt),
+    })
+  )
+
+  const gradeOverrides: ArchiveGradeOverrideRow[] = overrideRows.map(
+    (override) => ({
+      id: override.id,
+      gradeStudentId: override.gradeStudentId,
+      gradeItemId: override.gradeItemId,
+      overrideLabel: override.overrideLabel,
+      createdAt: dateToJson(override.createdAt),
+      updatedAt: dateToJson(override.updatedAt),
+    })
+  )
+
+  const gradeFrozenScores: ArchiveGradeFrozenScoreRow[] = frozenScoreRows.map(
+    (frozenScore) => ({
+      id: frozenScore.id,
+      gradeStudentId: frozenScore.gradeStudentId,
+      gradeItemId: frozenScore.gradeItemId,
+      weightedScore: nullableDecimalToJson(frozenScore.weightedScore),
+      weightedMaxScore: decimalToJson(frozenScore.weightedMaxScore),
+      percentage: nullableDecimalToJson(frozenScore.percentage),
+      gradeLabel: frozenScore.gradeLabel,
+      frozenByUserId: frozenScore.frozenByUserId,
+      frozenAt: dateToJson(frozenScore.frozenAt),
+      createdAt: dateToJson(frozenScore.createdAt),
+      updatedAt: dateToJson(frozenScore.updatedAt),
+    })
+  )
+
+  const gradeItemExclusions: ArchiveGradeItemExclusionRow[] =
+    itemExclusionRows.map((itemExclusion) => ({
+      id: itemExclusion.id,
+      gradeStudentId: itemExclusion.gradeStudentId,
+      gradeItemId: itemExclusion.gradeItemId,
+      createdAt: dateToJson(itemExclusion.createdAt),
+      updatedAt: dateToJson(itemExclusion.updatedAt),
+    }))
+
+  const gradeConstraints: ArchiveGradeConstraintRow[] = constraintRows.map(
+    (constraint) => ({
+      id: constraint.id,
+      gradeId: constraint.gradeId,
+      name: constraint.name,
+      kind: constraint.kind,
+      targetGradeItemId: constraint.targetGradeItemId,
+      aggregate: constraint.aggregate,
+      tolerance: decimalToJson(constraint.tolerance),
+      expression: constraint.expression,
+      color: constraint.color,
+      message: constraint.message,
+      disabledReason: constraint.disabledReason,
+      enabled: constraint.enabled,
+      order: constraint.order,
+      createdAt: dateToJson(constraint.createdAt),
+      updatedAt: dateToJson(constraint.updatedAt),
+    })
+  )
+
+  const gradeConstraintViewpoints: ArchiveGradeConstraintViewpointRow[] =
+    viewpointRows.map((viewpoint) => ({
+      id: viewpoint.id,
+      constraintId: viewpoint.constraintId,
+      gradeItemId: viewpoint.gradeItemId,
+      order: viewpoint.order,
+      createdAt: dateToJson(viewpoint.createdAt),
+      updatedAt: dateToJson(viewpoint.updatedAt),
+    }))
+
+  const gradeConstraintLabelValues: ArchiveGradeConstraintLabelValueRow[] =
+    labelValueRows.map((labelValue) => ({
+      id: labelValue.id,
+      constraintId: labelValue.constraintId,
+      label: labelValue.label,
+      value: decimalToJson(labelValue.value),
+      order: labelValue.order,
+      createdAt: dateToJson(labelValue.createdAt),
+      updatedAt: dateToJson(labelValue.updatedAt),
+    }))
+
+  const gradeConstraintExclusionLabels: ArchiveGradeConstraintExclusionLabelRow[] =
+    exclusionLabelRows.map((exclusionLabel) => ({
+      id: exclusionLabel.id,
+      constraintId: exclusionLabel.constraintId,
+      label: exclusionLabel.label,
+      order: exclusionLabel.order,
+      createdAt: dateToJson(exclusionLabel.createdAt),
+      updatedAt: dateToJson(exclusionLabel.updatedAt),
+    }))
+
+  const gradeExportSettings: ArchiveGradeExportSettingsRow[] = exportSettingsRow
+    ? [
+        {
+          id: exportSettingsRow.id,
+          gradeId: exportSettingsRow.gradeId,
+          settingsJson: exportSettingsRow.settingsJson,
+          createdAt: dateToJson(exportSettingsRow.createdAt),
+          updatedAt: dateToJson(exportSettingsRow.updatedAt),
+        },
+      ]
+    : []
+
+  // ── 外部参照 ─────────────────────────────────────────────
+  const [studentRows, classroomRows] = await Promise.all([
+    prisma.student.findMany({
+      where: {
+        id: {
+          in: studentJoinRows.map((gradeStudent) => gradeStudent.studentId),
+        },
+      },
+    }),
+    prisma.classroom.findMany({
+      where: {
+        id: {
+          in: classroomJoinRows.map(
+            (gradeClassroom) => gradeClassroom.classroomId
+          ),
+        },
+      },
+    }),
+  ])
+
+  const studentsData: ArchiveCwStudent[] = studentRows.map((student) => ({
+    id: student.id,
+    studentNumber: student.studentNumber,
+    lastName: student.lastName,
+    firstName: student.firstName,
+    lastNameKana: student.lastNameKana,
+    firstNameKana: student.firstNameKana,
+    enrollmentYear: student.enrollmentYear,
+    updatedAt: dateToJson(student.updatedAt),
   }))
 
-  // v1.11.0: 設定JSONを廃し、評価項目参照は uuid 一次・名前二次で持ち出す（issue #1063）
-  const gradeConstraints = grade.gradeConstraints.map((gradeConstraint) => ({
-    name: gradeConstraint.name,
-    kind: gradeConstraint.kind,
-    targetGradeItemId: gradeConstraint.targetGradeItemId,
-    targetGradeItemName: gradeConstraint.targetGradeItem?.name ?? null,
-    aggregate: gradeConstraint.aggregate,
-    tolerance: Number(gradeConstraint.tolerance),
-    viewpointGradeItemIds: gradeConstraint.viewpoints.map(
-      (viewpoint) => viewpoint.gradeItemId
-    ),
-    viewpointGradeItemNames: gradeConstraint.viewpoints.map(
-      (viewpoint) => viewpoint.gradeItem.name
-    ),
-    labelValues: Object.fromEntries(
-      gradeConstraint.labelValues.map((labelValue) => [
-        labelValue.label,
-        Number(labelValue.value),
-      ])
-    ),
-    exclusionLabels: gradeConstraint.exclusionLabels.map(
-      (exclusionLabel) => exclusionLabel.label
-    ),
-    expression: gradeConstraint.expression,
-    color: gradeConstraint.color,
-    message: gradeConstraint.message,
-    enabled: gradeConstraint.enabled,
-    order: gradeConstraint.order,
+  const classesData: ArchiveCwClass[] = classroomRows.map((classroom) => ({
+    id: classroom.id,
+    name: classroom.name,
+    classroomCode: classroom.classroomCode,
+    grade: classroom.grade,
+    description: classroom.description,
+    isVisible: classroom.isVisible,
   }))
+
+  // 学級所属は「対象生徒 × 登録学級」の範囲だけ carry する。取り込み先で名簿の
+  // 学級表示・並びを復元する裏付けになる
+  const membershipRows = await prisma.studentClassroomMembership.findMany({
+    where: {
+      studentId: { in: studentRows.map((student) => student.id) },
+      classroomId: { in: classroomRows.map((classroom) => classroom.id) },
+    },
+  })
+  const membershipsData: ArchiveCwMembership[] = membershipRows.map(
+    (membership) => ({
+      id: membership.id,
+      studentId: membership.studentId,
+      classroomId: membership.classroomId,
+      startDate: dateToJson(membership.startDate),
+      endDate: nullableDateToJson(membership.endDate),
+      attendanceNumber: membership.attendanceNumber,
+      notes: membership.notes,
+    })
+  )
+
+  // 試験・小計・採点領域はアーカイブに含められない（答案画像を伴う別アーカイブの領分）。
+  // uuid が当たらなかったときに名前で当てるための同定情報だけを添える。
+  const [examRows, subtotalRows, cropRegionRows] = await Promise.all([
+    prisma.exam.findMany({
+      where: {
+        id: {
+          in: [
+            ...new Set(
+              dataSourceRows
+                .map((dataSource) => dataSource.examId)
+                .filter((examId): examId is string => examId !== null)
+            ),
+          ],
+        },
+      },
+    }),
+    prisma.subtotal.findMany({
+      where: {
+        id: {
+          in: [
+            ...new Set(
+              dataSourceRows
+                .map((dataSource) => dataSource.subtotalId)
+                .filter(
+                  (subtotalId): subtotalId is string => subtotalId !== null
+                )
+            ),
+          ],
+        },
+      },
+    }),
+    prisma.cropRegion.findMany({
+      where: {
+        id: {
+          in: [
+            ...new Set(
+              dataSourceRows
+                .map((dataSource) => dataSource.cropRegionId)
+                .filter(
+                  (cropRegionId): cropRegionId is string =>
+                    cropRegionId !== null
+                )
+            ),
+          ],
+        },
+      },
+      include: { examPage: { select: { examId: true } } },
+    }),
+  ])
+
+  const examRefs: ArchiveGradeExamRef[] = examRows.map((exam) => ({
+    id: exam.id,
+    examName: exam.examName,
+    examDate: nullableDateToJson(exam.examDate),
+  }))
+
+  // 小計名はグループ内でしか一意でないため、名前で当てるときの絞り込みに試験が要る。
+  // 小計は試験ではなく小計グループに属するので、その試験を参照している
+  // データソースから逆に辿る
+  const examIdBySubtotalId = new Map(
+    dataSourceRows
+      .filter(
+        (dataSource) =>
+          dataSource.subtotalId !== null && dataSource.examId !== null
+      )
+      .map((dataSource) => [dataSource.subtotalId!, dataSource.examId!])
+  )
+  const subtotalRefs: ArchiveGradeSubtotalRef[] = subtotalRows.flatMap(
+    (subtotal) => {
+      const examId = examIdBySubtotalId.get(subtotal.id)
+      if (!examId) return []
+      return [{ id: subtotal.id, examId, name: subtotal.name }]
+    }
+  )
+
+  const cropRegionRefs: ArchiveGradeCropRegionRef[] = cropRegionRows.map(
+    (cropRegion) => ({
+      id: cropRegion.id,
+      examId: cropRegion.examPage.examId,
+      label: cropRegion.label,
+    })
+  )
+
+  // ── 内包する試験外成績資料（収集は coursework モジュールへ委譲） ──
+  const courseworkIds = new Set(
+    dataSourceRows.flatMap((dataSource) =>
+      dataSource.courseworkId ? [dataSource.courseworkId] : []
+    )
+  )
+  // coursework 型は評価項目を指す。親の資料 id は行に無いので項目から辿る
+  const courseworkItemIds = dataSourceRows.flatMap((dataSource) =>
+    dataSource.courseworkItemId ? [dataSource.courseworkItemId] : []
+  )
+  if (courseworkItemIds.length > 0) {
+    const referencedItems = await prisma.courseworkItem.findMany({
+      where: { id: { in: courseworkItemIds } },
+      select: { courseworkId: true },
+    })
+    for (const referencedItem of referencedItems) {
+      courseworkIds.add(referencedItem.courseworkId)
+    }
+  }
+  const courseworkArchive = await collectCourseworkArchiveData([
+    ...courseworkIds,
+  ])
 
   return {
-    gradeData: {
-      grade: {
-        name: grade.name,
-        description: grade.description,
-        referenceDate: grade.referenceDate?.toISOString() ?? null,
-      },
-      exportSettings: grade.exportSettings
-        ? { settingsJson: grade.exportSettings.settingsJson }
-        : null,
-      gradeItems,
-      classroomRefs,
-      examRefs,
-      studentRefs,
-      gradeItemExclusions:
-        gradeItemExclusions.length > 0 ? gradeItemExclusions : undefined,
-      gradeOverrides: gradeOverrides.length > 0 ? gradeOverrides : undefined,
-      gradeFrozenScores:
-        gradeFrozenScores.length > 0 ? gradeFrozenScores : undefined,
-      gradeConstraints:
-        gradeConstraints.length > 0 ? gradeConstraints : undefined,
-    },
+    grades,
+    gradeClassrooms,
+    gradeStudents,
+    gradeItems,
+    gradeDataSources,
+    gradeDataSourceEstimationSources,
+    gradeBoundarySets,
+    gradeBoundaries,
+    gradeOverrides,
+    gradeFrozenScores,
+    gradeItemExclusions,
+    gradeConstraints,
+    gradeConstraintViewpoints,
+    gradeConstraintLabelValues,
+    gradeConstraintExclusionLabels,
+    gradeExportSettings,
+    studentsData,
+    classesData,
+    membershipsData,
+    examRefs,
+    subtotalRefs,
+    cropRegionRefs,
     courseworkArchive,
-    boundariesData: { boundarySets },
     counts: {
       gradeItems: gradeItems.length,
-      dataSources: totalDataSources,
-      manualScores: manualScoresCount,
-      boundarySets: boundarySets.length,
-      boundaries: totalBoundaries,
-      classrooms: classroomRefs.length,
-      students: studentRefs.length,
+      dataSources: gradeDataSources.length,
+      manualScores: courseworkArchive.counts.scores,
+      boundarySets: gradeBoundarySets.length,
+      boundaries: gradeBoundaries.length,
+      classrooms: gradeClassrooms.length,
+      students: gradeStudents.length,
     },
   }
 }

--- a/electron-src/lib/export/individual-report/dataFetcher.ts
+++ b/electron-src/lib/export/individual-report/dataFetcher.ts
@@ -192,7 +192,6 @@ export async function fetchIndividualReportData(
 
         // 統計データ（subtotalScoresから直接グループ情報を取得可能）
         const statistics = calculateStatisticsForStudent(
-          scoringData.studentId,
           scoringData.totalScore,
           allScoringData,
           studentClassrooms,

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -34,6 +34,10 @@ export interface StudentClassroomForStatistics {
  * studentId → 合計点の索引を構築する。
  * 生徒ごとに calculateStatisticsForStudent を呼ぶ際、呼び出し側で一度だけ構築し
  * 渡すことで O(生徒数^2) の再構築を避ける。
+ *
+ * ここが人（Student）キーなのは正しい。突き合わせ相手が学級の在籍者一覧
+ * （StudentClassroomMembership＝人の所属）だからで、受験者（ExamStudent）では
+ * 学級の母集団と噛み合わない（#962 §3.3 の棚卸し結果）。
  */
 export function buildScoreByStudentId(
   allScoringData: ScoringData[]
@@ -297,7 +301,6 @@ export function getDiscriminationLevel(r: number | null): DiscriminationLevel {
  *   各学級全体を母集団として学級平均・順位を算出（複数学級対応）。
  */
 export function calculateStatisticsForStudent(
-  _studentId: string,
   studentScore: number | null,
   allScoringData: ScoringData[],
   studentClassrooms: StudentClassroomForStatistics[],

--- a/electron-src/lib/import/coursework-archive/dataCreator.ts
+++ b/electron-src/lib/import/coursework-archive/dataCreator.ts
@@ -127,7 +127,8 @@ export async function importCourseworkData(
       tx,
       data.membershipsData,
       students.map,
-      classes.map
+      classes.map,
+      students.createdIds
     )
   }
 

--- a/electron-src/lib/import/coursework-archive/idRemapper.ts
+++ b/electron-src/lib/import/coursework-archive/idRemapper.ts
@@ -27,15 +27,29 @@ import {
 type IdMap = Map<string, string>
 
 /**
+ * uuid の形をしているか。旧アーカイブの変換で合成した id
+ * （`legacy-student:S001` など）を主キーとして DB へ書き込まないための判定。
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const isUuid = (value: string): boolean => UUID_PATTERN.test(value)
+
+/**
  * 生徒を解決する。返り値は archiveStudentId → 実 studentId のマップ。
  * 未解決（lookup-only で見つからない）生徒はマップに含めない。
+ *
+ * `createdIds` には**このインポートで新規作成した**生徒の実 id だけが入る。
+ * 学級所属の復元は新規作成した生徒に限る必要があり（既存生徒に適用すると、
+ * 取り込み先で異動済みの生徒に旧学級の在籍行を復活させてしまう）、
+ * 呼び出し側が「既存に一致した生徒」と区別できるようにするため返す。
  */
 export async function resolveStudents(
   tx: TransactionClient,
   students: ArchiveCwStudent[],
   options: { method: CourseworkMatchingMethod; allowCreate: boolean }
-): Promise<{ map: IdMap; warnings: string[] }> {
+): Promise<{ map: IdMap; createdIds: Set<string>; warnings: string[] }> {
   const map: IdMap = new Map()
+  const createdIds = new Set<string>()
   const warnings: string[] = []
   const existing = await tx.student.findMany()
   const byId = new Map(
@@ -78,13 +92,26 @@ export async function resolveStudents(
       )
       continue
     }
+    // 氏名を持たないレコードからは作らない。旧 .grade（v1.12.0 以前）は生徒を
+    // 学籍番号だけで参照しており氏名を持ち出していないため、作ると氏名が空の生徒が
+    // 名簿に並ぶ。作らずに済ませて、先に生徒を登録してもらう方が復旧できる
+    if (!student.lastName && !student.firstName) {
+      warnings.push(
+        `生徒（${student.studentNumber}）は氏名の情報が無いため作成しませんでした。` +
+          `先に生徒を登録してから取り込み直してください`
+      )
+      continue
+    }
     const uniqueNumber = await generateUniqueStudentNumber(
       tx,
       student.studentNumber
     )
     const created = await tx.student.create({
       data: {
-        id: student.id,
+        // 合成された非 uuid の id（旧 .grade 由来の `legacy-student:…`）を主キーへ
+        // 持ち込まない。持ち込むと id は原則 uuid という規約を破ったまま
+        // 以後のアーカイブと同期へ伝播する
+        ...(isUuid(student.id) ? { id: student.id } : {}),
         studentNumber: uniqueNumber,
         lastName: student.lastName,
         firstName: student.firstName,
@@ -94,9 +121,10 @@ export async function resolveStudents(
       },
     })
     map.set(student.id, created.id)
+    createdIds.add(created.id)
   }
 
-  return { map, warnings }
+  return { map, createdIds, warnings }
 }
 
 /** 学級を解決する。返り値は archiveClassroomId → 実 classroomId のマップ。 */
@@ -141,7 +169,8 @@ export async function resolveClassrooms(
     const uniqueName = await generateUniqueClassName(tx, classroom.name)
     const created = await tx.classroom.create({
       data: {
-        id: classroom.id,
+        // 生徒と同じく、合成された非 uuid の id は主キーへ持ち込まない
+        ...(isUuid(classroom.id) ? { id: classroom.id } : {}),
         name: uniqueName,
         classroomCode: classroom.classroomCode,
         grade: classroom.grade,
@@ -188,17 +217,23 @@ export async function resolveTags(
  * 新規作成された生徒の名簿（membership）を復元する。
  * 既存 membership がある (studentId, classroomId) はスキップ（冪等）。
  * lookup-only（allowCreate=false）では呼ばない想定。
+ *
+ * **既存生徒には適用しない。** 取り込み先で別学級へ異動済みの生徒に旧学級の在籍行を
+ * 足してしまうと、成績だけでなく試験の学級別集計・受験日スナップショット・学級からの
+ * 一括追加の母集団まで、取り込みと無関係なところが変わる。
  */
 export async function restoreMemberships(
   tx: TransactionClient,
   memberships: ArchiveCwMembership[],
   studentMap: IdMap,
-  classroomMap: IdMap
+  classroomMap: IdMap,
+  createdStudentIds: Set<string>
 ): Promise<void> {
   for (const membership of memberships) {
     const studentId = studentMap.get(membership.studentId)
     const classroomId = classroomMap.get(membership.classroomId)
     if (!studentId || !classroomId) continue
+    if (!createdStudentIds.has(studentId)) continue
     const exists = await tx.studentClassroomMembership.findFirst({
       where: { studentId, classroomId },
       select: { id: true },

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -1,21 +1,26 @@
 /**
  * 成績算出アーカイブ (.grade) 展開・解析
+ *
+ * v1.13.0 の grade-exam.json はテーブルごとの平坦なセクション。
+ * v1.12.0 以前は射影形式（gradeData / boundariesData に分かれていた）で、
+ * 形の知識は変換器側（grade-transformers/legacyShape）が持つ。ここでは
+ * どちらの形で読んだかだけを見分け、変換器チェーンへ渡す。
  */
 
 import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
-import type {
-  ArchiveBoundariesData,
-  ArchiveCoursework,
-  ArchiveGradeData,
-  ArchiveManualScoresData,
-  GradeArchiveData,
-  GradeArchiveManifest,
-} from "../../../../src/types/gradeArchive.types"
+import type { GradeArchiveManifest } from "../../../../src/types/gradeArchive.types"
 import {
   isCurrentCollectedCourseworkData,
   isLegacyCollectedCourseworkData,
   type LegacyCollectedCourseworkData,
 } from "../coursework-transformers/legacyShape"
+import type {
+  LegacyArchiveBoundariesData,
+  LegacyArchiveCoursework,
+  LegacyArchiveGradeData,
+  LegacyArchiveManualScoresData,
+} from "../grade-transformers/legacyShape"
+import type { AnyGradeArchiveData } from "../grade-transformers/types"
 import { normalizeLegacyClassroomKeys } from "../shared/legacyClassroomKeys"
 
 // archiver で作った ZIP を展開するために unzipper を使用
@@ -37,10 +42,36 @@ async function extractZip(
   return files
 }
 
-/** 成績算出アーカイブ（.grade）を展開し、マニフェスト・成績データ・手動スコア・境界値を解析する */
+/** v1.13.0 の平坦なセクション形式か（成績本体のセクションが揃っているか） */
+function isFlatGradeSections(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false
+  const sections = value as Record<string, unknown>
+  const REQUIRED = [
+    "grades",
+    "gradeClassrooms",
+    "gradeStudents",
+    "gradeItems",
+    "gradeDataSources",
+    "gradeBoundarySets",
+    "gradeBoundaries",
+    "gradeOverrides",
+    "gradeFrozenScores",
+    "gradeItemExclusions",
+    "gradeConstraints",
+  ]
+  return REQUIRED.every((key) => Array.isArray(sections[key]))
+}
+
+/** 検証済みの配列として読む。壊れていれば空配列（呼び出し側で落ちないように） */
+function readArray(sections: Record<string, unknown>, key: string): unknown[] {
+  const value = sections[key]
+  return Array.isArray(value) ? value : []
+}
+
+/** 成績算出アーカイブ（.grade）を展開し、マニフェストと各セクションを解析する */
 export async function extractGradeArchive(
   archivePath: string
-): Promise<{ success: boolean; data?: GradeArchiveData; error?: string }> {
+): Promise<{ success: boolean; data?: AnyGradeArchiveData; error?: string }> {
   try {
     const files = await extractZip(archivePath)
 
@@ -48,20 +79,18 @@ export async function extractGradeArchive(
     if (!manifestJson) {
       return { success: false, error: "manifest.jsonが見つかりません" }
     }
-
     const manifest: GradeArchiveManifest = JSON.parse(manifestJson)
+
     // 学級リネーム前の旧キー（classId/classes/className/classCode）は読取り時に現行キー（classroom*）へ正規化
-    const gradeData: ArchiveGradeData = normalizeLegacyClassroomKeys(
+    const gradeJson = normalizeLegacyClassroomKeys(
       JSON.parse(files["grade-exam.json"] ?? "{}")
     )
-    const boundariesData: ArchiveBoundariesData = JSON.parse(
-      files["boundaries.json"] ?? '{"boundarySets":[]}'
-    )
+
     // 試験外成績資料の埋め込み。
     //   v1.12.0+: courseworks.json は coursework-archive 形式（テーブルごとの平坦なセクション）。
     //   v1.5.0〜1.11.0: 同じくオブジェクトだが入れ子・射影形式。変換器が展開する。
-    //   v1.4.0 : courseworks.json は名前ベースの ArchiveCoursework[] 配列。
-    let courseworks: ArchiveCoursework[] | undefined
+    //   v1.4.0 : courseworks.json は名前ベースの配列。
+    let courseworks: LegacyArchiveCoursework[] | undefined
     let courseworkArchive: CollectedCourseworkData | undefined
     let legacyCourseworkArchive: LegacyCollectedCourseworkData | undefined
     if (files["courseworks.json"]) {
@@ -79,8 +108,60 @@ export async function extractGradeArchive(
         legacyCourseworkArchive = parsed
       }
     }
+
+    // v1.13.0: 成績本体もテーブルごとの平坦なセクション
+    if (isFlatGradeSections(gradeJson)) {
+      const sections = gradeJson as Record<string, unknown>
+      return {
+        success: true,
+        data: {
+          manifest,
+          grades: readArray(sections, "grades"),
+          gradeClassrooms: readArray(sections, "gradeClassrooms"),
+          gradeStudents: readArray(sections, "gradeStudents"),
+          gradeItems: readArray(sections, "gradeItems"),
+          gradeDataSources: readArray(sections, "gradeDataSources"),
+          gradeDataSourceEstimationSources: readArray(
+            sections,
+            "gradeDataSourceEstimationSources"
+          ),
+          gradeBoundarySets: readArray(sections, "gradeBoundarySets"),
+          gradeBoundaries: readArray(sections, "gradeBoundaries"),
+          gradeOverrides: readArray(sections, "gradeOverrides"),
+          gradeFrozenScores: readArray(sections, "gradeFrozenScores"),
+          gradeItemExclusions: readArray(sections, "gradeItemExclusions"),
+          gradeConstraints: readArray(sections, "gradeConstraints"),
+          gradeConstraintViewpoints: readArray(
+            sections,
+            "gradeConstraintViewpoints"
+          ),
+          gradeConstraintLabelValues: readArray(
+            sections,
+            "gradeConstraintLabelValues"
+          ),
+          gradeConstraintExclusionLabels: readArray(
+            sections,
+            "gradeConstraintExclusionLabels"
+          ),
+          gradeExportSettings: readArray(sections, "gradeExportSettings"),
+          studentsData: readArray(sections, "studentsData"),
+          classesData: readArray(sections, "classesData"),
+          membershipsData: readArray(sections, "membershipsData"),
+          examRefs: readArray(sections, "examRefs"),
+          subtotalRefs: readArray(sections, "subtotalRefs"),
+          cropRegionRefs: readArray(sections, "cropRegionRefs"),
+          courseworkArchive: courseworkArchive ?? EMPTY_COURSEWORK_ARCHIVE,
+        } as AnyGradeArchiveData,
+      }
+    }
+
+    // v1.12.0 以前（射影形式）。境界は別ファイルに分かれていた
+    const gradeData = gradeJson as LegacyArchiveGradeData
+    const boundariesData: LegacyArchiveBoundariesData = JSON.parse(
+      files["boundaries.json"] ?? '{"boundarySets":[]}'
+    )
     // 旧 v1.3.0 以前: manual-scores.json があれば後方互換用に読む
-    const manualScoresData: ArchiveManualScoresData | undefined = files[
+    const manualScoresData: LegacyArchiveManualScoresData | undefined = files[
       "manual-scores.json"
     ]
       ? JSON.parse(files["manual-scores.json"])
@@ -105,4 +186,20 @@ export async function extractGradeArchive(
       error: error instanceof Error ? error.message : "Unknown error",
     }
   }
+}
+
+/** 内包資料が無い（1件も参照していない）成績の既定値 */
+const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
+  courseworks: [],
+  courseworkClassrooms: [],
+  courseworkTags: [],
+  courseworkStudents: [],
+  courseworkItems: [],
+  courseworkLetterScales: [],
+  courseworkScores: [],
+  studentsData: [],
+  classesData: [],
+  membershipsData: [],
+  tagsData: [],
+  counts: { courseworks: 0, items: 0, scores: 0, students: 0, classrooms: 0 },
 }

--- a/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveImporter.ts
@@ -1,11 +1,26 @@
 /**
  * 成績算出アーカイブのインポート
+ *
+ * v1.13.0 の .grade はテーブルごとの平坦なセクションで、各行は Prisma の行そのまま。
+ * 取り込みは「アーカイブ内の uuid → 取り込み先の実 id」の対応を作りながら行を写す。
+ *
+ * 外部参照（アーカイブに含まれない実体）の解決:
+ *   生徒・学級 = uuid 一次 → 学籍番号 / 学級名 二次（full レコードを carry しているので効く）
+ *   試験       = uuid 一次 → ユーザー指定のマッピング → 試験名
+ *   小計・領域 = uuid 一次 → 当該試験内の名前・ラベル
+ *   資料       = 内包する courseworkArchive の取り込み結果から解決
+ *
+ * 生徒・学級は uuid・名前のどちらでも当たらなければ**作る**（.exam / .coursework と同じ）。
+ * 学級所属も復元するので、対象生徒と、その紐づけ先の学級が取り込み先に増える。
+ * 学籍番号・学級名が既存と衝突する場合はサフィックスで退避する。
+ * 試験・小計・採点領域はアーカイブに含まれないので作れない。解決できなかった参照は
+ * その行ごと落とし、必ず warning で伝える。
  */
 
 import type { Prisma } from "@prisma/client"
 
 import type {
-  GradeArchiveData,
+  ArchiveGradeExamRef,
   GradeArchiveImportOptions,
   GradeArchiveImportPreview,
 } from "../../../../src/types/gradeArchive.types"
@@ -14,111 +29,94 @@ import prisma from "../../prisma/client"
 import { writeConstraintConfig } from "../../prisma/gradeConstraint"
 import { buildEstimationSourceRows } from "../../prisma/gradeDataSource"
 import { importCourseworkData } from "../coursework-archive/dataCreator"
+import {
+  resolveClassrooms,
+  resolveStudents,
+  restoreMemberships,
+} from "../coursework-archive/idRemapper"
 import { transformGradeToLatest } from "../grade-transformers"
+import type { AnyGradeArchiveData } from "../grade-transformers/types"
 
-/** アーカイブ側の生徒参照の最小形（uuid一次・学籍番号二次で解決する） */
-interface ArchiveStudentReference {
-  id?: string
-  studentNumber: string
-}
-
-/**
- * アーカイブの生徒参照から既存 Student を解決する。
- * uuid 一次（同一PC由来／exam-archive 経由で uuid ごと作られた生徒に当たる）、
- * 学籍番号二次（別PCで先に登録された生徒に当たる）。
- * grade-archive は生徒マスタを作らない（既存への lookup のみ）方針なので、
- * どちらでも当たらなければ null を返し、呼び出し側がスキップする。
- */
-async function resolveStudent(
-  tx: Prisma.TransactionClient,
-  reference: ArchiveStudentReference
-) {
-  if (reference.id) {
-    const byId = await tx.student.findUnique({ where: { id: reference.id } })
-    if (byId) return byId
-  }
-  return tx.student.findUnique({
-    where: { studentNumber: reference.studentNumber },
-  })
-}
+/** アーカイブ内 uuid → 取り込み先の実 id */
+type IdMap = Map<string, string>
 
 /**
  * インポート前のプレビュー（照合結果）
  */
 export async function previewGradeArchiveImport(
-  rawData: GradeArchiveData
+  rawData: AnyGradeArchiveData
 ): Promise<GradeArchiveImportPreview> {
-  // 旧バージョンを現行（courseworkArchive 形式）へ正規化してから照合する。
+  // 旧バージョンを現行（平坦なセクション）へ正規化してから照合する。
   // 変換で失われるデータの警告は取り込み前に見せる必要があるので捨てない。
   const { data, warnings } = transformGradeToLatest(rawData)
-  const { gradeData } = data
   const courseworkArchive = data.courseworkArchive
 
-  // Classroom照合（複数学級対応）
+  // Classroom照合（uuid一次・学級名二次）。当たらなければ取り込みで新規作成される
   const classroomMatches = await Promise.all(
-    gradeData.classroomRefs.map(async (ref) => {
+    data.classesData.map(async (classroom) => {
       const existing =
-        (ref.id
-          ? await prisma.classroom.findUnique({ where: { id: ref.id } })
-          : null) ??
-        (await prisma.classroom.findUnique({ where: { name: ref.name } }))
-      return { found: !!existing, name: ref.name }
+        (await prisma.classroom.findUnique({ where: { id: classroom.id } })) ??
+        (await prisma.classroom.findUnique({ where: { name: classroom.name } }))
+      return { found: !!existing, name: classroom.name }
     })
   )
+  const classroomCreateCount = classroomMatches.filter(
+    (classroomMatch) => !classroomMatch.found
+  ).length
 
-  // Exam照合
+  // Exam照合（uuid一次・試験名二次）
   const examMatches = await Promise.all(
-    gradeData.examRefs.map(async (ref) => {
-      const byId = ref.id
-        ? await prisma.exam.findUnique({
-            where: { id: ref.id },
-            select: { id: true },
-          })
-        : null
+    data.examRefs.map(async (examRef) => {
+      const byId = await prisma.exam.findUnique({
+        where: { id: examRef.id },
+        select: { id: true },
+      })
       const exams = byId
         ? [byId]
         : await prisma.exam.findMany({
-            where: { examName: ref.examName },
+            where: { examName: examRef.examName },
             select: { id: true },
           })
       return {
-        examName: ref.examName,
+        examName: examRef.examName,
         found: exams.length > 0,
         examId: exams[0]?.id ?? null,
       }
     })
   )
 
-  // 埋め込み資料の照合候補（正規化済みのため courseworkArchive のみ参照）
-  const cwPreviewItems = (courseworkArchive?.courseworks ?? []).map(
-    (coursework) => ({
-      id: coursework.id,
-      name: coursework.name,
-      itemCount: (courseworkArchive?.courseworkItems ?? []).filter(
-        (item) => item.courseworkId === coursework.id
-      ).length,
-      studentCount: (courseworkArchive?.courseworkStudents ?? []).filter(
-        (courseworkStudent) => courseworkStudent.courseworkId === coursework.id
-      ).length,
-    })
-  )
+  // 埋め込み資料の照合候補
+  const cwPreviewItems = courseworkArchive.courseworks.map((coursework) => ({
+    id: coursework.id,
+    name: coursework.name,
+    itemCount: courseworkArchive.courseworkItems.filter(
+      (item) => item.courseworkId === coursework.id
+    ).length,
+    studentCount: courseworkArchive.courseworkStudents.filter(
+      (courseworkStudent) => courseworkStudent.courseworkId === coursework.id
+    ).length,
+  }))
 
   // Student照合（uuid一次・学籍番号二次）。import 本体と同じ順序で数えないと
   // 「見つかりません」の件数が実際の取り込み結果とずれる。
-  const studentReferences = [
-    ...(courseworkArchive?.studentsData ?? []),
-    ...gradeData.studentRefs,
-  ]
   const uniqueStudentReferences = new Map<
     string,
-    { id?: string; studentNumber: string }
+    { id: string; studentNumber: string; hasName: boolean }
   >()
-  for (const studentReference of studentReferences) {
-    // 学籍番号で名寄せする（同じ生徒が資料側と成績側の両方に現れる）
-    if (!uniqueStudentReferences.has(studentReference.studentNumber)) {
-      uniqueStudentReferences.set(studentReference.studentNumber, {
-        id: studentReference.id,
-        studentNumber: studentReference.studentNumber,
+  for (const student of [
+    ...courseworkArchive.studentsData,
+    ...data.studentsData,
+  ]) {
+    // 学籍番号で名寄せする（同じ生徒が資料側と成績側の両方に現れる）。
+    // 氏名を持つ側を優先して残す（旧 .grade の成績側は氏名を持たないが、
+    // 内包資料側は持っているため、同じ生徒でも作成可否が変わる）
+    const existing = uniqueStudentReferences.get(student.studentNumber)
+    const hasName = Boolean(student.lastName || student.firstName)
+    if (!existing || (!existing.hasName && hasName)) {
+      uniqueStudentReferences.set(student.studentNumber, {
+        id: student.id,
+        studentNumber: student.studentNumber,
+        hasName,
       })
     }
   }
@@ -131,29 +129,26 @@ export async function previewGradeArchiveImport(
   const existingNumberSet = new Set(
     existingStudents.map((student) => student.studentNumber)
   )
-  const resolvedStudentNumbers = [...uniqueStudentReferences.values()].filter(
+  const unmatchedStudents = [...uniqueStudentReferences.values()].filter(
     (studentReference) =>
-      (studentReference.id !== undefined &&
-        existingStudentIds.has(studentReference.id)) ||
-      existingNumberSet.has(studentReference.studentNumber)
+      !existingStudentIds.has(studentReference.id) &&
+      !existingNumberSet.has(studentReference.studentNumber)
   )
-  const uniqueNumbers = [...uniqueStudentReferences.keys()]
-  const resolvedNumberSet = new Set(
-    resolvedStudentNumbers.map(
-      (studentReference) => studentReference.studentNumber
-    )
-  )
+  // 既存に当たらなかった生徒は、氏名を持っていれば作成され、持っていなければ
+  // 作れずに落ちる（旧アーカイブは氏名を持ち出していない）
+  const studentCreateCount = unmatchedStudents.filter(
+    (studentReference) => studentReference.hasName
+  ).length
+  const studentSkipCount = unmatchedStudents.length - studentCreateCount
 
   // 埋め込み資料のマッチング候補（uuid一次・名前二次）を算出
   const courseworkMatches = await Promise.all(
     cwPreviewItems.map(async (courseworkPreview) => {
       // uuid 完全一致（同一PC由来）
-      const uuidMatch = courseworkPreview.id
-        ? await prisma.coursework.findUnique({
-            where: { id: courseworkPreview.id },
-            select: { id: true, name: true },
-          })
-        : null
+      const uuidMatch = await prisma.coursework.findUnique({
+        where: { id: courseworkPreview.id },
+        select: { id: true, name: true },
+      })
       // 名前一致候補（名前は非ユニークなので複数あり得る。uuid一致は除外）
       const nameCandidates = (
         await prisma.coursework.findMany({
@@ -175,21 +170,63 @@ export async function previewGradeArchiveImport(
   return {
     manifest: data.manifest,
     classroomMatches,
+    classroomCreateCount,
     examMatches,
-    studentMatchCount: resolvedNumberSet.size,
-    studentMissingCount: uniqueNumbers.filter(
-      (studentNumber) => !resolvedNumberSet.has(studentNumber)
-    ).length,
+    studentMatchCount: uniqueStudentReferences.size - unmatchedStudents.length,
+    studentCreateCount,
+    studentSkipCount,
     courseworkMatches,
     warnings,
   }
 }
 
 /**
+ * 参照している試験を uuid 一次・マッピング・試験名の順で解決する。
+ * 解決できなければマップに入れない（そのデータソースは参照なしで取り込む）。
+ */
+async function resolveExams(
+  tx: Prisma.TransactionClient,
+  examRefs: ArchiveGradeExamRef[],
+  examMapping: Record<string, string> | undefined,
+  warnings: string[]
+): Promise<IdMap> {
+  const map: IdMap = new Map()
+  for (const examRef of examRefs) {
+    const byId = await tx.exam.findUnique({
+      where: { id: examRef.id },
+      select: { id: true },
+    })
+    if (byId) {
+      map.set(examRef.id, byId.id)
+      continue
+    }
+    const mapped = examMapping?.[examRef.examName]
+    if (mapped) {
+      map.set(examRef.id, mapped)
+      continue
+    }
+    // 試験名は unique でないため、同名が複数あれば取り違えうる。
+    // ユーザーがウィザードで指定していない場合の最後の手段として先頭を採る
+    const byName = await tx.exam.findFirst({
+      where: { examName: examRef.examName },
+      select: { id: true },
+    })
+    if (byName) {
+      map.set(examRef.id, byName.id)
+      continue
+    }
+    warnings.push(
+      `試験「${examRef.examName}」が見つからないため、参照しているデータソースの試験参照を外しました`
+    )
+  }
+  return map
+}
+
+/**
  * 実際のインポート実行
  */
 export async function importGradeArchive(
-  rawData: GradeArchiveData,
+  rawData: AnyGradeArchiveData,
   options: GradeArchiveImportOptions = {}
 ): Promise<{
   success: boolean
@@ -200,571 +237,484 @@ export async function importGradeArchive(
 }> {
   try {
     const { examMapping, courseworkDecisions = {} } = options
-    // 旧バージョン（1.3.0 manual / 1.4.0 名前ベース）を現行へ正規化してから取り込む
+    // 旧バージョン（1.3.0 manual / 1.4.0 名前ベース / 1.12.0 射影形式）を現行へ正規化
     const { data, warnings: transformWarnings } =
       transformGradeToLatest(rawData)
     const warnings: string[] = [...transformWarnings]
+
+    const archiveGrade = data.grades[0]
+    if (!archiveGrade) {
+      return { success: false, error: "アーカイブに成績が含まれていません" }
+    }
+
     const result = await prisma.$transaction(
       async (tx: Prisma.TransactionClient) => {
-        const { gradeData, boundariesData } = data
+        // ── 1. 内包する試験外成績資料の復元（coursework モジュールへ委譲） ──
+        // 成績の生徒解決より先に走らせる。旧 .grade は生徒の氏名を持たないため
+        // 成績側だけでは生徒を作れないが、内包資料は氏名を持っている。先に資料を
+        // 取り込んでおけば、成績側は作られた生徒へ学籍番号で当たれる
+        // （逆順だと、生徒は DB に居るのに成績の名簿だけ空という結果になる）。
+        // 単体の .coursework と同じく未一致は作る。ここだけ lookup のみにすると、
+        // 同じ資料が単体では点数まで復元されるのに .grade 経由だと空になる
+        const courseworkResult = await importCourseworkData(
+          tx,
+          data.courseworkArchive,
+          {
+            allowCreate: true,
+            studentMatching: "studentNumber",
+            courseworkDecisions,
+          }
+        )
+        warnings.push(...courseworkResult.warnings)
 
-        // 1. Grade作成
+        // ── 2. 外部参照の解決 ──────────────────────────────────
+        // 生徒・学級は uuid 一次 → 学籍番号 / 学級名 二次で既存を探し、
+        // どちらにも当たらなければ作る（.exam / .coursework と同じ挙動）。
+        const studentResolution = await resolveStudents(tx, data.studentsData, {
+          method: "studentNumber",
+          allowCreate: true,
+        })
+        warnings.push(...studentResolution.warnings)
+        const classroomResolution = await resolveClassrooms(
+          tx,
+          data.classesData,
+          { allowCreate: true }
+        )
+        warnings.push(...classroomResolution.warnings)
+        // 学級所属を戻すのは「この取り込みで新規作成した生徒」だけ。既存生徒にも
+        // 適用すると、取り込み先で別学級へ異動済みの生徒に旧学級の在籍行が復活し、
+        // 取り込みと無関係な試験の学級別集計・受験日スナップショットまで変わる
+        await restoreMemberships(
+          tx,
+          data.membershipsData,
+          studentResolution.map,
+          classroomResolution.map,
+          studentResolution.createdIds
+        )
+        const examIdMap = await resolveExams(
+          tx,
+          data.examRefs,
+          examMapping,
+          warnings
+        )
+
+        // 小計・採点領域は uuid 一次、当該試験内の名前・ラベル二次。
+        // 小計名はグループ内、領域ラベルは試験内でしか一意でないので必ず試験で絞る
+        const subtotalIdMap: IdMap = new Map()
+        for (const subtotalRef of data.subtotalRefs) {
+          const byId = await tx.subtotal.findUnique({
+            where: { id: subtotalRef.id },
+            select: { id: true },
+          })
+          if (byId) {
+            subtotalIdMap.set(subtotalRef.id, byId.id)
+            continue
+          }
+          const examId = examIdMap.get(subtotalRef.examId)
+          if (!examId) continue
+          const byName = await tx.subtotal.findFirst({
+            where: {
+              name: subtotalRef.name,
+              subtotalGroup: { examSubtotalGroups: { some: { examId } } },
+            },
+            select: { id: true },
+          })
+          if (byName) subtotalIdMap.set(subtotalRef.id, byName.id)
+        }
+
+        const cropRegionIdMap: IdMap = new Map()
+        for (const cropRegionRef of data.cropRegionRefs) {
+          const byId = await tx.cropRegion.findUnique({
+            where: { id: cropRegionRef.id },
+            select: { id: true },
+          })
+          if (byId) {
+            cropRegionIdMap.set(cropRegionRef.id, byId.id)
+            continue
+          }
+          const examId = examIdMap.get(cropRegionRef.examId)
+          if (!examId) continue
+          const byLabel = await tx.cropRegion.findFirst({
+            where: { label: cropRegionRef.label, examPage: { examId } },
+            select: { id: true },
+          })
+          if (byLabel) cropRegionIdMap.set(cropRegionRef.id, byLabel.id)
+        }
+
+        // 資料そのものの参照（coursework_total 型）は資料を直接引いて解決する。
+        // 評価項目経由でしか作らないと、評価項目が0件の資料への参照が
+        // 取り込み先に実在していても解決できず「参照なし」で作られてしまう。
+        const courseworkItemIdMap = courseworkResult.itemIdMap
+        /** アーカイブ資料uuid → 実 Coursework.id（coursework_total 型の参照解決用） */
+        const courseworkIdMap: IdMap = new Map()
+        for (const archiveCoursework of data.courseworkArchive.courseworks) {
+          const byId = await tx.coursework.findUnique({
+            where: { id: archiveCoursework.id },
+            select: { id: true },
+          })
+          if (byId) {
+            courseworkIdMap.set(archiveCoursework.id, byId.id)
+            continue
+          }
+          const byName = await tx.coursework.findFirst({
+            where: { name: archiveCoursework.name },
+            select: { id: true },
+          })
+          if (byName) courseworkIdMap.set(archiveCoursework.id, byName.id)
+        }
+        // 評価項目から親を辿れるものは、そちらの結果を優先する
+        // （ユーザーがウィザードで別の資料へ寄せた場合に追従する）
+        for (const [archiveItemId, actualItemId] of courseworkItemIdMap) {
+          const archiveItem = data.courseworkArchive.courseworkItems.find(
+            (item) => item.id === archiveItemId
+          )
+          if (!archiveItem) continue
+          const actualItem = await tx.courseworkItem.findUnique({
+            where: { id: actualItemId },
+            select: { courseworkId: true },
+          })
+          if (actualItem) {
+            courseworkIdMap.set(
+              archiveItem.courseworkId,
+              actualItem.courseworkId
+            )
+          }
+        }
+
+        // ── 3. 成績本体を写す（アーカイブ uuid → 新 id の対応を作りながら） ──
         const grade = await tx.grade.create({
           data: {
-            name: gradeData.grade.name,
-            description: gradeData.grade.description,
-            // v1.2.0+: 基準日（古いアーカイブではundefined → null）
-            referenceDate: gradeData.grade.referenceDate
-              ? new Date(gradeData.grade.referenceDate)
+            name: archiveGrade.name,
+            description: archiveGrade.description,
+            referenceDate: archiveGrade.referenceDate
+              ? new Date(archiveGrade.referenceDate)
               : null,
           },
         })
 
-        // 1.5. GradeExportSettings作成 (v1.2.0+、Gradeと1:1)
-        if (gradeData.exportSettings) {
+        for (const exportSettings of data.gradeExportSettings) {
           await tx.gradeExportSettings.create({
             data: {
               gradeId: grade.id,
-              settingsJson: gradeData.exportSettings.settingsJson,
+              settingsJson: exportSettings.settingsJson,
             },
           })
         }
 
-        // 2. Classroom照合→GradeClassroom作成（uuid一次・名前二次）
-        for (let i = 0; i < gradeData.classroomRefs.length; i++) {
-          const ref = gradeData.classroomRefs[i]
-          const classroom =
-            (ref.id
-              ? await tx.classroom.findUnique({ where: { id: ref.id } })
-              : null) ??
-            (await tx.classroom.findUnique({ where: { name: ref.name } }))
-          if (classroom) {
-            await tx.gradeClassroom.create({
-              data: {
-                gradeId: grade.id,
-                classroomId: classroom.id,
-                order: i,
-              },
-            })
-          }
-        }
-
-        // 3. Student照合→GradeStudent作成（uuid一次・学籍番号二次）
-        for (const studentRef of gradeData.studentRefs) {
-          const student = await resolveStudent(tx, studentRef)
-          if (student) {
-            await tx.gradeStudent.create({
-              data: {
-                gradeId: grade.id,
-                studentId: student.id,
-                customOrder: studentRef.customOrder,
-              },
-            })
-          }
-        }
-
-        // 3.5. Coursework（試験外成績資料）の復元。
-        //   transformGradeToLatest により旧 v1.3.0(manual)/v1.4.0(名前ベース) は
-        //   現行の courseworkArchive 形式へ正規化済み。独立 coursework モジュールへ委譲し、
-        //   既存生徒・学級への lookup のみ（allowCreate=false）で grade の従来挙動を維持する。
-        // 評価項目の参照解決。アーカイブ側の uuid → 作成した GradeItem.id という
-        // 「旧世界→新世界」の対応で、DB のどこにも存在しない取り込み固有の情報
-        // （coursework の itemIdToActual と同じ性質）。DB にある構造の写しではない。
-        /** アーカイブ評価項目uuid → 作成した GradeItem.id（照合の一次キー） */
-        const gradeItemIdByArchiveId = new Map<string, string>()
-        /**
-         * 評価項目名 → 作成した GradeItem.id。uuid を持たない v1.9.0 以前の
-         * アーカイブ専用のフォールバック。GradeItem には (gradeId, name) の unique が
-         * 無く名前は衝突しうるので、一次キーには使わない。
-         */
-        const gradeItemIdByName = new Map<string, string>()
-        /** 名前が重複し、名前フォールバックでは一意に定まらない評価項目名 */
-        const ambiguousGradeItemNames = new Set<string>()
-
-        /** アーカイブデータソースuuid → 作成した GradeDataSource.id（推定参照の解決用） */
-        const dataSourceIdByArchiveId = new Map<string, string>()
-        /** 推定の参照。全データソース作成後に張るため一旦ためる（前方参照があるため） */
-        const estimationLinks: {
-          dataSourceId: string
-          archiveSourceIds: string[]
-        }[] = []
-
-        /**
-         * アーカイブ側の評価項目参照から、作成した GradeItem.id を解決する。
-         * uuid 一次・名前二次。名前が曖昧なときは取り違えるより落として警告する
-         * （境界・上書き・確定値は成績そのもので、誤った項目へ付けるほうが害が大きい）。
-         */
-        const resolveGradeItemId = (
-          reference: { gradeItemId?: string; gradeItemName: string | null },
-          describeTarget: () => string
-        ): string | null => {
-          if (reference.gradeItemId) {
-            const byArchiveId = gradeItemIdByArchiveId.get(
-              reference.gradeItemId
-            )
-            if (byArchiveId) return byArchiveId
-          }
-          if (!reference.gradeItemName) return null
-          if (ambiguousGradeItemNames.has(reference.gradeItemName)) {
-            warnings.push(
-              `${describeTarget()}: 同名の評価項目「${reference.gradeItemName}」が複数あり対象を特定できないため取り込みませんでした`
-            )
-            return null
-          }
-          return gradeItemIdByName.get(reference.gradeItemName) ?? null
-        }
-
-        /** アーカイブ項目uuid → 実 CourseworkItem.id（DataSource 再リンクの一次キー） */
-        const itemIdToActual = new Map<string, string>()
-        /** `${courseworkName}:${itemName}` → 実 CourseworkItem.id（名前フォールバック） */
-        const itemNameToActual = new Map<string, string>()
-
-        if (data.courseworkArchive) {
-          const cwResult = await importCourseworkData(
-            tx,
-            data.courseworkArchive,
-            {
-              allowCreate: false,
-              studentMatching: "studentNumber",
-              courseworkDecisions,
-            }
+        for (const gradeClassroom of data.gradeClassrooms) {
+          const classroomId = classroomResolution.map.get(
+            gradeClassroom.classroomId
           )
-          warnings.push(...cwResult.warnings)
-          for (const [archiveItemId, actualId] of cwResult.itemIdMap) {
-            itemIdToActual.set(archiveItemId, actualId)
-          }
-          const courseworkNameById = new Map(
-            data.courseworkArchive.courseworks.map((coursework) => [
-              coursework.id,
-              coursework.name,
-            ])
-          )
-          for (const item of data.courseworkArchive.courseworkItems) {
-            const actual = cwResult.itemIdMap.get(item.id)
-            const courseworkName = courseworkNameById.get(item.courseworkId)
-            if (actual && courseworkName) {
-              itemNameToActual.set(`${courseworkName}:${item.name}`, actual)
-            }
-          }
-        }
-
-        // 4. GradeItem + DataSource作成
-        for (const giData of gradeData.gradeItems) {
-          const gradeItem = await tx.gradeItem.create({
+          if (!classroomId) continue
+          await tx.gradeClassroom.create({
             data: {
               gradeId: grade.id,
-              name: giData.name,
-              order: giData.order,
+              classroomId,
+              order: gradeClassroom.order,
             },
           })
-          // 作った直後に対応を控える。後段の参照解決はこれで賄い、
-          // 書き込みトランザクション中に評価項目を引き直さない。
-          if (giData.id) {
-            gradeItemIdByArchiveId.set(giData.id, gradeItem.id)
-          }
-          if (gradeItemIdByName.has(giData.name)) {
-            ambiguousGradeItemNames.add(giData.name)
-          } else {
-            gradeItemIdByName.set(giData.name, gradeItem.id)
-          }
-
-          for (const dsData of giData.dataSources) {
-            // 旧アーカイブ互換: project_total → exam_total
-            if (dsData.type === "project_total") {
-              dsData.type = "exam_total"
-            }
-
-            // CourseworkItem 解決（uuid一次・名前二次）。
-            //   旧 v1.3.0 の "manual" は transformGradeToLatest で "coursework" へ
-            //   正規化済み（courseworkItemId / courseworkName / courseworkItemName を付与）。
-            let courseworkItemId: string | null = null
-            if (dsData.type === "coursework") {
-              // アーカイブ項目uuidで一次解決
-              if (dsData.courseworkItemId) {
-                courseworkItemId =
-                  itemIdToActual.get(dsData.courseworkItemId) ?? null
-              }
-              // 名前フォールバック（uuid不一致時）
-              if (
-                !courseworkItemId &&
-                dsData.courseworkName &&
-                dsData.courseworkItemName
-              ) {
-                courseworkItemId =
-                  itemNameToActual.get(
-                    `${dsData.courseworkName}:${dsData.courseworkItemName}`
-                  ) ?? null
-              }
-              if (!courseworkItemId) {
-                warnings.push(
-                  `成績項目「${giData.name}」のデータソース「${dsData.name}」: 参照先の試験外成績資料が見つかりませんでした`
-                )
-              }
-            }
-
-            // Coursework（資料全体）解決（uuid一次・名前二次）。
-            //   exam/subtotal/cropRegion と同じく import 時に直接照合する。
-            let courseworkId: string | null = null
-            if (dsData.type === "coursework_total") {
-              if (dsData.courseworkId) {
-                const byId = await tx.coursework.findUnique({
-                  where: { id: dsData.courseworkId },
-                  select: { id: true },
-                })
-                courseworkId = byId?.id ?? null
-              }
-              if (!courseworkId && dsData.courseworkName) {
-                const byName = await tx.coursework.findFirst({
-                  where: { name: dsData.courseworkName },
-                  select: { id: true },
-                })
-                courseworkId = byName?.id ?? null
-              }
-              if (!courseworkId) {
-                warnings.push(
-                  `成績項目「${giData.name}」のデータソース「${dsData.name}」: 参照先の試験外成績資料が見つかりませんでした`
-                )
-              }
-            }
-
-            // 試験照合。uuid 一次（同一PC由来なら確実に当たる）→ ユーザーが
-            // ウィザードで指定したマッピング → 試験名。試験名は unique でないため
-            // 名前だけだと同名試験を取り違える。
-            let examId: string | null = null
-            if (
-              dsData.type === "exam_total" ||
-              dsData.type === "subtotal" ||
-              dsData.type === "crop_region"
-            ) {
-              if (dsData.examId) {
-                const byId = await tx.exam.findUnique({
-                  where: { id: dsData.examId },
-                  select: { id: true },
-                })
-                examId = byId?.id ?? null
-              }
-              if (!examId && dsData.examName) {
-                examId = examMapping?.[dsData.examName] ?? null
-              }
-              if (!examId && dsData.examName) {
-                const exams = await tx.exam.findMany({
-                  where: { examName: dsData.examName },
-                  select: { id: true },
-                })
-                examId = exams[0]?.id ?? null
-              }
-            }
-
-            // Subtotal照合（uuid一次・名前二次）。
-            // 名前フォールバックは必ず当該試験の小計グループへ絞る。小計名は
-            // グループ内でしか一意でなく、絞らないと別の試験の同名小計に当たる。
-            let subtotalId: string | null = null
-            if (dsData.type === "subtotal" && examId) {
-              if (dsData.subtotalId) {
-                const byId = await tx.subtotal.findUnique({
-                  where: { id: dsData.subtotalId },
-                  select: { id: true },
-                })
-                subtotalId = byId?.id ?? null
-              }
-              if (!subtotalId && dsData.subtotalName) {
-                const subtotals = await tx.subtotal.findMany({
-                  where: {
-                    name: dsData.subtotalName,
-                    subtotalGroup: {
-                      examSubtotalGroups: { some: { examId } },
-                    },
-                  },
-                  select: { id: true },
-                })
-                subtotalId = subtotals[0]?.id ?? null
-              }
-            }
-
-            // CropRegion照合（uuid一次・ラベル二次）。
-            // ラベルは同一試験内でも重複しうるので一次キーにはしない。
-            let cropRegionId: string | null = null
-            if (dsData.type === "crop_region" && examId) {
-              if (dsData.cropRegionId) {
-                const byId = await tx.cropRegion.findUnique({
-                  where: { id: dsData.cropRegionId },
-                  select: { id: true },
-                })
-                cropRegionId = byId?.id ?? null
-              }
-              if (!cropRegionId && dsData.cropRegionLabel) {
-                const regions = await tx.cropRegion.findMany({
-                  where: {
-                    label: dsData.cropRegionLabel,
-                    examPage: { examId: examId },
-                  },
-                  select: { id: true },
-                })
-                cropRegionId = regions[0]?.id ?? null
-              }
-            }
-
-            const createdDataSource = await tx.gradeDataSource.create({
-              data: {
-                gradeItemId: gradeItem.id,
-                type: dsData.type,
-                examId,
-                subtotalId,
-                cropRegionId,
-                courseworkItemId,
-                courseworkId,
-                name: dsData.name,
-                // v1.6.0: GradeDataSource.maxScore 列は廃止。満点はライブ算出するため挿入しない。
-                weight: dsData.weight,
-                order: dsData.order,
-                absentMethod: dsData.absentMethod ?? "null",
-                absentRatio: dsData.absentRatio ?? 1.0,
-                absentOffset: dsData.absentOffset ?? 0,
-                treatExpectedAsMissing: dsData.treatExpectedAsMissing ?? false,
-                estimationMode: dsData.estimationMode ?? "all",
-              },
-            })
-            // 推定の参照は全データソース作成後にまとめて張る（前方参照があるため）
-            if (dsData.id) {
-              dataSourceIdByArchiveId.set(dsData.id, createdDataSource.id)
-            }
-            if (dsData.estimationSourceIds?.length) {
-              estimationLinks.push({
-                dataSourceId: createdDataSource.id,
-                archiveSourceIds: dsData.estimationSourceIds,
-              })
-            }
-          }
         }
 
-        // 4.5. 推定に使う他データソースを張る。
-        //   export元idを新idへ解決できたものだけ作る。旧アーカイブ（v1.11.0未満）は
-        //   データソースidを持たないため解決できず、参照は捨てて警告する
-        //   （旧importerはexport元idをそのまま書き戻しており dangling になっていた）。
-        for (const estimationLink of estimationLinks) {
-          const resolvedSourceIds = estimationLink.archiveSourceIds
-            .map((archiveSourceId) =>
-              dataSourceIdByArchiveId.get(archiveSourceId)
-            )
-            .filter((sourceId): sourceId is string => sourceId !== undefined)
-          const droppedCount =
-            estimationLink.archiveSourceIds.length - resolvedSourceIds.length
-          if (droppedCount > 0) {
-            warnings.push(
-              `欠損推定の参照${droppedCount}件を解決できなかったため取り込みませんでした。` +
-                `該当データソースの推定設定を確認してください。`
-            )
+        const gradeStudentIdMap: IdMap = new Map()
+        // アーカイブの別々の生徒が取り込み先の同じ生徒へ解決することがある
+        // （片方が uuid で、もう片方が学籍番号で当たる場合）。@@unique(gradeId, studentId)
+        // があるので素直に作ると2回目で落ちて取り込み全体がロールバックする。
+        // 先に作った対象者へ寄せ、寄せたことを伝える
+        const gradeStudentIdByStudentId = new Map<string, string>()
+        let mergedGradeStudents = 0
+        for (const archiveGradeStudent of data.gradeStudents) {
+          const studentId = studentResolution.map.get(
+            archiveGradeStudent.studentId
+          )
+          if (!studentId) continue
+          const alreadyCreated = gradeStudentIdByStudentId.get(studentId)
+          if (alreadyCreated) {
+            gradeStudentIdMap.set(archiveGradeStudent.id, alreadyCreated)
+            mergedGradeStudents++
+            continue
           }
-          if (resolvedSourceIds.length === 0) continue
+          const created = await tx.gradeStudent.create({
+            data: {
+              gradeId: grade.id,
+              studentId,
+              customOrder: archiveGradeStudent.customOrder,
+            },
+          })
+          gradeStudentIdMap.set(archiveGradeStudent.id, created.id)
+          gradeStudentIdByStudentId.set(studentId, created.id)
+        }
+        if (mergedGradeStudents > 0) {
+          warnings.push(
+            `アーカイブの対象生徒${mergedGradeStudents}名が取り込み先の同じ生徒に一致したため、1名にまとめました`
+          )
+        }
+
+        const gradeItemIdMap: IdMap = new Map()
+        for (const archiveGradeItem of data.gradeItems) {
+          const created = await tx.gradeItem.create({
+            data: {
+              gradeId: grade.id,
+              name: archiveGradeItem.name,
+              order: archiveGradeItem.order,
+            },
+          })
+          gradeItemIdMap.set(archiveGradeItem.id, created.id)
+        }
+
+        const dataSourceIdMap: IdMap = new Map()
+        for (const archiveDataSource of data.gradeDataSources) {
+          const gradeItemId = gradeItemIdMap.get(archiveDataSource.gradeItemId)
+          if (!gradeItemId) continue
+          const created = await tx.gradeDataSource.create({
+            data: {
+              gradeItemId,
+              type: archiveDataSource.type,
+              examId: archiveDataSource.examId
+                ? (examIdMap.get(archiveDataSource.examId) ?? null)
+                : null,
+              subtotalId: archiveDataSource.subtotalId
+                ? (subtotalIdMap.get(archiveDataSource.subtotalId) ?? null)
+                : null,
+              cropRegionId: archiveDataSource.cropRegionId
+                ? (cropRegionIdMap.get(archiveDataSource.cropRegionId) ?? null)
+                : null,
+              courseworkItemId: archiveDataSource.courseworkItemId
+                ? (courseworkItemIdMap.get(
+                    archiveDataSource.courseworkItemId
+                  ) ?? null)
+                : null,
+              courseworkId: archiveDataSource.courseworkId
+                ? (courseworkIdMap.get(archiveDataSource.courseworkId) ?? null)
+                : null,
+              name: archiveDataSource.name,
+              weight: archiveDataSource.weight,
+              order: archiveDataSource.order,
+              absentMethod: archiveDataSource.absentMethod,
+              absentRatio: archiveDataSource.absentRatio,
+              absentOffset: archiveDataSource.absentOffset,
+              treatExpectedAsMissing: archiveDataSource.treatExpectedAsMissing,
+              estimationMode: archiveDataSource.estimationMode,
+            },
+          })
+          dataSourceIdMap.set(archiveDataSource.id, created.id)
+        }
+
+        // 推定の参照は全データソース作成後に張る（同一成績内の前方参照があるため）
+        const estimationSourceIdsByDataSource = new Map<string, string[]>()
+        let droppedEstimationSources = 0
+        for (const estimationSource of data.gradeDataSourceEstimationSources) {
+          const dataSourceId = dataSourceIdMap.get(
+            estimationSource.dataSourceId
+          )
+          const sourceDataSourceId = dataSourceIdMap.get(
+            estimationSource.sourceDataSourceId
+          )
+          if (!dataSourceId || !sourceDataSourceId) {
+            droppedEstimationSources++
+            continue
+          }
+          const existing = estimationSourceIdsByDataSource.get(dataSourceId)
+          if (existing) existing.push(sourceDataSourceId)
+          else
+            estimationSourceIdsByDataSource.set(dataSourceId, [
+              sourceDataSourceId,
+            ])
+        }
+        if (droppedEstimationSources > 0) {
+          warnings.push(
+            `欠損推定の参照${droppedEstimationSources}件を解決できなかったため取り込みませんでした。` +
+              `該当データソースの推定設定を確認してください。`
+          )
+        }
+        for (const [
+          dataSourceId,
+          sourceDataSourceIds,
+        ] of estimationSourceIdsByDataSource) {
           await tx.gradeDataSource.update({
-            where: { id: estimationLink.dataSourceId },
+            where: { id: dataSourceId },
             data: {
               estimationSources: {
                 create: buildEstimationSourceRows(
-                  estimationLink.dataSourceId,
-                  resolvedSourceIds
+                  dataSourceId,
+                  sourceDataSourceIds
                 ),
               },
             },
           })
         }
 
-        // 5. （v1.4.0で廃止）旧 ManualScore 挿入は Coursework 復元(3.5)に統合済み
-
-        // 6. BoundarySet/Boundary挿入
-        for (const bsData of boundariesData.boundarySets) {
-          // 対象は必ず評価項目（総合は v1.10.0 で撤去済み。transformer が破棄する）
-          if (!bsData.gradeItemName) continue
-          const gradeItemId = resolveGradeItemId(
-            bsData,
-            () => `成績境界セット（${bsData.gradeItemName}）`
-          )
-          if (gradeItemId === null) continue
-
-          const boundarySet = await tx.gradeBoundarySet.create({
+        // ── 4. 境界セット ────────────────────────────────────
+        const boundarySetIdMap: IdMap = new Map()
+        for (const archiveBoundarySet of data.gradeBoundarySets) {
+          const gradeItemId = gradeItemIdMap.get(archiveBoundarySet.gradeItemId)
+          if (!gradeItemId) continue
+          const created = await tx.gradeBoundarySet.create({
             data: { gradeId: grade.id, gradeItemId },
           })
-
-          if (bsData.boundaries.length > 0) {
-            await tx.gradeBoundary.createMany({
-              data: bsData.boundaries.map((boundary) => ({
-                gradeBoundarySetId: boundarySet.id,
-                label: boundary.label,
-                minPercentage: boundary.minPercentage,
-                order: boundary.order,
-              })),
-            })
-          }
+          boundarySetIdMap.set(archiveBoundarySet.id, created.id)
+        }
+        const boundaryRows = data.gradeBoundaries.flatMap((archiveBoundary) => {
+          const gradeBoundarySetId = boundarySetIdMap.get(
+            archiveBoundary.gradeBoundarySetId
+          )
+          if (!gradeBoundarySetId) return []
+          return [
+            {
+              gradeBoundarySetId,
+              label: archiveBoundary.label,
+              minPercentage: archiveBoundary.minPercentage,
+              order: archiveBoundary.order,
+            },
+          ]
+        })
+        if (boundaryRows.length > 0) {
+          await tx.gradeBoundary.createMany({ data: boundaryRows })
         }
 
-        // 7. GradeItemExclusion挿入（後方互換: optionalフィールド）
-        if (
-          gradeData.gradeItemExclusions &&
-          gradeData.gradeItemExclusions.length > 0
-        ) {
-          for (const excl of gradeData.gradeItemExclusions) {
-            const student = await resolveStudent(tx, excl)
-            if (!student) continue
-
-            const gradeItemId = resolveGradeItemId(
-              excl,
-              () => `生徒「${excl.studentNumber}」の評価項目除外`
-            )
-            if (gradeItemId === null) continue
-
-            await tx.gradeItemExclusion.create({
-              data: {
-                gradeId: grade.id,
-                studentId: student.id,
-                gradeItemId,
-              },
-            })
+        // ── 5. セル3種 ──────────────────────────────────────
+        // 名簿に載らなかった生徒（照合できなかった生徒）のセルは作らない。
+        // 作れてしまうと、どの画面にも出ない孤児が復活する（#962）
+        let droppedCells = 0
+        const resolveCell = (archiveCell: {
+          gradeStudentId: string
+          gradeItemId: string
+        }): { gradeStudentId: string; gradeItemId: string } | null => {
+          const gradeStudentId = gradeStudentIdMap.get(
+            archiveCell.gradeStudentId
+          )
+          const gradeItemId = gradeItemIdMap.get(archiveCell.gradeItemId)
+          if (!gradeStudentId || !gradeItemId) {
+            droppedCells++
+            return null
           }
+          return { gradeStudentId, gradeItemId }
         }
 
-        // 8. GradeOverride挿入（後方互換: optionalフィールド）
-        if (gradeData.gradeOverrides && gradeData.gradeOverrides.length > 0) {
-          for (const gradeOverride of gradeData.gradeOverrides) {
-            const student = await resolveStudent(tx, gradeOverride)
-            if (!student) continue
-
-            // 対象は必ず評価項目（総合は v1.10.0 で撤去済み。transformer が破棄する）
-            if (!gradeOverride.gradeItemName) continue
-            const gradeItemId = resolveGradeItemId(
-              gradeOverride,
-              () => `生徒「${gradeOverride.studentNumber}」の成績上書き`
-            )
-            if (gradeItemId === null) continue
-
-            await tx.gradeOverride.create({
-              data: {
-                gradeId: grade.id,
-                studentId: student.id,
-                gradeItemId,
-                overrideLabel: gradeOverride.overrideLabel,
-              },
-            })
-          }
+        for (const archiveOverride of data.gradeOverrides) {
+          const cell = resolveCell(archiveOverride)
+          if (!cell) continue
+          await tx.gradeOverride.create({
+            data: { ...cell, overrideLabel: archiveOverride.overrideLabel },
+          })
         }
 
-        // 9. GradeFrozenScore 挿入（v1.9.0+。旧アーカイブでは undefined ＝確定なし）。
-        // 確定操作者は持ち出していないため frozenByUserId は付けない（＝操作者不明）。
-        if (
-          gradeData.gradeFrozenScores &&
-          gradeData.gradeFrozenScores.length > 0
-        ) {
-          for (const gradeFrozenScore of gradeData.gradeFrozenScores) {
-            const student = await resolveStudent(tx, gradeFrozenScore)
-            if (!student) continue
-
-            const gradeItemId = resolveGradeItemId(
-              gradeFrozenScore,
-              () => `生徒「${gradeFrozenScore.studentNumber}」の確定成績値`
-            )
-            if (gradeItemId === null) continue
-
-            await tx.gradeFrozenScore.create({
-              data: {
-                gradeId: grade.id,
-                studentId: student.id,
-                gradeItemId,
-                weightedScore: gradeFrozenScore.weightedScore,
-                weightedMaxScore: gradeFrozenScore.weightedMaxScore,
-                percentage: gradeFrozenScore.percentage,
-                gradeLabel: gradeFrozenScore.gradeLabel,
-                frozenAt: new Date(gradeFrozenScore.frozenAt),
-              },
-            })
-          }
+        for (const archiveFrozenScore of data.gradeFrozenScores) {
+          const cell = resolveCell(archiveFrozenScore)
+          if (!cell) continue
+          // 確定操作者は取り込み先に同じ User が居る保証が無い。
+          // 居なければ null（操作者不明）にして値そのものは残す
+          const frozenByUserId = archiveFrozenScore.frozenByUserId
+            ? ((
+                await tx.user.findUnique({
+                  where: { id: archiveFrozenScore.frozenByUserId },
+                  select: { id: true },
+                })
+              )?.id ?? null)
+            : null
+          await tx.gradeFrozenScore.create({
+            data: {
+              ...cell,
+              weightedScore: archiveFrozenScore.weightedScore,
+              weightedMaxScore: archiveFrozenScore.weightedMaxScore,
+              percentage: archiveFrozenScore.percentage,
+              gradeLabel: archiveFrozenScore.gradeLabel,
+              frozenByUserId,
+              frozenAt: new Date(archiveFrozenScore.frozenAt),
+            },
+          })
         }
 
-        // 観点間の制約ルール（v1.7.0+）。
-        //   比較先・集計対象は評価項目への参照なので uuid 一次・名前二次で解決する
-        //   （v1.11.0 で設定JSONから昇格。issue #1063）。
-        //   式（expression）だけは自由記述で項目名を含むため文字列のまま取り込む。
-        if (
-          gradeData.gradeConstraints &&
-          gradeData.gradeConstraints.length > 0
-        ) {
-          for (const gradeConstraint of gradeData.gradeConstraints) {
-            const targetGradeItemId = resolveGradeItemId(
-              {
-                gradeItemId: gradeConstraint.targetGradeItemId ?? undefined,
-                gradeItemName: gradeConstraint.targetGradeItemName ?? null,
-              },
-              () => `制約ルール「${gradeConstraint.name}」の比較先`
-            )
-            const targetWasSpecified = Boolean(
-              gradeConstraint.targetGradeItemId ??
-              gradeConstraint.targetGradeItemName
-            )
+        for (const archiveExclusion of data.gradeItemExclusions) {
+          const cell = resolveCell(archiveExclusion)
+          if (!cell) continue
+          await tx.gradeItemExclusion.create({ data: cell })
+        }
 
-            const viewpointReferences = gradeConstraint.viewpointGradeItemIds
-              ?.length
-              ? gradeConstraint.viewpointGradeItemIds.map(
-                  (gradeItemId, index) => ({
-                    gradeItemId,
-                    gradeItemName:
-                      gradeConstraint.viewpointGradeItemNames?.[index] ?? null,
-                  })
-                )
-              : (gradeConstraint.viewpointGradeItemNames ?? []).map(
-                  (gradeItemName) => ({ gradeItemName })
-                )
-            const resolvedViewpointIds = viewpointReferences
-              .map((viewpointReference) =>
-                resolveGradeItemId(
-                  viewpointReference,
-                  () => `制約ルール「${gradeConstraint.name}」の集計対象`
-                )
-              )
-              .filter(
-                (gradeItemId): gradeItemId is string => gradeItemId !== null
-              )
+        if (droppedCells > 0) {
+          warnings.push(
+            `対象生徒または評価項目を解決できない上書き・確定値・除外設定 ${droppedCells}件を取り込みませんでした`
+          )
+        }
 
-            // 参照を1つでも失うと判定の意味が変わる（集計対象が減れば平均が動き、
-            // 空になれば「比較先以外の全項目」という別の設定に化ける）。
-            // 黙って別物として動かさず、無効化して再設定を促す。
-            const lostTarget = targetWasSpecified && targetGradeItemId === null
-            const lostViewpoint =
-              resolvedViewpointIds.length !== viewpointReferences.length
-            const brokenReason = lostTarget
-              ? "取り込み時に比較先の評価項目を解決できなかったため無効化しました。再設定してください。"
-              : lostViewpoint
-                ? "取り込み時に集計対象の観点を解決できなかったため無効化しました。再設定してください。"
-                : null
-            if (brokenReason) {
-              warnings.push(
-                `制約ルール「${gradeConstraint.name}」: ${brokenReason}`
-              )
+        // ── 6. 観点間の制約ルール ─────────────────────────────
+        // 参照を1つでも失うと判定の意味が変わる（集計対象が減れば平均が動き、
+        // 空になれば「比較先以外の全項目」という別の設定に化ける）。
+        // 黙って別物として動かさず、無効化して再設定を促す。
+        for (const archiveConstraint of data.gradeConstraints) {
+          const targetGradeItemId = archiveConstraint.targetGradeItemId
+            ? (gradeItemIdMap.get(archiveConstraint.targetGradeItemId) ?? null)
+            : null
+          const lostTarget =
+            archiveConstraint.targetGradeItemId !== null &&
+            targetGradeItemId === null
+
+          const archiveViewpoints = data.gradeConstraintViewpoints
+            .filter(
+              (viewpoint) => viewpoint.constraintId === archiveConstraint.id
+            )
+            .sort((left, right) => left.order - right.order)
+          const resolvedViewpointIds = archiveViewpoints.flatMap(
+            (viewpoint) => {
+              const gradeItemId = gradeItemIdMap.get(viewpoint.gradeItemId)
+              return gradeItemId ? [gradeItemId] : []
             }
+          )
+          const lostViewpoint =
+            resolvedViewpointIds.length !== archiveViewpoints.length
 
-            const createdConstraint = await tx.gradeConstraint.create({
-              data: {
-                gradeId: grade.id,
-                name: gradeConstraint.name,
-                kind: gradeConstraint.kind,
-                targetGradeItemId,
-                aggregate: gradeConstraint.aggregate ?? "average",
-                tolerance: gradeConstraint.tolerance ?? 1,
-                expression: gradeConstraint.expression,
-                color: gradeConstraint.color,
-                // 診断は disabledReason へ。message は教員が書いた違反の説明で、
-                // 結果表のツールチップに出るため汚さない。
-                message: gradeConstraint.message,
-                disabledReason: brokenReason,
-                enabled: gradeConstraint.enabled && !brokenReason,
-                order: gradeConstraint.order,
-              },
-            })
-
-            // 設定リレーションのidは親idから決定論的に作るため本体作成後に書く
-            await writeConstraintConfig(tx, createdConstraint.id, {
-              viewpointGradeItemIds: resolvedViewpointIds,
-              labelValues: gradeConstraint.labelValues ?? {},
-              exclusionLabels: gradeConstraint.exclusionLabels ?? [],
-            })
+          const brokenReason = lostTarget
+            ? "取り込み時に比較先の評価項目を解決できなかったため無効化しました。再設定してください。"
+            : lostViewpoint
+              ? "取り込み時に集計対象の観点を解決できなかったため無効化しました。再設定してください。"
+              : archiveConstraint.disabledReason
+          if (lostTarget || lostViewpoint) {
+            warnings.push(
+              `制約ルール「${archiveConstraint.name}」: ${brokenReason}`
+            )
           }
+
+          const createdConstraint = await tx.gradeConstraint.create({
+            data: {
+              gradeId: grade.id,
+              name: archiveConstraint.name,
+              kind: archiveConstraint.kind,
+              targetGradeItemId,
+              aggregate: archiveConstraint.aggregate,
+              tolerance: archiveConstraint.tolerance,
+              expression: archiveConstraint.expression,
+              color: archiveConstraint.color,
+              // 診断は disabledReason へ。message は教員が書いた違反の説明で、
+              // 結果表のツールチップに出るため汚さない。
+              message: archiveConstraint.message,
+              disabledReason: brokenReason,
+              enabled: archiveConstraint.enabled && !brokenReason,
+              order: archiveConstraint.order,
+            },
+          })
+
+          // 設定リレーションのidは親idから決定論的に作るため本体作成後に書く
+          await writeConstraintConfig(tx, createdConstraint.id, {
+            viewpointGradeItemIds: resolvedViewpointIds,
+            labelValues: Object.fromEntries(
+              data.gradeConstraintLabelValues
+                .filter(
+                  (labelValue) =>
+                    labelValue.constraintId === archiveConstraint.id
+                )
+                .sort((left, right) => left.order - right.order)
+                .map((labelValue) => [
+                  labelValue.label,
+                  Number(labelValue.value),
+                ])
+            ),
+            exclusionLabels: data.gradeConstraintExclusionLabels
+              .filter(
+                (exclusionLabel) =>
+                  exclusionLabel.constraintId === archiveConstraint.id
+              )
+              .sort((left, right) => left.order - right.order)
+              .map((exclusionLabel) => exclusionLabel.label),
+          })
         }
 
         return { success: true, gradeId: grade.id }
@@ -781,8 +731,8 @@ export async function importGradeArchive(
       entityType: "Grade",
       entityId: result.gradeId ?? "",
       scopeId: result.gradeId ?? null,
-      scopeLabel: data.gradeData.grade.name,
-      target: data.gradeData.grade.name,
+      scopeLabel: archiveGrade.name,
+      target: archiveGrade.name,
     })
 
     // 警告は呼び出し側（UI）へ返して通知する

--- a/electron-src/lib/import/grade-transformers/V1_10_0_to_V1_11_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_10_0_to_V1_11_0.ts
@@ -6,13 +6,12 @@
  * 存在しないので、importer が名前フォールバックで解決する。
  */
 
+import type { GradeArchiveVersion } from "../../../../src/types/gradeArchive.types"
 import type {
-  ArchiveGradeConstraint,
-  GradeArchiveData,
-  GradeArchiveVersion,
-  GradeTransformResult,
-  GradeVersionTransformer,
-} from "../../../../src/types/gradeArchive.types"
+  LegacyArchiveGradeConstraint,
+  LegacyGradeArchiveData,
+} from "./legacyShape"
+import type { GradeTransformResult, GradeVersionTransformer } from "./types"
 
 /** 旧 config の形（kind別。壊れたJSONは既定値へ落とす） */
 interface LegacyConstraintConfig {
@@ -38,7 +37,7 @@ export class V1_10_0_to_V1_11_0_Transformer implements GradeVersionTransformer {
   readonly fromVersion: GradeArchiveVersion = "1.10.0"
   readonly toVersion: GradeArchiveVersion = "1.11.0"
 
-  transform(data: GradeArchiveData): GradeTransformResult {
+  transform(data: LegacyGradeArchiveData): GradeTransformResult {
     const warnings: string[] = []
     const legacyConstraints = (data.gradeData.gradeConstraints ?? []).filter(
       (gradeConstraint) => gradeConstraint.config !== undefined
@@ -54,7 +53,7 @@ export class V1_10_0_to_V1_11_0_Transformer implements GradeVersionTransformer {
       }
     }
 
-    const gradeConstraints: ArchiveGradeConstraint[] = (
+    const gradeConstraints: LegacyArchiveGradeConstraint[] = (
       data.gradeData.gradeConstraints ?? []
     ).map((gradeConstraint) => {
       if (gradeConstraint.config === undefined) return gradeConstraint

--- a/electron-src/lib/import/grade-transformers/V1_11_0_to_V1_12_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_11_0_to_V1_12_0.ts
@@ -9,21 +9,18 @@
  * 展開の実体は coursework-transformers/legacyShape が持つ（二重実装の回避）。
  */
 
-import type {
-  GradeArchiveData,
-  GradeTransformResult,
-  GradeVersionTransformer,
-} from "../../../../src/types/gradeArchive.types"
 import {
   flattenLegacyCourseworks,
   isLegacyCollectedCourseworkData,
 } from "../coursework-transformers/legacyShape"
+import type { LegacyGradeArchiveData } from "./legacyShape"
+import type { GradeTransformResult, GradeVersionTransformer } from "./types"
 
 export class V1_11_0_to_V1_12_0_Transformer implements GradeVersionTransformer {
   readonly fromVersion = "1.11.0" as const
   readonly toVersion = "1.12.0" as const
 
-  transform(data: GradeArchiveData): GradeTransformResult {
+  transform(data: LegacyGradeArchiveData): GradeTransformResult {
     const legacy = data.legacyCourseworkArchive
     if (!isLegacyCollectedCourseworkData(legacy)) {
       return { data, warnings: [] }

--- a/electron-src/lib/import/grade-transformers/V1_12_0_to_V1_13_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_12_0_to_V1_13_0.ts
@@ -1,0 +1,68 @@
+/**
+ * 1.12.0 → 1.13.0: 成績本体をテーブルごとの平坦なセクションへ展開する。
+ *
+ * 1.12.0 までは成績本体を入れ子へ射影し、外部参照（生徒・評価項目）を名前で持っていた。
+ * DB の行の形と対応が取れず、列を足すたびに射影と復元の両方を書く必要があった。
+ * 1.13.0 では exam / coursework と同じく Prisma の行をそのまま持つ。
+ *
+ * 展開の詳細（id を持たない行の id の組み立て、名前参照の解決）は legacyShape が担う。
+ */
+
+import type { GradeArchiveVersion } from "../../../../src/types/gradeArchive.types"
+import { flattenLegacyGrade } from "./legacyShape"
+import type {
+  AnyGradeArchiveData,
+  GradeTransformResult,
+  GradeVersionTransformer,
+} from "./types"
+import { isGradeArchiveUpTo1_12_0 } from "./types"
+
+/** 内包資料が空のときの既定値。1.12.0 の変換で必ず埋まっているはずだが念のため */
+const EMPTY_COURSEWORK_ARCHIVE = {
+  courseworks: [],
+  courseworkClassrooms: [],
+  courseworkTags: [],
+  courseworkStudents: [],
+  courseworkItems: [],
+  courseworkLetterScales: [],
+  courseworkScores: [],
+  studentsData: [],
+  classesData: [],
+  membershipsData: [],
+  tagsData: [],
+  counts: { courseworks: 0, items: 0, scores: 0, students: 0, classrooms: 0 },
+}
+
+export class V1_12_0_to_V1_13_0_Transformer implements GradeVersionTransformer {
+  readonly fromVersion: GradeArchiveVersion = "1.12.0"
+  readonly toVersion: GradeArchiveVersion = "1.13.0"
+
+  transform(data: AnyGradeArchiveData): GradeTransformResult {
+    if (!isGradeArchiveUpTo1_12_0(data)) {
+      return { data, warnings: [] }
+    }
+
+    const flattened = flattenLegacyGrade(data)
+    const warnings = [...flattened.warnings]
+
+    // 旧形式は行の作成日時を持ち出していない。復元できないので下限値を入れている
+    warnings.push(
+      "1.12.0→1.13.0: 旧アーカイブは各行の作成日時を持たないため、取り込み時に現在時刻で作り直します"
+    )
+
+    return {
+      data: {
+        manifest: { ...data.manifest, version: this.toVersion },
+        ...flattened.sections,
+        studentsData: flattened.studentsData,
+        classesData: flattened.classesData,
+        membershipsData: flattened.membershipsData,
+        examRefs: flattened.examRefs,
+        subtotalRefs: flattened.subtotalRefs,
+        cropRegionRefs: flattened.cropRegionRefs,
+        courseworkArchive: data.courseworkArchive ?? EMPTY_COURSEWORK_ARCHIVE,
+      },
+      warnings,
+    }
+  }
+}

--- a/electron-src/lib/import/grade-transformers/V1_3_0_to_V1_4_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_3_0_to_V1_4_0.ts
@@ -13,19 +13,18 @@
  */
 
 import type {
-  ArchiveCoursework,
-  ArchiveDataSource,
-  ArchiveGradeItem,
-  GradeArchiveData,
-  GradeTransformResult,
-  GradeVersionTransformer,
-} from "../../../../src/types/gradeArchive.types"
+  LegacyArchiveCoursework,
+  LegacyArchiveDataSource,
+  LegacyArchiveGradeItem,
+  LegacyGradeArchiveData,
+} from "./legacyShape"
+import type { GradeTransformResult, GradeVersionTransformer } from "./types"
 
 export class V1_3_0_to_V1_4_0_Transformer implements GradeVersionTransformer {
   readonly fromVersion = "1.3.0" as const
   readonly toVersion = "1.4.0" as const
 
-  transform(data: GradeArchiveData): GradeTransformResult {
+  transform(data: LegacyGradeArchiveData): GradeTransformResult {
     const warnings: string[] = []
     const manualScores = data.manualScoresData?.manualScores ?? []
     const gradeName = data.manifest.gradeName
@@ -36,71 +35,72 @@ export class V1_3_0_to_V1_4_0_Transformer implements GradeVersionTransformer {
       customOrder: studentRef.customOrder,
     }))
 
-    const generated: ArchiveCoursework[] = []
+    const generated: LegacyArchiveCoursework[] = []
     let converted = false
 
     // gradeItems / dataSources を新規オブジェクトで作り直す（入力は破壊しない）
-    const newGradeItems: ArchiveGradeItem[] = data.gradeData.gradeItems.map(
-      (giData) => ({
+    const newGradeItems: LegacyArchiveGradeItem[] =
+      data.gradeData.gradeItems.map((giData) => ({
         ...giData,
-        dataSources: giData.dataSources.map((dsData): ArchiveDataSource => {
-          if (dsData.type !== "manual") return dsData
-          converted = true
+        dataSources: giData.dataSources.map(
+          (dsData): LegacyArchiveDataSource => {
+            if (dsData.type !== "manual") return dsData
+            converted = true
 
-          // 決定的 id（preview と import で一致させる）
-          const key = `${gradeName}::${giData.name}::${dsData.name}`
-          const courseworkId = `legacy-manual-cw:${key}`
-          const itemId = `legacy-manual-item:${key}`
+            // 決定的 id（preview と import で一致させる）
+            const key = `${gradeName}::${giData.name}::${dsData.name}`
+            const courseworkId = `legacy-manual-cw:${key}`
+            const itemId = `legacy-manual-item:${key}`
 
-          const itemScores = manualScores
-            .filter(
-              (manualScore) =>
-                manualScore.gradeItemName === giData.name &&
-                manualScore.dataSourceName === dsData.name
-            )
-            .map((manualScore) => ({
-              studentNumber: manualScore.studentNumber,
-              score: manualScore.score,
-              letterValue: manualScore.letterValue ?? null,
-              adjustment: manualScore.adjustment ?? null,
-              adjustmentReason: manualScore.adjustmentReason ?? null,
-              comment: manualScore.comment ?? null,
-            }))
+            const itemScores = manualScores
+              .filter(
+                (manualScore) =>
+                  manualScore.gradeItemName === giData.name &&
+                  manualScore.dataSourceName === dsData.name
+              )
+              .map((manualScore) => ({
+                studentNumber: manualScore.studentNumber,
+                score: manualScore.score,
+                letterValue: manualScore.letterValue ?? null,
+                adjustment: manualScore.adjustment ?? null,
+                adjustmentReason: manualScore.adjustmentReason ?? null,
+                comment: manualScore.comment ?? null,
+              }))
 
-          generated.push({
-            id: courseworkId,
-            name: dsData.name,
-            description: null,
-            date: null,
-            classrooms: [],
-            tags: [],
-            students: cwStudents,
-            items: [
-              {
-                id: itemId,
-                name: dsData.name,
-                order: 0,
-                // 旧1.3.0 "manual" の満点 → CourseworkItem.maxScore
-                //（ArchiveDataSource.maxScore は v1.6.0 で optional 化済み）
-                maxScore: dsData.maxScore ?? 0,
-                inputMode: dsData.inputMode ?? "numeric",
-                letterScales: dsData.letterScales ?? [],
-                scores: itemScores,
-              },
-            ],
-          })
+            generated.push({
+              id: courseworkId,
+              name: dsData.name,
+              description: null,
+              date: null,
+              classrooms: [],
+              tags: [],
+              students: cwStudents,
+              items: [
+                {
+                  id: itemId,
+                  name: dsData.name,
+                  order: 0,
+                  // 旧1.3.0 "manual" の満点 → CourseworkItem.maxScore
+                  //（LegacyArchiveDataSource.maxScore は v1.6.0 で optional 化済み）
+                  maxScore: dsData.maxScore ?? 0,
+                  inputMode: dsData.inputMode ?? "numeric",
+                  letterScales: dsData.letterScales ?? [],
+                  scores: itemScores,
+                },
+              ],
+            })
 
-          // manual → coursework へ昇格し、参照先を付与（id 一次・名前二次）
-          return {
-            ...dsData,
-            type: "coursework",
-            courseworkItemId: itemId,
-            courseworkName: dsData.name,
-            courseworkItemName: dsData.name,
+            // manual → coursework へ昇格し、参照先を付与（id 一次・名前二次）
+            return {
+              ...dsData,
+              type: "coursework",
+              courseworkItemId: itemId,
+              courseworkName: dsData.name,
+              courseworkItemName: dsData.name,
+            }
           }
-        }),
-      })
-    )
+        ),
+      }))
 
     if (converted) {
       warnings.push("v1.3.0 の外部成績を試験外成績資料に変換しました")

--- a/electron-src/lib/import/grade-transformers/V1_4_0_to_V1_5_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_4_0_to_V1_5_0.ts
@@ -16,14 +16,11 @@ import type {
   ArchiveCwTag,
 } from "../../../../src/types/courseworkArchive.types"
 import type {
-  GradeArchiveData,
-  GradeTransformResult,
-  GradeVersionTransformer,
-} from "../../../../src/types/gradeArchive.types"
-import type {
   LegacyArchiveCourseworkRef,
   LegacyCollectedCourseworkData,
 } from "../coursework-transformers/legacyShape"
+import type { LegacyGradeArchiveData } from "./legacyShape"
+import type { GradeTransformResult, GradeVersionTransformer } from "./types"
 
 /** LWW で既存を上書きしないための過去日時 */
 const EPOCH = new Date(0).toISOString()
@@ -38,7 +35,7 @@ export class V1_4_0_to_V1_5_0_Transformer implements GradeVersionTransformer {
   readonly fromVersion = "1.4.0" as const
   readonly toVersion = "1.5.0" as const
 
-  transform(data: GradeArchiveData): GradeTransformResult {
+  transform(data: LegacyGradeArchiveData): GradeTransformResult {
     const legacy = data.courseworks ?? []
 
     const studentNumbers = new Set<string>()

--- a/electron-src/lib/import/grade-transformers/V1_9_0_to_V1_10_0.ts
+++ b/electron-src/lib/import/grade-transformers/V1_9_0_to_V1_10_0.ts
@@ -1,9 +1,6 @@
-import type {
-  GradeArchiveData,
-  GradeArchiveVersion,
-  GradeTransformResult,
-  GradeVersionTransformer,
-} from "../../../../src/types/gradeArchive.types"
+import type { GradeArchiveVersion } from "../../../../src/types/gradeArchive.types"
+import type { LegacyGradeArchiveData } from "./legacyShape"
+import type { GradeTransformResult, GradeVersionTransformer } from "./types"
 
 /**
  * 1.9.0 → 1.10.0: 総合（overall）の撤去。
@@ -19,7 +16,7 @@ export class V1_9_0_to_V1_10_0_Transformer implements GradeVersionTransformer {
   readonly fromVersion: GradeArchiveVersion = "1.9.0"
   readonly toVersion: GradeArchiveVersion = "1.10.0"
 
-  transform(data: GradeArchiveData): GradeTransformResult {
+  transform(data: LegacyGradeArchiveData): GradeTransformResult {
     const warnings: string[] = []
 
     const boundarySets = data.boundariesData.boundarySets.filter(

--- a/electron-src/lib/import/grade-transformers/index.ts
+++ b/electron-src/lib/import/grade-transformers/index.ts
@@ -1,7 +1,7 @@
 /**
  * grade-archive バージョン変換器
  *
- * 旧バージョンの外部成績データを現行（1.6.0）の courseworkArchive 形式へ正規化する。
+ * 旧バージョンのアーカイブを現行（1.13.0＝テーブルごとの平坦なセクション）へ正規化する。
  *
  * 【検出は manifest.version ではなくデータ形状ベース】
  * grade はバージョン履歴が入り組んでおり（1.3.0 の manual / 1.4.0 の名前ベース /
@@ -9,53 +9,39 @@
  * そこで「どのフィールドを持っているか」で適用する変換器を決める:
  *   - manual 型 DataSource あり        → 1.3.0 → 1.4.0（manual を名前ベース資料へ。
  *                                        点数の有無に関わらず変換し "manual" 型を残さない）
- *   - courseworks（名前ベース配列）あり → 1.4.0 → 1.5.0（courseworkArchive へ）
- *   - courseworkArchive あり           → 既に現行形式（1.5.0/1.6.0 とも同形。変換不要）
+ *   - courseworks（名前ベース配列）あり → 1.4.0 → 1.5.0（入れ子形式の内包資料へ）
  *   - 境界セット/上書きに targetType あり → 1.9.0 → 1.10.0（総合エントリを破棄）
- * 1.6.0 は GradeDataSource.maxScore 列の廃止のみで、外部成績の構造は 1.5.0 と同形のため
- * 専用の transformer は持たない（ArchiveDataSource.maxScore は optional で旧読込互換）。
+ *   - 制約ルールに config あり          → 1.10.0 → 1.11.0（設定JSONを構造化）
+ *   - 内包資料が入れ子形式             → 1.11.0 → 1.12.0（平坦なセクションへ）
+ *   - gradeData を持つ（射影形式）      → 1.12.0 → 1.13.0（成績本体も平坦なセクションへ）
+ * 1.6.0〜1.9.0 は加算的な変更のみで、専用の transformer は持たない。
  */
 
-import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
-import type {
-  GradeArchiveData,
-  GradeArchiveVersion,
-  GradeChainTransformResult,
-} from "../../../../src/types/gradeArchive.types"
+import type { GradeArchiveVersion } from "../../../../src/types/gradeArchive.types"
 import { GRADE_CURRENT_VERSION } from "../../../../src/types/gradeArchive.types"
 import { isLegacyCollectedCourseworkData } from "../coursework-transformers/legacyShape"
+import type { LegacyGradeArchiveData } from "./legacyShape"
+import type { AnyGradeArchiveData, GradeChainTransformResult } from "./types"
+import { isGradeArchiveUpTo1_12_0 } from "./types"
 import { V1_3_0_to_V1_4_0_Transformer } from "./V1_3_0_to_V1_4_0"
 import { V1_4_0_to_V1_5_0_Transformer } from "./V1_4_0_to_V1_5_0"
 import { V1_9_0_to_V1_10_0_Transformer } from "./V1_9_0_to_V1_10_0"
 import { V1_10_0_to_V1_11_0_Transformer } from "./V1_10_0_to_V1_11_0"
 import { V1_11_0_to_V1_12_0_Transformer } from "./V1_11_0_to_V1_12_0"
-
-const EMPTY_COURSEWORK_ARCHIVE: CollectedCourseworkData = {
-  courseworks: [],
-  courseworkClassrooms: [],
-  courseworkTags: [],
-  courseworkStudents: [],
-  courseworkItems: [],
-  courseworkLetterScales: [],
-  courseworkScores: [],
-  studentsData: [],
-  classesData: [],
-  membershipsData: [],
-  tagsData: [],
-  counts: { courseworks: 0, items: 0, scores: 0, students: 0, classrooms: 0 },
-}
+import { V1_12_0_to_V1_13_0_Transformer } from "./V1_12_0_to_V1_13_0"
 
 const v1_3_0 = new V1_3_0_to_V1_4_0_Transformer()
 const v1_4_0 = new V1_4_0_to_V1_5_0_Transformer()
 const v1_9_0 = new V1_9_0_to_V1_10_0_Transformer()
 const v1_10_0 = new V1_10_0_to_V1_11_0_Transformer()
 const v1_11_0 = new V1_11_0_to_V1_12_0_Transformer()
+const v1_12_0 = new V1_12_0_to_V1_13_0_Transformer()
 
 /**
  * 総合（overall）の名残を持つか。境界セット・手動上書きのどちらかに targetType があるか、
  * 対象評価項目名を持たないエントリがあれば 1.9.0 以前の形。
  */
-function hasOverallResidue(data: GradeArchiveData): boolean {
+function hasOverallResidue(data: LegacyGradeArchiveData): boolean {
   const boundaryResidue = data.boundariesData.boundarySets.some(
     (boundarySet) =>
       boundarySet.targetType !== undefined || boundarySet.gradeItemName === null
@@ -69,14 +55,14 @@ function hasOverallResidue(data: GradeArchiveData): boolean {
 }
 
 /** 制約ルールが旧 config（設定JSON）を持つか。持てば 1.10.0 以前の形 */
-function hasLegacyConstraintConfig(data: GradeArchiveData): boolean {
+function hasLegacyConstraintConfig(data: LegacyGradeArchiveData): boolean {
   return (data.gradeData.gradeConstraints ?? []).some(
     (gradeConstraint) => gradeConstraint.config !== undefined
   )
 }
 
 /** manual 型 DataSource を持つか（点数未入力でも true） */
-function hasManualDataSource(data: GradeArchiveData): boolean {
+function hasManualDataSource(data: LegacyGradeArchiveData): boolean {
   return data.gradeData.gradeItems.some((gradeItem) =>
     gradeItem.dataSources.some((dataSource) => dataSource.type === "manual")
   )
@@ -88,7 +74,8 @@ function hasManualDataSource(data: GradeArchiveData): boolean {
  * 総合エントリが残っていれば元は 1.9.0 であり、現行版と報告してはいけない
  * （appliedTransformations に 1.9.0→1.10.0 を積みながら originalVersion=1.10.0 という矛盾になる）。
  */
-function detectOriginalVersion(data: GradeArchiveData): GradeArchiveVersion {
+function detectOriginalVersion(data: AnyGradeArchiveData): GradeArchiveVersion {
+  if (!isGradeArchiveUpTo1_12_0(data)) return GRADE_CURRENT_VERSION
   if (data.courseworks) return "1.4.0"
   if (hasManualDataSource(data) || data.manualScoresData) return "1.3.0"
   if (hasOverallResidue(data)) return "1.9.0"
@@ -98,15 +85,15 @@ function detectOriginalVersion(data: GradeArchiveData): GradeArchiveVersion {
   if (isLegacyCollectedCourseworkData(data.legacyCourseworkArchive)) {
     return "1.11.0"
   }
-  return GRADE_CURRENT_VERSION
+  return "1.12.0"
 }
 
 /**
  * grade アーカイブを現行バージョンへ正規化する。
- * 完了後は data.courseworkArchive が必ず存在し、importer は単一経路で処理できる。
+ * 完了後は必ず平坦なセクションの形になり、importer は単一経路で処理できる。
  */
 export function transformGradeToLatest(
-  data: GradeArchiveData
+  data: AnyGradeArchiveData
 ): GradeChainTransformResult {
   let current = data
   const warnings: string[] = []
@@ -114,63 +101,81 @@ export function transformGradeToLatest(
   const appliedTransformations: GradeChainTransformResult["appliedTransformations"] =
     []
 
-  const hasCoursework = (candidate: GradeArchiveData) =>
+  /**
+   * 旧形状のうち条件に合うものだけへ変換器を当てる。
+   * 変換器は旧形状しか受け取らないので、現行形になった時点でどれも当たらなくなる。
+   */
+  const applyIf = (
+    shouldApply: (candidate: LegacyGradeArchiveData) => boolean,
+    transformer: {
+      transform: (input: LegacyGradeArchiveData) => {
+        data: AnyGradeArchiveData
+        warnings: string[]
+      }
+    },
+    from: GradeArchiveVersion,
+    to: GradeArchiveVersion
+  ): void => {
+    if (!isGradeArchiveUpTo1_12_0(current)) return
+    if (!shouldApply(current)) return
+    const result = transformer.transform(current)
+    current = result.data
+    warnings.push(...result.warnings)
+    appliedTransformations.push({ from, to })
+  }
+
+  const hasCoursework = (candidate: LegacyGradeArchiveData) =>
     Boolean(candidate.courseworkArchive || candidate.legacyCourseworkArchive)
 
   // 1.3.0 → 1.4.0: manual 型の外部成績を名前ベース資料へ
   //   点数の有無に関わらず、manual 型 DataSource が残らないよう変換する。
-  if (!hasCoursework(current) && hasManualDataSource(current)) {
-    const result = v1_3_0.transform(current)
-    current = result.data
-    warnings.push(...result.warnings)
-    appliedTransformations.push({ from: "1.3.0", to: "1.4.0" })
-  }
+  applyIf(
+    (candidate) => !hasCoursework(candidate) && hasManualDataSource(candidate),
+    v1_3_0,
+    "1.3.0",
+    "1.4.0"
+  )
 
   // 1.4.0 → 1.5.0: 名前ベース資料を入れ子形式の内包資料へ（空配列でも変換して統一）
-  if (!hasCoursework(current) && current.courseworks !== undefined) {
-    const result = v1_4_0.transform(current)
-    current = result.data
-    warnings.push(...result.warnings)
-    appliedTransformations.push({ from: "1.4.0", to: "1.5.0" })
-  }
+  applyIf(
+    (candidate) =>
+      !hasCoursework(candidate) && candidate.courseworks !== undefined,
+    v1_4_0,
+    "1.4.0",
+    "1.5.0"
+  )
 
   // 1.9.0 → 1.10.0: 総合（overall）の撤去。移し先が無いので破棄し warning で知らせる
-  if (hasOverallResidue(current)) {
-    const result = v1_9_0.transform(current)
-    current = result.data
-    warnings.push(...result.warnings)
-    appliedTransformations.push({ from: "1.9.0", to: "1.10.0" })
-  }
+  applyIf(hasOverallResidue, v1_9_0, "1.9.0", "1.10.0")
 
   // 1.10.0 → 1.11.0: 制約ルールの設定JSON（config）を構造化フィールドへ展開
-  if (hasLegacyConstraintConfig(current)) {
-    const result = v1_10_0.transform(current)
-    current = result.data
-    warnings.push(...result.warnings)
-    appliedTransformations.push({ from: "1.10.0", to: "1.11.0" })
-  }
+  applyIf(hasLegacyConstraintConfig, v1_10_0, "1.10.0", "1.11.0")
 
   // 1.11.0 → 1.12.0: 内包資料をテーブルごとの平坦なセクションへ展開
-  if (isLegacyCollectedCourseworkData(current.legacyCourseworkArchive)) {
-    const result = v1_11_0.transform(current)
-    current = result.data
-    warnings.push(...result.warnings)
-    appliedTransformations.push({ from: "1.11.0", to: "1.12.0" })
-  }
+  applyIf(
+    (candidate) =>
+      isLegacyCollectedCourseworkData(candidate.legacyCourseworkArchive),
+    v1_11_0,
+    "1.11.0",
+    "1.12.0"
+  )
 
-  // 外部成績を持たない旧アーカイブは空の courseworkArchive を補う
-  if (!current.courseworkArchive) {
-    current = { ...current, courseworkArchive: EMPTY_COURSEWORK_ARCHIVE }
-  }
+  // 1.12.0 → 1.13.0: 成績本体もテーブルごとの平坦なセクションへ展開
+  applyIf(() => true, v1_12_0, "1.12.0", "1.13.0")
 
-  // マニフェストを現行バージョンへ
-  current = {
-    ...current,
-    manifest: { ...current.manifest, version: GRADE_CURRENT_VERSION },
+  // ここまでで必ず現行の形になっている。なっていなければ変換の取りこぼしなので
+  // 黙って先へ流さず落とす（射影形式のまま importer へ渡すと実行時に崩れる）
+  if (isGradeArchiveUpTo1_12_0(current)) {
+    throw new Error(
+      "grade アーカイブを現行バージョンへ変換できませんでした（射影形式のまま残っています）"
+    )
   }
 
   return {
-    data: current,
+    data: {
+      ...current,
+      manifest: { ...current.manifest, version: GRADE_CURRENT_VERSION },
+    },
     originalVersion,
     finalVersion: GRADE_CURRENT_VERSION,
     appliedTransformations,

--- a/electron-src/lib/import/grade-transformers/legacyShape.ts
+++ b/electron-src/lib/import/grade-transformers/legacyShape.ts
@@ -1,0 +1,880 @@
+/**
+ * v1.12.0 以前（射影形式）の .grade の形と、v1.13.0 の平坦なセクションへの展開。
+ *
+ * 旧形式は「成績本体を入れ子へ射影し、外部参照を名前で持つ」形だった。
+ * 生徒は学籍番号、評価項目は名前（v1.10.0 以降は uuid 併記）で参照しており、
+ * 行の id も createdAt/updatedAt も持たない行が多い。
+ *
+ * 展開では、id を持たない行の id を自然キーから組み立てる
+ * （`deterministicId.ts` と同じ方針。同じアーカイブを何度読んでも同じ id になる＝冪等）。
+ * 組み立てた id はアーカイブ内の結合キーとしてのみ使い、DB へは書き込まない
+ * （import は全ての行を新しい uuid で作る）。
+ *
+ * 旧形式の知識はこのファイルだけが持つ。`src/types/gradeArchive.types.ts` は
+ * 現行の形だけを宣言する。
+ */
+
+import type {
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
+  CollectedCourseworkData,
+} from "../../../../src/types/courseworkArchive.types"
+import type {
+  ArchiveGradeBoundaryRow,
+  ArchiveGradeBoundarySetRow,
+  ArchiveGradeClassroomRow,
+  ArchiveGradeConstraintExclusionLabelRow,
+  ArchiveGradeConstraintLabelValueRow,
+  ArchiveGradeConstraintRow,
+  ArchiveGradeConstraintViewpointRow,
+  ArchiveGradeCropRegionRef,
+  ArchiveGradeDataSourceEstimationSourceRow,
+  ArchiveGradeDataSourceRow,
+  ArchiveGradeExamRef,
+  ArchiveGradeExportSettingsRow,
+  ArchiveGradeFrozenScoreRow,
+  ArchiveGradeItemExclusionRow,
+  ArchiveGradeItemRow,
+  ArchiveGradeOverrideRow,
+  ArchiveGradeRow,
+  ArchiveGradeStudentRow,
+  ArchiveGradeSubtotalRef,
+  GradeArchiveManifest,
+  GradeSections,
+} from "../../../../src/types/gradeArchive.types"
+import type { LegacyCollectedCourseworkData } from "../coursework-transformers/legacyShape"
+
+// =============================================================================
+// v1.12.0 以前の形状定義（ここだけが知っていればよい負債）
+// =============================================================================
+
+/** 旧形式のアーカイブ全体 */
+export interface LegacyGradeArchiveData {
+  manifest: GradeArchiveManifest
+  gradeData: LegacyArchiveGradeData
+  /**
+   * 旧 v1.3.0 以前の外部成績(manual型 DataSource)の点数。
+   * v1.4.0 以降は Coursework に昇格したため新規 export では書かない。
+   */
+  manualScoresData?: LegacyArchiveManualScoresData
+  /** v1.4.0: 参照中の試験外成績資料の名前ベース埋め込み */
+  courseworks?: LegacyArchiveCoursework[]
+  /** v1.12.0: 内包資料を coursework-archive の平坦なセクションで持つ */
+  courseworkArchive?: CollectedCourseworkData
+  /** v1.5.0〜1.11.0 が内包していた入れ子・射影形式の資料データ */
+  legacyCourseworkArchive?: LegacyCollectedCourseworkData
+  boundariesData: LegacyArchiveBoundariesData
+}
+
+export interface LegacyArchiveGradeData {
+  grade: {
+    name: string
+    description: string | null
+    /** v1.2.0+ */
+    referenceDate?: string | null
+  }
+  /** v1.2.0+ */
+  exportSettings?: { settingsJson: string } | null
+  gradeItems: LegacyArchiveGradeItem[]
+  /** 対象学級。v1.10.0+ は uuid を持つ */
+  classroomRefs: { id?: string; name: string }[]
+  /** 参照する試験。v1.10.0+ は uuid を持つ */
+  examRefs: {
+    id?: string
+    examName: string
+    examDate: string | null
+    dataSourceName: string
+  }[]
+  /** 対象生徒。v1.10.0+ は uuid を持つ */
+  studentRefs: {
+    id?: string
+    studentNumber: string
+    classroomName: string | null
+    customOrder: number | null
+  }[]
+  gradeItemExclusions?: {
+    studentNumber: string
+    gradeItemId?: string
+    gradeItemName: string
+  }[]
+  gradeOverrides?: {
+    studentNumber: string
+    /**
+     * @deprecated v1.10.0 で総合（overall）を撤去。"overall" の行は transformer が破棄する。
+     */
+    targetType?: string
+    gradeItemId?: string
+    /** v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
+    gradeItemName: string | null
+    overrideLabel: string
+  }[]
+  /** v1.9.0+。確定操作者は持ち出していない */
+  gradeFrozenScores?: {
+    studentNumber: string
+    gradeItemId?: string
+    gradeItemName: string
+    weightedScore: number | null
+    weightedMaxScore: number
+    percentage: number | null
+    gradeLabel: string | null
+    frozenAt: string
+  }[]
+  /** v1.7.0+ */
+  gradeConstraints?: LegacyArchiveGradeConstraint[]
+}
+
+export interface LegacyArchiveGradeConstraint {
+  name: string
+  kind: string
+  /**
+   * @deprecated v1.11.0 で廃止。kind別の設定JSON（評価項目を名前で参照していた）。
+   */
+  config?: string
+  targetGradeItemId?: string | null
+  targetGradeItemName?: string | null
+  aggregate?: string
+  tolerance?: number
+  viewpointGradeItemIds?: string[]
+  viewpointGradeItemNames?: string[]
+  labelValues?: Record<string, number>
+  exclusionLabels?: string[]
+  expression: string
+  color: string
+  message: string | null
+  enabled: boolean
+  order: number
+}
+
+export interface LegacyArchiveGradeItem {
+  /** v1.10.0+ */
+  id?: string
+  name: string
+  order: number
+  dataSources: LegacyArchiveDataSource[]
+}
+
+export interface LegacyArchiveDataSource {
+  /** v1.11.0+ */
+  id?: string
+  type: string
+  name: string
+  /**
+   * @deprecated v1.6.0 で GradeDataSource.maxScore 列が廃止された。
+   * 旧 1.3.0 の "manual" 型では CourseworkItem.maxScore の出所になるので残す。
+   */
+  maxScore?: number
+  weight: number
+  order: number
+  examName: string | null
+  subtotalName: string | null
+  cropRegionLabel: string | null
+  absentMethod?: string
+  absentRatio?: number
+  absentOffset?: number
+  treatExpectedAsMissing?: boolean
+  estimationMode?: string
+  estimationSourceIds?: string[]
+  courseworkId?: string | null
+  courseworkItemId?: string | null
+  courseworkName?: string | null
+  courseworkItemName?: string | null
+  /** v1.10.0+ */
+  examId?: string | null
+  subtotalId?: string | null
+  cropRegionId?: string | null
+  /** 旧 v1.3.0 の入力モード（読取専用） */
+  inputMode?: string
+  /** 旧 v1.3.0 の文字評価→点数の変換表（読取専用） */
+  letterScales?: { label: string; score: number; order: number }[]
+}
+
+/** v1.4.0 の名前ベース資料埋め込み */
+export interface LegacyArchiveCoursework {
+  id: string
+  name: string
+  description: string | null
+  date: string | null
+  classrooms: { classroomName: string; order: number }[]
+  tags: { tagName: string }[]
+  students: { studentNumber: string; customOrder: number | null }[]
+  items: LegacyArchiveCourseworkItem[]
+}
+
+export interface LegacyArchiveCourseworkItem {
+  id: string
+  name: string
+  order: number
+  maxScore: number
+  inputMode: string
+  letterScales: { label: string; score: number; order: number }[]
+  scores: {
+    studentNumber: string
+    score: number | null
+    letterValue: string | null
+    adjustment: number | null
+    adjustmentReason: string | null
+    comment: string | null
+  }[]
+}
+
+export interface LegacyArchiveManualScoresData {
+  manualScores: {
+    gradeItemName: string
+    dataSourceName: string
+    studentNumber: string
+    score: number | null
+    letterValue?: string | null
+    adjustment?: number | null
+    adjustmentReason?: string | null
+    comment?: string | null
+  }[]
+}
+
+export interface LegacyArchiveBoundariesData {
+  boundarySets: {
+    /**
+     * @deprecated v1.10.0 で総合（overall）を撤去。"overall" のセットは transformer が破棄する。
+     */
+    targetType?: string
+    gradeItemId?: string
+    /** v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
+    gradeItemName: string | null
+    boundaries: {
+      label: string
+      minPercentage: number
+      order: number
+    }[]
+  }[]
+}
+
+// =============================================================================
+// 展開（v1.12.0 以前の射影形式 → v1.13.0 の平坦なセクション）
+// =============================================================================
+
+/** 復元できない日時の下限値。LWW で既存を上書きしない */
+const UNKNOWN_TIMESTAMP = new Date(0).toISOString()
+
+/** 自然キーから決定論的に組み立てる結合行の id（`deterministicId.ts` と同じ規則） */
+const joinIds = (parentId: string, childKey: string): string =>
+  `${parentId}:${childKey}`
+
+/** 旧形式は数値で持っていた Decimal を、現行の文字列表現へ揃える */
+const toDecimalString = (value: number | null | undefined): string =>
+  String(value ?? 0)
+
+const toOptionalDecimalString = (
+  value: number | null | undefined
+): string | null =>
+  value === null || value === undefined ? null : String(value)
+
+/**
+ * 旧形式が持つ生徒参照から uuid を決める。
+ * v1.10.0+ は uuid を持つのでそれを使う。無い場合は学籍番号から組み立てる
+ * （取り込み先の実 uuid には当たらないので、学籍番号の二次照合へ落ちる＝旧来の挙動）。
+ */
+export const legacyStudentId = (reference: {
+  id?: string
+  studentNumber: string
+}): string => reference.id ?? `legacy-student:${reference.studentNumber}`
+
+/** 学級も同様。v1.10.0+ は uuid を持つ */
+const legacyClassroomId = (reference: { id?: string; name: string }): string =>
+  reference.id ?? `legacy-classroom:${reference.name}`
+
+/** 展開結果。セクション群と外部参照、および失われたものの警告 */
+export interface FlattenedLegacyGrade {
+  sections: GradeSections
+  studentsData: ArchiveCwStudent[]
+  classesData: ArchiveCwClass[]
+  membershipsData: ArchiveCwMembership[]
+  examRefs: ArchiveGradeExamRef[]
+  subtotalRefs: ArchiveGradeSubtotalRef[]
+  cropRegionRefs: ArchiveGradeCropRegionRef[]
+  warnings: string[]
+}
+
+/**
+ * 旧形式の成績データを平坦なセクションへ展開する。
+ *
+ * 評価項目・データソースは v1.10.0/v1.11.0 以降 uuid を持つ。持たない旧アーカイブでは
+ * 名前から組み立てる（同一成績内で名前が重複していると1つに畳まれるが、旧 importer も
+ * 名前でしか照合できておらず同じ結果になる）。
+ */
+export function flattenLegacyGrade(
+  data: LegacyGradeArchiveData
+): FlattenedLegacyGrade {
+  const warnings: string[] = []
+  const { gradeData, boundariesData } = data
+  const gradeId = data.manifest.gradeId
+
+  const grade: ArchiveGradeRow = {
+    id: gradeId,
+    name: gradeData.grade.name,
+    description: gradeData.grade.description,
+    referenceDate: gradeData.grade.referenceDate ?? null,
+    createdAt: UNKNOWN_TIMESTAMP,
+    updatedAt: UNKNOWN_TIMESTAMP,
+  }
+
+  // ── 評価項目とデータソース ─────────────────────────────────
+  const gradeItems: ArchiveGradeItemRow[] = []
+  const gradeDataSources: ArchiveGradeDataSourceRow[] = []
+  const estimationSources: ArchiveGradeDataSourceEstimationSourceRow[] = []
+  /** 評価項目名 → id（旧形式の名前参照を解決するため） */
+  const gradeItemIdByName = new Map<string, string>()
+  /**
+   * 名前が重複し、名前フォールバックでは一意に定まらない評価項目名。
+   * GradeItem に (gradeId, name) の unique は無いので実際に起こる。
+   * 取り違えるより落とす（境界・上書き・確定値は成績そのもので、
+   * 誤った項目へ付けるほうが害が大きい）。
+   */
+  const ambiguousGradeItemNames = new Set<string>()
+
+  // 旧形式は参照先の試験・小計・採点領域を名前でしか持たないことがある
+  // （v1.10.0 未満）。行は uuid しか持てないので、名前から決定論的な id を組み立て、
+  // 同定情報は refs セクションへ添える（取り込み側が名前で当て直す）。
+  const examRefs: ArchiveGradeExamRef[] = []
+  const subtotalRefs: ArchiveGradeSubtotalRef[] = []
+  const cropRegionRefs: ArchiveGradeCropRegionRef[] = []
+  const seenExamIds = new Set<string>()
+  const seenSubtotalIds = new Set<string>()
+  const seenCropRegionIds = new Set<string>()
+
+  // 内包資料は変換済み（1.11.0→1.12.0 が先に走る）。旧形式のデータソースが資料を
+  // 名前でしか参照していない場合に備え、名前 → uuid の索引を作る
+  const courseworkIdByName = new Map<string, string>()
+  const courseworkItemIdByName = new Map<string, string>()
+  if (data.courseworkArchive) {
+    const courseworkNameById = new Map<string, string>()
+    for (const coursework of data.courseworkArchive.courseworks) {
+      courseworkNameById.set(coursework.id, coursework.name)
+      if (!courseworkIdByName.has(coursework.name)) {
+        courseworkIdByName.set(coursework.name, coursework.id)
+      }
+    }
+    for (const courseworkItem of data.courseworkArchive.courseworkItems) {
+      const courseworkName = courseworkNameById.get(courseworkItem.courseworkId)
+      if (!courseworkName) continue
+      const key = `${courseworkName}:${courseworkItem.name}`
+      if (!courseworkItemIdByName.has(key)) {
+        courseworkItemIdByName.set(key, courseworkItem.id)
+      }
+    }
+  }
+
+  gradeData.gradeItems.forEach((legacyItem, itemIndex) => {
+    // 合成 id には並び順を混ぜる。名前だけだと同名の評価項目が1つの id へ潰れ、
+    // 両方のデータソースが片方へ寄ってしまう（重み倍・もう片方は全欠測）。
+    // 名前で指す参照の曖昧さは ambiguousGradeItemNames が別途弾く
+    const gradeItemId =
+      legacyItem.id ?? joinIds(gradeId, `item:${itemIndex}:${legacyItem.name}`)
+    if (gradeItemIdByName.has(legacyItem.name)) {
+      ambiguousGradeItemNames.add(legacyItem.name)
+    } else {
+      gradeItemIdByName.set(legacyItem.name, gradeItemId)
+    }
+    gradeItems.push({
+      id: gradeItemId,
+      gradeId,
+      name: legacyItem.name,
+      order: legacyItem.order,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+
+    for (const legacySource of legacyItem.dataSources) {
+      const dataSourceId =
+        legacySource.id ?? joinIds(gradeItemId, legacySource.name)
+
+      // 試験: uuid → 試験名から合成
+      let examId = legacySource.examId ?? null
+      if (!examId && legacySource.examName) {
+        examId = `legacy-exam:${legacySource.examName}`
+      }
+      if (examId && !seenExamIds.has(examId)) {
+        seenExamIds.add(examId)
+        const examName =
+          legacySource.examName ??
+          gradeData.examRefs.find((examRef) => examRef.id === examId)
+            ?.examName ??
+          ""
+        if (examName) {
+          examRefs.push({
+            id: examId,
+            examName,
+            examDate:
+              gradeData.examRefs.find((examRef) => examRef.id === examId)
+                ?.examDate ?? null,
+          })
+        }
+      }
+
+      // 小計・採点領域: uuid → 名前から合成。名前で当て直すには試験の絞り込みが要る
+      // 合成 id には試験を混ぜる。小計名はグループ内、領域ラベルは試験内でしか
+      // 一意でないので、名前だけだと別の試験の同名参照と衝突して取り違える
+      let subtotalId = legacySource.subtotalId ?? null
+      if (!subtotalId && legacySource.subtotalName && examId) {
+        subtotalId = `legacy-subtotal:${examId}:${legacySource.subtotalName}`
+      }
+      if (subtotalId && examId && legacySource.subtotalName) {
+        if (!seenSubtotalIds.has(subtotalId)) {
+          seenSubtotalIds.add(subtotalId)
+          subtotalRefs.push({
+            id: subtotalId,
+            examId,
+            name: legacySource.subtotalName,
+          })
+        }
+      }
+
+      let cropRegionId = legacySource.cropRegionId ?? null
+      if (!cropRegionId && legacySource.cropRegionLabel && examId) {
+        cropRegionId = `legacy-crop-region:${examId}:${legacySource.cropRegionLabel}`
+      }
+      if (cropRegionId && examId && legacySource.cropRegionLabel) {
+        if (!seenCropRegionIds.has(cropRegionId)) {
+          seenCropRegionIds.add(cropRegionId)
+          cropRegionRefs.push({
+            id: cropRegionId,
+            examId,
+            label: legacySource.cropRegionLabel,
+          })
+        }
+      }
+
+      // 資料: uuid → 資料名・評価項目名から内包資料の行を引く
+      const courseworkItemId =
+        legacySource.courseworkItemId ??
+        (legacySource.courseworkName && legacySource.courseworkItemName
+          ? (courseworkItemIdByName.get(
+              `${legacySource.courseworkName}:${legacySource.courseworkItemName}`
+            ) ?? null)
+          : null)
+      const courseworkId =
+        legacySource.courseworkId ??
+        (legacySource.courseworkName
+          ? (courseworkIdByName.get(legacySource.courseworkName) ?? null)
+          : null)
+
+      gradeDataSources.push({
+        id: dataSourceId,
+        gradeItemId,
+        // Project 時代（アプリ v0.5.x 以前）の型名を現行へ直す。
+        // 残すと gradeCalculator のどの分岐にも一致せず、その評価項目の
+        // 試験合計が理由も示されず全生徒で空欄になる
+        type:
+          legacySource.type === "project_total"
+            ? "exam_total"
+            : legacySource.type,
+        examId,
+        subtotalId,
+        cropRegionId,
+        courseworkItemId,
+        courseworkId,
+        name: legacySource.name,
+        weight: toDecimalString(legacySource.weight),
+        order: legacySource.order,
+        absentMethod: legacySource.absentMethod ?? "null",
+        absentRatio: toDecimalString(legacySource.absentRatio ?? 1),
+        absentOffset: toDecimalString(legacySource.absentOffset ?? 0),
+        treatExpectedAsMissing: legacySource.treatExpectedAsMissing ?? false,
+        estimationMode: legacySource.estimationMode ?? "all",
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+
+      // 推定の参照は export 元のデータソース id を並べていた。id を持たない旧
+      // アーカイブでは解決できないので落とす（旧 importer と同じ判断）
+      const sourceIds = legacySource.estimationSourceIds ?? []
+      sourceIds.forEach((sourceDataSourceId, index) => {
+        estimationSources.push({
+          id: joinIds(dataSourceId, sourceDataSourceId),
+          dataSourceId,
+          sourceDataSourceId,
+          order: index,
+          createdAt: UNKNOWN_TIMESTAMP,
+          updatedAt: UNKNOWN_TIMESTAMP,
+        })
+      })
+    }
+  })
+
+  let ambiguousReferences = 0
+  /** 旧形式のセル参照（uuid 一次・項目名二次）から評価項目 id を解決する */
+  const resolveGradeItemId = (reference: {
+    gradeItemId?: string
+    gradeItemName: string | null
+  }): string | null => {
+    if (reference.gradeItemId) {
+      const byId = gradeItems.find(
+        (gradeItem) => gradeItem.id === reference.gradeItemId
+      )
+      if (byId) return byId.id
+    }
+    if (reference.gradeItemName === null) return null
+    if (ambiguousGradeItemNames.has(reference.gradeItemName)) {
+      ambiguousReferences++
+      return null
+    }
+    return gradeItemIdByName.get(reference.gradeItemName) ?? null
+  }
+
+  // ── 対象学級・対象者 ───────────────────────────────────────
+  const gradeClassrooms: ArchiveGradeClassroomRow[] =
+    gradeData.classroomRefs.map((classroomRef, index) => {
+      const classroomId = legacyClassroomId(classroomRef)
+      return {
+        id: joinIds(gradeId, classroomId),
+        gradeId,
+        classroomId,
+        order: index,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      }
+    })
+
+  const gradeStudents: ArchiveGradeStudentRow[] = []
+  /** 学籍番号 → 対象者 id（セルは学籍番号でしか生徒を指していない） */
+  const gradeStudentIdByStudentNumber = new Map<string, string>()
+  for (const studentRef of gradeData.studentRefs) {
+    const studentId = legacyStudentId(studentRef)
+    const gradeStudentId = joinIds(gradeId, studentId)
+    gradeStudents.push({
+      id: gradeStudentId,
+      gradeId,
+      studentId,
+      customOrder: studentRef.customOrder,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+    if (!gradeStudentIdByStudentNumber.has(studentRef.studentNumber)) {
+      gradeStudentIdByStudentNumber.set(
+        studentRef.studentNumber,
+        gradeStudentId
+      )
+    }
+  }
+
+  // ── セル3種 ───────────────────────────────────────────────
+  let droppedCells = 0
+  /** 旧形式のセルを (gradeStudentId, gradeItemId) へ解決する。解決できなければ null */
+  const resolveCell = (reference: {
+    studentNumber: string
+    gradeItemId?: string
+    gradeItemName: string | null
+  }): { gradeStudentId: string; gradeItemId: string } | null => {
+    const gradeStudentId = gradeStudentIdByStudentNumber.get(
+      reference.studentNumber
+    )
+    const gradeItemId = resolveGradeItemId(reference)
+    if (!gradeStudentId || !gradeItemId) {
+      droppedCells++
+      return null
+    }
+    return { gradeStudentId, gradeItemId }
+  }
+
+  const gradeOverrides: ArchiveGradeOverrideRow[] = []
+  for (const legacyOverride of gradeData.gradeOverrides ?? []) {
+    const cell = resolveCell(legacyOverride)
+    if (!cell) continue
+    gradeOverrides.push({
+      id: joinIds(cell.gradeStudentId, cell.gradeItemId),
+      gradeStudentId: cell.gradeStudentId,
+      gradeItemId: cell.gradeItemId,
+      overrideLabel: legacyOverride.overrideLabel,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+  }
+
+  const gradeFrozenScores: ArchiveGradeFrozenScoreRow[] = []
+  for (const legacyFrozen of gradeData.gradeFrozenScores ?? []) {
+    const cell = resolveCell(legacyFrozen)
+    if (!cell) continue
+    gradeFrozenScores.push({
+      id: joinIds(cell.gradeStudentId, cell.gradeItemId),
+      gradeStudentId: cell.gradeStudentId,
+      gradeItemId: cell.gradeItemId,
+      weightedScore: toOptionalDecimalString(legacyFrozen.weightedScore),
+      weightedMaxScore: toDecimalString(legacyFrozen.weightedMaxScore),
+      percentage: toOptionalDecimalString(legacyFrozen.percentage),
+      gradeLabel: legacyFrozen.gradeLabel,
+      // 旧形式は確定操作者を持ち出していない
+      frozenByUserId: null,
+      frozenAt: legacyFrozen.frozenAt,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+  }
+
+  const gradeItemExclusions: ArchiveGradeItemExclusionRow[] = []
+  for (const legacyExclusion of gradeData.gradeItemExclusions ?? []) {
+    const cell = resolveCell(legacyExclusion)
+    if (!cell) continue
+    gradeItemExclusions.push({
+      id: joinIds(cell.gradeStudentId, cell.gradeItemId),
+      gradeStudentId: cell.gradeStudentId,
+      gradeItemId: cell.gradeItemId,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+  }
+
+  if (droppedCells > 0) {
+    warnings.push(
+      `1.12.0→1.13.0: 対象生徒または評価項目を解決できない上書き・確定値・除外設定 ${droppedCells}件を破棄しました`
+    )
+  }
+  if (ambiguousReferences > 0) {
+    warnings.push(
+      `1.12.0→1.13.0: 同名の評価項目が複数あり対象を特定できない参照 ${ambiguousReferences}件を破棄しました`
+    )
+  }
+
+  // ── 境界セット ───────────────────────────────────────────
+  const gradeBoundarySets: ArchiveGradeBoundarySetRow[] = []
+  const gradeBoundaries: ArchiveGradeBoundaryRow[] = []
+  let droppedBoundarySets = 0
+  for (const legacySet of boundariesData.boundarySets) {
+    const gradeItemId = resolveGradeItemId(legacySet)
+    if (!gradeItemId) {
+      droppedBoundarySets++
+      continue
+    }
+    const boundarySetId = joinIds(gradeId, gradeItemId)
+    gradeBoundarySets.push({
+      id: boundarySetId,
+      gradeId,
+      gradeItemId,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+    for (const legacyBoundary of legacySet.boundaries) {
+      gradeBoundaries.push({
+        id: joinIds(boundarySetId, legacyBoundary.label),
+        gradeBoundarySetId: boundarySetId,
+        label: legacyBoundary.label,
+        minPercentage: toDecimalString(legacyBoundary.minPercentage),
+        order: legacyBoundary.order,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    }
+  }
+  if (droppedBoundarySets > 0) {
+    warnings.push(
+      `1.12.0→1.13.0: 対象の評価項目を解決できない成績境界セット ${droppedBoundarySets}件を破棄しました`
+    )
+  }
+
+  // ── 制約ルール ───────────────────────────────────────────
+  const gradeConstraints: ArchiveGradeConstraintRow[] = []
+  const gradeConstraintViewpoints: ArchiveGradeConstraintViewpointRow[] = []
+  const gradeConstraintLabelValues: ArchiveGradeConstraintLabelValueRow[] = []
+  const gradeConstraintExclusionLabels: ArchiveGradeConstraintExclusionLabelRow[] =
+    []
+  let droppedViewpoints = 0
+
+  gradeData.gradeConstraints?.forEach((legacyConstraint, constraintIndex) => {
+    const constraintId = joinIds(gradeId, `constraint:${constraintIndex}`)
+    const targetGradeItemId = legacyConstraint.targetGradeItemId
+      ? (resolveGradeItemId({
+          gradeItemId: legacyConstraint.targetGradeItemId,
+          gradeItemName: legacyConstraint.targetGradeItemName ?? null,
+        }) ?? null)
+      : (gradeItemIdByName.get(legacyConstraint.targetGradeItemName ?? "") ??
+        null)
+
+    // 観点は uuid 配列と名前配列の2本の平行配列で持っていた（同順が前提）。
+    // 現行は1行1参照なので、ここで対応を確定させて平行配列を解消する。
+    const viewpointIds = legacyConstraint.viewpointGradeItemIds ?? []
+    const viewpointNames = legacyConstraint.viewpointGradeItemNames ?? []
+    const viewpointCount = Math.max(viewpointIds.length, viewpointNames.length)
+    let lostViewpoints = 0
+    for (let index = 0; index < viewpointCount; index++) {
+      const gradeItemId = resolveGradeItemId({
+        gradeItemId: viewpointIds[index],
+        gradeItemName: viewpointNames[index] ?? null,
+      })
+      if (!gradeItemId) {
+        droppedViewpoints++
+        lostViewpoints++
+        continue
+      }
+      gradeConstraintViewpoints.push({
+        id: joinIds(constraintId, gradeItemId),
+        constraintId,
+        gradeItemId,
+        order: index,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    }
+
+    // 参照を1つでも失うとルールの意味が変わる（集計対象が減れば平均が動き、
+    // 比較先を失えば別物になる）。ここで落ちたことは取り込み側からは見えないので、
+    // この時点で無効化理由を書き込む。有効のまま通すと、減った観点で判定する
+    // 別のルールとして静かに動き続ける
+    const lostTarget =
+      Boolean(
+        legacyConstraint.targetGradeItemId ??
+        legacyConstraint.targetGradeItemName
+      ) && targetGradeItemId === null
+    const disabledReason = lostTarget
+      ? "取り込み時に比較先の評価項目を解決できなかったため無効化しました。再設定してください。"
+      : lostViewpoints > 0
+        ? "取り込み時に集計対象の観点を解決できなかったため無効化しました。再設定してください。"
+        : null
+    if (disabledReason) {
+      warnings.push(
+        `1.12.0→1.13.0: 制約ルール「${legacyConstraint.name}」: ${disabledReason}`
+      )
+    }
+
+    gradeConstraints.push({
+      id: constraintId,
+      gradeId,
+      name: legacyConstraint.name,
+      kind: legacyConstraint.kind,
+      targetGradeItemId,
+      aggregate: legacyConstraint.aggregate ?? "average",
+      tolerance: toDecimalString(legacyConstraint.tolerance ?? 1),
+      expression: legacyConstraint.expression,
+      color: legacyConstraint.color,
+      message: legacyConstraint.message,
+      disabledReason,
+      enabled: legacyConstraint.enabled && !disabledReason,
+      order: legacyConstraint.order,
+      createdAt: UNKNOWN_TIMESTAMP,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+
+    Object.entries(legacyConstraint.labelValues ?? {}).forEach(
+      ([label, value], index) => {
+        gradeConstraintLabelValues.push({
+          id: joinIds(constraintId, label),
+          constraintId,
+          label,
+          value: toDecimalString(value),
+          order: index,
+          createdAt: UNKNOWN_TIMESTAMP,
+          updatedAt: UNKNOWN_TIMESTAMP,
+        })
+      }
+    )
+
+    ;(legacyConstraint.exclusionLabels ?? []).forEach((label, index) => {
+      gradeConstraintExclusionLabels.push({
+        id: joinIds(constraintId, label),
+        constraintId,
+        label,
+        order: index,
+        createdAt: UNKNOWN_TIMESTAMP,
+        updatedAt: UNKNOWN_TIMESTAMP,
+      })
+    })
+  })
+
+  if (droppedViewpoints > 0) {
+    warnings.push(
+      `1.12.0→1.13.0: 評価項目を解決できない制約ルールの観点 ${droppedViewpoints}件を破棄しました`
+    )
+  }
+
+  // ── 出力設定 ─────────────────────────────────────────────
+  const gradeExportSettings: ArchiveGradeExportSettingsRow[] =
+    gradeData.exportSettings
+      ? [
+          {
+            id: joinIds(gradeId, "exportSettings"),
+            gradeId,
+            settingsJson: gradeData.exportSettings.settingsJson,
+            createdAt: UNKNOWN_TIMESTAMP,
+            updatedAt: UNKNOWN_TIMESTAMP,
+          },
+        ]
+      : []
+
+  // ── 外部参照 ─────────────────────────────────────────────
+  // 旧形式は生徒・学級の full レコードを持たない（学籍番号・学級名だけ）。
+  // 取り込み先の実体と突き合わせるのに必要な最小限を組み立てる。
+  // 旧形式は生徒を学籍番号だけで参照しており、氏名を持ち出していない。
+  // uuid / 学籍番号での照合は効くが、取り込み先に居ない生徒は作れない
+  // （氏名が空の生徒を名簿へ並べるより、作らずに知らせる方が復旧できる）。
+  const studentsData: ArchiveCwStudent[] = gradeData.studentRefs.map(
+    (studentRef) => ({
+      id: legacyStudentId(studentRef),
+      studentNumber: studentRef.studentNumber,
+      lastName: "",
+      firstName: "",
+      lastNameKana: "",
+      firstNameKana: "",
+      enrollmentYear: null,
+      updatedAt: UNKNOWN_TIMESTAMP,
+    })
+  )
+  if (studentsData.length > 0) {
+    warnings.push(
+      "1.12.0→1.13.0: 旧アーカイブは生徒の氏名・学級所属を持ちません。" +
+        "取り込み先に居ない生徒は作成されないため、先に生徒を登録してください"
+    )
+  }
+
+  const classesData: ArchiveCwClass[] = gradeData.classroomRefs.map(
+    (classroomRef) => ({
+      id: legacyClassroomId(classroomRef),
+      name: classroomRef.name,
+      classroomCode: null,
+      grade: null,
+      description: null,
+      isVisible: true,
+    })
+  )
+
+  // 旧形式は学級所属（在籍期間・出席番号）を持たない。在籍期間を捏造すると
+  // 受験日スナップショットの判定を狂わせるので、復元せず空で渡す。
+  // 対象学級そのものは classroomRefs から作られ、成績への紐づけも復元される
+  const membershipsData: ArchiveCwMembership[] = []
+
+  // 試験・小計・採点領域の同定情報はデータソースを走査する過程で積んである
+
+  return {
+    sections: {
+      grades: [grade],
+      gradeClassrooms,
+      gradeStudents,
+      gradeItems,
+      gradeDataSources,
+      gradeDataSourceEstimationSources: estimationSources,
+      gradeBoundarySets,
+      gradeBoundaries,
+      gradeOverrides,
+      gradeFrozenScores,
+      gradeItemExclusions,
+      gradeConstraints,
+      gradeConstraintViewpoints,
+      gradeConstraintLabelValues,
+      gradeConstraintExclusionLabels,
+      gradeExportSettings,
+    },
+    studentsData,
+    classesData,
+    membershipsData,
+    examRefs,
+    subtotalRefs,
+    cropRegionRefs,
+    warnings,
+  }
+}
+
+/** 旧形式（射影された gradeData を持つ）か判定する */
+export function isLegacyGradeArchiveData(
+  value: unknown
+): value is LegacyGradeArchiveData {
+  if (typeof value !== "object" || value === null) return false
+  const gradeData = (value as { gradeData?: unknown }).gradeData
+  if (typeof gradeData !== "object" || gradeData === null) return false
+  return Array.isArray((gradeData as { gradeItems?: unknown }).gradeItems)
+}

--- a/electron-src/lib/import/grade-transformers/types.ts
+++ b/electron-src/lib/import/grade-transformers/types.ts
@@ -1,0 +1,61 @@
+/**
+ * grade-archive のバージョン変換の型
+ *
+ * バージョンごとに「アーカイブ全体の形」を宣言し、変換器を V<FROM> → V<TO> として
+ * 型付けする。旧バージョンの形の知識はこのディレクトリの中だけに閉じ込め、
+ * src/types 側は現行の形（GradeArchiveData）だけを持つ。
+ *
+ * 1.3.0〜1.12.0 は「成績本体を入れ子へ射影し、外部参照を名前で持つ」同一の骨格で、
+ * 差分は加算的なフィールド（optional）で表せる。したがって版ごとに型を分けず
+ * `LegacyGradeArchiveData` 1つで受け、実際に骨格が変わった 1.12.0 → 1.13.0 だけを
+ * 別の型として宣言する。
+ */
+
+import type {
+  GradeArchiveData,
+  GradeArchiveVersion,
+} from "../../../../src/types/gradeArchive.types"
+import {
+  isLegacyGradeArchiveData,
+  type LegacyGradeArchiveData,
+} from "./legacyShape"
+
+/** 1.3.0〜1.12.0 のアーカイブ全体（射影形式） */
+export type GradeArchiveDataUpTo1_12_0 = LegacyGradeArchiveData
+
+/** 1.13.0 のアーカイブ全体（現行。テーブルごとの平坦なセクション） */
+export type GradeArchiveDataV1_13_0 = GradeArchiveData
+
+/** 読み込み時点では版が確定していないので、扱いうる版の総和で受ける */
+export type AnyGradeArchiveData =
+  GradeArchiveDataUpTo1_12_0 | GradeArchiveDataV1_13_0
+
+/** どの版の形かを判定する（manifest.version ではなく実データの形で決める） */
+export function isGradeArchiveUpTo1_12_0(
+  data: AnyGradeArchiveData
+): data is GradeArchiveDataUpTo1_12_0 {
+  return isLegacyGradeArchiveData(data)
+}
+
+export interface GradeTransformResult {
+  data: AnyGradeArchiveData
+  warnings: string[]
+}
+
+export interface GradeVersionTransformer {
+  readonly fromVersion: GradeArchiveVersion
+  readonly toVersion: GradeArchiveVersion
+  transform(data: AnyGradeArchiveData): GradeTransformResult
+}
+
+/** チェーン完了後は現行の形であることが保証される */
+export interface GradeChainTransformResult {
+  data: GradeArchiveDataV1_13_0
+  originalVersion: GradeArchiveVersion
+  finalVersion: GradeArchiveVersion
+  appliedTransformations: {
+    from: GradeArchiveVersion
+    to: GradeArchiveVersion
+  }[]
+  warnings: string[]
+}

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -58,12 +58,32 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
   {
     // 答案・採点・確定・複合回答・返却版は ExamStudent の子であり、
     // ExamStudent.id は変わらないので移し替えは要らない（上の ExamStudent で追従する）。
+    //
+    // UNIQUE([gradeId, studentId]) があるため移行先の重複を回避しつつ更新する。
+    // 上書き・確定値・除外設定は GradeStudent の onDelete:Cascade 子なので、重複行を
+    // そのまま delete すると道連れになる。移行先に同じ評価項目の行が無いものは先に
+    // 付け替え、衝突するものだけを（移行先の値を残して）捨てる。
     model: "GradeStudent",
-    move: (tx, from, to) =>
-      tx.gradeStudent.updateMany({
+    move: async (tx, from, to) => {
+      const rows = await tx.gradeStudent.findMany({
         where: { studentId: from },
-        data: { studentId: to },
-      }),
+      })
+      for (const gradeStudent of rows) {
+        const duplicate = await tx.gradeStudent.findFirst({
+          where: { gradeId: gradeStudent.gradeId, studentId: to },
+        })
+        if (!duplicate) {
+          await tx.gradeStudent.update({
+            where: { id: gradeStudent.id },
+            data: { studentId: to },
+          })
+          continue
+        }
+
+        await moveGradeCells(tx, gradeStudent.id, duplicate.id)
+        await tx.gradeStudent.delete({ where: { id: gradeStudent.id } })
+      }
+    },
   },
   {
     // UNIQUE([courseworkId, studentId]) があるため移行先の重複を回避しつつ更新する。
@@ -114,31 +134,69 @@ export const STUDENT_CASCADE_MOVERS: CascadeMover[] = [
       }
     },
   },
-  {
-    model: "GradeOverride",
-    move: (tx, from, to) =>
-      tx.gradeOverride.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
-  {
-    model: "GradeFrozenScore",
-    move: (tx, from, to) =>
-      tx.gradeFrozenScore.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
-  {
-    model: "GradeItemExclusion",
-    move: (tx, from, to) =>
-      tx.gradeItemExclusion.updateMany({
-        where: { studentId: from },
-        data: { studentId: to },
-      }),
-  },
 ]
+
+/**
+ * 成績のセル3種を、統合される対象者から移行先の対象者へ移し替える。
+ * 移行先に同じ評価項目の行が既にあるものは移さない（移行先の値を残す＝旧来の挙動）。
+ * 移さなかった行は呼び出し側の GradeStudent 削除で cascade により消える。
+ */
+async function moveGradeCells(
+  tx: PrismaTransaction,
+  fromGradeStudentId: string,
+  toGradeStudentId: string
+): Promise<void> {
+  const overrides = await tx.gradeOverride.findMany({
+    where: { gradeStudentId: fromGradeStudentId },
+  })
+  for (const override of overrides) {
+    const conflicting = await tx.gradeOverride.findFirst({
+      where: {
+        gradeStudentId: toGradeStudentId,
+        gradeItemId: override.gradeItemId,
+      },
+    })
+    if (conflicting) continue
+    await tx.gradeOverride.update({
+      where: { id: override.id },
+      data: { gradeStudentId: toGradeStudentId },
+    })
+  }
+
+  const frozenScores = await tx.gradeFrozenScore.findMany({
+    where: { gradeStudentId: fromGradeStudentId },
+  })
+  for (const frozenScore of frozenScores) {
+    const conflicting = await tx.gradeFrozenScore.findFirst({
+      where: {
+        gradeStudentId: toGradeStudentId,
+        gradeItemId: frozenScore.gradeItemId,
+      },
+    })
+    if (conflicting) continue
+    await tx.gradeFrozenScore.update({
+      where: { id: frozenScore.id },
+      data: { gradeStudentId: toGradeStudentId },
+    })
+  }
+
+  const itemExclusions = await tx.gradeItemExclusion.findMany({
+    where: { gradeStudentId: fromGradeStudentId },
+  })
+  for (const itemExclusion of itemExclusions) {
+    const conflicting = await tx.gradeItemExclusion.findFirst({
+      where: {
+        gradeStudentId: toGradeStudentId,
+        gradeItemId: itemExclusion.gradeItemId,
+      },
+    })
+    if (conflicting) continue
+    await tx.gradeItemExclusion.update({
+      where: { id: itemExclusion.id },
+      data: { gradeStudentId: toGradeStudentId },
+    })
+  }
+}
 
 /**
  * Classroom に onDelete:Cascade で紐づく子テーブル全件。

--- a/electron-src/lib/prisma/coursework.ts
+++ b/electron-src/lib/prisma/coursework.ts
@@ -484,13 +484,17 @@ async function assertSameCoursework(
   const [items, courseworkStudents] = await Promise.all([
     prisma.courseworkItem.findMany({
       where: {
-        id: { in: [...new Set(scores.map((s) => s.courseworkItemId))] },
+        id: {
+          in: [...new Set(scores.map((score) => score.courseworkItemId))],
+        },
       },
       select: { id: true, courseworkId: true },
     }),
     prisma.courseworkStudent.findMany({
       where: {
-        id: { in: [...new Set(scores.map((s) => s.courseworkStudentId))] },
+        id: {
+          in: [...new Set(scores.map((score) => score.courseworkStudentId))],
+        },
       },
       select: { id: true, courseworkId: true },
     }),

--- a/electron-src/lib/prisma/grade.ts
+++ b/electron-src/lib/prisma/grade.ts
@@ -282,7 +282,11 @@ export async function duplicateGrade(id: string) {
           where: { id },
           include: {
             gradeClassrooms: { orderBy: { order: "asc" } },
-            gradeStudents: true,
+            // 対象者は上書き・除外設定を子として持つ。複製先の対象者へ張り替えるため
+            // 一緒に引く（確定値は複製しない。後述）
+            gradeStudents: {
+              include: { overrides: true, itemExclusions: true },
+            },
             gradeItems: {
               include: {
                 dataSources: {
@@ -295,8 +299,6 @@ export async function duplicateGrade(id: string) {
             boundarySets: {
               include: { boundaries: { orderBy: { order: "asc" } } },
             },
-            gradeOverrides: true,
-            gradeItemExclusions: true,
             gradeConstraints: {
               include: gradeConstraintInclude,
               orderBy: { order: "asc" },
@@ -354,15 +356,18 @@ export async function duplicateGrade(id: string) {
           })
         }
 
-        // 4. 対象生徒（独立行）
-        if (source.gradeStudents.length > 0) {
-          await tx.gradeStudent.createMany({
-            data: source.gradeStudents.map((gradeStudent) => ({
+        // 4. 対象生徒。上書き・除外設定は対象者の子なので、新しい対象者の id を
+        //    後続で使えるよう1件ずつ作って旧→新の対応を持つ。
+        const gradeStudentIdMap = new Map<string, string>()
+        for (const gradeStudent of source.gradeStudents) {
+          const newGradeStudent = await tx.gradeStudent.create({
+            data: {
               gradeId: grade.id,
               studentId: gradeStudent.studentId,
               customOrder: gradeStudent.customOrder,
-            })),
+            },
           })
+          gradeStudentIdMap.set(gradeStudent.id, newGradeStudent.id)
         }
 
         // 5. 評価項目 + データソース。
@@ -455,35 +460,35 @@ export async function duplicateGrade(id: string) {
           }
         }
 
-        // 7. 評定の手動上書き（gradeItemId を再リンク／独立行）
-        if (source.gradeOverrides.length > 0) {
-          await tx.gradeOverride.createMany({
-            data: source.gradeOverrides.map((gradeOverride) => ({
-              gradeId: grade.id,
-              studentId: gradeOverride.studentId,
-              gradeItemId: remapItemId(gradeOverride.gradeItemId),
-              overrideLabel: gradeOverride.overrideLabel,
-            })),
-          })
+        // 7-8. 評定の手動上書きと評価項目ごとの除外。どちらも対象者×評価項目のセルなので、
+        //   複製先の対象者 id と評価項目 id の両方へ再リンクする。解決できなければ
+        //   複製元が壊れているため throw してロールバックする（矛盾した行を作らない）。
+        const remapGradeStudentId = (oldId: string): string => {
+          const newId = gradeStudentIdMap.get(oldId)
+          if (!newId) {
+            throw new Error(`GradeStudent ${oldId} の複製先が見つかりません`)
+          }
+          return newId
+        }
+        const overrideRows = source.gradeStudents.flatMap((gradeStudent) =>
+          gradeStudent.overrides.map((override) => ({
+            gradeStudentId: remapGradeStudentId(gradeStudent.id),
+            gradeItemId: remapItemId(override.gradeItemId),
+            overrideLabel: override.overrideLabel,
+          }))
+        )
+        if (overrideRows.length > 0) {
+          await tx.gradeOverride.createMany({ data: overrideRows })
         }
 
-        // 8. 評価項目ごとの生徒除外（gradeItemId 必須のため remap 結果を非nullで使う／独立行）
-        if (source.gradeItemExclusions.length > 0) {
-          await tx.gradeItemExclusion.createMany({
-            data: source.gradeItemExclusions.map((exclusion) => {
-              const newItemId = itemIdMap.get(exclusion.gradeItemId)
-              if (!newItemId) {
-                throw new Error(
-                  `GradeItem ${exclusion.gradeItemId} の複製先が見つかりません`
-                )
-              }
-              return {
-                gradeId: grade.id,
-                studentId: exclusion.studentId,
-                gradeItemId: newItemId,
-              }
-            }),
-          })
+        const exclusionRows = source.gradeStudents.flatMap((gradeStudent) =>
+          gradeStudent.itemExclusions.map((itemExclusion) => ({
+            gradeStudentId: remapGradeStudentId(gradeStudent.id),
+            gradeItemId: remapItemId(itemExclusion.gradeItemId),
+          }))
+        )
+        if (exclusionRows.length > 0) {
+          await tx.gradeItemExclusion.createMany({ data: exclusionRows })
         }
 
         // 9. 観点間の制約ルール。

--- a/electron-src/lib/prisma/gradeFrozenScore.ts
+++ b/electron-src/lib/prisma/gradeFrozenScore.ts
@@ -11,16 +11,11 @@
 
 import { Decimal } from "@prisma/client/runtime/client"
 
+import type { GradeCellTarget } from "../../../src/types/grade.types"
 import { calculateGrades } from "../shared/calculations/gradeCalculator"
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
-
-/** 確定・解除の対象セル（生徒×評価項目）。総合の行は存在しない */
-export interface GradeFrozenTarget {
-  studentId: string
-  gradeItemId: string
-}
 
 interface FreezeGradeScoresResult {
   success: boolean
@@ -37,19 +32,19 @@ interface UnfreezeGradeScoresResult {
 }
 
 /** 対象セルの同定キー。id の組でキーし、行・列の並び順には依存しない */
-const targetKey = (target: GradeFrozenTarget): string =>
-  `${target.studentId}:${target.gradeItemId}`
+const targetKey = (target: GradeCellTarget): string =>
+  `${target.gradeStudentId}:${target.gradeItemId}`
 
 /**
  * 成績値を確定（凍結）する。
  *
- * targets 未指定なら Grade 全体（全生徒 × 全評価項目）を一括で確定する。
+ * targets 未指定なら Grade 全体（全対象者 × 全評価項目）を一括で確定する。
  * 既に確定済みのセルを含めて指定した場合は、その時点のライブ値で確定し直す（再確定）。
  * 除外セル（GradeItemExclusion）は値を持たないため確定対象から外す。
  */
 export async function freezeGradeScores(options: {
   gradeId: string
-  targets?: GradeFrozenTarget[]
+  targets?: GradeCellTarget[]
   frozenByUserId?: string | null
 }): Promise<FreezeGradeScoresResult> {
   const { gradeId, targets, frozenByUserId = null } = options
@@ -67,8 +62,7 @@ export async function freezeGradeScores(options: {
       targets !== undefined ? new Set(targets.map(targetKey)) : null
 
     const rows: {
-      gradeId: string
-      studentId: string
+      gradeStudentId: string
       gradeItemId: string
       weightedScore: Decimal | null
       weightedMaxScore: Decimal
@@ -81,8 +75,8 @@ export async function freezeGradeScores(options: {
 
     for (const student of calculation.result.students) {
       for (const gradeItemResult of student.gradeItemResults) {
-        const target: GradeFrozenTarget = {
-          studentId: student.studentId,
+        const target: GradeCellTarget = {
+          gradeStudentId: student.gradeStudentId,
           gradeItemId: gradeItemResult.gradeItemId,
         }
         if (requestedKeys !== null && !requestedKeys.has(targetKey(target))) {
@@ -92,8 +86,7 @@ export async function freezeGradeScores(options: {
         if (gradeItemResult.isExcluded) continue
 
         rows.push({
-          gradeId,
-          studentId: target.studentId,
+          gradeStudentId: target.gradeStudentId,
           gradeItemId: target.gradeItemId,
           weightedScore:
             gradeItemResult.weightedScore !== null
@@ -120,18 +113,18 @@ export async function freezeGradeScores(options: {
     // 古い確定行が残り、除外を解除した瞬間に過去の値が甦ってしまう。
     const deleteWhere =
       targets === undefined
-        ? { gradeId }
+        ? { gradeStudent: { gradeId } }
         : {
-            gradeId,
+            gradeStudent: { gradeId },
             OR: targets.map((target) => ({
-              studentId: target.studentId,
+              gradeStudentId: target.gradeStudentId,
               gradeItemId: target.gradeItemId,
             })),
           }
 
-    // 再確定を上書きではなく「消して入れ直す」で表現する。unique(gradeId, studentId,
-    // gradeItemId) の1行1セルなので、対象範囲を削除してから作り直せば
-    // 新規確定・再確定のどちらも同じ経路で扱える。
+    // 再確定を上書きではなく「消して入れ直す」で表現する。
+    // unique(gradeStudentId, gradeItemId) の1行1セルなので、対象範囲を削除してから
+    // 作り直せば新規確定・再確定のどちらも同じ経路で扱える。
     await prisma.$transaction(async (tx) => {
       await tx.gradeFrozenScore.deleteMany({ where: deleteWhere })
       if (rows.length > 0) {
@@ -169,7 +162,7 @@ export async function freezeGradeScores(options: {
  */
 export async function unfreezeGradeScores(options: {
   gradeId: string
-  targets?: GradeFrozenTarget[]
+  targets?: GradeCellTarget[]
   userId?: string | null
 }): Promise<UnfreezeGradeScoresResult> {
   const { gradeId, targets, userId = null } = options
@@ -180,11 +173,11 @@ export async function unfreezeGradeScores(options: {
 
     const deleted = await prisma.gradeFrozenScore.deleteMany({
       where: {
-        gradeId,
+        gradeStudent: { gradeId },
         ...(targets !== undefined
           ? {
               OR: targets.map((target) => ({
-                studentId: target.studentId,
+                gradeStudentId: target.gradeStudentId,
                 gradeItemId: target.gradeItemId,
               })),
             }

--- a/electron-src/lib/prisma/gradeItemExclusion.ts
+++ b/electron-src/lib/prisma/gradeItemExclusion.ts
@@ -1,26 +1,23 @@
 /**
  * GradeItemExclusion（評価項目除外設定）データアクセス層
+ *
+ * 除外の主語は「その成績の対象者」（GradeStudent）であり、人（Student）ではない。
+ * 名簿に載っていない生徒の除外設定は書けない（FK が拒否する）。
  */
 
+import type { GradeItemExclusionInput } from "../../../src/types/grade.types"
 import prisma from "./client"
+import { assertGradeCellsInSameGrade } from "./gradeScopeGuard"
 
 /**
- * 試験の全除外設定を取得
+ * 成績の全除外設定を取得
  */
 export async function getGradeItemExclusions(gradeId: string) {
   try {
     const exclusions = await prisma.gradeItemExclusion.findMany({
-      where: { gradeId },
+      where: { gradeStudent: { gradeId } },
     })
-    return {
-      success: true,
-      exclusions: exclusions.map((exclusion) => ({
-        id: exclusion.id,
-        gradeId: exclusion.gradeId,
-        studentId: exclusion.studentId,
-        gradeItemId: exclusion.gradeItemId,
-      })),
-    }
+    return { success: true, exclusions }
   } catch (error) {
     console.error("Error getting grade item exclusions:", error)
     return {
@@ -33,35 +30,28 @@ export async function getGradeItemExclusions(gradeId: string) {
 /**
  * 除外設定の切り替え（excluded=trueで作成、falseで削除）
  */
-export async function setGradeItemExclusion(data: {
-  gradeId: string
-  studentId: string
-  gradeItemId: string
-  excluded: boolean
-}) {
+export async function setGradeItemExclusion(input: GradeItemExclusionInput) {
   try {
-    if (data.excluded) {
+    if (input.excluded) {
+      await assertGradeCellsInSameGrade([input])
       await prisma.gradeItemExclusion.upsert({
         where: {
-          gradeId_studentId_gradeItemId: {
-            gradeId: data.gradeId,
-            studentId: data.studentId,
-            gradeItemId: data.gradeItemId,
+          gradeStudentId_gradeItemId: {
+            gradeStudentId: input.gradeStudentId,
+            gradeItemId: input.gradeItemId,
           },
         },
         update: {},
         create: {
-          gradeId: data.gradeId,
-          studentId: data.studentId,
-          gradeItemId: data.gradeItemId,
+          gradeStudentId: input.gradeStudentId,
+          gradeItemId: input.gradeItemId,
         },
       })
     } else {
       await prisma.gradeItemExclusion.deleteMany({
         where: {
-          gradeId: data.gradeId,
-          studentId: data.studentId,
-          gradeItemId: data.gradeItemId,
+          gradeStudentId: input.gradeStudentId,
+          gradeItemId: input.gradeItemId,
         },
       })
     }
@@ -79,33 +69,32 @@ export async function setGradeItemExclusion(data: {
  * 一括更新（トランザクション）
  */
 export async function batchUpdateGradeItemExclusions(
-  gradeId: string,
-  updates: { studentId: string; gradeItemId: string; excluded: boolean }[]
+  updates: GradeItemExclusionInput[]
 ) {
   try {
+    const added = updates.filter((update) => update.excluded)
+    await assertGradeCellsInSameGrade(added)
+
     await prisma.$transaction(async (tx) => {
       for (const update of updates) {
         if (update.excluded) {
           await tx.gradeItemExclusion.upsert({
             where: {
-              gradeId_studentId_gradeItemId: {
-                gradeId,
-                studentId: update.studentId,
+              gradeStudentId_gradeItemId: {
+                gradeStudentId: update.gradeStudentId,
                 gradeItemId: update.gradeItemId,
               },
             },
             update: {},
             create: {
-              gradeId,
-              studentId: update.studentId,
+              gradeStudentId: update.gradeStudentId,
               gradeItemId: update.gradeItemId,
             },
           })
         } else {
           await tx.gradeItemExclusion.deleteMany({
             where: {
-              gradeId,
-              studentId: update.studentId,
+              gradeStudentId: update.gradeStudentId,
               gradeItemId: update.gradeItemId,
             },
           })

--- a/electron-src/lib/prisma/gradeOverride.ts
+++ b/electron-src/lib/prisma/gradeOverride.ts
@@ -1,47 +1,65 @@
 /**
  * GradeOverride（成績ラベル上書き）のPrisma操作関数
+ *
+ * 上書きの主語は「その成績の対象者」（GradeStudent）であり、人（Student）ではない。
+ * 名簿に載っていない生徒の上書きは書けない（FK が拒否する）。
  */
 
+import type { GradeCellTarget } from "../../../src/types/grade.types"
 import { recordAuditLog } from "./auditLog"
 import { resolveGradeScope } from "./auditScope"
 import prisma from "./client"
+import { assertGradeCellsInSameGrade } from "./gradeScopeGuard"
+
+/** 監査ログのスコープ用に、対象者から所属する成績を引く */
+async function resolveGradeIdOf(
+  gradeStudentId: string
+): Promise<string | null> {
+  const gradeStudent = await prisma.gradeStudent.findUnique({
+    where: { id: gradeStudentId },
+    select: { gradeId: true },
+  })
+  return gradeStudent?.gradeId ?? null
+}
 
 /**
- * 上書きを upsert。対象は生徒×評価項目で、gradeItemId は NOT NULL なので
+ * 上書きを upsert。対象は対象者×評価項目で、どちらも NOT NULL なので
  * 複合uniqueをそのまま使える（NULL が unique 制約をすり抜ける問題は起きない）。
  */
-export async function upsertGradeOverride(data: {
-  gradeId: string
-  studentId: string
-  gradeItemId: string
-  overrideLabel: string
-}) {
+export async function upsertGradeOverride(
+  data: GradeCellTarget & { overrideLabel: string }
+) {
   try {
+    // 対象者と評価項目が同じ成績のものであることを書き込み前に検査する。
+    // FK は「それぞれが実在すること」しか保証しない。
+    await assertGradeCellsInSameGrade([data])
+
     const result = await prisma.gradeOverride.upsert({
       where: {
-        gradeId_studentId_gradeItemId: {
-          gradeId: data.gradeId,
-          studentId: data.studentId,
+        gradeStudentId_gradeItemId: {
+          gradeStudentId: data.gradeStudentId,
           gradeItemId: data.gradeItemId,
         },
       },
       create: {
-        gradeId: data.gradeId,
-        studentId: data.studentId,
+        gradeStudentId: data.gradeStudentId,
         gradeItemId: data.gradeItemId,
         overrideLabel: data.overrideLabel,
       },
       update: { overrideLabel: data.overrideLabel },
     })
 
-    const scope = await resolveGradeScope(data.gradeId)
-    await recordAuditLog({
-      action: "grade.override.update",
-      entityType: "GradeOverride",
-      entityId: result.id,
-      scopeId: scope.scopeId,
-      scopeLabel: scope.scopeLabel,
-    })
+    const gradeId = await resolveGradeIdOf(data.gradeStudentId)
+    if (gradeId) {
+      const scope = await resolveGradeScope(gradeId)
+      await recordAuditLog({
+        action: "grade.override.update",
+        entityType: "GradeOverride",
+        entityId: result.id,
+        scopeId: scope.scopeId,
+        scopeLabel: scope.scopeLabel,
+      })
+    }
 
     return { success: true, override: result }
   } catch (error) {
@@ -56,32 +74,30 @@ export async function upsertGradeOverride(data: {
 /**
  * 上書きを削除（自動計算に戻す）
  */
-export async function deleteGradeOverride(data: {
-  gradeId: string
-  studentId: string
-  gradeItemId: string
-}) {
+export async function deleteGradeOverride(target: GradeCellTarget) {
   try {
     const existing = await prisma.gradeOverride.findUnique({
       where: {
-        gradeId_studentId_gradeItemId: {
-          gradeId: data.gradeId,
-          studentId: data.studentId,
-          gradeItemId: data.gradeItemId,
+        gradeStudentId_gradeItemId: {
+          gradeStudentId: target.gradeStudentId,
+          gradeItemId: target.gradeItemId,
         },
       },
     })
     if (existing) {
       await prisma.gradeOverride.delete({ where: { id: existing.id } })
 
-      const scope = await resolveGradeScope(data.gradeId)
-      await recordAuditLog({
-        action: "grade.override.delete",
-        entityType: "GradeOverride",
-        entityId: existing.id,
-        scopeId: scope.scopeId,
-        scopeLabel: scope.scopeLabel,
-      })
+      const gradeId = await resolveGradeIdOf(target.gradeStudentId)
+      if (gradeId) {
+        const scope = await resolveGradeScope(gradeId)
+        await recordAuditLog({
+          action: "grade.override.delete",
+          entityType: "GradeOverride",
+          entityId: existing.id,
+          scopeId: scope.scopeId,
+          scopeLabel: scope.scopeLabel,
+        })
+      }
     }
     return { success: true }
   } catch (error) {

--- a/electron-src/lib/prisma/gradeScopeGuard.ts
+++ b/electron-src/lib/prisma/gradeScopeGuard.ts
@@ -1,0 +1,73 @@
+/**
+ * 成績のセルの対象者と評価項目が同じ成績に属することの検査
+ *
+ * 成績のセル（GradeOverride / GradeFrozenScore / GradeItemExclusion）は
+ * 「対象者（GradeStudent）」と「評価項目（GradeItem）」の2つを参照する。FK が保証するのは
+ * **それぞれが実在すること**だけで、両者が同じ Grade に属することは強制されない。
+ * 食い違ったまま書けると、成績 A の対象者に成績 B の評価項目の上書き・確定値がぶら下がり、
+ * どちらの画面にも出ないのに DB には残る — #962 で塞いだのと同じ穴が別の入口から開く。
+ *
+ * どちらの id も string なので取り違えてもコンパイルは通る。書き込みの入口で
+ * 実際に成績を突き合わせて弾く（examScopeGuard / assertSameCoursework と同じ考え方）。
+ */
+
+import prisma from "./client"
+import type { Tx } from "./transactionClient"
+
+type PrismaLike = typeof prisma | Tx
+
+/** 検査に失敗したときのエラー。呼び出し側は success:false へ倒す */
+class GradeScopeMismatchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "GradeScopeMismatchError"
+  }
+}
+
+/**
+ * 成績のセルの対象者と評価項目が同じ成績のものか検査する。
+ * 解決できない id があればその時点でエラーにする（存在しない親を指す行を作らせない）。
+ */
+export async function assertGradeCellsInSameGrade(
+  cells: { gradeStudentId: string; gradeItemId: string }[],
+  client: PrismaLike = prisma
+): Promise<void> {
+  if (cells.length === 0) return
+
+  const [gradeStudents, gradeItems] = await Promise.all([
+    client.gradeStudent.findMany({
+      where: {
+        id: { in: [...new Set(cells.map((cell) => cell.gradeStudentId))] },
+      },
+      select: { id: true, gradeId: true },
+    }),
+    client.gradeItem.findMany({
+      where: {
+        id: { in: [...new Set(cells.map((cell) => cell.gradeItemId))] },
+      },
+      select: { id: true, gradeId: true },
+    }),
+  ])
+
+  const gradeIdByGradeStudent = new Map(
+    gradeStudents.map((gradeStudent) => [gradeStudent.id, gradeStudent.gradeId])
+  )
+  const gradeIdByGradeItem = new Map(
+    gradeItems.map((gradeItem) => [gradeItem.id, gradeItem.gradeId])
+  )
+
+  for (const cell of cells) {
+    const studentGradeId = gradeIdByGradeStudent.get(cell.gradeStudentId)
+    const itemGradeId = gradeIdByGradeItem.get(cell.gradeItemId)
+    if (!studentGradeId || !itemGradeId) {
+      throw new GradeScopeMismatchError(
+        "対象生徒または評価項目が見つかりません"
+      )
+    }
+    if (studentGradeId !== itemGradeId) {
+      throw new GradeScopeMismatchError(
+        "対象生徒と評価項目が別の成績に属しています"
+      )
+    }
+  }
+}

--- a/electron-src/lib/prisma/returnSnapshot.ts
+++ b/electron-src/lib/prisma/returnSnapshot.ts
@@ -122,7 +122,13 @@ export interface CaptureReturnSnapshotResult {
 /** float のノイズによる誤検知を防ぐため小数4桁に丸める */
 const round = (value: number): number => Math.round(value * 1e4) / 1e4
 
-/** 試験の現在状態（有効スコア・注釈・領域）をまとめて読み込む */
+/**
+ * 試験の現在状態（有効スコア・注釈・領域）をまとめて読み込む。
+ *
+ * 索引のキーは受験者（ExamStudent）と採点領域（CropRegion）の id で、人（Student）では
+ * ない。返却スナップショットは「その試験の受験者の答案」を対象とするため、受験者を
+ * 主語にするのが正しい（#962 §3.3 の棚卸し結果。Phase A の配線変更で解消済み）。
+ */
 interface ExamState {
   /** cropRegionId -> { label, maxScore } */
   regions: Map<string, { label: string | null; maxScore: number | null }>

--- a/electron-src/lib/shared/calculations/absentEstimation.ts
+++ b/electron-src/lib/shared/calculations/absentEstimation.ts
@@ -1,11 +1,14 @@
 /**
  * 欠測時の代替スコア推定
- * rawScoreMap には推定前の実スコアのみが格納される（循環推定の防止）。
+ * 素点行列（RawScoreMatrix）には推定前の実スコアのみが格納される（循環推定の防止）。
  * - zero: 0点
  * - average: 同一生徒の他DataSource比率の平均 × 満点
  * - regression: OLS重回帰による予測。多重共線性（合計＝小計の和など）で線形従属になった
  *   説明変数はランク落ちで除外して残りの独立列で継続する。独立列が1つも残らない場合や
  *   サンプル不足の場合のみ average にフォールバックする。
+ *
+ * 推定対象は行（対象者）と列（データソース）の実体で指定する。以前は studentId と
+ * dataSourceId をそれぞれ string で受けており、取り違えても型では捕まらなかった。
  */
 
 import type {
@@ -16,6 +19,15 @@ import type {
   EstimationSourceContribution,
 } from "../../../../src/types/grade.types"
 import type { DataSourceInfo } from "./gradeCalculatorTypes"
+import type {
+  RawScoreMatrix,
+  RawScoreRow,
+  RawScoreRowEntity,
+} from "./rawScoreMatrix"
+
+/** 推定は行を識別できれば足りるので、行の実体は最小限の形で受ける */
+type EstimationRow = RawScoreRow<RawScoreRowEntity>
+type EstimationMatrix = RawScoreMatrix<RawScoreRowEntity>
 
 /**
  * 欠測推定の生の結果（乗率・加減点の適用前）。
@@ -59,69 +71,44 @@ interface AbsentEstimation {
  */
 export function estimateAbsentScore(
   method: AbsentMethod,
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
 ): AbsentEstimation | null {
   if (method === "zero") {
     return { value: 0, effectiveMethod: "zero" }
   }
   if (method === "average") {
-    return estimateByAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
-      allDataSources
-    )
+    return estimateByAverage(targetRow, dataSource, matrix, allDataSources)
   }
   if (method === "regression") {
-    return estimateByRegression(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
-      allDataSources
-    )
+    return estimateByRegression(targetRow, dataSource, matrix, allDataSources)
   }
   if (method === "equipercentile") {
     return estimateByEquipercentile(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources
     )
   }
   if (method === "zscore") {
-    return estimateByZScore(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
-      allDataSources
-    )
+    return estimateByZScore(targetRow, dataSource, matrix, allDataSources)
   }
   return null
 }
 
 /**
- * 当ソース(dataSourceId)を実測した他生徒の素点分布（平均・母標準偏差・整列済み素点列）。
+ * 当ソースを実測した他生徒の素点分布（平均・母標準偏差・整列済み素点列）。
  * 対象生徒自身は欠測なので母数から自然に外れる。標準偏差法・順位法の載せ替え先に使う。
  */
 function collectTargetDistribution(
-  studentId: string,
-  dataSourceId: string,
-  rawScoreMap: Map<string, Map<string, number | null>>
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix
 ): { mean: number; sd: number; sorted: number[] } | null {
-  const scores: number[] = []
-  for (const [otherStudentId, otherScores] of rawScoreMap) {
-    if (otherStudentId === studentId) continue
-    const score = otherScores.get(dataSourceId)
-    if (score !== null && score !== undefined) scores.push(score)
-  }
+  const scores = matrix.measuredColumn(dataSource, { except: targetRow })
   if (scores.length < 2) return null
   const mean = scores.reduce((sum, score) => sum + score, 0) / scores.length
   const variance =
@@ -131,32 +118,42 @@ function collectTargetDistribution(
 }
 
 /**
+ * 説明変数1つ分。表示用の内訳（contribution）と、分布の引き直しに使う列の実体を持つ。
+ * 内訳だけだと再び id 文字列からソースを引き当てる必要が生じるため実体を添える。
+ */
+interface PredictorContribution {
+  dataSource: DataSourceInfo
+  contribution: EstimationSourceContribution
+}
+
+/**
  * 対象生徒が実測を持つ他ソースを、標準偏差法・順位法の説明変数として集める。
  * average と同じく「自ソース以外・満点>0・対象生徒が実測を持つ」ソースが対象。
  */
 function collectPredictorContributions(
-  studentId: string,
-  dataSourceId: string,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
-): EstimationSourceContribution[] {
-  const studentScores = rawScoreMap.get(studentId)
-  if (!studentScores) return []
-  const contributions: EstimationSourceContribution[] = []
-  for (const dataSource of allDataSources) {
-    if (dataSource.id === dataSourceId) continue
-    if (dataSource.maxScore <= 0) continue
-    const score = studentScores.get(dataSource.id)
-    if (score === null || score === undefined) continue
-    contributions.push({
-      id: dataSource.id,
-      name: dataSource.name,
-      score,
-      maxScore: dataSource.maxScore,
-      ratio: score / dataSource.maxScore,
+): PredictorContribution[] {
+  const predictors: PredictorContribution[] = []
+  for (const predictorSource of allDataSources) {
+    if (predictorSource.id === dataSource.id) continue
+    if (predictorSource.maxScore <= 0) continue
+    const score = matrix.scoreOf(targetRow, predictorSource)
+    if (score === null) continue
+    predictors.push({
+      dataSource: predictorSource,
+      contribution: {
+        id: predictorSource.id,
+        name: predictorSource.name,
+        score,
+        maxScore: predictorSource.maxScore,
+        ratio: score / predictorSource.maxScore,
+      },
     })
   }
-  return contributions
+  return predictors
 }
 
 /**
@@ -167,16 +164,15 @@ function collectPredictorContributions(
  * どのソースにも分散が無い / 対象生徒に使える他ソースが無い場合は average にフォールバック。
  */
 function estimateByZScore(
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
 ): AbsentEstimation | null {
   const predictors = collectPredictorContributions(
-    studentId,
-    dataSourceId,
-    rawScoreMap,
+    targetRow,
+    dataSource,
+    matrix,
     allDataSources
   )
   if (predictors.length === 0) return null
@@ -185,31 +181,31 @@ function estimateByZScore(
   const zValues: number[] = []
   for (const predictor of predictors) {
     const distribution = collectTargetDistribution(
-      studentId,
-      predictor.id,
-      rawScoreMap
+      targetRow,
+      predictor.dataSource,
+      matrix
     )
     if (!distribution || distribution.sd <= 0) continue
-    zValues.push((predictor.score - distribution.mean) / distribution.sd)
+    zValues.push(
+      (predictor.contribution.score - distribution.mean) / distribution.sd
+    )
   }
   if (zValues.length === 0) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "insufficient_samples"
     )
   }
 
-  const target = collectTargetDistribution(studentId, dataSourceId, rawScoreMap)
+  const target = collectTargetDistribution(targetRow, dataSource, matrix)
   if (!target || target.sd <= 0) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "insufficient_samples"
     )
@@ -220,9 +216,9 @@ function estimateByZScore(
   const predicted = target.mean + standardizedStanding * target.sd
 
   return {
-    value: clamp(predicted, 0, maxScore),
+    value: clamp(predicted, 0, dataSource.maxScore),
     effectiveMethod: "zscore",
-    averageSources: predictors,
+    averageSources: predictors.map((predictor) => predictor.contribution),
     standardizedStanding,
     targetMean: target.mean,
     targetStandardDeviation: target.sd,
@@ -236,16 +232,15 @@ function estimateByZScore(
  * 使える他ソースが無い / 当ソースの実測が2名未満なら average にフォールバック。
  */
 function estimateByEquipercentile(
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
 ): AbsentEstimation | null {
   const predictors = collectPredictorContributions(
-    studentId,
-    dataSourceId,
-    rawScoreMap,
+    targetRow,
+    dataSource,
+    matrix,
     allDataSources
   )
   if (predictors.length === 0) return null
@@ -254,31 +249,31 @@ function estimateByEquipercentile(
   const percentiles: number[] = []
   for (const predictor of predictors) {
     const distribution = collectTargetDistribution(
-      studentId,
-      predictor.id,
-      rawScoreMap
+      targetRow,
+      predictor.dataSource,
+      matrix
     )
     if (!distribution) continue
-    percentiles.push(percentileRankOf(predictor.score, distribution.sorted))
+    percentiles.push(
+      percentileRankOf(predictor.contribution.score, distribution.sorted)
+    )
   }
   if (percentiles.length === 0) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "insufficient_samples"
     )
   }
 
-  const target = collectTargetDistribution(studentId, dataSourceId, rawScoreMap)
+  const target = collectTargetDistribution(targetRow, dataSource, matrix)
   if (!target) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "insufficient_samples"
     )
@@ -290,9 +285,9 @@ function estimateByEquipercentile(
   const predicted = quantileOf(percentileRank, target.sorted)
 
   return {
-    value: clamp(predicted, 0, maxScore),
+    value: clamp(predicted, 0, dataSource.maxScore),
     effectiveMethod: "equipercentile",
-    averageSources: predictors,
+    averageSources: predictors.map((predictor) => predictor.contribution),
     percentileRank,
     targetMean: target.mean,
   }
@@ -336,38 +331,26 @@ function quantileOf(p: number, sorted: number[]): number {
  * → 平均比率 × 当該DataSource.maxScore
  */
 function estimateByAverage(
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
 ): AbsentEstimation | null {
-  const studentScores = rawScoreMap.get(studentId)
-  if (!studentScores) return null
-
-  const averageSources: EstimationSourceContribution[] = []
-  let ratioSum = 0
-
-  for (const dataSource of allDataSources) {
-    if (dataSource.id === dataSourceId) continue
-    if (dataSource.maxScore <= 0) continue
-    const score = studentScores.get(dataSource.id)
-    if (score === null || score === undefined) continue
-    const ratio = score / dataSource.maxScore
-    averageSources.push({
-      id: dataSource.id,
-      name: dataSource.name,
-      score,
-      maxScore: dataSource.maxScore,
-      ratio,
-    })
-    ratioSum += ratio
-  }
+  const averageSources = collectPredictorContributions(
+    targetRow,
+    dataSource,
+    matrix,
+    allDataSources
+  ).map((predictor) => predictor.contribution)
 
   if (averageSources.length === 0) return null
-  const averageRatio = ratioSum / averageSources.length
+  const averageRatio =
+    averageSources.reduce(
+      (sum, averageSource) => sum + averageSource.ratio,
+      0
+    ) / averageSources.length
   return {
-    value: clamp(averageRatio * maxScore, 0, maxScore),
+    value: clamp(averageRatio * dataSource.maxScore, 0, dataSource.maxScore),
     effectiveMethod: "average",
     averageSources,
     averageRatio,
@@ -381,35 +364,18 @@ function estimateByAverage(
  * β = (X^T X)^(-1) X^T Y で係数を算出し、対象生徒のスコアを予測。
  */
 function estimateByRegression(
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[]
 ): AbsentEstimation | null {
-  // predictor ID → 表示名（説明変数の項名に使う）
-  const nameByDataSourceId = new Map(
-    allDataSources.map((dataSource) => [dataSource.id, dataSource.name])
+  // 他DataSource（predictor変数）のうち、対象生徒が実測を持つものだけを使う
+  const availablePredictors = allDataSources.filter(
+    (candidate) =>
+      candidate.id !== dataSource.id &&
+      candidate.maxScore > 0 &&
+      matrix.scoreOf(targetRow, candidate) !== null
   )
-
-  // 他DataSourceのID一覧（predictor変数）
-  const predictorDsIds = allDataSources
-    .filter(
-      (dataSource) => dataSource.id !== dataSourceId && dataSource.maxScore > 0
-    )
-    .map((dataSource) => dataSource.id)
-
-  if (predictorDsIds.length === 0) return null
-
-  // 対象生徒のpredictor値を取得
-  const targetStudentScores = rawScoreMap.get(studentId)
-  if (!targetStudentScores) return null
-
-  // 対象生徒が持っているpredictorのみを使用
-  const availablePredictors = predictorDsIds.filter((id) => {
-    const score = targetStudentScores.get(id)
-    return score !== null && score !== undefined
-  })
 
   if (availablePredictors.length === 0) return null
 
@@ -417,16 +383,16 @@ function estimateByRegression(
   const X: number[][] = [] // 各行 = [1, x1, x2, ...] (切片含む)
   const Y: number[] = []
 
-  for (const [otherStudentId, scores] of rawScoreMap) {
-    if (otherStudentId === studentId) continue
-    const y = scores.get(dataSourceId)
-    if (y === null || y === undefined) continue
+  for (const otherRow of matrix.rows) {
+    if (otherRow.gradeStudent.id === targetRow.gradeStudent.id) continue
+    const y = matrix.scoreOf(otherRow, dataSource)
+    if (y === null) continue
 
     const row: number[] = [1] // 切片項
     let complete = true
-    for (const predId of availablePredictors) {
-      const x = scores.get(predId)
-      if (x === null || x === undefined) {
+    for (const predictor of availablePredictors) {
+      const x = matrix.scoreOf(otherRow, predictor)
+      if (x === null) {
         complete = false
         break
       }
@@ -436,6 +402,18 @@ function estimateByRegression(
 
     X.push(row)
     Y.push(y)
+  }
+
+  // 訓練行が1つも集まらなければ回帰は組めない（対象生徒の説明変数を全部揃えた他生徒が
+  // 居ない場合に起こる）。以降は X[0] を参照するのでここで先に落とす。
+  if (X.length === 0) {
+    return fallbackToAverage(
+      targetRow,
+      dataSource,
+      matrix,
+      allDataSources,
+      "insufficient_samples"
+    )
   }
 
   // OLS: β = (X^T X)^(-1) X^T Y。多重共線性がある列はランク落ちで除外して解く。
@@ -451,10 +429,9 @@ function estimateByRegression(
   const minSamples = retainedColumns.length + 1
   if (X.length < minSamples) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "insufficient_samples"
     )
@@ -463,10 +440,9 @@ function estimateByRegression(
   // 独立な説明変数が1つも残らない（切片のみ）＝回帰不能 → 平均比率法にフォールバック
   if (retainedColumns.length <= 1) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "singular_matrix"
     )
@@ -476,10 +452,9 @@ function estimateByRegression(
   const reducedBeta = solveNormalEquations(X, Y, retainedColumns)
   if (!reducedBeta) {
     return fallbackToAverage(
-      studentId,
-      dataSourceId,
-      maxScore,
-      rawScoreMap,
+      targetRow,
+      dataSource,
+      matrix,
       allDataSources,
       "singular_matrix"
     )
@@ -495,10 +470,10 @@ function estimateByRegression(
 
   // 対象生徒のpredictor値で予測（従属列は係数0なので寄与しない）。
   // 構造的恒等式（合計＝小計の和）は対象生徒でも成り立つため、どの従属列を落としても予測値は不変。
-  const xTarget = [1]
-  for (const predId of availablePredictors) {
-    xTarget.push(targetStudentScores.get(predId)!)
-  }
+  // availablePredictors は「対象生徒が実測を持つ」で絞ってあるので scoreOf は非null。
+  const targetScoreOf = (predictor: DataSourceInfo): number =>
+    matrix.scoreOf(targetRow, predictor) ?? 0
+  const xTarget = [1, ...availablePredictors.map(targetScoreOf)]
 
   let predicted = 0
   for (let j = 0; j < p; j++) {
@@ -509,21 +484,20 @@ function estimateByRegression(
   // ランク落ち除外した従属列は droppedPredictors に回す。
   const regressionTerms: EstimationRegressionTerm[] = []
   const droppedPredictors: EstimationDroppedPredictor[] = []
-  availablePredictors.forEach((predId, index) => {
+  availablePredictors.forEach((predictor, index) => {
     const column = index + 1
-    const name = nameByDataSourceId.get(predId) ?? predId
     if (retainedColumnSet.has(column)) {
       regressionTerms.push({
-        id: predId,
-        name,
-        value: targetStudentScores.get(predId)!,
+        id: predictor.id,
+        name: predictor.name,
+        value: targetScoreOf(predictor),
         coefficient: beta[column],
       })
     } else {
       droppedPredictors.push({
-        id: predId,
-        name,
-        value: targetStudentScores.get(predId)!,
+        id: predictor.id,
+        name: predictor.name,
+        value: targetScoreOf(predictor),
       })
     }
   })
@@ -537,7 +511,7 @@ function estimateByRegression(
   )
 
   return {
-    value: clamp(predicted, 0, maxScore),
+    value: clamp(predicted, 0, dataSource.maxScore),
     effectiveMethod: "regression",
     intercept: beta[0],
     regressionTerms,
@@ -551,18 +525,16 @@ function estimateByRegression(
  * averageの推定結果にフォールバック理由を付与して返す。
  */
 function fallbackToAverage(
-  studentId: string,
-  dataSourceId: string,
-  maxScore: number,
-  rawScoreMap: Map<string, Map<string, number | null>>,
+  targetRow: EstimationRow,
+  dataSource: DataSourceInfo,
+  matrix: EstimationMatrix,
   allDataSources: DataSourceInfo[],
   reason: EstimationFallbackReason
 ): AbsentEstimation | null {
   const fallback = estimateByAverage(
-    studentId,
-    dataSourceId,
-    maxScore,
-    rawScoreMap,
+    targetRow,
+    dataSource,
+    matrix,
     allDataSources
   )
   if (fallback === null) return null
@@ -743,29 +715,29 @@ function multipleCorrelationR(
  * @returns { correlation, sampleSize } または算出不能時 null
  */
 export function computeSourceFit(
-  dataSourceId: string,
-  predictorIds: string[],
-  rawScoreMap: Map<string, Map<string, number | null>>
+  dataSource: DataSourceInfo,
+  predictors: DataSourceInfo[],
+  matrix: EstimationMatrix
 ): { correlation: number; sampleSize: number } | null {
-  if (predictorIds.length === 0) return null
+  if (predictors.length === 0) return null
 
   const X: number[][] = []
   const Y: number[] = []
-  for (const [, scores] of rawScoreMap) {
-    const y = scores.get(dataSourceId)
-    if (y === null || y === undefined) continue
-    const row: number[] = [1]
+  for (const row of matrix.rows) {
+    const y = matrix.scoreOf(row, dataSource)
+    if (y === null) continue
+    const designRow: number[] = [1]
     let complete = true
-    for (const predictorId of predictorIds) {
-      const x = scores.get(predictorId)
-      if (x === null || x === undefined) {
+    for (const predictor of predictors) {
+      const x = matrix.scoreOf(row, predictor)
+      if (x === null) {
         complete = false
         break
       }
-      row.push(x)
+      designRow.push(x)
     }
     if (!complete) continue
-    X.push(row)
+    X.push(designRow)
     Y.push(y)
   }
 

--- a/electron-src/lib/shared/calculations/gradeCalculator.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculator.ts
@@ -24,12 +24,15 @@ import {
 } from "./absentEstimation"
 import { findExamStudentScores } from "./examScoreCalculator"
 import type { DataSourceInfo, ExamDataCache } from "./gradeCalculatorTypes"
+import { gradeStudentForCalcInclude } from "./gradeCalculatorTypes"
 import { determineGradeLabel } from "./gradeLabel"
 import { findCourseworkStudentScore, getRawScore } from "./rawScoreCalculator"
+import type { RawScoreCell, RawScoreRow } from "./rawScoreMatrix"
+import { RawScoreMatrix } from "./rawScoreMatrix"
 import { resolveEffectiveScores } from "./scoreResolution"
 
 /**
- * 素点行列（rawScoreMap）と推定に必要な付随データを構築する。
+ * 素点行列と推定に必要な付随データを構築する。
  * calculateGrades のパス1と computeSourceFits が共有する（素点組み立ての単一実装＝SSOT）。
  * @returns 構築した文脈。Grade が存在しない場合は null。
  */
@@ -82,18 +85,14 @@ async function buildGradeCalcContext(gradeId: string) {
 
   if (!grade) return null
 
-  // 2. 試験の登録生徒一覧を取得
-  const examStudents = await prisma.gradeStudent.findMany({
+  // 2. 成績の対象者一覧を取得。
+  //
+  // 上書き・確定値・除外設定は対象者の子として同じクエリで引く。以前は Grade 単位で
+  // 別々に引いて `${studentId}:${gradeItemId}` の文字列キーで突き合わせており、
+  // 名簿に居ない生徒の設定も一緒に読み込んでいた（#962 §3.3）。
+  const gradeStudents = await prisma.gradeStudent.findMany({
     where: { gradeId },
-    include: {
-      student: {
-        include: {
-          memberships: {
-            include: { classroom: { select: { id: true, name: true } } },
-          },
-        },
-      },
-    },
+    include: gradeStudentForCalcInclude,
     orderBy: [{ customOrder: "asc" }, { createdAt: "asc" }],
   })
 
@@ -101,27 +100,7 @@ async function buildGradeCalcContext(gradeId: string) {
     (gradeClassroom) => gradeClassroom.classroomId
   )
 
-  // 3. 上書きデータを取得
-  const overrides = await prisma.gradeOverride.findMany({
-    where: { gradeId },
-  })
-  const overrideMap = new Map<string, string>()
-  for (const override of overrides) {
-    const key = `${override.studentId}:${override.gradeItemId}`
-    overrideMap.set(key, override.overrideLabel)
-  }
-
-  // 3.5. 除外データを取得
-  const exclusions = await prisma.gradeItemExclusion.findMany({
-    where: { gradeId },
-  })
-  const exclusionSet = new Set(
-    exclusions.map(
-      (exclusion) => `${exclusion.studentId}:${exclusion.gradeItemId}`
-    )
-  )
-
-  // 4. 全DataSourceから使用される試験試験IDを収集
+  // 3. 全DataSourceから使用される試験試験IDを収集
   const allDataSources = grade.gradeItems.flatMap(
     (gradeItem) => gradeItem.dataSources
   )
@@ -139,7 +118,7 @@ async function buildGradeCalcContext(gradeId: string) {
     ),
   ]
 
-  // 5. 試験のスコアデータを事前取得
+  // 4. 試験のスコアデータを事前取得
   //
   // 起点は ExamStudent（その試験の受験者）で、採点行はその子として引く。
   // 「試験から外した生徒の採点行」は受験者が居ないので構造的に集まらない
@@ -237,15 +216,19 @@ async function buildGradeCalcContext(gradeId: string) {
     }
   })
 
-  // === パス1: 全生徒 × 全DataSourceの rawScore を収集 ===
-  // Map<studentId, Map<dataSourceId, number | null>>
-  const rawScoreMap = new Map<string, Map<string, number | null>>()
+  // データソース id → 実体。素点行列のセルへ列の実体を同梱するために引く
+  const dataSourceInfoById = new Map(
+    dataSourceInfos.map((dataSourceInfo) => [dataSourceInfo.id, dataSourceInfo])
+  )
 
-  for (const examStudent of examStudents) {
-    const studentScores = new Map<string, number | null>()
+  // === パス1: 全対象者 × 全DataSourceの rawScore を収集して素点行列を組む ===
+  const rawScoreRows: RawScoreRow[] = []
+
+  for (const gradeStudent of gradeStudents) {
+    const cells: RawScoreCell[] = []
     for (const dataSource of allDataSources) {
       let raw = await getRawScore(
-        examStudent.student.id,
+        gradeStudent.studentId,
         dataSource,
         examDataCache
       )
@@ -258,7 +241,7 @@ async function buildGradeCalcContext(gradeId: string) {
         dataSource.examId
       ) {
         const examStudentScores = findExamStudentScores(
-          examStudent.student.id,
+          gradeStudent.studentId,
           dataSource.examId,
           examDataCache
         )
@@ -267,20 +250,19 @@ async function buildGradeCalcContext(gradeId: string) {
         }
       }
 
-      studentScores.set(dataSource.id, raw)
+      const dataSourceInfo = dataSourceInfoById.get(dataSource.id)
+      if (dataSourceInfo)
+        cells.push({ dataSource: dataSourceInfo, rawScore: raw })
     }
-    rawScoreMap.set(examStudent.student.id, studentScores)
+    rawScoreRows.push({ gradeStudent, cells })
   }
 
   return {
     grade,
-    examStudents,
     classroomIds,
-    overrideMap,
-    exclusionSet,
     liveMaxScoreMap,
     dataSourceInfos,
-    rawScoreMap,
+    rawScoreMatrix: new RawScoreMatrix(rawScoreRows),
     allDataSources,
   }
 }
@@ -322,7 +304,7 @@ export async function computeSourceFits(gradeId: string): Promise<{
     if (!context) {
       return { success: false, error: "Grade exam not found" }
     }
-    const { dataSourceInfos, rawScoreMap, allDataSources } = context
+    const { dataSourceInfos, rawScoreMatrix, allDataSources } = context
 
     // 構造的兄弟（同一試験/資料）の同定キー。R算出時に説明変数から除外する。
     const groupKeyById = new Map<string, string>()
@@ -345,7 +327,7 @@ export async function computeSourceFits(gradeId: string): Promise<{
       // 派生値なので「兄弟だけ在る partial 欠測」は起きず、Rと推定が乖離するケースは生じない。
       // selected で兄弟のみ選んだ退化構成では R=算出不能 になるが、その構成では実推定も兄弟を使えず
       // average へ落ちるため、算出不能の表示は誠実（レビュー指摘#1への回答）。
-      const predictorIds = (
+      const predictors = (
         dataSourceInfo.estimationMode === "selected"
           ? dataSourceInfos.filter((candidate) =>
               dataSourceInfo.estimationSourceIds.includes(candidate.id)
@@ -358,12 +340,11 @@ export async function computeSourceFits(gradeId: string): Promise<{
         .filter(
           (candidate) => groupKeyById.get(candidate.id) !== targetGroupKey
         )
-        .map((candidate) => candidate.id)
 
       fits[dataSourceInfo.id] = computeSourceFit(
-        dataSourceInfo.id,
-        predictorIds,
-        rawScoreMap
+        dataSourceInfo,
+        predictors,
+        rawScoreMatrix
       )
     }
     return { success: true, fits }
@@ -416,32 +397,11 @@ export async function calculateGrades(
     }
     const {
       grade,
-      examStudents,
       classroomIds,
-      overrideMap,
-      exclusionSet,
       liveMaxScoreMap,
       dataSourceInfos,
-      rawScoreMap,
+      rawScoreMatrix,
     } = context
-
-    // 確定（凍結）済みセルを (studentId, gradeItemId) で引けるようにする。
-    // 序数ではなく id の組でキーする（生徒の並べ替え・項目の追加でずれないため）。
-    const frozenByCell = new Map<
-      string,
-      Awaited<ReturnType<typeof prisma.gradeFrozenScore.findMany>>[number]
-    >()
-    if (applyFrozen) {
-      const frozenScores = await prisma.gradeFrozenScore.findMany({
-        where: { gradeId: grade.id },
-      })
-      for (const frozenScore of frozenScores) {
-        frozenByCell.set(
-          `${frozenScore.studentId}:${frozenScore.gradeItemId}`,
-          frozenScore
-        )
-      }
-    }
 
     // 各ソースの実測素点分布（平均・標準偏差）はソース単位で一定なので、生徒ループの外で
     // 1ソース1回だけ算出してマップ化する。閲覧生徒は除外しない（＝クラスの実測分布として
@@ -453,23 +413,27 @@ export async function calculateGrades(
     for (const dataSourceInfo of dataSourceInfos) {
       distributionBySource.set(
         dataSourceInfo.id,
-        computeSourceDistribution(dataSourceInfo.id, rawScoreMap)
+        computeSourceDistribution(dataSourceInfo, rawScoreMatrix)
       )
     }
 
     // === パス2: 推定 + 重み付け ===
     const students: StudentGradeResult[] = []
 
-    for (const examStudent of examStudents) {
-      const student = examStudent.student
+    for (const rawScoreRow of rawScoreMatrix.rows) {
+      const gradeStudent = rawScoreRow.gradeStudent
+      const student = gradeStudent.student
       const membership = student.memberships.find((membership) =>
         classroomIds.includes(membership.classroomId)
       )
       const gradeItemResults: GradeItemResult[] = []
 
       for (const gradeItem of grade.gradeItems) {
-        // 除外チェック
-        if (exclusionSet.has(`${student.id}:${gradeItem.id}`)) {
+        // 除外チェック。除外設定は対象者の子なので、この対象者の分しか見えない
+        const isExcluded = gradeStudent.itemExclusions.some(
+          (itemExclusion) => itemExclusion.gradeItemId === gradeItem.id
+        )
+        if (isExcluded) {
           gradeItemResults.push({
             gradeItemId: gradeItem.id,
             gradeItemName: gradeItem.name,
@@ -502,16 +466,17 @@ export async function calculateGrades(
             (sourceInfo) => sourceInfo.id === dataSource.id
           )
 
-          const studentScores = rawScoreMap.get(student.id)
-          let rawScore = studentScores?.get(dataSource.id) ?? null
+          let rawScore = dataSourceInfo
+            ? rawScoreMatrix.scoreOf(rawScoreRow, dataSourceInfo)
+            : null
           let isEstimated = false
           let estimationDetail: EstimationDetail | null = null
 
           // rawScoreがnullかつ推定設定がある場合、代替スコアを算出
-          if (rawScore === null && absentMethod !== "null") {
+          if (rawScore === null && absentMethod !== "null" && dataSourceInfo) {
             // ソース選択対応: estimationMode === "selected" の場合、指定IDのみ使用
             const sourcesToUse =
-              dataSourceInfo?.estimationMode === "selected"
+              dataSourceInfo.estimationMode === "selected"
                 ? dataSourceInfos.filter((sourceInfo) =>
                     dataSourceInfo.estimationSourceIds.includes(sourceInfo.id)
                   )
@@ -519,10 +484,9 @@ export async function calculateGrades(
 
             const estimation = estimateAbsentScore(
               absentMethod,
-              student.id,
-              dataSource.id,
-              maxScore,
-              rawScoreMap,
+              rawScoreRow,
+              dataSourceInfo,
+              rawScoreMatrix,
               sourcesToUse
             )
             if (estimation !== null) {
@@ -647,12 +611,20 @@ export async function calculateGrades(
           percentage,
           boundarySet?.boundaries ?? []
         )
-        const itemOverrideKey = `${student.id}:${gradeItem.id}`
-        const overrideGradeLabel = overrideMap.get(itemOverrideKey) ?? null
+        // 上書き・確定値も対象者の子。この対象者の分しか見えないので、名簿から外した
+        // 生徒の設定を拾うことは構造的に起こらない
+        const overrideGradeLabel =
+          gradeStudent.overrides.find(
+            (override) => override.gradeItemId === gradeItem.id
+          )?.overrideLabel ?? null
         // ライブの実効値＝自動算出を手動上書きで調整した後の値。確定操作はこれを取り込む。
         const liveGradeLabel = overrideGradeLabel ?? originalGradeLabel
 
-        const frozenScore = frozenByCell.get(`${student.id}:${gradeItem.id}`)
+        const frozenScore = applyFrozen
+          ? gradeStudent.frozenScores.find(
+              (candidate) => candidate.gradeItemId === gradeItem.id
+            )
+          : undefined
         if (frozenScore) {
           const frozenWeightedScore =
             frozenScore.weightedScore !== null
@@ -709,6 +681,7 @@ export async function calculateGrades(
       }
 
       students.push({
+        gradeStudentId: gradeStudent.id,
         studentId: student.id,
         studentNumber: student.studentNumber,
         lastName: student.lastName,
@@ -772,14 +745,10 @@ export async function calculateGrades(
  * 意味論が異なる（あちらは対象生徒を母数から除く leave-one-out ＋整列列を返す）ため別実装。
  */
 function computeSourceDistribution(
-  dataSourceId: string,
-  rawScoreMap: Map<string, Map<string, number | null>>
+  dataSource: DataSourceInfo,
+  rawScoreMatrix: RawScoreMatrix
 ): EstimationTargetDistribution | undefined {
-  const scores: number[] = []
-  for (const [, studentScores] of rawScoreMap) {
-    const score = studentScores.get(dataSourceId)
-    if (score !== null && score !== undefined) scores.push(score)
-  }
+  const scores = rawScoreMatrix.measuredColumn(dataSource)
   if (scores.length < 2) return undefined
   const mean = scores.reduce((sum, score) => sum + score, 0) / scores.length
   const variance =

--- a/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
+++ b/electron-src/lib/shared/calculations/gradeCalculatorTypes.ts
@@ -3,8 +3,34 @@
  * gradeCalculator / rawScoreCalculator / examScoreCalculator / absentEstimation で共有する。
  */
 
+import type { Prisma } from "@prisma/client"
+
 import type { AbsentMethod } from "../../../../src/types/grade.types"
 import type { QuestionScoreForSubtotal } from "./subtotalCalculator"
+
+/**
+ * 成績算出が読む対象者1行分の include。
+ *
+ * 上書き・確定値・除外設定は対象者の子なので、行と一緒に引けば「その対象者のセル」が
+ * 経路上に必ず現れる。名簿に居ない生徒の設定を拾うことは構造的に起こらない（#962）。
+ */
+export const gradeStudentForCalcInclude = {
+  student: {
+    include: {
+      memberships: {
+        include: { classroom: { select: { id: true, name: true } } },
+      },
+    },
+  },
+  overrides: true,
+  frozenScores: true,
+  itemExclusions: true,
+} satisfies Prisma.GradeStudentInclude
+
+/** 成績算出のループ軸となる対象者1行（人・所属・セル設定つき） */
+export type GradeStudentForCalc = Prisma.GradeStudentGetPayload<{
+  include: typeof gradeStudentForCalcInclude
+}>
 
 /**
  * 試験の受験者1人分の解決済みスコア。

--- a/electron-src/lib/shared/calculations/rawScoreMatrix.ts
+++ b/electron-src/lib/shared/calculations/rawScoreMatrix.ts
@@ -1,0 +1,99 @@
+/**
+ * 素点行列（対象者 × データソース）
+ *
+ * 以前は `Map<studentId, Map<dataSourceId, number | null>>` だった。DB に
+ * 「その生徒のその成績での行」を表す実体が無く、2つの id を突き合わせるしかなかったためで、
+ * 裸の string へ射影した時点で型の守りが外れていた（studentId と dataSourceId は
+ * どちらも string なので、取り違えても Map は黙って undefined を返す）。
+ *
+ * GradeStudent が子を持つようになり実体で引けるようになったので、行はその成績の対象者を、
+ * セルは列のデータソースを同梱する（#962 §3.3）。索引は内部に閉じ、公開する API は
+ * すべて実体を受け取る。
+ */
+
+import type {
+  DataSourceInfo,
+  GradeStudentForCalc,
+} from "./gradeCalculatorTypes"
+
+/**
+ * 行の実体に求める最小限の形＝同定できること。
+ * 行列と推定は行を「識別して素点を引く」ためにしか使わないので、
+ * 実際に何の実体かは呼び出し側（成績算出では GradeStudent）が決める。
+ */
+export interface RawScoreRowEntity {
+  id: string
+}
+
+/** 素点行列の1セル。列の実体（データソース）と素点を同梱する */
+export interface RawScoreCell {
+  dataSource: DataSourceInfo
+  /** 推定前の実測素点。未実施・未採点なら null（推定値はここには入らない） */
+  rawScore: number | null
+}
+
+/** 素点行列の1行。行の主語はその成績の対象者（GradeStudent） */
+export interface RawScoreRow<
+  TGradeStudent extends RawScoreRowEntity = GradeStudentForCalc,
+> {
+  gradeStudent: TGradeStudent
+  cells: RawScoreCell[]
+}
+
+/**
+ * 素点行列。行＝対象者、列＝データソース。
+ *
+ * 推定（absentEstimation）とモデル適合度（computeSourceFit）が共有する読み取り専用の入力で、
+ * 構築は gradeCalculator の buildGradeCalcContext が一手に担う（素点組み立ての単一実装）。
+ */
+export class RawScoreMatrix<
+  TGradeStudent extends RawScoreRowEntity = GradeStudentForCalc,
+> {
+  readonly rows: readonly RawScoreRow<TGradeStudent>[]
+  /** 行の id → セル（データソース id 引き）。公開 API は実体しか受け取らない */
+  private readonly cellIndex: Map<string, Map<string, RawScoreCell>>
+
+  constructor(rows: RawScoreRow<TGradeStudent>[]) {
+    this.rows = rows
+    this.cellIndex = new Map(
+      rows.map((row) => [
+        row.gradeStudent.id,
+        new Map(row.cells.map((cell) => [cell.dataSource.id, cell])),
+      ])
+    )
+  }
+
+  /** 指定の行・列のセル。行列に無い組み合わせなら undefined */
+  cellOf(
+    row: RawScoreRow<TGradeStudent>,
+    dataSource: DataSourceInfo
+  ): RawScoreCell | undefined {
+    return this.cellIndex.get(row.gradeStudent.id)?.get(dataSource.id)
+  }
+
+  /** 指定の行・列の素点。セルが無い場合も欠測として null を返す */
+  scoreOf(
+    row: RawScoreRow<TGradeStudent>,
+    dataSource: DataSourceInfo
+  ): number | null {
+    return this.cellOf(row, dataSource)?.rawScore ?? null
+  }
+
+  /**
+   * 指定データソースを実測した素点の列（欠測は除く）。
+   * @param options.except 除く行（leave-one-out。推定対象の生徒自身を母数から外す用途）
+   */
+  measuredColumn(
+    dataSource: DataSourceInfo,
+    options?: { except?: RawScoreRow<TGradeStudent> }
+  ): number[] {
+    const exceptId = options?.except?.gradeStudent.id
+    const scores: number[] = []
+    for (const row of this.rows) {
+      if (exceptId !== undefined && row.gradeStudent.id === exceptId) continue
+      const score = this.scoreOf(row, dataSource)
+      if (score !== null) scores.push(score)
+    }
+    return scores
+  }
+}

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -1,5 +1,10 @@
 import { ipcRenderer } from "electron"
 
+import type {
+  GradeCellTarget,
+  GradeItemExclusionInput,
+} from "../../src/types/grade.types"
+
 /** 成績算出のIPC API（成績CRUD・データソース・評定境界・手動点数・Excel出力） */
 export function createGradeApi() {
   return {
@@ -131,17 +136,11 @@ export function createGradeApi() {
       }) => ipcRenderer.invoke("grade:upsertBoundarySet", data),
       deleteBoundarySet: (id: string) =>
         ipcRenderer.invoke("grade:deleteBoundarySet", id),
-      upsertGradeOverride: (data: {
-        gradeId: string
-        studentId: string
-        gradeItemId: string
-        overrideLabel: string
-      }) => ipcRenderer.invoke("grade:upsertGradeOverride", data),
-      deleteGradeOverride: (data: {
-        gradeId: string
-        studentId: string
-        gradeItemId: string
-      }) => ipcRenderer.invoke("grade:deleteGradeOverride", data),
+      upsertGradeOverride: (
+        data: GradeCellTarget & { overrideLabel: string }
+      ) => ipcRenderer.invoke("grade:upsertGradeOverride", data),
+      deleteGradeOverride: (target: GradeCellTarget) =>
+        ipcRenderer.invoke("grade:deleteGradeOverride", target),
       getGradeConstraints: (gradeId: string) =>
         ipcRenderer.invoke("grade:getGradeConstraints", gradeId),
       createGradeConstraint: (data: {
@@ -174,39 +173,24 @@ export function createGradeApi() {
         ipcRenderer.invoke("grade:deleteGradeConstraint", id),
       getGradeItemExclusions: (gradeId: string) =>
         ipcRenderer.invoke("grade:getGradeItemExclusions", gradeId),
-      setGradeItemExclusion: (data: {
-        gradeId: string
-        studentId: string
-        gradeItemId: string
-        excluded: boolean
-      }) => ipcRenderer.invoke("grade:setGradeItemExclusion", data),
-      batchUpdateGradeItemExclusions: (
-        gradeId: string,
-        updates: {
-          studentId: string
-          gradeItemId: string
-          excluded: boolean
-        }[]
-      ) =>
-        ipcRenderer.invoke(
-          "grade:batchUpdateGradeItemExclusions",
-          gradeId,
-          updates
-        ),
+      setGradeItemExclusion: (input: GradeItemExclusionInput) =>
+        ipcRenderer.invoke("grade:setGradeItemExclusion", input),
+      batchUpdateGradeItemExclusions: (updates: GradeItemExclusionInput[]) =>
+        ipcRenderer.invoke("grade:batchUpdateGradeItemExclusions", updates),
       calculateGrades: (gradeId: string) =>
         ipcRenderer.invoke("grade:calculateGrades", gradeId),
       computeSourceFits: (gradeId: string) =>
         ipcRenderer.invoke("grade:computeSourceFits", gradeId),
       // 成績値の確定（凍結）。targets 未指定は Grade 全体の一括確定・一括解除。
-      // 対象セルの同定は (studentId, gradeItemId)。総合の行は存在しない。
+      // 対象セルの同定は (gradeStudentId, gradeItemId)。総合の行は存在しない。
       freezeGradeScores: (data: {
         gradeId: string
-        targets?: { studentId: string; gradeItemId: string }[]
+        targets?: GradeCellTarget[]
         frozenByUserId?: string | null
       }) => ipcRenderer.invoke("grade:freezeGradeScores", data),
       unfreezeGradeScores: (data: {
         gradeId: string
-        targets?: { studentId: string; gradeItemId: string }[]
+        targets?: GradeCellTarget[]
         userId?: string | null
       }) => ipcRenderer.invoke("grade:unfreezeGradeScores", data),
       getExamCandidates: () => ipcRenderer.invoke("grade:getExamCandidates"),

--- a/prisma/migrations/20260730000000_rewire_grade_cells_to_grade_student/migration.sql
+++ b/prisma/migrations/20260730000000_rewire_grade_cells_to_grade_student/migration.sql
@@ -1,0 +1,124 @@
+-- 成績のセル3種（GradeOverride / GradeFrozenScore / GradeItemExclusion）を
+-- Student 直結から GradeStudent（その成績の対象者）経由へ配線し直す。
+--
+-- これまで3テーブルは (gradeId, studentId) の2列で「その成績のその生徒」を表しており、
+-- GradeStudent という実体があるのにそれを参照していなかった。GradeStudent を参照する
+-- 子テーブルが1つも無かったため「成績から生徒を外す」操作（学級ごとの削除）では
+-- DB の cascade が働かず、名簿から消えた生徒の上書き・確定値・除外設定が残り続けていた。
+-- 残った行は成績算出のループが GradeStudent 軸なので普段は無害だが、同じ生徒を再び
+-- 追加した瞬間に過去の設定が甦る。特に GradeFrozenScore は「確定した成績値」であり、
+-- 教員が知らないうちに古い確定値が復活するのは実害が大きい（#962）。
+--
+-- gradeId / studentId の2列は残さず GradeStudent へ畳む。両方を残すと
+-- gradeId ≠ gradeStudent.gradeId が起こりうるため（ExamStudent 系の
+-- ReturnSnapshot.examId と同じ判断。20260728000000 を参照）。
+--
+-- バックフィルは GradeStudent との INNER JOIN で行うため、孤児は自然に落ちる。
+-- 破棄は削除確認の説明が以前から約束していた挙動であり、仕様変更ではなく仕様への適合。
+-- 破棄件数は AuditLog に記録する（起動時のモーダルは data フォルダの手動コピー運用では
+-- 最初にそのコピーを開いた人にしか出ず、周知手段として機能しないため）。
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+-- ── 1. GradeOverride ────────────────────────────────────────────
+CREATE TABLE "new_GradeOverride" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeStudentId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "overrideLabel" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeOverride_gradeStudentId_fkey" FOREIGN KEY ("gradeStudentId") REFERENCES "GradeStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "GradeOverride_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_GradeOverride" ("id", "gradeStudentId", "gradeItemId", "overrideLabel", "createdAt", "updatedAt")
+SELECT go."id", gs."id", go."gradeItemId", go."overrideLabel", go."createdAt", go."updatedAt"
+FROM "GradeOverride" go
+JOIN "GradeStudent" gs ON gs."gradeId" = go."gradeId" AND gs."studentId" = go."studentId";
+
+-- ── 2. GradeFrozenScore ─────────────────────────────────────────
+CREATE TABLE "new_GradeFrozenScore" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeStudentId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "weightedScore" DECIMAL,
+    "weightedMaxScore" DECIMAL NOT NULL,
+    "percentage" DECIMAL,
+    "gradeLabel" TEXT,
+    "frozenByUserId" TEXT,
+    "frozenAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeFrozenScore_gradeStudentId_fkey" FOREIGN KEY ("gradeStudentId") REFERENCES "GradeStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "GradeFrozenScore_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "GradeFrozenScore_frozenByUserId_fkey" FOREIGN KEY ("frozenByUserId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+INSERT INTO "new_GradeFrozenScore" ("id", "gradeStudentId", "gradeItemId", "weightedScore", "weightedMaxScore", "percentage", "gradeLabel", "frozenByUserId", "frozenAt", "createdAt", "updatedAt")
+SELECT gfs."id", gs."id", gfs."gradeItemId", gfs."weightedScore", gfs."weightedMaxScore", gfs."percentage", gfs."gradeLabel", gfs."frozenByUserId", gfs."frozenAt", gfs."createdAt", gfs."updatedAt"
+FROM "GradeFrozenScore" gfs
+JOIN "GradeStudent" gs ON gs."gradeId" = gfs."gradeId" AND gs."studentId" = gfs."studentId";
+
+-- ── 3. GradeItemExclusion ───────────────────────────────────────
+CREATE TABLE "new_GradeItemExclusion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "gradeStudentId" TEXT NOT NULL,
+    "gradeItemId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GradeItemExclusion_gradeStudentId_fkey" FOREIGN KEY ("gradeStudentId") REFERENCES "GradeStudent" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "GradeItemExclusion_gradeItemId_fkey" FOREIGN KEY ("gradeItemId") REFERENCES "GradeItem" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+INSERT INTO "new_GradeItemExclusion" ("id", "gradeStudentId", "gradeItemId", "createdAt", "updatedAt")
+SELECT gie."id", gs."id", gie."gradeItemId", gie."createdAt", gie."updatedAt"
+FROM "GradeItemExclusion" gie
+JOIN "GradeStudent" gs ON gs."gradeId" = gie."gradeId" AND gs."studentId" = gie."studentId";
+
+-- ── 4. 破棄した孤児の件数を監査ログへ記録（1件以上あるときだけ） ──
+INSERT INTO "AuditLog" ("id", "createdAt", "updatedAt", "userId", "action", "category", "scopeId", "scopeLabel", "entityType", "entityId", "summary", "metadata")
+SELECT
+    lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)), 2) || '-' || substr('89ab', (abs(random()) % 4) + 1, 1) || substr(hex(randomblob(2)), 2) || '-' || hex(randomblob(6))),
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    strftime('%Y-%m-%dT%H:%M:%f', 'now') || '+00:00',
+    NULL,
+    'system.migration.cleanup_orphaned_grade_cells',
+    'system',
+    NULL,
+    NULL,
+    'System',
+    '20260730000000_rewire_grade_cells_to_grade_student',
+    '成績の対象者として登録されていない生徒の上書き・確定値・除外設定 ' ||
+        (((SELECT COUNT(*) FROM "GradeOverride") - (SELECT COUNT(*) FROM "new_GradeOverride"))
+         + ((SELECT COUNT(*) FROM "GradeFrozenScore") - (SELECT COUNT(*) FROM "new_GradeFrozenScore"))
+         + ((SELECT COUNT(*) FROM "GradeItemExclusion") - (SELECT COUNT(*) FROM "new_GradeItemExclusion"))) ||
+        ' 件を、データ移行時に破棄しました。該当する生徒を成績へ再び追加しても、以前の設定は復元されません。',
+    json_object(
+        'gradeOverride', (SELECT COUNT(*) FROM "GradeOverride") - (SELECT COUNT(*) FROM "new_GradeOverride"),
+        'gradeFrozenScore', (SELECT COUNT(*) FROM "GradeFrozenScore") - (SELECT COUNT(*) FROM "new_GradeFrozenScore"),
+        'gradeItemExclusion', (SELECT COUNT(*) FROM "GradeItemExclusion") - (SELECT COUNT(*) FROM "new_GradeItemExclusion")
+    )
+WHERE (((SELECT COUNT(*) FROM "GradeOverride") - (SELECT COUNT(*) FROM "new_GradeOverride"))
+       + ((SELECT COUNT(*) FROM "GradeFrozenScore") - (SELECT COUNT(*) FROM "new_GradeFrozenScore"))
+       + ((SELECT COUNT(*) FROM "GradeItemExclusion") - (SELECT COUNT(*) FROM "new_GradeItemExclusion"))) > 0;
+
+-- ── 5. 差し替えとインデックス再作成 ──────────────────────────────
+DROP TABLE "GradeOverride";
+ALTER TABLE "new_GradeOverride" RENAME TO "GradeOverride";
+CREATE UNIQUE INDEX "GradeOverride_gradeStudentId_gradeItemId_key" ON "GradeOverride"("gradeStudentId", "gradeItemId");
+CREATE INDEX "GradeOverride_gradeStudentId_idx" ON "GradeOverride"("gradeStudentId");
+CREATE INDEX "GradeOverride_gradeItemId_idx" ON "GradeOverride"("gradeItemId");
+
+DROP TABLE "GradeFrozenScore";
+ALTER TABLE "new_GradeFrozenScore" RENAME TO "GradeFrozenScore";
+CREATE UNIQUE INDEX "GradeFrozenScore_gradeStudentId_gradeItemId_key" ON "GradeFrozenScore"("gradeStudentId", "gradeItemId");
+CREATE INDEX "GradeFrozenScore_gradeStudentId_idx" ON "GradeFrozenScore"("gradeStudentId");
+CREATE INDEX "GradeFrozenScore_gradeItemId_idx" ON "GradeFrozenScore"("gradeItemId");
+
+DROP TABLE "GradeItemExclusion";
+ALTER TABLE "new_GradeItemExclusion" RENAME TO "GradeItemExclusion";
+CREATE UNIQUE INDEX "GradeItemExclusion_gradeStudentId_gradeItemId_key" ON "GradeItemExclusion"("gradeStudentId", "gradeItemId");
+CREATE INDEX "GradeItemExclusion_gradeStudentId_idx" ON "GradeItemExclusion"("gradeStudentId");
+CREATE INDEX "GradeItemExclusion_gradeItemId_idx" ON "GradeItemExclusion"("gradeItemId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,22 +46,19 @@ model Classroom {
 }
 
 model Student {
-  id                  String                       @id @default(uuid())
-  studentNumber       String                       @unique
-  lastName            String
-  firstName           String
-  lastNameKana        String
-  firstNameKana       String
-  enrollmentYear      Int?
-  createdAt           DateTime                     @default(now())
-  updatedAt           DateTime                     @updatedAt
-  examStudents        ExamStudent[]
-  memberships         StudentClassroomMembership[]
-  gradeStudents       GradeStudent[]
-  gradeOverrides      GradeOverride[]
-  gradeFrozenScores   GradeFrozenScore[]
-  gradeItemExclusions GradeItemExclusion[]
-  courseworkStudents  CourseworkStudent[]
+  id                 String                       @id @default(uuid())
+  studentNumber      String                       @unique
+  lastName           String
+  firstName          String
+  lastNameKana       String
+  firstNameKana      String
+  enrollmentYear     Int?
+  createdAt          DateTime                     @default(now())
+  updatedAt          DateTime                     @updatedAt
+  examStudents       ExamStudent[]
+  memberships        StudentClassroomMembership[]
+  gradeStudents      GradeStudent[]
+  courseworkStudents CourseworkStudent[]
 }
 
 model StudentClassroomMembership {
@@ -670,15 +667,12 @@ model Grade {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
-  gradeItems          GradeItem[]
-  boundarySets        GradeBoundarySet[]
-  gradeClassrooms     GradeClassroom[]
-  gradeStudents       GradeStudent[]
-  gradeOverrides      GradeOverride[]
-  gradeFrozenScores   GradeFrozenScore[]
-  gradeItemExclusions GradeItemExclusion[]
-  gradeConstraints    GradeConstraint[]
-  exportSettings      GradeExportSettings?
+  gradeItems       GradeItem[]
+  boundarySets     GradeBoundarySet[]
+  gradeClassrooms  GradeClassroom[]
+  gradeStudents    GradeStudent[]
+  gradeConstraints GradeConstraint[]
+  exportSettings   GradeExportSettings?
 }
 
 /// 観点間の制約ルール（不適切な観点/評定の組合せを検知して着色）
@@ -789,9 +783,9 @@ model GradeItem {
   grade                Grade                      @relation(fields: [gradeId], references: [id], onDelete: Cascade)
   dataSources          GradeDataSource[]
   boundarySets         GradeBoundarySet[]
-  gradeOverrides       GradeOverride[]
-  gradeFrozenScores    GradeFrozenScore[]
-  gradeItemExclusions  GradeItemExclusion[]
+  overrides            GradeOverride[]
+  frozenScores         GradeFrozenScore[]
+  itemExclusions       GradeItemExclusion[]
   constraintTargets    GradeConstraint[]          @relation("GradeConstraintTarget")
   constraintViewpoints GradeConstraintViewpoint[]
 
@@ -824,8 +818,11 @@ model GradeStudent {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  grade   Grade   @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  student Student @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  grade          Grade                @relation(fields: [gradeId], references: [id], onDelete: Cascade)
+  student        Student              @relation(fields: [studentId], references: [id], onDelete: Cascade)
+  overrides      GradeOverride[]
+  frozenScores   GradeFrozenScore[]
+  itemExclusions GradeItemExclusion[]
 
   @@unique([gradeId, studentId])
   @@index([gradeId])
@@ -899,21 +896,20 @@ model GradeDataSourceEstimationSource {
 }
 
 /// 評価項目ごとの対象生徒除外設定
+/// 評価項目を成績算出から外す設定。対象は「その成績の対象者（GradeStudent）× 評価項目」で、
+/// 人（Student）ではない。名簿から外された生徒の除外設定は存在しえない（#962）。
 model GradeItemExclusion {
-  id          String   @id @default(uuid())
-  gradeId     String
-  studentId   String
-  gradeItemId String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id             String   @id @default(uuid())
+  gradeStudentId String
+  gradeItemId    String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  grade     Grade     @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  student   Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
-  gradeItem GradeItem @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+  gradeStudent GradeStudent @relation(fields: [gradeStudentId], references: [id], onDelete: Cascade)
+  gradeItem    GradeItem    @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
 
-  @@unique([gradeId, studentId, gradeItemId])
-  @@index([gradeId])
-  @@index([studentId])
+  @@unique([gradeStudentId, gradeItemId])
+  @@index([gradeStudentId])
   @@index([gradeItemId])
 }
 
@@ -938,22 +934,21 @@ model GradeBoundarySet {
 }
 
 /// 成績ラベルの手動上書き（生徒×評価項目）。総合の行は持たない（GradeBoundarySet と同じ理由）
+/// 成績ラベルの手動上書き。対象は「その成績の対象者（GradeStudent）× 評価項目」で、
+/// 人（Student）ではない。名簿から外された生徒の上書きは存在しえない（#962）。
 model GradeOverride {
-  id            String   @id @default(uuid())
-  gradeId       String
-  studentId     String
-  gradeItemId   String
-  overrideLabel String
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id             String   @id @default(uuid())
+  gradeStudentId String
+  gradeItemId    String
+  overrideLabel  String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  grade     Grade     @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  student   Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
-  gradeItem GradeItem @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+  gradeStudent GradeStudent @relation(fields: [gradeStudentId], references: [id], onDelete: Cascade)
+  gradeItem    GradeItem    @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
 
-  @@unique([gradeId, studentId, gradeItemId])
-  @@index([gradeId])
-  @@index([studentId])
+  @@unique([gradeStudentId, gradeItemId])
+  @@index([gradeStudentId])
   @@index([gradeItemId])
 }
 
@@ -964,14 +959,15 @@ model GradeOverride {
 /// 調整の記録で、こちらは「その調整の結果を含む今の値をこれで確定する」という凍結。
 /// 算出時の採用順は 確定値 > 手動上書き > リアルタイム算出値。
 ///
-/// 対象は生徒×評価項目のみ。総合（overall）の行は作らない — 総合の境界セットを作る導線が
-/// UI に存在せず評定自体が GradeItem の一つとして運用されているため。これにより gradeItemId を
-/// NOT NULL にでき、SQLite が unique 制約で NULL を互いに別物と扱う罠も踏まない。
+/// 対象は「その成績の対象者（GradeStudent）× 評価項目」のみ。人（Student）ではないので、
+/// 名簿から外された生徒の確定値は存在しえない（#962。以前は外して再追加すると確定値が甦った）。
+/// 総合（overall）の行は作らない — 総合の境界セットを作る導線が UI に存在せず評定自体が
+/// GradeItem の一つとして運用されているため。これにより gradeItemId を NOT NULL にでき、
+/// SQLite が unique 制約で NULL を互いに別物と扱う罠も踏まない。
 model GradeFrozenScore {
-  id          String @id @default(uuid())
-  gradeId     String
-  studentId   String
-  gradeItemId String
+  id             String @id @default(uuid())
+  gradeStudentId String
+  gradeItemId    String
 
   /// 確定時の重み付け得点。全ソース欠測など算出不能なら null
   weightedScore    Decimal?
@@ -988,14 +984,12 @@ model GradeFrozenScore {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @default(now()) @updatedAt
 
-  grade     Grade     @relation(fields: [gradeId], references: [id], onDelete: Cascade)
-  student   Student   @relation(fields: [studentId], references: [id], onDelete: Cascade)
-  gradeItem GradeItem @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
-  frozenBy  User?     @relation(fields: [frozenByUserId], references: [id], onDelete: SetNull)
+  gradeStudent GradeStudent @relation(fields: [gradeStudentId], references: [id], onDelete: Cascade)
+  gradeItem    GradeItem    @relation(fields: [gradeItemId], references: [id], onDelete: Cascade)
+  frozenBy     User?        @relation(fields: [frozenByUserId], references: [id], onDelete: SetNull)
 
-  @@unique([gradeId, studentId, gradeItemId])
-  @@index([gradeId])
-  @@index([studentId])
+  @@unique([gradeStudentId, gradeItemId])
+  @@index([gradeStudentId])
   @@index([gradeItemId])
 }
 

--- a/src/components/common/classroom-roster/ClassroomRemovalDialog.tsx
+++ b/src/components/common/classroom-roster/ClassroomRemovalDialog.tsx
@@ -43,6 +43,11 @@ interface ClassroomRemovalDialogProps {
     entry: ClassroomRosterEntry,
     deleteStudents: boolean
   ) => Promise<void>
+  /**
+   * 専属生徒を削除したときに連動して消えるものの列挙。
+   * 生徒の削除は対象者ごと消すので、その子データも DB の cascade で失われる（#962）。
+   */
+  deletionLosses?: string[]
   onClose: () => void
 }
 
@@ -61,6 +66,7 @@ export function ClassroomRemovalDialog({
   mode,
   fetchRemovalPreview,
   onConfirm,
+  deletionLosses,
   onClose,
 }: ClassroomRemovalDialogProps) {
   const [choice, setChoice] = useState<RemovalChoice>("unlink")
@@ -239,10 +245,23 @@ export function ClassroomRemovalDialog({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>生徒データを削除しますか？</AlertDialogTitle>
-            <AlertDialogDescription>
-              「{finalConfirmEntry?.name}」にのみ所属する {deleteCount}名 の
-              生徒と、その入力済みデータも削除されます。この操作は取り消せません。
-              本当に削除しますか？
+            <AlertDialogDescription className="space-y-2">
+              <span className="block">
+                「{finalConfirmEntry?.name}」にのみ所属する {deleteCount}名 を
+                対象から外します。連動して以下も削除されます：
+              </span>
+              <span className="text-muted-foreground block pl-4">
+                {(deletionLosses ?? ["その生徒の入力済みデータ"]).map(
+                  (loss) => (
+                    <span key={loss} className="block">
+                      ・{loss}
+                    </span>
+                  )
+                )}
+              </span>
+              <span className="block font-medium">
+                この操作は取り消せません。本当に削除しますか？
+              </span>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/common/classroom-roster/ClassroomRosterManager.tsx
+++ b/src/components/common/classroom-roster/ClassroomRosterManager.tsx
@@ -62,6 +62,8 @@ interface ClassroomRosterManagerProps {
   fetchRemovalPreview?: (
     entry: ClassroomRosterEntry
   ) => Promise<ClassroomRemovalPreview>
+  /** 専属生徒を削除したときに連動して消えるもの（最終確認に列挙する） */
+  deletionLosses?: string[]
   /** 変更後に親へ再読込を通知 */
   onChanged?: () => void
   /** 追加ダイアログの外部制御（任意） */
@@ -142,6 +144,7 @@ export function ClassroomRosterManager({
   onReorder,
   onRemove,
   fetchRemovalPreview,
+  deletionLosses,
   onChanged,
   showAddDialog: externalShowAddDialog,
   onShowAddDialogChange,
@@ -284,6 +287,7 @@ export function ClassroomRosterManager({
         entry={removalTarget}
         mode={removalMode}
         fetchRemovalPreview={fetchRemovalPreview}
+        deletionLosses={deletionLosses}
         onConfirm={async (entry, deleteStudents) => {
           await onRemove(entry, deleteStudents)
           onChanged?.()

--- a/src/components/common/roster-table/RosterTable.tsx
+++ b/src/components/common/roster-table/RosterTable.tsx
@@ -70,6 +70,12 @@ export function RosterTable({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [showResetDialog, setShowResetDialog] = useState(false)
   const [isResetting, setIsResetting] = useState(false)
+  /** 削除確認の対象。null なら確認ダイアログを出していない */
+  const [pendingRemovalIds, setPendingRemovalIds] = useState<string[] | null>(
+    null
+  )
+  const [isRemoving, setIsRemoving] = useState(false)
+  const [removalError, setRemovalError] = useState<string | null>(null)
 
   const additionalColumns = useMemo(
     () => slots?.additionalColumns ?? [],
@@ -207,21 +213,24 @@ export function RosterTable({
     }
   }
 
-  const handleRemoveSelected = async () => {
-    const ids = Array.from(selectedIds)
-    if (ids.length === 0) return
-
-    if (slots?.onBeforeRemove) {
-      const proceed = await slots.onBeforeRemove(ids)
-      if (!proceed) return
-    }
-
+  const handleConfirmRemove = async () => {
+    if (!pendingRemovalIds) return
+    setIsRemoving(true)
+    setRemovalError(null)
     try {
-      await adapter.removeRows(ids)
+      await adapter.removeRows(pendingRemovalIds)
       setSelectedIds(new Set())
       await loadData()
+      setPendingRemovalIds(null)
     } catch (error) {
+      // 失敗はダイアログを開いたまま伝える。閉じてしまうと console 以外に痕跡が残らず、
+      // 消えていないのに消えたように見える
       console.error("Failed to remove rows:", error)
+      setRemovalError(
+        error instanceof Error ? error.message : "削除に失敗しました"
+      )
+    } finally {
+      setIsRemoving(false)
     }
   }
 
@@ -241,7 +250,7 @@ export function RosterTable({
           <Button
             variant="destructive"
             size="sm"
-            onClick={handleRemoveSelected}
+            onClick={() => setPendingRemovalIds(Array.from(selectedIds))}
           >
             選択した生徒を削除 ({selectedIds.size})
           </Button>
@@ -321,6 +330,64 @@ export function RosterTable({
               disabled={isResetting}
             >
               {isResetting ? "リセット中..." : "リセット"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 生徒削除の確認ダイアログ。名簿から外すと子データも cascade で消えるため、
+          何が失われるかを事前に明示する（試験05の削除確認と同じ扱い） */}
+      <AlertDialog
+        open={pendingRemovalIds !== null}
+        onOpenChange={(open) => {
+          if (!open && !isRemoving) {
+            setPendingRemovalIds(null)
+            setRemovalError(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              選択した生徒{pendingRemovalIds?.length ?? 0}名を削除しますか？
+            </AlertDialogTitle>
+            <AlertDialogDescription className="space-y-2">
+              <span className="block">
+                生徒を削除すると、以下のデータも連動して削除されます：
+              </span>
+              <span className="text-muted-foreground block pl-4">
+                {(slots?.removalLosses ?? ["この名簿に入力された値"]).map(
+                  (loss) => (
+                    <span key={loss} className="block">
+                      ・{loss}
+                    </span>
+                  )
+                )}
+              </span>
+              <span className="block font-medium">
+                この操作は取り消すことができません。
+              </span>
+              {removalError && (
+                <span className="text-destructive block font-medium">
+                  {removalError}
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRemoving}>
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              // 既定の「クリックで閉じる」を止め、削除が終わるまでダイアログを残す。
+              // 閉じてしまうと進行表示も失敗通知も出せない。
+              onClick={(event) => {
+                event.preventDefault()
+                void handleConfirmRemove()
+              }}
+              disabled={isRemoving}
+            >
+              {isRemoving ? "削除中..." : "削除"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/common/roster-table/types.ts
+++ b/src/components/common/roster-table/types.ts
@@ -97,8 +97,11 @@ export interface RosterTableSlots {
     cellClassName?: string
   }
   /**
-   * 削除前のガード。false を返すと共通側の削除は行わない
-   * （ホスト側で確認モーダルを出すなどに使う）。
+   * 削除確認ダイアログで「連動して消えるもの」として並べる項目。
+   *
+   * 名簿から生徒を外すと、その名簿の対象者にぶら下がる子データも DB の cascade で
+   * 一緒に消える（#962 の配線変更以降）。取り消せない操作なので、試験の
+   * StudentRemovalConfirmModal と同じく何が失われるかを事前に明示する。
    */
-  onBeforeRemove?: (studentIds: string[]) => Promise<boolean> | boolean
+  removalLosses?: string[]
 }

--- a/src/components/coursework/02-students/CourseworkStudentsContainer.tsx
+++ b/src/components/coursework/02-students/CourseworkStudentsContainer.tsx
@@ -238,6 +238,11 @@ export function CourseworkStudentsContainer({
             entries={classroomEntries}
             removalMode="can-delete-students"
             description="ドラッグで並び替えできます。学級を外すときは、専属生徒を残すか削除するか選べます。"
+            deletionLosses={[
+              "この資料の全評価項目に入力された点数・評価記号",
+              "加減点とその理由",
+              "成績通知書に載せるコメント",
+            ]}
             onReorder={async (orderedClassroomIds) => {
               const result =
                 await window.electronAPI.coursework.setClassroomOrders(
@@ -281,6 +286,13 @@ export function CourseworkStudentsContainer({
       <RosterTable
         adapter={rosterAdapter}
         enableRemove
+        slots={{
+          removalLosses: [
+            "この資料の全評価項目に入力された点数・評価記号",
+            "加減点とその理由",
+            "成績通知書に載せるコメント",
+          ],
+        }}
         registerHandle={setRosterHandle}
         onRowsChange={(rows) => setStudentCount(rows.length)}
       />

--- a/src/components/grades/02-students/StudentsContainer.tsx
+++ b/src/components/grades/02-students/StudentsContainer.tsx
@@ -229,6 +229,11 @@ export function StudentsContainer({ gradeId }: StudentsContainerProps) {
             entries={classroomEntries}
             removalMode="can-delete-students"
             description="ドラッグで並び替えできます。学級を外すときは、専属生徒を残すか削除するか選べます。"
+            deletionLosses={[
+              "この成績で確定（凍結）した成績値",
+              "手動で上書きした評定",
+              "評価項目ごとの除外設定",
+            ]}
             onReorder={async (orderedClassroomIds) => {
               const result = await window.electronAPI.grade.setClassroomOrders(
                 gradeId,

--- a/src/components/grades/03-data-sources/StudentExclusionModal.tsx
+++ b/src/components/grades/03-data-sources/StudentExclusionModal.tsx
@@ -23,6 +23,7 @@ import {
 import { useGradeItemExclusions } from "@/hooks/grades/useGradeItemExclusions"
 import type { GradeItemWithDataSources } from "@/types/grade.types"
 
+/** 成績の名簿1行。除外の書き込み先は人ではなく対象者（id）なので実体で受け取る */
 interface ExclusionStudent {
   id: string
   gradeId: string
@@ -109,7 +110,7 @@ export function StudentExclusionModal({
                     (candidate) => classroomIdSet.has(candidate.classroomId)
                   )
                   return (
-                    <TableRow key={gradeStudent.studentId}>
+                    <TableRow key={gradeStudent.id}>
                       <TableCell className="sticky left-0 z-10 bg-white">
                         <div className="flex items-center gap-2 text-sm whitespace-nowrap">
                           {membership && (
@@ -127,19 +128,19 @@ export function StudentExclusionModal({
                         </div>
                       </TableCell>
                       {gradeItems.map((gradeItem) => {
-                        const excluded = isExcluded(
-                          gradeStudent.studentId,
-                          gradeItem.id
-                        )
+                        const excluded = isExcluded({
+                          gradeStudentId: gradeStudent.id,
+                          gradeItemId: gradeItem.id,
+                        })
                         return (
                           <TableCell key={gradeItem.id} className="text-center">
                             <Checkbox
                               checked={!excluded}
                               onCheckedChange={() =>
-                                toggleExclusion(
-                                  gradeStudent.studentId,
-                                  gradeItem.id
-                                )
+                                toggleExclusion({
+                                  gradeStudentId: gradeStudent.id,
+                                  gradeItemId: gradeItem.id,
+                                })
                               }
                             />
                           </TableCell>

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -5,7 +5,9 @@ import { useMemo, useState } from "react"
 import { evaluateConstraints } from "@/lib/gradeConstraints"
 import type {
   GradeCalculationResult,
+  GradeCellTarget,
   GradeConstraintData,
+  GradeOverrideInput,
 } from "@/types/grade.types"
 
 import { ConstraintLegend } from "./ConstraintLegend"
@@ -16,15 +18,11 @@ import { GradeItemBreakdownPopover } from "./GradeItemBreakdownPopover"
 interface ResultsTableProps {
   result: GradeCalculationResult
   constraints?: GradeConstraintData[]
-  onGradeOverride: (params: {
-    studentId: string
-    gradeItemId: string
-    overrideLabel: string | null
-  }) => void
+  onGradeOverride: (params: GradeOverrideInput) => void
   /** 対象セルを現在のライブ値で確定し直す */
-  onRefreezeCell: (target: { studentId: string; gradeItemId: string }) => void
+  onRefreezeCell: (target: GradeCellTarget) => void
   /** 対象セルの確定を解除する */
-  onUnfreezeCell: (target: { studentId: string; gradeItemId: string }) => void
+  onUnfreezeCell: (target: GradeCellTarget) => void
 }
 
 type SortKey = "registrationOrder" | "attendanceNumber" | string
@@ -45,7 +43,7 @@ export function ResultsTable({
   const [sortKey, setSortKey] = useState<SortKey>("registrationOrder")
   const [sortAsc, setSortAsc] = useState(true)
 
-  // 制約ルールを評価。違反（studentId → 違反一覧）と、評価できなかったルールの理由を得る
+  // 制約ルールを評価。違反（gradeStudentId → 違反一覧）と、評価できなかったルールの理由を得る
   const constraintEvaluation = useMemo(
     () => evaluateConstraints(result, constraints),
     [result, constraints]
@@ -78,20 +76,22 @@ export function ResultsTable({
     }
   }
 
-  // 登録順（result.students の元順序）の1始まり順位を studentId で引ける Map。
+  // 登録順（result.students の元順序）の1始まり順位を対象者で引ける Map。
   // レンダー毎・比較毎の indexOf(O(n)) を避けるため一度だけ構築する。
-  const registrationRankByStudentId = useMemo(
+  const registrationRankByGradeStudentId = useMemo(
     () =>
       new Map(
-        result.students.map((student, index) => [student.studentId, index])
+        result.students.map((student, index) => [student.gradeStudentId, index])
       ),
     [result.students]
   )
 
   const sortedStudents = [...result.students].sort((studentA, studentB) => {
     if (sortKey === "registrationOrder") {
-      const aIndex = registrationRankByStudentId.get(studentA.studentId) ?? 0
-      const bIndex = registrationRankByStudentId.get(studentB.studentId) ?? 0
+      const aIndex =
+        registrationRankByGradeStudentId.get(studentA.gradeStudentId) ?? 0
+      const bIndex =
+        registrationRankByGradeStudentId.get(studentB.gradeStudentId) ?? 0
       return sortAsc ? aIndex - bIndex : bIndex - aIndex
     }
     let comparison = 0
@@ -154,7 +154,7 @@ export function ResultsTable({
           <tbody>
             {sortedStudents.map((student) => {
               const violations =
-                violationsByStudent.get(student.studentId) ?? []
+                violationsByStudent.get(student.gradeStudentId) ?? []
               const rowColor = violations[0]?.color
               const rowTitle =
                 violations.length > 0
@@ -168,14 +168,15 @@ export function ResultsTable({
                   : undefined
               return (
                 <tr
-                  key={student.studentId}
+                  key={student.gradeStudentId}
                   className="border-t"
                   style={rowColor ? { backgroundColor: rowColor } : undefined}
                   title={rowTitle}
                 >
                   <td className="text-muted-foreground px-2 py-1.5 text-center">
-                    {(registrationRankByStudentId.get(student.studentId) ?? 0) +
-                      1}
+                    {(registrationRankByGradeStudentId.get(
+                      student.gradeStudentId
+                    ) ?? 0) + 1}
                   </td>
                   <td className="px-2 py-1.5 text-center">
                     {student.attendanceNumber ?? "-"}
@@ -235,7 +236,7 @@ export function ResultsTable({
                             }
                             onCommit={(newLabel) =>
                               onGradeOverride({
-                                studentId: student.studentId,
+                                gradeStudentId: student.gradeStudentId,
                                 gradeItemId: gradeItem.id,
                                 overrideLabel: newLabel,
                               })
@@ -248,13 +249,13 @@ export function ResultsTable({
                               frozenGradeLabel={itemResult.gradeLabel}
                               onRefreeze={() =>
                                 onRefreezeCell({
-                                  studentId: student.studentId,
+                                  gradeStudentId: student.gradeStudentId,
                                   gradeItemId: gradeItem.id,
                                 })
                               }
                               onUnfreeze={() =>
                                 onUnfreezeCell({
-                                  studentId: student.studentId,
+                                  gradeStudentId: student.gradeStudentId,
                                   gradeItemId: gradeItem.id,
                                 })
                               }

--- a/src/components/grades/list/GradeImportDialog.tsx
+++ b/src/components/grades/list/GradeImportDialog.tsx
@@ -113,12 +113,60 @@ export function GradeImportDialog({
             <Badge variant="outline">
               生徒 {preview.studentMatchCount} 一致
             </Badge>
-            {preview.studentMissingCount > 0 && (
+            {preview.studentCreateCount > 0 && (
+              <Badge variant="secondary">
+                生徒 {preview.studentCreateCount} 名を新規登録
+              </Badge>
+            )}
+            {preview.classroomCreateCount > 0 && (
+              <Badge variant="secondary">
+                学級 {preview.classroomCreateCount} 件を新規登録
+              </Badge>
+            )}
+            {preview.studentSkipCount > 0 && (
               <Badge variant="destructive">
-                生徒 {preview.studentMissingCount} 名が見つかりません
+                生徒 {preview.studentSkipCount} 名が見つかりません
               </Badge>
             )}
           </div>
+
+          {/* 生徒マスタ・学級マスタへ書き込むことは事前に明示する。
+              取り込みは成績を作るだけでなく、既存に無い生徒・学級を登録する */}
+          {(preview.studentCreateCount > 0 ||
+            preview.classroomCreateCount > 0) && (
+            <div className="border-border/60 bg-muted/40 mb-4 rounded border p-3 text-sm">
+              <div className="mb-1 font-medium">
+                この取り込みで生徒・学級が追加されます
+              </div>
+              <p className="text-muted-foreground">
+                既存の生徒・学級に一致しなかったものを新しく登録します
+                {preview.studentCreateCount > 0 && (
+                  <>（生徒 {preview.studentCreateCount} 名</>
+                )}
+                {preview.studentCreateCount > 0 &&
+                  preview.classroomCreateCount > 0 &&
+                  " / "}
+                {preview.classroomCreateCount > 0 && (
+                  <>学級 {preview.classroomCreateCount} 件</>
+                )}
+                {(preview.studentCreateCount > 0 ||
+                  preview.classroomCreateCount > 0) && <>）</>}
+                。学籍番号・学級名が既存と重なる場合は末尾に連番を付けて登録します。
+              </p>
+            </div>
+          )}
+
+          {preview.studentSkipCount > 0 && (
+            <div className="mb-4 rounded border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-700 dark:bg-amber-950/40">
+              <div className="mb-1 font-medium text-amber-800 dark:text-amber-300">
+                生徒 {preview.studentSkipCount} 名は取り込めません
+              </div>
+              <p className="text-muted-foreground">
+                古い形式のアーカイブは生徒の氏名を持たないため、この生徒は登録できません。
+                先に生徒を登録してから取り込み直すと、その生徒の成績も一緒に戻ります。
+              </p>
+            </div>
+          )}
 
           {/* 変換で失われるデータの警告（取り込み前に見せる） */}
           {preview.warnings.length > 0 && (

--- a/src/hooks/grades/useGradeItemExclusions.ts
+++ b/src/hooks/grades/useGradeItemExclusions.ts
@@ -2,20 +2,20 @@
 
 import { useCallback, useEffect, useState } from "react"
 
-interface ExclusionRecord {
-  id: string
-  gradeId: string
-  studentId: string
-  gradeItemId: string
-}
+import type { GradeCellTarget } from "@/types/grade.types"
 
-/** 生徒ごとの成績評定項目除外設定の取得・トグル操作を管理するフック */
+/**
+ * 除外セルの同定キー。除外の主語は「その成績の対象者」（GradeStudent）であり、
+ * 人（Student）ではない。どちらも string なので、実体ではなくキーを組み立てる
+ * この一箇所に集約して取り違えを防ぐ。
+ */
+const buildKey = (target: GradeCellTarget) =>
+  `${target.gradeStudentId}:${target.gradeItemId}`
+
+/** 対象者ごとの成績評定項目除外設定の取得・トグル操作を管理するフック */
 export function useGradeItemExclusions(gradeId: string) {
   const [exclusionSet, setExclusionSet] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(true)
-
-  const buildKey = (studentId: string, gradeItemId: string) =>
-    `${studentId}:${gradeItemId}`
 
   const loadExclusions = useCallback(async () => {
     setLoading(true)
@@ -23,13 +23,7 @@ export function useGradeItemExclusions(gradeId: string) {
       const result =
         await window.electronAPI.grade.getGradeItemExclusions(gradeId)
       if (result.success && result.exclusions) {
-        setExclusionSet(
-          new Set(
-            result.exclusions.map((exclusion: ExclusionRecord) =>
-              buildKey(exclusion.studentId, exclusion.gradeItemId)
-            )
-          )
-        )
+        setExclusionSet(new Set(result.exclusions.map(buildKey)))
       }
     } catch (error) {
       console.error("Failed to load grade item exclusions:", error)
@@ -43,14 +37,13 @@ export function useGradeItemExclusions(gradeId: string) {
   }, [loadExclusions])
 
   const isExcluded = useCallback(
-    (studentId: string, gradeItemId: string) =>
-      exclusionSet.has(buildKey(studentId, gradeItemId)),
+    (target: GradeCellTarget) => exclusionSet.has(buildKey(target)),
     [exclusionSet]
   )
 
   const toggleExclusion = useCallback(
-    async (studentId: string, gradeItemId: string) => {
-      const key = buildKey(studentId, gradeItemId)
+    async (target: GradeCellTarget) => {
+      const key = buildKey(target)
       const currentlyExcluded = exclusionSet.has(key)
       const newExcluded = !currentlyExcluded
 
@@ -65,27 +58,7 @@ export function useGradeItemExclusions(gradeId: string) {
         return next
       })
 
-      try {
-        const result = await window.electronAPI.grade.setGradeItemExclusion({
-          gradeId,
-          studentId,
-          gradeItemId,
-          excluded: newExcluded,
-        })
-        if (!result.success) {
-          // ロールバック
-          setExclusionSet((prev) => {
-            const next = new Set(prev)
-            if (currentlyExcluded) {
-              next.add(key)
-            } else {
-              next.delete(key)
-            }
-            return next
-          })
-        }
-      } catch {
-        // ロールバック
+      const rollback = () => {
         setExclusionSet((prev) => {
           const next = new Set(prev)
           if (currentlyExcluded) {
@@ -96,8 +69,18 @@ export function useGradeItemExclusions(gradeId: string) {
           return next
         })
       }
+
+      try {
+        const result = await window.electronAPI.grade.setGradeItemExclusion({
+          ...target,
+          excluded: newExcluded,
+        })
+        if (!result.success) rollback()
+      } catch {
+        rollback()
+      }
     },
-    [exclusionSet, gradeId]
+    [exclusionSet]
   )
 
   return {

--- a/src/hooks/grades/useGradeResults.ts
+++ b/src/hooks/grades/useGradeResults.ts
@@ -1,20 +1,11 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { useAuth } from "@/contexts/AuthContext"
-import type { GradeCalculationResult } from "@/types/grade.types"
-
-interface SetGradeOverrideParams {
-  studentId: string
-  gradeItemId: string
-  /** 上書きラベル。null の場合は上書きを削除（自動計算に戻す） */
-  overrideLabel: string | null
-}
-
-/** 確定・解除の対象セル（生徒×評価項目）。未指定なら Grade 全体が対象 */
-interface GradeFrozenTarget {
-  studentId: string
-  gradeItemId: string
-}
+import type {
+  GradeCalculationResult,
+  GradeCellTarget,
+  GradeOverrideInput,
+} from "@/types/grade.types"
 
 /**
  * 成績評定の計算結果取得、評定上書き（オーバーライド）、成績値の確定（凍結）を管理するフック。
@@ -63,13 +54,13 @@ export function useGradeResults(gradeId: string) {
   }, [calculate])
 
   const setGradeOverride = useCallback(
-    async (params: SetGradeOverrideParams) => {
+    async (params: GradeOverrideInput) => {
       if (!result) return
 
       // 確定済みセルは確定値が最優先なので、上書きを保存しただけでは表示が動かない。
       // 調整の結果をその場で取り込み直す（＝そのセルだけ再確定）必要がある。
       const editedItemResult = result.students
-        .find((student) => student.studentId === params.studentId)
+        .find((student) => student.gradeStudentId === params.gradeStudentId)
         ?.gradeItemResults.find(
           (gradeItemResult) =>
             gradeItemResult.gradeItemId === params.gradeItemId
@@ -83,7 +74,8 @@ export function useGradeResults(gradeId: string) {
           return {
             ...prev,
             students: prev.students.map((student) => {
-              if (student.studentId !== params.studentId) return student
+              if (student.gradeStudentId !== params.gradeStudentId)
+                return student
 
               return {
                 ...student,
@@ -105,32 +97,38 @@ export function useGradeResults(gradeId: string) {
 
       // DB 永続化
       try {
-        if (params.overrideLabel) {
-          await window.electronAPI.grade.upsertGradeOverride({
-            gradeId,
-            studentId: params.studentId,
-            gradeItemId: params.gradeItemId,
-            overrideLabel: params.overrideLabel,
-          })
-        } else {
-          await window.electronAPI.grade.deleteGradeOverride({
-            gradeId,
-            studentId: params.studentId,
-            gradeItemId: params.gradeItemId,
-          })
+        // 保存の失敗は例外ではなく success:false で返る（DB 層が捕まえて畳むため）。
+        // 見落とすと、書けていない上書きが楽観更新のまま画面に残り続ける。
+        const persisted = params.overrideLabel
+          ? await window.electronAPI.grade.upsertGradeOverride({
+              gradeStudentId: params.gradeStudentId,
+              gradeItemId: params.gradeItemId,
+              overrideLabel: params.overrideLabel,
+            })
+          : await window.electronAPI.grade.deleteGradeOverride({
+              gradeStudentId: params.gradeStudentId,
+              gradeItemId: params.gradeItemId,
+            })
+        if (!persisted.success) {
+          setError(persisted.error ?? "評定の保存に失敗しました")
+          await calculate({ silent: true })
+          return
         }
 
         if (wasFrozen) {
-          await window.electronAPI.grade.freezeGradeScores({
+          const refrozen = await window.electronAPI.grade.freezeGradeScores({
             gradeId,
             targets: [
               {
-                studentId: params.studentId,
+                gradeStudentId: params.gradeStudentId,
                 gradeItemId: params.gradeItemId,
               },
             ],
             frozenByUserId: user?.id ?? null,
           })
+          if (!refrozen.success) {
+            setError(refrozen.error ?? "成績値の再確定に失敗しました")
+          }
           await calculate({ silent: true })
         }
       } catch (err) {
@@ -147,7 +145,7 @@ export function useGradeResults(gradeId: string) {
    * 既に確定済みのセルを含めれば、その時点のライブ値で確定し直す（再確定）。
    */
   const freezeScores = useCallback(
-    async (targets?: GradeFrozenTarget[]) => {
+    async (targets?: GradeCellTarget[]) => {
       try {
         const response = await window.electronAPI.grade.freezeGradeScores({
           gradeId,
@@ -169,7 +167,7 @@ export function useGradeResults(gradeId: string) {
 
   /** 成績値の確定を解除する。targets 未指定なら Grade 全体を一括解除 */
   const unfreezeScores = useCallback(
-    async (targets?: GradeFrozenTarget[]) => {
+    async (targets?: GradeCellTarget[]) => {
       try {
         const response = await window.electronAPI.grade.unfreezeGradeScores({
           gradeId,

--- a/src/lib/gradeConstraints.ts
+++ b/src/lib/gradeConstraints.ts
@@ -37,7 +37,7 @@ export const DEFAULT_EXCLUSION_LABELS = ["A", "C"]
 export const DEFAULT_CONSTRAINT_COLOR = "#fecaca"
 
 interface ConstraintEvaluation {
-  /** studentId → 違反ルール一覧 */
+  /** gradeStudentId（成績の対象者）→ 違反ルール一覧。行の主語は人ではなく対象者 */
   violations: Map<string, ConstraintViolation[]>
   /** constraintId → 該当生徒数（プレビュー用） */
   counts: Map<string, number>
@@ -389,14 +389,14 @@ export function evaluateConstraints(
       }
 
       if (violated) {
-        const list = violations.get(student.studentId) ?? []
+        const list = violations.get(student.gradeStudentId) ?? []
         list.push({
           constraintId: constraint.id,
           name: constraint.name,
           color: constraint.color,
           message: constraint.message,
         })
-        violations.set(student.studentId, list)
+        violations.set(student.gradeStudentId, list)
         counts.set(constraint.id, (counts.get(constraint.id) ?? 0) + 1)
       }
     }

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -230,17 +230,14 @@ export interface GradeAPI {
     deleteBoundarySet: (
       id: string
     ) => Promise<{ success: boolean; error?: string }>
-    upsertGradeOverride: (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-      overrideLabel: string
-    }) => Promise<{ success: boolean; override?: unknown; error?: string }>
-    deleteGradeOverride: (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-    }) => Promise<{ success: boolean; error?: string }>
+    upsertGradeOverride: (
+      data: import("../grade.types").GradeCellTarget & {
+        overrideLabel: string
+      }
+    ) => Promise<{ success: boolean; override?: unknown; error?: string }>
+    deleteGradeOverride: (
+      target: import("../grade.types").GradeCellTarget
+    ) => Promise<{ success: boolean; error?: string }>
     getGradeConstraints: (gradeId: string) => Promise<{
       success: boolean
       constraints?: import("../grade.types").GradeConstraintData[]
@@ -267,23 +264,14 @@ export interface GradeAPI {
     ) => Promise<{ success: boolean; error?: string }>
     getGradeItemExclusions: (gradeId: string) => Promise<{
       success: boolean
-      exclusions?: Array<{
-        id: string
-        gradeId: string
-        studentId: string
-        gradeItemId: string
-      }>
+      exclusions?: import("@prisma/client").GradeItemExclusion[]
       error?: string
     }>
-    setGradeItemExclusion: (data: {
-      gradeId: string
-      studentId: string
-      gradeItemId: string
-      excluded: boolean
-    }) => Promise<{ success: boolean; error?: string }>
+    setGradeItemExclusion: (
+      input: import("../grade.types").GradeItemExclusionInput
+    ) => Promise<{ success: boolean; error?: string }>
     batchUpdateGradeItemExclusions: (
-      gradeId: string,
-      updates: { studentId: string; gradeItemId: string; excluded: boolean }[]
+      updates: import("../grade.types").GradeItemExclusionInput[]
     ) => Promise<{ success: boolean; error?: string }>
     calculateGrades: (gradeId: string) => Promise<{
       success: boolean
@@ -303,13 +291,13 @@ export interface GradeAPI {
      */
     freezeGradeScores: (data: {
       gradeId: string
-      targets?: { studentId: string; gradeItemId: string }[]
+      targets?: import("../grade.types").GradeCellTarget[]
       frozenByUserId?: string | null
     }) => Promise<{ success: boolean; frozenCount?: number; error?: string }>
     /** 成績値の確定を解除する（リアルタイム算出値へ戻す）。targets 未指定は Grade 全体 */
     unfreezeGradeScores: (data: {
       gradeId: string
-      targets?: { studentId: string; gradeItemId: string }[]
+      targets?: import("../grade.types").GradeCellTarget[]
       userId?: string | null
     }) => Promise<{ success: boolean; unfrozenCount?: number; error?: string }>
     getExamCandidates: () => Promise<{

--- a/src/types/grade.types.ts
+++ b/src/types/grade.types.ts
@@ -153,8 +153,41 @@ export type GradeBoundaryData = Omit<
   minPercentage: number
 }
 
+/**
+ * 成績のセル1つを指す座標（IPC 境界の唯一の定義）。
+ *
+ * 行の主語は「その成績の対象者」（GradeStudent）であり、人（Student）ではない。
+ * 名簿から外された生徒の上書き・確定値・除外設定は存在しえない（#962）。
+ *
+ * renderer / preload / handler / DB 層の4層が同じ形を書くと、余剰プロパティ検査が
+ * 効かず1層だけ直しても typecheck が通ってしまう（実行時にだけ壊れる）。定義はここ1箇所。
+ */
+export interface GradeCellTarget {
+  gradeStudentId: string
+  gradeItemId: string
+}
+
+/** 成績ラベルの手動上書きの入力。overrideLabel が null なら上書きを削除する */
+export interface GradeOverrideInput extends GradeCellTarget {
+  overrideLabel: string | null
+}
+
+/** 評価項目の除外設定の入力。excluded=false なら除外を解除する */
+export interface GradeItemExclusionInput extends GradeCellTarget {
+  excluded: boolean
+}
+
 /** 生徒別成績結果 */
 export interface StudentGradeResult {
+  /**
+   * その成績の対象者（GradeStudent）の id。上書き・確定・除外の書き込み先はこれで指す。
+   * 人の id（studentId）とは別物で、どちらも string なので取り違えても型では捕まらない。
+   */
+  gradeStudentId: string
+  /**
+   * 人（Student）の id。学級所属は人に紐づくため、名簿の突き合わせや個票の出力対象の
+   * 指定にはこちらを使う。出力用であり DB へは書き戻さない。
+   */
   studentId: string
   studentNumber: string
   lastName: string

--- a/src/types/gradeArchive.types.ts
+++ b/src/types/gradeArchive.types.ts
@@ -1,9 +1,23 @@
 /**
  * 成績算出アーカイブ(.grade)の型定義
+ *
+ * exam-archive / coursework-archive と同じく「Prisma のクエリが返した行をそのまま JSON に
+ * 持つ」方針。射影・詰め替えはせず、JSON にそのまま載らない型だけを `JSON.stringify` と
+ * 同じ規則で文字列にする（DateTime → ISO 文字列、Decimal → decimal.js の toJSON と同じ文字列）。
+ * 列を足したらここにも足すこと。
+ *
+ * アーカイブに含まれない実体（生徒・学級・試験・小計・採点領域）への参照は、行が持つ uuid を
+ * 一次キーとし、同定情報を別セクションで添える。生徒・学級は full レコードを carry するので
+ * uuid → 学籍番号/学級名 のフォールバックが効く（coursework-archive と同じモデル）。
+ * 試験・小計・採点領域はアーカイブに含められないため、名前・ラベルのヒントだけを添える。
+ *
+ * 旧バージョンの形は変換器側（grade-transformers）が持つ。ここは現行の形だけを宣言する。
  */
 
-import type { LegacyCollectedCourseworkData } from "../../electron-src/lib/import/coursework-transformers/legacyShape"
 import type {
+  ArchiveCwClass,
+  ArchiveCwMembership,
+  ArchiveCwStudent,
   CollectedCourseworkData,
   CourseworkImportDecisions,
 } from "./courseworkArchive.types"
@@ -25,256 +39,301 @@ export interface GradeArchiveManifest {
   }
 }
 
-export interface GradeArchiveData {
-  manifest: GradeArchiveManifest
-  gradeData: ArchiveGradeData
-  /**
-   * 旧 v1.3.0 以前の外部成績(manual型 DataSource)の点数。
-   * v1.4.0 以降は Coursework に昇格したため新規 export では書かない（空配列）。
-   * 旧アーカイブ読込時の後方互換フォールバック用に optional で残す。
-   */
-  manualScoresData?: ArchiveManualScoresData
-  /**
-   * v1.4.0: 参照中の試験外成績資料（Coursework）の名前ベース埋め込み。
-   * 読込後方互換用に残す。v1.5.0 以降は courseworkArchive を使う。
-   */
-  courseworks?: ArchiveCoursework[]
-  /**
-   * v1.12.0+: 試験外成績資料を coursework-archive と同じ形（テーブルごとの平坦な
-   * セクション）で内包する。収集・生成ロジックは独立 coursework モジュールへ委譲。
-   */
-  courseworkArchive?: CollectedCourseworkData
-  /**
-   * v1.5.0〜1.11.0 が内包していた入れ子・射影形式の資料データ。
-   * 形の定義は変換器側（coursework-transformers）が持ち、
-   * V1_11_0_to_V1_12_0 が courseworkArchive へ展開する。
-   */
-  legacyCourseworkArchive?: LegacyCollectedCourseworkData
-  boundariesData: ArchiveBoundariesData
-}
+// =============================================================================
+// 成績本体のセクション（テーブルごとに平坦。Prisma の行をそのまま持つ）
+// =============================================================================
 
-export interface ArchiveGradeData {
-  grade: {
-    name: string
-    description: string | null
-    /** 基準日（後方互換: v1.2.0+。古いアーカイブではundefined） */
-    referenceDate?: string | null
-  }
-  /** 成績出力設定（後方互換: v1.2.0+。GradeExportSettingsと1:1） */
-  exportSettings?: { settingsJson: string } | null
-  gradeItems: ArchiveGradeItem[]
-  /**
-   * 対象学級。v1.10.0+ は uuid を持ち、照合は uuid 一次・名前二次
-   * （exam / coursework アーカイブと同じ方式）。旧アーカイブには id が無い。
-   */
-  classroomRefs: { id?: string; name: string }[]
-  /** 参照する試験。v1.10.0+ は uuid を持ち、照合は uuid 一次・試験名二次 */
-  examRefs: {
-    id?: string
-    examName: string
-    examDate: string | null
-    dataSourceName: string
-  }[]
-  /** 対象生徒。v1.10.0+ は uuid を持ち、照合は uuid 一次・学籍番号二次 */
-  studentRefs: {
-    id?: string
-    studentNumber: string
-    classroomName: string | null
-    customOrder: number | null
-  }[]
-  /** GradeItem除外設定（後方互換: optional） */
-  gradeItemExclusions?: {
-    studentNumber: string
-    /** v1.10.0+: 参照先評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
-    gradeItemId?: string
-    /** 参照先評価項目名（uuid不一致時・旧アーカイブのフォールバック） */
-    gradeItemName: string
-  }[]
-  /** 成績ラベル手動上書き（後方互換: optional） */
-  gradeOverrides?: {
-    studentNumber: string
-    /**
-     * @deprecated v1.10.0 で総合（overall）を撤去。旧アーカイブにのみ現れる。
-     * "overall" の行は transformer が破棄する。
-     */
-    targetType?: string
-    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
-    gradeItemId?: string
-    /** 対象評価項目名。v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
-    gradeItemName: string | null
-    overrideLabel: string
-  }[]
-  /**
-   * 成績値の確定（凍結）（後方互換: v1.9.0+。古いアーカイブではundefined）。
-   * 生徒×評価項目のみ（総合の行は存在しない）。外部参照は他の grade-archive 要素と
-   * 揃えて名前ベース（生徒=学籍番号 / 評価項目=項目名）。
-   * 確定操作者（frozenByUserId）はアーカイブの移動先に同じ User が居る保証が無いため
-   * 持ち出さない（取り込み時は null＝操作者不明になる）。
-   */
-  gradeFrozenScores?: {
-    studentNumber: string
-    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
-    gradeItemId?: string
-    /** 対象評価項目名（uuid不一致時・旧アーカイブのフォールバック） */
-    gradeItemName: string
-    weightedScore: number | null
-    weightedMaxScore: number
-    percentage: number | null
-    gradeLabel: string | null
-    frozenAt: string
-  }[]
-  /** 観点間の制約ルール（後方互換: v1.7.0+。古いアーカイブではundefined） */
-  gradeConstraints?: ArchiveGradeConstraint[]
-}
-
-/**
- * 観点間の制約ルール1件。
- *
- * v1.11.0 で設定JSON（config）を廃し、評価項目への参照を uuid 一次・名前二次で持つ
- * （issue #1063）。旧 config は名前だけで参照していたため、評価項目をリネームすると
- * 制約が失効した。ArchiveGradeItem と同じ照合方式に揃える。
- */
-export interface ArchiveGradeConstraint {
-  name: string
-  kind: string
-  /**
-   * @deprecated v1.11.0 で廃止。kind別の設定JSON（評価項目を名前で参照していた）。
-   * 旧アーカイブの読込にのみ使う。v1.11.0+ の export では出力しない。
-   */
-  config?: string
-  /** v1.11.0+: 比較先（評定）の評価項目uuid（照合の一次キー） */
-  targetGradeItemId?: string | null
-  /** v1.11.0+: 比較先の評価項目名（uuid不一致時の二次フォールバック） */
-  targetGradeItemName?: string | null
-  /** v1.11.0+: 観点の集計方法 "average" | "sum" */
-  aggregate?: string
-  /** v1.11.0+: 許容する評定との差 */
-  tolerance?: number
-  /** v1.11.0+: 集計対象の観点の評価項目uuid（照合の一次キー） */
-  viewpointGradeItemIds?: string[]
-  /** v1.11.0+: 集計対象の観点名（uuid不一致時の二次フォールバック。上の配列と同順） */
-  viewpointGradeItemNames?: string[]
-  /** v1.11.0+: ラベル→数値の対応（例 { A: 5, B: 3, C: 1 }） */
-  labelValues?: Record<string, number>
-  /** v1.11.0+: 混在禁止ラベル（mutual_exclusion 用） */
-  exclusionLabels?: string[]
-  expression: string
-  color: string
-  message: string | null
-  enabled: boolean
-  order: number
-}
-
-export interface ArchiveGradeItem {
-  /**
-   * v1.10.0+: export元の評価項目uuid（照合の一次キー）。
-   * 評価項目名は unique でなく（GradeItem に (gradeId, name) の制約は無い）教員が
-   * 自由に付けられるため、名前だけでは同名の項目を区別できない。旧アーカイブには
-   * 無いので optional で、その場合のみ名前フォールバックへ落ちる。
-   */
-  id?: string
-  name: string
-  order: number
-  dataSources: ArchiveDataSource[]
-}
-
-export interface ArchiveDataSource {
-  /**
-   * v1.11.0+: export元のデータソースuuid。estimationSourceIds の解決に使う。
-   * これが無い旧アーカイブでは estimationSourceIds を解決できず、推定の参照は捨てられる
-   * （旧importerは解決せずexport元idをそのまま書き戻しており、dangling idになっていた）。
-   */
-  id?: string
-  type: string // "exam_total" | "subtotal" | "crop_region" | "coursework" | "coursework_total"（旧: "manual"）
-  name: string
-  /**
-   * @deprecated v1.6.0 で GradeDataSource.maxScore 列が廃止された（満点は元データから
-   * computeLiveMaxScore でライブ算出）。v1.6.0+ の export では出力しない。
-   *
-   * 削除せず optional で残す理由: 旧 1.3.0 アーカイブの "manual" 型データソースでは、
-   * この値が CourseworkItem.maxScore（実在する列）の出所になる
-   * （V1_3_0_to_V1_4_0 transformer / importer の manual→coursework 変換）。
-   * このフィールドを別用途へ転用してはならない（必ずアーカイブ版を切ること）。
-   */
-  maxScore?: number
-  weight: number
-  order: number
-  examName: string | null
-  subtotalName: string | null
-  cropRegionLabel: string | null
-  absentMethod?: string
-  absentRatio?: number
-  absentOffset?: number
-  treatExpectedAsMissing?: boolean
-  estimationMode?: string
-  estimationSourceIds?: string[]
-  /** v1.4.0+: type==="coursework"（項目参照）/ v1.8.0+: type==="coursework_total"（資料全体）の参照先資料uuid（照合の一次キー） */
-  courseworkId?: string | null
-  /** v1.4.0+: type==="coursework" の参照先評価項目uuid（照合の一次キー） */
-  courseworkItemId?: string | null
-  /** v1.4.0+: type==="coursework"（項目参照）/ v1.8.0+: type==="coursework_total"（資料全体）の参照先資料名（uuid不一致時の二次フォールバック） */
-  courseworkName?: string | null
-  /** v1.4.0+: type==="coursework" の参照先評価項目名（名前フォールバック） */
-  courseworkItemName?: string | null
-  /** v1.10.0+: 参照先試験のuuid（照合の一次キー）。旧アーカイブには無い */
-  examId?: string | null
-  /**
-   * v1.10.0+: 参照先小計のuuid（照合の一次キー）。旧アーカイブには無い。
-   * 小計名は `@@unique([subtotalGroupId, name])` でグループ内でしか一意でなく、
-   * 名前だけでは別の試験の同名小計に当たりうる。
-   */
-  subtotalId?: string | null
-  /**
-   * v1.10.0+: 参照先採点領域のuuid（照合の一次キー）。旧アーカイブには無い。
-   * 領域ラベルは同一試験内でも重複しうる。
-   */
-  cropRegionId?: string | null
-  /**
-   * 旧 v1.3.0 の入力モード（"numeric" | "letter"）。読取専用の後方互換用。
-   * v1.4.0 以降は CourseworkItem.inputMode が保持する。
-   */
-  inputMode?: string
-  /**
-   * 旧 v1.3.0 の文字評価→点数の変換表。読取専用の後方互換用。
-   * v1.4.0 以降は CourseworkItem.letterScales が保持する。
-   */
-  letterScales?: { label: string; score: number; order: number }[]
-}
-
-/**
- * v1.4.0+: 試験外成績資料（Coursework）の埋め込みデータ。
- * 点数を失わないため自己完結。外部参照は名前ベース
- * （生徒=学籍番号 / 学級=学級名 / タグ=タグ名）。
- */
-export interface ArchiveCoursework {
-  /** v1.4.0+: export元の資料uuid（照合の一次キー） */
+/** Grade の行 */
+export interface ArchiveGradeRow {
   id: string
   name: string
   description: string | null
-  date: string | null
-  classrooms: { classroomName: string; order: number }[]
-  tags: { tagName: string }[]
-  students: { studentNumber: string; customOrder: number | null }[]
-  items: ArchiveCourseworkItem[]
+  referenceDate: string | null
+  createdAt: string
+  updatedAt: string
 }
 
-export interface ArchiveCourseworkItem {
-  /** v1.4.0+: export元の評価項目uuid（照合の一次キー） */
+/** GradeClassroom（成績×学級）の行 */
+export interface ArchiveGradeClassroomRow {
   id: string
+  gradeId: string
+  classroomId: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeStudent（成績の対象者＝名簿）の行 */
+export interface ArchiveGradeStudentRow {
+  id: string
+  gradeId: string
+  studentId: string
+  customOrder: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeItem（評価項目）の行 */
+export interface ArchiveGradeItemRow {
+  id: string
+  gradeId: string
   name: string
   order: number
-  maxScore: number
-  inputMode: string
-  letterScales: { label: string; score: number; order: number }[]
-  scores: {
-    studentNumber: string
-    score: number | null
-    letterValue: string | null
-    adjustment: number | null
-    adjustmentReason: string | null
-    comment: string | null
-  }[]
+  createdAt: string
+  updatedAt: string
 }
+
+/** GradeDataSource（成績データソース）の行 */
+export interface ArchiveGradeDataSourceRow {
+  id: string
+  gradeItemId: string
+  type: string
+  /** 参照先はアーカイブ外。examRefs が同定情報を持つ */
+  examId: string | null
+  subtotalId: string | null
+  cropRegionId: string | null
+  /** 参照先は内包する courseworkArchive の行 */
+  courseworkItemId: string | null
+  courseworkId: string | null
+  name: string
+  /** Decimal */
+  weight: string
+  order: number
+  absentMethod: string
+  /** Decimal */
+  absentRatio: string
+  /** Decimal */
+  absentOffset: string
+  treatExpectedAsMissing: boolean
+  estimationMode: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeDataSourceEstimationSource（欠損推定に使う他データソース）の行 */
+export interface ArchiveGradeDataSourceEstimationSourceRow {
+  id: string
+  dataSourceId: string
+  sourceDataSourceId: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeBoundarySet（評価項目ごとの成績境界セット）の行 */
+export interface ArchiveGradeBoundarySetRow {
+  id: string
+  gradeId: string
+  gradeItemId: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeBoundary（境界1本）の行 */
+export interface ArchiveGradeBoundaryRow {
+  id: string
+  gradeBoundarySetId: string
+  label: string
+  /** Decimal */
+  minPercentage: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeOverride（成績ラベルの手動上書き）の行 */
+export interface ArchiveGradeOverrideRow {
+  id: string
+  gradeStudentId: string
+  gradeItemId: string
+  overrideLabel: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * GradeFrozenScore（成績値の確定）の行。
+ *
+ * `frozenByUserId` は行のまま持ち出すが、取り込み先に同じ User が居る保証は無い。
+ * 解決できなければ null（操作者不明）にして取り込む。
+ */
+export interface ArchiveGradeFrozenScoreRow {
+  id: string
+  gradeStudentId: string
+  gradeItemId: string
+  /** Decimal */
+  weightedScore: string | null
+  /** Decimal */
+  weightedMaxScore: string
+  /** Decimal */
+  percentage: string | null
+  gradeLabel: string | null
+  frozenByUserId: string | null
+  frozenAt: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeItemExclusion（評価項目ごとの除外設定）の行 */
+export interface ArchiveGradeItemExclusionRow {
+  id: string
+  gradeStudentId: string
+  gradeItemId: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeConstraint（観点間の制約ルール）の行 */
+export interface ArchiveGradeConstraintRow {
+  id: string
+  gradeId: string
+  name: string
+  kind: string
+  targetGradeItemId: string | null
+  aggregate: string
+  /** Decimal */
+  tolerance: string
+  expression: string
+  color: string
+  message: string | null
+  disabledReason: string | null
+  enabled: boolean
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeConstraintViewpoint（制約の集計対象の観点）の行 */
+export interface ArchiveGradeConstraintViewpointRow {
+  id: string
+  constraintId: string
+  gradeItemId: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeConstraintLabelValue（ラベル→数値の対応）の行 */
+export interface ArchiveGradeConstraintLabelValueRow {
+  id: string
+  constraintId: string
+  label: string
+  /** Decimal */
+  value: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeConstraintExclusionLabel（混在禁止ラベル）の行 */
+export interface ArchiveGradeConstraintExclusionLabelRow {
+  id: string
+  constraintId: string
+  label: string
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** GradeExportSettings（出力設定）の行 */
+export interface ArchiveGradeExportSettingsRow {
+  id: string
+  gradeId: string
+  settingsJson: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** 成績本体のセクション群（テーブルごとに平坦） */
+export interface GradeSections {
+  grades: ArchiveGradeRow[]
+  gradeClassrooms: ArchiveGradeClassroomRow[]
+  gradeStudents: ArchiveGradeStudentRow[]
+  gradeItems: ArchiveGradeItemRow[]
+  gradeDataSources: ArchiveGradeDataSourceRow[]
+  gradeDataSourceEstimationSources: ArchiveGradeDataSourceEstimationSourceRow[]
+  gradeBoundarySets: ArchiveGradeBoundarySetRow[]
+  gradeBoundaries: ArchiveGradeBoundaryRow[]
+  gradeOverrides: ArchiveGradeOverrideRow[]
+  gradeFrozenScores: ArchiveGradeFrozenScoreRow[]
+  gradeItemExclusions: ArchiveGradeItemExclusionRow[]
+  gradeConstraints: ArchiveGradeConstraintRow[]
+  gradeConstraintViewpoints: ArchiveGradeConstraintViewpointRow[]
+  gradeConstraintLabelValues: ArchiveGradeConstraintLabelValueRow[]
+  gradeConstraintExclusionLabels: ArchiveGradeConstraintExclusionLabelRow[]
+  gradeExportSettings: ArchiveGradeExportSettingsRow[]
+}
+
+// =============================================================================
+// 外部参照（アーカイブに含めない実体を取り込み先で同定するための情報）
+// =============================================================================
+
+/**
+ * 参照している試験の同定情報。
+ *
+ * 試験そのものは .grade に含められない（答案画像を伴う別アーカイブの領分）ため、
+ * uuid が当たらなければ試験名で当てる。名前は unique ではないので一次キーにはしない。
+ */
+export interface ArchiveGradeExamRef {
+  id: string
+  examName: string
+  examDate: string | null
+}
+
+/**
+ * 参照している小計の同定情報。
+ * 小計名は `@@unique([subtotalGroupId, name])` でグループ内でしか一意でないため、
+ * 名前で当てるときは必ず所属試験で絞る。
+ */
+export interface ArchiveGradeSubtotalRef {
+  id: string
+  examId: string
+  name: string
+}
+
+/**
+ * 参照している採点領域の同定情報。
+ * 領域ラベルは同一試験内でも重複しうるので、名前フォールバックは最初の1件に当たる。
+ */
+export interface ArchiveGradeCropRegionRef {
+  id: string
+  examId: string
+  label: string
+}
+
+/**
+ * 外部参照セクション。
+ *
+ * 生徒・学級・所属は coursework-archive と同形の full レコードで carry し、
+ * uuid 一次 → 学籍番号 / 学級名 のフォールバックで取り込み先の実体へ解決する。
+ * 試験・小計・採点領域は carry できないので同定情報だけを添える。
+ */
+export interface GradeExternalSections {
+  studentsData: ArchiveCwStudent[]
+  classesData: ArchiveCwClass[]
+  membershipsData: ArchiveCwMembership[]
+  examRefs: ArchiveGradeExamRef[]
+  subtotalRefs: ArchiveGradeSubtotalRef[]
+  cropRegionRefs: ArchiveGradeCropRegionRef[]
+}
+
+/** 収集結果（export 側が組み立て、archiveCreator が JSON へ書く） */
+export interface CollectedGradeData
+  extends GradeSections, GradeExternalSections {
+  /** 内包する試験外成績資料。収集・生成は coursework-archive モジュールへ委譲 */
+  courseworkArchive: CollectedCourseworkData
+  counts: GradeArchiveManifest["counts"]
+}
+
+/** アーカイブ全体（manifest + 各セクション） */
+export interface GradeArchiveData extends GradeSections, GradeExternalSections {
+  manifest: GradeArchiveManifest
+  courseworkArchive: CollectedCourseworkData
+}
+
+// =============================================================================
+// インポート
+// =============================================================================
 
 /** インポート実行時のオプション */
 export interface GradeArchiveImportOptions {
@@ -284,7 +343,7 @@ export interface GradeArchiveImportOptions {
   courseworkDecisions?: CourseworkImportDecisions
 }
 
-/** v1.4.0+: 資料1件分のマッチング候補（ウィザードでユーザーに提示） */
+/** 資料1件分のマッチング候補（ウィザードでユーザーに提示） */
 export interface GradeArchiveCourseworkMatch {
   /** アーカイブ内の資料uuid（決定マップのキー） */
   archiveId: string
@@ -297,53 +356,27 @@ export interface GradeArchiveCourseworkMatch {
   nameCandidates: { id: string; name: string }[]
 }
 
-export interface ArchiveManualScoresData {
-  manualScores: {
-    gradeItemName: string
-    dataSourceName: string
-    studentNumber: string
-    score: number | null
-    /** 文字評価記号（後方互換: v1.3.0+） */
-    letterValue?: string | null
-    /** 加点・減点（後方互換: v1.3.0+） */
-    adjustment?: number | null
-    /** 加減点の理由（後方互換: v1.3.0+） */
-    adjustmentReason?: string | null
-    /** コメント（後方互換: v1.3.0+） */
-    comment?: string | null
-  }[]
-}
-
-export interface ArchiveBoundariesData {
-  boundarySets: {
-    /**
-     * @deprecated v1.10.0 で総合（overall）を撤去。旧アーカイブにのみ現れる。
-     * "overall" のセットは transformer が破棄する。
-     */
-    targetType?: string
-    /** v1.10.0+: 対象評価項目のuuid（照合の一次キー）。旧アーカイブには無い */
-    gradeItemId?: string
-    /** 対象評価項目名。v1.10.0 以降は必ず非null（旧アーカイブでは null = 総合） */
-    gradeItemName: string | null
-    boundaries: {
-      label: string
-      minPercentage: number
-      order: number
-    }[]
-  }[]
-}
-
 export interface GradeArchiveImportPreview {
   manifest: GradeArchiveManifest
   classroomMatches: { found: boolean; name: string }[]
+  /** 既存に一致せず、取り込みで新規作成される学級の数 */
+  classroomCreateCount: number
   examMatches: {
     examName: string
     found: boolean
     examId: string | null
   }[]
+  /** uuid または学籍番号で既存の生徒に一致した数 */
   studentMatchCount: number
-  studentMissingCount: number
-  /** v1.4.0+: 埋め込み資料ごとのマッチング候補（ユーザー判断用） */
+  /** 既存に一致せず、取り込みで新規作成される生徒の数 */
+  studentCreateCount: number
+  /**
+   * 既存に一致せず、作成もできない生徒の数。
+   * 旧アーカイブ（v1.12.0 以前）は生徒の氏名を持ち出していないため作成できない。
+   * この生徒の名簿行・上書き・確定値・除外設定は取り込まれない。
+   */
+  studentSkipCount: number
+  /** 埋め込み資料ごとのマッチング候補（ユーザー判断用） */
   courseworkMatches: GradeArchiveCourseworkMatch[]
   /**
    * 旧バージョンからの変換で失われるデータの警告（取り込み前に見せる）。
@@ -354,30 +387,25 @@ export interface GradeArchiveImportPreview {
 }
 
 // =============================================================================
-// バージョントランスフォーマー
+// バージョン
 // =============================================================================
 
 /**
- * トランスフォーマーが扱うバージョン。
+ * アーカイブバージョン（追加時にユニオンへ足す）
+ *
  * - 1.3.0: 外部成績は manual-scores.json（manual型 DataSource）
  * - 1.4.0: courseworks.json に名前ベースで埋め込み
  * - 1.5.0: courseworks.json を coursework-archive 形式（UUIDベース）で内包
- * - 1.6.0: GradeDataSource.maxScore 列を廃止（満点はライブ算出）。外部成績の構造は
- *   1.5.0 と同形のため専用 transformer は無し（ArchiveDataSource.maxScore は optional で旧読込互換）。
- * - 1.7.0: 観点間の制約ルール（GradeConstraint）を追加。gradeConstraints は optional で
- *   旧アーカイブ読込時は空配列扱い。構造は加算的なため専用 transformer は無し。
- * - 1.8.0: 資料全体を参照する coursework_total 型 DataSource を追加。参照先資料は
- *   既存の ArchiveDataSource.courseworkId / courseworkName（optional）で表現するため
- *   新規フィールドは無く、旧アーカイブには coursework_total が存在しないだけなので
- *   専用 transformer は無し（加算的変更）。
- * - 1.9.0: 成績値の確定（GradeFrozenScore）を追加。gradeFrozenScores は optional で
- *   旧アーカイブ読込時は「確定なし」扱い。構造は加算的なため専用 transformer は無し。
- * - 1.10.0: 総合（overall）を撤去。境界セット・手動上書きの targetType を廃し、対象は
- *   必ず評価項目になった。旧アーカイブの総合エントリは破棄されるため、加算的変更ではなく
- *   専用 transformer（V1_9_0_to_V1_10_0）を持つ。
- *   併せて外部参照（評価項目・生徒・学級・試験・小計・採点領域）の照合を
- *   uuid 一次・名前二次へ（exam / coursework アーカイブと同じ方式）。
- *   これらの名前・ラベルはいずれも同定に足りず、名前だけでは取り違える。
+ * - 1.6.0: GradeDataSource.maxScore 列を廃止（満点はライブ算出）
+ * - 1.7.0: 観点間の制約ルール（GradeConstraint）を追加
+ * - 1.8.0: 資料全体を参照する coursework_total 型 DataSource を追加
+ * - 1.9.0: 成績値の確定（GradeFrozenScore）を追加
+ * - 1.10.0: 総合（overall）を撤去。外部参照の照合を uuid 一次・名前二次へ
+ * - 1.11.0: 制約ルールの設定JSON（config）を構造化フィールドへ
+ * - 1.12.0: 内包資料を coursework 1.1.0（テーブルごとの平坦なセクション）へ
+ * - 1.13.0: 成績本体もテーブルごとの平坦なセクションへ変更し、各行を Prisma の行のまま持つ。
+ *   外部参照は uuid 一次・名前二次（生徒・学級は full レコードを carry）。
+ *   上書き・確定値・除外設定の参照が studentNumber → gradeStudentId（#962 Phase C）
  *
  * 検出は manifest.version 文字列ではなくデータ形状で行う（旧アーカイブのバージョン
  * 表記が不正確でも確実に正規化するため。詳細は grade-transformers/index.ts）。
@@ -393,26 +421,9 @@ export type GradeArchiveVersion =
   | "1.10.0"
   | "1.11.0"
   | "1.12.0"
-export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.12.0"
+  | "1.13.0"
+export const GRADE_CURRENT_VERSION: GradeArchiveVersion = "1.13.0"
 
-export interface GradeTransformResult {
-  data: GradeArchiveData
-  warnings: string[]
-}
-
-export interface GradeVersionTransformer {
-  readonly fromVersion: GradeArchiveVersion
-  readonly toVersion: GradeArchiveVersion
-  transform(data: GradeArchiveData): GradeTransformResult
-}
-
-export interface GradeChainTransformResult {
-  data: GradeArchiveData
-  originalVersion: GradeArchiveVersion
-  finalVersion: GradeArchiveVersion
-  appliedTransformations: {
-    from: GradeArchiveVersion
-    to: GradeArchiveVersion
-  }[]
-  warnings: string[]
-}
+// バージョン変換の型（版ごとのアーカイブ全体の型・変換器・チェーン）は
+// electron-src/lib/import/grade-transformers/types.ts が持つ。
+// 旧版の形の知識をこのファイルへ持ち込まないこと。


### PR DESCRIPTION
Closes #1089

`docs/membership-key-rewiring-plan.md` の Phase C。対象9テーブル・3サブシステムが
これで揃い、本計画は完了します（§13・§14 に実施結果を記録）。

## セル3種の配線変更

`GradeOverride` / `GradeFrozenScore` / `GradeItemExclusion` を `gradeStudentId` へ。
`gradeId` / `studentId` の2列は残さず畳みました（両方残すと `gradeId ≠ gradeStudent.gradeId`
が起こりうるため。`ReturnSnapshot.examId` と同じ判断）。

migration `20260730000000` で付け替え、対象者へ到達できない孤児は破棄して件数を
AuditLog へ記録します。破棄は削除確認の説明が以前から約束していた挙動です。

## 素点行列の実体化（計画 §3.3）

`Map<studentId, Map<dataSourceId, number|null>>` を `RawScoreMatrix` へ。行が対象者、
セルが列のデータソースを同梱し、索引は実装の内側に閉じます。`absentEstimation` の
9関数は実体を受けるようになり、**満点は列から取れるので引数が1つ減りました**
（別ソースの満点を渡す取り違えが構造的に起こらない）。

上書き・確定値・除外は対象者の include から読むようになり、`${studentId}:${gradeItemId}`
の文字列連結キー3種と `findMany` 3本が消えています。

**副産物**: `estimateByRegression` に潜在的なクラッシュがありました（訓練行が0件のとき
`X[0].length` で throw し、成績算出全体が失敗する）。行列化のついでに塞いでいます。

## `.grade` アーカイブの作り直し（1.12.0 → 1.13.0）

成績本体もテーブルごとの平坦なセクションにし、各行を Prisma の行のまま持ちます。

| 対象 | 旧 | 新 |
| --- | --- | --- |
| セル3種 | `{ studentNumber, gradeItemName, … }` | 行そのまま |
| 制約ルールの子 | 観点を**2本の平行配列**へ潰す | 中間テーブルの行の配列 |
| 境界 | 別ファイルへ射影 | 行として同一セクション |
| Decimal | `Number(...)` | 文字列（exam / coursework と同一規則） |

外部参照は uuid 一次・名前二次で解決し、**未一致の生徒・学級は作成します**
（`.exam` / `.coursework` と同じ挙動。従来は grade だけが lookup のみで、別PCへ
持って行くと名簿が空の成績ができていました）。

ただし**氏名を持たない旧アーカイブからは作りません**（作ると氏名が空の生徒が並ぶ）。
**学級所属の復元も新規作成した生徒に限ります**（既存生徒に適用すると、取り込み先で
異動済みの生徒に旧学級の在籍行が復活し、無関係な試験の学級別集計まで変わる）。

## 名簿削除の確認ダイアログ

資料・成績の名簿から生徒を外す操作に確認を入れ、連動して消えるものを明示しました。
学級ごと外す2段階モーダルの文言も「入力済みデータ」から具体的な列挙へ変えています。

## レビュー指摘の反映

`/code-review high` の指摘9件（すべて correctness）を修正済みです。作り直しで
持ち込んだ退行が中心でした。

- 旧アーカイブの合成 id の衝突3件（同名評価項目・別試験の同名小計/領域・`project_total` 正規化の欠落）
- 生徒/学級を作るようにしたことの副作用4件（学級所属の書き換え・非uuid id の主キー化・
  同一人物へ解決したときの unique 違反・プレビュー表示）
- 制約ルールの観点欠落の検知漏れ・`coursework_total` 参照の解決漏れ

## ⚠️ 注意

**該当する生徒がいる場合、このマージ後は成績算出の結果が変わります。**
これまでは名簿から外したはずの生徒の設定が残り、再追加時に復活していました。

**取り込み時に生徒・学級が増えるようになります。** プレビューで件数を事前に表示します。

## 検証

- `npx tsc --noEmit` クリーン
- `npm run lint` エラー0（警告142は既存）
- `npx vitest run` **117ファイル / 1,194テスト全通過**

追加テスト: migration の付け替え・孤児破棄・FK参照名、削除時のセル消滅と再追加時の
非復元、スコープ検査、アーカイブの行そのまま保持・生徒/学級の新規作成・学級所属を
書き換えないこと・旧アーカイブの合成id衝突の回帰。

## 未了

- **実 DB のコピーへ migration を当てるリハーサルは未実施**です（実データが必要）。
  Phase A / B と同じ状態です
- 「移行前後で算出結果が完全に一致すること」のテストは書けていません（旧実装が既に無く
  事後には比較できないため）。代わりに意図した差分をスコープテストで固定しています
- `.coursework` / `.grade` / `.asb` には **uuid を書き換えて統合する機能がありません**
  （`.exam` / `.student` のみ `idChoice: use_import_id` を持つ）。本計画の範囲外で別件です

🤖 Generated with [Claude Code](https://claude.com/claude-code)
