### PR TITLE
refactor(types): インライン型 import をトップレベル import type へ統一する

### DIFF
--- a/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
+++ b/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
@@ -8,6 +8,7 @@
  * ref: https://github.com/KeppyNaushika/score-at-once-electron/issues/661
  */
 
+import type * as NodeFs from "fs"
 import sharp from "sharp"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -37,7 +38,7 @@ vi.mock("electron", () => ({
 
 // fs モック（一時ファイル書き込み・削除をスキップ）
 vi.mock("fs", async () => {
-  const actual = await vi.importActual<typeof import("fs")>("fs")
+  const actual = await vi.importActual<typeof NodeFs>("fs")
   return {
     ...actual,
     default: {

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -104,7 +104,7 @@ export function registerArchiveHandlers(): void {
       examId: string
       userId: string
       outputPath?: string
-      exportMode?: import("../../src/types/examArchive.types").ArchiveExportMode
+      exportMode?: ArchiveExportMode
     }) => {
       return await exportExam(options)
     },

--- a/electron-src/lib/prisma/auditActor.ts
+++ b/electron-src/lib/prisma/auditActor.ts
@@ -7,6 +7,9 @@
  *   electron/認証ストアが利用できない環境（テスト等）では null を返す（ベストエフォート）。
  */
 
+// 型のみの import なので実行時には完全に消える（authStore は下の遅延requireで読む）
+import type * as AuthStore from "../authStore"
+
 let cachedReader: (() => string | null) | null = null
 
 /** 現在ログイン中の操作者ユーザーIDを返す（取得不能時は null） */
@@ -14,8 +17,7 @@ export function getCurrentActorUserId(): string | null {
   try {
     if (!cachedReader) {
       // 遅延require: electron非搭載環境（vitest等）でのトップレベル副作用を避ける
-      const { AuthStoreManager } =
-        require("../authStore") as typeof import("../authStore")
+      const { AuthStoreManager } = require("../authStore") as typeof AuthStore
       cachedReader = () => AuthStoreManager.getAuthToken()
     }
     return cachedReader()

--- a/electron-src/nextServerEmbedded.ts
+++ b/electron-src/nextServerEmbedded.ts
@@ -1,6 +1,7 @@
 import { app } from "electron"
 import type { Server } from "http"
 import type { IncomingMessage, ServerResponse } from "http"
+import type * as NodeModule from "module"
 import type { NextServer } from "next/dist/server/next"
 import { delimiter, join } from "path"
 
@@ -18,7 +19,7 @@ let httpServer: Server | null = null
 const ensurePackagedNodePath = (basePath: string) => {
   try {
     const fs = require("fs")
-    const Module = require("module") as typeof import("module") & {
+    const Module = require("module") as typeof NodeModule & {
       _initPaths(): void
     }
 

--- a/electron-src/preload-apis/answerSheetBuilderApi.ts
+++ b/electron-src/preload-apis/answerSheetBuilderApi.ts
@@ -1,5 +1,15 @@
 import { ipcRenderer } from "electron"
 
+import type {
+  ASBConvertToExamArgs,
+  ASBDeleteImageArgs,
+  ASBExportPdfArgs,
+  ASBExportPngArgs,
+  ASBPrintArgs,
+  ASBUploadImageArgs,
+} from "../../src/types/answerSheetBuilder.types"
+import type { AnswerSheetDefinition } from "../../src/types/answerSheetDefinition.types"
+
 /** 解答用紙ビルダーのIPC API（定義CRUD・PDF/PNG出力・印刷・インポート/エクスポート） */
 export function createAnswerSheetBuilderApi() {
   return {
@@ -8,34 +18,25 @@ export function createAnswerSheetBuilderApi() {
         ipcRenderer.invoke("asb:list-definitions", userId),
       loadDefinition: (id: string) =>
         ipcRenderer.invoke("asb:load-definition", id),
-      saveDefinition: (
-        definition: import("../../src/types/answerSheetDefinition.types").AnswerSheetDefinition,
-        userId: string
-      ) => ipcRenderer.invoke("asb:save-definition", definition, userId),
+      saveDefinition: (definition: AnswerSheetDefinition, userId: string) =>
+        ipcRenderer.invoke("asb:save-definition", definition, userId),
       deleteDefinition: (id: string) =>
         ipcRenderer.invoke("asb:delete-definition", id),
-      exportPdf: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBExportPdfArgs
-      ) => ipcRenderer.invoke("asb:export-pdf", args),
-      exportPng: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBExportPngArgs
-      ) => ipcRenderer.invoke("asb:export-png", args),
+      exportPdf: (args: ASBExportPdfArgs) =>
+        ipcRenderer.invoke("asb:export-pdf", args),
+      exportPng: (args: ASBExportPngArgs) =>
+        ipcRenderer.invoke("asb:export-png", args),
       selectSavePath: (options: {
         type: "pdf" | "png"
         defaultName?: string
       }) => ipcRenderer.invoke("asb:select-save-path", options),
-      convertToExam: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBConvertToExamArgs
-      ) => ipcRenderer.invoke("asb:convert-to-exam", args),
-      print: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBPrintArgs
-      ) => ipcRenderer.invoke("asb:print", args),
-      uploadImage: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBUploadImageArgs
-      ) => ipcRenderer.invoke("asb:upload-image", args),
-      deleteImage: (
-        args: import("../../src/types/answerSheetBuilder.types").ASBDeleteImageArgs
-      ) => ipcRenderer.invoke("asb:delete-image", args),
+      convertToExam: (args: ASBConvertToExamArgs) =>
+        ipcRenderer.invoke("asb:convert-to-exam", args),
+      print: (args: ASBPrintArgs) => ipcRenderer.invoke("asb:print", args),
+      uploadImage: (args: ASBUploadImageArgs) =>
+        ipcRenderer.invoke("asb:upload-image", args),
+      deleteImage: (args: ASBDeleteImageArgs) =>
+        ipcRenderer.invoke("asb:delete-image", args),
       selectImportFile: () => ipcRenderer.invoke("asb:select-import-file"),
       analyzeAsbArchive: (filePath: string) =>
         ipcRenderer.invoke("asb:analyze-asb-archive", filePath),

--- a/electron-src/preload-apis/archiveApi.ts
+++ b/electron-src/preload-apis/archiveApi.ts
@@ -1,5 +1,18 @@
 import { ipcRenderer } from "electron"
 
+import type {
+  ArchiveExportMode,
+  FileOverviewData,
+  IdIntegrationConfig,
+  MatchingConfig,
+  ScoringConflictConfig,
+  UpdateDecisions,
+} from "../../src/types/examArchive.types"
+import type {
+  StudentArchiveFileOverviewData,
+  StudentArchiveIdIntegrationConfig,
+} from "../../src/types/studentArchive.types"
+
 /** 試験・生徒アーカイブのIPC API（エクスポート・インポート・競合検出・ID統合） */
 export function createArchiveApi() {
   return {
@@ -9,7 +22,7 @@ export function createArchiveApi() {
         examId: string
         userId: string
         outputPath?: string
-        exportMode?: import("../../src/types/examArchive.types").ArchiveExportMode
+        exportMode?: ArchiveExportMode
       }) => ipcRenderer.invoke("archive:exportExam", options),
       analyzeArchive: (options: { archivePath: string }) =>
         ipcRenderer.invoke("archive:analyzeArchive", options),
@@ -17,25 +30,25 @@ export function createArchiveApi() {
         ipcRenderer.invoke("archive:preMatch", options),
       detectConflicts: (options: {
         archivePath: string
-        matchingConfig: import("../../src/types/examArchive.types").MatchingConfig
+        matchingConfig: MatchingConfig
       }) => ipcRenderer.invoke("archive:detectConflicts", options),
       idIntegrationImport: (options: {
         archivePath: string
-        preMatchResult: import("../../src/types/examArchive.types").FileOverviewData
-        integrationConfig: import("../../src/types/examArchive.types").IdIntegrationConfig
+        preMatchResult: FileOverviewData
+        integrationConfig: IdIntegrationConfig
         currentUserId: string
-        scoringConflictConfig?: import("../../src/types/examArchive.types").ScoringConflictConfig
-        updateDecisions?: import("../../src/types/examArchive.types").UpdateDecisions
+        scoringConflictConfig?: ScoringConflictConfig
+        updateDecisions?: UpdateDecisions
       }) => ipcRenderer.invoke("archive:idIntegrationImport", options),
       detectScoringConflicts: (options: {
         archivePath: string
-        preMatchResult: import("../../src/types/examArchive.types").FileOverviewData
-        integrationConfig: import("../../src/types/examArchive.types").IdIntegrationConfig
+        preMatchResult: FileOverviewData
+        integrationConfig: IdIntegrationConfig
       }) => ipcRenderer.invoke("archive:detectScoringConflicts", options),
       bulkExportExams: (options: {
         examIds: string[]
         userId: string
-        exportMode?: import("../../src/types/examArchive.types").ArchiveExportMode
+        exportMode?: ArchiveExportMode
       }) => ipcRenderer.invoke("archive:bulkExportExams", options),
       selectImportFile: () => ipcRenderer.invoke("archive:selectImportFile"),
       convertHszToScore: (options: { hszPath: string }) =>
@@ -58,9 +71,9 @@ export function createArchiveApi() {
         ipcRenderer.invoke("studentArchive:preMatch", options),
       import: (options: {
         archivePath: string
-        preMatchResult: import("../../src/types/studentArchive.types").StudentArchiveFileOverviewData
-        integrationConfig: import("../../src/types/studentArchive.types").StudentArchiveIdIntegrationConfig
-        updateDecisions?: import("../../src/types/examArchive.types").UpdateDecisions
+        preMatchResult: StudentArchiveFileOverviewData
+        integrationConfig: StudentArchiveIdIntegrationConfig
+        updateDecisions?: UpdateDecisions
       }) => ipcRenderer.invoke("studentArchive:import", options),
     },
   }

--- a/electron-src/preload-apis/courseworkApi.ts
+++ b/electron-src/preload-apis/courseworkApi.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from "electron"
 
 import type { CourseworkScoreUpsertInput } from "../../src/types/coursework.types"
+import type {
+  CourseworkImportDecisions,
+  CourseworkMatchingMethod,
+} from "../../src/types/courseworkArchive.types"
 
 /** 試験外成績資料（Coursework）の IPC API（資料・評価項目・点数・名簿・タグ） */
 export function createCourseworkApi() {
@@ -139,8 +143,8 @@ export function createCourseworkApi() {
         ipcRenderer.invoke("coursework:analyzeArchive", options),
       importArchive: (options: {
         archivePath: string
-        courseworkDecisions?: import("../../src/types/courseworkArchive.types").CourseworkImportDecisions
-        studentMatching?: import("../../src/types/courseworkArchive.types").CourseworkMatchingMethod
+        courseworkDecisions?: CourseworkImportDecisions
+        studentMatching?: CourseworkMatchingMethod
       }) => ipcRenderer.invoke("coursework:importArchive", options),
     },
   }

--- a/electron-src/preload-apis/exportApi.ts
+++ b/electron-src/preload-apis/exportApi.ts
@@ -1,6 +1,8 @@
 import { ipcRenderer } from "electron"
 
+import type { IndividualReportOptions } from "../lib/export/individual-report/types"
 import type { ExportRDataOptions } from "../lib/export/r-exametrika/rDataExporter"
+import type { StudentExportPlacement } from "../lib/shared/types"
 
 /** 出力機能のIPC API（PDF/Excel出力・ストリーミング生成・個人成績表・印刷） */
 export function createExportApi() {
@@ -60,11 +62,8 @@ export function createExportApi() {
       getIndividualReportData: (options: {
         examId: string
         selectedExamStudentIds: string[]
-        options: import("../lib/export/individual-report/types").IndividualReportOptions
-        studentPlacements?: Record<
-          string,
-          import("../lib/shared/types").StudentExportPlacement
-        >
+        options: IndividualReportOptions
+        studentPlacements?: Record<string, StudentExportPlacement>
       }) => ipcRenderer.invoke("export:getIndividualReportData", options),
       getSubtotalGroupsForReport: (examId: string) =>
         ipcRenderer.invoke("export:getSubtotalGroupsForReport", examId),
@@ -97,10 +96,7 @@ export function createExportApi() {
       getExcelPreviewData: (options: {
         examId: string
         selectedExamStudentIds: string[]
-        studentPlacements?: Record<
-          string,
-          import("../lib/shared/types").StudentExportPlacement
-        >
+        studentPlacements?: Record<string, StudentExportPlacement>
       }) => ipcRenderer.invoke("export:getExcelPreviewData", options),
       // 印刷ダイアログを開く
       openPrintDialog: (options: {
@@ -124,10 +120,7 @@ export function createExportApi() {
       examId: string
       selectedExamStudentIds: string[]
       outputPath?: string
-      studentPlacements?: Record<
-        string,
-        import("../lib/shared/types").StudentExportPlacement
-      >
+      studentPlacements?: Record<string, StudentExportPlacement>
     }) => ipcRenderer.invoke("export-grading-data-excel", options),
 
     // R / exametrika 向けデータ出力（#834）

--- a/electron-src/preload-apis/gradeApi.ts
+++ b/electron-src/preload-apis/gradeApi.ts
@@ -4,6 +4,7 @@ import type {
   GradeCellTarget,
   GradeItemExclusionInput,
 } from "../../src/types/grade.types"
+import type { GradeArchiveImportOptions } from "../../src/types/gradeArchive.types"
 
 /** 成績算出のIPC API（成績CRUD・データソース・評定境界・手動点数・Excel出力） */
 export function createGradeApi() {
@@ -218,7 +219,7 @@ export function createGradeApi() {
       importArchive: () => ipcRenderer.invoke("grade:importArchive"),
       executeImport: (
         archiveData: unknown,
-        options?: import("../../src/types/gradeArchive.types").GradeArchiveImportOptions
+        options?: GradeArchiveImportOptions
       ) => ipcRenderer.invoke("grade:executeImport", archiveData, options),
     },
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,21 @@ export default [
       // Import sorting
       "simple-import-sort/imports": "error",
       "simple-import-sort/exports": "error",
+
+      // 型注釈に埋め込むインライン型 import（`import("./x").Foo`）を禁止する。
+      // 型の一部でありモジュール解決の走査から漏れるため、knip 等の静的解析が
+      // 参照を検出できず、実際には使われている型を未使用と誤判定する（#1082/#1083）。
+      // grep もできない。トップレベルの `import type { Foo } from "./x"` を使う。
+      // セレクタの TSImportType は型注釈側の記法のみを指し、実行時の動的 import
+      // （ImportExpression）は別ノードなので影響しない。
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSImportType",
+          message:
+            'インライン型 import は使わず、トップレベルの `import type { X } from "..."` を使ってください（静的解析が参照を追えなくなります）。',
+        },
+      ],
     },
   },
 ]

--- a/src/components/exams/02-template/hooks/useMouseHandlers.ts
+++ b/src/components/exams/02-template/hooks/useMouseHandlers.ts
@@ -11,6 +11,7 @@ import {
   MoveState,
   ResizeState,
 } from "@/components/exams/02-template/types"
+import type { CropRegionAreaType } from "@/types/cropRegionAreaType.types"
 
 /**
  * Custom hook for handling mouse events on the canvas
@@ -53,7 +54,7 @@ export function useMouseHandlers({
     label?: string
   }[]
   onAddAreaByDrag: (
-    type: import("@/types/cropRegionAreaType.types").CropRegionAreaType,
+    type: CropRegionAreaType,
     coords: { x: number; y: number; width: number; height: number }
   ) => void
   onUpdateArea: (

--- a/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
+++ b/src/components/exams/07-score-at-once/ScoringSidePanel/ScoringSidePanel.tsx
@@ -1,4 +1,9 @@
-"use client"
+import type {
+  ClickScoringAction,
+  ClickScoringConfig,
+} from "@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig"
+
+;("use client")
 
 import {
   AlertTriangle,
@@ -107,11 +112,11 @@ interface ScoringSidePanelProps {
   onSelectUnscored?: () => void
   onOpenPartialScoreModal?: () => void
   partialScoreInput: string
-  clickScoringConfig?: import("@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig").ClickScoringConfig
+  clickScoringConfig?: ClickScoringConfig
   clickScoringDebounceMs?: number
   onClickActionChange?: (
     clickCount: 2 | 3 | 4,
-    action: import("@/components/exams/07-score-at-once/ScoringMain/hooks/useClickScoringConfig").ClickScoringAction
+    action: ClickScoringAction
   ) => void
   onClickScoringDebounceMsChange?: (value: number) => void
   // Navigation Controls props

--- a/src/types/electron/answerSheetBuilderApi.d.ts
+++ b/src/types/electron/answerSheetBuilderApi.d.ts
@@ -1,31 +1,43 @@
 /**
  * 解答用紙作成（Answer Sheet Builder）関連API
  */
+
+import type {
+  AnswerSheetDefinition,
+  ASBConvertResult,
+  ASBConvertToExamArgs,
+  ASBDefinitionListItem,
+  ASBDeleteImageArgs,
+  ASBExportPdfArgs,
+  ASBExportPngArgs,
+  ASBExportResult,
+  ASBPrintArgs,
+  ASBUploadImageArgs,
+  ASBUploadImageResult,
+} from "../answerSheetBuilder.types"
+import type { AsbArchiveManifest } from "../asbArchive.types"
+
 export interface AnswerSheetBuilderAPI {
   answerSheetBuilder: {
     listDefinitions: (userId: string) => Promise<{
       success: boolean
-      data?: import("../answerSheetBuilder.types").ASBDefinitionListItem[]
+      data?: ASBDefinitionListItem[]
       error?: string
     }>
     loadDefinition: (id: string) => Promise<{
       success: boolean
-      data?: import("../answerSheetBuilder.types").AnswerSheetDefinition
+      data?: AnswerSheetDefinition
       error?: string
     }>
     saveDefinition: (
-      definition: import("../answerSheetBuilder.types").AnswerSheetDefinition,
+      definition: AnswerSheetDefinition,
       userId: string
     ) => Promise<{ success: boolean; error?: string }>
     deleteDefinition: (
       id: string
     ) => Promise<{ success: boolean; error?: string }>
-    exportPdf: (
-      args: import("../answerSheetBuilder.types").ASBExportPdfArgs
-    ) => Promise<import("../answerSheetBuilder.types").ASBExportResult>
-    exportPng: (
-      args: import("../answerSheetBuilder.types").ASBExportPngArgs
-    ) => Promise<import("../answerSheetBuilder.types").ASBExportResult>
+    exportPdf: (args: ASBExportPdfArgs) => Promise<ASBExportResult>
+    exportPng: (args: ASBExportPngArgs) => Promise<ASBExportResult>
     selectSavePath: (options: {
       type: "pdf" | "png"
       defaultName?: string
@@ -35,17 +47,11 @@ export interface AnswerSheetBuilderAPI {
       canceled?: boolean
       error?: string
     }>
-    convertToExam: (
-      args: import("../answerSheetBuilder.types").ASBConvertToExamArgs
-    ) => Promise<import("../answerSheetBuilder.types").ASBConvertResult>
-    print: (
-      args: import("../answerSheetBuilder.types").ASBPrintArgs
-    ) => Promise<{ success: boolean; error?: string }>
-    uploadImage: (
-      args: import("../answerSheetBuilder.types").ASBUploadImageArgs
-    ) => Promise<import("../answerSheetBuilder.types").ASBUploadImageResult>
+    convertToExam: (args: ASBConvertToExamArgs) => Promise<ASBConvertResult>
+    print: (args: ASBPrintArgs) => Promise<{ success: boolean; error?: string }>
+    uploadImage: (args: ASBUploadImageArgs) => Promise<ASBUploadImageResult>
     deleteImage: (
-      args: import("../answerSheetBuilder.types").ASBDeleteImageArgs
+      args: ASBDeleteImageArgs
     ) => Promise<{ success: boolean; error?: string }>
     selectImportFile: () => Promise<{
       success: boolean
@@ -55,7 +61,7 @@ export interface AnswerSheetBuilderAPI {
     }>
     analyzeAsbArchive: (filePath: string) => Promise<{
       success: boolean
-      manifest?: import("../asbArchive.types").AsbArchiveManifest
+      manifest?: AsbArchiveManifest
       error?: string
     }>
     exportDefinition: (

--- a/src/types/electron/archiveApi.d.ts
+++ b/src/types/electron/archiveApi.d.ts
@@ -1,6 +1,32 @@
 /**
  * 試験アーカイブ・生徒アーカイブ（エクスポート/インポート）関連API
  */
+
+import type {
+  AnalyzeArchiveOptions,
+  AnalyzeArchiveResult,
+  ArchiveDataCounts,
+  ArchiveExportMode,
+  BulkExportExamsOptions,
+  BulkExportExamsResult,
+  ConflictDetectionResult,
+  DetectConflictsOptions,
+  ExportExamResult,
+  FileOverviewData,
+  IdIntegrationConfig,
+  ScoringConflictConfig,
+  ScoringConflictData,
+  UpdateDecisions,
+} from "../examArchive.types"
+import type {
+  ExportStudentsArchiveOptions,
+  ExportStudentsArchiveResult,
+  StudentArchiveFileOverviewData,
+  StudentArchiveIdIntegrationConfig,
+  StudentArchiveImportResult,
+  StudentArchiveManifest,
+} from "../studentArchive.types"
+
 export interface ArchiveAPI {
   // =============================================================================
   // 試験アーカイブ（エクスポート/インポート）関連
@@ -13,22 +39,22 @@ export interface ArchiveAPI {
       examId: string
       userId: string
       outputPath?: string
-      exportMode?: import("../examArchive.types").ArchiveExportMode
-    }) => Promise<import("../examArchive.types").ExportExamResult>
+      exportMode?: ArchiveExportMode
+    }) => Promise<ExportExamResult>
 
     /**
      * アーカイブファイルを解析してプレビュー情報を取得
      */
     analyzeArchive: (
-      options: import("../examArchive.types").AnalyzeArchiveOptions
-    ) => Promise<import("../examArchive.types").AnalyzeArchiveResult>
+      options: AnalyzeArchiveOptions
+    ) => Promise<AnalyzeArchiveResult>
 
     /**
      * 事前照合を実行（Step 2: ファイル概要表示用）
      */
     preMatch: (options: { archivePath: string }) => Promise<{
       success: boolean
-      data?: import("../examArchive.types").FileOverviewData
+      data?: FileOverviewData
       error?: string
     }>
 
@@ -36,27 +62,27 @@ export interface ArchiveAPI {
      * 競合を検出（マージインポート用ドライラン）
      */
     detectConflicts: (
-      options: import("../examArchive.types").DetectConflictsOptions
-    ) => Promise<import("../examArchive.types").ConflictDetectionResult>
+      options: DetectConflictsOptions
+    ) => Promise<ConflictDetectionResult>
 
     /**
      * ID統合インポートを実行（新しいフロー）
      */
     idIntegrationImport: (options: {
       archivePath: string
-      preMatchResult: import("../examArchive.types").FileOverviewData
-      integrationConfig: import("../examArchive.types").IdIntegrationConfig
+      preMatchResult: FileOverviewData
+      integrationConfig: IdIntegrationConfig
       currentUserId: string
-      scoringConflictConfig?: import("../examArchive.types").ScoringConflictConfig
-      updateDecisions?: import("../examArchive.types").UpdateDecisions
+      scoringConflictConfig?: ScoringConflictConfig
+      updateDecisions?: UpdateDecisions
     }) => Promise<{
       success: boolean
       examId?: string
       summary?: {
-        created: import("../examArchive.types").ArchiveDataCounts
-        updated: import("../examArchive.types").ArchiveDataCounts
-        skipped: import("../examArchive.types").ArchiveDataCounts
-        unchanged: import("../examArchive.types").ArchiveDataCounts
+        created: ArchiveDataCounts
+        updated: ArchiveDataCounts
+        skipped: ArchiveDataCounts
+        unchanged: ArchiveDataCounts
       }
       warnings?: string[]
       error?: string
@@ -67,11 +93,11 @@ export interface ArchiveAPI {
      */
     detectScoringConflicts: (options: {
       archivePath: string
-      preMatchResult: import("../examArchive.types").FileOverviewData
-      integrationConfig: import("../examArchive.types").IdIntegrationConfig
+      preMatchResult: FileOverviewData
+      integrationConfig: IdIntegrationConfig
     }) => Promise<{
       success: boolean
-      data?: import("../examArchive.types").ScoringConflictData
+      data?: ScoringConflictData
       error?: string
     }>
 
@@ -79,8 +105,8 @@ export interface ArchiveAPI {
      * 複数試験を一括エクスポート
      */
     bulkExportExams: (
-      options: import("../examArchive.types").BulkExportExamsOptions
-    ) => Promise<import("../examArchive.types").BulkExportExamsResult>
+      options: BulkExportExamsOptions
+    ) => Promise<BulkExportExamsResult>
 
     /**
      * インポートファイル選択ダイアログ
@@ -123,8 +149,8 @@ export interface ArchiveAPI {
      * 選択した生徒・学級データを.studentsファイルとしてエクスポート
      */
     exportStudents: (
-      options: import("../studentArchive.types").ExportStudentsArchiveOptions
-    ) => Promise<import("../studentArchive.types").ExportStudentsArchiveResult>
+      options: ExportStudentsArchiveOptions
+    ) => Promise<ExportStudentsArchiveResult>
 
     /**
      * .studentsファイル選択ダイアログ
@@ -141,7 +167,7 @@ export interface ArchiveAPI {
      */
     analyzeArchive: (options: { archivePath: string }) => Promise<{
       success: boolean
-      manifest?: import("../studentArchive.types").StudentArchiveManifest
+      manifest?: StudentArchiveManifest
       error?: string
     }>
 
@@ -150,7 +176,7 @@ export interface ArchiveAPI {
      */
     preMatch: (options: { archivePath: string }) => Promise<{
       success: boolean
-      data?: import("../studentArchive.types").StudentArchiveFileOverviewData
+      data?: StudentArchiveFileOverviewData
       error?: string
     }>
 
@@ -159,9 +185,9 @@ export interface ArchiveAPI {
      */
     import: (options: {
       archivePath: string
-      preMatchResult: import("../studentArchive.types").StudentArchiveFileOverviewData
-      integrationConfig: import("../studentArchive.types").StudentArchiveIdIntegrationConfig
-      updateDecisions?: import("../examArchive.types").UpdateDecisions
-    }) => Promise<import("../studentArchive.types").StudentArchiveImportResult>
+      preMatchResult: StudentArchiveFileOverviewData
+      integrationConfig: StudentArchiveIdIntegrationConfig
+      updateDecisions?: UpdateDecisions
+    }) => Promise<StudentArchiveImportResult>
   }
 }

--- a/src/types/electron/courseworkApi.d.ts
+++ b/src/types/electron/courseworkApi.d.ts
@@ -1,17 +1,34 @@
 /**
  * Coursework（試験外成績資料）関連 API
  */
+
+import type {
+  CourseworkItemWithLetterScales,
+  CourseworkScoreUpsertInput,
+  CourseworkScoreWithCourseworkStudent,
+  CourseworkStudentWithMemberships,
+  CourseworkSummary,
+  CourseworkWithRelations,
+} from "../coursework.types"
+import type {
+  CourseworkArchiveImportPreview,
+  CourseworkArchiveImportResult,
+  CourseworkImportDecisions,
+  CourseworkMatchingMethod,
+  ExportCourseworkArchiveResult,
+} from "../courseworkArchive.types"
+
 export interface CourseworkAPI {
   coursework: {
     // Coursework（トップレベル）
     getAll: () => Promise<{
       success: boolean
-      courseworks?: import("../coursework.types").CourseworkSummary[]
+      courseworks?: CourseworkSummary[]
       error?: string
     }>
     getById: (id: string) => Promise<{
       success: boolean
-      coursework?: import("../coursework.types").CourseworkWithRelations
+      coursework?: CourseworkWithRelations
       error?: string
     }>
     create: (data: {
@@ -20,7 +37,7 @@ export interface CourseworkAPI {
       date?: string | null
     }) => Promise<{
       success: boolean
-      coursework?: import("../coursework.types").CourseworkWithRelations
+      coursework?: CourseworkWithRelations
       error?: string
     }>
     update: (
@@ -32,7 +49,7 @@ export interface CourseworkAPI {
       }
     ) => Promise<{
       success: boolean
-      coursework?: import("../coursework.types").CourseworkWithRelations
+      coursework?: CourseworkWithRelations
       error?: string
     }>
     delete: (id: string) => Promise<{
@@ -66,7 +83,7 @@ export interface CourseworkAPI {
       letterScales?: { label: string; score: number; order: number }[]
     }) => Promise<{
       success: boolean
-      item?: import("../coursework.types").CourseworkItemWithLetterScales
+      item?: CourseworkItemWithLetterScales
       error?: string
     }>
     updateItem: (
@@ -79,7 +96,7 @@ export interface CourseworkAPI {
       }
     ) => Promise<{
       success: boolean
-      item?: import("../coursework.types").CourseworkItemWithLetterScales
+      item?: CourseworkItemWithLetterScales
       error?: string
     }>
     deleteItem: (id: string) => Promise<{
@@ -94,17 +111,17 @@ export interface CourseworkAPI {
     // 点数
     getScores: (courseworkItemId: string) => Promise<{
       success: boolean
-      scores?: import("../coursework.types").CourseworkScoreWithCourseworkStudent[]
+      scores?: CourseworkScoreWithCourseworkStudent[]
       error?: string
     }>
     batchUpsertScores: (
-      scores: import("../coursework.types").CourseworkScoreUpsertInput[]
+      scores: CourseworkScoreUpsertInput[]
     ) => Promise<{ success: boolean; error?: string }>
 
     // 名簿
     getStudents: (courseworkId: string) => Promise<{
       success: boolean
-      students?: import("../coursework.types").CourseworkStudentWithMemberships[]
+      students?: CourseworkStudentWithMemberships[]
       error?: string
     }>
     getClassrooms: (courseworkId: string) => Promise<{
@@ -206,9 +223,7 @@ export interface CourseworkAPI {
     // アーカイブ（.coursework のエクスポート／インポート）
     exportArchive: (
       courseworkId: string
-    ) => Promise<
-      import("../courseworkArchive.types").ExportCourseworkArchiveResult
-    >
+    ) => Promise<ExportCourseworkArchiveResult>
     selectImportFile: () => Promise<{
       success: boolean
       filePath?: string
@@ -217,15 +232,13 @@ export interface CourseworkAPI {
     }>
     analyzeArchive: (options: { archivePath: string }) => Promise<{
       success: boolean
-      preview?: import("../courseworkArchive.types").CourseworkArchiveImportPreview
+      preview?: CourseworkArchiveImportPreview
       error?: string
     }>
     importArchive: (options: {
       archivePath: string
-      courseworkDecisions?: import("../courseworkArchive.types").CourseworkImportDecisions
-      studentMatching?: import("../courseworkArchive.types").CourseworkMatchingMethod
-    }) => Promise<
-      import("../courseworkArchive.types").CourseworkArchiveImportResult
-    >
+      courseworkDecisions?: CourseworkImportDecisions
+      studentMatching?: CourseworkMatchingMethod
+    }) => Promise<CourseworkArchiveImportResult>
   }
 }

--- a/src/types/electron/drawingApi.d.ts
+++ b/src/types/electron/drawingApi.d.ts
@@ -1,40 +1,48 @@
 /**
  * 描画アノテーション関連API
  */
+
+import type {
+  AnnotationWithContext,
+  DrawingAnnotation,
+  DrawingAnnotationStats,
+  DrawingCreateData,
+  DrawingType,
+  DrawingUpdateData,
+} from "../drawingAnnotation.types"
+
 export interface DrawingAPI {
   drawing: {
-    create: (
-      data: import("../drawingAnnotation.types").DrawingCreateData
-    ) => Promise<{
+    create: (data: DrawingCreateData) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation
+      data?: DrawingAnnotation
       error?: string
     }>
     getByQuestionScore: (
       questionScoreId: string,
-      type?: import("../drawingAnnotation.types").DrawingType,
+      type?: DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
+      data?: DrawingAnnotation[]
       error?: string
     }>
     getByExamStudent: (
       examStudentId: string,
-      type?: import("../drawingAnnotation.types").DrawingType,
+      type?: DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
+      data?: DrawingAnnotation[]
       error?: string
     }>
     getByExam: (
       examId: string,
-      type?: import("../drawingAnnotation.types").DrawingType,
+      type?: DrawingType,
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
+      data?: DrawingAnnotation[]
       error?: string
     }>
     // main 側は questionScore（examStudentId / cropRegion）を include して返すので、
@@ -45,15 +53,15 @@ export interface DrawingAPI {
       userId?: string
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").AnnotationWithContext[]
+      data?: AnnotationWithContext[]
       error?: string
     }>
     update: (
       id: string,
-      data: import("../drawingAnnotation.types").DrawingUpdateData
+      data: DrawingUpdateData
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation
+      data?: DrawingAnnotation
       error?: string
     }>
     delete: (id: string) => Promise<{
@@ -62,36 +70,34 @@ export interface DrawingAPI {
     }>
     deleteByQuestionScore: (
       questionScoreId: string,
-      type?: import("../drawingAnnotation.types").DrawingType
+      type?: DrawingType
     ) => Promise<{
       success: boolean
       error?: string
     }>
-    batchCreate: (
-      annotations: import("../drawingAnnotation.types").DrawingCreateData[]
-    ) => Promise<{
+    batchCreate: (annotations: DrawingCreateData[]) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
+      data?: DrawingAnnotation[]
       error?: string
     }>
     batchUpdate: (
       updates: Array<{
         id: string
-        data: import("../drawingAnnotation.types").DrawingUpdateData
+        data: DrawingUpdateData
       }>
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation[]
+      data?: DrawingAnnotation[]
       error?: string
     }>
     getStats: (questionScoreId: string) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotationStats
+      data?: DrawingAnnotationStats
       error?: string
     }>
     getById: (id: string) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation | null
+      data?: DrawingAnnotation | null
       error?: string
     }>
     toggleFavorite: (
@@ -99,12 +105,12 @@ export interface DrawingAPI {
       isFavorite: boolean
     ) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").DrawingAnnotation
+      data?: DrawingAnnotation
       error?: string
     }>
     getForBrowse: (examId: string) => Promise<{
       success: boolean
-      data?: import("../drawingAnnotation.types").AnnotationWithContext[]
+      data?: AnnotationWithContext[]
       error?: string
     }>
   }

--- a/src/types/electron/examApi.d.ts
+++ b/src/types/electron/examApi.d.ts
@@ -1,6 +1,7 @@
 import type { Exam, Prisma } from "@prisma/client"
 
 import type { ExamPageWithContent } from "@/electron-src/lib/prisma/examPage"
+import type { GradingDataInfo } from "@/electron-src/lib/prisma/gradingData"
 import type { ExamSummary } from "@/lib/examStatus"
 
 import type { ExamStudentStatus } from "../examStudentStatus.types"
@@ -87,10 +88,7 @@ export interface ExamAPI {
     totalGradingItems?: number
     // main 側の SSOT をそのまま参照する（手書きで写すと今回のように
     // フィールド名と数える範囲がずれ、削除確認の表示が実態とずれる）
-    studentData?: Record<
-      string,
-      import("@/electron-src/lib/prisma/gradingData").GradingDataInfo
-    >
+    studentData?: Record<string, GradingDataInfo>
     error?: string
   }>
 }

--- a/src/types/electron/gradeApi.d.ts
+++ b/src/types/electron/gradeApi.d.ts
@@ -1,16 +1,37 @@
 /**
  * Grade（成績算出）関連API
  */
+
+import type { GradeItemExclusion } from "@prisma/client"
+
+import type {
+  GradeBoundarySetWithItemAndBoundaries,
+  GradeCalculationResult,
+  GradeCellTarget,
+  GradeConstraintData,
+  GradeConstraintInput,
+  GradeDataSourceWithRelations,
+  GradeItemExclusionInput,
+  GradeItemWithDataSources,
+  GradeWithRelations,
+} from "../grade.types"
+import type {
+  GradeArchiveData,
+  GradeArchiveImportOptions,
+  GradeArchiveImportPreview,
+} from "../gradeArchive.types"
+import type { StudentWithMemberships } from "../prismaExtensions"
+
 export interface GradeAPI {
   grade: {
     getAll: () => Promise<{
       success: boolean
-      grades?: import("../grade.types").GradeWithRelations[]
+      grades?: GradeWithRelations[]
       error?: string
     }>
     getById: (id: string) => Promise<{
       success: boolean
-      grade?: import("../grade.types").GradeWithRelations
+      grade?: GradeWithRelations
       error?: string
     }>
     create: (data: {
@@ -19,7 +40,7 @@ export interface GradeAPI {
       referenceDate?: string | null
     }) => Promise<{
       success: boolean
-      grade?: import("../grade.types").GradeWithRelations
+      grade?: GradeWithRelations
       error?: string
     }>
     update: (
@@ -31,13 +52,13 @@ export interface GradeAPI {
       }
     ) => Promise<{
       success: boolean
-      grade?: import("../grade.types").GradeWithRelations
+      grade?: GradeWithRelations
       error?: string
     }>
     delete: (id: string) => Promise<{ success: boolean; error?: string }>
     duplicate: (id: string) => Promise<{
       success: boolean
-      grade?: import("../grade.types").GradeWithRelations
+      grade?: GradeWithRelations
       error?: string
     }>
     // 生徒・学級管理
@@ -93,7 +114,7 @@ export interface GradeAPI {
       activeOnly?: boolean
     ) => Promise<{
       success: boolean
-      students?: import("../prismaExtensions").StudentWithMemberships[]
+      students?: StudentWithMemberships[]
       error?: string
     }>
     addStudentsFromClassroom: (
@@ -143,12 +164,12 @@ export interface GradeAPI {
     // GradeItem
     getGradeItems: (gradeId: string) => Promise<{
       success: boolean
-      gradeItems?: import("../grade.types").GradeItemWithDataSources[]
+      gradeItems?: GradeItemWithDataSources[]
       error?: string
     }>
     createGradeItem: (data: { gradeId: string; name: string }) => Promise<{
       success: boolean
-      gradeItem?: import("../grade.types").GradeItemWithDataSources
+      gradeItem?: GradeItemWithDataSources
       error?: string
     }>
     updateGradeItem: (
@@ -156,7 +177,7 @@ export interface GradeAPI {
       data: { name?: string }
     ) => Promise<{
       success: boolean
-      gradeItem?: import("../grade.types").GradeItemWithDataSources
+      gradeItem?: GradeItemWithDataSources
       error?: string
     }>
     deleteGradeItem: (id: string) => Promise<{
@@ -187,7 +208,7 @@ export interface GradeAPI {
       estimationSourceIds?: string[]
     }) => Promise<{
       success: boolean
-      dataSource?: import("../grade.types").GradeDataSourceWithRelations
+      dataSource?: GradeDataSourceWithRelations
       error?: string
     }>
     updateDataSource: (
@@ -204,7 +225,7 @@ export interface GradeAPI {
       }
     ) => Promise<{
       success: boolean
-      dataSource?: import("../grade.types").GradeDataSourceWithRelations
+      dataSource?: GradeDataSourceWithRelations
       error?: string
     }>
     deleteDataSource: (
@@ -215,7 +236,7 @@ export interface GradeAPI {
     ) => Promise<{ success: boolean; error?: string }>
     getBoundarySets: (gradeId: string) => Promise<{
       success: boolean
-      boundarySets?: import("../grade.types").GradeBoundarySetWithItemAndBoundaries[]
+      boundarySets?: GradeBoundarySetWithItemAndBoundaries[]
       error?: string
     }>
     upsertBoundarySet: (data: {
@@ -224,39 +245,39 @@ export interface GradeAPI {
       boundaries: { label: string; minPercentage: number; order: number }[]
     }) => Promise<{
       success: boolean
-      boundarySet?: import("../grade.types").GradeBoundarySetWithItemAndBoundaries
+      boundarySet?: GradeBoundarySetWithItemAndBoundaries
       error?: string
     }>
     deleteBoundarySet: (
       id: string
     ) => Promise<{ success: boolean; error?: string }>
     upsertGradeOverride: (
-      data: import("../grade.types").GradeCellTarget & {
+      data: GradeCellTarget & {
         overrideLabel: string
       }
     ) => Promise<{ success: boolean; override?: unknown; error?: string }>
     deleteGradeOverride: (
-      target: import("../grade.types").GradeCellTarget
+      target: GradeCellTarget
     ) => Promise<{ success: boolean; error?: string }>
     getGradeConstraints: (gradeId: string) => Promise<{
       success: boolean
-      constraints?: import("../grade.types").GradeConstraintData[]
+      constraints?: GradeConstraintData[]
       error?: string
     }>
     createGradeConstraint: (data: {
       gradeId: string
-      constraint: import("../grade.types").GradeConstraintInput
+      constraint: GradeConstraintInput
     }) => Promise<{
       success: boolean
-      constraint?: import("../grade.types").GradeConstraintData
+      constraint?: GradeConstraintData
       error?: string
     }>
     updateGradeConstraint: (data: {
       id: string
-      constraint: Partial<import("../grade.types").GradeConstraintInput>
+      constraint: Partial<GradeConstraintInput>
     }) => Promise<{
       success: boolean
-      constraint?: import("../grade.types").GradeConstraintData
+      constraint?: GradeConstraintData
       error?: string
     }>
     deleteGradeConstraint: (
@@ -264,18 +285,18 @@ export interface GradeAPI {
     ) => Promise<{ success: boolean; error?: string }>
     getGradeItemExclusions: (gradeId: string) => Promise<{
       success: boolean
-      exclusions?: import("@prisma/client").GradeItemExclusion[]
+      exclusions?: GradeItemExclusion[]
       error?: string
     }>
     setGradeItemExclusion: (
-      input: import("../grade.types").GradeItemExclusionInput
+      input: GradeItemExclusionInput
     ) => Promise<{ success: boolean; error?: string }>
     batchUpdateGradeItemExclusions: (
-      updates: import("../grade.types").GradeItemExclusionInput[]
+      updates: GradeItemExclusionInput[]
     ) => Promise<{ success: boolean; error?: string }>
     calculateGrades: (gradeId: string) => Promise<{
       success: boolean
-      result?: import("../grade.types").GradeCalculationResult
+      result?: GradeCalculationResult
       error?: string
     }>
     /** 各データソースのモデル適合度 R（手法選択画面の判断材料）を保存設定で算出 */
@@ -291,13 +312,13 @@ export interface GradeAPI {
      */
     freezeGradeScores: (data: {
       gradeId: string
-      targets?: import("../grade.types").GradeCellTarget[]
+      targets?: GradeCellTarget[]
       frozenByUserId?: string | null
     }) => Promise<{ success: boolean; frozenCount?: number; error?: string }>
     /** 成績値の確定を解除する（リアルタイム算出値へ戻す）。targets 未指定は Grade 全体 */
     unfreezeGradeScores: (data: {
       gradeId: string
-      targets?: import("../grade.types").GradeCellTarget[]
+      targets?: GradeCellTarget[]
       userId?: string | null
     }) => Promise<{ success: boolean; unfrozenCount?: number; error?: string }>
     getExamCandidates: () => Promise<{
@@ -358,13 +379,13 @@ export interface GradeAPI {
     }>
     importArchive: () => Promise<{
       success: boolean
-      preview?: import("../gradeArchive.types").GradeArchiveImportPreview
-      archiveData?: import("../gradeArchive.types").GradeArchiveData
+      preview?: GradeArchiveImportPreview
+      archiveData?: GradeArchiveData
       error?: string
     }>
     executeImport: (
-      archiveData: import("../gradeArchive.types").GradeArchiveData,
-      options?: import("../gradeArchive.types").GradeArchiveImportOptions
+      archiveData: GradeArchiveData,
+      options?: GradeArchiveImportOptions
     ) => Promise<{
       success: boolean
       gradeId?: string

--- a/src/types/electron/omrApi.d.ts
+++ b/src/types/electron/omrApi.d.ts
@@ -1,43 +1,45 @@
 /**
  * OMR（光学マーク認識）・OMR Config関連API
  */
+
+import type { ComputedCell } from "../answerSheetBuilder.types"
+import type {
+  CropRegionOmrConfigWithOptions,
+  MarkerDetectionResult,
+  OMRBatchProgress,
+  OMRCellConfig,
+  OMRRecognitionParams,
+  OMRSheetResult,
+  Point,
+} from "../omr.types"
+
 export interface OmrAPI {
   omr: {
     detectMarkers: (
       imagePath: string,
       colorThreshold?: number
-    ) => Promise<import("../omr.types").MarkerDetectionResult>
+    ) => Promise<MarkerDetectionResult>
     recognizeSheet: (args: {
       imagePath: string
-      cells: import("../answerSheetBuilder.types").ComputedCell[]
-      cellConfigs: Record<string, import("../omr.types").OMRCellConfig>
-      expectedCorners: [
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-      ]
-      params: import("../omr.types").OMRRecognitionParams
+      cells: ComputedCell[]
+      cellConfigs: Record<string, OMRCellConfig>
+      expectedCorners: [Point, Point, Point, Point]
+      params: OMRRecognitionParams
       pageIndex?: number
       examStudentId?: string
-    }) => Promise<import("../omr.types").OMRSheetResult>
+    }) => Promise<OMRSheetResult>
     batchRecognize: (args: {
       imagePaths: {
         path: string
         examStudentId?: string
         studentName?: string
       }[]
-      cells: import("../answerSheetBuilder.types").ComputedCell[]
-      cellConfigs: Record<string, import("../omr.types").OMRCellConfig>
-      expectedCorners: [
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-        import("../omr.types").Point,
-      ]
-      params: import("../omr.types").OMRRecognitionParams
+      cells: ComputedCell[]
+      cellConfigs: Record<string, OMRCellConfig>
+      expectedCorners: [Point, Point, Point, Point]
+      params: OMRRecognitionParams
       pageIndex?: number
-    }) => Promise<import("../omr.types").OMRSheetResult[]>
+    }) => Promise<OMRSheetResult[]>
     detectMasterMarkers: (
       examId: string,
       colorThreshold?: number
@@ -47,7 +49,7 @@ export interface OmrAPI {
       pages: Array<{
         examPageId: string
         pageNumber: number
-        result: import("../omr.types").MarkerDetectionResult
+        result: MarkerDetectionResult
       }>
       error?: string
     }>
@@ -62,7 +64,7 @@ export interface OmrAPI {
       error?: string
     }>
     onBatchProgress: (
-      callback: (progress: import("../omr.types").OMRBatchProgress) => void
+      callback: (progress: OMRBatchProgress) => void
     ) => () => void
   }
 
@@ -95,7 +97,7 @@ export interface OmrAPI {
       }>
     }) => Promise<{
       success: boolean
-      config?: import("../omr.types").CropRegionOmrConfigWithOptions
+      config?: CropRegionOmrConfigWithOptions
       error?: string
     }>
     delete: (cropRegionId: string) => Promise<{
@@ -104,7 +106,7 @@ export interface OmrAPI {
     }>
     getByExam: (examId: string) => Promise<{
       success: boolean
-      configs?: import("../omr.types").CropRegionOmrConfigWithOptions[]
+      configs?: CropRegionOmrConfigWithOptions[]
       error?: string
     }>
   }


### PR DESCRIPTION
Closes #1084

## 背景

型注釈に埋め込む `import("...").Foo` 形式は、式ではなく型の一部であるためモジュール解決の走査から漏れる。knip 等の静的解析が参照を検出できず、実際に使われている型を未使用と誤判定する。

PR #1083 ではこの形式の参照を手作業でパス解決して消費者集合に加えることで、以下6件の誤削除を回避した。

- `ASBExportResult` / `ASBConvertResult` / `ASBUploadImageResult`
- `BulkExportExamsOptions` / `DetectConflictsOptions`
- `GradingDataInfo`

この回避策は解析を走らせるたびにやり直しになる。書き方を統一して恒久的に解消する。

`src/types/electron/` の22ファイル中16ファイルは既にトップレベル `import type` で書かれて動作しており、インライン形式に技術的必要性はない。

## 変更内容

### 1. インライン型 import 158箇所 / 18ファイルを変換

issue 起票時点は151箇所だったが、その後 `gradeApi.d.ts` が 23 → 30 に増えていた。放置すると増え続ける。

| ファイル | 箇所 |
| --- | --- |
| `src/types/electron/gradeApi.d.ts` | 30 |
| `src/types/electron/archiveApi.d.ts` | 28 |
| `src/types/electron/omrApi.d.ts` | 21 |
| `src/types/electron/drawingApi.d.ts` | 20 |
| `src/types/electron/answerSheetBuilderApi.d.ts` | 14 |
| `src/types/electron/courseworkApi.d.ts` | 14 |
| `electron-src/preload-apis/archiveApi.ts` | 12 |
| その他9ファイル | 19 |

同名衝突は1件も発生せず、`as` によるリネームは不要だった。`archiveHandlers.ts` の1箇所は既存のトップレベル import へマージされている。

### 2. `typeof import("...")` 3箇所も同様に変換

遅延 `require` に型を付けている箇所。issue には挙がっていなかったが、モジュール参照が型の中に埋まっている点は同じで、同じ死角にあたる。

| ファイル | 変更 |
| --- | --- |
| `electron-src/lib/prisma/auditActor.ts` | `typeof import("../authStore")` → `import type * as AuthStore` |
| `electron-src/nextServerEmbedded.ts` | `typeof import("module")` → `import type * as NodeModule` |
| `__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts` | `vi.importActual<typeof import("fs")>` → `typeof NodeFs` |

`auditActor.ts` の「electron 非搭載環境（vitest 等）でのトップレベル副作用を避ける」意図は保たれる。`import type` は実行時に完全に消えるため。その旨をコメントに明記した。

### 3. 再発防止ルール

```javascript
"no-restricted-syntax": [
  "error",
  { selector: "TSImportType", message: "インライン型 import は使わず..." },
],
```

一度直しても書き方が戻れば同じことになるため、ESLint で塞ぐ。

`TSImportType` は型注釈側の記法のみを指すノードで、実行時の動的 import は `ImportExpression` という別ノードである。パーサで確認済みで、**このルールは `await import()` に一切影響しない。**

## 安全性

`.d.ts` にトップレベル import を足すとそのファイルは script ではなく module として扱われるため、グローバル宣言を持つファイルでは破壊的になりうる。確認した結果、変換対象は影響を受けない。

- `declare global` を使うのは `electron-src/preload.ts` と `src/types/electron.d.ts` の2ファイルのみで、いずれも変換対象外
- 変換した `.d.ts` はすべて `export interface XxxAPI` を持ち、既に module
- 同じ構造の `examApi.d.ts` がトップレベル import で実際に動作している

コードの意味は変わらない（型注釈の書き方のみ）。

## 検証

| 項目 | 結果 |
| --- | --- |
| `npm run typecheck` | エラー 0 |
| `npm run lint` | エラー 0（warning 142件は既存） |
| `prettier --check` | 全ファイル適合 |
| `npx vitest run` | 117ファイル / 1194テスト 全通過 |
| インライン型 import 残存 | 0件 |