### PR TITLE
feat(grade): 境界セットの削除と評価項目の並び替えをUIへ繋ぐ

### DIFF
--- a/src/components/grades/03-data-sources/DataSourcesContainer.tsx
+++ b/src/components/grades/03-data-sources/DataSourcesContainer.tsx
@@ -2,7 +2,7 @@
 
 import type { DragEndEvent } from "@dnd-kit/core"
 import { arrayMove } from "@dnd-kit/sortable"
-import { Pencil, Plus, Settings, Trash2, Users } from "lucide-react"
+import { Plus, Settings, Users } from "lucide-react"
 import Link from "next/link"
 import { useCallback, useState } from "react"
 import { toast } from "sonner"
@@ -31,6 +31,7 @@ import type {
 
 import { AddDataSourceInline } from "./AddDataSourceInline"
 import { DataSourceRow } from "./DataSourceRow"
+import { GradeItemSection } from "./GradeItemSection"
 import { StudentExclusionModal } from "./StudentExclusionModal"
 
 interface DataSourcesContainerProps {
@@ -45,6 +46,7 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     createGradeItem,
     updateGradeItem,
     deleteGradeItem,
+    reorderGradeItems,
     createDataSource,
     updateDataSource,
     batchUpdateDataSources,
@@ -54,8 +56,6 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
   } = useDataSources(gradeId)
 
   const [newItemName, setNewItemName] = useState("")
-  const [editingItemId, setEditingItemId] = useState<string | null>(null)
-  const [editingItemName, setEditingItemName] = useState("")
 
   // 対象生徒モーダル
   const [exclusionModalOpen, setExclusionModalOpen] = useState(false)
@@ -109,6 +109,49 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     [reorderDataSources]
   )
 
+  const handleGradeItemDragEnd = useCallback(
+    (gradeItems: GradeItemWithDataSources[]) => (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = gradeItems.findIndex(
+        (gradeItem) => gradeItem.id === active.id
+      )
+      const newIndex = gradeItems.findIndex(
+        (gradeItem) => gradeItem.id === over.id
+      )
+      if (oldIndex === -1 || newIndex === -1) return
+      const reordered = arrayMove(gradeItems, oldIndex, newIndex)
+      void reorderGradeItems(
+        reordered.map((gradeItem, index) => ({
+          id: gradeItem.id,
+          order: index,
+        }))
+      )
+    },
+    [reorderGradeItems]
+  )
+
+  const handleRenameGradeItem = useCallback(
+    async (gradeItemId: string, name: string) => {
+      await updateGradeItem(gradeItemId, name)
+    },
+    [updateGradeItem]
+  )
+
+  const handleDeleteGradeItem = useCallback(
+    async (gradeItemId: string) => {
+      const result = await deleteGradeItem(gradeItemId)
+      // 制約ルールの集計対象が変わると判定の意味が変わるため無効化される。
+      // 黙って着色が消えるのを避け、その場で知らせる。
+      if (result.disabledConstraintNames?.length) {
+        toast.warning(
+          `制約ルール「${result.disabledConstraintNames.join("」「")}」を無効化しました（集計対象が変わったため再設定してください）`
+        )
+      }
+    },
+    [deleteGradeItem]
+  )
+
   // 一括欠測設定
   const [batchMode, setBatchMode] = useState(false)
   const [selectedDataSourceIds, setSelectedDataSourceIds] = useState<
@@ -135,18 +178,6 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
     if (!newItemName.trim()) return
     await createGradeItem(newItemName.trim())
     setNewItemName("")
-  }
-
-  const handleStartEditItem = (item: GradeItemWithDataSources) => {
-    setEditingItemId(item.id)
-    setEditingItemName(item.name)
-  }
-
-  const handleSaveEditItem = async () => {
-    if (!editingItemId || !editingItemName.trim()) return
-    await updateGradeItem(editingItemId, editingItemName.trim())
-    setEditingItemId(null)
-    setEditingItemName("")
   }
 
   const toggleDsSelection = (dataSourceId: string) => {
@@ -373,100 +404,50 @@ export function DataSourcesContainer({ gradeId }: DataSourcesContainerProps) {
       )}
 
       {/* GradeItem ごとのセクション */}
-      {exam.gradeItems.map((gradeItem) => (
-        <div key={gradeItem.id} className="mb-8 rounded-lg border p-4">
-          {/* GradeItem ヘッダー */}
-          <div className="mb-3 flex items-center justify-between">
-            {editingItemId === gradeItem.id ? (
-              <div className="flex items-center gap-2">
-                <Input
-                  value={editingItemName}
-                  onChange={(e) => setEditingItemName(e.target.value)}
-                  className="h-8 w-48"
-                  onKeyDown={(e) =>
-                    e.key === "Enter" &&
-                    !e.nativeEvent.isComposing &&
-                    handleSaveEditItem()
-                  }
-                  autoFocus
-                />
-                <Button variant="ghost" size="sm" onClick={handleSaveEditItem}>
-                  保存
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setEditingItemId(null)}
-                >
-                  取消
-                </Button>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2">
-                <h3 className="text-sm font-semibold text-blue-600">
-                  {gradeItem.name}
-                </h3>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-6 w-6"
-                  onClick={() => handleStartEditItem(gradeItem)}
-                >
-                  <Pencil className="h-3 w-3" />
-                </Button>
-              </div>
+      <SortableTableProvider
+        items={exam.gradeItems.map((gradeItem) => gradeItem.id)}
+        onDragEnd={handleGradeItemDragEnd(exam.gradeItems)}
+      >
+        {exam.gradeItems.map((gradeItem) => (
+          <GradeItemSection
+            key={gradeItem.id}
+            gradeItem={gradeItem}
+            onRename={handleRenameGradeItem}
+            onDelete={handleDeleteGradeItem}
+          >
+            {/* DataSource リスト */}
+            {gradeItem.dataSources.length > 0 && (
+              <SortableTableProvider
+                items={gradeItem.dataSources.map((dataSource) => dataSource.id)}
+                onDragEnd={handleDataSourceDragEnd(gradeItem.dataSources)}
+              >
+                <div className="mb-3 space-y-2">
+                  {gradeItem.dataSources.map((dataSource) => (
+                    <DataSourceRow
+                      key={dataSource.id}
+                      dataSource={dataSource}
+                      allDataSources={allDataSources}
+                      sourceFit={sourceFits[dataSource.id]}
+                      batchMode={batchMode}
+                      selected={selectedDataSourceIds.has(dataSource.id)}
+                      onToggleSelect={toggleDsSelection}
+                      onUpdate={updateDataSource}
+                      onDelete={deleteDataSource}
+                    />
+                  ))}
+                </div>
+              </SortableTableProvider>
             )}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-destructive"
-              onClick={async () => {
-                const result = await deleteGradeItem(gradeItem.id)
-                // 制約ルールの集計対象が変わると判定の意味が変わるため無効化される。
-                // 黙って着色が消えるのを避け、その場で知らせる。
-                if (result.disabledConstraintNames?.length) {
-                  toast.warning(
-                    `制約ルール「${result.disabledConstraintNames.join("」「")}」を無効化しました（集計対象が変わったため再設定してください）`
-                  )
-                }
-              }}
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
 
-          {/* DataSource リスト */}
-          {gradeItem.dataSources.length > 0 && (
-            <SortableTableProvider
-              items={gradeItem.dataSources.map((dataSource) => dataSource.id)}
-              onDragEnd={handleDataSourceDragEnd(gradeItem.dataSources)}
-            >
-              <div className="mb-3 space-y-2">
-                {gradeItem.dataSources.map((dataSource) => (
-                  <DataSourceRow
-                    key={dataSource.id}
-                    dataSource={dataSource}
-                    allDataSources={allDataSources}
-                    sourceFit={sourceFits[dataSource.id]}
-                    batchMode={batchMode}
-                    selected={selectedDataSourceIds.has(dataSource.id)}
-                    onToggleSelect={toggleDsSelection}
-                    onUpdate={updateDataSource}
-                    onDelete={deleteDataSource}
-                  />
-                ))}
-              </div>
-            </SortableTableProvider>
-          )}
-
-          {/* インラインデータソース追加 */}
-          <AddDataSourceInline
-            gradeItemId={gradeItem.id}
-            onCreate={createDataSource}
-            onCreated={reload}
-          />
-        </div>
-      ))}
+            {/* インラインデータソース追加 */}
+            <AddDataSourceInline
+              gradeItemId={gradeItem.id}
+              onCreate={createDataSource}
+              onCreated={reload}
+            />
+          </GradeItemSection>
+        ))}
+      </SortableTableProvider>
 
       {exam.gradeItems.length === 0 && (
         <div className="py-8 text-center text-sm text-muted-foreground">

--- a/src/components/grades/03-data-sources/GradeItemSection.tsx
+++ b/src/components/grades/03-data-sources/GradeItemSection.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { Pencil, Trash2 } from "lucide-react"
+import { useState } from "react"
+
+import { DragHandle, useSortableRow } from "@/components/common/sortable-table"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { GradeItemWithDataSources } from "@/types/grade.types"
+
+interface GradeItemSectionProps {
+  gradeItem: GradeItemWithDataSources
+  onRename: (gradeItemId: string, name: string) => Promise<void>
+  onDelete: (gradeItemId: string) => Promise<void>
+  /** 配下のデータソース一覧と追加フォーム */
+  children: React.ReactNode
+}
+
+/**
+ * 評価項目1件の枠。並び替え（ドラッグ）・名称のインライン編集・削除を担う。
+ *
+ * 配下のデータソース一覧は children として受け取るため、データソース側の DnD は
+ * この枠の内側で別の DndContext として完結する（掴む要素が重ならないので競合しない）。
+ */
+export function GradeItemSection({
+  gradeItem,
+  onRename,
+  onDelete,
+  children,
+}: GradeItemSectionProps) {
+  const { setNodeRef, style, dragHandleProps } = useSortableRow(gradeItem.id)
+  // null は非編集中。編集中の名前そのものを状態に持ち、フラグを別に持たない
+  const [editingName, setEditingName] = useState<string | null>(null)
+
+  const handleSaveName = async () => {
+    const trimmedName = editingName?.trim()
+    if (!trimmedName) return
+    await onRename(gradeItem.id, trimmedName)
+    setEditingName(null)
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="mb-8 flex gap-2 rounded-lg border p-4"
+    >
+      <DragHandle dragHandleProps={dragHandleProps} className="mt-1 h-fit" />
+      <div className="min-w-0 flex-1">
+        <div className="mb-3 flex items-center justify-between">
+          {editingName !== null ? (
+            <div className="flex items-center gap-2">
+              <Input
+                value={editingName}
+                onChange={(e) => setEditingName(e.target.value)}
+                className="h-8 w-48"
+                onKeyDown={(e) =>
+                  e.key === "Enter" &&
+                  !e.nativeEvent.isComposing &&
+                  handleSaveName()
+                }
+                autoFocus
+              />
+              <Button variant="ghost" size="sm" onClick={handleSaveName}>
+                保存
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setEditingName(null)}
+              >
+                取消
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-semibold text-blue-600">
+                {gradeItem.name}
+              </h3>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => setEditingName(gradeItem.name)}
+              >
+                <Pencil className="h-3 w-3" />
+              </Button>
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-destructive"
+            onClick={() => onDelete(gradeItem.id)}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/grades/05-boundaries/BoundariesContainer.tsx
+++ b/src/components/grades/05-boundaries/BoundariesContainer.tsx
@@ -1,11 +1,25 @@
 "use client"
 
+import { Trash2 } from "lucide-react"
 import Link from "next/link"
+import { useState } from "react"
+import { toast } from "sonner"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { useBoundaries } from "@/hooks/grades/useBoundaries"
+import type { GradeBoundarySetWithItemAndBoundaries } from "@/types/grade.types"
 
 import { BoundaryEditor } from "./BoundaryEditor"
 import { BoundaryPresetSelector } from "./BoundaryPresetSelector"
@@ -16,8 +30,11 @@ interface BoundariesContainerProps {
 }
 
 export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
-  const { exam, boundarySets, loading, saveBoundarySet } =
+  const { exam, boundarySets, loading, saveBoundarySet, deleteBoundarySet } =
     useBoundaries(gradeId)
+
+  const [deletionTargetBoundarySet, setDeletionTargetBoundarySet] =
+    useState<GradeBoundarySetWithItemAndBoundaries | null>(null)
 
   if (loading || !exam) {
     return (
@@ -29,18 +46,26 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
 
   const gradeItems = exam.gradeItems
 
-  const getExistingBoundaries = (gradeItemId: string) => {
-    const matchedBoundarySet = boundarySets.find(
-      (boundarySet) => boundarySet.gradeItemId === gradeItemId
-    )
-    return matchedBoundarySet?.boundaries ?? []
-  }
+  const findBoundarySet = (gradeItemId: string) =>
+    boundarySets.find((boundarySet) => boundarySet.gradeItemId === gradeItemId)
 
   const handleSave = async (
     gradeItemId: string,
     boundaries: { label: string; minPercentage: number; order: number }[]
   ) => {
     await saveBoundarySet({ gradeItemId, boundaries })
+  }
+
+  const handleDelete = async (
+    targetBoundarySet: GradeBoundarySetWithItemAndBoundaries
+  ) => {
+    const result = await deleteBoundarySet(targetBoundarySet.id)
+    if (!result.success) {
+      toast.error("成績境界を削除できませんでした", {
+        description: result.error,
+      })
+    }
+    setDeletionTargetBoundarySet(null)
   }
 
   return (
@@ -51,18 +76,34 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
       </p>
 
       <div className="space-y-4">
-        {gradeItems.map((gradeItem) => (
-          <Card key={gradeItem.id} className="space-y-3 p-4">
-            <h3 className="text-base font-semibold">{gradeItem.name}</h3>
-            <BoundaryPresetSelector
-              onSelect={(boundaries) => handleSave(gradeItem.id, boundaries)}
-            />
-            <BoundaryEditor
-              boundaries={getExistingBoundaries(gradeItem.id)}
-              onSave={(boundaries) => handleSave(gradeItem.id, boundaries)}
-            />
-          </Card>
-        ))}
+        {gradeItems.map((gradeItem) => {
+          const boundarySet = findBoundarySet(gradeItem.id)
+          return (
+            <Card key={gradeItem.id} className="space-y-3 p-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-base font-semibold">{gradeItem.name}</h3>
+                {boundarySet && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive"
+                    onClick={() => setDeletionTargetBoundarySet(boundarySet)}
+                  >
+                    <Trash2 className="mr-1 h-3.5 w-3.5" />
+                    境界設定を削除
+                  </Button>
+                )}
+              </div>
+              <BoundaryPresetSelector
+                onSelect={(boundaries) => handleSave(gradeItem.id, boundaries)}
+              />
+              <BoundaryEditor
+                boundarySet={boundarySet}
+                onSave={(boundaries) => handleSave(gradeItem.id, boundaries)}
+              />
+            </Card>
+          )
+        })}
       </div>
 
       <Separator className="my-8" />
@@ -78,6 +119,37 @@ export function BoundariesContainer({ gradeId }: BoundariesContainerProps) {
           <Link href={`/grades/${gradeId}/06-results`}>次へ: 結果</Link>
         </Button>
       </div>
+
+      <AlertDialog
+        open={deletionTargetBoundarySet !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletionTargetBoundarySet(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              「{deletionTargetBoundarySet?.gradeItem.name}
+              」の成績境界を削除しますか？
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              この評価項目には成績ラベルが付かなくなり、結果画面と出力のラベル欄が空になります。確定済みの成績値に記録されたラベルはそのまま残ります。制約ルールが選べるラベルからもこの評価項目のラベルが外れるため、そのラベルを使っているルールは設定し直してください。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deletionTargetBoundarySet) {
+                  void handleDelete(deletionTargetBoundarySet)
+                }
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/components/grades/05-boundaries/BoundaryEditor.tsx
+++ b/src/components/grades/05-boundaries/BoundaryEditor.tsx
@@ -13,10 +13,11 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
-import type { GradeBoundaryData } from "@/types/grade.types"
+import type { GradeBoundarySetWithItemAndBoundaries } from "@/types/grade.types"
 
 interface BoundaryEditorProps {
-  boundaries: GradeBoundaryData[]
+  /** 対象評価項目の境界セット。まだ作られていなければ undefined */
+  boundarySet: GradeBoundarySetWithItemAndBoundaries | undefined
   onSave: (
     boundaries: { label: string; minPercentage: number; order: number }[]
   ) => Promise<void>
@@ -36,25 +37,26 @@ let nextId = 1
  * ラベルと最低パーセンテージの組み合わせを編集し、変更を500msデバウンスで自動保存する。
  * DnDで行を並び替え可能。minPercentageが降順でない場合は赤い枠線で警告する。
  */
-export function BoundaryEditor({ boundaries, onSave }: BoundaryEditorProps) {
+export function BoundaryEditor({ boundarySet, onSave }: BoundaryEditorProps) {
   const [items, setItems] = useState<EditableBoundary[]>([])
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // 境界セット自体を依存に取る。未作成のうちは undefined で参照が変わらないため、
+  // 保存前に追加した行が再レンダリングのたびに消えることはない。セットが削除されて
+  // undefined へ戻ったときだけ行が空に戻る。
   useEffect(() => {
-    if (boundaries.length > 0) {
-      const sorted = [...boundaries].sort(
-        (firstBoundary, secondBoundary) =>
-          secondBoundary.minPercentage - firstBoundary.minPercentage
-      )
-      setItems(
-        sorted.map((boundary) => ({
-          id: `boundary-${nextId++}`,
-          label: boundary.label,
-          minPercentage: String(boundary.minPercentage),
-        }))
-      )
-    }
-  }, [boundaries])
+    const sorted = [...(boundarySet?.boundaries ?? [])].sort(
+      (firstBoundary, secondBoundary) =>
+        secondBoundary.minPercentage - firstBoundary.minPercentage
+    )
+    setItems(
+      sorted.map((boundary) => ({
+        id: `boundary-${nextId++}`,
+        label: boundary.label,
+        minPercentage: String(boundary.minPercentage),
+      }))
+    )
+  }, [boundarySet])
 
   const debouncedSave = useCallback(
     (updatedItems: EditableBoundary[]) => {

--- a/src/components/grades/06-results/EditableGradeLabel.tsx
+++ b/src/components/grades/06-results/EditableGradeLabel.tsx
@@ -60,10 +60,6 @@ export function EditableGradeLabel({
     [commit]
   )
 
-  if (!gradeLabel && !overrideLabel) {
-    return <span className="text-xs text-muted-foreground">-</span>
-  }
-
   if (editing) {
     return (
       <input
@@ -76,6 +72,20 @@ export function EditableGradeLabel({
         placeholder={gradeLabel ?? ""}
         autoFocus
       />
+    )
+  }
+
+  // 境界未設定でも上書きは可能。観点別評価のラベルは教員の任意文字列で、境界は
+  // 自動算出の補助にすぎないため、境界が無いことを入力の制約にしてはならない。
+  if (!gradeLabel && !overrideLabel) {
+    return (
+      <span
+        className="cursor-pointer text-xs text-muted-foreground hover:text-foreground"
+        title="クリックして成績ラベルを手動入力"
+        onClick={startEdit}
+      >
+        -
+      </span>
     )
   }
 

--- a/src/hooks/grades/useBoundaries.ts
+++ b/src/hooks/grades/useBoundaries.ts
@@ -54,5 +54,17 @@ export function useBoundaries(gradeId: string) {
     [gradeId, loadData]
   )
 
-  return { exam, boundarySets, loading, saveBoundarySet }
+  const deleteBoundarySet = useCallback(
+    async (boundarySetId: string) => {
+      const result =
+        await window.electronAPI.grade.deleteBoundarySet(boundarySetId)
+      if (result.success) {
+        await loadData()
+      }
+      return result
+    },
+    [loadData]
+  )
+
+  return { exam, boundarySets, loading, saveBoundarySet, deleteBoundarySet }
 }

--- a/src/hooks/grades/useDataSources.ts
+++ b/src/hooks/grades/useDataSources.ts
@@ -94,6 +94,18 @@ export function useDataSources(gradeId: string) {
     [loadData, loadSourceFits]
   )
 
+  const reorderGradeItems = useCallback(
+    async (gradeItemOrders: { id: string; order: number }[]) => {
+      const result =
+        await window.electronAPI.grade.reorderGradeItems(gradeItemOrders)
+      if (result.success) {
+        await loadData()
+      }
+      return result
+    },
+    [loadData]
+  )
+
   const createDataSource = useCallback(
     async (data: {
       gradeItemId: string
@@ -228,6 +240,7 @@ export function useDataSources(gradeId: string) {
     createGradeItem,
     updateGradeItem,
     deleteGradeItem,
+    reorderGradeItems,
     createDataSource,
     updateDataSource,
     batchUpdateDataSources,


### PR DESCRIPTION
Closes #1101
Closes #1113

## 概要

main 側は実装済みで UI 導線だけが無かった API 2 件を接続する。作業中に見つかった「境界未設定だと手動上書きの入口ごと消える」問題（#1113）も併せて直す。

## 1. 境界セットの削除（#1101）

`grade.deleteBoundarySet` は lib → IPC → preload → 型定義まで揃っていたが、呼び出し元が統合テストだけだった。

- `05-boundaries` の各評価項目カードに「境界設定を削除」ボタンを追加（境界セットが存在するときだけ表示）
- `AlertDialog` で影響を提示してから削除する

**使用中の境界セットの扱い** — `GradeBoundarySet` は `@@unique([gradeId, gradeItemId])` で評価項目と 1:1 であり、他テーブルから参照する FK は存在しない（子の `GradeBoundary` のみ cascade）。つまり「未使用の境界セット」という状態自体が無く、存在する＝使用中である。そこで削除はブロックせず、確認ダイアログで結果を明示する方針とした。

- この評価項目に成績ラベルが付かなくなる
- 確定済み（`GradeFrozenScore`）に記録されたラベルはそのまま残る
- 制約ルールが選べるラベルからこの項目のラベルが外れる

**なぜ削除できる必要があるか** — 従来も `BoundaryEditor` で全行消せば境界を 0 件にはできたが、`upsertBoundarySet` は既存セットの子だけを入れ替える実装なので **親のセット行が空のまま残る**。`gradeStatus.ts` の進捗判定は `_count.boundarySets > 0` を見ているため、境界が 0 件でも「境界設定済み」と判定され続けていた。

**`BoundaryEditor` の prop 変更が必須だった理由** — 従来は `boundaries.length > 0` のときだけ state へ取り込む実装で、セットを消しても編集行が画面に残る。かといって単に条件を外すと、未作成時に親が毎レンダー新しい `[]` を渡すため保存前に追加した行が即座に消える。参照の安定した境界セット実体（未作成なら `undefined`）を依存に取ることで両立させた。

## 2. 評価項目の並び替え（#1101）

データソース・学級は並び替えられるのに評価項目だけできず、出力の列順が制御できなかった。

- `GradeItem` セクションを `SortableTableProvider` で包み `grade.reorderGradeItems` へ接続
- 既存の `components/common/sortable-table`（dnd-kit）を使用。楽観更新なし・成功後リロードという `reorderDataSources` と同じ挙動に揃えた
- 枠と見出し操作を `GradeItemSection.tsx` へ切り出し、改名の編集状態をローカル state へ移した（`DataSourcesContainer` は 498 → 479 行）

データソース側の DnD が評価項目枠の内側にネストするが、掴むハンドルが別要素なので競合しない。

## 3. 境界未設定でも手動入力できるようにする（#1113）

- 空セルからも編集を開始できるようにした
- `if (editing)` の分岐を空セル判定より前へ移動。順序が逆のままでは `editing` が立っても空セル分岐が先に返り、入力欄が描画されない

## 検証

- `npm run check-all` — exit 0（typecheck / eslint / tailwind 正規化 / prettier）
- `npm run check:hooks` — 未使用のフック返り値なし
- 新規の ESLint 指摘・`eslint-disable` の追加はゼロ。`BoundaryEditor` と `useBoundaries` に残る `react-hooks/set-state-in-effect` 警告は変更前から同数存在するもの
- 対象コンポーネントの既存テストは無いため追加していない

## スキーマ変更

なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)