### PR TITLE
fix(lint): eslint 警告 76 件を解消しゼロ件のルールを error へ昇格する

### DIFF
--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -1473,7 +1473,7 @@ describe("grade-archive ラウンドトリップ", () => {
     const grade = await prisma.grade.create({
       data: { name: `成績_legacy_${suffix}` },
     })
-    const gradeStudent = await prisma.gradeStudent.create({
+    await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
     await prisma.gradeItem.create({
@@ -1619,7 +1619,7 @@ describe("grade-archive ラウンドトリップ", () => {
     await prisma.gradeClassroom.create({
       data: { gradeId: grade.id, classroomId: classroom.id, order: 0 },
     })
-    const gradeStudent = await prisma.gradeStudent.create({
+    await prisma.gradeStudent.create({
       data: { gradeId: grade.id, studentId: student.id },
     })
 

--- a/__tests__/migration/deployPendingMigrations.test.ts
+++ b/__tests__/migration/deployPendingMigrations.test.ts
@@ -67,9 +67,9 @@ afterEach(() => {
 })
 
 const loadDeployer = async () => {
-  const module =
+  const migrationDeployer =
     await import("../../electron-src/lib/prisma/schema/migrationDeployer")
-  return module.deployPendingMigrations
+  return migrationDeployer.deployPendingMigrations
 }
 
 describe("deployPendingMigrations", () => {

--- a/electron-src/appInitializer.ts
+++ b/electron-src/appInitializer.ts
@@ -59,7 +59,8 @@ export async function initializeApp(): Promise<void> {
     } catch (dbError) {
       console.error("Database setup failed:", dbError)
       throw new Error(
-        `Database initialization failed: ${dbError instanceof Error ? dbError.message : dbError}`
+        `Database initialization failed: ${dbError instanceof Error ? dbError.message : dbError}`,
+        { cause: dbError }
       )
     }
 
@@ -89,6 +90,8 @@ export async function initializeApp(): Promise<void> {
     console.error("Failed to initialize application:", error)
     // アプリケーションを終了させるのではなく、エラー状態を明確にする
     const errorMessage = error instanceof Error ? error.message : String(error)
-    throw new Error(`Application initialization failed: ${errorMessage}`)
+    throw new Error(`Application initialization failed: ${errorMessage}`, {
+      cause: error,
+    })
   }
 }

--- a/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
+++ b/electron-src/ipc-handlers/answerSheetBuilderHandlers.ts
@@ -267,11 +267,11 @@ export function setupAnswerSheetBuilderHandlers(): void {
   // NOTE: Uses BrowserWindow with try-finally for cleanup, kept as manual ipcMain.handle
   ipcMain.handle("asb:print", async (_event, args: ASBPrintArgs) => {
     let tempHtmlPath: string | null = null
-    let tempPdfPath: string | null = null
     let win: BrowserWindow | null = null
     try {
       tempHtmlPath = path.join(os.tmpdir(), `asb-print-${Date.now()}.html`)
-      tempPdfPath = path.join(os.tmpdir(), `asb-print-${Date.now()}.pdf`)
+      // プレビュー中は削除しないので finally からは参照しない
+      const tempPdfPath = path.join(os.tmpdir(), `asb-print-${Date.now()}.pdf`)
       fs.writeFileSync(tempHtmlPath, args.html, "utf-8")
 
       win = new BrowserWindow({

--- a/electron-src/lib/dataManager.ts
+++ b/electron-src/lib/dataManager.ts
@@ -102,7 +102,8 @@ export const initializeDataDirectory = async (): Promise<void> => {
     console.error("App is packaged:", app.isPackaged)
 
     throw new Error(
-      `Data directory initialization failed: ${error instanceof Error ? error.message : error}`
+      `Data directory initialization failed: ${error instanceof Error ? error.message : error}`,
+      { cause: error }
     )
   }
 }

--- a/electron-src/lib/prisma/schema/migrationDeployer.ts
+++ b/electron-src/lib/prisma/schema/migrationDeployer.ts
@@ -98,7 +98,8 @@ export const deployPendingMigrations = (options?: {
           restoreBackup(backupPath)
         }
         throw new Error(
-          `Migration ${dirName} failed: ${error instanceof Error ? error.message : error}`
+          `Migration ${dirName} failed: ${error instanceof Error ? error.message : error}`,
+          { cause: error }
         )
       }
     }

--- a/electron-src/tsconfig.json
+++ b/electron-src/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "lib": ["dom", "es2017"],
+    "lib": ["dom", "es2022"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": false,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,15 +102,18 @@ export default [
       // React Hooks（v7 の React Compiler 由来ルール）
       // recommended は 16 ルールだが上2つしか有効化していなかったため追加する。
       // 既存の違反を先に潰す必要があるので、いったん全て warn で可視化し、
-      // 件数がゼロになったものから error へ引き上げる。カッコ内は導入時点の件数。
+      // 件数がゼロになったものから error へ引き上げる方針。
       //
-      // 実バグ（優先して潰す）
-      "react-hooks/set-state-in-render": "warn", // 2件 useMemo内setStateで無限ループ危険
-      "react-hooks/static-components": "warn", // 3件 レンダー中のコンポーネント定義で状態リセット
-      "react-hooks/immutability": "warn", // 5件 props書き換え・宣言前アクセス
-      // 設計課題（key での作り直しへ移行が必要。件数が多く別途対応）
-      "react-hooks/set-state-in-effect": "warn", // 88件
-      "react-hooks/refs": "warn", // 22件
+      // 違反ゼロにしたので error（再混入を止める）
+      "react-hooks/set-state-in-render": "error",
+      "react-hooks/static-components": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/refs": "error",
+      // 残る違反は「effect から非同期ローダーを呼ぶ」形が大半。ルールは setState への
+      // 到達可能性だけを見るため await 後の更新も警告になるが、Suspense を使わない
+      // 現構成では代替手段がない。props→state のミラーリングや開くたびのリセットは
+      // key での作り直し・派生値化に置き換え済みなので、新規の混入はその形を疑うこと。
+      "react-hooks/set-state-in-effect": "warn", // 68件（うち大半は非同期ローダー呼び出し）
       // 現時点で違反ゼロ（将来の混入を防ぐ保険）
       "react-hooks/error-boundaries": "warn",
       "react-hooks/globals": "warn",
@@ -141,7 +144,7 @@ export default [
       // Canvas 描画のため ref から生の HTMLImageElement が必要で next/image に
       // 置き換えられない。Electron アプリで LCP 最適化の対象でもないので入れない。
       "@next/next/no-html-link-for-pages": "off",
-      "@next/next/no-assign-module-variable": "warn", // 1件 module のシャドウイング
+      "@next/next/no-assign-module-variable": "error",
       "@next/next/no-sync-scripts": "error",
       "@next/next/no-document-import-in-page": "error",
       "@next/next/no-head-import-in-document": "error",
@@ -153,10 +156,9 @@ export default [
       "no-console": "off",
       "no-undef": "off", // TypeScript handles this
 
-      // ESLint 10 の recommended で新規に有効化されたルール。
-      // 既存違反があるため一旦 warn で可視化する（ゼロになったら error へ）。
-      "no-useless-assignment": "warn", // 12件 読まれない代入
-      "preserve-caught-error": "warn", // 7件 catch した原因を cause で引き継いでいない
+      // ESLint 10 の recommended で新規に有効化されたルール。違反ゼロにしたので error。
+      "no-useless-assignment": "error", // 読まれない代入
+      "preserve-caught-error": "error", // catch した原因を cause で引き継いでいない
 
       // Import sorting
       "simple-import-sort/imports": "error",

--- a/src/app/classrooms/[classroomId]/components/ClassroomScoreTrendChart.tsx
+++ b/src/app/classrooms/[classroomId]/components/ClassroomScoreTrendChart.tsx
@@ -76,7 +76,8 @@ export function ClassroomScoreTrendChart({
 
   const [seriesList, setSeriesList] = useState<SeriesConfig[]>(() => [
     {
-      id: `cs${nextIdRef.current++}`,
+      // 初期系列のidは固定。nextIdRef は追加系列（createId）専用にする
+      id: "cs0",
       label: "学級平均（合計）",
       tags: new Set<string>(),
       subtotalId: "__total__",

--- a/src/app/classrooms/[classroomId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/page.tsx
@@ -224,14 +224,17 @@ export default function ClassroomDetailPage() {
           </div>
         </div>
 
-        {/* モーダル */}
-        <ClassroomModal
-          isOpen={isClassroomModalOpen}
-          onClose={() => setIsClassroomModalOpen(false)}
-          onSave={handleSaveClassroom}
-          classroomToEdit={classroomData}
-        />
+        {/* モーダル（閉じている間はマウントしない。開くたびにフォームを作り直す） */}
+        {isClassroomModalOpen && (
+          <ClassroomModal
+            isOpen={isClassroomModalOpen}
+            onClose={() => setIsClassroomModalOpen(false)}
+            onSave={handleSaveClassroom}
+            classroomToEdit={classroomData}
+          />
+        )}
 
+        {/* 入力途中の表を開き直しても保つため、閉じてもマウントしたままにする */}
         <ClassroomStudentImportModal
           isOpen={isStudentImportModalOpen}
           onClose={() => setIsStudentImportModalOpen(false)}
@@ -240,16 +243,18 @@ export default function ClassroomDetailPage() {
           className={classroomData?.name || ""}
         />
 
-        <StudentClassroomMembershipModal
-          isOpen={isMembershipModalOpen}
-          onClose={() => setIsMembershipModalOpen(false)}
-          onSave={handleSaveMembership}
-          studentId={membershipToEdit?.studentId}
-          classroomId={classroomId}
-          availableStudents={students}
-          availableClassrooms={[]}
-          membershipToEdit={membershipToEdit}
-        />
+        {isMembershipModalOpen && (
+          <StudentClassroomMembershipModal
+            isOpen={isMembershipModalOpen}
+            onClose={() => setIsMembershipModalOpen(false)}
+            onSave={handleSaveMembership}
+            studentId={membershipToEdit?.studentId}
+            classroomId={classroomId}
+            availableStudents={students}
+            availableClassrooms={[]}
+            membershipToEdit={membershipToEdit}
+          />
+        )}
       </div>
     </ProtectedRoute>
   )

--- a/src/app/login/PasscodeModal.tsx
+++ b/src/app/login/PasscodeModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -43,15 +43,8 @@ export function PasscodeModal({
   const { inputRef: passcodeInputRef, onOpenAutoFocus } =
     useDialogAutoFocus(isOpen)
 
-  // 呼び出し側（login/page.tsx）は選択中ユーザーを保持したまま isOpen だけを
-  // 落とすため、このコンポーネントはアンマウントされず state が残る。
-  // 前回の誤ったパスコードとエラーを持ち越さないよう、開くたびに作り直す。
-  useEffect(() => {
-    if (isOpen) {
-      setPasscode("")
-      setError("")
-    }
-  }, [isOpen])
+  // 呼び出し側（login/page.tsx）は閉じている間このコンポーネントを
+  // マウントしないため、開くたびに入力とエラーは初期値から始まる。
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,10 +27,6 @@ export default function UserSelection() {
   const [selectedUser, setSelectedUser] = useState<User | null>(null)
   const { quickLogin } = useAuth()
 
-  useEffect(() => {
-    loadUsers()
-  }, [])
-
   const loadUsers = async () => {
     try {
       const result = await window.electronAPI.fetchUsers()
@@ -42,6 +38,10 @@ export default function UserSelection() {
       setIsLoading(false)
     }
   }
+
+  useEffect(() => {
+    loadUsers()
+  }, [])
 
   const handleUserSelect = async (user: User) => {
     if (user.passcodeType && user.passcodeType !== "none") {
@@ -164,7 +164,8 @@ export default function UserSelection() {
         onUserCreated={handleUserCreated}
       />
 
-      {selectedUser && (
+      {/* 閉じている間はマウントしない。開くたびに入力とエラーが作り直される */}
+      {selectedUser && showPasscodeModal && (
         <PasscodeModal
           isOpen={showPasscodeModal}
           onClose={() => setShowPasscodeModal(false)}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -162,25 +162,30 @@ export default function SettingsPage() {
           </TabsContent>
         </Tabs>
 
-        <UserEditModal
-          isOpen={isUserEditOpen}
-          onClose={() => {
-            setIsUserEditOpen(false)
-            setSelectedUser(null)
-          }}
-          onUserUpdated={handleUserUpdated}
-          user={selectedUser}
-        />
+        {/* 閉じている間はマウントしない。開くたびに対象ユーザーの値でフォームが作り直される */}
+        {isUserEditOpen && (
+          <UserEditModal
+            isOpen={isUserEditOpen}
+            onClose={() => {
+              setIsUserEditOpen(false)
+              setSelectedUser(null)
+            }}
+            onUserUpdated={handleUserUpdated}
+            user={selectedUser}
+          />
+        )}
 
-        <PasscodeEditModal
-          isOpen={isPasscodeEditOpen}
-          onClose={() => {
-            setIsPasscodeEditOpen(false)
-            setSelectedUser(null)
-          }}
-          onPasscodeUpdated={handlePasscodeUpdated}
-          user={selectedUser}
-        />
+        {isPasscodeEditOpen && (
+          <PasscodeEditModal
+            isOpen={isPasscodeEditOpen}
+            onClose={() => {
+              setIsPasscodeEditOpen(false)
+              setSelectedUser(null)
+            }}
+            onPasscodeUpdated={handlePasscodeUpdated}
+            user={selectedUser}
+          />
+        )}
       </div>
     </ProtectedRoute>
   )

--- a/src/app/students/[studentId]/components/ScoreTrendChart.tsx
+++ b/src/app/students/[studentId]/components/ScoreTrendChart.tsx
@@ -74,7 +74,8 @@ export function ScoreTrendChart({ results }: ScoreTrendChartProps) {
 
   const [seriesList, setSeriesList] = useState<SeriesConfig[]>(() => [
     {
-      id: `s${nextIdRef.current++}`,
+      // 初期系列のidは固定。nextIdRef は追加系列（createId）専用にする
+      id: "s0",
       label: "合計",
       tags: new Set<string>(),
       subtotalId: "__total__",

--- a/src/app/students/[studentId]/components/TagAnalyticsCard.tsx
+++ b/src/app/students/[studentId]/components/TagAnalyticsCard.tsx
@@ -63,9 +63,6 @@ interface TagAnalyticsCardProps {
 }
 
 export function TagAnalyticsCard({ results }: TagAnalyticsCardProps) {
-  const nextIdRef = useRef(1)
-  const createId = useCallback(() => `b${nextIdRef.current++}`, [])
-
   // 初期状態：タグが1つ以上あれば各タグを系列に、なければ合計1つ
   const [seriesList, setSeriesList] = useState<BarSeriesConfig[]>(() => {
     const tagSet = new Set<string>()
@@ -76,7 +73,7 @@ export function TagAnalyticsCard({ results }: TagAnalyticsCardProps) {
 
     if (tags.length > 0) {
       return tags.map((tag, i) => ({
-        id: `b${nextIdRef.current++}`,
+        id: `b${i}`,
         label: tag,
         tags: new Set([tag]),
         subtotalId: "__total__",
@@ -85,7 +82,7 @@ export function TagAnalyticsCard({ results }: TagAnalyticsCardProps) {
     }
     return [
       {
-        id: createId(),
+        id: "b0",
         label: "合計",
         tags: new Set<string>(),
         subtotalId: "__total__",
@@ -93,6 +90,10 @@ export function TagAnalyticsCard({ results }: TagAnalyticsCardProps) {
       },
     ]
   })
+
+  // 初期系列が b0.. を使い切っているので、追加系列はその次から採番する
+  const nextIdRef = useRef(seriesList.length)
+  const createId = useCallback(() => `b${nextIdRef.current++}`, [])
 
   // 全タグ一覧
   const allTags = useMemo(() => {

--- a/src/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/computeMultiPageLayout.ts
@@ -675,8 +675,8 @@ export function computeMultiPageLayoutFromDefinition(
 
   for (let majorIndex = 0; majorIndex < majorQuestions.length; majorIndex++) {
     const major = majorQuestions[majorIndex]
-    let col = colBoundsArr[currentColIdx]
-    let colHorizWidth = col.contentRight - col.majorNumX - majorNumWidth
+    const col = colBoundsArr[currentColIdx]
+    const colHorizWidth = col.contentRight - col.majorNumX - majorNumWidth
     const majorHeight = computeMajorHeight(
       major,
       baseRowHeight,
@@ -715,9 +715,8 @@ export function computeMultiPageLayoutFromDefinition(
         currentColIdx = 0
         colCurrentY.fill(contentTop)
       }
-
-      col = colBoundsArr[currentColIdx]
-      colHorizWidth = col.contentRight - col.majorNumX - majorNumWidth
+      // 段が変わっても以降は colBoundsArr[currentColIdx] を直接参照するため、
+      // col / colHorizWidth の付け替えは不要（読まれない）
     }
 
     // スペーシング

--- a/src/components/answer-sheet-builder/hooks/useUndoableReducer.ts
+++ b/src/components/answer-sheet-builder/hooks/useUndoableReducer.ts
@@ -5,12 +5,14 @@
  * テキスト入力連打対策のデバウンスあり。
  */
 
-import { useCallback, useReducer, useRef } from "react"
+import { useCallback, useReducer } from "react"
 
 interface UndoableState<S> {
   past: S[]
   present: S
   future: S[]
+  /** 直近に履歴へ積んだアクション。連打のデバウンス判定に使う */
+  lastAction: { type: string; timestamp: number } | null
 }
 
 const MAX_HISTORY = 50
@@ -38,8 +40,6 @@ export function useUndoableReducer<S, A extends { type: string }>(
   innerReducer: (state: S, action: A) => S,
   initialState: S
 ): UndoableResult<S, A> {
-  const lastActionRef = useRef<{ type: string; timestamp: number } | null>(null)
-
   function undoableReducer(
     undoState: UndoableState<S>,
     action: A
@@ -48,6 +48,7 @@ export function useUndoableReducer<S, A extends { type: string }>(
       if (undoState.past.length === 0) return undoState
       const previous = undoState.past[undoState.past.length - 1]
       return {
+        ...undoState,
         past: undoState.past.slice(0, -1),
         present: previous,
         future: [undoState.present, ...undoState.future],
@@ -58,6 +59,7 @@ export function useUndoableReducer<S, A extends { type: string }>(
       if (undoState.future.length === 0) return undoState
       const next = undoState.future[0]
       return {
+        ...undoState,
         past: [...undoState.past, undoState.present],
         present: next,
         future: undoState.future.slice(1),
@@ -80,12 +82,12 @@ export function useUndoableReducer<S, A extends { type: string }>(
 
     // デバウンス: 同一アクションタイプが短時間内に連続した場合、pastを増やさない
     const now = Date.now()
-    const last = lastActionRef.current
+    const last = undoState.lastAction
     const isBatched =
       last !== null &&
       last.type === action.type &&
       now - last.timestamp < BATCH_TIME_MS
-    lastActionRef.current = { type: action.type, timestamp: now }
+    const lastAction = { type: action.type, timestamp: now }
 
     if (isBatched) {
       // pastは変えず、presentだけ更新
@@ -93,6 +95,7 @@ export function useUndoableReducer<S, A extends { type: string }>(
         ...undoState,
         present: newPresent,
         future: [],
+        lastAction,
       }
     }
 
@@ -106,6 +109,7 @@ export function useUndoableReducer<S, A extends { type: string }>(
       past: newPast,
       present: newPresent,
       future: [],
+      lastAction,
     }
   }
 
@@ -113,6 +117,7 @@ export function useUndoableReducer<S, A extends { type: string }>(
     past: [],
     present: initialState,
     future: [],
+    lastAction: null,
   })
 
   const undo = useCallback(() => rawDispatch({ type: "UNDO" } as A), [])

--- a/src/components/auth/PasscodeEditModal.tsx
+++ b/src/components/auth/PasscodeEditModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -50,25 +50,27 @@ interface PasscodeEditModalProps {
 
 type PasscodeType = "none" | "4digit" | "6digit" | "alphanumeric"
 
+/** DBに入っている文字列を PasscodeType へ絞り込む（未知の値は none 扱い） */
+function toPasscodeType(value: string | null | undefined): PasscodeType {
+  return value === "4digit" || value === "6digit" || value === "alphanumeric"
+    ? value
+    : "none"
+}
+
 export function PasscodeEditModal({
   isOpen,
   onClose,
   onPasscodeUpdated,
   user,
 }: PasscodeEditModalProps) {
-  const [passcodeType, setPasscodeType] = useState<PasscodeType>("none")
+  // 呼び出し側（settings/page.tsx）は閉じている間このコンポーネントを
+  // マウントしないため、開くたびに対象ユーザーの値から始まる。
+  const [passcodeType, setPasscodeType] = useState<PasscodeType>(
+    toPasscodeType(user?.passcodeType)
+  )
   const [passcode, setPasscode] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")
-
-  // ユーザー情報が変更されたときに初期値を設定
-  useEffect(() => {
-    if (user) {
-      setPasscodeType((user.passcodeType as PasscodeType) || "none")
-      setPasscode("")
-      setError("")
-    }
-  }, [user])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/components/auth/UserEditModal.tsx
+++ b/src/components/auth/UserEditModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -42,15 +42,8 @@ export function UserEditModal({
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState("")
 
-  // Update form data when user prop changes
-  useEffect(() => {
-    if (user) {
-      setFormData({
-        username: user.username,
-        name: user.name,
-      })
-    }
-  }, [user])
+  // 呼び出し側（settings/page.tsx）は閉じている間このコンポーネントを
+  // マウントしないため、開くたびに対象ユーザーの値から始まる。
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/components/classroom/ClassroomModal.tsx
+++ b/src/components/classroom/ClassroomModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -45,42 +45,21 @@ export default function ClassroomModal({
   onSave,
   classroomToEdit,
 }: ClassroomModalProps) {
-  const [name, setName] = useState("")
-  const [classroomCode, setClassroomCode] = useState("")
-  const [grade, setGrade] = useState<number | undefined>(undefined)
-  const [description, setDescription] = useState("")
-  const [isVisible, setIsVisible] = useState(true)
+  // 呼び出し側は閉じている間このコンポーネントをマウントしないため、
+  // 開くたびに classroomToEdit の内容からフォームが始まる。
+  const [name, setName] = useState(classroomToEdit?.name ?? "")
+  const [classroomCode, setClassroomCode] = useState(
+    classroomToEdit?.classroomCode ?? ""
+  )
+  const [grade, setGrade] = useState<number | undefined>(
+    classroomToEdit?.grade ?? undefined
+  )
+  const [description, setDescription] = useState(
+    classroomToEdit?.description ?? ""
+  )
+  const [isVisible, setIsVisible] = useState(classroomToEdit?.isVisible ?? true)
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const { inputRef: nameInputRef, onOpenAutoFocus } = useDialogAutoFocus(isOpen)
-
-  useEffect(() => {
-    let cancelled = false
-    const frame = requestAnimationFrame(() => {
-      if (cancelled) {
-        return
-      }
-
-      if (classroomToEdit) {
-        setName(classroomToEdit.name)
-        setClassroomCode(classroomToEdit.classroomCode ?? "")
-        setGrade(classroomToEdit.grade ?? undefined)
-        setDescription(classroomToEdit.description ?? "")
-        setIsVisible(classroomToEdit.isVisible ?? true)
-      } else {
-        setName("")
-        setClassroomCode("")
-        setGrade(undefined)
-        setDescription("")
-        setIsVisible(true)
-      }
-      setErrors({})
-    })
-
-    return () => {
-      cancelled = true
-      cancelAnimationFrame(frame)
-    }
-  }, [classroomToEdit, isOpen])
 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {}

--- a/src/components/classroom/ClassroomStudentImportModal.tsx
+++ b/src/components/classroom/ClassroomStudentImportModal.tsx
@@ -29,6 +29,58 @@ interface ClassroomStudentImportRow {
   endDate: string
 }
 
+const ValidationMessages = ({
+  validation,
+}: {
+  validation: { valid: number; errors: string[]; warnings: string[] }
+}) => (
+  <div className="space-y-2">
+    {validation.errors.length > 0 && (
+      <div className="rounded-md bg-red-50 p-3">
+        <div className="flex">
+          <AlertCircle className="h-5 w-5 text-red-400" />
+          <div className="ml-3">
+            <h3 className="text-sm font-medium text-red-800">エラー</h3>
+            <div className="mt-2 text-sm text-red-700">
+              <ul className="list-disc space-y-1 pl-5">
+                {validation.errors.map((error, index) => (
+                  <li key={index}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    )}
+
+    {validation.warnings.length > 0 && (
+      <div className="rounded-md bg-yellow-50 p-3">
+        <div className="flex">
+          <AlertCircle className="h-5 w-5 text-yellow-400" />
+          <div className="ml-3">
+            <h3 className="text-sm font-medium text-yellow-800">警告</h3>
+            <div className="mt-2 text-sm text-yellow-700">
+              <ul className="list-disc space-y-1 pl-5">
+                {validation.warnings.map((warning, index) => (
+                  <li key={index}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    )}
+
+    {validation.valid > 0 && (
+      <div className="rounded-md bg-green-50 p-3">
+        <div className="text-sm text-green-700">
+          ✅ {validation.valid}件の学籍番号が有効です
+        </div>
+      </div>
+    )}
+  </div>
+)
+
 export default function ClassroomStudentImportModal({
   isOpen,
   onClose,
@@ -201,58 +253,6 @@ export default function ClassroomStudentImportModal({
       setIsProcessing(false)
     }
   }
-
-  const ValidationMessages = ({
-    validation,
-  }: {
-    validation: { valid: number; errors: string[]; warnings: string[] }
-  }) => (
-    <div className="space-y-2">
-      {validation.errors.length > 0 && (
-        <div className="rounded-md bg-red-50 p-3">
-          <div className="flex">
-            <AlertCircle className="h-5 w-5 text-red-400" />
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">エラー</h3>
-              <div className="mt-2 text-sm text-red-700">
-                <ul className="list-disc space-y-1 pl-5">
-                  {validation.errors.map((error, index) => (
-                    <li key={index}>{error}</li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {validation.warnings.length > 0 && (
-        <div className="rounded-md bg-yellow-50 p-3">
-          <div className="flex">
-            <AlertCircle className="h-5 w-5 text-yellow-400" />
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-yellow-800">警告</h3>
-              <div className="mt-2 text-sm text-yellow-700">
-                <ul className="list-disc space-y-1 pl-5">
-                  {validation.warnings.map((warning, index) => (
-                    <li key={index}>{warning}</li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {validation.valid > 0 && (
-        <div className="rounded-md bg-green-50 p-3">
-          <div className="text-sm text-green-700">
-            ✅ {validation.valid}件の学籍番号が有効です
-          </div>
-        </div>
-      )}
-    </div>
-  )
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>

--- a/src/components/common/EditableTable.tsx
+++ b/src/components/common/EditableTable.tsx
@@ -34,16 +34,15 @@ function EditableCell<T>({
   table,
 }: EditableCellProps<T>) {
   const initialValue = getValue()
-  const [value, setValue] = useState(initialValue)
+  // 編集中の下書き。null なら確定済みのセル値をそのまま表示する
+  const [draftValue, setDraftValue] = useState<string | null>(null)
+  const strValue = draftValue ?? String(initialValue ?? "")
   const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    setValue(initialValue)
-  }, [initialValue])
 
   const onBlur = () => {
     const meta = table.options.meta as TableMeta | undefined
-    meta?.updateData(row.index, column.id, String(value ?? ""))
+    meta?.updateData(row.index, column.id, strValue)
+    setDraftValue(null)
   }
 
   const moveFocus = (target: HTMLInputElement) => {
@@ -104,7 +103,6 @@ function EditableCell<T>({
     { placeholder?: string; validate?: (value: string) => boolean } | undefined
 
   // 非空かつ検証NGのセルは赤背景で警告（保存されない入力を可視化）
-  const strValue = String(value ?? "")
   const isInvalid =
     strValue.trim() !== "" && meta?.validate ? !meta.validate(strValue) : false
 
@@ -112,7 +110,7 @@ function EditableCell<T>({
     <input
       ref={inputRef}
       value={strValue}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setDraftValue(e.target.value)}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       className={`absolute inset-0 h-full w-full border-none px-4 py-2 text-sm focus:ring-1 focus:ring-blue-500 focus:outline-none ${

--- a/src/components/common/classroom-roster/ClassroomRemovalDialog.tsx
+++ b/src/components/common/classroom-roster/ClassroomRemovalDialog.tsx
@@ -79,7 +79,9 @@ export function ClassroomRemovalDialog({
   // プレビュー取得関数は毎レンダー identity が変わりうるので ref で持ち、
   // useEffect の再発火を「対象(entry)/モードが変わったとき」だけに限定する。
   const fetchRemovalPreviewRef = useRef(fetchRemovalPreview)
-  fetchRemovalPreviewRef.current = fetchRemovalPreview
+  useEffect(() => {
+    fetchRemovalPreviewRef.current = fetchRemovalPreview
+  })
 
   // 対象が変わるたびに選択をリセットし、削除プレビューを取得
   useEffect(() => {

--- a/src/components/common/classroom-roster/ClassroomRosterManager.tsx
+++ b/src/components/common/classroom-roster/ClassroomRosterManager.tsx
@@ -150,7 +150,12 @@ export function ClassroomRosterManager({
   onShowAddDialogChange,
 }: ClassroomRosterManagerProps) {
   const [internalShowAddDialog, setInternalShowAddDialog] = useState(false)
-  const [localEntries, setLocalEntries] = useState(entries)
+  // DnD の楽観更新。どの entries に対する並びかを一緒に持ち、
+  // 親がデータを読み直したら（entries が差し替わったら）破棄して最新に従う
+  const [reorderedEntries, setReorderedEntries] = useState<{
+    source: ClassroomRosterEntry[]
+    entries: ClassroomRosterEntry[]
+  } | null>(null)
   const [availableClassrooms, setAvailableClassrooms] = useState<
     AvailableClassroomOption[]
   >([])
@@ -166,9 +171,8 @@ export function ClassroomRosterManager({
   const showAddDialog = externalShowAddDialog ?? internalShowAddDialog
   const setShowAddDialog = onShowAddDialogChange ?? setInternalShowAddDialog
 
-  useEffect(() => {
-    setLocalEntries(entries)
-  }, [entries])
+  const localEntries =
+    reorderedEntries?.source === entries ? reorderedEntries.entries : entries
 
   const loadAvailableClassrooms = useCallback(async () => {
     if (!fetchAvailableClassrooms) return
@@ -197,14 +201,14 @@ export function ClassroomRosterManager({
     const newOrder = [...localEntries]
     const [removed] = newOrder.splice(oldIndex, 1)
     newOrder.splice(newIndex, 0, removed)
-    setLocalEntries(newOrder)
+    setReorderedEntries({ source: entries, entries: newOrder })
 
     try {
       await onReorder(newOrder.map((entry) => entry.id))
       onChanged?.()
     } catch (err) {
       console.error("Failed to reorder classrooms:", err)
-      setLocalEntries(entries)
+      setReorderedEntries(null)
     }
   }
 

--- a/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
+++ b/src/components/coursework/04-scores/CourseworkScoresContainer.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from "@tanstack/react-table"
 import Link from "next/link"
-import { useCallback, useMemo, useRef } from "react"
+import { useCallback, useMemo } from "react"
 
 import { EditableTable } from "@/components/common/EditableTable"
 import { Button } from "@/components/ui/button"
@@ -43,9 +43,6 @@ export function CourseworkScoresContainer({
   const { items, studentRows, loading, bulkUpdateCells } =
     useCourseworkScores(courseworkId)
 
-  // 前回のテーブルデータを保持（diff検出用）
-  const prevDataRef = useRef<ScoreRow[]>([])
-
   const tableData = useMemo(() => {
     const data = studentRows.map((row): ScoreRow => {
       const tableRow: ScoreRow = {
@@ -69,7 +66,6 @@ export function CourseworkScoresContainer({
       }
       return tableRow
     })
-    prevDataRef.current = data
     return data
   }, [studentRows, items])
 
@@ -181,7 +177,8 @@ export function CourseworkScoresContainer({
 
   const handleDataChange = useCallback(
     (newData: ScoreRow[]) => {
-      const prev = prevDataRef.current
+      // 変更前の値は今描画しているテーブルデータそのもの
+      const prev = tableData
       const changes: {
         courseworkItemId: string
         courseworkStudentId: string
@@ -280,7 +277,7 @@ export function CourseworkScoresContainer({
         bulkUpdateCells(changes)
       }
     },
-    [items, bulkUpdateCells]
+    [items, tableData, bulkUpdateCells]
   )
 
   if (loading) {

--- a/src/components/coursework/list/CourseworkImportDialog.tsx
+++ b/src/components/coursework/list/CourseworkImportDialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -45,11 +45,23 @@ export function CourseworkImportDialog({
   onCancel,
   onConfirm,
 }: CourseworkImportDialogProps) {
-  const [selections, setSelections] = useState<Record<string, string>>({})
+  // ユーザーが明示的に変更した分のみ保持する。どの preview に対する選択かを
+  // 一緒に持ち、preview が切り替わったら前回の選択は無効になる
+  const [manualSelections, setManualSelections] = useState<{
+    preview: CourseworkArchiveImportPreview | null
+    values: Record<string, string>
+  }>({ preview: null, values: {} })
+  const selections = useMemo(
+    () => (manualSelections.preview === preview ? manualSelections.values : {}),
+    [manualSelections, preview]
+  )
 
-  useEffect(() => {
-    setSelections({})
-  }, [preview])
+  const selectArchive = (archiveId: string, value: string) => {
+    setManualSelections({
+      preview,
+      values: { ...selections, [archiveId]: value },
+    })
+  }
 
   const initialSelections = useMemo(() => {
     const init: Record<string, string> = {}
@@ -109,10 +121,7 @@ export function CourseworkImportDialog({
                   <RadioGroup
                     value={effectiveSelections[coursework.archiveId] ?? "new"}
                     onValueChange={(value) =>
-                      setSelections((prev) => ({
-                        ...prev,
-                        [coursework.archiveId]: value,
-                      }))
+                      selectArchive(coursework.archiveId, value)
                     }
                     className="space-y-1"
                   >

--- a/src/components/exams/01-upload/components/MasterAnswerManager.tsx
+++ b/src/components/exams/01-upload/components/MasterAnswerManager.tsx
@@ -66,17 +66,19 @@ export function MasterAnswerManager({
       />
 
       {/* パスワード入力ダイアログ */}
-      <PasswordDialog
-        isOpen={passwordDialog.isOpen}
-        onClose={handlePasswordCancel}
-        onSubmit={handlePasswordSubmit}
-        fileName={passwordDialog.fileName}
-        error={
-          passwordDialog.hasError ? "パスワードが正しくありません" : undefined
-        }
-        isLoading={passwordDialog.isLoading}
-        isFirstAttempt={!passwordDialog.hasError}
-      />
+      {passwordDialog.isOpen && (
+        <PasswordDialog
+          isOpen={passwordDialog.isOpen}
+          onClose={handlePasswordCancel}
+          onSubmit={handlePasswordSubmit}
+          fileName={passwordDialog.fileName}
+          error={
+            passwordDialog.hasError ? "パスワードが正しくありません" : undefined
+          }
+          isLoading={passwordDialog.isLoading}
+          isFirstAttempt={!passwordDialog.hasError}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/exams/02-template/components/CropRegionEditor.tsx
+++ b/src/components/exams/02-template/components/CropRegionEditor.tsx
@@ -157,7 +157,8 @@ const CropRegionEditor = ({
         examPageId: examPageId,
       }
 
-      let newAreaSpecifics = {}
+      // switch に default があるため初期値は不要（必ずどこかで代入される）
+      let newAreaSpecifics: Pick<CropRegionArea, "label" | "type" | "points">
       switch (type) {
         case "STUDENT_NAME":
           newAreaSpecifics = {

--- a/src/components/exams/02-template/hooks/useCropRegionSave.ts
+++ b/src/components/exams/02-template/hooks/useCropRegionSave.ts
@@ -178,7 +178,8 @@ export function useCropRegionSave(
       defaultPoints?: number
     ): Promise<CropRegionArea | null> => {
       // タイプに応じたラベルと配点を設定
-      let label = ""
+      // label は switch の default で必ず代入されるため初期値を持たない
+      let label: string
       let points = null
 
       switch (type) {

--- a/src/components/exams/03-region-info/components/OmrConfigInlineForm.tsx
+++ b/src/components/exams/03-region-info/components/OmrConfigInlineForm.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Trash2 } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -76,12 +76,13 @@ export function OmrConfigInlineForm({
   })
   const [saving, setSaving] = useState(false)
 
-  // numChoicesが変わったらラベルを調整
-  useEffect(() => {
+  /** 選択肢数の変更に合わせてラベルと正解の選択位置を詰める */
+  const changeNumChoices = (nextNumChoices: number) => {
+    setNumChoices(nextNumChoices)
     setChoiceLabels((prev) => {
-      if (prev.length >= numChoices) return prev.slice(0, numChoices)
+      if (prev.length >= nextNumChoices) return prev.slice(0, nextNumChoices)
       const newLabels = [...prev]
-      for (let i = prev.length; i < numChoices; i++) {
+      for (let i = prev.length; i < nextNumChoices; i++) {
         newLabels.push(DEFAULT_CHOICE_LABELS[i] ?? `${i + 1}`)
       }
       return newLabels
@@ -89,11 +90,11 @@ export function OmrConfigInlineForm({
     setCorrectIndices((prev) => {
       const next = new Set<number>()
       prev.forEach((idx) => {
-        if (idx < numChoices) next.add(idx)
+        if (idx < nextNumChoices) next.add(idx)
       })
       return next
     })
-  }, [numChoices])
+  }
 
   const handleSave = useCallback(async () => {
     setSaving(true)
@@ -150,7 +151,7 @@ export function OmrConfigInlineForm({
           min={2}
           max={10}
           value={numChoices}
-          onChange={(e) => setNumChoices(Number(e.target.value) || 4)}
+          onChange={(e) => changeNumChoices(Number(e.target.value) || 4)}
           className="h-8 w-20"
         />
         <Select value={choiceLayout} onValueChange={setChoiceLayout}>

--- a/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
+++ b/src/components/exams/06-student-answers/student-answer-management/components/StudentAnswerUpload.tsx
@@ -128,15 +128,17 @@ export function StudentAnswerUpload({
       </div>
 
       {/* PDFパスワードダイアログ */}
-      <PasswordDialog
-        isOpen={passwordDialog.isOpen}
-        onClose={handlePasswordCancel}
-        onSubmit={handlePasswordSubmit}
-        fileName={passwordDialog.fileName}
-        error={passwordDialog.hasError ? "invalid-password" : undefined}
-        isLoading={passwordDialog.isLoading}
-        isFirstAttempt={!passwordDialog.hasError}
-      />
+      {passwordDialog.isOpen && (
+        <PasswordDialog
+          isOpen={passwordDialog.isOpen}
+          onClose={handlePasswordCancel}
+          onSubmit={handlePasswordSubmit}
+          fileName={passwordDialog.fileName}
+          error={passwordDialog.hasError ? "invalid-password" : undefined}
+          isLoading={passwordDialog.isLoading}
+          isFirstAttempt={!passwordDialog.hasError}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/hooks/useMarkerCorrection.ts
@@ -36,7 +36,9 @@ export function useMarkerCorrection({
   const originalBuffersRef = useRef<Map<string, ArrayBuffer>>(new Map())
   const runIdRef = useRef(0)
   const filesRef = useRef(files)
-  filesRef.current = files
+  useEffect(() => {
+    filesRef.current = files
+  })
   const [correctingFileIds, setCorrectingFileIds] = useState<Set<string>>(
     new Set()
   )

--- a/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
+++ b/src/components/exams/06-student-answers/student-answer-table/utils/tableDataUtils.ts
@@ -174,24 +174,21 @@ export function calculateCellsWithExistingAnswers<
   for (const examStudent of sortedStudents) {
     for (const examPage of examPages) {
       // そのセルに対応する答案があるかチェック
-      let hasAnswerForCell = false
-
-      if (mode === "upload" && existingAnswers) {
-        // アップロードモード: existingAnswers（DB答案の占有信号）から判定
-        hasAnswerForCell = existingAnswers.some(
-          (answer) =>
-            answer.examStudentId === examStudent.id &&
-            answer.examPageId === examPage.id
-        )
-      } else {
-        // 確認モード: files から判定
-        hasAnswerForCell = files.some(
-          (file) =>
-            file.examStudentId === examStudent.id &&
-            file.examPageId === examPage.id &&
-            !disabledState.files.has(file.id)
-        )
-      }
+      const hasAnswerForCell =
+        mode === "upload" && existingAnswers
+          ? // アップロードモード: existingAnswers（DB答案の占有信号）から判定
+            existingAnswers.some(
+              (answer) =>
+                answer.examStudentId === examStudent.id &&
+                answer.examPageId === examPage.id
+            )
+          : // 確認モード: files から判定
+            files.some(
+              (file) =>
+                file.examStudentId === examStudent.id &&
+                file.examPageId === examPage.id &&
+                !disabledState.files.has(file.id)
+            )
 
       if (hasAnswerForCell) {
         addCellToLookup(cells, examStudent, examPage)

--- a/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
+++ b/src/components/exams/07-score-at-once/ScoringData/hooks/useBatchScoring.ts
@@ -1,6 +1,6 @@
 // import { checkForAutoFinalization } from "@/components/exams/07-score-at-once/hooks/scoring-data/utils/auto-finalization"
 import type { QuestionScore } from "@prisma/client"
-import { useCallback, useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { toast } from "sonner"
 
 import type {
@@ -32,7 +32,9 @@ export function useBatchScoring({
 }: UseBatchScoringProps) {
   // questionScoresの最新値をrefで保持（useCallbackの依存配列から除去するため）
   const questionScoresRef = useRef(questionScores)
-  questionScoresRef.current = questionScores
+  useEffect(() => {
+    questionScoresRef.current = questionScores
+  })
 
   /** 採点行を画面状態から取り除く（ref も同期してループ中の次反復に反映させる） */
   const removeScoreFromState = useCallback(
@@ -107,7 +109,7 @@ export function useBatchScoring({
       // 引数の解析
       let answerIds: string | string[]
       let status: ScoringStatus
-      let inputPartialScore: number | null = null
+      let inputPartialScore: number | null
 
       if (
         typeof statusOrAnswerIds === "string" &&

--- a/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridNavigation.ts
+++ b/src/components/exams/07-score-at-once/ScoringGrid/hooks/useGridNavigation.ts
@@ -2,7 +2,7 @@
  * グリッドナビゲーションフック
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 interface UseGridNavigationProps {
   externalItemsPerRow?: number[]
@@ -12,18 +12,17 @@ interface UseGridNavigationProps {
 export function useGridNavigation({
   externalItemsPerRow,
 }: UseGridNavigationProps) {
-  const [itemsPerRow, setItemsPerRow] = useState([5])
+  // Alt+[-/+] によるこの画面だけの上書き。null なら外部指定に追従する
+  const [overrideItemsPerRow, setOverrideItemsPerRow] = useState<
+    number[] | null
+  >(null)
+  const itemsPerRow = useMemo(
+    () => overrideItemsPerRow ?? externalItemsPerRow ?? [5],
+    [overrideItemsPerRow, externalItemsPerRow]
+  )
 
-  // 外部からのitemsPerRowを使用
-  useEffect(() => {
-    if (externalItemsPerRow) {
-      setItemsPerRow(externalItemsPerRow)
-    }
-  }, [externalItemsPerRow])
-
-  // itemsPerRowの変更を通知（親コンポーネントで保存）
   const handleItemsPerRowChange = useCallback((value: number[]) => {
-    setItemsPerRow(value)
+    setOverrideItemsPerRow(value)
   }, [])
 
   // 答案表示数の増減機能

--- a/src/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/AnswerIndividualView.tsx
@@ -1,14 +1,7 @@
 "use client"
 
 import { useParams } from "next/navigation"
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { getScoringStatusFromArray } from "@/components/exams/07-score-at-once/types"
 import type { LineStyle } from "@/types/drawingAnnotation.types"
@@ -182,7 +175,7 @@ export default function AnswerIndividualView({
     containerRef,
     imageLoaded,
     loadedImages,
-    textBoundsCache,
+    textBoundsCacheRef,
   } = useImageCanvas({
     currentScoringData,
     currentCropRegion,
@@ -225,14 +218,16 @@ export default function AnswerIndividualView({
   }, [loadedImages, onImageSizeChanged])
 
   // scrollContainerRefの同期（split表示のスクロール同期用）
-  // useLayoutEffectでDOMコミット直後に確実に設定
-  useLayoutEffect(() => {
-    if (scrollContainerRef && containerRef.current) {
-      ;(
-        scrollContainerRef as React.MutableRefObject<HTMLDivElement | null>
-      ).current = containerRef.current
-    }
-  })
+  // コールバックrefならDOMのコミットと同時に両方のrefへ行き渡る
+  const setContainerElement = useCallback(
+    (element: HTMLDivElement | null) => {
+      containerRef.current = element
+      if (scrollContainerRef) {
+        scrollContainerRef.current = element
+      }
+    },
+    [containerRef, scrollContainerRef]
+  )
 
   // Canvas・テキストボックス統合フック
   const {
@@ -353,7 +348,7 @@ export default function AnswerIndividualView({
       // Shift制約で正円/正方形にするため
       imageAspectRatio,
       // テキスト境界キャッシュ（ヒットテスト用）
-      textBoundsCache,
+      textBoundsCacheRef,
     })
 
   // お気に入りアノテーションIDのセット
@@ -464,7 +459,7 @@ export default function AnswerIndividualView({
     <div className="relative h-full w-full overflow-hidden">
       {/* CSS スクロール + scale 方式のメインキャンバス */}
       <div
-        ref={containerRef}
+        ref={setContainerElement}
         className="grid h-full w-full overflow-auto"
         style={{
           cursor:

--- a/src/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModal.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/RichTextEditorModal.tsx
@@ -69,47 +69,29 @@ export function RichTextEditorModal({
   canvasWidth = 800,
   canvasHeight = 600,
   backgroundImageUrl,
-  fontSize: initialFontSize = 5,
+  // 文字サイズとアンカー方向は親が保持する制御プロパティ。ローカルに複製しない
+  fontSize = 5,
   onFontSizeChange,
-  anchorDirection: initialAnchorDirection = "top-left",
+  anchorDirection = "top-left",
   onAnchorDirectionChange,
 }: RichTextEditorModalProps) {
-  const [fontSize, setFontSizeLocal] = useState(initialFontSize)
   const [isBold, setIsBold] = useState(false)
   const [isItalic, setIsItalic] = useState(false)
   const [isUnderline, setIsUnderline] = useState(false)
 
-  // アンカー方向の設定
-  const [anchorDirection, setAnchorDirectionLocal] = useState<AnchorDirection>(
-    initialAnchorDirection
-  )
-
-  // 親への通知付きsetFontSize
   const setFontSize = useCallback(
     (size: number) => {
-      setFontSizeLocal(size)
       onFontSizeChange?.(size)
     },
     [onFontSizeChange]
   )
 
-  // 親への通知付きsetAnchorDirection
   const setAnchorDirection = useCallback(
     (direction: AnchorDirection) => {
-      setAnchorDirectionLocal(direction)
       onAnchorDirectionChange?.(direction)
     },
     [onAnchorDirectionChange]
   )
-
-  // propsが変更されたときにローカル状態を更新
-  useEffect(() => {
-    setFontSizeLocal(initialFontSize)
-  }, [initialFontSize])
-
-  useEffect(() => {
-    setAnchorDirectionLocal(initialAnchorDirection)
-  }, [initialAnchorDirection])
 
   // 背景画像表示設定
   const [showBackground, setShowBackground] = useState(false)

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/types.ts
@@ -70,9 +70,8 @@ export interface UseImageCanvasReturn {
   containerRef: React.RefObject<HTMLDivElement | null>
   imageLoaded: boolean
   loadedImages: HTMLImageElement[]
-  textBoundsCache: Map<
-    string,
-    { x: number; y: number; width: number; height: number }
+  textBoundsCacheRef: React.MutableRefObject<
+    Map<string, { x: number; y: number; width: number; height: number }>
   >
 }
 

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useCanvasDrawing.ts
@@ -932,7 +932,9 @@ export function useCanvasDrawing({
   // executeTextCanvasDrawのfinally内で再帰呼び出しする際、
   // 古いクロージャのdrawTextCanvasではなく最新版を使用する
   const latestDrawTextCanvasRef = useRef(drawTextCanvas)
-  latestDrawTextCanvasRef.current = drawTextCanvas
+  useEffect(() => {
+    latestDrawTextCanvasRef.current = drawTextCanvas
+  })
 
   const executeTextCanvasDraw = useCallback(async () => {
     if (isDrawingTextCanvasRef.current) {

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageCanvas.ts
@@ -100,6 +100,6 @@ export function useImageCanvas({
     containerRef,
     imageLoaded,
     loadedImages,
-    textBoundsCache: textBoundsCacheRef.current,
+    textBoundsCacheRef,
   }
 }

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/core/useImageLoader.ts
@@ -41,7 +41,7 @@ export function useImageLoader({
         return
       }
 
-      let imagesToLoad: { path: string; pageNumber: number }[] = []
+      let imagesToLoad: { path: string; pageNumber: number }[]
 
       if (showMultiplePages && studentAnswerImages) {
         // 複数ページ表示：同一生徒の全ページを取得

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/useAnswerIndividualEvents.ts
@@ -58,10 +58,10 @@ interface UseAnswerDisplayEventsProps {
   currentHandle: string | null
   hoveredElementId: string | null
 
-  // テキスト境界キャッシュ（ヒットテスト用）
-  textBoundsCache?: Map<
-    string,
-    { x: number; y: number; width: number; height: number }
+  // テキスト境界キャッシュ（ヒットテスト用）。中身は描画のたびに書き換わるので
+  // レンダー中ではなくイベントハンドラ内で .current を読む
+  textBoundsCacheRef?: React.MutableRefObject<
+    Map<string, { x: number; y: number; width: number; height: number }>
   >
 
   // Drawing actions
@@ -118,7 +118,7 @@ export function useAnswerIndividualEvents(props: UseAnswerDisplayEventsProps) {
   // Initialize hit test utilities（ズームを渡して画面上の当たり判定サイズを一定に）
   const { hitTestElement, hitTestHandle } = useHitTestUtils({
     zoom,
-    textBoundsCache: props.textBoundsCache,
+    textBoundsCacheRef: props.textBoundsCacheRef,
   })
 
   // Initialize edit mode utilities

--- a/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useHitTest.ts
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/hooks/utils/useHitTest.ts
@@ -74,17 +74,16 @@ type HitTestResult = string | null
 interface UseHitTestUtilsProps {
   /** 現在のズーム倍率（画面上のピクセルサイズを一定にするため） */
   zoom?: number
-  /** テキスト要素の境界キャッシュ（レンダリング結果から取得） */
-  textBoundsCache?: Map<
-    string,
-    { x: number; y: number; width: number; height: number }
+  /** テキスト要素の境界キャッシュ（描画結果。当たり判定時に .current を読む） */
+  textBoundsCacheRef?: React.MutableRefObject<
+    Map<string, { x: number; y: number; width: number; height: number }>
   >
 }
 
 /** 描画要素（線・矩形・楕円・テキスト）に対するズーム対応の当たり判定ユーティリティフック */
 export function useHitTestUtils({
   zoom = 1,
-  textBoundsCache,
+  textBoundsCacheRef,
 }: UseHitTestUtilsProps = {}) {
   // ズームを考慮した許容値を計算（画面上で一定サイズになるように）
   const { handleRadius, lineWidth } = useMemo(() => {
@@ -299,7 +298,7 @@ export function useHitTestUtils({
           }
 
           // 2. キャッシュされた境界を使用（レンダリング結果と完全一致）
-          const cachedBounds = textBoundsCache?.get(element.id)
+          const cachedBounds = textBoundsCacheRef?.current.get(element.id)
           if (cachedBounds) {
             const left = cachedBounds.x
             const top = cachedBounds.y
@@ -375,7 +374,7 @@ export function useHitTestUtils({
       distanceToLineSegment,
       HANDLE_RADIUS,
       LINE_WIDTH,
-      textBoundsCache,
+      textBoundsCacheRef,
     ]
   )
 

--- a/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/CroppedAnswerImage.tsx
@@ -61,18 +61,10 @@ export default function CroppedAnswerImage({
 }: CroppedAnswerImageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
-  const [imageLoaded, setImageLoaded] = useState(false)
-
-  // imageUrl変更時にimageLoadedをリセット
-  // リセットしないと、新画像のonLoadでsetImageLoaded(true)がno-opとなり
-  // キャンバスの再描画が発火しない
-  const prevImageUrlRef = useRef(imageUrl)
-  if (prevImageUrlRef.current !== imageUrl) {
-    prevImageUrlRef.current = imageUrl
-    if (imageLoaded) {
-      setImageLoaded(false)
-    }
-  }
+  // 「どのURLを読み終えたか」を持つことで、imageUrl が変われば読み込み済み判定が
+  // 自動的に外れる。真偽値だと新画像のonLoadがno-opになり再描画が発火しない。
+  const [loadedImageUrl, setLoadedImageUrl] = useState<string | null>(null)
+  const imageLoaded = loadedImageUrl === imageUrl
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -182,7 +174,7 @@ export default function CroppedAnswerImage({
   ])
 
   const handleImageLoad = () => {
-    setImageLoaded(true)
+    setLoadedImageUrl(imageUrl)
   }
 
   // 行表示: 幅100%、高さは自動

--- a/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionForm.tsx
+++ b/src/components/exams/07-score-at-once/ScoringMain/ScoreDecisionPanel/ScoreDecisionForm.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { CheckCircle, Clock, Info } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
@@ -38,6 +38,30 @@ interface ScoreDecisionFormProps {
   onDecided: () => void
 }
 
+/** 既存の確定があればそれを、無ければ先頭の提案をフォームの初期値にする */
+function toInitialFormValues(cell: ScoreDecisionFormProps["cell"]) {
+  if (cell.decision) {
+    return {
+      verdict: cell.decision.verdict,
+      score: cell.decision.score !== null ? String(cell.decision.score) : "",
+      comment: cell.decision.comment ?? "",
+      sourceQuestionScoreId: cell.decision.sourceQuestionScoreId,
+    }
+  }
+
+  const firstProposal = cell.proposals[0]
+  return {
+    verdict: firstProposal?.status ?? "correct",
+    score:
+      firstProposal?.partialScore !== null &&
+      firstProposal?.partialScore !== undefined
+        ? String(firstProposal.partialScore)
+        : "",
+    comment: "",
+    sourceQuestionScoreId: firstProposal?.questionScoreId ?? null,
+  }
+}
+
 /**
  * 1セル分の比較・確定フォーム（裁定パネルの右ペイン）。
  *
@@ -51,33 +75,17 @@ export function ScoreDecisionForm({
   onDecided,
 }: ScoreDecisionFormProps) {
   const { user } = useAuth()
-  const [verdict, setVerdict] = useState<ScoringStatus>("correct")
-  const [score, setScore] = useState("")
-  const [comment, setComment] = useState("")
+
+  // 呼び出し側（ScoreDecisionPanel）がセルごとの key でこのフォームを作り直すため、
+  // 既存の確定（あれば）を初期値としてそのまま state に置ける。
+  const initial = toInitialFormValues(cell)
+  const [verdict, setVerdict] = useState<ScoringStatus>(initial.verdict)
+  const [score, setScore] = useState(initial.score)
+  const [comment, setComment] = useState(initial.comment)
   const [sourceQuestionScoreId, setSourceQuestionScoreId] = useState<
     string | null
-  >(null)
+  >(initial.sourceQuestionScoreId)
   const [deciding, setDeciding] = useState(false)
-
-  // セルを切り替えたら、既存の確定（あれば）を初期値としてフォームを組み直す
-  useEffect(() => {
-    if (cell.decision) {
-      setVerdict(cell.decision.verdict)
-      setScore(cell.decision.score !== null ? String(cell.decision.score) : "")
-      setComment(cell.decision.comment ?? "")
-      setSourceQuestionScoreId(cell.decision.sourceQuestionScoreId)
-    } else {
-      setVerdict(cell.proposals[0]?.status ?? "correct")
-      setScore(
-        cell.proposals[0]?.partialScore !== null &&
-          cell.proposals[0]?.partialScore !== undefined
-          ? String(cell.proposals[0].partialScore)
-          : ""
-      )
-      setComment("")
-      setSourceQuestionScoreId(cell.proposals[0]?.questionScoreId ?? null)
-    }
-  }, [cell])
 
   const needsScore = NEEDS_SCORE.includes(verdict)
   const parsedScore = score === "" ? null : Number(score)

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/useAnswerWhiteness.ts
@@ -71,9 +71,11 @@ export function useAnswerWhiteness({
   // 毎レンダーで新しい配列になるため、effectの依存には入れずrefで最新値を渡す。
   // 再算出の要否はsignature（答案の顔ぶれ）で判定する。
   const pageAnswerImagesRef = useRef(pageAnswerImages)
-  pageAnswerImagesRef.current = pageAnswerImages
   const cropRegionsRef = useRef(cropRegions)
-  cropRegionsRef.current = cropRegions
+  useEffect(() => {
+    pageAnswerImagesRef.current = pageAnswerImages
+    cropRegionsRef.current = cropRegions
+  })
 
   useEffect(() => {
     if (!enabled) return

--- a/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
+++ b/src/components/exams/07-score-at-once/ScoringMain/hooks/usePartialScore.ts
@@ -75,7 +75,7 @@ export function usePartialScore({
       }
 
       const currentInput = partialScoreInput || ""
-      let newInput = ""
+      let newInput: string
 
       // 小数点の処理
       if (key === ".") {

--- a/src/components/exams/08-export/ExportMainView.tsx
+++ b/src/components/exams/08-export/ExportMainView.tsx
@@ -414,17 +414,19 @@ export default function ExportMainView() {
           </div>
         </div>
 
-        {/* プログレスモーダル */}
-        <ExportProgressModal
-          isOpen={showProgressModal}
-          onClose={() => setShowProgressModal(false)}
-          progress={exportProgress}
-          status={exportStatus}
-          currentStep={currentStep}
-          embeddedPagesCount={embeddedPagesCount}
-          totalPagesCount={totalPagesCount}
-          canvasRenderingComplete={canvasRenderingComplete}
-        />
+        {/* プログレスモーダル（閉じている間はマウントしない） */}
+        {showProgressModal && (
+          <ExportProgressModal
+            isOpen={showProgressModal}
+            onClose={() => setShowProgressModal(false)}
+            progress={exportProgress}
+            status={exportStatus}
+            currentStep={currentStep}
+            embeddedPagesCount={embeddedPagesCount}
+            totalPagesCount={totalPagesCount}
+            canvasRenderingComplete={canvasRenderingComplete}
+          />
+        )}
 
         {/* 警告モーダル */}
         <ExportWarningModal

--- a/src/components/exams/08-export/components/ExportProgressModal.tsx
+++ b/src/components/exams/08-export/components/ExportProgressModal.tsx
@@ -122,17 +122,6 @@ export default function ExportProgressModal({
     }
   }, [totalPagesCount, embeddedPagesCount, progressDetails.canvasTotal])
 
-  // isOpenがtrueになったらisClosingをリセット（モーダルが開く時）
-  useEffect(() => {
-    if (isOpen) {
-      // requestAnimationFrameでマイクロタスク後に実行してカスケードを回避
-      const frame = requestAnimationFrame(() => {
-        setIsClosing(false)
-      })
-      return () => cancelAnimationFrame(frame)
-    }
-  }, [isOpen])
-
   useEffect(() => {
     if (status === "completed" && progress === 100) {
       const timer = setTimeout(() => {

--- a/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
+++ b/src/components/exams/08-export/components/PdfCanvasRenderer.tsx
@@ -436,7 +436,9 @@ export function PdfCanvasRenderer({
 
   // レンダリング開始トリガーを監視
   const renderAllPagesRef = useRef(renderAllPagesParallel)
-  renderAllPagesRef.current = renderAllPagesParallel
+  useEffect(() => {
+    renderAllPagesRef.current = renderAllPagesParallel
+  })
 
   useEffect(() => {
     if (startRendering && !isRendering && pages.length > 0) {

--- a/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
+++ b/src/components/exams/08-export/hooks/useIndividualReportPreview.ts
@@ -42,7 +42,9 @@ export function useIndividualReportPreview({
 
   // optionsの最新値を保持（データ取得時に使用）
   const optionsRef = useRef(options)
-  optionsRef.current = options
+  useEffect(() => {
+    optionsRef.current = options
+  })
 
   // 選択された生徒が変わったらプレビュー対象をリセット
   useEffect(() => {

--- a/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
+++ b/src/components/exams/08-export/hooks/useScoredAnswerPreview.ts
@@ -8,7 +8,6 @@ import type { AnswerOverlaySettings } from "@/types/scoringOverlay.types"
 import {
   preloadScoringMarkImages,
   renderAnswerSheetToCanvas,
-  type ScoringDataForPdf,
   type SubtotalDataForPdf,
   type TotalScoreDataForPdf,
 } from "../utils/pdfCanvasRenderer"

--- a/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
+++ b/src/components/grades/05-boundaries/ConstraintRulesEditor.tsx
@@ -221,13 +221,13 @@ function ConstraintCard({
   onUpdate,
   onDelete,
 }: ConstraintCardProps) {
-  const [name, setName] = useState(constraint.name)
-  const [expression, setExpression] = useState(constraint.expression)
-  const [message, setMessage] = useState(constraint.message ?? "")
-
-  useEffect(() => setName(constraint.name), [constraint.name])
-  useEffect(() => setExpression(constraint.expression), [constraint.expression])
-  useEffect(() => setMessage(constraint.message ?? ""), [constraint.message])
+  // 入力中の下書き。null なら確定済みの constraint をそのまま表示する
+  const [nameDraft, setNameDraft] = useState<string | null>(null)
+  const [expressionDraft, setExpressionDraft] = useState<string | null>(null)
+  const [messageDraft, setMessageDraft] = useState<string | null>(null)
+  const name = nameDraft ?? constraint.name
+  const expression = expressionDraft ?? constraint.expression
+  const message = messageDraft ?? constraint.message ?? ""
 
   const exprError =
     constraint.kind === "expression"
@@ -243,8 +243,11 @@ function ConstraintCard({
         />
         <Input
           value={name}
-          onChange={(e) => setName(e.target.value)}
-          onBlur={() => name !== constraint.name && onUpdate({ name })}
+          onChange={(e) => setNameDraft(e.target.value)}
+          onBlur={() => {
+            if (name !== constraint.name) onUpdate({ name })
+            setNameDraft(null)
+          }}
           className="h-8 flex-1"
           placeholder="ルール名"
         />
@@ -309,10 +312,11 @@ function ConstraintCard({
         <div className="space-y-1">
           <Textarea
             value={expression}
-            onChange={(e) => setExpression(e.target.value)}
-            onBlur={() =>
-              expression !== constraint.expression && onUpdate({ expression })
-            }
+            onChange={(e) => setExpressionDraft(e.target.value)}
+            onBlur={() => {
+              if (expression !== constraint.expression) onUpdate({ expression })
+              setExpressionDraft(null)
+            }}
             className="font-mono text-xs"
             rows={2}
             placeholder='has("A") and has("C")'
@@ -332,11 +336,13 @@ function ConstraintCard({
         </Label>
         <Input
           value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          onBlur={() =>
-            (message || null) !== constraint.message &&
-            onUpdate({ message: message || null })
-          }
+          onChange={(e) => setMessageDraft(e.target.value)}
+          onBlur={() => {
+            if ((message || null) !== constraint.message) {
+              onUpdate({ message: message || null })
+            }
+            setMessageDraft(null)
+          }}
           className="h-8"
           placeholder="違反時にホバーで表示される説明（任意）"
         />

--- a/src/components/grades/06-results/ResultsTable.tsx
+++ b/src/components/grades/06-results/ResultsTable.tsx
@@ -27,6 +27,29 @@ interface ResultsTableProps {
 
 type SortKey = "registrationOrder" | "attendanceNumber" | string
 
+/** ソート状態を示す列ヘッダー。クリックでソート対象を切り替える */
+const SortHeader = ({
+  label,
+  sortId,
+  sortKey,
+  sortAsc,
+  onSort,
+}: {
+  label: string
+  sortId: SortKey
+  sortKey: SortKey
+  sortAsc: boolean
+  onSort: (sortId: SortKey) => void
+}) => (
+  <th
+    className="cursor-pointer px-2 py-2 text-center font-medium hover:underline"
+    onClick={() => onSort(sortId)}
+  >
+    {label}
+    {sortKey === sortId && (sortAsc ? " ↑" : " ↓")}
+  </th>
+)
+
 /**
  * 成績算出結果の一覧テーブル
  *
@@ -94,7 +117,7 @@ export function ResultsTable({
         registrationRankByGradeStudentId.get(studentB.gradeStudentId) ?? 0
       return sortAsc ? aIndex - bIndex : bIndex - aIndex
     }
-    let comparison = 0
+    let comparison: number
     if (sortKey === "attendanceNumber") {
       comparison =
         (studentA.attendanceNumber ?? 999) - (studentB.attendanceNumber ?? 999)
@@ -111,22 +134,6 @@ export function ResultsTable({
     return sortAsc ? comparison : -comparison
   })
 
-  const SortHeader = ({
-    label,
-    sortId,
-  }: {
-    label: string
-    sortId: SortKey
-  }) => (
-    <th
-      className="cursor-pointer px-2 py-2 text-center font-medium hover:underline"
-      onClick={() => handleSort(sortId)}
-    >
-      {label}
-      {sortKey === sortId && (sortAsc ? " ↑" : " ↓")}
-    </th>
-  )
-
   return (
     <>
       {activeConstraints.length > 0 && (
@@ -139,14 +146,29 @@ export function ResultsTable({
         <table className="w-full text-sm">
           <thead className="bg-muted/50">
             <tr>
-              <SortHeader label="順序" sortId="registrationOrder" />
-              <SortHeader label="番号" sortId="attendanceNumber" />
+              <SortHeader
+                label="順序"
+                sortId="registrationOrder"
+                sortKey={sortKey}
+                sortAsc={sortAsc}
+                onSort={handleSort}
+              />
+              <SortHeader
+                label="番号"
+                sortId="attendanceNumber"
+                sortKey={sortKey}
+                sortAsc={sortAsc}
+                onSort={handleSort}
+              />
               <th className="px-2 py-2 text-left font-medium">氏名</th>
               {result.gradeItems.map((gradeItem) => (
                 <SortHeader
                   key={gradeItem.id}
                   label={gradeItem.name}
                   sortId={gradeItem.id}
+                  sortKey={sortKey}
+                  sortAsc={sortAsc}
+                  onSort={handleSort}
                 />
               ))}
             </tr>

--- a/src/components/grades/07-export/ExportContainer.tsx
+++ b/src/components/grades/07-export/ExportContainer.tsx
@@ -44,16 +44,15 @@ interface ExportContainerProps {
 export function ExportContainer({ gradeId }: ExportContainerProps) {
   const { result, loading, error, recalculate } = useGradeResults(gradeId)
 
-  // 生徒選択（共有ステート）
-  const [selectedStudents, setSelectedStudents] = useState<Set<string>>(
-    new Set()
-  )
+  // 生徒選択（共有ステート）。null は「まだ触っていない」= 全員選択の意味
+  const [selectedStudentsState, setSelectedStudentsState] =
+    useState<Set<string> | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [selectedClassroom, setSelectedClassroom] = useState<string>("__all__")
   const [selectionTab, setSelectionTab] = useState<"selection" | "preview">(
     "selection"
   )
-  const [previewStudentId, setPreviewStudentId] = useState("")
+  const [previewStudentIdState, setPreviewStudentId] = useState("")
 
   // 個人成績通知書オプション
   const [reportOptions, setReportOptionsState] = useState<GradeReportOptions>(
@@ -136,15 +135,15 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
 
   const studentsRef = useMemo(() => result?.students ?? [], [result])
 
-  // result が来たら全員選択を初期化
-  useMemo(() => {
-    if (studentsRef.length > 0 && selectedStudents.size === 0) {
-      setSelectedStudents(
-        new Set(studentsRef.map((student) => student.studentId))
-      )
-      setPreviewStudentId(studentsRef[0]?.studentId ?? "")
-    }
-  }, [studentsRef]) // eslint-disable-line react-hooks/exhaustive-deps
+  // 初期状態（未操作）は全員選択・先頭生徒プレビューとして算出で表現する
+  const selectedStudents = useMemo(
+    () =>
+      selectedStudentsState ??
+      new Set(studentsRef.map((student) => student.studentId)),
+    [selectedStudentsState, studentsRef]
+  )
+  const previewStudentId =
+    previewStudentIdState || (studentsRef[0]?.studentId ?? "")
 
   const classNames = useMemo(() => {
     const names = new Set<string>()
@@ -174,25 +173,23 @@ export function ExportContainer({ gradeId }: ExportContainerProps) {
 
   const selectAllFiltered = () => {
     const ids = filteredStudents.map((student) => student.studentId)
-    setSelectedStudents((prev) => new Set([...prev, ...ids]))
+    setSelectedStudentsState(new Set([...selectedStudents, ...ids]))
   }
 
   const deselectAllFiltered = () => {
     const filteredIds = new Set(
       filteredStudents.map((student) => student.studentId)
     )
-    setSelectedStudents(
-      (prev) => new Set([...prev].filter((id) => !filteredIds.has(id)))
+    setSelectedStudentsState(
+      new Set([...selectedStudents].filter((id) => !filteredIds.has(id)))
     )
   }
 
   const toggleStudent = (id: string) => {
-    setSelectedStudents((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
+    const next = new Set(selectedStudents)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    setSelectedStudentsState(next)
   }
 
   const selectedStudentIds = useMemo(() => {

--- a/src/components/grades/07-export/PreviewPane.tsx
+++ b/src/components/grades/07-export/PreviewPane.tsx
@@ -22,7 +22,8 @@ export function PreviewPane({ html }: PreviewPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const hostRef = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState<number | null>(null)
-  const contentSizeRef = useRef({ width: 595, height: 842 })
+  // 実測したコンテンツ寸法。レンダーで読むのでrefではなくstateで持つ
+  const [contentSize, setContentSize] = useState({ width: 595, height: 842 })
   const initializedRef = useRef(false)
 
   // Shadow DOMにHTMLを挿入し、実際の描画サイズを測定
@@ -61,7 +62,11 @@ export function PreviewPane({ html }: PreviewPaneProps) {
       const width = wrapper.offsetWidth
       const height = wrapper.offsetHeight
       if (width > 0 && height > 0) {
-        contentSizeRef.current = { width, height }
+        setContentSize((prev) =>
+          prev.width === width && prev.height === height
+            ? prev
+            : { width, height }
+        )
       }
 
       // 初期スケールを算出
@@ -73,8 +78,8 @@ export function PreviewPane({ html }: PreviewPaneProps) {
             container.clientWidth -
             parseFloat(computedStyle.paddingLeft) -
             parseFloat(computedStyle.paddingRight)
-          if (availableWidth > 0 && contentSizeRef.current.width > 0) {
-            setScale(Math.min(availableWidth / contentSizeRef.current.width, 1))
+          if (availableWidth > 0 && width > 0) {
+            setScale(Math.min(availableWidth / width, 1))
             initializedRef.current = true
           }
         }
@@ -123,7 +128,7 @@ export function PreviewPane({ html }: PreviewPaneProps) {
   }, [handleWheel])
 
   const effectiveScale = scale ?? 1
-  const { width: contentWidth, height: contentHeight } = contentSizeRef.current
+  const { width: contentWidth, height: contentHeight } = contentSize
 
   return (
     <div

--- a/src/components/grades/list/GradeImportDialog.tsx
+++ b/src/components/grades/list/GradeImportDialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { TriangleAlert } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -48,12 +48,22 @@ export function GradeImportDialog({
   onConfirm,
 }: GradeImportDialogProps) {
   // archiveId → 選択値（"new" | "reuse:<id>"）。ユーザーが明示的に変更した分のみ保持。
-  const [selections, setSelections] = useState<Record<string, string>>({})
+  // どの preview に対する選択かを一緒に持ち、preview が切り替わったら前回分は無効になる
+  const [manualSelections, setManualSelections] = useState<{
+    preview: GradeArchiveImportPreview | null
+    values: Record<string, string>
+  }>({ preview: null, values: {} })
+  const selections = useMemo(
+    () => (manualSelections.preview === preview ? manualSelections.values : {}),
+    [manualSelections, preview]
+  )
 
-  // preview が切り替わったら手動選択をリセット（前回インポートの選択が残らないように）
-  useEffect(() => {
-    setSelections({})
-  }, [preview])
+  const selectArchive = (archiveId: string, value: string) => {
+    setManualSelections({
+      preview,
+      values: { ...selections, [archiveId]: value },
+    })
+  }
 
   // preview が変わったら初期選択を計算（uuid一致→統合、無ければ新規）
   const initialSelections = useMemo(() => {
@@ -212,10 +222,7 @@ export function GradeImportDialog({
                       effectiveSelections[courseworkMatch.archiveId] ?? "new"
                     }
                     onValueChange={(value) =>
-                      setSelections((prev) => ({
-                        ...prev,
-                        [courseworkMatch.archiveId]: value,
-                      }))
+                      selectArchive(courseworkMatch.archiveId, value)
                     }
                     className="space-y-1"
                   >

--- a/src/components/import/HszDisclaimerModal.tsx
+++ b/src/components/import/HszDisclaimerModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { AlertTriangle, FileArchive, Loader2 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -29,13 +29,151 @@ const FORMAT_INFO = {
   },
 } as const
 
+interface HszDisclaimerBodyProps {
+  fileName: string
+  productName: string
+  companyName: string
+  isProcessing: boolean
+  onAccept: () => void
+  onDismiss: () => void
+}
+
+/**
+ * 免責事項ダイアログの中身
+ *
+ * 閉じている間は呼び出し側でマウントしないため、開くたびに同意チェックが
+ * 外れた状態から始まる。
+ */
+function HszDisclaimerBody({
+  fileName,
+  productName,
+  companyName,
+  isProcessing,
+  onAccept,
+  onDismiss,
+}: HszDisclaimerBodyProps) {
+  const [agreed, setAgreed] = useState(false)
+
+  return (
+    <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-amber-500" />
+          他社フォーマットの変換
+        </DialogTitle>
+        <DialogDescription>
+          {productName}
+          のデータファイルを一括採点形式に変換します
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-2">
+        {/* ファイル名表示 */}
+        <div className="flex items-center gap-3 rounded-lg bg-muted p-3">
+          <FileArchive className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <span className="text-sm font-medium break-all">{fileName}</span>
+        </div>
+
+        {/* 変換に関する注意事項 */}
+        <div className="space-y-2 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+          <p className="text-sm font-medium">変換に関する注意事項</p>
+          <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
+            <li>
+              採点領域の座標は自動変換されますが、精度を保証するものではありません
+            </li>
+            <li>
+              変換後、テンプレート編集画面で各領域の位置を確認・調整してください
+            </li>
+            <li>
+              模範解答画像と採点領域のみがインポートされます（生徒・採点結果は含まれません）
+            </li>
+          </ul>
+        </div>
+
+        {/* 免責事項 */}
+        <div className="space-y-3 rounded-lg border p-4">
+          <p className="text-sm font-medium">免責事項</p>
+          <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
+            <p>
+              本ソフトウェアは、{companyName}
+              とは一切の関係がなく、同社からの承認・推奨・技術提供を受けたものではありません。
+            </p>
+            <p>
+              本ソフトウェアに含まれるファイル読み込み機能は、公開されているデータ形式をもとに独自に実装した変換機能であり、同社のソフトウェアの技術・ソースコード・ライセンスに依拠するものではありません。
+            </p>
+            <ul className="list-inside list-disc space-y-1.5 pl-1">
+              <li>
+                <span className="font-medium">動作の保証について：</span>
+                本機能による読み込み結果の正確性・完全性について、いかなる保証も行いません。読み込み後のデータについては、必ずご自身で内容をご確認ください。
+              </li>
+              <li>
+                <span className="font-medium">データ形式の変更について：</span>
+                ソフトウェアの更新等によりデータ形式が変更された場合、本機能が正常に動作しなくなる可能性があります。
+              </li>
+              <li>
+                <span className="font-medium">データの利用について：</span>
+                読み込むファイルに含まれるコンテンツ（問題文・解答等）の著作権は、その作成者または権利者に帰属します。ファイルの利用にあたっては、各コンテンツの利用条件を遵守してください。
+              </li>
+              <li>
+                <span className="font-medium">免責：</span>
+                本機能の使用により生じたいかなる損害についても、本ソフトウェアの開発者は一切の責任を負いません。
+              </li>
+            </ul>
+          </div>
+
+          {/* 商標表示 */}
+          <div className="border-t pt-2 text-[11px] leading-relaxed text-muted-foreground">
+            <p>
+              「百問繚乱」は、株式会社シンプルエデュケーションの登録商標または商標です。
+            </p>
+            <p>
+              「リアテンダント」は、大日本印刷株式会社の登録商標または商標です。
+            </p>
+            <p>
+              その他、本ソフトウェア内で使用されている会社名・製品名等は、各社の登録商標または商標です。
+            </p>
+          </div>
+        </div>
+
+        {/* 同意チェックボックス */}
+        <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 select-none has-checked:border-amber-400 has-checked:bg-amber-50 dark:has-checked:bg-amber-950/20">
+          <Checkbox
+            checked={agreed}
+            onCheckedChange={(checked) => setAgreed(checked === true)}
+            disabled={isProcessing}
+            className="mt-0.5"
+          />
+          <span className="text-sm">
+            上記の免責事項を確認し、同意のうえ変換を行います
+          </span>
+        </label>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onDismiss} disabled={isProcessing}>
+          キャンセル
+        </Button>
+        <Button onClick={onAccept} disabled={isProcessing || !agreed}>
+          {isProcessing ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              変換中...
+            </>
+          ) : (
+            "変換して読み込む"
+          )}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  )
+}
+
 interface HszDisclaimerModalProps {
   wizard: UseImportWizardReturn
 }
 
 export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
   const { state, acceptHszDisclaimer, dismissHszDisclaimer } = wizard
-  const [agreed, setAgreed] = useState(false)
 
   const fileName = state.hszOriginalPath
     ? (state.hszOriginalPath.split(/[/\\]/).pop() ?? "")
@@ -43,13 +181,6 @@ export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
 
   const formatKey = state.sourceFormat === "dat" ? "dat" : "hsz"
   const { productName, companyName } = FORMAT_INFO[formatKey]
-
-  // モーダルが開くたびに同意状態をリセット
-  useEffect(() => {
-    if (state.showHszDisclaimer) {
-      setAgreed(false)
-    }
-  }, [state.showHszDisclaimer])
 
   return (
     <Dialog
@@ -60,125 +191,16 @@ export function HszDisclaimerModal({ wizard }: HszDisclaimerModalProps) {
         }
       }}
     >
-      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-amber-500" />
-            他社フォーマットの変換
-          </DialogTitle>
-          <DialogDescription>
-            {productName}
-            のデータファイルを一括採点形式に変換します
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          {/* ファイル名表示 */}
-          <div className="flex items-center gap-3 rounded-lg bg-muted p-3">
-            <FileArchive className="h-5 w-5 shrink-0 text-muted-foreground" />
-            <span className="text-sm font-medium break-all">{fileName}</span>
-          </div>
-
-          {/* 変換に関する注意事項 */}
-          <div className="space-y-2 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
-            <p className="text-sm font-medium">変換に関する注意事項</p>
-            <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
-              <li>
-                採点領域の座標は自動変換されますが、精度を保証するものではありません
-              </li>
-              <li>
-                変換後、テンプレート編集画面で各領域の位置を確認・調整してください
-              </li>
-              <li>
-                模範解答画像と採点領域のみがインポートされます（生徒・採点結果は含まれません）
-              </li>
-            </ul>
-          </div>
-
-          {/* 免責事項 */}
-          <div className="space-y-3 rounded-lg border p-4">
-            <p className="text-sm font-medium">免責事項</p>
-            <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
-              <p>
-                本ソフトウェアは、{companyName}
-                とは一切の関係がなく、同社からの承認・推奨・技術提供を受けたものではありません。
-              </p>
-              <p>
-                本ソフトウェアに含まれるファイル読み込み機能は、公開されているデータ形式をもとに独自に実装した変換機能であり、同社のソフトウェアの技術・ソースコード・ライセンスに依拠するものではありません。
-              </p>
-              <ul className="list-inside list-disc space-y-1.5 pl-1">
-                <li>
-                  <span className="font-medium">動作の保証について：</span>
-                  本機能による読み込み結果の正確性・完全性について、いかなる保証も行いません。読み込み後のデータについては、必ずご自身で内容をご確認ください。
-                </li>
-                <li>
-                  <span className="font-medium">
-                    データ形式の変更について：
-                  </span>
-                  ソフトウェアの更新等によりデータ形式が変更された場合、本機能が正常に動作しなくなる可能性があります。
-                </li>
-                <li>
-                  <span className="font-medium">データの利用について：</span>
-                  読み込むファイルに含まれるコンテンツ（問題文・解答等）の著作権は、その作成者または権利者に帰属します。ファイルの利用にあたっては、各コンテンツの利用条件を遵守してください。
-                </li>
-                <li>
-                  <span className="font-medium">免責：</span>
-                  本機能の使用により生じたいかなる損害についても、本ソフトウェアの開発者は一切の責任を負いません。
-                </li>
-              </ul>
-            </div>
-
-            {/* 商標表示 */}
-            <div className="border-t pt-2 text-[11px] leading-relaxed text-muted-foreground">
-              <p>
-                「百問繚乱」は、株式会社シンプルエデュケーションの登録商標または商標です。
-              </p>
-              <p>
-                「リアテンダント」は、大日本印刷株式会社の登録商標または商標です。
-              </p>
-              <p>
-                その他、本ソフトウェア内で使用されている会社名・製品名等は、各社の登録商標または商標です。
-              </p>
-            </div>
-          </div>
-
-          {/* 同意チェックボックス */}
-          <label className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 select-none has-checked:border-amber-400 has-checked:bg-amber-50 dark:has-checked:bg-amber-950/20">
-            <Checkbox
-              checked={agreed}
-              onCheckedChange={(checked) => setAgreed(checked === true)}
-              disabled={state.isProcessing}
-              className="mt-0.5"
-            />
-            <span className="text-sm">
-              上記の免責事項を確認し、同意のうえ変換を行います
-            </span>
-          </label>
-        </div>
-
-        <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={dismissHszDisclaimer}
-            disabled={state.isProcessing}
-          >
-            キャンセル
-          </Button>
-          <Button
-            onClick={acceptHszDisclaimer}
-            disabled={state.isProcessing || !agreed}
-          >
-            {state.isProcessing ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                変換中...
-              </>
-            ) : (
-              "変換して読み込む"
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
+      {state.showHszDisclaimer === true && (
+        <HszDisclaimerBody
+          fileName={fileName}
+          productName={productName}
+          companyName={companyName}
+          isProcessing={state.isProcessing}
+          onAccept={acceptHszDisclaimer}
+          onDismiss={dismissHszDisclaimer}
+        />
+      )}
     </Dialog>
   )
 }

--- a/src/components/import/steps/id-integration/MatchedItemRow.tsx
+++ b/src/components/import/steps/id-integration/MatchedItemRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ChevronDown, ChevronRight } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import {
   Select,
@@ -11,11 +11,12 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import type { IdChoice } from "@/types/examArchive.types"
+import { isIdChoice } from "@/types/examArchive.types"
 
 import { SubtotalMappingEditor } from "./SubtotalMappingEditor"
 import { SubtotalPreview } from "./SubtotalPreview"
 import type { DecisionType, MatchedItemRowProps } from "./types"
-import { ENTITY_LABELS } from "./types"
+import { ENTITY_LABELS, isDecisionType } from "./types"
 
 /**
  * マッチしたアイテムの行（共通コンポーネント）
@@ -28,20 +29,9 @@ export function MatchedItemRow({
   onDecisionChange,
   wizard,
 }: MatchedItemRowProps) {
-  const [decision, setDecision] = useState<DecisionType>(
-    currentDecision ?? "same_person"
-  )
-  const [idChoice, setIdChoice] = useState<IdChoice>(
-    currentIdChoice ?? "use_existing_id"
-  )
-
-  useEffect(() => {
-    if (currentDecision !== undefined) setDecision(currentDecision)
-  }, [currentDecision])
-
-  useEffect(() => {
-    if (currentIdChoice !== undefined) setIdChoice(currentIdChoice)
-  }, [currentIdChoice])
+  // 決定内容はウィザードの state が正。ローカルには複製せず props から算出する
+  const decision: DecisionType = currentDecision ?? "same_person"
+  const idChoice: IdChoice = currentIdChoice ?? "use_existing_id"
 
   const [showPreview, setShowPreview] = useState(false)
 
@@ -56,18 +46,13 @@ export function MatchedItemRow({
     item.additionalInfo?.existingSubtotals?.length
 
   const handleDecisionChange = (value: string) => {
-    const newDecision = value as DecisionType
-    setDecision(newDecision)
-    onDecisionChange(
-      newDecision,
-      newDecision === "same_person" ? idChoice : undefined
-    )
+    if (!isDecisionType(value)) return
+    onDecisionChange(value, value === "same_person" ? idChoice : undefined)
   }
 
   const handleIdChoiceChange = (value: string) => {
-    const newIdChoice = value as IdChoice
-    setIdChoice(newIdChoice)
-    onDecisionChange(decision, newIdChoice)
+    if (!isIdChoice(value)) return
+    onDecisionChange(decision, value)
   }
 
   return (

--- a/src/components/import/steps/id-integration/types.ts
+++ b/src/components/import/steps/id-integration/types.ts
@@ -20,6 +20,11 @@ export type EntityType = "student" | "classroom" | "subtotalGroup"
 export type DecisionType = "same_person" | "create_new" | "skip"
 export type NoMatchDecisionType = "create_new" | "skip"
 
+/** UIのSelect等が返す string を DecisionType へ絞り込む */
+export function isDecisionType(value: string): value is DecisionType {
+  return value === "same_person" || value === "create_new" || value === "skip"
+}
+
 /** エンティティごとのラベル設定 */
 interface EntityLabels {
   samePerson: string

--- a/src/components/pdf-tools/export-panel/ExportPanel.tsx
+++ b/src/components/pdf-tools/export-panel/ExportPanel.tsx
@@ -49,7 +49,9 @@ export default function ExportPanel({
 }: ExportPanelProps) {
   // excludedPages の最新値をrefで保持（useEffectの依存配列に入れず、再生成時のみ参照）
   const excludedPagesRef = useRef(excludedPages)
-  excludedPagesRef.current = excludedPages
+  useEffect(() => {
+    excludedPagesRef.current = excludedPages
+  })
 
   // インポートファイルが変更されたら出力ページを更新（除外ページを反映）
   useEffect(() => {

--- a/src/components/pdf-tools/export-panel/InterleaveSettings.tsx
+++ b/src/components/pdf-tools/export-panel/InterleaveSettings.tsx
@@ -41,10 +41,12 @@ export default function InterleaveSettings({
 }: InterleaveSettingsProps) {
   // useRefで最新の値を保持（依存配列に入れずに最新値を参照するため）
   const configRef = useRef(config)
-  configRef.current = config
 
   const onConfigChangeRef = useRef(onConfigChange)
-  onConfigChangeRef.current = onConfigChange
+  useEffect(() => {
+    configRef.current = config
+    onConfigChangeRef.current = onConfigChange
+  })
 
   // ファイルが変更されたらtransformsを同期
   useEffect(() => {

--- a/src/components/pdf-tools/import-panel/FileDropzone.tsx
+++ b/src/components/pdf-tools/import-panel/FileDropzone.tsx
@@ -129,17 +129,19 @@ export default function FileDropzone({
       </div>
 
       {/* パスワード保護PDFの入力ダイアログ */}
-      <PasswordDialog
-        isOpen={passwordDialog.isOpen}
-        onClose={handlePasswordCancel}
-        onSubmit={handlePasswordSubmit}
-        fileName={passwordDialog.fileName}
-        error={
-          passwordDialog.hasError ? "パスワードが正しくありません" : undefined
-        }
-        isLoading={passwordDialog.isLoading}
-        isFirstAttempt={!passwordDialog.hasError}
-      />
+      {passwordDialog.isOpen && (
+        <PasswordDialog
+          isOpen={passwordDialog.isOpen}
+          onClose={handlePasswordCancel}
+          onSubmit={handlePasswordSubmit}
+          fileName={passwordDialog.fileName}
+          error={
+            passwordDialog.hasError ? "パスワードが正しくありません" : undefined
+          }
+          isLoading={passwordDialog.isLoading}
+          isFirstAttempt={!passwordDialog.hasError}
+        />
+      )}
     </>
   )
 }

--- a/src/components/student-import/steps/FinalConfirmStep.tsx
+++ b/src/components/student-import/steps/FinalConfirmStep.tsx
@@ -32,7 +32,7 @@ export function FinalConfirmStep({ wizard, onExecute }: FinalConfirmStepProps) {
     const studentNoMatch = student.noMatch.length
 
     let studentMerge = studentAutoMatched
-    let studentNew = 0
+    let studentNew: number
     let studentSkip = 0
 
     if (config.student.strategy === "all_new") {
@@ -54,7 +54,7 @@ export function FinalConfirmStep({ wizard, onExecute }: FinalConfirmStepProps) {
     const classroomNoMatch = classroomResult.noMatch.length
 
     let classroomMerge = classroomAutoMatched
-    let classroomNew = 0
+    let classroomNew: number
     let classroomSkip = 0
 
     if (config.classroom.strategy === "all_new") {

--- a/src/components/student/StudentClassroomMembershipModal.tsx
+++ b/src/components/student/StudentClassroomMembershipModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Search } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -62,6 +62,14 @@ interface StudentClassroomMembershipModalProps {
   } | null
 }
 
+/** Date/文字列を <input type="date"> が受け付ける YYYY-MM-DD へ整える */
+const formatDateForInput = (date: Date | string | null | undefined): string => {
+  if (!date) return ""
+  const parsedDate = typeof date === "string" ? new Date(date) : date
+  if (isNaN(parsedDate.getTime())) return ""
+  return parsedDate.toISOString().split("T")[0]
+}
+
 export default function StudentClassroomMembershipModal({
   isOpen,
   onClose,
@@ -72,55 +80,26 @@ export default function StudentClassroomMembershipModal({
   availableClassrooms,
   membershipToEdit,
 }: StudentClassroomMembershipModalProps) {
-  const [studentId, setStudentId] = useState(initialStudentId || "")
-  const [classroomId, setClassroomId] = useState(initialClassroomId || "")
-  const [attendanceNumber, setAttendanceNumber] = useState<string>("")
-  const [startDate, setStartDate] = useState("")
-  const [endDate, setEndDate] = useState("")
-  const [notes, setNotes] = useState("")
+  // 呼び出し側は閉じている間このコンポーネントをマウントしないため、
+  // 開くたびに membershipToEdit（無ければ初期指定）の内容からフォームが始まる。
+  const [studentId, setStudentId] = useState(
+    membershipToEdit?.studentId ?? initialStudentId ?? ""
+  )
+  const [classroomId, setClassroomId] = useState(
+    membershipToEdit?.classroomId ?? initialClassroomId ?? ""
+  )
+  const [attendanceNumber, setAttendanceNumber] = useState<string>(
+    membershipToEdit?.attendanceNumber?.toString() ?? ""
+  )
+  const [startDate, setStartDate] = useState(() =>
+    formatDateForInput(membershipToEdit?.startDate)
+  )
+  const [endDate, setEndDate] = useState(() =>
+    formatDateForInput(membershipToEdit?.endDate)
+  )
+  const [notes, setNotes] = useState(membershipToEdit?.notes ?? "")
   const [studentSearchTerm, setStudentSearchTerm] = useState("")
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
-
-  const formatDateForInput = (
-    date: Date | string | null | undefined
-  ): string => {
-    if (!date) return ""
-    const parsedDate = typeof date === "string" ? new Date(date) : date
-    if (isNaN(parsedDate.getTime())) return ""
-    return parsedDate.toISOString().split("T")[0]
-  }
-
-  useEffect(() => {
-    let canceled = false
-    const frame = requestAnimationFrame(() => {
-      if (canceled) {
-        return
-      }
-
-      if (membershipToEdit) {
-        setStudentId(membershipToEdit.studentId)
-        setClassroomId(membershipToEdit.classroomId)
-        setAttendanceNumber(membershipToEdit.attendanceNumber?.toString() || "")
-        setStartDate(formatDateForInput(membershipToEdit.startDate))
-        setEndDate(formatDateForInput(membershipToEdit.endDate))
-        setNotes(membershipToEdit.notes || "")
-      } else {
-        setStudentId(initialStudentId || "")
-        setClassroomId(initialClassroomId || "")
-        setAttendanceNumber("")
-        setStartDate("")
-        setEndDate("")
-        setNotes("")
-      }
-      setStudentSearchTerm("")
-      setErrors({})
-    })
-
-    return () => {
-      canceled = true
-      cancelAnimationFrame(frame)
-    }
-  }, [membershipToEdit, initialStudentId, initialClassroomId, isOpen])
 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {}

--- a/src/components/student/StudentModal.tsx
+++ b/src/components/student/StudentModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { Prisma } from "@prisma/client"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -42,48 +42,23 @@ export default function StudentModal({
   onUpdate,
   studentToEdit,
 }: StudentModalProps) {
-  const [studentId, setStudentId] = useState("")
-  const [lastName, setLastName] = useState("")
-  const [firstName, setFirstName] = useState("")
-  const [lastNameKana, setLastNameKana] = useState("")
-  const [firstNameKana, setFirstNameKana] = useState("")
+  // 呼び出し側は閉じている間このコンポーネントをマウントしないため、
+  // 開くたびに studentToEdit の内容からフォームが始まる。
+  const [studentId, setStudentId] = useState(studentToEdit?.studentNumber ?? "")
+  const [lastName, setLastName] = useState(studentToEdit?.lastName ?? "")
+  const [firstName, setFirstName] = useState(studentToEdit?.firstName ?? "")
+  const [lastNameKana, setLastNameKana] = useState(
+    studentToEdit?.lastNameKana ?? ""
+  )
+  const [firstNameKana, setFirstNameKana] = useState(
+    studentToEdit?.firstNameKana ?? ""
+  )
   const [enrollmentYear, setEnrollmentYear] = useState<number | undefined>(
-    undefined
+    studentToEdit?.enrollmentYear ?? undefined
   )
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const { inputRef: studentIdInputRef, onOpenAutoFocus } =
     useDialogAutoFocus(isOpen)
-
-  useEffect(() => {
-    let canceled = false
-    const frame = requestAnimationFrame(() => {
-      if (canceled) {
-        return
-      }
-
-      if (studentToEdit) {
-        setStudentId(studentToEdit.studentNumber)
-        setLastName(studentToEdit.lastName)
-        setFirstName(studentToEdit.firstName)
-        setLastNameKana(studentToEdit.lastNameKana)
-        setFirstNameKana(studentToEdit.firstNameKana)
-        setEnrollmentYear(studentToEdit.enrollmentYear ?? undefined)
-      } else {
-        setStudentId("")
-        setLastName("")
-        setFirstName("")
-        setLastNameKana("")
-        setFirstNameKana("")
-        setEnrollmentYear(undefined)
-      }
-      setErrors({})
-    })
-
-    return () => {
-      canceled = true
-      cancelAnimationFrame(frame)
-    }
-  }, [studentToEdit, isOpen])
 
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {}

--- a/src/components/subtotal-groups/SubtotalGroupsPageContainer.tsx
+++ b/src/components/subtotal-groups/SubtotalGroupsPageContainer.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Plus, Search } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import LoadingSpinner from "@/components/common/LoadingSpinner"
 import { SubtotalGroupCard } from "@/components/subtotal-groups/components/SubtotalGroupCard"
@@ -12,7 +12,6 @@ import { Input } from "@/components/ui/input"
 
 export function SubtotalGroupsPageContainer() {
   const [subtotalGroups, setSubtotalGroups] = useState<SubtotalGroup[]>([])
-  const [filteredGroups, setFilteredGroups] = useState<SubtotalGroup[]>([])
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState("")
   const [showModal, setShowModal] = useState(false)
@@ -29,7 +28,6 @@ export function SubtotalGroupsPageContainer() {
           "IPCハンドラーが利用できません。Electronアプリを再起動してください。"
         )
         setSubtotalGroups([])
-        setFilteredGroups([])
         return
       }
 
@@ -38,14 +36,12 @@ export function SubtotalGroupsPageContainer() {
       const result = await window.electronAPI.getSubtotalGroups()
       if (result.success && result.subtotalGroups) {
         setSubtotalGroups(result.subtotalGroups)
-        setFilteredGroups(result.subtotalGroups)
       } else {
         console.error("Failed to fetch subtotal groups:", result.error)
       }
     } catch (error) {
       console.error("Error fetching subtotal groups:", error)
       setSubtotalGroups([])
-      setFilteredGroups([])
     } finally {
       setLoading(false)
     }
@@ -54,6 +50,12 @@ export function SubtotalGroupsPageContainer() {
   useEffect(() => {
     fetchSubtotalGroups()
   }, [fetchSubtotalGroups])
+
+  // 新規作成
+  const handleCreate = useCallback(() => {
+    setEditingGroup(null)
+    setShowModal(true)
+  }, [])
 
   // キーボードショートカット
   useEffect(() => {
@@ -74,34 +76,25 @@ export function SubtotalGroupsPageContainer() {
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [fetchSubtotalGroups, showModal])
+  }, [fetchSubtotalGroups, handleCreate, showModal])
 
   // 検索フィルタリング（グループ名と小計項目名で検索）
-  useEffect(() => {
-    if (!searchTerm) {
-      setFilteredGroups(subtotalGroups)
-    } else {
-      const searchLower = searchTerm.toLowerCase()
-      const filtered = subtotalGroups.filter((group) => {
-        // グループ名で検索
-        const matchesGroupName = group.name.toLowerCase().includes(searchLower)
+  const filteredGroups = useMemo(() => {
+    if (!searchTerm) return subtotalGroups
 
-        // 小計項目名で検索
-        const matchesSubtotalName = group.subtotals.some((subtotal) =>
-          subtotal.name.toLowerCase().includes(searchLower)
-        )
+    const searchLower = searchTerm.toLowerCase()
+    return subtotalGroups.filter((group) => {
+      // グループ名で検索
+      const matchesGroupName = group.name.toLowerCase().includes(searchLower)
 
-        return matchesGroupName || matchesSubtotalName
-      })
-      setFilteredGroups(filtered)
-    }
+      // 小計項目名で検索
+      const matchesSubtotalName = group.subtotals.some((subtotal) =>
+        subtotal.name.toLowerCase().includes(searchLower)
+      )
+
+      return matchesGroupName || matchesSubtotalName
+    })
   }, [searchTerm, subtotalGroups])
-
-  // 新規作成
-  const handleCreate = () => {
-    setEditingGroup(null)
-    setShowModal(true)
-  }
 
   // 編集
   const handleEdit = (group: SubtotalGroup) => {

--- a/src/components/subtotal-groups/components/SubtotalGroupModal.tsx
+++ b/src/components/subtotal-groups/components/SubtotalGroupModal.tsx
@@ -18,7 +18,7 @@ import {
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { GripVertical, Plus, Trash2 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 
 import type {
   SubtotalGroup,
@@ -121,11 +121,21 @@ export function SubtotalGroupModal({
   onSave,
   editingGroup,
 }: SubtotalGroupModalProps) {
+  // 呼び出し側（SubtotalGroupsPageContainer）は閉じている間このコンポーネントを
+  // マウントしないため、開くたびに editingGroup の内容からフォームが始まる。
   const [formData, setFormData] = useState<SubtotalGroupFormData>({
-    name: "",
+    name: editingGroup?.name ?? "",
     subtotals: [],
   })
-  const [subtotals, setSubtotals] = useState<SubtotalFormData[]>([])
+  const [subtotals, setSubtotals] = useState<SubtotalFormData[]>(() =>
+    [...(editingGroup?.subtotals ?? [])]
+      .sort((subtotalA, subtotalB) => subtotalA.order - subtotalB.order)
+      .map((subtotal, index) => ({
+        id: subtotal.id,
+        name: subtotal.name,
+        order: index,
+      }))
+  )
   const [saving, setSaving] = useState(false)
 
   const sensors = useSensors(
@@ -134,31 +144,6 @@ export function SubtotalGroupModal({
       coordinateGetter: sortableKeyboardCoordinates,
     })
   )
-
-  // フォームを初期化
-  useEffect(() => {
-    if (editingGroup) {
-      setFormData({
-        name: editingGroup.name,
-        subtotals: [],
-      })
-      setSubtotals(
-        editingGroup.subtotals
-          .sort((subtotalA, subtotalB) => subtotalA.order - subtotalB.order)
-          .map((subtotal, index) => ({
-            id: subtotal.id,
-            name: subtotal.name,
-            order: index,
-          }))
-      )
-    } else {
-      setFormData({
-        name: "",
-        subtotals: [],
-      })
-      setSubtotals([])
-    }
-  }, [editingGroup, isOpen])
 
   // 小計項目を追加
   const addSubtotal = () => {

--- a/src/components/tag/TagsPageContainer.tsx
+++ b/src/components/tag/TagsPageContainer.tsx
@@ -130,16 +130,11 @@ function TagModal({
   onClose: () => void
   onSave: (name: string, color: string | null) => Promise<void>
 }) {
-  const [name, setName] = useState("")
-  const [color, setColor] = useState<string | null>(null)
+  // 呼び出し側は閉じている間このコンポーネントをマウントしないため、
+  // 開くたびに対象タグの値からフォームが始まる。
+  const [name, setName] = useState(tag?.name ?? "")
+  const [color, setColor] = useState<string | null>(tag?.color ?? null)
   const { inputRef: nameInputRef, onOpenAutoFocus } = useDialogAutoFocus(open)
-
-  useEffect(() => {
-    if (open) {
-      setName(tag?.name ?? "")
-      setColor(tag?.color ?? null)
-    }
-  }, [open, tag])
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -316,12 +311,15 @@ export function TagsPageContainer() {
 
   return (
     <>
-      <TagModal
-        open={showModal}
-        tag={modalTag}
-        onClose={() => setShowModal(false)}
-        onSave={handleSave}
-      />
+      {/* 閉じている間はマウントしない。開くたびに対象タグの値でフォームが作り直される */}
+      {showModal && (
+        <TagModal
+          open={showModal}
+          tag={modalTag}
+          onClose={() => setShowModal(false)}
+          onSave={handleSave}
+        />
+      )}
 
       <div className="flex h-full flex-col">
         <div className="flex items-center justify-between border-b px-4 py-3">

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -39,12 +39,9 @@ export function ColorPicker({
   className,
 }: ColorPickerProps) {
   const [open, setOpen] = React.useState(false)
-  const [inputValue, setInputValue] = React.useState(value)
-
-  // 外部からのvalue変更を反映
-  React.useEffect(() => {
-    setInputValue(value)
-  }, [value])
+  // HEXとして未完成な入力途中の下書き。null なら外部のvalueをそのまま表示する
+  const [draftValue, setDraftValue] = React.useState<string | null>(null)
+  const inputValue = draftValue ?? value
 
   // HEX形式のバリデーション
   const isValidHex = (hex: string): boolean => {
@@ -58,24 +55,26 @@ export function ColorPicker({
     if (!newValue.startsWith("#")) {
       newValue = "#" + newValue
     }
-    setInputValue(newValue)
 
-    // 有効なHEX形式なら親に通知
+    // 有効なHEX形式なら親に通知し、以降は外部のvalueに追従させる
     if (isValidHex(newValue)) {
+      setDraftValue(null)
       onChange(newValue)
+    } else {
+      setDraftValue(newValue)
     }
   }
 
   // ネイティブカラーピッカーからの変更
   const handleNativeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newColor = e.target.value.toUpperCase()
-    setInputValue(newColor)
+    setDraftValue(null)
     onChange(newColor)
   }
 
   // プリセット選択
   const handlePresetClick = (color: string) => {
-    setInputValue(color)
+    setDraftValue(null)
     onChange(color)
   }
 

--- a/src/components/ui/password-dialog.tsx
+++ b/src/components/ui/password-dialog.tsx
@@ -42,6 +42,8 @@ export function PasswordDialog({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (password.trim()) {
+      // 誤りだったときに前回の入力が残らないよう、送信と同時に消す
+      setPassword("")
       onSubmit(password)
     }
   }
@@ -81,31 +83,12 @@ export function PasswordDialog({
     }
   }, [error, isFirstAttempt])
 
-  // ダイアログが開かれた時にパスワードをクリア
-  useEffect(() => {
-    if (isOpen) {
-      let canceled = false
-      const frame = requestAnimationFrame(() => {
-        if (canceled) {
-          return
-        }
-        setPassword("")
-        setIsShaking(false)
-      })
-      return () => {
-        canceled = true
-        cancelAnimationFrame(frame)
-      }
-    }
-  }, [isOpen])
-
   // パスワード違いの再試行では、呼び出し側（usePdfPasswordConversion）が
-  // isOpen を true のまま isLoading だけ戻すため、Dialog は再マウントされず
-  // onOpenAutoFocus も [isOpen] のリセット効果も再発火しない。
-  // 誤ったパスワードが残ったまま無フォーカスになるので、ここで入力を作り直す。
+  // isOpen を true のまま isLoading だけ戻すため Dialog は再マウントされず、
+  // onOpenAutoFocus も再発火しない。入力のクリアは handleSubmit 側で済むので、
+  // ここではフォーカスを戻すだけにする。
   useEffect(() => {
     if (isOpen && !isLoading && error && !isFirstAttempt) {
-      setPassword("")
       inputRef.current?.focus()
     }
   }, [isOpen, isLoading, error, isFirstAttempt, inputRef])

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -33,10 +33,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true)
   const router = useRouter()
 
-  useEffect(() => {
-    checkAuth()
-  }, [])
-
   const checkAuth = async () => {
     try {
       // electron-storeから認証トークンを取得
@@ -66,6 +62,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setIsLoading(false)
     }
   }
+
+  useEffect(() => {
+    checkAuth()
+  }, [])
 
   const quickLogin = async (selectedUser: User) => {
     try {

--- a/src/hooks/usePdfPasswordConversion.ts
+++ b/src/hooks/usePdfPasswordConversion.ts
@@ -39,15 +39,18 @@ interface PdfConversionOutcome {
  *
  * const images = await convertPdfWithRetry(file) // null = キャンセル
  *
- * <PasswordDialog
- *   isOpen={passwordDialog.isOpen}
- *   onClose={handlePasswordCancel}
- *   onSubmit={handlePasswordSubmit}
- *   fileName={passwordDialog.fileName}
- *   error={passwordDialog.hasError ? "パスワードが正しくありません" : undefined}
- *   isLoading={passwordDialog.isLoading}
- *   isFirstAttempt={!passwordDialog.hasError}
- * />
+ * // 閉じている間はマウントしない（開くたびに入力が初期値から始まる）
+ * {passwordDialog.isOpen && (
+ *   <PasswordDialog
+ *     isOpen={passwordDialog.isOpen}
+ *     onClose={handlePasswordCancel}
+ *     onSubmit={handlePasswordSubmit}
+ *     fileName={passwordDialog.fileName}
+ *     error={passwordDialog.hasError ? "パスワードが正しくありません" : undefined}
+ *     isLoading={passwordDialog.isLoading}
+ *     isFirstAttempt={!passwordDialog.hasError}
+ *   />
+ * )}
  * ```
  */
 export function usePdfPasswordConversion() {

--- a/src/hooks/useTableSort.ts
+++ b/src/hooks/useTableSort.ts
@@ -101,7 +101,7 @@ export function useTableSort<T extends object>(
       if (aVal == null) return sortConfig.direction === "asc" ? 1 : -1
       if (bVal == null) return sortConfig.direction === "asc" ? -1 : 1
 
-      let comparison = 0
+      let comparison: number
 
       // 型に応じた比較
       if (typeof aVal === "number" && typeof bVal === "number") {

--- a/src/lib/pdfConverter.ts
+++ b/src/lib/pdfConverter.ts
@@ -120,14 +120,14 @@ export async function convertPdfToImages(
     // PDF.js エラーハンドリング
     if (error && typeof error === "object" && "name" in error) {
       if (error.name === "PasswordException") {
-        throw new Error("password-required")
+        throw new Error("password-required", { cause: error })
       } else if (error.name === "InvalidPDFException" && password) {
-        throw new Error("invalid-password")
+        throw new Error("invalid-password", { cause: error })
       }
     }
     // パスワード関連以外のエラーのみログ出力
     console.error("PDF変換エラー:", error)
     const errorMessage = error instanceof Error ? error.message : "不明なエラー"
-    throw new Error(`PDF変換エラー: ${errorMessage}`)
+    throw new Error(`PDF変換エラー: ${errorMessage}`, { cause: error })
   }
 }

--- a/src/types/examArchive.types.ts
+++ b/src/types/examArchive.types.ts
@@ -379,6 +379,11 @@ export type SubtotalGroupMatchingStrategy = "by_name" | "individual" | "all_new"
  */
 export type IdChoice = "use_import_id" | "use_existing_id"
 
+/** UIのSelect等が返す string を IdChoice へ絞り込む */
+export function isIdChoice(value: string): value is IdChoice {
+  return value === "use_import_id" || value === "use_existing_id"
+}
+
 /**
  * 個別のID統合決定
  *


### PR DESCRIPTION
Closes #1109

## 概要

eslint の警告 143 件のうち 76 件を解消し、違反ゼロになったルールを error へ
引き上げた。残り 67 件は `react-hooks/set-state-in-effect` のみ。

| ルール | 前 | 後 |
| --- | --- | --- |
| `@typescript-eslint/no-unused-vars` | 3 | **0** |
| `@next/next/no-assign-module-variable` | 1 | **0** |
| `preserve-caught-error` | 7 | **0** |
| `no-useless-assignment` | 12 | **0** |
| `react-hooks/immutability` | 5 | **0** |
| `react-hooks/static-components` | 3 | **0** |
| `react-hooks/set-state-in-render` | 2 | **0** |
| `react-hooks/refs` | 22 | **0** |
| `react-hooks/set-state-in-effect` | 88 | 67 |

## 修正内容

### 実バグ

- `ResultsTable` / `ClassroomStudentImportModal`: レンダー中に定義していた
  コンポーネントをモジュールトップへ巻き上げ。再レンダーのたびに部分木の状態が
  失われる状態だった
- `ExportContainer`: `useMemo` 内の `setState` を「未操作なら全員選択」という
  派生値に置き換え

### モーダルのフォーム初期化

閉じている間もマウントされ続けるため effect でリセットしていたものを、
呼び出し側で条件描画する形に統一し、初期値は `useState` に直接置いた。

`requestAnimationFrame` で包まれていて lint に検出されていなかった
`ClassroomModal` / `StudentModal` / `StudentClassroomMembershipModal` /
`ExportProgressModal` / `password-dialog` も同様に整理した。

なお、開いたまま対象だけが差し替わる `ScoreDecisionForm` は `key` による
作り直しが正しいので既存のまま。判断基準は下記のとおり。

| 状況 | 手段 |
| --- | --- |
| 閉じている間もマウントされ続ける | 呼び出し側で条件描画 |
| 開いたまま対象だけが差し替わる | `key` |

`password-dialog` は 3 つの effect が重なっていたので責務を分けた。
入力のクリアは送信という出来事の一部なので `handleSubmit` へ移し、
effect にはフォーカス復帰という DOM 操作だけを残している。

### props から state への複製

`color-picker` / `EditableCell` / `ConstraintRulesEditor` は
「入力途中の下書き。null なら外部の値に従う」という形に統一。
`MatchedItemRow` / `RichTextEditorModal` は親が値を持つ制御コンポーネントなので
複製自体を撤去した。

### ref の扱い

- 最新値を保持する ref への代入 12 箇所を、レンダー中からコミット後の effect へ
- `useUndoableReducer`: デバウンス情報を ref から reducer state へ移し、
  reducer を純粋にした
- `PreviewPane`: 実測したコンテンツ寸法を ref から state へ
- `CroppedAnswerImage`: 読み込み判定を真偽値から「どの URL を読み終えたか」へ。
  真偽値だと新画像の `onLoad` が no-op になり再描画が発火しない
- `useImageCanvas`: `textBoundsCache` を値ではなく ref で受け渡す形に変更

### 型アサーションの排除

Select が返す `string` に対する `as` を型ガードへ置き換えた
（`isDecisionType` / `isIdChoice` / `toPasscodeType`）。

### その他

`cause` を使うため `electron-src/tsconfig.json` の `lib` を `es2017` から
`es2022` へ。`target` は元々 `ES2022` なので出力は変わらない。

## 意図的に手を付けなかったもの

楽観更新が機能上必要なため、props ミラーリングを残した箇所がある。

- `EditableTable` の `tableData`: `CourseworkScoresContainer` が useMemo 派生を
  渡すため、DB 往復まで編集が消える
- `BoundaryEditor` の `items`: プリセット選択で外部から差し替わる
- `NoMatchItemRow`: 一括クリアとの協調があり、未コミットの中間選択を保持している

残る 67 件の大半は「effect から非同期ローダーを呼ぶ」形。ルールが setState への
到達可能性だけを見るため `await` 後の更新も警告になる。関数の定義位置で警告が
出たり消えたりする性質のもので、解消にはデータ取得層の導入が必要。
判断の根拠は `eslint.config.mjs` に記録した。

## 検証

- `npm run typecheck` 通過
- `npm run lint` exit 0（0 errors / 67 warnings）
- `npx vitest run` 117 ファイル 1193 テスト全通過
