### PR TITLE
refactor(lint): eslint-disable 11 件を撤廃し依存配列と any を error で強制する

### DIFF
--- a/__tests__/renderer/helpers/mockElectronAPI.ts
+++ b/__tests__/renderer/helpers/mockElectronAPI.ts
@@ -77,6 +77,7 @@ export function createMockElectronAPI() {
  * window.electronAPI をクリーンアップ
  */
 export function cleanupMockElectronAPI() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  delete (window as any).electronAPI
+  // window.electronAPI は必須プロパティとして宣言されているため delete 演算子は使えない。
+  // Reflect なら型を偽らずに実行時のプロパティだけを取り除ける
+  Reflect.deleteProperty(window, "electronAPI")
 }

--- a/__tests__/renderer/hooks/scoring/helpers/mockDrawingAPI.ts
+++ b/__tests__/renderer/hooks/scoring/helpers/mockDrawingAPI.ts
@@ -157,6 +157,7 @@ export function createMockDrawingAPI(): MockDrawingAPI {
 
 /** window.electronAPI をクリーンアップ */
 export function cleanupMockDrawingAPI() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  delete (window as any).electronAPI
+  // window.electronAPI は必須プロパティとして宣言されているため delete 演算子は使えない。
+  // Reflect なら型を偽らずに実行時のプロパティだけを取り除ける
+  Reflect.deleteProperty(window, "electronAPI")
 }

--- a/electron-src/ipc-handlers/courseworkHandlers.ts
+++ b/electron-src/ipc-handlers/courseworkHandlers.ts
@@ -200,7 +200,7 @@ export function setupCourseworkHandlers(): void {
     async (
       courseworkId: string,
       classroomId: string,
-      deleteStudents = true
+      deleteStudents: boolean = true
     ) => {
       return removeClassroomFromCoursework(
         courseworkId,

--- a/electron-src/ipc-handlers/examClassroomHandlers.ts
+++ b/electron-src/ipc-handlers/examClassroomHandlers.ts
@@ -63,7 +63,7 @@ export function setupExamClassroomHandlers(): void {
   // Add students from class (B案: 統合型フロー)
   registerHandler(
     "exam-class:add-students-from-class",
-    async (examId: string, classroomId: string, activeOnly = true) => {
+    async (examId: string, classroomId: string, activeOnly: boolean = true) => {
       return await addStudentsFromClassroom(examId, classroomId, activeOnly)
     }
   )

--- a/electron-src/ipc-handlers/gradeHandlers.ts
+++ b/electron-src/ipc-handlers/gradeHandlers.ts
@@ -159,21 +159,25 @@ export function setupGradeHandlers(): void {
 
   registerHandler(
     "grade:getAvailableClassrooms",
-    async (gradeId: string, activeOnly = true) => {
+    async (gradeId: string, activeOnly: boolean = true) => {
       return getAvailableClassroomsForGrade(gradeId, activeOnly)
     }
   )
 
   registerHandler(
     "grade:getAvailableStudents",
-    async (gradeId: string, activeOnly = true) => {
+    async (gradeId: string, activeOnly: boolean = true) => {
       return getAvailableStudentsForGrade(gradeId, activeOnly)
     }
   )
 
   registerHandler(
     "grade:addStudentsFromClassroom",
-    async (gradeId: string, classroomId: string, activeOnly = true) => {
+    async (
+      gradeId: string,
+      classroomId: string,
+      activeOnly: boolean = true
+    ) => {
       return addStudentsFromClassroomToGrade(gradeId, classroomId, activeOnly)
     }
   )
@@ -187,7 +191,11 @@ export function setupGradeHandlers(): void {
 
   registerHandler(
     "grade:removeClassroom",
-    async (gradeId: string, classroomId: string, deleteStudents = true) => {
+    async (
+      gradeId: string,
+      classroomId: string,
+      deleteStudents: boolean = true
+    ) => {
       return removeClassroomFromGrade(gradeId, classroomId, deleteStudents)
     }
   )

--- a/electron-src/ipc-handlers/ipcHandlerUtils.ts
+++ b/electron-src/ipc-handlers/ipcHandlerUtils.ts
@@ -4,18 +4,18 @@
 
 import { ipcMain } from "electron"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type HandlerFunction = (...args: any[]) => any
-
 /**
  * IPC ハンドラーを登録し、try-catch + エラーログを自動適用する。
  * エラー時は例外をそのまま再スローする（呼び出し元でハンドリングされる）。
+ *
+ * 引数と戻り値の型は渡した handler から推論する。ipcMain.handle のリスナーは
+ * 可変長引数が any[] で宣言されているため、こちら側で型変数として受け直せる。
  */
-export function registerHandler(
+export function registerHandler<HandlerArgs extends unknown[], HandlerResult>(
   channel: string,
-  handler: HandlerFunction
+  handler: (...args: HandlerArgs) => HandlerResult | Promise<HandlerResult>
 ): void {
-  ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
+  ipcMain.handle(channel, async (_event, ...args: HandlerArgs) => {
     try {
       return await handler(...args)
     } catch (err) {
@@ -29,12 +29,15 @@ export function registerHandler(
  * IPC ハンドラーを登録し、try-catch + エラーログを自動適用する。
  * エラー時は例外をスローせず、{ success: false, error: message } を返す。
  */
-export function registerSafeHandler(
+export function registerSafeHandler<
+  HandlerArgs extends unknown[],
+  HandlerResult,
+>(
   channel: string,
-  handler: HandlerFunction,
+  handler: (...args: HandlerArgs) => HandlerResult | Promise<HandlerResult>,
   fallbackError?: string
 ): void {
-  ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
+  ipcMain.handle(channel, async (_event, ...args: HandlerArgs) => {
     try {
       return await handler(...args)
     } catch (err) {

--- a/electron-src/ipc-handlers/studentHandlers.ts
+++ b/electron-src/ipc-handlers/studentHandlers.ts
@@ -171,14 +171,14 @@ export function setupStudentHandlers(): void {
 
   registerHandler(
     "get-classrooms-not-in-exam",
-    async (examId: string, activeOnly = true) => {
+    async (examId: string, activeOnly: boolean = true) => {
       return await getClassroomsNotInExam(examId, activeOnly)
     }
   )
 
   registerHandler(
     "get-students-not-in-exam",
-    async (examId: string, activeOnly = true) => {
+    async (examId: string, activeOnly: boolean = true) => {
       return await getStudentsNotInExam(examId, activeOnly)
     }
   )

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,7 +97,10 @@ export default [
     rules: {
       // React Hooks
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
+      // 違反ゼロにしたので error。依存を偽る抑制コメントは置かず、
+      // 「effect から最新の props を読むが再実行の引き金にはしない」箇所は
+      // useEffectEvent を使う（ref での代用は宣言順に依存するため避ける）。
+      "react-hooks/exhaustive-deps": "error",
 
       // React Hooks（v7 の React Compiler 由来ルール）
       // recommended は 16 ルールだが上2つしか有効化していなかったため追加する。
@@ -136,7 +139,8 @@ export default [
           ignoreRestSiblings: true,
         },
       ],
-      "@typescript-eslint/no-explicit-any": "warn",
+      // 違反ゼロにしたので error（コード規約の「any は原則禁止」を機械的に担保する）
+      "@typescript-eslint/no-explicit-any": "error",
 
       // Next.js
       // プラグインを登録するだけではルールは有効にならないため個別に指定する。

--- a/src/app/settings/components/AuditLogsTab.tsx
+++ b/src/app/settings/components/AuditLogsTab.tsx
@@ -204,14 +204,14 @@ export function AuditLogsTab() {
     })()
   }, [])
 
-  // 検索テキストはデバウンスしてフィルタへ反映
+  // 検索テキストはデバウンスしてフィルタへ反映。
+  // 更新関数形にすることで、待機中に他のフィルタが変わっても上書きしない
   useEffect(() => {
     const id = setTimeout(() => {
-      setFilter({ ...filter, search: searchText || undefined })
+      setFilter((prev) => ({ ...prev, search: searchText || undefined }))
     }, 300)
     return () => clearTimeout(id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchText])
+  }, [searchText, setFilter])
 
   const categoryOptions = useMemo(
     () => Object.entries(CATEGORY_LABELS) as [AuditCategory, string][],

--- a/src/app/settings/hooks/useAuditLogs.ts
+++ b/src/app/settings/hooks/useAuditLogs.ts
@@ -1,6 +1,12 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from "react"
 
 import type { AuditLogFilter } from "@/electron-src/lib/prisma/auditQuery"
 import type { AuditLogEntry } from "@/types/electron/auditLogApi"
@@ -14,7 +20,8 @@ interface UseAuditLogsResult {
   loadingMore: boolean
   error: string | null
   filter: AuditLogFilter
-  setFilter: (filter: AuditLogFilter) => void
+  /** 直前のフィルタを受け取る更新関数も渡せる（デバウンス中の取りこぼしを防ぐため） */
+  setFilter: Dispatch<SetStateAction<AuditLogFilter>>
   hasMore: boolean
   loadMore: () => void
 }
@@ -87,10 +94,6 @@ export function useAuditLogs(): UseAuditLogsResult {
     })()
   }, [entries.length, fetchPage, filter])
 
-  const setFilter = useCallback((next: AuditLogFilter) => {
-    setFilterState(next)
-  }, [])
-
   return {
     entries,
     total,
@@ -98,7 +101,7 @@ export function useAuditLogs(): UseAuditLogsResult {
     loadingMore,
     error,
     filter,
-    setFilter,
+    setFilter: setFilterState,
     hasMore: entries.length < total,
     loadMore,
   }

--- a/src/components/exams/04-question-group/components/QuestionAssignmentMatrixWithFillHandle.tsx
+++ b/src/components/exams/04-question-group/components/QuestionAssignmentMatrixWithFillHandle.tsx
@@ -2,7 +2,7 @@
 
 import type { Subtotal } from "@prisma/client"
 import { Grid3X3, RotateCcw } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -54,6 +54,43 @@ export function QuestionAssignmentMatrixWithFillHandle({
 
   // 全ての小計項目をフラットな配列に変換（列データ）
   const allSubtotals = subtotalGroups.flatMap((group) => group.subtotals)
+
+  // 既存の関連付けを読み込み
+  const loadAssignments = useCallback(async () => {
+    setLoading(true)
+    const newAssignments: AssignmentState = {}
+
+    for (const region of cropRegions) {
+      try {
+        const result = await window.electronAPI.getCropSubtotalsByCropRegionId(
+          region.id
+        )
+        if (result && Array.isArray(result)) {
+          newAssignments[region.id] = new Set(
+            result.map(
+              (cropSubtotal: CropSubtotalWithSubtotalGroup) =>
+                cropSubtotal.subtotalId
+            )
+          )
+        } else {
+          newAssignments[region.id] = new Set()
+        }
+      } catch {
+        newAssignments[region.id] = new Set()
+      }
+    }
+
+    setAssignments(newAssignments)
+    setOriginalAssignments(
+      Object.fromEntries(
+        Object.entries(newAssignments).map(([key, value]) => [
+          key,
+          Array.from(value),
+        ])
+      )
+    )
+    setLoading(false)
+  }, [cropRegions])
 
   // フィルハンドルのドラッグ管理
   const {
@@ -120,51 +157,13 @@ export function QuestionAssignmentMatrixWithFillHandle({
     },
   })
 
-  // 既存の関連付けを読み込み
-  const loadAssignments = async () => {
-    setLoading(true)
-    const newAssignments: AssignmentState = {}
-
-    for (const region of cropRegions) {
-      try {
-        const result = await window.electronAPI.getCropSubtotalsByCropRegionId(
-          region.id
-        )
-        if (result && Array.isArray(result)) {
-          newAssignments[region.id] = new Set(
-            result.map(
-              (cropSubtotal: CropSubtotalWithSubtotalGroup) =>
-                cropSubtotal.subtotalId
-            )
-          )
-        } else {
-          newAssignments[region.id] = new Set()
-        }
-      } catch {
-        newAssignments[region.id] = new Set()
-      }
-    }
-
-    setAssignments(newAssignments)
-    setOriginalAssignments(
-      Object.fromEntries(
-        Object.entries(newAssignments).map(([key, value]) => [
-          key,
-          Array.from(value),
-        ])
-      )
-    )
-    setLoading(false)
-  }
-
   useEffect(() => {
     if (cropRegions.length > 0) {
       loadAssignments()
     } else {
       setLoading(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cropRegions])
+  }, [cropRegions, loadAssignments])
 
   // チェックボックスの状態を変更（逐次保存）
   const handleAssignmentChange = async (

--- a/src/components/exams/04-question-group/components/SubtotalAssignmentMatrixWithFillHandle.tsx
+++ b/src/components/exams/04-question-group/components/SubtotalAssignmentMatrixWithFillHandle.tsx
@@ -2,7 +2,7 @@
 
 import type { Subtotal } from "@prisma/client"
 import { Calculator, RotateCcw } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -54,6 +54,48 @@ export function SubtotalAssignmentMatrixWithFillHandle({
 
   // 全ての小計項目をフラットな配列に変換（列データ）
   const allSubtotals = subtotalGroups.flatMap((group) => group.subtotals)
+
+  // 既存の関連付けを読み込み
+  const loadAssignments = useCallback(async () => {
+    setLoading(true)
+    const newAssignments: SubtotalAssignmentState = {}
+
+    for (const region of subtotalRegions) {
+      try {
+        const result = await window.electronAPI.getCropSubtotalsByCropRegionId(
+          region.id
+        )
+
+        if (result && Array.isArray(result)) {
+          newAssignments[region.id] = new Set(
+            result.map(
+              (definition: CropSubtotalWithSubtotalGroup) =>
+                definition.subtotalId
+            )
+          )
+        } else {
+          newAssignments[region.id] = new Set()
+        }
+      } catch (error) {
+        console.error(
+          `Error loading subtotal assignments for region ${region.id}:`,
+          error
+        )
+        newAssignments[region.id] = new Set()
+      }
+    }
+
+    setAssignments(newAssignments)
+    setOriginalAssignments(
+      Object.fromEntries(
+        Object.entries(newAssignments).map(([key, value]) => [
+          key,
+          Array.from(value),
+        ])
+      )
+    )
+    setLoading(false)
+  }, [subtotalRegions])
 
   // フィルハンドルのドラッグ管理
   const {
@@ -123,56 +165,13 @@ export function SubtotalAssignmentMatrixWithFillHandle({
     },
   })
 
-  // 既存の関連付けを読み込み
-  const loadAssignments = async () => {
-    setLoading(true)
-    const newAssignments: SubtotalAssignmentState = {}
-
-    for (const region of subtotalRegions) {
-      try {
-        const result = await window.electronAPI.getCropSubtotalsByCropRegionId(
-          region.id
-        )
-
-        if (result && Array.isArray(result)) {
-          newAssignments[region.id] = new Set(
-            result.map(
-              (definition: CropSubtotalWithSubtotalGroup) =>
-                definition.subtotalId
-            )
-          )
-        } else {
-          newAssignments[region.id] = new Set()
-        }
-      } catch (error) {
-        console.error(
-          `Error loading subtotal assignments for region ${region.id}:`,
-          error
-        )
-        newAssignments[region.id] = new Set()
-      }
-    }
-
-    setAssignments(newAssignments)
-    setOriginalAssignments(
-      Object.fromEntries(
-        Object.entries(newAssignments).map(([key, value]) => [
-          key,
-          Array.from(value),
-        ])
-      )
-    )
-    setLoading(false)
-  }
-
   useEffect(() => {
     if (subtotalRegions.length > 0) {
       loadAssignments()
     } else {
       setLoading(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subtotalRegions])
+  }, [subtotalRegions, loadAssignments])
 
   // チェックボックスの状態を変更（逐次保存）
   const handleAssignmentChange = async (

--- a/src/components/exams/06-student-answers/student-answer-table/components/ConfirmChangesModal.tsx
+++ b/src/components/exams/06-student-answers/student-answer-table/components/ConfirmChangesModal.tsx
@@ -6,7 +6,7 @@ import {
   ArrowRight,
   Loader2,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 
 import type { PendingChange } from "@/components/exams/06-student-answers/types"
 import { Button } from "@/components/ui/button"
@@ -55,14 +55,18 @@ export function ConfirmChangesModal({
   const [phase, setPhase] = useState<"list" | "confirm">("list")
   const [isApplying, setIsApplying] = useState(false)
 
-  const effectivePolicy = (change: PendingChange): PlacementScorePolicy =>
-    isPageChange(change) ? "discard" : (samePagePolicies[change.id] ?? "carry")
+  const effectivePolicy = useCallback(
+    (change: PendingChange): PlacementScorePolicy =>
+      isPageChange(change)
+        ? "discard"
+        : (samePagePolicies[change.id] ?? "carry"),
+    [samePagePolicies]
+  )
 
   const discardChanges = useMemo(
     () =>
       pendingChanges.filter((change) => effectivePolicy(change) === "discard"),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pendingChanges, samePagePolicies]
+    [pendingChanges, effectivePolicy]
   )
   const carryCount = pendingChanges.length - discardChanges.length
   const unackedCount = discardChanges.filter(

--- a/src/components/exams/07-score-at-once/ScoringIndividual/MasterAnswerView.tsx
+++ b/src/components/exams/07-score-at-once/ScoringIndividual/MasterAnswerView.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 interface MasterAnswerViewProps {
   /** 模範解答の画像URL（単一ページ用、後方互換） */
@@ -50,7 +57,12 @@ export const MasterAnswerView = forwardRef<
   },
   ref
 ) {
-  const urls = masterImageUrls ?? (masterImageUrl ? [masterImageUrl] : [])
+  // 単一URLも配列に揃える。毎レンダー新しい配列を作ると読み込みeffectが回り続けるため
+  // memo 化し、呼び出し側（ScoringMainView）が渡す安定した参照をそのまま活かす
+  const urls = useMemo(
+    () => masterImageUrls ?? (masterImageUrl ? [masterImageUrl] : []),
+    [masterImageUrls, masterImageUrl]
+  )
   const [loadedImages, setLoadedImages] = useState<HTMLImageElement[]>([])
   const internalRef = useRef<HTMLDivElement>(null)
 
@@ -100,8 +112,7 @@ export const MasterAnswerView = forwardRef<
     return () => {
       cancelled = true
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(urls)])
+  }, [urls])
 
   // ホイールズーム: Ctrl/Meta + ホイールを答案側コンテナに転送
   // 答案側の既存のwheelハンドラがzoom計算を行い、onZoomChanged経由で同期される

--- a/src/components/exams/07-score-at-once/hooks/useCommand.ts
+++ b/src/components/exams/07-score-at-once/hooks/useCommand.ts
@@ -15,7 +15,14 @@
  * ```
  */
 
-import { useCallback, useEffect, useId, useMemo, useRef } from "react"
+import {
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useId,
+  useMemo,
+  useRef,
+} from "react"
 
 import { useShortcutContext } from "../ScoringMain/contexts/ShortcutProvider"
 import type { CommandHandler, CommandMetadata } from "../types"
@@ -93,13 +100,13 @@ export function useCommand(
     handlerRef.current()
   }, [])
 
-  // メタデータを安定化（内容が変わらない限り再登録しない）
+  // メタデータは参照が毎レンダー変わりうるので、再登録の要否は内容の署名で判定する。
+  // 値そのものは Effect Event で読む（読むだけで再登録の引き金にはしない）
   const metadataSignature = useMemo(
     () => createMetadataSignature(options.metadata),
     [options.metadata]
   )
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- metadataSignature already reflects changes to options.metadata
-  const stableMetadata = useMemo(() => options.metadata, [metadataSignature])
+  const readMetadata = useEffectEvent(() => options.metadata)
 
   // when句を安定化
   const when = options.when || "true"
@@ -113,7 +120,7 @@ export function useCommand(
       registrationId,
       handler: stableHandler,
       when,
-      metadata: stableMetadata,
+      metadata: readMetadata(),
     }
 
     // コマンドを登録
@@ -127,7 +134,7 @@ export function useCommand(
     commandId,
     stableHandler,
     when,
-    stableMetadata,
+    metadataSignature,
     registerCommand,
     unregisterCommand,
   ])

--- a/src/components/exams/08-export/components/individual-report/SubtotalGroupSelector.tsx
+++ b/src/components/exams/08-export/components/individual-report/SubtotalGroupSelector.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useEffectEvent, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -24,58 +24,56 @@ export function SubtotalGroupSelector({
   const [groups, setGroups] = useState<SubtotalGroupInfo[]>([])
   const [loading, setLoading] = useState(true)
 
-  // グループ一覧を取得（ページ読み込み時のみ）
+  // 保存済みの選択を、実在するグループだけに整える。取得直後に一度だけ走る初期化であり、
+  // 以後の選択変更で再実行してはならない（全解除を打ち消してしまう）ため Effect Event にする
+  const reconcileSelection = useEffectEvent((availableGroupIds: string[]) => {
+    const restoredGroupIds = selection.selectedGroupIds
+    if (restoredGroupIds.length === 0) {
+      // 保存された選択が無い（初回）ときは全グループを選択
+      onChange({ enabled: true, selectedGroupIds: availableGroupIds })
+      return
+    }
+    const validGroupIds = restoredGroupIds.filter((groupId) =>
+      availableGroupIds.includes(groupId)
+    )
+    if (validGroupIds.length === 0) {
+      // 保存された選択がすべて消えていたら全グループへ戻す
+      onChange({ enabled: true, selectedGroupIds: availableGroupIds })
+      return
+    }
+    if (validGroupIds.length !== restoredGroupIds.length) {
+      // 消えたグループが混ざっていた分だけ取り除く
+      onChange({ enabled: true, selectedGroupIds: validGroupIds })
+    }
+  })
+
+  // グループ一覧を取得する
   useEffect(() => {
+    let cancelled = false
     const fetchGroups = async () => {
       try {
         setLoading(true)
         const result =
           await window.electronAPI.export.getSubtotalGroupsForReport(examId)
+        if (cancelled) return
         if (result.success && result.subtotalGroups) {
           setGroups(result.subtotalGroups)
-          const fetchedGroupIds = result.subtotalGroups.map(
-            (subtotalGroup) => subtotalGroup.id
-          )
-
-          // localStorageから復元された選択がある場合、有効なIDのみにフィルタ
-          // 復元された選択がない（初回）または無効な場合のみ、全グループを選択
-          if (selection.selectedGroupIds.length > 0) {
-            // 有効なグループIDのみにフィルタ
-            const validIds = selection.selectedGroupIds.filter((id) =>
-              fetchedGroupIds.includes(id)
+          if (result.subtotalGroups.length > 0) {
+            reconcileSelection(
+              result.subtotalGroups.map((subtotalGroup) => subtotalGroup.id)
             )
-            if (validIds.length > 0) {
-              // 有効な選択があればそのまま使用（localStorageの値を維持）
-              if (validIds.length !== selection.selectedGroupIds.length) {
-                // 無効なIDがあった場合のみ更新
-                onChange({
-                  enabled: true,
-                  selectedGroupIds: validIds,
-                })
-              }
-            } else {
-              // 有効な選択がない場合は全グループを選択
-              onChange({
-                enabled: true,
-                selectedGroupIds: fetchedGroupIds,
-              })
-            }
-          } else if (result.subtotalGroups.length > 0) {
-            // 初回（選択がない）の場合は全グループを選択
-            onChange({
-              enabled: true,
-              selectedGroupIds: fetchedGroupIds,
-            })
           }
         }
       } catch (error) {
         console.error("Failed to fetch subtotal groups:", error)
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
     fetchGroups()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true
+    }
   }, [examId])
 
   // グループがない場合は表示しない

--- a/src/components/exams/08-export/hooks/useExcelPreview.ts
+++ b/src/components/exams/08-export/hooks/useExcelPreview.ts
@@ -48,6 +48,7 @@ export interface ExcelPreviewData {
 
 interface UseExcelPreviewProps {
   examId: string
+  /** 呼び出し側で安定した参照を渡すこと（毎レンダー新しい配列だと再取得が止まらない） */
   selectedExamStudentIds: string[]
   enabled: boolean
 }
@@ -62,8 +63,6 @@ export function useExcelPreview({
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // selectedExamStudentIdsのJSON文字列でオブジェクト参照変化を無視
-  const selectedExamStudentIdsKey = JSON.stringify(selectedExamStudentIds)
 
   useEffect(() => {
     if (!enabled || !examId || selectedExamStudentIds.length === 0) {
@@ -145,8 +144,7 @@ export function useExcelPreview({
         clearTimeout(debounceTimerRef.current)
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [examId, selectedExamStudentIdsKey, enabled])
+  }, [examId, selectedExamStudentIds, enabled])
 
   return { previewData, isLoading, error }
 }


### PR DESCRIPTION
Closes #1111

## 概要

`eslint-disable` コメント 11 件をすべて解消し、違反ゼロになった 2 つのルールを error へ昇格した。抑制コメントは残していない。

## react-hooks/exhaustive-deps（8 件）

依存を ref で迂回するのではなく、**参照が毎レンダー変わる原因側**を直した。

| 箇所 | 直し方 |
| --- | --- |
| `AuditLogsTab` | `setFilter` を `Dispatch<SetStateAction>` にし更新関数形へ。無意味な `useCallback` ラッパも削除 |
| `SubtotalGroupSelector` | 保存済み選択の整合を `useEffectEvent` へ切り出し。取得 effect は `[examId]` のみ＋キャンセル処理を追加 |
| `useExcelPreview` | `JSON.stringify` によるキーを廃止し配列を直接依存へ |
| `MasterAnswerView` | `urls` の生成を `useMemo` 化し `[urls]` を依存に |
| `useCommand` | 依存を偽装していた中間 `useMemo` を廃し `useEffectEvent` へ |
| `ConfirmChangesModal` | `effectivePolicy` を `useCallback` 化 |
| Matrix 2 件 | `loadAssignments` を `useCallback` 化して fill-handle フックより前へ移動 |

`useExcelPreview` と `MasterAnswerView` は、呼び出し側（`ExportMainView.tsx:86`、`ScoringMainView.tsx:616`）が**既に `useMemo` で安定した配列を渡していた**ため、キー化も ref も不要だった。

### 挙動に関する注記

- `AuditLogsTab`: 更新関数形にしたことで、デバウンス待機中に他のフィルタが変わっても上書きしなくなる（潜在バグの解消）
- `SubtotalGroupSelector`: 整合処理は「取得直後に一度だけ」の初期化なので `useEffectEvent` にした。常時整合する effect に書き換えると、ユーザーの「全解除」を即座に打ち消してしまうため

## @typescript-eslint/no-explicit-any（3 件）

`ipcHandlerUtils` の `(...args: any[]) => any` をジェネリクスへ置換した。`ipcMain.handle` のリスナーは可変長引数が `any[]` 宣言なので、こちら側で型変数として受け直せる。`as` も不要。

```ts
export function registerHandler<HandlerArgs extends unknown[], HandlerResult>(
  channel: string,
  handler: (...args: HandlerArgs) => HandlerResult | Promise<HandlerResult>
): void {
  ipcMain.handle(channel, async (_event, ...args: HandlerArgs) => { ... })
}
```

この結果、**`any` が隠していた型欠落が 8 件露出した**（`activeOnly = true` のように既定値だけで型注釈がない引数が `unknown` になる）。型注釈を明示して解消済み。IPC 引数の型が呼び出し側から推論されるようになった。

テストヘルパー 2 件は `delete (window as any)` を `Reflect.deleteProperty` へ。`window.electronAPI` は必須プロパティ宣言のため `delete` 演算子が使えないが、`Reflect` なら型を偽らずに実行時のプロパティだけ取り除ける。

## eslint.config.mjs

違反ゼロになったので昇格した。

- `react-hooks/exhaustive-deps`: warn → **error**
- `@typescript-eslint/no-explicit-any`: warn → **error**（CLAUDE.md の「any は原則禁止」を機械的に担保）

## 検証

- `npm run check-all`: **0 errors / 67 warnings**、format 通過
  - 67 件はすべて既存の `react-hooks/set-state-in-effect` で、本 PR で増減なし
- `npx vitest run`: **1193 passed / 117 files**
- `eslint-disable` の残存: **0 件**

## 残件（本 PR の対象外）

- `set-state-in-effect` 67 件のうち、多段パイプライン型の約 13 件は連鎖レンダーの実害がありうるため別途対応
- 残る約 50 件は「effect から非同期ローダーを呼ぶ」形。解消には取得層（クエリライブラリまたは自作キャッシュ）の導入判断が必要
- `as` 351 箇所 / 166 ファイルを検出するルールは未設定