### PR TITLE
refactor(imports): 組み込みモジュールを名前空間 import へ統一し別名 import を排除する

### DIFF
--- a/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
+++ b/__tests__/answer-sheet-builder/unit/htmlToPngBuffer.test.ts
@@ -202,8 +202,10 @@ describe("htmlToPngBuffer", () => {
     await htmlToPngBuffer(html, 210, 297, 300)
 
     // writeFileSyncに渡されたHTMLを検証
+    // printUtils は名前空間 import（`import * as fs from "fs"`）なので、
+    // モックの default キーではなく名前空間直下の writeFileSync が呼ばれる
     const fs = await import("fs")
-    const writeCall = vi.mocked(fs.default.writeFileSync).mock.calls[0]
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0]
     const writtenHtml = writeCall[1] as string
 
     expect(writtenHtml).toContain("width: 100vw !important")

--- a/__tests__/exam/integration/examDelete.test.ts
+++ b/__tests__/exam/integration/examDelete.test.ts
@@ -4,7 +4,7 @@
  * deleteExam が DB レコードを cascade 削除するだけでなく、
  * 試験ディレクトリ配下の画像ファイルも削除することを検証する。
  */
-import * as fs from "fs/promises"
+import * as fsPromises from "fs/promises"
 import * as os from "os"
 import * as path from "path"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
@@ -46,7 +46,7 @@ describe("deleteExam", () => {
 
   afterAll(async () => {
     await prisma.user.delete({ where: { id: userId } })
-    await fs.rm(TEST_DATA_DIR, { recursive: true, force: true })
+    await fsPromises.rm(TEST_DATA_DIR, { recursive: true, force: true })
     await disconnectTestPrisma()
   })
 
@@ -60,9 +60,9 @@ describe("deleteExam", () => {
       getExamDirectory(exam.id),
       "master-answers"
     )
-    await fs.mkdir(masterAnswersDir, { recursive: true })
+    await fsPromises.mkdir(masterAnswersDir, { recursive: true })
     const imagePath = path.join(masterAnswersDir, "page-1.png")
-    await fs.writeFile(imagePath, "dummy-image")
+    await fsPromises.writeFile(imagePath, "dummy-image")
     await prisma.masterImage.create({
       data: {
         examPageId: examPage.id,
@@ -78,7 +78,7 @@ describe("deleteExam", () => {
       await prisma.examPage.findUnique({ where: { id: examPage.id } })
     ).toBeNull()
     // 画像ファイルとディレクトリが残っていないこと
-    await expect(fs.stat(getExamDirectory(exam.id))).rejects.toThrow()
+    await expect(fsPromises.stat(getExamDirectory(exam.id))).rejects.toThrow()
   })
 
   it("試験ディレクトリが存在しない場合も削除に失敗しない", async () => {

--- a/__tests__/helpers/testDataFactory.ts
+++ b/__tests__/helpers/testDataFactory.ts
@@ -4,7 +4,7 @@
  * テスト用のアーカイブデータ、Prismaレコード、ID統合設定を生成するヘルパー
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type { ExtractedArchiveData } from "../../electron-src/lib/import/exam-archive/archiveExtractor"
 import type {
@@ -34,7 +34,7 @@ import type {
 // =============================================================================
 
 export function generateId(): string {
-  return randomUUID()
+  return crypto.randomUUID()
 }
 
 // =============================================================================

--- a/__tests__/helpers/testExamBuilder.ts
+++ b/__tests__/helpers/testExamBuilder.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CropRegion, PrismaClient } from "@prisma/client"
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 interface FullTestExamOptions {
   /** ページ数 (default: 2) */
@@ -138,7 +138,7 @@ export async function createFullTestExam(
   // 1. ユーザー作成
   const user = await prisma.user.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       username: `testuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       name: "テストユーザー",
       role: "teacher",
@@ -148,7 +148,7 @@ export async function createFullTestExam(
   // 2. 試験作成
   const exam = await prisma.exam.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       examName,
       examDate: new Date("2025-07-01"),
     },
@@ -157,7 +157,7 @@ export async function createFullTestExam(
   // 3. UserExam作成
   const userExam = await prisma.userExam.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       userId: user.id,
       examId: exam.id,
       role: "OWNER",
@@ -169,7 +169,7 @@ export async function createFullTestExam(
   for (let i = 0; i < pageCount; i++) {
     const page = await prisma.examPage.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examId: exam.id,
         pageNumber: i + 1,
       },
@@ -183,7 +183,7 @@ export async function createFullTestExam(
     for (let j = 0; j < cropRegionsPerPage; j++) {
       const region = await prisma.cropRegion.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           examPageId: page.id,
           label: `問${cropRegions.length + 1}`,
           type: "QUESTION",
@@ -202,7 +202,7 @@ export async function createFullTestExam(
   // 6. 学級作成
   const classroom = await prisma.classroom.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       name: `${className}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     },
   })
@@ -216,7 +216,7 @@ export async function createFullTestExam(
   for (let i = 0; i < studentCount; i++) {
     const student = await prisma.student.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         studentNumber: `S${String(i + 1).padStart(3, "0")}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         lastName: `姓${i + 1}`,
         firstName: `名${i + 1}`,
@@ -230,7 +230,7 @@ export async function createFullTestExam(
     // メンバーシップ
     const membership = await prisma.studentClassroomMembership.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         studentId: student.id,
         classroomId: classroom.id,
         attendanceNumber: i + 1,
@@ -241,7 +241,7 @@ export async function createFullTestExam(
     // ExamStudent
     const examStudent = await prisma.examStudent.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examId: exam.id,
         studentId: student.id,
         status: "PARTICIPATING",
@@ -254,7 +254,7 @@ export async function createFullTestExam(
   // 8. ExamClassroom作成
   const examClassroom = await prisma.examClassroom.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       examId: exam.id,
       classroomId: classroom.id,
       administered: true,
@@ -267,7 +267,7 @@ export async function createFullTestExam(
   // 9. SubtotalGroup + Subtotal作成
   const subtotalGroup = await prisma.subtotalGroup.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       name: `小計G_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     },
   })
@@ -277,7 +277,7 @@ export async function createFullTestExam(
   for (let i = 0; i < subtotalNames.length; i++) {
     const subtotal = await prisma.subtotal.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         name: subtotalNames[i],
         subtotalGroupId: subtotalGroup.id,
         order: i,
@@ -289,7 +289,7 @@ export async function createFullTestExam(
   // 10. ExamSubtotalGroup作成
   const examSubtotalGroup = await prisma.examSubtotalGroup.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       examId: exam.id,
       subtotalGroupId: subtotalGroup.id,
     },
@@ -301,7 +301,7 @@ export async function createFullTestExam(
     const subtotalIdx = i % subtotals.length
     const cropSubtotal = await prisma.cropSubtotal.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         cropRegionId: cropRegions[i].id,
         subtotalId: subtotals[subtotalIdx].id,
         assignmentType: "auto",
@@ -317,7 +317,7 @@ export async function createFullTestExam(
       for (const student of students) {
         const questionScore = await prisma.questionScore.create({
           data: {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             cropRegionId: region.id,
             examStudentId: examStudentByStudentId.get(student.id)!.id,
             userId: user.id,
@@ -345,7 +345,7 @@ export async function createFullTestExam(
     // 最初のスコアにだけアノテーションを追加
     const drawingAnnotation = await prisma.drawingAnnotation.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         questionScoreId: questionScores[0].id,
         type: "circle",
         x: 10,
@@ -362,7 +362,7 @@ export async function createFullTestExam(
     for (const page of pages) {
       const masterImage = await prisma.masterImage.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           examPageId: page.id,
           imagePath: `exams/${exam.id}/master-images/page${page.pageNumber}.png`,
         },
@@ -378,7 +378,7 @@ export async function createFullTestExam(
       for (const student of students) {
         const studentAnswerImage = await prisma.studentAnswerImage.create({
           data: {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             examPageId: page.id,
             examStudentId: examStudentByStudentId.get(student.id)!.id,
             imagePath: `exams/${exam.id}/answer-sheets/${student.studentNumber}_page${page.pageNumber}.png`,
@@ -400,7 +400,7 @@ export async function createFullTestExam(
     for (const markType of ["correct", "incorrect"]) {
       const examMarkingFormat = await prisma.examMarkingFormat.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           examId: exam.id,
           markType,
           symbol: markType === "correct" ? "○" : "×",
@@ -413,7 +413,7 @@ export async function createFullTestExam(
     // ExamExportSettings
     examExportSettings = await prisma.examExportSettings.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examId: exam.id,
         settingsJson: JSON.stringify({ includeImages: true }),
       },
@@ -422,14 +422,14 @@ export async function createFullTestExam(
     // Tag + TagSubtotalGroup
     tag = await prisma.tag.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         name: `数学_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       },
     })
 
     tagSubtotalGroup = await prisma.tagSubtotalGroup.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         tagId: tag.id,
         subtotalGroupId: subtotalGroup.id,
       },

--- a/__tests__/import-export/unit/cascadeCoverage.test.ts
+++ b/__tests__/import-export/unit/cascadeCoverage.test.ts
@@ -10,8 +10,8 @@
  * 失敗して気付ける（規約をコードで強制する仕組み）。
  */
 
-import { readFileSync } from "fs"
-import { resolve } from "path"
+import * as fs from "fs"
+import * as path from "path"
 import { describe, expect, it } from "vitest"
 
 import {
@@ -25,8 +25,8 @@ import {
  * （FKを持つ＝owning側の）モデル名の集合を返す。
  */
 function cascadeChildrenFromSchema(target: string): string[] {
-  const src = readFileSync(
-    resolve(process.cwd(), "prisma/schema.prisma"),
+  const src = fs.readFileSync(
+    path.resolve(process.cwd(), "prisma/schema.prisma"),
     "utf8"
   )
   const modelRe = /^model\s+(\w+)\s*\{([\s\S]*?)^\}/gm

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -6,7 +6,7 @@
  */
 
 import { PrismaClient } from "@prisma/client"
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 import sharp from "sharp"
@@ -294,7 +294,7 @@ export async function seedStudents(): Promise<string[]> {
     const studentData = STUDENT_DATA[i]
     const student = await db.student.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         studentNumber: `S${String(i + 1).padStart(3, "0")}`,
         lastName: studentData.lastName,
         firstName: studentData.firstName,
@@ -317,15 +317,15 @@ export async function seedClasses(
 ): Promise<{ classAId: string; classBId: string }> {
   const db = getPrisma()
   const classroomA = await db.classroom.create({
-    data: { id: randomUUID(), name: "2年A組", grade: 2 },
+    data: { id: crypto.randomUUID(), name: "2年A組", grade: 2 },
   })
   const classroomB = await db.classroom.create({
-    data: { id: randomUUID(), name: "2年B組", grade: 2 },
+    data: { id: crypto.randomUUID(), name: "2年B組", grade: 2 },
   })
   for (let i = 0; i < 20; i++) {
     await db.studentClassroomMembership.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         studentId: studentIds[i],
         classroomId: classroomA.id,
         attendanceNumber: i + 1,
@@ -335,7 +335,7 @@ export async function seedClasses(
   for (let i = 20; i < 40; i++) {
     await db.studentClassroomMembership.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         studentId: studentIds[i],
         classroomId: classroomB.id,
         attendanceNumber: i - 19,
@@ -355,7 +355,7 @@ export async function seedSubtotalAndTag(): Promise<{
 }> {
   const db = getPrisma()
   const subtotalGroup = await db.subtotalGroup.create({
-    data: { id: randomUUID(), name: "観点別評価" },
+    data: { id: crypto.randomUUID(), name: "観点別評価" },
   })
   const subtotalNames = [
     "知識・技能",
@@ -366,7 +366,7 @@ export async function seedSubtotalAndTag(): Promise<{
   for (let i = 0; i < subtotalNames.length; i++) {
     const subtotal = await db.subtotal.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         name: subtotalNames[i],
         subtotalGroupId: subtotalGroup.id,
         order: i,
@@ -375,11 +375,11 @@ export async function seedSubtotalAndTag(): Promise<{
     subtotalIds.push(subtotal.id)
   }
   const tag = await db.tag.create({
-    data: { id: randomUUID(), name: "数学" },
+    data: { id: crypto.randomUUID(), name: "数学" },
   })
   await db.tagSubtotalGroup.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       tagId: tag.id,
       subtotalGroupId: subtotalGroup.id,
     },
@@ -403,7 +403,7 @@ export async function seedExamWithScoring(
   const db = getPrisma()
   const REGION_DEFINITIONS = computeRegionDefinitions(templatePath)
 
-  const examId = randomUUID()
+  const examId = crypto.randomUUID()
   await db.exam.create({
     data: {
       id: examId,
@@ -413,12 +413,12 @@ export async function seedExamWithScoring(
     },
   })
   await db.userExam.create({
-    data: { id: randomUUID(), userId, examId, role: "OWNER" },
+    data: { id: crypto.randomUUID(), userId, examId, role: "OWNER" },
   })
   for (const classroomId of [classAId, classBId]) {
     await db.examClassroom.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examId,
         classroomId,
         administered: true,
@@ -428,11 +428,11 @@ export async function seedExamWithScoring(
     })
   }
   await db.examSubtotalGroup.create({
-    data: { id: randomUUID(), examId, subtotalGroupId },
+    data: { id: crypto.randomUUID(), examId, subtotalGroupId },
   })
 
   const examPage = await db.examPage.create({
-    data: { id: randomUUID(), examId, pageNumber: 1 },
+    data: { id: crypto.randomUUID(), examId, pageNumber: 1 },
   })
 
   // マスター画像（プレースホルダー白PNG）
@@ -455,7 +455,7 @@ export async function seedExamWithScoring(
     .replace(/\\/g, "/")
   await db.masterImage.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       examPageId: examPage.id,
       imagePath: relMasterPath,
     },
@@ -466,7 +466,7 @@ export async function seedExamWithScoring(
   for (const region of REGION_DEFINITIONS) {
     const cropRegion = await db.cropRegion.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examPageId: examPage.id,
         label: region.label,
         type: "QUESTION_ANSWER",
@@ -486,7 +486,7 @@ export async function seedExamWithScoring(
     const subtotalIndex = majorNum <= 3 ? 0 : majorNum <= 5 ? 1 : 2
     await db.cropSubtotal.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         cropRegionId: cropRegion.id,
         subtotalId: subtotalIds[subtotalIndex],
         assignmentType: "QUESTION_ASSIGNMENT",
@@ -510,7 +510,7 @@ export async function seedExamWithScoring(
     const studentId = studentIds[i]
     const examStudent = await db.examStudent.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examId,
         studentId,
         status: "PARTICIPATING",
@@ -533,7 +533,7 @@ export async function seedExamWithScoring(
       .replace(/\\/g, "/")
     await db.studentAnswerImage.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         examPageId: examPage.id,
         examStudentId: examStudent.id,
         imagePath: relAnswerPath,
@@ -547,7 +547,7 @@ export async function seedExamWithScoring(
     for (const scoreEntry of scores) {
       await db.questionScore.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           cropRegionId: cropRegionIds[scoreEntry.regionIndex],
           examStudentId: examStudentIds[i],
           partialScore: scoreEntry.score,
@@ -578,7 +578,7 @@ export async function seedGradeProject(
 ): Promise<string> {
   const db = getPrisma()
 
-  const gradeId = randomUUID()
+  const gradeId = crypto.randomUUID()
   await db.grade.create({
     data: {
       id: gradeId,
@@ -589,13 +589,13 @@ export async function seedGradeProject(
   })
   for (const classroomId of [classAId, classBId]) {
     await db.gradeClassroom.create({
-      data: { id: randomUUID(), gradeId, classroomId },
+      data: { id: crypto.randomUUID(), gradeId, classroomId },
     })
   }
   for (let i = 0; i < studentIds.length; i++) {
     await db.gradeStudent.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         gradeId,
         studentId: studentIds[i],
         customOrder: i + 1,
@@ -618,7 +618,12 @@ export async function seedGradeProject(
   const gradeItemIds: string[] = []
   for (let i = 0; i < gradeItemNames.length; i++) {
     const gradeItem = await db.gradeItem.create({
-      data: { id: randomUUID(), gradeId, name: gradeItemNames[i], order: i },
+      data: {
+        id: crypto.randomUUID(),
+        gradeId,
+        name: gradeItemNames[i],
+        order: i,
+      },
     })
     gradeItemIds.push(gradeItem.id)
   }
@@ -626,7 +631,7 @@ export async function seedGradeProject(
   // 評定 → 合計点データソース
   await db.gradeDataSource.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       gradeItemId: gradeItemIds[3],
       type: "exam_total",
       examId,
@@ -639,7 +644,7 @@ export async function seedGradeProject(
   for (let subtotalIndex = 0; subtotalIndex < 3; subtotalIndex++) {
     await db.gradeDataSource.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         gradeItemId: gradeItemIds[subtotalIndex],
         type: "subtotal",
         examId,
@@ -659,7 +664,7 @@ export async function seedGradeProject(
   ]
   for (const gradeItemId of gradeItemIds) {
     const boundarySet = await db.gradeBoundarySet.create({
-      data: { id: randomUUID(), gradeId, gradeItemId },
+      data: { id: crypto.randomUUID(), gradeId, gradeItemId },
     })
     for (
       let boundaryIndex = 0;
@@ -668,7 +673,7 @@ export async function seedGradeProject(
     ) {
       await db.gradeBoundary.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           gradeBoundarySetId: boundarySet.id,
           label: boundaryLabels[boundaryIndex].label,
           minPercentage: boundaryLabels[boundaryIndex].minPercentage,
@@ -690,7 +695,7 @@ export async function seedSimpleExam(
   classAId: string
 ): Promise<string> {
   const db = getPrisma()
-  const examId = randomUUID()
+  const examId = crypto.randomUUID()
   await db.exam.create({
     data: {
       id: examId,
@@ -700,11 +705,11 @@ export async function seedSimpleExam(
     },
   })
   await db.userExam.create({
-    data: { id: randomUUID(), userId, examId, role: "OWNER" },
+    data: { id: crypto.randomUUID(), userId, examId, role: "OWNER" },
   })
   await db.examClassroom.create({
     data: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       examId,
       classroomId: classAId,
       administered: true,
@@ -713,7 +718,7 @@ export async function seedSimpleExam(
     },
   })
   await db.examPage.create({
-    data: { id: randomUUID(), examId, pageNumber: 1 },
+    data: { id: crypto.randomUUID(), examId, pageNumber: 1 },
   })
   console.log(`  [SEED] 通常試験 (examId=${examId})`)
   return examId

--- a/__tests__/screenshots/setup-data.ts
+++ b/__tests__/screenshots/setup-data.ts
@@ -15,7 +15,7 @@
  *   npx tsx __tests__/screenshots/setup-data.ts
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 
@@ -60,7 +60,7 @@ async function main() {
 
   // ========== 1. ユーザー ==========
   console.log("[1/2] ユーザー作成...")
-  const userId = randomUUID()
+  const userId = crypto.randomUUID()
   await prisma.user.create({
     data: {
       id: userId,
@@ -75,7 +75,7 @@ async function main() {
   // ========== 2. 解答用紙ビルダーテンプレート ==========
   console.log("[2/2] 解答用紙ビルダー定義作成...")
   const asbTemplateFile = path.join(TEST_DATA_DIR, "asb-template.json")
-  const asbDefId = randomUUID()
+  const asbDefId = crypto.randomUUID()
 
   if (fs.existsSync(asbTemplateFile)) {
     const template = JSON.parse(fs.readFileSync(asbTemplateFile, "utf-8"))
@@ -92,12 +92,16 @@ async function main() {
 
     for (const headerField of template.headerFields) {
       await prisma.asbHeaderField.create({
-        data: { ...headerField, id: randomUUID(), definitionId: asbDefId },
+        data: {
+          ...headerField,
+          id: crypto.randomUUID(),
+          definitionId: asbDefId,
+        },
       })
     }
 
     for (const majorQuestion of template.majorQuestions) {
-      const newMajorQuestionId = randomUUID()
+      const newMajorQuestionId = crypto.randomUUID()
       await prisma.asbMajorQuestion.create({
         data: {
           id: newMajorQuestionId,
@@ -107,7 +111,7 @@ async function main() {
         },
       })
       for (const subQuestion of majorQuestion.subQuestions) {
-        const newSubQuestionId = randomUUID()
+        const newSubQuestionId = crypto.randomUUID()
         await prisma.asbSubQuestion.create({
           data: {
             id: newSubQuestionId,
@@ -133,7 +137,7 @@ async function main() {
         for (const textElement of subQuestion.textElements || []) {
           await prisma.asbTextElement.create({
             data: {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               subQuestionId: newSubQuestionId,
               branchQuestionId: null,
               text: textElement.text,
@@ -145,7 +149,7 @@ async function main() {
           })
         }
         if (subQuestion.omrConfig) {
-          const newOmrId = randomUUID()
+          const newOmrId = crypto.randomUUID()
           await prisma.asbOmrConfig.create({
             data: {
               id: newOmrId,
@@ -161,7 +165,7 @@ async function main() {
             []) {
             await prisma.asbOmrChoiceOption.create({
               data: {
-                id: randomUUID(),
+                id: crypto.randomUUID(),
                 omrConfigId: newOmrId,
                 choiceIndex: choiceOption.choiceIndex,
                 label: choiceOption.label,
@@ -173,7 +177,7 @@ async function main() {
         for (const branchQuestion of subQuestion.branchQuestions || []) {
           await prisma.asbBranchQuestion.create({
             data: {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               subQuestionId: newSubQuestionId,
               label: branchQuestion.label,
               order: branchQuestion.order,

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -656,6 +656,67 @@ import type { ScoringStatus } from "@/types/scoringStatus.types"
 import { useExam, type ExamData } from "@/hooks/useExam"
 ```
 
+インライン型 import（`import("./x").Foo` を型注釈に埋め込む書き方）は**禁止**。型の一部でありモジュール解決の走査から漏れるため、knip 等の静的解析が参照を追えず、実際に使われている型を未使用と誤判定する。grep もできない。ESLint（`no-restricted-syntax` の `TSImportType`）で検出する。
+
+### 名前空間 import（`import * as`）
+
+以下は**名前空間 import に統一する**。ESLint で強制している。
+
+| モジュール    | 名前空間名   |
+| ------------- | ------------ |
+| `path`        | `path`       |
+| `fs`          | `fs`         |
+| `fs/promises` | `fsPromises` |
+| `os`          | `os`         |
+| `crypto`      | `crypto`     |
+| `exceljs`     | `ExcelJS`    |
+
+```typescript
+// ✅ 呼び出し箇所に出自が残る
+import * as crypto from "crypto"
+import * as fsPromises from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+
+const id = crypto.randomUUID() // Math.random() ではないと分かる
+const tmp = path.join(os.tmpdir(), name) // OS の一時ディレクトリだと分かる
+await fsPromises.readFile(tmp) // 同期版 fs ではないと分かる
+
+// ❌ 出自が消える
+import { randomUUID } from "crypto"
+import { tmpdir } from "os"
+import { join } from "path"
+
+const id = randomUUID() // crypto なのか自前ユーティリティなのか読めない
+const tmp = join(tmpdir(), name) // 配列の join かどうかも紛らわしい
+```
+
+**`fs/promises` を `fs` と名付けてはいけない。** 同期版と区別がつかず、実際に「同期 API が必要になった箇所で `const fs = require("fs")` を書いて外側を潰す」という事故が起きていた。
+
+型のみの import（`import type { Stats } from "fs"`）は対象外。
+
+`react` および shadcn/ui・Radix UI（`import * as React from "react"` / `import * as TooltipPrimitive from "@radix-ui/react-tooltip"`）は**ライブラリ側の慣例に従う**。
+
+### 別名 import（`as`）
+
+`as` による改名は、**同名の別束縛と衝突する場合に限る**。
+
+```typescript
+// ✅ DOM グローバルの MouseEvent と衝突する
+import type { MouseEvent as ReactMouseEvent } from "react"
+
+// ✅ ライブラリ側が推奨している形（Playwright の型定義に記載）
+import { _electron as electron } from "playwright"
+
+// ❌ 衝突がないのに改名している（定義側の名前をそのまま使う）
+import { createExam as dbCreateExam } from "../lib/prisma/exam"
+
+// ❌ ライブラリが正式名を用意しているのに自前で別名を付けている
+import { X as XIcon } from "lucide-react" // → import { XIcon } from "lucide-react"
+```
+
+呼び出し側で別名を付けたくなったら、**まず定義側の名前が命名規則に合っているかを疑う**。別名は命名の食い違いを import 文で隠すだけで、定義側の問題は残る。
+
 ---
 
 ## コメント規約

--- a/electron-src/appInitializer.ts
+++ b/electron-src/appInitializer.ts
@@ -2,12 +2,16 @@ import {
   initializeDataDirectory,
   migrateProjectsToExams,
 } from "./lib/dataManager"
-import { optimizeDatabaseForSharedDrive } from "./lib/prisma/databaseHealth"
+import { getPrismaClient } from "./lib/prisma/client"
+import {
+  checkDatabaseHealth,
+  optimizeDatabaseForSharedDrive,
+} from "./lib/prisma/databaseHealth"
+import { initializeSync } from "./lib/sync/syncService"
 
 // DB内の imagePath を projects/ → exams/ に一括更新（v0.6.x リネーム対応）
 async function migrateImagePathsInDatabase(): Promise<void> {
   try {
-    const { getPrismaClient } = await import("./lib/prisma/client")
     const prisma = getPrismaClient()
 
     const [masterResult, answerResult] = await prisma.$transaction([
@@ -66,7 +70,6 @@ export async function initializeApp(): Promise<void> {
     await optimizeDatabaseForSharedDrive()
 
     // データベース接続テスト
-    const { checkDatabaseHealth } = await import("./lib/prisma/databaseHealth")
     const isHealthy = await checkDatabaseHealth()
 
     if (!isHealthy) {
@@ -75,7 +78,6 @@ export async function initializeApp(): Promise<void> {
 
     // NAS同期の初期化（DBが準備完了してから）
     try {
-      const { initializeSync } = await import("./lib/sync/syncService")
       await initializeSync()
     } catch (syncError) {
       // sync初期化失敗はアプリ起動を妨げない

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -4,8 +4,12 @@ import { pathToFileURL } from "url"
 
 import { initializeApp } from "./appInitializer"
 import { setupAllIPCHandlers } from "./ipc-handlers"
+import { destroySharedSvgWindow } from "./ipc-handlers/exportHandlers"
 import { getAbsolutePathFromData } from "./lib/dataManager"
+import { cleanupDecryptedPdfCopies } from "./lib/pdf-tools/decryptedPdfCopy"
+import { getPrismaClient } from "./lib/prisma/client"
 import { DB_NEWER_THAN_APP_MARKER } from "./lib/prisma/schema/migrationGuard"
+import { stopSync } from "./lib/sync/syncService"
 import { startEmbeddedNextServer } from "./nextServerEmbedded"
 import { createMainWindow, setupWindowEvents } from "./windowManager"
 
@@ -107,8 +111,6 @@ app.on("ready", async () => {
 
     // 前回セッションで残ったパスワード保護PDFの復号済み複製を掃除する
     try {
-      const { cleanupDecryptedPdfCopies } =
-        await import("./lib/pdf-tools/decryptedPdfCopy")
       cleanupDecryptedPdfCopies()
     } catch (error) {
       console.warn("Failed to clean up decrypted PDF copies:", error)
@@ -165,8 +167,6 @@ process.on("unhandledRejection", (reason, promise) => {
 app.on("before-quit", async (_event) => {
   // SVG→PNG変換用の共有オフスクリーンウィンドウを破棄
   try {
-    const { destroySharedSvgWindow } =
-      await import("./ipc-handlers/exportHandlers")
     destroySharedSvgWindow()
   } catch (error) {
     console.warn("Failed to destroy shared SVG window:", error)
@@ -174,7 +174,6 @@ app.on("before-quit", async (_event) => {
 
   // NAS同期の停止
   try {
-    const { stopSync } = await import("./lib/sync/syncService")
     await stopSync()
   } catch (error) {
     console.warn("Failed to stop sync service:", error)
@@ -182,7 +181,6 @@ app.on("before-quit", async (_event) => {
 
   // Prismaクライアントのクリーンアップ
   try {
-    const { getPrismaClient } = await import("./lib/prisma/client")
     const prisma = getPrismaClient()
     await prisma.$disconnect()
   } catch (error) {

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -3,9 +3,9 @@
  */
 
 import { BrowserWindow, dialog, ipcMain, shell } from "electron"
-import fs from "fs"
-import os from "os"
-import path from "path"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 
 import type {
   ASBConvertToExamArgs,

--- a/electron-src/ipc-handlers/archiveHandlers.ts
+++ b/electron-src/ipc-handlers/archiveHandlers.ts
@@ -2,6 +2,7 @@
  * 試験アーカイブ（エクスポート/インポート）IPCハンドラー
  */
 
+import AdmZip from "adm-zip"
 import { dialog, ipcMain } from "electron"
 import * as path from "path"
 
@@ -152,7 +153,6 @@ export function registerArchiveHandlers(): void {
 
       if (ext === ".dat") {
         try {
-          const AdmZip = (await import("adm-zip")).default
           const zip = new AdmZip(filePath)
           const hasVersion = zip
             .getEntries()

--- a/electron-src/ipc-handlers/cropRegionHandlers.ts
+++ b/electron-src/ipc-handlers/cropRegionHandlers.ts
@@ -1,14 +1,14 @@
 import { Prisma } from "@prisma/client"
 
 import {
-  createCropRegion as dbCreateCropRegion,
-  createManyCropRegions as dbCreateManyCropRegions,
-  deleteCropRegion as dbDeleteCropRegion,
-  getCropRegionById as dbGetCropRegionById,
-  getCropRegionsByExamId as dbGetCropRegionsByExamId,
-  getQuestionAnswerRegionsByExamId as dbGetQuestionAnswerRegionsByExamId,
-  updateCropRegion as dbUpdateCropRegion,
-  updateCropRegionOrders as dbUpdateCropRegionOrders,
+  createCropRegion,
+  createManyCropRegions,
+  deleteCropRegion,
+  getCropRegionById,
+  getCropRegionsByExamId,
+  getQuestionAnswerRegionsByExamId,
+  updateCropRegion,
+  updateCropRegionOrders,
 } from "../lib/prisma/cropRegion"
 
 /**
@@ -60,21 +60,21 @@ function serializeCropRegion<
 }
 
 import {
-  createCropSubtotal as dbCreateCropSubtotal,
-  createManyCropSubtotals as dbCreateManyCropSubtotals,
-  deleteCropSubtotal as dbDeleteCropSubtotal,
-  deleteCropSubtotalsByCropRegionId as dbDeleteCropSubtotalsByCropRegionId,
-  getCropSubtotalsByCropRegionId as dbGetCropSubtotalsByCropRegionId,
-  getCropSubtotalsBySubtotalId as dbGetCropSubtotalsBySubtotalId,
-  getSubtotalDefinitionsByCropRegionId as dbGetSubtotalDefsByCropRegionId,
+  createCropSubtotal,
+  createManyCropSubtotals,
+  deleteCropSubtotal,
+  deleteCropSubtotalsByCropRegionId,
+  getCropSubtotalsByCropRegionId,
+  getCropSubtotalsBySubtotalId,
+  getSubtotalDefinitionsByCropRegionId,
 } from "../lib/prisma/cropSubtotal"
 import {
-  createManySubtotals as dbCreateManySubtotals,
-  createSubtotal as dbCreateSubtotal,
-  deleteSubtotal as dbDeleteSubtotal,
-  getSubtotalById as dbGetSubtotalById,
-  getSubtotalsByGroupId as dbGetSubtotalsByGroupId,
-  updateSubtotal as dbUpdateSubtotal,
+  createManySubtotals,
+  createSubtotal,
+  deleteSubtotal,
+  getSubtotalById,
+  getSubtotalsByGroupId,
+  updateSubtotal,
 } from "../lib/prisma/subtotal"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
@@ -84,37 +84,37 @@ export function setupCropRegionHandlers(): void {
   registerHandler(
     "create-crop-region",
     async (data: Prisma.CropRegionUncheckedCreateInput) => {
-      return await dbCreateCropRegion(data)
+      return await createCropRegion(data)
     }
   )
 
   registerHandler(
     "create-many-crop-regions",
     async (data: Prisma.CropRegionCreateManyInput[]) => {
-      return await dbCreateManyCropRegions(data)
+      return await createManyCropRegions(data)
     }
   )
 
   registerHandler(
     "update-crop-region",
     async (id: string, data: Prisma.CropRegionUpdateInput) => {
-      return await dbUpdateCropRegion(id, data)
+      return await updateCropRegion(id, data)
     }
   )
 
   registerHandler(
     "update-crop-region-orders",
     async (updates: Array<{ id: string; orderIndex: number }>) => {
-      return await dbUpdateCropRegionOrders(updates)
+      return await updateCropRegionOrders(updates)
     }
   )
 
   registerHandler("delete-crop-region", async (id: string) => {
-    return await dbDeleteCropRegion(id)
+    return await deleteCropRegion(id)
   })
 
   registerHandler("get-crop-regions-by-exam-id", async (examId: string) => {
-    const result = await dbGetCropRegionsByExamId(examId)
+    const result = await getCropRegionsByExamId(examId)
     // questionScoresのDecimalをnumberに変換
     return result?.map(serializeCropRegion) || []
   })
@@ -122,14 +122,14 @@ export function setupCropRegionHandlers(): void {
   registerHandler(
     "get-question-answer-regions-by-exam-id",
     async (examId: string) => {
-      const result = await dbGetQuestionAnswerRegionsByExamId(examId)
+      const result = await getQuestionAnswerRegionsByExamId(examId)
       // questionScoresのDecimalをnumberに変換
       return result?.map(serializeCropRegion) || []
     }
   )
 
   registerHandler("get-crop-region-by-id", async (id: string) => {
-    const result = await dbGetCropRegionById(id)
+    const result = await getCropRegionById(id)
     // questionScoresのDecimalをnumberに変換
     return result ? serializeCropRegion(result) : null
   })
@@ -138,69 +138,69 @@ export function setupCropRegionHandlers(): void {
   registerHandler(
     "create-subtotal",
     async (data: Prisma.SubtotalUncheckedCreateInput) => {
-      return await dbCreateSubtotal(data)
+      return await createSubtotal(data)
     }
   )
 
   registerHandler(
     "create-many-subtotals",
     async (data: Prisma.SubtotalUncheckedCreateInput[]) => {
-      return await dbCreateManySubtotals(data)
+      return await createManySubtotals(data)
     }
   )
 
   registerHandler(
     "update-subtotal",
     async (id: string, data: Prisma.SubtotalUpdateInput) => {
-      return await dbUpdateSubtotal(id, data)
+      return await updateSubtotal(id, data)
     }
   )
 
   registerHandler("delete-subtotal", async (id: string) => {
-    return await dbDeleteSubtotal(id)
+    return await deleteSubtotal(id)
   })
 
   registerHandler(
     "get-subtotals-by-group-id",
     async (subtotalGroupId: string) => {
-      return await dbGetSubtotalsByGroupId(subtotalGroupId)
+      return await getSubtotalsByGroupId(subtotalGroupId)
     }
   )
 
   registerHandler("get-subtotal-by-id", async (id: string) => {
-    return await dbGetSubtotalById(id)
+    return await getSubtotalById(id)
   })
 
   // --- CropSubtotal Handlers ---
   registerHandler(
     "create-crop-subtotal",
     async (data: Prisma.CropSubtotalUncheckedCreateInput) => {
-      return await dbCreateCropSubtotal(data)
+      return await createCropSubtotal(data)
     }
   )
 
   registerHandler(
     "create-many-crop-subtotals",
     async (data: Prisma.CropSubtotalUncheckedCreateInput[]) => {
-      return await dbCreateManyCropSubtotals(data)
+      return await createManyCropSubtotals(data)
     }
   )
 
   registerHandler("delete-crop-subtotal", async (id: string) => {
-    return await dbDeleteCropSubtotal(id)
+    return await deleteCropSubtotal(id)
   })
 
   registerHandler(
     "delete-crop-subtotals-by-crop-region-id",
     async (cropRegionId: string) => {
-      return await dbDeleteCropSubtotalsByCropRegionId(cropRegionId)
+      return await deleteCropSubtotalsByCropRegionId(cropRegionId)
     }
   )
 
   registerHandler(
     "get-crop-subtotals-by-crop-region-id",
     async (cropRegionId: string) => {
-      return await dbGetCropSubtotalsByCropRegionId(cropRegionId)
+      return await getCropSubtotalsByCropRegionId(cropRegionId)
     }
   )
 
@@ -208,7 +208,7 @@ export function setupCropRegionHandlers(): void {
   registerSafeHandler(
     "get-assignments-by-question-crop-region-id",
     async (cropRegionId: string) => {
-      const assignments = await dbGetCropSubtotalsByCropRegionId(cropRegionId)
+      const assignments = await getCropSubtotalsByCropRegionId(cropRegionId)
       return {
         success: true,
         assignments: assignments || [],
@@ -219,7 +219,7 @@ export function setupCropRegionHandlers(): void {
   registerHandler(
     "get-crop-subtotals-by-subtotal-id",
     async (subtotalId: string) => {
-      return await dbGetCropSubtotalsBySubtotalId(subtotalId)
+      return await getCropSubtotalsBySubtotalId(subtotalId)
     }
   )
 
@@ -227,7 +227,7 @@ export function setupCropRegionHandlers(): void {
   registerHandler(
     "get-subtotal-definitions-by-crop-region-id",
     async (cropRegionId: string) => {
-      return await dbGetSubtotalDefsByCropRegionId(cropRegionId)
+      return await getSubtotalDefinitionsByCropRegionId(cropRegionId)
     }
   )
 }

--- a/electron-src/ipc-handlers/examHandlers.ts
+++ b/electron-src/ipc-handlers/examHandlers.ts
@@ -1,15 +1,15 @@
 import { Prisma } from "@prisma/client"
 
 import {
-  createExam as dbCreateExam,
-  deleteExam as dbDeleteExam,
-  getExam as dbGetExam,
-  getExamById as dbFetchExamById,
-  getExamsForList as dbFetchExamsForList,
-  getExamWithPages as dbGetExamWithPages,
-  updateExam as dbUpdateExam,
+  createExam,
+  deleteExam,
+  getExam,
+  getExamById,
+  getExamsForList,
+  getExamWithPages,
+  updateExam,
 } from "../lib/prisma/exam"
-import { getExamPagesByExamId as dbGetExamPagesByExamId } from "../lib/prisma/examPage"
+import { getExamPagesByExamId } from "../lib/prisma/examPage"
 import { registerHandler } from "./ipcHandlerUtils"
 
 /**
@@ -42,7 +42,7 @@ export function setupExamHandlers(): void {
   // 試験一覧用の軽量エンドポイント。進捗は計算せず「元データ」を返し、
   // renderer の getExamProgress → getExamWorkflowStatus が計算する（計算の唯一の実装は renderer）。
   registerHandler("fetch-exams-summary", async (userId: string) => {
-    const exams = await dbFetchExamsForList(userId)
+    const exams = await getExamsForList(userId)
     return exams.map((exam) => ({
       id: exam.id,
       examName: exam.examName,
@@ -76,16 +76,16 @@ export function setupExamHandlers(): void {
 
   // 試験の基本スカラーのみ（リレーション無し・軽量）。編集/スカラー参照用途向け。
   registerHandler("get-exam", async (examId: string) => {
-    return dbGetExam(examId)
+    return getExam(examId)
   })
 
   // 試験スカラー + examPages（masterImages 含む）を1クエリで。採点画面用。
   registerHandler("get-exam-with-pages", async (examId: string) => {
-    return dbGetExamWithPages(examId)
+    return getExamWithPages(examId)
   })
 
   registerHandler("fetch-exam-by-id", async (examId: string) => {
-    const exam = await dbFetchExamById(examId)
+    const exam = await getExamById(examId)
     if (!exam) {
       return null
     }
@@ -131,7 +131,7 @@ export function setupExamHandlers(): void {
     "create-exam",
     async (examData: Omit<Prisma.ExamCreateInput, "user">, userId: string) => {
       if (!userId) throw new Error("User ID is required to create a exam.")
-      const exam = await dbCreateExam(examData, userId)
+      const exam = await createExam(examData, userId)
 
       // Dateオブジェクトをそのまま返す
       return {
@@ -147,20 +147,20 @@ export function setupExamHandlers(): void {
   registerHandler(
     "update-exam",
     async (examId: string, data: Prisma.ExamUpdateInput) => {
-      const exam = await dbUpdateExam(examId, data)
+      const exam = await updateExam(examId, data)
       // Dateオブジェクトをそのまま返す
       return exam
     }
   )
 
   registerHandler("delete-exam", async (examId: string) => {
-    const exam = await dbDeleteExam(examId)
+    const exam = await deleteExam(examId)
     // Dateオブジェクトをそのまま返す
     return exam
   })
 
   registerHandler("get-exam-pages-by-exam-id", async (examId: string) => {
-    const examPages = await dbGetExamPagesByExamId(examId)
+    const examPages = await getExamPagesByExamId(examId)
     // Dateオブジェクトをそのまま返す
     return examPages
   })

--- a/electron-src/ipc-handlers/miscHandlers.ts
+++ b/electron-src/ipc-handlers/miscHandlers.ts
@@ -1,7 +1,13 @@
 import { Prisma } from "@prisma/client"
-import * as fs from "fs/promises"
+import { shell } from "electron"
+import * as fsPromises from "fs/promises"
+import * as path from "path"
 
-import { getAbsolutePathFromData } from "../lib/dataManager"
+import {
+  calculateDataSize,
+  getAbsolutePathFromData,
+  getDataDirectory,
+} from "../lib/dataManager"
 import {
   createClassroom,
   deleteClassroom,
@@ -30,9 +36,12 @@ import {
 } from "../lib/prisma/studentAnswer/placementApply"
 import { setStudentAnswerAbsent } from "../lib/prisma/studentAnswer/status"
 import {
-  createUser as createUserWithPasscode,
+  createUser,
   fetchUsers,
   getCurrentUser,
+  updateUser,
+  updateUserPasscode,
+  verifyPasscode,
 } from "../lib/prisma/user"
 import { registerHandler, registerSafeHandler } from "./ipcHandlerUtils"
 
@@ -56,7 +65,7 @@ export function setupMiscHandlers(): void {
       passcode?: string
       passcodeType?: "none" | "4digit" | "6digit" | "alphanumeric"
     }) => {
-      return await createUserWithPasscode({
+      return await createUser({
         username: userData.username,
         name: userData.name,
         passcode: userData.passcode,
@@ -68,7 +77,6 @@ export function setupMiscHandlers(): void {
   registerHandler(
     "verify-passcode",
     async (userId: string, passcode: string) => {
-      const { verifyPasscode } = await import("../lib/prisma/user")
       return await verifyPasscode(userId, passcode)
     }
   )
@@ -76,7 +84,6 @@ export function setupMiscHandlers(): void {
   registerHandler(
     "update-user",
     async (userId: string, userData: { username?: string; name?: string }) => {
-      const { updateUser } = await import("../lib/prisma/user")
       return await updateUser(userId, userData)
     }
   )
@@ -84,7 +91,6 @@ export function setupMiscHandlers(): void {
   registerHandler(
     "update-user-passcode",
     async (userId: string, passcode?: string, passcodeType?: string) => {
-      const { updateUserPasscode } = await import("../lib/prisma/user")
       return await updateUserPasscode(
         userId,
         passcode,
@@ -261,10 +267,6 @@ export function setupMiscHandlers(): void {
   )
 
   registerSafeHandler("read-file-as-base64", async (filePath: string) => {
-    const fs = await import("fs/promises")
-    const path = await import("path")
-    const { getDataDirectory } = await import("../lib/dataManager")
-
     // 相対パスの場合はdataディレクトリからの相対パスとして解決
     const resolvedPath = path.isAbsolute(filePath)
       ? filePath
@@ -272,7 +274,7 @@ export function setupMiscHandlers(): void {
 
     // ファイルの存在確認
     try {
-      await fs.access(resolvedPath)
+      await fsPromises.access(resolvedPath)
     } catch {
       return {
         success: false,
@@ -281,7 +283,7 @@ export function setupMiscHandlers(): void {
     }
 
     // ファイルを読み込んでBase64に変換
-    const buffer = await fs.readFile(resolvedPath)
+    const buffer = await fsPromises.readFile(resolvedPath)
     const base64Data = buffer.toString("base64")
 
     // MIMEタイプを推定
@@ -320,9 +322,6 @@ export function setupMiscHandlers(): void {
 
   // Data management handlers
   registerSafeHandler("get-data-directory-info", async () => {
-    const { getDataDirectory, calculateDataSize } =
-      await import("../lib/dataManager")
-
     const dataDirectory = getDataDirectory()
     const size = await calculateDataSize()
 
@@ -334,9 +333,6 @@ export function setupMiscHandlers(): void {
   })
 
   registerSafeHandler("open-data-directory", async () => {
-    const { shell } = await import("electron")
-    const { getDataDirectory } = await import("../lib/dataManager")
-
     const dataDirectory = getDataDirectory()
     await shell.openPath(dataDirectory)
 
@@ -344,16 +340,13 @@ export function setupMiscHandlers(): void {
   })
 
   registerSafeHandler("delete-all-data", async () => {
-    const { getDataDirectory } = await import("../lib/dataManager")
-    const fs = await import("fs/promises")
-
     const dataDirectory = getDataDirectory()
 
     // データフォルダを完全削除
-    await fs.rm(dataDirectory, { recursive: true, force: true })
+    await fsPromises.rm(dataDirectory, { recursive: true, force: true })
 
     // データディレクトリを再作成
-    await fs.mkdir(dataDirectory, { recursive: true })
+    await fsPromises.mkdir(dataDirectory, { recursive: true })
 
     return { success: true }
   })
@@ -361,7 +354,7 @@ export function setupMiscHandlers(): void {
   // 画像ファイル読み込みハンドラー
   registerSafeHandler("get-image-data", async (relativePath: string) => {
     const absolutePath = getAbsolutePathFromData(relativePath)
-    const imageBuffer = await fs.readFile(absolutePath)
+    const imageBuffer = await fsPromises.readFile(absolutePath)
     const base64 = imageBuffer.toString("base64")
 
     // MIMEタイプを推定
@@ -385,7 +378,7 @@ export function setupMiscHandlers(): void {
   registerSafeHandler("check-file-exists", async (relativePath: string) => {
     const absolutePath = getAbsolutePathFromData(relativePath)
     try {
-      await fs.access(absolutePath)
+      await fsPromises.access(absolutePath)
       return { success: true, exists: true, path: absolutePath }
     } catch (err) {
       return {

--- a/electron-src/ipc-handlers/omrHandlers.ts
+++ b/electron-src/ipc-handlers/omrHandlers.ts
@@ -3,8 +3,8 @@
  */
 
 import { BrowserWindow, ipcMain } from "electron"
-import fs from "fs"
-import path from "path"
+import * as fs from "fs"
+import * as path from "path"
 
 import type { ComputedCell } from "../../src/types/answerSheetLayout.types"
 import type {

--- a/electron-src/ipc-handlers/scoringHandlers.ts
+++ b/electron-src/ipc-handlers/scoringHandlers.ts
@@ -1,4 +1,4 @@
-import path from "path"
+import * as path from "path"
 
 import type {
   WhitenessTargetAnswerImage,

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -4,6 +4,7 @@ import * as ExcelJS from "exceljs"
 
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 
+import { fetchClassrooms } from "../lib/prisma/classroom"
 import {
   addStudentsToExam,
   getClassroomsNotInExam,
@@ -18,6 +19,7 @@ import {
   createStudent,
   deleteStudent,
   fetchStudents,
+  getClassroomExamResults,
   getStudentExamResults,
   updateStudent,
 } from "../lib/prisma/student"
@@ -204,7 +206,6 @@ export function setupStudentHandlers(): void {
   })
 
   registerHandler("get-class-exam-results", async (classroomId: string) => {
-    const { getClassroomExamResults } = await import("../lib/prisma/student")
     return await getClassroomExamResults(classroomId)
   })
 
@@ -276,7 +277,6 @@ export function setupStudentHandlers(): void {
   registerSafeHandler(
     "export-classrooms-excel",
     async (selectedClassroomIds: string[]) => {
-      const { fetchClassrooms } = await import("../lib/prisma/classroom")
       const allClassrooms = await fetchClassrooms()
       const selectedSet = new Set(selectedClassroomIds)
       const classrooms = allClassrooms.filter((classroom) =>

--- a/electron-src/lib/answer-sheet-builder/examConverter.ts
+++ b/electron-src/lib/answer-sheet-builder/examConverter.ts
@@ -5,8 +5,8 @@
  * → Exam + ExamPage + MasterImage + CropRegion 作成
  */
 
-import fs from "fs"
-import path from "path"
+import * as fs from "fs"
+import * as path from "path"
 
 import type { AnswerSheetDefinition } from "../../../src/types/answerSheetDefinition.types"
 import type {

--- a/electron-src/lib/authStore.ts
+++ b/electron-src/lib/authStore.ts
@@ -1,6 +1,6 @@
 import { app } from "electron"
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs"
-import { join } from "path"
+import * as fs from "fs"
+import * as path from "path"
 
 interface AuthData {
   authToken: string | null
@@ -8,7 +8,7 @@ interface AuthData {
 
 // 認証データファイルのパス
 const getAuthFilePath = (): string => {
-  return join(app.getPath("userData"), "auth.json")
+  return path.join(app.getPath("userData"), "auth.json")
 }
 
 export class AuthStoreManager {
@@ -18,8 +18,8 @@ export class AuthStoreManager {
   private static readAuthData(): AuthData {
     try {
       const filePath = getAuthFilePath()
-      if (existsSync(filePath)) {
-        const data = readFileSync(filePath, "utf8")
+      if (fs.existsSync(filePath)) {
+        const data = fs.readFileSync(filePath, "utf8")
         return JSON.parse(data)
       }
     } catch (error) {
@@ -34,7 +34,7 @@ export class AuthStoreManager {
   private static writeAuthData(data: AuthData): void {
     try {
       const filePath = getAuthFilePath()
-      writeFileSync(filePath, JSON.stringify(data, null, 2), "utf8")
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf8")
     } catch (error) {
       console.error("Failed to write auth data:", error)
       throw error
@@ -73,8 +73,8 @@ export class AuthStoreManager {
   static clearAll(): void {
     try {
       const filePath = getAuthFilePath()
-      if (existsSync(filePath)) {
-        unlinkSync(filePath)
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath)
       }
     } catch (error) {
       console.error("Failed to clear auth data:", error)

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -1,5 +1,6 @@
 import { app } from "electron"
-import * as fs from "fs/promises"
+import * as fs from "fs"
+import * as fsPromises from "fs/promises"
 import * as path from "path"
 
 // アプリケーションのルートディレクトリ（実行ファイルがある場所）
@@ -21,7 +22,6 @@ const getAppRootPath = (): string => {
 
     // Windowsでファイルパスが適切に解決されるかチェック
     try {
-      const fs = require("fs")
       const exists = fs.existsSync(rootPath)
       if (!exists) {
         console.error(`Windows root path does not exist: ${rootPath}`)
@@ -84,17 +84,17 @@ export const initializeDataDirectory = async (): Promise<void> => {
   try {
     // 親ディレクトリの存在確認と作成
     const parentDir = path.dirname(dataDir)
-    await fs.mkdir(parentDir, { recursive: true, mode: 0o755 })
+    await fsPromises.mkdir(parentDir, { recursive: true, mode: 0o755 })
 
     // データディレクトリの作成
-    await fs.mkdir(dataDir, { recursive: true, mode: 0o755 })
+    await fsPromises.mkdir(dataDir, { recursive: true, mode: 0o755 })
 
     // サブディレクトリの作成
     const examsDir = path.join(dataDir, "exams")
     const exportsDir = getExportsDirectory()
 
-    await fs.mkdir(examsDir, { recursive: true, mode: 0o755 })
-    await fs.mkdir(exportsDir, { recursive: true, mode: 0o755 })
+    await fsPromises.mkdir(examsDir, { recursive: true, mode: 0o755 })
+    await fsPromises.mkdir(exportsDir, { recursive: true, mode: 0o755 })
   } catch (error) {
     console.error("Failed to initialize data directory:", error)
     console.error("Data directory path:", dataDir)
@@ -114,7 +114,7 @@ export const migrateProjectsToExams = async (): Promise<boolean> => {
   const newExamsDir = path.join(dataDir, "exams")
 
   try {
-    await fs.access(oldProjectsDir)
+    await fsPromises.access(oldProjectsDir)
   } catch {
     // data/projects/ が存在しない場合はスキップ
     return false
@@ -122,17 +122,17 @@ export const migrateProjectsToExams = async (): Promise<boolean> => {
 
   try {
     // data/exams/ を作成
-    await fs.mkdir(newExamsDir, { recursive: true })
+    await fsPromises.mkdir(newExamsDir, { recursive: true })
 
     // 各試験ディレクトリをコピー
-    const examDirs = await fs.readdir(oldProjectsDir)
+    const examDirs = await fsPromises.readdir(oldProjectsDir)
     for (const dir of examDirs) {
       const oldPath = path.join(oldProjectsDir, dir)
       const newPath = path.join(newExamsDir, dir)
 
       // 移行先に既にある場合はスキップ
       try {
-        await fs.access(newPath)
+        await fsPromises.access(newPath)
         console.log(`Skipping already migrated exam directory: ${dir}`)
         continue
       } catch {
@@ -143,7 +143,7 @@ export const migrateProjectsToExams = async (): Promise<boolean> => {
     }
 
     // 旧ディレクトリを削除
-    await fs.rm(oldProjectsDir, { recursive: true, force: true })
+    await fsPromises.rm(oldProjectsDir, { recursive: true, force: true })
     console.log(
       `Successfully migrated data/projects/ → data/exams/ (${examDirs.length} directories)`
     )
@@ -156,9 +156,9 @@ export const migrateProjectsToExams = async (): Promise<boolean> => {
 
 // ディレクトリの再帰的コピー
 const copyDirectory = async (src: string, dest: string): Promise<void> => {
-  await fs.mkdir(dest, { recursive: true })
+  await fsPromises.mkdir(dest, { recursive: true })
 
-  const entries = await fs.readdir(src, { withFileTypes: true })
+  const entries = await fsPromises.readdir(src, { withFileTypes: true })
 
   for (const entry of entries) {
     const srcPath = path.join(src, entry.name)
@@ -167,7 +167,7 @@ const copyDirectory = async (src: string, dest: string): Promise<void> => {
     if (entry.isDirectory()) {
       await copyDirectory(srcPath, destPath)
     } else {
-      await fs.copyFile(srcPath, destPath)
+      await fsPromises.copyFile(srcPath, destPath)
     }
   }
 }
@@ -183,7 +183,7 @@ const getDirectorySize = async (dirPath: string): Promise<number> => {
   let totalSize = 0
 
   try {
-    const entries = await fs.readdir(dirPath, { withFileTypes: true })
+    const entries = await fsPromises.readdir(dirPath, { withFileTypes: true })
 
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name)
@@ -191,7 +191,7 @@ const getDirectorySize = async (dirPath: string): Promise<number> => {
       if (entry.isDirectory()) {
         totalSize += await getDirectorySize(fullPath)
       } else {
-        const stats = await fs.stat(fullPath)
+        const stats = await fsPromises.stat(fullPath)
         totalSize += stats.size
       }
     }

--- a/electron-src/lib/databaseSetup.ts
+++ b/electron-src/lib/databaseSetup.ts
@@ -1,6 +1,18 @@
 import { PrismaClient } from "@prisma/client"
 
-import { createSharedPrismaClient } from "./prisma/databaseInitializer"
+import { pruneAuditLogs } from "./prisma/auditQuery"
+import {
+  createSharedPrismaClient,
+  initializeDatabase,
+} from "./prisma/databaseInitializer"
+import {
+  createBackup,
+  restoreBackup,
+  runBridgeMigration,
+} from "./prisma/schema/bridgeMigrations"
+import { deployPendingMigrations } from "./prisma/schema/migrationDeployer"
+import { assertDatabaseNotNewerThanApp } from "./prisma/schema/migrationGuard"
+import { detectSchemaVersion } from "./prisma/schema/versionDetector"
 
 /**
  * データベースセットアップユーティリティ
@@ -168,8 +180,6 @@ export class DatabaseSetup {
    * this.prisma は次回クエリ時に自動再接続される。
    */
   private async runDeployPendingMigrations(): Promise<void> {
-    const { deployPendingMigrations } =
-      await import("./prisma/schema/migrationDeployer")
     await this.prisma.$disconnect()
     deployPendingMigrations()
   }
@@ -182,8 +192,6 @@ export class DatabaseSetup {
       let setupPerformed = false
 
       // DBファイルの作成とスキーマ適用（判定はテーブルの有無に基づく）
-      const { initializeDatabase } =
-        await import("./prisma/databaseInitializer")
       const result = initializeDatabase()
 
       if (result === "created") {
@@ -211,7 +219,6 @@ export class DatabaseSetup {
 
       // 監査ログの保持期間プルーニング（ベストエフォート。失敗しても起動を妨げない）
       try {
-        const { pruneAuditLogs } = await import("./prisma/auditQuery")
         await pruneAuditLogs()
       } catch (pruneError) {
         console.error("Audit log pruning skipped:", pruneError)
@@ -230,8 +237,6 @@ export class DatabaseSetup {
    * 既存DBのマイグレーション: バージョン検出 → ブリッジ → ベースライン → 将来マイグレーション適用
    */
   private async migrateExistingDatabase(): Promise<void> {
-    const { detectSchemaVersion } =
-      await import("./prisma/schema/versionDetector")
     const version = await detectSchemaVersion(this.prisma)
     console.info(`Detected schema version: ${version}`)
 
@@ -244,8 +249,6 @@ export class DatabaseSetup {
 
     if (version === "MIGRATED") {
       // DBがアプリより新しい場合は書き込み前に起動を中止する
-      const { assertDatabaseNotNewerThanApp } =
-        await import("./prisma/schema/migrationGuard")
       await assertDatabaseNotNewerThanApp(this.prisma)
 
       // 既にPrisma管理下 — ベースラインが最新か確認
@@ -259,9 +262,6 @@ export class DatabaseSetup {
     }
 
     // ブリッジマイグレーション実行（S3〜S9）
-    const { createBackup, restoreBackup, runBridgeMigration } =
-      await import("./prisma/schema/bridgeMigrations")
-
     const backupPath = createBackup()
     try {
       await runBridgeMigration(this.prisma, version)

--- a/electron-src/lib/export/excel/averageRows.ts
+++ b/electron-src/lib/export/excel/averageRows.ts
@@ -3,7 +3,7 @@ import * as ExcelJS from "exceljs"
 
 import type { ExamClassroomWithMembers } from "@/types/prismaExtensions"
 
-import { average as mean } from "../../shared/calculations/numericStats"
+import { calculateAverage } from "../../shared/calculations/numericStats"
 import type { ScoringData } from "../../shared/types"
 import { applyCellStyle } from "../../shared/utilities/excelUtilities"
 import type { SubtotalColumn } from "./dataFetcher"
@@ -12,7 +12,7 @@ import type { SubtotalColumn } from "./dataFetcher"
 function average(values: (number | null | undefined)[]): number | null {
   const numbers = values.filter((value): value is number => value != null)
   if (numbers.length === 0) return null
-  return Math.round(mean(numbers) * 10) / 10
+  return Math.round(calculateAverage(numbers) * 10) / 10
 }
 
 /** 指定生徒集合の 合計点／小計／設問 の平均行（ヘッダー列順）を作る */

--- a/electron-src/lib/export/individual-report/statisticsCalculator.ts
+++ b/electron-src/lib/export/individual-report/statisticsCalculator.ts
@@ -5,10 +5,10 @@
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
 
 import {
-  average as calculateAverage,
-  boxPlot as calculateBoxPlotData,
-  rank as calculateRank,
-  stdDev as calculateStdDev,
+  calculateAverage,
+  calculateBoxPlot,
+  calculateRank,
+  calculateStandardDeviation,
 } from "../../shared/calculations/numericStats"
 import type { DiscriminationLevel, ScoringData } from "../../shared/types"
 import type {
@@ -164,8 +164,8 @@ export function calculateSubtotalStatistics(
       subtotalLabel: template.subtotalLabel,
       maxScore: template.maxScore,
       average: calculateAverage(scores),
-      stdDev: calculateStdDev(scores),
-      boxPlot: calculateBoxPlotData(scores),
+      stdDev: calculateStandardDeviation(scores),
+      boxPlot: calculateBoxPlot(scores),
       subtotalGroupId: template.subtotalGroupId,
       subtotalGroupName: template.subtotalGroupName,
     }
@@ -257,8 +257,8 @@ export function calculateDiscriminationIndices(
       continue
     }
 
-    const itemStdDev = calculateStdDev(itemScores)
-    const totalStdDev = calculateStdDev(correctedTotals)
+    const itemStdDev = calculateStandardDeviation(itemScores)
+    const totalStdDev = calculateStandardDeviation(correctedTotals)
 
     if (itemStdDev === 0 || totalStdDev === 0) {
       indices[questionId] = null
@@ -320,8 +320,8 @@ export function calculateStatisticsForStudent(
 
   // 全体統計
   const overallAverage = calculateAverage(allScores)
-  const overallStdDev = calculateStdDev(allScores)
-  const overallBoxPlot = calculateBoxPlotData(allScores)
+  const overallStdDev = calculateStandardDeviation(allScores)
+  const overallBoxPlot = calculateBoxPlot(allScores)
 
   // studentId → 合計点の索引（学級母集団の絞り込み用）
   const scoreById = scoreByStudentId ?? buildScoreByStudentId(allScoringData)
@@ -343,8 +343,8 @@ export function calculateStatisticsForStudent(
         grade: classroom.grade,
         memberStudentIds: classroom.memberStudentIds,
         average: calculateAverage(classroomScores),
-        stdDev: calculateStdDev(classroomScores),
-        boxPlot: calculateBoxPlotData(classroomScores),
+        stdDev: calculateStandardDeviation(classroomScores),
+        boxPlot: calculateBoxPlot(classroomScores),
         total: presentIds.length,
         rank:
           studentScore !== null

--- a/electron-src/lib/export/r-exametrika/rDataExporter.ts
+++ b/electron-src/lib/export/r-exametrika/rDataExporter.ts
@@ -6,7 +6,7 @@
  * 元の status を保持する（JSON）。CSV は欠席/未採点を欠測値（空欄）とする。
  */
 import { dialog } from "electron"
-import * as fs from "fs/promises"
+import * as fsPromises from "fs/promises"
 
 import type { ExportResult } from "../../shared/types"
 import { fetchExportData } from "../excel/dataFetcher"
@@ -154,7 +154,7 @@ export async function exportRData(
       return { success: false, error: "出力パスが指定されていません" }
     }
 
-    await fs.writeFile(finalOutputPath, content, "utf-8")
+    await fsPromises.writeFile(finalOutputPath, content, "utf-8")
     return { success: true, outputPath: finalOutputPath }
   } catch (error) {
     console.error("R data export error:", error)

--- a/electron-src/lib/import/asb-archive/idRemapper.ts
+++ b/electron-src/lib/import/asb-archive/idRemapper.ts
@@ -4,7 +4,7 @@
  * インポート時に全IDを新UUIDに置換して競合を防ぐ
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type { AnswerSheetDefinition } from "../../../../src/types/answerSheetDefinition.types"
 import type { AsbIdMappings } from "../../../../src/types/asbArchive.types"
@@ -16,7 +16,7 @@ export function generateAsbIdMappings(
   definition: AnswerSheetDefinition
 ): AsbIdMappings {
   const mappings: AsbIdMappings = {
-    definition: { [definition.id]: randomUUID() },
+    definition: { [definition.id]: crypto.randomUUID() },
     headerField: {},
     majorQuestion: {},
     subQuestion: {},
@@ -28,45 +28,45 @@ export function generateAsbIdMappings(
   }
 
   for (const headerField of definition.settings.headerFields) {
-    mappings.headerField[headerField.id] = randomUUID()
+    mappings.headerField[headerField.id] = crypto.randomUUID()
   }
 
   for (const majorQuestion of definition.majorQuestions) {
-    mappings.majorQuestion[majorQuestion.id] = randomUUID()
+    mappings.majorQuestion[majorQuestion.id] = crypto.randomUUID()
 
     for (const subQuestion of majorQuestion.subQuestions) {
-      mappings.subQuestion[subQuestion.id] = randomUUID()
+      mappings.subQuestion[subQuestion.id] = crypto.randomUUID()
 
       for (const textElement of subQuestion.textElements) {
-        mappings.textElement[textElement.id] = randomUUID()
+        mappings.textElement[textElement.id] = crypto.randomUUID()
       }
       if (subQuestion.imageElements) {
         for (const imageElement of subQuestion.imageElements) {
-          mappings.imageElement[imageElement.id] = randomUUID()
+          mappings.imageElement[imageElement.id] = crypto.randomUUID()
         }
       }
       if (subQuestion.manuscriptPaper?.charGuides) {
         for (const charGuide of subQuestion.manuscriptPaper.charGuides) {
-          mappings.charGuide[charGuide.id] = randomUUID()
+          mappings.charGuide[charGuide.id] = crypto.randomUUID()
         }
       }
       if (subQuestion.omrConfig) {
-        mappings.omrConfig[subQuestion.id] = randomUUID()
+        mappings.omrConfig[subQuestion.id] = crypto.randomUUID()
       }
 
       for (const branchQuestion of subQuestion.branchQuestions) {
-        mappings.branchQuestion[branchQuestion.id] = randomUUID()
+        mappings.branchQuestion[branchQuestion.id] = crypto.randomUUID()
 
         for (const textElement of branchQuestion.textElements) {
-          mappings.textElement[textElement.id] = randomUUID()
+          mappings.textElement[textElement.id] = crypto.randomUUID()
         }
         if (branchQuestion.imageElements) {
           for (const imageElement of branchQuestion.imageElements) {
-            mappings.imageElement[imageElement.id] = randomUUID()
+            mappings.imageElement[imageElement.id] = crypto.randomUUID()
           }
         }
         if (branchQuestion.omrConfig) {
-          mappings.omrConfig[branchQuestion.id] = randomUUID()
+          mappings.omrConfig[branchQuestion.id] = crypto.randomUUID()
         }
       }
     }

--- a/electron-src/lib/import/asb-transformers/V1_0_0_to_V1_1_0.ts
+++ b/electron-src/lib/import/asb-transformers/V1_0_0_to_V1_1_0.ts
@@ -9,7 +9,7 @@
  * あわせて counts.charGuides を再集計する（旧マニフェストには存在しないカウント）。
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type {
   AsbArchiveData,
@@ -38,7 +38,7 @@ export class V1_0_0_to_V1_1_0_Transformer implements AsbVersionTransformer {
               ...manuscriptPaper,
               charGuides: manuscriptPaper.charGuides.map((charGuide) => ({
                 ...charGuide,
-                id: charGuide.id ?? randomUUID(),
+                id: charGuide.id ?? crypto.randomUUID(),
               })),
             },
           }

--- a/electron-src/lib/import/coursework-archive/dataCreator.ts
+++ b/electron-src/lib/import/coursework-archive/dataCreator.ts
@@ -11,7 +11,7 @@
  * grade-archive はこの importCourseworkData をトランザクション内で呼び出して内包する。
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type {
   ArchiveCourseworkItemRow,
@@ -356,7 +356,7 @@ export async function importCourseworkData(
       if (!actualItemId) {
         actualItemId = await createItem(
           courseworkId,
-          preserveUuids ? item.id : randomUUID(),
+          preserveUuids ? item.id : crypto.randomUUID(),
           item
         )
       }
@@ -417,7 +417,7 @@ export async function importCourseworkData(
 
     // 新規作成。decision 未指定（uuid 不一致の初回取込）のみ元 uuid を保持して冪等化。
     const preserveUuids = !decision
-    const newCourseworkId = preserveUuids ? coursework.id : randomUUID()
+    const newCourseworkId = preserveUuids ? coursework.id : crypto.randomUUID()
     const created = await tx.coursework.create({
       data: {
         id: newCourseworkId,

--- a/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
+++ b/electron-src/lib/import/grade-archive/gradeArchiveExtractor.ts
@@ -7,6 +7,8 @@
  * どちらの形で読んだかだけを見分け、変換器チェーンへ渡す。
  */
 
+import AdmZip from "adm-zip"
+
 import type { CollectedCourseworkData } from "../../../../src/types/courseworkArchive.types"
 import type { GradeArchiveManifest } from "../../../../src/types/gradeArchive.types"
 import {
@@ -28,8 +30,6 @@ import { normalizeLegacyClassroomKeys } from "../shared/legacyClassroomKeys"
 async function extractZip(
   archivePath: string
 ): Promise<Record<string, string>> {
-  // Node.js built-in で ZIP を解凍
-  const AdmZip = (await import("adm-zip")).default
   const zip = new AdmZip(archivePath)
   const entries = zip.getEntries()
   const files: Record<string, string> = {}

--- a/electron-src/lib/import/merge/importExamCore.ts
+++ b/electron-src/lib/import/merge/importExamCore.ts
@@ -5,7 +5,7 @@
  * 不一致時は新規作成する。UserExam/ExamSubtotalGroup/ExamStudentの参加情報も扱う。
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type { FileOverviewData } from "../../../../src/types/examArchive.types"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
@@ -165,7 +165,7 @@ export async function processUserExam(
     if (!existingUserExam) {
       await tx.userExam.create({
         data: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           userId: currentUserId,
           examId: newExamId,
           role: "MEMBER",
@@ -177,7 +177,7 @@ export async function processUserExam(
   } else {
     await tx.userExam.create({
       data: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         userId: currentUserId,
         examId: newExamId,
         role: "OWNER",

--- a/electron-src/lib/import/merge/importSubtotals.ts
+++ b/electron-src/lib/import/merge/importSubtotals.ts
@@ -5,7 +5,7 @@
  * グループがスキップされた配下の小計・関連データ欠落の紐づけは警告として集約する。
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
 import type { IdMappings, PrismaTransaction } from "./types"
@@ -114,7 +114,7 @@ async function createNewSubtotal(
   const existingById = await tx.subtotal.findUnique({
     where: { id: subtotal.id },
   })
-  const newId = existingById ? randomUUID() : subtotal.id
+  const newId = existingById ? crypto.randomUUID() : subtotal.id
 
   await tx.subtotal.create({
     data: {

--- a/electron-src/lib/import/merge/processors/subtotalGroupProcessor.ts
+++ b/electron-src/lib/import/merge/processors/subtotalGroupProcessor.ts
@@ -2,7 +2,7 @@
  * 小計グループのID統合処理
  */
 
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import type {
   FileOverviewData,
@@ -57,7 +57,7 @@ export async function processSubtotalGroupIdIntegration(
       if (existingByName) {
         // B5修正: create_new の意図を尊重し、サフィックス付きで新規作成
         const newName = await generateUniqueName(importGroup.name, tx)
-        const newId = randomUUID()
+        const newId = crypto.randomUUID()
         await tx.subtotalGroup.create({
           data: {
             id: newId,
@@ -76,7 +76,7 @@ export async function processSubtotalGroupIdIntegration(
         })
         if (existingById) {
           // IDが衝突する場合は新規IDで作成
-          const newId = randomUUID()
+          const newId = crypto.randomUUID()
           await tx.subtotalGroup.create({
             data: {
               id: newId,
@@ -220,5 +220,5 @@ async function generateUniqueName(
     if (!existing) return candidate
   }
   // フォールバック: ランダム名
-  return `${baseName} (${randomUUID().slice(0, 8)})`
+  return `${baseName} (${crypto.randomUUID().slice(0, 8)})`
 }

--- a/electron-src/lib/omr/digitRecognizer.ts
+++ b/electron-src/lib/omr/digitRecognizer.ts
@@ -12,8 +12,8 @@
  * 4. 0-1正規化 → ONNX推論 → 数字（0-9）+ 信頼度
  */
 
-import fs from "fs"
-import path from "path"
+import * as fs from "fs"
+import * as path from "path"
 import sharp from "sharp"
 
 import type { ComputedCell } from "../../../src/types/answerSheetLayout.types"

--- a/electron-src/lib/pdf-tools/decryptedPdfCopy.ts
+++ b/electron-src/lib/pdf-tools/decryptedPdfCopy.ts
@@ -5,7 +5,7 @@
  * パスワード復号してレンダリングしたページ画像から、保護なしのPDFを一時ファイル
  * として再構成する。以後の結合・分割・回転はこの複製のパスに対して行う。
  */
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 import { app } from "electron"
 import * as fs from "fs"
 import * as path from "path"
@@ -55,7 +55,10 @@ export async function writeDecryptedPdfCopy(
 
   const outputDir = decryptedCopyDir()
   fs.mkdirSync(outputDir, { recursive: true })
-  const outputPath = path.join(outputDir, `decrypted-${randomUUID()}.pdf`)
+  const outputPath = path.join(
+    outputDir,
+    `decrypted-${crypto.randomUUID()}.pdf`
+  )
   fs.writeFileSync(outputPath, await pdfDoc.save())
   return outputPath
 }

--- a/electron-src/lib/printUtils.ts
+++ b/electron-src/lib/printUtils.ts
@@ -6,9 +6,9 @@
  */
 
 import { app, BrowserWindow } from "electron"
-import fs from "fs"
-import os from "os"
-import path from "path"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 import sharp from "sharp"
 
 let mathjaxCache: string | null = null

--- a/electron-src/lib/prisma/cropRegionAssignment.ts
+++ b/electron-src/lib/prisma/cropRegionAssignment.ts
@@ -6,7 +6,7 @@
  * 担当0人の設問は全員担当とみなす（絞り込みの規則は renderer の
  * `useAssignedCropRegions` が持つ）。
  */
-import { createHash } from "crypto"
+import * as crypto from "crypto"
 
 import { recordAuditLog } from "./auditLog"
 import { resolveExamScopeByCropRegion, resolveUserLabel } from "./auditScope"
@@ -34,7 +34,8 @@ export function buildAssignmentId(
     ASSIGNMENT_NAMESPACE.replace(/-/g, ""),
     "hex"
   )
-  const hash = createHash("sha1")
+  const hash = crypto
+    .createHash("sha1")
     .update(namespaceBytes)
     .update(`${cropRegionId}:${userId}`)
     .digest()

--- a/electron-src/lib/prisma/exam.ts
+++ b/electron-src/lib/prisma/exam.ts
@@ -1,5 +1,5 @@
-import type { Prisma as PrismaTypes } from "@prisma/client"
-import * as fs from "fs/promises"
+import type { Prisma } from "@prisma/client"
+import * as fsPromises from "fs/promises"
 
 import { getExamDirectory } from "../dataManager"
 import { diffFields, recordAuditLog } from "./auditLog"
@@ -158,7 +158,7 @@ export const getExamWithPages = async (id: string) => {
 
 /** 試験を作成し、指定ユーザーをOWNERとしてUserExamに登録する */
 export const createExam = async (
-  data: Omit<PrismaTypes.ExamCreateInput, "userExams">,
+  data: Omit<Prisma.ExamCreateInput, "userExams">,
   userId: string
 ) => {
   const exam = await prisma.exam.create({
@@ -220,10 +220,7 @@ export const createExam = async (
 }
 
 /** 試験情報を更新する */
-export const updateExam = async (
-  id: string,
-  data: PrismaTypes.ExamUpdateInput
-) => {
+export const updateExam = async (id: string, data: Prisma.ExamUpdateInput) => {
   // 差分記録用に変更前を取得
   const before = await prisma.exam.findUnique({
     where: { id },
@@ -274,7 +271,7 @@ export const deleteExam = async (id: string) => {
   // 模範解答・答案の画像はDBのcascadeでは消えないため、試験ディレクトリごと削除する。
   // ファイル削除の失敗で試験削除自体を巻き戻さない（DBは既に削除済み）。
   try {
-    await fs.rm(getExamDirectory(id), { recursive: true, force: true })
+    await fsPromises.rm(getExamDirectory(id), { recursive: true, force: true })
   } catch (fileError) {
     console.warn(`Failed to delete exam directory for ${id}:`, fileError)
   }

--- a/electron-src/lib/prisma/gradeDataSource.ts
+++ b/electron-src/lib/prisma/gradeDataSource.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Prisma } from "@prisma/client"
-import { randomUUID } from "crypto"
+import * as crypto from "crypto"
 
 import { toGradeDataSourceType } from "../../../src/types/grade.types"
 import type { GradeDataSourceMaxScoreRef } from "../../../src/types/prismaExtensions"
@@ -264,7 +264,7 @@ export async function createDataSource(data: {
     const nextOrder = (maxOrder._max.order ?? -1) + 1
 
     // estimationSources のidは自分のidから決定論的に作るため、先にidを確定させる
-    const dataSourceId = randomUUID()
+    const dataSourceId = crypto.randomUUID()
 
     const dataSource = await prisma.gradeDataSource.create({
       data: {

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -1,6 +1,6 @@
 import { ExamPage, MasterImage, Prisma } from "@prisma/client"
-import fs from "fs/promises"
-import path from "path"
+import * as fsPromises from "fs/promises"
+import * as path from "path"
 
 import {
   getAbsolutePathFromData,
@@ -51,7 +51,7 @@ export const uploadMasterAnswers = async (
   const uploadedAnswers: MasterImageWithExamPage[] = []
 
   const examAnswerDir = getMasterAnswersDirectory(examId)
-  await fs.mkdir(examAnswerDir, { recursive: true })
+  await fsPromises.mkdir(examAnswerDir, { recursive: true })
 
   for (const [index, fileData] of filesData.entries()) {
     try {
@@ -64,7 +64,7 @@ export const uploadMasterAnswers = async (
       const relativePath = getRelativePathFromData(destinationPath)
 
       // Save file
-      await fs.writeFile(destinationPath, fileBuffer)
+      await fsPromises.writeFile(destinationPath, fileBuffer)
 
       const pageNumber = highestPageNumber + 1 + index
 
@@ -191,7 +191,7 @@ export const deleteMasterAnswer = async (
     })
 
     try {
-      await fs.unlink(filePath)
+      await fsPromises.unlink(filePath)
     } catch (fileError: unknown) {
       if (
         fileError &&

--- a/electron-src/lib/prisma/pdfExport.ts
+++ b/electron-src/lib/prisma/pdfExport.ts
@@ -1,8 +1,8 @@
 import type { CropRegion } from "@prisma/client"
-import crypto from "crypto"
+import * as crypto from "crypto"
 import { dialog } from "electron"
-import fs from "fs"
-import path from "path"
+import * as fs from "fs"
+import * as path from "path"
 import { PageSizes, PDFDocument } from "pdf-lib"
 
 import { getAbsolutePathFromData } from "../dataManager"

--- a/electron-src/lib/prisma/studentAnswer/crud.ts
+++ b/electron-src/lib/prisma/studentAnswer/crud.ts
@@ -3,7 +3,7 @@
  * - アップロード、取得、削除、関連付け
  */
 import type { Prisma } from "@prisma/client"
-import * as fs from "fs/promises"
+import * as fsPromises from "fs/promises"
 import * as path from "path"
 
 import type {
@@ -138,7 +138,7 @@ export async function uploadStudentAnswers(
     const examDir = getAnswerSheetsDirectory(examId)
 
     // 試験ディレクトリを作成
-    await fs.mkdir(examDir, { recursive: true })
+    await fsPromises.mkdir(examDir, { recursive: true })
 
     const uploadedSheets: Array<{
       id: string
@@ -233,13 +233,13 @@ export async function uploadStudentAnswers(
 
       if (existingRecord) {
         if (fileData.overwrite) {
-          await fs.writeFile(filePath, buffer)
+          await fsPromises.writeFile(filePath, buffer)
 
           try {
             const oldFilePath = getAbsolutePathFromData(
               existingRecord.imagePath
             )
-            await fs.unlink(oldFilePath)
+            await fsPromises.unlink(oldFilePath)
           } catch {
             // ファイルが存在しない場合は無視
           }
@@ -263,7 +263,7 @@ export async function uploadStudentAnswers(
           })
         }
       } else {
-        await fs.writeFile(filePath, buffer)
+        await fsPromises.writeFile(filePath, buffer)
 
         const answerSheet = await prisma.studentAnswerImage.create({
           data: {
@@ -671,8 +671,7 @@ export async function deleteStudentAnswer(answerSheetId: string) {
     // ファイル削除は DB コミット後。失敗しても孤立ファイルが残るだけなので警告に留める
     // （パス解決の失敗も含めて握る。ここで例外を投げると削除済みの DB と矛盾する）。
     try {
-      const { getAbsolutePathFromData } = await import("../../dataManager")
-      await fs.unlink(getAbsolutePathFromData(answerSheet.imagePath))
+      await fsPromises.unlink(getAbsolutePathFromData(answerSheet.imagePath))
     } catch (fileError) {
       console.warn("Failed to delete file:", fileError)
     }

--- a/electron-src/lib/shared/calculations/numericStats.ts
+++ b/electron-src/lib/shared/calculations/numericStats.ts
@@ -16,21 +16,21 @@ export interface BoxPlotData {
 }
 
 /** 母集団の平均（空配列は0） */
-export function average(values: number[]): number {
+export function calculateAverage(values: number[]): number {
   if (values.length === 0) return 0
   return values.reduce((sum, v) => sum + v, 0) / values.length
 }
 
 /** 母標準偏差（空配列は0） */
-export function stdDev(values: number[]): number {
+export function calculateStandardDeviation(values: number[]): number {
   if (values.length === 0) return 0
-  const avg = average(values)
+  const avg = calculateAverage(values)
   const squaredDiffs = values.map((value) => (value - avg) ** 2)
   return Math.sqrt(squaredDiffs.reduce((sum, v) => sum + v, 0) / values.length)
 }
 
 /** ソート済み配列の中央値（空配列は0） */
-function median(sortedValues: number[]): number {
+function calculateMedian(sortedValues: number[]): number {
   const n = sortedValues.length
   if (n === 0) return 0
   if (n === 1) return sortedValues[0]
@@ -46,7 +46,7 @@ function median(sortedValues: number[]): number {
  * データを下位半分と上位半分に分けてそれぞれの中央値を Q1/Q3 とする。
  * n が奇数の場合、中央値は両半分から除外する。
  */
-export function boxPlot(values: number[]): BoxPlotData {
+export function calculateBoxPlot(values: number[]): BoxPlotData {
   if (values.length === 0) {
     return { min: 0, q1: 0, median: 0, q3: 0, max: 0 }
   }
@@ -57,15 +57,15 @@ export function boxPlot(values: number[]): BoxPlotData {
   const upperHalf = sorted.slice(n % 2 === 0 ? midIndex : midIndex + 1)
   return {
     min: sorted[0],
-    q1: median(lowerHalf),
-    median: median(sorted),
-    q3: median(upperHalf),
+    q1: calculateMedian(lowerHalf),
+    median: calculateMedian(sorted),
+    q3: calculateMedian(upperHalf),
     max: sorted[n - 1],
   }
 }
 
 /** 順位（同点同順位。降順ソートで score 以下になる最初の位置+1） */
-export function rank(score: number, allScores: number[]): number {
+export function calculateRank(score: number, allScores: number[]): number {
   const sorted = [...allScores].sort((a, b) => b - a)
   return sorted.findIndex((value) => value <= score) + 1
 }

--- a/electron-src/nextServerEmbedded.ts
+++ b/electron-src/nextServerEmbedded.ts
@@ -3,7 +3,7 @@ import type { Server } from "http"
 import type { IncomingMessage, ServerResponse } from "http"
 import type * as NodeModule from "module"
 import type { NextServer } from "next/dist/server/next"
-import { delimiter, join } from "path"
+import * as path from "path"
 
 // Electron公式推奨の環境判定方法
 const isDev = !app.isPackaged
@@ -24,9 +24,9 @@ const ensurePackagedNodePath = (basePath: string) => {
     }
 
     const candidatePaths = [
-      join(basePath, "app.asar", "node_modules"),
-      join(basePath, "app.asar.unpacked", "node_modules"),
-      join(basePath, "node_modules"),
+      path.join(basePath, "app.asar", "node_modules"),
+      path.join(basePath, "app.asar.unpacked", "node_modules"),
+      path.join(basePath, "node_modules"),
     ].filter((p: string) => fs.existsSync(p))
 
     if (!candidatePaths.length) {
@@ -37,11 +37,11 @@ const ensurePackagedNodePath = (basePath: string) => {
     }
 
     const existing = process.env.NODE_PATH
-      ? process.env.NODE_PATH.split(delimiter).filter(Boolean)
+      ? process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
       : []
     const updated = Array.from(new Set([...candidatePaths, ...existing]))
 
-    process.env.NODE_PATH = updated.join(delimiter)
+    process.env.NODE_PATH = updated.join(path.delimiter)
     Module._initPaths()
   } catch (error) {
     console.warn("Failed to extend NODE_PATH for packaged runtime:", error)
@@ -71,8 +71,8 @@ export async function startEmbeddedNextServer(): Promise<void> {
       // .nextとpublicディレクトリの存在確認
       try {
         const fs = require("fs")
-        const nextDir = join(appDir, ".next")
-        const publicDir = join(appDir, "public")
+        const nextDir = path.join(appDir, ".next")
+        const publicDir = path.join(appDir, "public")
 
         if (!fs.existsSync(nextDir)) {
           console.warn(`⚠ Warning: .next directory not found at ${nextDir}`)
@@ -82,7 +82,7 @@ export async function startEmbeddedNextServer(): Promise<void> {
         }
 
         // PDF workerファイルの存在確認
-        const pdfWorkerPath = join(publicDir, "js", "pdf.worker.min.mjs")
+        const pdfWorkerPath = path.join(publicDir, "js", "pdf.worker.min.mjs")
         if (!fs.existsSync(pdfWorkerPath)) {
           console.error(`❌ PDF worker file not found at ${pdfWorkerPath}`)
         }

--- a/electron-src/windowManager.ts
+++ b/electron-src/windowManager.ts
@@ -6,7 +6,7 @@ import {
   Menu,
   RenderProcessGoneDetails,
 } from "electron"
-import { join } from "path"
+import * as path from "path"
 
 import menu from "./menu"
 
@@ -20,13 +20,13 @@ export function createMainWindow(): BrowserWindow {
     if (process.platform === "darwin") {
       // macOSの場合は.icnsファイルを使用
       return isDev
-        ? join(__dirname, "../public/icons/icon.icns")
-        : join(process.resourcesPath, "app.asar/public/icons/icon.icns")
+        ? path.join(__dirname, "../public/icons/icon.icns")
+        : path.join(process.resourcesPath, "app.asar/public/icons/icon.icns")
     } else {
       // Windows/Linuxの場合はPNGファイルを使用
       return isDev
-        ? join(__dirname, "../public/icons/icon-win.png")
-        : join(process.resourcesPath, "app.asar/public/icons/icon-win.png")
+        ? path.join(__dirname, "../public/icons/icon-win.png")
+        : path.join(process.resourcesPath, "app.asar/public/icons/icon-win.png")
     }
   }
 
@@ -38,7 +38,7 @@ export function createMainWindow(): BrowserWindow {
     show: false, // 最初は非表示
     icon: iconPath, // アイコンを設定
     webPreferences: {
-      preload: join(__dirname, "preload.js"),
+      preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
       webSecurity: true, // セキュリティ有効化（ローカルファイルアクセスはappimg://プロトコルで対応）

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -168,12 +168,36 @@ export default [
       // grep もできない。トップレベルの `import type { Foo } from "./x"` を使う。
       // セレクタの TSImportType は型注釈側の記法のみを指し、実行時の動的 import
       // （ImportExpression）は別ノードなので影響しない。
+      // Node 組み込み（path/fs/os/crypto）と exceljs は名前空間 import に統一する。
+      // 呼び出し箇所に出自を残すのが目的で、`crypto.randomUUID()` は `Math.random()`
+      // ではないことを、`os.tmpdir()` は OS の一時ディレクトリであることを、
+      // `path.join()` は配列の join ではないことをその場で示す。
+      // 名前付き import にすると `randomUUID()` `tmpdir()` `join()` となり出自が消える。
+      // 型のみの import（`import type { Stats } from "fs"` 等）は対象外。
       "no-restricted-syntax": [
         "error",
         {
           selector: "TSImportType",
           message:
             'インライン型 import は使わず、トップレベルの `import type { X } from "..."` を使ってください（静的解析が参照を追えなくなります）。',
+        },
+        {
+          selector:
+            'ImportDeclaration[importKind!="type"][source.value=/^(node:)?(path|fs|os|crypto)$|^exceljs$/] > ImportSpecifier[importKind!="type"]',
+          message:
+            'path / fs / os / crypto / exceljs は名前空間 import に統一してください（例: `import * as path from "path"` → `path.join()`）。呼び出し箇所に出自を残すためです。',
+        },
+        {
+          selector:
+            'ImportDeclaration[importKind!="type"][source.value=/^(node:)?(path|fs|os|crypto)$|^exceljs$/] > ImportDefaultSpecifier',
+          message:
+            'path / fs / os / crypto / exceljs は default ではなく名前空間 import に統一してください（例: `import * as fs from "fs"`）。',
+        },
+        {
+          selector:
+            'ImportDeclaration[source.value=/^(node:)?fs\\u002Fpromises$/] > :matches(ImportNamespaceSpecifier, ImportDefaultSpecifier)[local.name="fs"]',
+          message:
+            '同期版の `fs` と区別がつかないため、`import * as fsPromises from "fs/promises"` としてください。',
         },
       ],
     },

--- a/prisma/prisma.config.ts
+++ b/prisma/prisma.config.ts
@@ -1,4 +1,4 @@
-import path from "node:path"
+import * as path from "node:path"
 
 import { defineConfig } from "prisma/config"
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Plus, Settings, User as UserIcon } from "lucide-react"
+import { Plus, Settings, UserIcon } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 

--- a/src/components/answer-sheet-builder/AnswerSheetDefinitionDetail.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetDefinitionDetail.tsx
@@ -1,13 +1,7 @@
 "use client"
 
 import type { Tag } from "@prisma/client"
-import {
-  ArrowRight,
-  Download,
-  Pencil,
-  Tag as TagIcon,
-  X as XIcon,
-} from "lucide-react"
+import { ArrowRight, Download, Pencil, TagIcon, XIcon } from "lucide-react"
 import { useRouter } from "next/navigation"
 import React, { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"

--- a/src/components/common/ListFilterBar.tsx
+++ b/src/components/common/ListFilterBar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { LucideIcon } from "lucide-react"
-import { Calendar, School, Search, Tag, X as XIcon } from "lucide-react"
+import { Calendar, School, Search, Tag, XIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
 import { Badge } from "@/components/ui/badge"

--- a/src/components/common/ToastProvider.tsx
+++ b/src/components/common/ToastProvider.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { Toaster as Sonner } from "sonner"
+import { Toaster } from "sonner"
 
-type ToasterProps = React.ComponentProps<typeof Sonner>
+type ToasterProps = React.ComponentProps<typeof Toaster>
 
 const ToastProvider = ({ ...props }: ToasterProps) => {
   return (
-    <Sonner
+    <Toaster
       theme="light" // デフォルトのテーマを指定 (必要に応じて変更)
       className="toaster group"
       toastOptions={{

--- a/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/TableContent.tsx
@@ -28,7 +28,7 @@ import {
   Table,
   TableBody,
   TableHead,
-  TableHeader as UITableHeader,
+  TableHeader,
   TableRow,
 } from "@/components/ui/table"
 import type { ExamStudentWithMemberships } from "@/types/prismaExtensions"
@@ -130,7 +130,7 @@ export function TableContent({
 }: TableContentProps) {
   return (
     <Table>
-      <UITableHeader>
+      <TableHeader>
         <TableRow>
           {/* 生徒名列ヘッダー */}
           <TableHead className="w-32 border text-center">生徒名</TableHead>
@@ -179,7 +179,7 @@ export function TableContent({
             </TableHead>
           ))}
         </TableRow>
-      </UITableHeader>
+      </TableHeader>
       <TableBody>
         {tableRows.map(({ examStudent, cells }) => (
           <TableRow key={examStudent.id}>

--- a/src/components/exams/08-export/components/individual-report/computeReportData.ts
+++ b/src/components/exams/08-export/components/individual-report/computeReportData.ts
@@ -10,10 +10,10 @@ import type {
   SubtotalStatistics,
 } from "@/electron-src/lib/export/individual-report/types"
 import {
-  average,
-  boxPlot,
-  rank,
-  stdDev,
+  calculateAverage,
+  calculateBoxPlot,
+  calculateRank,
+  calculateStandardDeviation,
 } from "@/electron-src/lib/shared/calculations/numericStats"
 import type { SubtotalScore } from "@/electron-src/lib/shared/types"
 import type { ExamStudentStatus } from "@/types/examStudentStatus.types"
@@ -75,8 +75,8 @@ export function computeFilteredStats(
     .map((entry) => entry.totalScore)
     .filter((score): score is number => score !== null)
 
-  const overallAvg = average(allScores)
-  const overallStd = stdDev(allScores)
+  const overallAvg = calculateAverage(allScores)
+  const overallStd = calculateStandardDeviation(allScores)
   const studentScore = report.scoringData.totalScore
   const deviation =
     studentScore === null || overallStd === 0
@@ -96,10 +96,13 @@ export function computeFilteredStats(
       .filter((score): score is number => score !== null)
     return {
       ...classroom,
-      average: average(classroomScores),
-      stdDev: stdDev(classroomScores),
+      average: calculateAverage(classroomScores),
+      stdDev: calculateStandardDeviation(classroomScores),
       total: filteredMembers.length,
-      rank: studentScore !== null ? rank(studentScore, classroomScores) : 0,
+      rank:
+        studentScore !== null
+          ? calculateRank(studentScore, classroomScores)
+          : 0,
     }
   })
 
@@ -115,7 +118,8 @@ export function computeFilteredStats(
     personal: {
       ...report.statistics.personal,
       deviation,
-      overallRank: studentScore !== null ? rank(studentScore, allScores) : 0,
+      overallRank:
+        studentScore !== null ? calculateRank(studentScore, allScores) : 0,
     },
   }
 }
@@ -179,8 +183,8 @@ export function computeFilteredSubtotalStats(
       subtotalId: stat.subtotalId,
       subtotalLabel: stat.subtotalLabel,
       subtotalGroupId: stat.subtotalGroupId,
-      boxPlot: boxPlot(filteredScores),
-      average: average(filteredScores),
+      boxPlot: calculateBoxPlot(filteredScores),
+      average: calculateAverage(filteredScores),
       maxScore: stat.maxScore,
     }
   })
@@ -215,9 +219,9 @@ export function computeFilteredOverallStat(
     subtotalGroupId: "__overall__",
     boxPlot:
       filteredScores.length > 0
-        ? boxPlot(filteredScores)
+        ? calculateBoxPlot(filteredScores)
         : { min: 0, q1: 0, median: 0, q3: 0, max: 0 },
-    average: average(filteredScores),
+    average: calculateAverage(filteredScores),
     maxScore: totalMaxScore,
   }
 }

--- a/src/components/exams/forms/CreateExamWindow.tsx
+++ b/src/components/exams/forms/CreateExamWindow.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Tag as TagIcon, X as XIcon } from "lucide-react"
+import { TagIcon, XIcon } from "lucide-react"
 import React, { useCallback, useEffect, useState } from "react"
 
 import { useExams } from "@/components/hooks/useExams"

--- a/src/components/exams/forms/EditExamWindow.tsx
+++ b/src/components/exams/forms/EditExamWindow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Exam } from "@prisma/client"
-import { Tag as TagIcon, X as XIcon } from "lucide-react"
+import { TagIcon, XIcon } from "lucide-react"
 import React, { useCallback, useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"

--- a/src/components/help/usePageHelp.tsx
+++ b/src/components/help/usePageHelp.tsx
@@ -4,17 +4,17 @@ import { BookOpen } from "lucide-react"
 import { usePathname } from "next/navigation"
 import React, { useState } from "react"
 
-import { HelpContent01Upload as UploadHelpContent } from "@/components/help/page-specific/HelpContent01Upload"
-import { HelpContent02Template as TemplateHelpContent } from "@/components/help/page-specific/HelpContent02Template"
-import { HelpContent03RegionInfo as RegionInfoHelpContent } from "@/components/help/page-specific/HelpContent03RegionInfo"
-import { HelpContent04QuestionGroup as QuestionGroupHelpContent } from "@/components/help/page-specific/HelpContent04QuestionGroup"
-import { HelpContent05Students as StudentsHelpContent } from "@/components/help/page-specific/HelpContent05Students"
-import { HelpContent06StudentAnswers as StudentAnswersHelpContent } from "@/components/help/page-specific/HelpContent06StudentAnswers"
-import { HelpContent07Scoring as ScoringHelpContent } from "@/components/help/page-specific/HelpContent07Scoring"
-import { HelpContent08Export as ExportHelpContent } from "@/components/help/page-specific/HelpContent08Export"
-import { HelpContentClassrooms as ClassroomsHelpContent } from "@/components/help/page-specific/HelpContentClassrooms"
-import { HelpContentStudents as StudentsMasterHelpContent } from "@/components/help/page-specific/HelpContentStudents"
-import { HelpContentSubtotalGroups as SubtotalGroupsHelpContent } from "@/components/help/page-specific/HelpContentSubtotalGroups"
+import { HelpContent01Upload } from "@/components/help/page-specific/HelpContent01Upload"
+import { HelpContent02Template } from "@/components/help/page-specific/HelpContent02Template"
+import { HelpContent03RegionInfo } from "@/components/help/page-specific/HelpContent03RegionInfo"
+import { HelpContent04QuestionGroup } from "@/components/help/page-specific/HelpContent04QuestionGroup"
+import { HelpContent05Students } from "@/components/help/page-specific/HelpContent05Students"
+import { HelpContent06StudentAnswers } from "@/components/help/page-specific/HelpContent06StudentAnswers"
+import { HelpContent07Scoring } from "@/components/help/page-specific/HelpContent07Scoring"
+import { HelpContent08Export } from "@/components/help/page-specific/HelpContent08Export"
+import { HelpContentClassrooms } from "@/components/help/page-specific/HelpContentClassrooms"
+import { HelpContentStudents } from "@/components/help/page-specific/HelpContentStudents"
+import { HelpContentSubtotalGroups } from "@/components/help/page-specific/HelpContentSubtotalGroups"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -29,17 +29,17 @@ import {
 const pageHelpComponents: {
   [key: string]: React.ComponentType
 } = {
-  "01-upload": UploadHelpContent,
-  "02-template": TemplateHelpContent,
-  "03-region-info": RegionInfoHelpContent,
-  "04-question-group": QuestionGroupHelpContent,
-  "05-students": StudentsHelpContent,
-  "06-student-answers": StudentAnswersHelpContent,
-  "07-score-at-once": ScoringHelpContent,
-  "08-export": ExportHelpContent,
-  "subtotal-groups": SubtotalGroupsHelpContent,
-  classrooms: ClassroomsHelpContent,
-  students: StudentsMasterHelpContent,
+  "01-upload": HelpContent01Upload,
+  "02-template": HelpContent02Template,
+  "03-region-info": HelpContent03RegionInfo,
+  "04-question-group": HelpContent04QuestionGroup,
+  "05-students": HelpContent05Students,
+  "06-student-answers": HelpContent06StudentAnswers,
+  "07-score-at-once": HelpContent07Scoring,
+  "08-export": HelpContent08Export,
+  "subtotal-groups": HelpContentSubtotalGroups,
+  classrooms: HelpContentClassrooms,
+  students: HelpContentStudents,
 }
 
 /** 現在のページに対応するヘルプコンテンツを全画面モーダルで表示するフック */

--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -2,7 +2,7 @@
 
 import type { DragEndEvent } from "@dnd-kit/core"
 import { arrayMove } from "@dnd-kit/sortable"
-import { Edit2, PlusCircle, Trash2, X as XIcon } from "lucide-react"
+import { Edit2, PlusCircle, Trash2, XIcon } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from "path"
+import * as path from "path"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({


### PR DESCRIPTION
Closes #1096

## 概要

呼び出し箇所に出自が残らない import の書き方を規約化し、既存コードを追従させた。

## 変更内容

### ESLint ルール追加（`eslint.config.mjs`）

`no-restricted-syntax` に 3 つのセレクタを追加した。

1. `path` / `fs` / `os` / `crypto` / `exceljs` の**名前付き import** を禁止（`node:` 接頭辞付きも対象）
2. 同モジュールの **default import** を禁止
3. `fs/promises` を **`fs` という名前で束縛すること**を禁止

`importKind!="type"` で型のみの import は除外している。

### 規約の明文化（`docs/coding-style.md`）

- 名前空間 import に統一するモジュールの一覧表と、○/× の対比例
- `fs/promises` を `fs` と名付けてはいけない理由（同期 API が必要になった箇所で外側の束縛を潰す事故が起きていた）
- 別名 import は同名の別束縛と衝突する場合に限る、という規約
- 「呼び出し側で別名を付けたくなったら、まず定義側の名前を疑う」

### 既存コードの追従（55 ファイル）

- `path` / `fs` / `fs/promises` / `os` / `crypto` の import を名前空間形式へ。`import * as fs from "fs/promises"` となっていた 6 箇所は `fsPromises` へ改名
- `randomUUID()` → `crypto.randomUUID()`、`join()` → `path.join()` など呼び出し側を追従
- lucide-react の `X as XIcon` / `Tag as TagIcon` / `User as UserIcon` を正式名の import へ
- ヘルプ内容 11 件の `HelpContentNN as NNHelpContent` を定義側の名前へ
- `Toaster as Sonner`、`TableHeader as UITableHeader`、`Prisma as PrismaTypes`、`getExamPagesByExamId as dbGetExamPagesByExamId` などの不要な別名を除去
- `numericStats` の `average` / `stdDev` / `boxPlot` / `rank` / `median` を `calculate` 接頭辞付きへ改名（別名で隠れていた命名の食い違いの解消）

### テスト側の追従

`printUtils` のモックが `fs.default.writeFileSync` を見ていた箇所を、名前空間直下の `fs.writeFileSync` へ変更した（名前空間 import では default キーを経由しないため）。

## 検証

| 項目                | 結果                                                                      |
| ------------------- | ------------------------------------------------------------------------- |
| `npm run lint`      | 0 errors（warning 142 件はすべて既存の `react-hooks` / `preserve-caught-error` 系） |
| `npm run format`    | 差分なし                                                                  |
| `npm run typecheck` | 通過（tsc + electron-src 両方）                                           |
| `npx vitest run`    | 117 files / 1194 tests 全 pass                                            |

## 補足

`scripts/**` は ESLint の ignores 対象のため `scripts/bulk-rename.mjs` は追従していない。v0.6.x の一回限りのリネーム用スクリプトであり、対象外と判断した。
