### PR TITLE
fix(schema): 監査の残作業を潰し、同期漏れと中間テーブルのid衝突を塞ぐ

### DIFF
--- a/__tests__/exam/integration/subtotalGroupSelection.test.ts
+++ b/__tests__/exam/integration/subtotalGroupSelection.test.ts
@@ -7,6 +7,8 @@
 import * as path from "path"
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { buildExamSubtotalGroupId } from "../../../electron-src/lib/prisma/deterministicId"
+
 const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
 
 vi.mock("../../../electron-src/lib/prisma/client", async () => {
@@ -18,6 +20,7 @@ vi.mock("../../../electron-src/lib/prisma/client", async () => {
 })
 
 import {
+  addSubtotalGroupToExam,
   getSubtotalGroupSelection,
   setSubtotalGroupSelection,
 } from "@/electron-src/lib/prisma/subtotalGroup"
@@ -40,7 +43,11 @@ async function createTestData() {
   for (const name of ["国語", "数学", "英語"]) {
     const group = await testPrisma.subtotalGroup.create({ data: { name } })
     await testPrisma.examSubtotalGroup.create({
-      data: { examId: exam.id, subtotalGroupId: group.id },
+      data: {
+        id: buildExamSubtotalGroupId(exam.id, group.id),
+        examId: exam.id,
+        subtotalGroupId: group.id,
+      },
     })
     groupIds.push(group.id)
   }
@@ -97,5 +104,44 @@ describe("小計グループ出力選択フラグ", () => {
     const selection = await getSubtotalGroupSelection(exam.id)
     expect(selection.tableGroupIds).toEqual([])
     expect(selection.boxPlotGroupIds).toEqual([])
+  })
+})
+
+describe("試験への小計グループ追加", () => {
+  it("同じ組み合わせを2回追加しても1行のまま（重複でフラグが二重化しない）", async () => {
+    // 重複すると selectedForTable / selectedForBoxPlot が行ごとに食い違い、
+    // どちらが効くかが読み取り順次第になる
+    const exam = await testPrisma.exam.create({
+      data: { examName: "重複テスト" },
+    })
+    const group = await testPrisma.subtotalGroup.create({
+      data: { name: "国語" },
+    })
+
+    const first = await addSubtotalGroupToExam(exam.id, group.id)
+    const second = await addSubtotalGroupToExam(exam.id, group.id)
+
+    expect(first.success).toBe(true)
+    expect(second.success).toBe(true)
+    expect(
+      await testPrisma.examSubtotalGroup.count({
+        where: { examId: exam.id, subtotalGroupId: group.id },
+      })
+    ).toBe(1)
+  })
+
+  it("idが(試験, 小計グループ)から決まる（2端末で同じidになりNAS同期で衝突しない）", async () => {
+    const exam = await testPrisma.exam.create({
+      data: { examName: "決定論的idテスト" },
+    })
+    const group = await testPrisma.subtotalGroup.create({
+      data: { name: "数学" },
+    })
+
+    const result = await addSubtotalGroupToExam(exam.id, group.id)
+
+    expect(result.examSubtotalGroup?.id).toBe(
+      buildExamSubtotalGroupId(exam.id, group.id)
+    )
   })
 })

--- a/__tests__/helpers/ipcHandlerHarness.ts
+++ b/__tests__/helpers/ipcHandlerHarness.ts
@@ -1,0 +1,43 @@
+/**
+ * IPCハンドラをテストから直接呼ぶためのハーネス
+ *
+ * `__tests__/setup.ts` が electron の `ipcMain.handle` を `vi.fn()` に差し替えているので、
+ * `registerXxxHandlers()` を呼ぶとコールバックはモックに記録されるだけで実行できない。
+ * 記録された呼び出しからチャンネル名でコールバックを取り出し、`_event` を補って呼ぶ。
+ *
+ * これが無いと、ハンドラに書いた分岐（「対象が1件も無ければエラーを返す」等）を
+ * 実行時に検証できない。main の関数に切り出せる処理はそちらでテストする方が軽いので、
+ * ハーネスを使うのは「ハンドラ自身が持つ判断」を見たいときに限る。
+ */
+import { ipcMain } from "electron"
+import { expect, vi } from "vitest"
+
+type RegisteredHandler = (
+  event: unknown,
+  ...args: unknown[]
+) => unknown | Promise<unknown>
+
+/**
+ * 登録済みハンドラを取り出す。
+ *
+ * @param registerHandlers - `registerOmrHandlers` 等の登録関数。呼ぶ前にモックを初期化する
+ * @param channel - `omr:detect-master-markers` 等のチャンネル名
+ */
+export function captureIpcHandler(
+  registerHandlers: () => void,
+  channel: string
+): (...args: unknown[]) => Promise<unknown> {
+  const handleMock = vi.mocked(ipcMain.handle)
+  handleMock.mockClear()
+
+  registerHandlers()
+
+  const registration = handleMock.mock.calls.find((call) => call[0] === channel)
+  expect(
+    registration,
+    `IPCチャンネル ${channel} が登録されていない`
+  ).toBeDefined()
+
+  const handler = registration![1] as RegisteredHandler
+  return async (...args: unknown[]) => handler({}, ...args)
+}

--- a/__tests__/helpers/testExamBuilder.ts
+++ b/__tests__/helpers/testExamBuilder.ts
@@ -7,6 +7,8 @@
 import type { CropRegion, PrismaClient } from "@prisma/client"
 import * as crypto from "crypto"
 
+import { buildExamSubtotalGroupId } from "../../electron-src/lib/prisma/deterministicId"
+
 interface FullTestExamOptions {
   /** ページ数 (default: 2) */
   pageCount?: number
@@ -288,7 +290,7 @@ export async function createFullTestExam(
   // 10. ExamSubtotalGroup作成
   const examSubtotalGroup = await prisma.examSubtotalGroup.create({
     data: {
-      id: crypto.randomUUID(),
+      id: buildExamSubtotalGroupId(exam.id, subtotalGroup.id),
       examId: exam.id,
       subtotalGroupId: subtotalGroup.id,
     },

--- a/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
+++ b/__tests__/import-export/integration/gradeArchiveRoundTrip.test.ts
@@ -14,6 +14,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { LegacyGradeArchiveData } from "../../../electron-src/lib/import/grade-transformers/legacyShape"
+import { buildExamSubtotalGroupId } from "../../../electron-src/lib/prisma/deterministicId"
 import type { GradeArchiveData } from "../../../src/types/gradeArchive.types"
 import {
   cleanupTestDatabase,
@@ -1658,7 +1659,11 @@ describe("grade-archive ラウンドトリップ", () => {
         data: { name: groupName },
       })
       await prisma.examSubtotalGroup.create({
-        data: { examId, subtotalGroupId: group.id },
+        data: {
+          id: buildExamSubtotalGroupId(examId, group.id),
+          examId,
+          subtotalGroupId: group.id,
+        },
       })
       return prisma.subtotal.create({
         data: { subtotalGroupId: group.id, name: "大問1", order: 0 },

--- a/__tests__/import-export/integration/idChangeExecutor.test.ts
+++ b/__tests__/import-export/integration/idChangeExecutor.test.ts
@@ -11,6 +11,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { IdChangeTarget } from "../../../electron-src/lib/import/merge/types"
+import { buildExamSubtotalGroupId } from "../../../electron-src/lib/prisma/deterministicId"
 import {
   createEmptyIdMappings,
   generateId,
@@ -65,7 +66,10 @@ describe("executeIdChanges", () => {
       })
 
       // ExamSubtotalGroup
-      const examSubtotalGroupId = generateId()
+      const examSubtotalGroupId = buildExamSubtotalGroupId(
+        examId,
+        existingGroupId
+      )
       await prisma.examSubtotalGroup.create({
         data: {
           id: examSubtotalGroupId,
@@ -114,9 +118,17 @@ describe("executeIdChanges", () => {
       })
       expect(oldGroup).toBeNull()
 
-      // FK参照が更新されていること
+      // FK参照が更新されていること。
+      // ExamSubtotalGroup は id が (試験, 小計グループ) から決まるので、
+      // 付け替えに伴って id も組み直される（旧idでは引けない）
+      expect(
+        await prisma.examSubtotalGroup.findUnique({
+          where: { id: examSubtotalGroupId },
+        })
+      ).toBeNull()
+
       const examSubtotalGroup = await prisma.examSubtotalGroup.findUnique({
-        where: { id: examSubtotalGroupId },
+        where: { id: buildExamSubtotalGroupId(examId, newGroupId) },
       })
       expect(examSubtotalGroup!.subtotalGroupId).toBe(newGroupId)
 
@@ -183,18 +195,16 @@ describe("executeIdChanges", () => {
       })
 
       // 複数のExamSubtotalGroup
-      const examSubtotalGroup1Id = generateId()
-      const examSubtotalGroup2Id = generateId()
       await prisma.examSubtotalGroup.create({
         data: {
-          id: examSubtotalGroup1Id,
+          id: buildExamSubtotalGroupId(exam1Id, existingGroupId),
           examId: exam1Id,
           subtotalGroupId: existingGroupId,
         },
       })
       await prisma.examSubtotalGroup.create({
         data: {
-          id: examSubtotalGroup2Id,
+          id: buildExamSubtotalGroupId(exam2Id, existingGroupId),
           examId: exam2Id,
           subtotalGroupId: existingGroupId,
         },
@@ -235,12 +245,12 @@ describe("executeIdChanges", () => {
         await executeIdChanges(targets, idMappings, warnings, tx)
       })
 
-      // 全てのFK参照が更新されていること
+      // 全てのFK参照が更新されていること（idも組み直される）
       const examSubtotalGroup1 = await prisma.examSubtotalGroup.findUnique({
-        where: { id: examSubtotalGroup1Id },
+        where: { id: buildExamSubtotalGroupId(exam1Id, newGroupId) },
       })
       const examSubtotalGroup2 = await prisma.examSubtotalGroup.findUnique({
-        where: { id: examSubtotalGroup2Id },
+        where: { id: buildExamSubtotalGroupId(exam2Id, newGroupId) },
       })
       expect(examSubtotalGroup1!.subtotalGroupId).toBe(newGroupId)
       expect(examSubtotalGroup2!.subtotalGroupId).toBe(newGroupId)

--- a/__tests__/import-export/unit/deterministicIdCoverage.test.ts
+++ b/__tests__/import-export/unit/deterministicIdCoverage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * 決定論的idテーブルの書き込み経路の網羅テスト
+ *
+ * `@id`（`@default(uuid())` 無し）で宣言されたテーブルは、idを親子キーから組み立てる
+ * 前提で運用する。`@default(uuid())` のままだと、2端末が同じ組み合わせを追加したときに
+ * id 違い・`@@unique` 同値の行ができてNAS同期で衝突するためで、同一idなら行レベルLWWが
+ * 1行へ収束する。
+ *
+ * この不変式は**DBが強制できない**（id は任意の文字列を受け付ける）。実際、
+ * ExamSubtotalGroup を決定論的idへ移した際、`crypto.randomUUID()` を書く経路が
+ * 取り残されて残り、後の取り込みが unique 違反で全滅する状態を作った。移行は実行時に
+ * あった行しか直さないので、取り残した経路は新しい旧形式の行を作り続ける。
+ *
+ * ここでは「決定論的idのテーブルへ id を渡さず create している箇所が無いか」を
+ * ソースから検査する。id を省くと Prisma が型エラーにするので TypeScript も守るが、
+ * uuid を渡す書き方は型では止められないため、生成関数の使用まで見る。
+ */
+import * as fs from "fs"
+import * as path from "path"
+import { describe, expect, it } from "vitest"
+
+const ROOT = path.resolve(__dirname, "../../..")
+const SCHEMA_PATH = path.join(ROOT, "prisma/schema.prisma")
+
+/** 決定論的id前提のモデル（`@id` のみで `@default` を持たない） */
+function deterministicIdModels(): string[] {
+  const schema = fs.readFileSync(SCHEMA_PATH, "utf-8")
+  return [...schema.matchAll(/model\s+(\w+)\s*\{([\s\S]*?)\n\}/g)]
+    .filter(([, , body]) => /^\s+id\s+String\s+@id\s*$/m.test(body))
+    .map(([, name]) => name)
+}
+
+/** 走査対象のソース（生成物・依存は除く） */
+function sourceFiles(): string[] {
+  const targets = ["electron-src", "src", "scripts", "__tests__"]
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === ".next") continue
+        walk(full)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        found.push(full)
+      }
+    }
+  }
+  for (const target of targets) walk(path.join(ROOT, target))
+  return found
+}
+
+/** モデル名 → Prisma クライアントのプロパティ名 */
+const toClientProperty = (model: string): string =>
+  model.charAt(0).toLowerCase() + model.slice(1)
+
+/** `openParenIndex` の丸括弧に対応する閉じ括弧までの中身を返す */
+function callArgument(text: string, openParenIndex: number): string {
+  let depth = 0
+  for (let i = openParenIndex; i < text.length; i++) {
+    if (text[i] === "(") depth++
+    else if (text[i] === ")") {
+      depth--
+      if (depth === 0) return text.slice(openParenIndex + 1, i)
+    }
+  }
+  return text.slice(openParenIndex + 1)
+}
+
+describe("決定論的idテーブルの書き込み経路", () => {
+  it("id を uuid で作っている箇所が無い", () => {
+    const models = deterministicIdModels()
+    expect(models.length).toBeGreaterThan(0)
+
+    const violations: string[] = []
+
+    for (const file of sourceFiles()) {
+      const text = fs.readFileSync(file, "utf-8")
+      for (const model of models) {
+        const property = toClientProperty(model)
+        const callPattern = new RegExp(
+          `\\.${property}\\.(create|upsert|createMany)\\(`,
+          "g"
+        )
+        for (const match of text.matchAll(callPattern)) {
+          // 引数の括弧を対応させて呼び出し1件分だけを取る。固定文字数で切ると
+          // 次の別モデルの生成コードを拾って誤検知する
+          const body = callArgument(text, match.index + match[0].length - 1)
+          if (/randomUUID\(\)|generateId\(\)|uuidv4\(\)/.test(body)) {
+            violations.push(
+              `${path.relative(ROOT, file)}: ${model}.${match[1]} に uuid を渡している`
+            )
+          }
+        }
+      }
+    }
+
+    // 決定論的idは deterministicId.ts の build*Id を使って組み立てること。
+    // uuid を渡すと、DB は受け付けるが2端末で別idの同値行ができて同期で衝突する
+    expect(violations).toEqual([])
+  })
+})

--- a/__tests__/migration/asbHeaderFieldTimestamps.test.ts
+++ b/__tests__/migration/asbHeaderFieldTimestamps.test.ts
@@ -1,0 +1,186 @@
+/**
+ * 20260802030000_asb_header_field_timestamps のデータ移行テスト
+ *
+ * 検証すること:
+ * - createdAt / updatedAt が**親 AsbDefinition の時刻**を引き継ぐ
+ * - 移行を走らせた時刻（now）が入らない
+ * - 他の列が変わらない
+ * - 定義の削除でカスケード削除される（作り直しでFKが壊れていない）
+ *
+ * updatedAt は sqlite-nas-sync の LWW 判定に使われる。ここに「移行を走らせた時刻」を
+ * 入れると、後からアップグレードした端末の触ってもいない行が、先にアップグレードした
+ * 端末の実際の編集を上回って勝ち、編集が黙って巻き戻る。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "asb-header-field-timestamps")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations")
+const TARGET_MIGRATION = "20260802030000_asb_header_field_timestamps"
+
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const migrationNames = (): string[] =>
+  fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const applyMigration = (db: SqliteDatabase, name: string): void => {
+  db.exec(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf-8")
+  )
+}
+
+async function buildDatabaseBeforeTargetMigration(): Promise<void> {
+  bootstrapSchema(DB_PATH)
+  const prisma = createPrismaClientForPath(DB_PATH)
+  try {
+    await createBaseline(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  const names = migrationNames()
+  const targetIndex = names.indexOf(TARGET_MIGRATION)
+  expect(targetIndex).toBeGreaterThan(0)
+
+  withDatabase((db) => {
+    for (const name of names.slice(0, targetIndex)) {
+      if (name === "20260322232329_init") continue
+      applyMigration(db, name)
+    }
+  })
+}
+
+const DEFINITION_CREATED = "2026-05-01T00:00:00.000+00:00"
+const DEFINITION_UPDATED = "2026-06-15T09:30:00.000+00:00"
+
+function seedLegacyRows(db: SqliteDatabase): void {
+  const run = (sql: string, params: unknown[]) => db.prepare(sql).run(params)
+
+  run(
+    `INSERT INTO "User" (id, username, name, role, createdAt, updatedAt) VALUES (?,?,?,?,?,?)`,
+    [
+      "user-1",
+      "teacher",
+      "教員",
+      "teacher",
+      DEFINITION_CREATED,
+      DEFINITION_CREATED,
+    ]
+  )
+  run(
+    `INSERT INTO "AsbDefinition" (id, name, userId, createdAt, updatedAt) VALUES (?,?,?,?,?)`,
+    ["def-1", "数学 解答用紙", "user-1", DEFINITION_CREATED, DEFINITION_UPDATED]
+  )
+  run(
+    `INSERT INTO "AsbHeaderField" (id, definitionId, type, label, widthMm, heightMm, gridCount, lineStyle, lineWidth, "order")
+     VALUES (?,?,?,?,?,?,?,?,?,?)`,
+    ["field-1", "def-1", "field", "氏名", 40, 8, 0, "solid", 0.4, 0]
+  )
+}
+
+interface HeaderFieldRow {
+  id: string
+  label: string
+  widthMm: number
+  order: number
+  createdAt: string
+  updatedAt: string
+}
+
+const readRows = (): HeaderFieldRow[] =>
+  withDatabase(
+    (db) =>
+      db
+        .prepare(
+          `SELECT id, label, widthMm, "order", createdAt, updatedAt
+           FROM "AsbHeaderField" ORDER BY "order" ASC`
+        )
+        .all() as HeaderFieldRow[]
+  )
+
+async function migrate(): Promise<void> {
+  await buildDatabaseBeforeTargetMigration()
+  withDatabase((db) => {
+    seedLegacyRows(db)
+    applyMigration(db, TARGET_MIGRATION)
+  })
+}
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("ヘッダー項目に作成日時・更新日時を足す", () => {
+  it("親の定義の時刻を引き継ぐ（移行を走らせた時刻を入れない）", async () => {
+    await migrate()
+
+    const [row] = readRows()
+    expect(row.createdAt).toBe(DEFINITION_CREATED)
+    expect(row.updatedAt).toBe(DEFINITION_UPDATED)
+  })
+
+  it("他の列は変わらない", async () => {
+    await migrate()
+
+    expect(readRows()[0]).toMatchObject({
+      id: "field-1",
+      label: "氏名",
+      widthMm: 40,
+      order: 0,
+    })
+  })
+
+  it("定義を消すとカスケード削除される（作り直しでFKが壊れていない）", async () => {
+    await migrate()
+
+    const definition = withDatabase(
+      (db) =>
+        db
+          .prepare(
+            `SELECT sql FROM sqlite_master WHERE type='table' AND name='AsbHeaderField'`
+          )
+          .get() as { sql: string }
+    )
+    expect(definition.sql).toContain('REFERENCES "AsbDefinition" ("id")')
+
+    const remaining = withDatabase((db) => {
+      db.pragma("foreign_keys = ON")
+      db.prepare(`DELETE FROM "AsbDefinition" WHERE id = 'def-1'`).run()
+      return db
+        .prepare(`SELECT COUNT(*) AS count FROM "AsbHeaderField"`)
+        .get() as { count: number }
+    })
+    expect(remaining.count).toBe(0)
+    expect(withDatabase((db) => db.pragma("foreign_key_check"))).toEqual([])
+  })
+})

--- a/__tests__/migration/examSubtotalGroupDeterministicId.test.ts
+++ b/__tests__/migration/examSubtotalGroupDeterministicId.test.ts
@@ -1,0 +1,209 @@
+/**
+ * 20260802040000_exam_subtotal_group_deterministic_id のデータ移行テスト
+ *
+ * 検証すること:
+ * - 重複行が1件へ潰れ、残るのは createdAt が最も古いもの
+ * - フラグは重複行をまたいで OR される（読み取り側が「1行でも true なら選択」のため）
+ * - 既存行のidが `examId:subtotalGroupId` へ振り直される
+ * - @@unique が効き、同じ組み合わせの2行目を作れない
+ * - 試験の削除でカスケード削除される（作り直しでFKが壊れていない）
+ *
+ * 手順は「本マイグレーションの1つ手前まで適用 → 旧形状のデータを投入 →
+ * 本マイグレーションだけを適用」。
+ */
+import Database from "better-sqlite3"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createBaseline } from "../../electron-src/lib/prisma/schema/baselineMigrations"
+import { bootstrapSchema } from "../../electron-src/lib/prisma/schema/schemaBootstrap"
+import { createPrismaClientForPath } from "../helpers/testPrismaClient"
+
+const TEST_ROOT = path.join(os.tmpdir(), "exam-subtotal-group-deterministic-id")
+const DB_PATH = path.join(TEST_ROOT, "database.db")
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../prisma/migrations")
+const TARGET_MIGRATION = "20260802040000_exam_subtotal_group_deterministic_id"
+
+vi.mock("../../electron-src/lib/prisma/databaseInitializer", () => ({
+  getDatabasePath: () => DB_PATH,
+}))
+
+type SqliteDatabase = InstanceType<typeof Database>
+
+const withDatabase = <T>(operation: (db: SqliteDatabase) => T): T => {
+  const db = new Database(DB_PATH)
+  try {
+    return operation(db)
+  } finally {
+    db.close()
+  }
+}
+
+const migrationNames = (): string[] =>
+  fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+
+const applyMigration = (db: SqliteDatabase, name: string): void => {
+  db.exec(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, name, "migration.sql"), "utf-8")
+  )
+}
+
+async function buildDatabaseBeforeTargetMigration(): Promise<void> {
+  bootstrapSchema(DB_PATH)
+  const prisma = createPrismaClientForPath(DB_PATH)
+  try {
+    await createBaseline(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+
+  const names = migrationNames()
+  const targetIndex = names.indexOf(TARGET_MIGRATION)
+  expect(targetIndex).toBeGreaterThan(0)
+
+  withDatabase((db) => {
+    for (const name of names.slice(0, targetIndex)) {
+      if (name === "20260322232329_init") continue
+      applyMigration(db, name)
+    }
+  })
+}
+
+const OLD_ISO = "2026-07-01T00:00:00.000+00:00"
+const NEW_ISO = "2026-07-02T00:00:00.000+00:00"
+
+/**
+ * 旧形状（uuid の id・unique 無し）のデータを投入する。
+ * exam-1 × group-1 は重複2行。**古い方が false・新しい方が true** にしてあり、
+ * 「最古の行の値をそのまま採る」実装だと選択が消えることを検知できる。
+ */
+function seedLegacyRows(db: SqliteDatabase): void {
+  const run = (sql: string, params: unknown[]) => db.prepare(sql).run(params)
+
+  run(
+    `INSERT INTO "Exam" (id, examName, createdAt, updatedAt) VALUES (?,?,?,?)`,
+    ["exam-1", "1学期期末", OLD_ISO, OLD_ISO]
+  )
+  run(
+    `INSERT INTO "SubtotalGroup" (id, name, createdAt, updatedAt) VALUES (?,?,?,?)`,
+    ["group-1", "大問別", OLD_ISO, OLD_ISO]
+  )
+  run(
+    `INSERT INTO "SubtotalGroup" (id, name, createdAt, updatedAt) VALUES (?,?,?,?)`,
+    ["group-2", "観点別", OLD_ISO, OLD_ISO]
+  )
+
+  for (const [id, groupId, selectedForTable, createdAt] of [
+    ["uuid-old", "group-1", 0, OLD_ISO],
+    ["uuid-new", "group-1", 1, NEW_ISO],
+    ["uuid-other", "group-2", 0, OLD_ISO],
+  ] as const) {
+    run(
+      `INSERT INTO "ExamSubtotalGroup" (id, examId, subtotalGroupId, selectedForTable, selectedForBoxPlot, createdAt, updatedAt)
+       VALUES (?,?,?,?,?,?,?)`,
+      [id, "exam-1", groupId, selectedForTable, 0, createdAt, createdAt]
+    )
+  }
+}
+
+interface ExamSubtotalGroupRow {
+  id: string
+  subtotalGroupId: string
+  selectedForTable: number
+}
+
+const readRows = (): ExamSubtotalGroupRow[] =>
+  withDatabase(
+    (db) =>
+      db
+        .prepare(
+          `SELECT id, subtotalGroupId, selectedForTable
+           FROM "ExamSubtotalGroup" ORDER BY subtotalGroupId ASC`
+        )
+        .all() as ExamSubtotalGroupRow[]
+  )
+
+async function migrate(): Promise<void> {
+  await buildDatabaseBeforeTargetMigration()
+  withDatabase((db) => {
+    seedLegacyRows(db)
+    applyMigration(db, TARGET_MIGRATION)
+  })
+}
+
+beforeEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+  fs.mkdirSync(TEST_ROOT, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true })
+})
+
+describe("試験と小計点グループの紐付けを決定論的idにする", () => {
+  it("重複行が1件へ潰れ、フラグは重複行をまたいで OR される", async () => {
+    // 新しい行にしか無い選択（selectedForTable=1）を捨てると、
+    // 箱ひげ図・小計点テーブルの対象が予告なく外れる
+    await migrate()
+
+    const duplicated = readRows().filter(
+      (row) => row.subtotalGroupId === "group-1"
+    )
+    expect(duplicated).toHaveLength(1)
+    expect(duplicated[0].selectedForTable).toBe(1)
+  })
+
+  it("idが examId:subtotalGroupId へ振り直される", async () => {
+    await migrate()
+
+    expect(readRows().map((row) => row.id)).toEqual([
+      "exam-1:group-1",
+      "exam-1:group-2",
+    ])
+  })
+
+  it("同じ組み合わせの2行目を作れない", async () => {
+    await migrate()
+
+    withDatabase((db) => {
+      expect(() =>
+        db
+          .prepare(
+            `INSERT INTO "ExamSubtotalGroup" (id, examId, subtotalGroupId, selectedForTable, selectedForBoxPlot, createdAt, updatedAt)
+             VALUES (?,?,?,?,?,?,?)`
+          )
+          .run(["dup", "exam-1", "group-1", 0, 0, NEW_ISO, NEW_ISO])
+      ).toThrow(/UNIQUE/)
+    })
+  })
+
+  it("試験を消すとカスケード削除される（作り直しでFKが壊れていない）", async () => {
+    await migrate()
+
+    const definition = withDatabase(
+      (db) =>
+        db
+          .prepare(
+            `SELECT sql FROM sqlite_master WHERE type='table' AND name='ExamSubtotalGroup'`
+          )
+          .get() as { sql: string }
+    )
+    expect(definition.sql).toContain('REFERENCES "Exam" ("id")')
+
+    const remaining = withDatabase((db) => {
+      db.pragma("foreign_keys = ON")
+      db.prepare(`DELETE FROM "Exam" WHERE id = 'exam-1'`).run()
+      return db
+        .prepare(`SELECT COUNT(*) AS count FROM "ExamSubtotalGroup"`)
+        .get() as { count: number }
+    })
+    expect(remaining.count).toBe(0)
+    expect(withDatabase((db) => db.pragma("foreign_key_check"))).toEqual([])
+  })
+})

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -198,6 +198,10 @@ describe("DateTime正規化マイグレーション", () => {
   const POST_MIGRATION_TABLES = new Set([
     "AsbCharGuide",
     "AsbDefinitionTag", // 20260713000000 で追加。normalize migration より後で ISO text 生成
+    // 表そのものは normalize migration より前からあるが、当時は DateTime 列を持たなかった。
+    // createdAt/updatedAt は 20260802030000（同期対象にするための追加）で ISO text として
+    // 生まれるため、integer(ms) の混在が起こらない
+    "AsbHeaderField",
     "AuditLog",
     "Coursework",
     "CourseworkClassroom", // 旧 CourseworkClass（20260704010000 でリネーム）

--- a/__tests__/omr/integration/detectMasterMarkers.test.ts
+++ b/__tests__/omr/integration/detectMasterMarkers.test.ts
@@ -1,0 +1,125 @@
+/**
+ * omr:detect-master-markers ハンドラの統合テスト
+ *
+ * 模範解答画像を ExamPage へ畳んだ際、旧実装の `if (!masterImage)` を機械的に
+ * `if (!examPage)` へ置き換えた結果その条件が成立しなくなり、画像を持たないページで
+ * `path.join(dataDir, "")` がデータディレクトリを sharp へ渡して**試験全体の検出が
+ * 落ちる**不具合を作った（正常なページの結果ごと破棄されていた）。
+ *
+ * `imagePath` を nullable にしたので「ガードを外すとコンパイルが通らない」形にはなったが、
+ * 「画像を持つページが1枚も無ければエラーを返す」という判断は型では守れない。
+ * そこはハンドラ自身が持つ分岐なので、ここで実行時に確かめる。
+ */
+import * as fsPromises from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import sharp from "sharp"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DATA_DIR = path.join(os.tmpdir(), "score-at-once-omr-master-markers")
+process.env.SCORE_AT_ONCE_DATA_DIR = TEST_DATA_DIR
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { setupOMRHandlers } from "@/electron-src/ipc-handlers/omrHandlers"
+import { getAbsolutePathFromData } from "@/electron-src/lib/dataManager"
+
+import { captureIpcHandler } from "../../helpers/ipcHandlerHarness"
+import {
+  cleanupTestDatabase,
+  disconnectTestPrisma,
+  getTestPrismaClient,
+} from "../../helpers/testPrismaClient"
+
+const prisma = getTestPrismaClient()
+
+interface DetectResult {
+  success: boolean
+  pages: Array<{ examPageId: string; pageNumber: number }>
+  error?: string
+}
+
+const detectMasterMarkers = () =>
+  captureIpcHandler(setupOMRHandlers, "omr:detect-master-markers")
+
+/** 白紙PNGを置き、data からの相対パスを返す（マーカーは無いので検出は失敗する） */
+async function writeBlankPng(relativePath: string): Promise<string> {
+  const absolutePath = getAbsolutePathFromData(relativePath)
+  await fsPromises.mkdir(path.dirname(absolutePath), { recursive: true })
+  await sharp({
+    create: {
+      width: 200,
+      height: 280,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .png()
+    .toFile(absolutePath)
+  return relativePath
+}
+
+beforeEach(async () => {
+  await cleanupTestDatabase()
+  await fsPromises.rm(TEST_DATA_DIR, { recursive: true, force: true })
+})
+
+afterAll(async () => {
+  await fsPromises.rm(TEST_DATA_DIR, { recursive: true, force: true })
+  await disconnectTestPrisma()
+})
+
+describe("omr:detect-master-markers", () => {
+  it("画像を持たないページを飛ばし、持つページの検出は行う", async () => {
+    const exam = await prisma.exam.create({
+      data: { examName: "マーカー検出" },
+    })
+    const withImage = await prisma.examPage.create({
+      data: {
+        examId: exam.id,
+        pageNumber: 1,
+        imagePath: await writeBlankPng(
+          `exams/${exam.id}/master-images/page1.png`
+        ),
+      },
+    })
+    await prisma.examPage.create({
+      data: { examId: exam.id, pageNumber: 2, imagePath: null },
+    })
+
+    const result = (await detectMasterMarkers()(exam.id)) as DetectResult
+
+    // 画像の無いページで例外が出ると、この1件も含めて結果が丸ごと失われる
+    expect(result.pages.map((page) => page.examPageId)).toEqual([withImage.id])
+  })
+
+  it("画像を持つページが1枚も無ければエラーを返す", async () => {
+    const exam = await prisma.exam.create({ data: { examName: "画像なし" } })
+    await prisma.examPage.create({
+      data: { examId: exam.id, pageNumber: 1, imagePath: null },
+    })
+
+    const result = (await detectMasterMarkers()(exam.id)) as DetectResult
+
+    // ページ数ではなく検出対象の数で判定する。ページはあるが画像が無い状態を
+    // 「検出0件で成功」にしてしまうと、UI が沈黙して原因が分からなくなる
+    expect(result.success).toBe(false)
+    expect(result.pages).toEqual([])
+    expect(result.error).toBe("マスター画像が見つかりません")
+  })
+
+  it("ページが1枚も無ければエラーを返す", async () => {
+    const exam = await prisma.exam.create({ data: { examName: "ページなし" } })
+
+    const result = (await detectMasterMarkers()(exam.id)) as DetectResult
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe("マスター画像が見つかりません")
+  })
+})

--- a/__tests__/screenshots/helpers/seed-in-test.ts
+++ b/__tests__/screenshots/helpers/seed-in-test.ts
@@ -11,6 +11,7 @@ import * as fs from "fs"
 import * as path from "path"
 import sharp from "sharp"
 
+import { buildExamSubtotalGroupId } from "../../../electron-src/lib/prisma/deterministicId"
 import { createPrismaClientForPath } from "../../helpers/testPrismaClient"
 import {
   computeRegionDefinitions,
@@ -428,7 +429,11 @@ export async function seedExamWithScoring(
     })
   }
   await db.examSubtotalGroup.create({
-    data: { id: crypto.randomUUID(), examId, subtotalGroupId },
+    data: {
+      id: buildExamSubtotalGroupId(examId, subtotalGroupId),
+      examId,
+      subtotalGroupId,
+    },
   })
 
   // マスター画像（プレースホルダー白PNG）

--- a/__tests__/sync/syncTableConfig.test.ts
+++ b/__tests__/sync/syncTableConfig.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 同期対象テーブルの整合テスト
+ *
+ * sqlite-nas-sync は「`id` と `updatedAt` を持つ非内部テーブル」を自動検出して同期する。
+ * `SYNC_EXCLUDE_TABLES` はそこから引く手動のリストなので、**テーブルを足したときに
+ * 書き足し忘れる**という壊れ方をする。実際 Asb 系で2度漏れた（`AsbCharGuide` は #913、
+ * `AsbDefinitionTag` はタグ対応）。
+ *
+ * そのとき起きたのは「親は除外されているのに子は同期される」という状態で、
+ * 端末Aで小問を消すと子の削除だけが端末Bへ伝わり、Bでは枠だけ残って中身が消えた。
+ * 作成は伝わらないのに削除は伝わる、という非対称になる。
+ *
+ * ここでは schema.prisma を読んで、その不整合が無いことを検査する。
+ */
+import * as fs from "fs"
+import * as path from "path"
+import { describe, expect, it } from "vitest"
+
+import { SYNC_EXCLUDE_TABLES } from "../../electron-src/lib/sync/syncTableConfig"
+
+const SCHEMA_PATH = path.resolve(__dirname, "../../prisma/schema.prisma")
+
+interface PrismaModel {
+  name: string
+  body: string
+}
+
+const readModels = (): PrismaModel[] => {
+  const schema = fs.readFileSync(SCHEMA_PATH, "utf-8")
+  return [...schema.matchAll(/model\s+(\w+)\s*\{([\s\S]*?)\n\}/g)].map(
+    (match) => ({ name: match[1], body: match[2] })
+  )
+}
+
+/** sqlite-nas-sync の自動検出条件（id と updatedAt を持つ） */
+const isDetectedBySync = (model: PrismaModel): boolean =>
+  /^\s+id\s+/m.test(model.body) && /^\s+updatedAt\s+/m.test(model.body)
+
+/** そのモデルが `@relation(fields: [...])` で参照している相手モデル名 */
+const referencedModels = (model: PrismaModel): string[] =>
+  [...model.body.matchAll(/^\s+\w+\s+(\w+)\??\s+@relation\(/gm)].map(
+    (match) => match[1]
+  )
+
+describe("同期対象テーブルの整合", () => {
+  it("除外リストのテーブルはすべて実在する（リネーム・削除の取り残しが無い）", () => {
+    const modelNames = new Set(readModels().map((model) => model.name))
+    const missing = SYNC_EXCLUDE_TABLES.filter(
+      (table) => !modelNames.has(table)
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  it("同期されるテーブルが、同期されないテーブルを参照していない", () => {
+    // **同期されない理由は2つある**。除外リストに載っているか、`updatedAt` が無くて
+    // ライブラリの自動検出から漏れるか。後者を見落とすと、この検査は元の不具合を
+    // 防げない — AsbHeaderField はまさに `updatedAt` が無いために同期対象外だった。
+    const excluded = new Set(SYNC_EXCLUDE_TABLES)
+    const models = readModels()
+    const unsynced = new Set(
+      models
+        .filter((model) => excluded.has(model.name) || !isDetectedBySync(model))
+        .map((model) => model.name)
+    )
+
+    const violations: string[] = []
+    for (const model of models) {
+      if (unsynced.has(model.name)) continue
+
+      for (const target of referencedModels(model)) {
+        if (unsynced.has(target)) {
+          const reason = excluded.has(target)
+            ? "除外リスト"
+            : "updatedAt が無く自動検出から漏れる"
+          violations.push(`${model.name} → ${target}（${reason}）`)
+        }
+      }
+    }
+
+    // 親が同期されないまま子だけ同期されると、参照先の無い行が相手端末に積まれ、
+    // さらに親の作成は伝わらないのに子の削除は伝わるという非対称が生まれる
+    // （ライブラリは foreign_keys を有効化せず、INSERT も FK 違反を捕まえない）
+    expect(violations).toEqual([])
+  })
+
+  it("除外リストに無いテーブルは、必ず同期対象として検出される", () => {
+    // 業務データは全て共有する方針なので、除外リストに載っていない＝同期されるべき。
+    // ところがライブラリの検出条件は `id` と `updatedAt` を持つことなので、
+    // **列を書き忘れただけで黙って同期対象から外れる**。AsbHeaderField は全71モデルで
+    // 唯一この列を欠いており、実際に共有から取り残されていた。
+    //
+    // 参照関係だけを見る検査ではこれを捕まえられない（子を持たないテーブルは
+    // 「同期されない親」として現れないため）。ここで直接検査する。
+    const undetected = readModels()
+      .filter((model) => !SYNC_EXCLUDE_TABLES.includes(model.name))
+      .filter((model) => !isDetectedBySync(model))
+      .map((model) => model.name)
+
+    expect(undetected).toEqual([])
+  })
+
+  it("除外されるのは端末ごとの設定に限る", () => {
+    // 業務データ（解答用紙定義・試験・成績・生徒・学級・小計点・タグ）は全て共有する。
+    // ここを増やすときは「この端末でしか意味を持たないか」を必ず問うこと
+    expect([...SYNC_EXCLUDE_TABLES].sort()).toEqual([
+      "UserKeyboardShortcut",
+      "UserPreference",
+    ])
+  })
+})

--- a/docs/schema-relation-audit.md
+++ b/docs/schema-relation-audit.md
@@ -135,8 +135,11 @@ PDF 出力に複製されており、過去2回のずれに続く3回目をこ�
   同じ組で2回呼べば重複行ができる
 - インポート側は `findFirst` で手動回避している（`electron-src/lib/import/merge/importExamCore.ts:201`）
 
-4.1 と同じく「制約の代用コード」が書かれている状態。`@@unique([examId, subtotalGroupId])` の追加で済むが、
-既存 DB に重複行があれば先に潰す必要がある。
+4.1 と同じく「制約の代用コード」が書かれている状態。
+
+ただし `@@unique` を足すだけでは済まない。`@default(uuid())` のままだと、2端末が同じ組み合わせを
+作ったとき id 違い・unique 同値の行ができて NAS 同期で衝突する。この表は真の多対多なので
+中間テーブル自体は残り、**unique を持つなら決定論的 id が要る**（手順は §6.2）。
 
 ### 4.3 `GradeDataSource.examId` は `crop_region` 型で冗長
 
@@ -189,3 +192,131 @@ PDF 出力に複製されており、過去2回のずれに続く3回目をこ�
 
 ただし `AsbHeaderField` は 5.1 の除外リストにも入っているため、**実害は無い**（二重に除外されている）。
 5.1 を直して Asb 系を同期対象にするなら、このとき初めて `updatedAt` の追加が必要になる。
+
+---
+
+## 6. 残作業
+
+4.1 は #1124 / PR #1125 で対応済み。以降も 4.4 を除いて対応した。
+
+| 項目                                               | 節  | 状態                  |
+| -------------------------------------------------- | --- | --------------------- |
+| Asb 系の同期除外リストが子テーブルに追随していない | 5.1 | ✅ 対応済み（§6.1）   |
+| `ExamSubtotalGroup` に `@@unique` が無い           | 4.2 | ✅ 対応済み（§6.2）   |
+| `GradeDataSource.examId` の型ごとの意味を明文化    | 4.3 | ✅ 対応済み（§6.3）   |
+| 個人成績表の設定が 1:1 の2枚に割れている           | 4.4 | 見送り（理由は §6.3） |
+| OMR ハンドラの実行時テストが無い                   | 6.4 | ✅ 対応済み（§6.4）   |
+
+対応の過程で判明し、別 issue へ切り出したもの:
+
+| issue | 内容                                                                      |
+| ----- | ------------------------------------------------------------------------- |
+| #1126 | 解答用紙定義を同期対象にしたが、保存方式（delete→recreate）と噛み合わない |
+| #1127 | 解答用紙定義の所有と共有の設計（`userId` 絞り込みと `getCurrentUser`）    |
+| #1128 | 複合uniqueを持つ中間テーブルの id を決定論的にする（14テーブル）          |
+
+### 6.1 Asb 系の同期除外（5.1）✅ 対応済み
+
+**調査結果**: 行はスキップされず**投入される**。ライブラリの接続は `journal_mode` しか
+設定せず `foreign_keys` を触らない（SQLite 既定は OFF）。`applyInsert` が捕まえる例外も
+`SQLITE_CONSTRAINT_UNIQUE` と `..._PRIMARYKEY` だけなので、参照先が無くても INSERT は通り、
+dangling 行が溜まる。
+
+さらに非対称がある。除外テーブルは changelog トリガー自体が作られない（トリガーは
+`config.tables` にのみ設置）ので**作成は伝わらない**が、子テーブルは同期対象なので
+**削除は伝わる**。端末Aで小問を消すと子の削除だけが端末Bへ届き、Bでは枠だけ残って
+中身が消えた。
+
+**採った方針**: 業務データはすべて共有する。除外に残すのは端末ごとの設定
+（`UserKeyboardShortcut` / `UserPreference`）だけとし、Asb 系は親も子も同期対象にした。
+`AsbHeaderField` に `createdAt` / `updatedAt` を追加している（migration
+`20260802030000_asb_header_field_timestamps`）— この2列が無いとライブラリの自動検出から
+外れるため。
+
+**再発防止**: `__tests__/sync/syncTableConfig.test.ts` が schema.prisma を読んで
+「同期されるテーブルが除外されたテーブルを参照していない」ことを検査する。原因そのものを
+見ているので、次に子テーブルが増えても漏れれば落ちる。
+
+なお画像ファイルの実体はローカル（`getDataDirectory()`）にあり NAS 共有は DB だけなので、
+`AsbImageElement` の行は同期されてもファイルは相手端末に無い。これは `ExamPage.imagePath` や
+`StudentAnswerImage` も同じ既存の性質で、画像共有自体は別課題（#1052）。
+
+### 6.2 `ExamSubtotalGroup` の unique（4.2）✅ 対応済み
+
+**unique の追加だけでは足りない。id の決定論化とセットで行う。**
+
+`@@unique([examId, subtotalGroupId])` を足しただけだと、2人の教員が同じ試験に同じ小計点グループを
+追加したとき、`@default(uuid())` のせいで **id 違い・unique 同値**の行が2つでき、NAS 同期で衝突する。
+これは既知の罠で、`CropRegionAssignment` / `GradeConstraintViewpoint` /
+`GradeConstraintLabelValue` / `GradeConstraintExclusionLabel` / `GradeDataSourceEstimationSource` は
+id を親子キーから決定論的に組み立てることで回避している（同一 id なら行レベル LWW が1行へ収束する）。
+
+§4.1 で `examPageId @unique` を避けたのと同じ制約がここにも効く。違いは、あちらは 1:1 なので
+畳めば unique 自体が要らなくなったのに対し、こちらは真の多対多なので中間テーブルが残り、
+**unique を持つなら決定論的 id が要る**という点。
+
+migration `20260802040000_exam_subtotal_group_deterministic_id` で対応した。以下は実施内容。
+
+1. **重複行の確認**（あれば移行で潰す）
+
+   ```sql
+   SELECT examId, subtotalGroupId, COUNT(*) FROM ExamSubtotalGroup
+   GROUP BY examId, subtotalGroupId HAVING COUNT(*) > 1;
+   ```
+
+2. **`deterministicId.ts` に `buildExamSubtotalGroupId(examId, subtotalGroupId)` を足す。**
+   既存の `joinIds` に倣って単純連結にすること。uuidv5 ではない理由が同ファイルの冒頭に書いてある —
+   既存行の id を振り直すマイグレーションが同じ id を組み立てられる必要があり、SQLite に sha1 が
+   無いので SQL 側で uuidv5 を再現できない
+3. **マイグレーション**: 重複を潰し、既存行の id を決定論的 id へ振り直し、`@@unique` と `@@index`
+   を追加する。他テーブルからの FK は無いので、DB 内で id を変えること自体は安全（確認してから進める）
+4. **アーカイブの扱いを決める。** `ExamSubtotalGroup.id` は他テーブルからは参照されないが、
+   **試験アーカイブが id を運んでいる**（`dataCollector.ts` が書き出し、`importExamCore.ts` が
+   その id で作る）。旧アーカイブの id は uuid 形式なので、そのまま取り込むと決定論的 id の
+   前提が崩れる。取り込み時に `buildExamSubtotalGroupId` で組み直すか、変換器で id を
+   置き換えるかを決めること。**「同じ組み合わせの行が、ローカルには決定論的 id で、
+   アーカイブには uuid で入っている」状態が unique 違反になる**ので、ここは飛ばせない
+5. **スキーマに `@id` のみ**（`@default(uuid())` を外す）と、決定論的 id の理由をコメントで残す。
+   他の決定論的 id テーブルと同じ書き方に揃える
+6. **代用コードを外す** — `addSubtotalGroupToExam` は素の `create` から upsert へ
+   （`electron-src/lib/prisma/subtotalGroup.ts`）、インポートの `findFirst`
+   （`electron-src/lib/import/merge/importExamCore.ts`）は id 一致で足りるようになる
+
+#### 何が直るか
+
+重複行があると `selectedForTable` / `selectedForBoxPlot` が行ごとに食い違い、どちらが効くかが
+読み取り順次第になる。Excel の小計点テーブルと箱ひげ図の対象が非決定的になる、という形で出る。
+
+### 6.3 低優先の2件（4.3 ✅ / 4.4 見送り）
+
+**4.3 は対応済み。** `GradeDataSource` に type ごとの参照列の表をコメントで置いた。
+特に `examId` は `subtotal` 型では必須（`SubtotalGroup` は `Exam` と多対多なので、どの試験の
+スコアを集計するかは `subtotalId` から辿れない）で、`crop_region` 型では冗長という違いがある。
+消されないように、その理由まで書いている。
+
+**4.4 は見送る。** `ExamIndividualReportSettings` と `ExamIndividualReportGraphSettings` を
+1枚にまとめる案だが、次の理由で今は動かさない。
+
+- この2枚は `20260731000200_normalize_exam_export_settings` で**意図して作られた**もので、
+  出力設定のJSON埋め込みを6テーブルへ正規化した際の分割線である。作られて日が浅く、
+  分割の意図が失われる前に潰すのは早い
+- 得られるのはテーブル1枚の削減だけで、監査時の評価どおり実害が無い。対して費用は
+  マイグレーション＋アーカイブ版上げ＋変換器＋`examSettings.ts` の書き換えと小さくない
+- 同じ正規化で作られた他の4枚（1:N のもの）は形が違うので、統合するなら
+  「1:1 の設定表をどう持つか」を6枚まとめて決める方がよい
+
+個人成績表の設定を作り直す機会が来たら、そのとき6枚まとめて見直す。
+
+### 6.4 OMR ハンドラのテスト空白 ✅ 対応済み
+
+`__tests__/helpers/ipcHandlerHarness.ts` の `captureIpcHandler` を追加した。
+`ipcMain.handle` のモックに記録された呼び出しからチャンネル名でコールバックを取り出し、
+`_event` を補って呼ぶ。OMR に限らずどのハンドラにも使える。
+
+これを使って `__tests__/omr/integration/detectMasterMarkers.test.ts` を置いた。型では守れない
+「画像を持つページが1枚も無ければエラーを返す」分岐（ページはあるが画像が無い状態を
+"検出0件で成功" にすると UI が沈黙する）と、「画像の無いページを飛ばしつつ持つページは
+検出する」ことを見ている。ガードを外すと実際に落ちることを確認済み。
+
+ハンドラに切り出せない判断だけをここで見る方針は変えない。main の関数に出せる処理は
+そちらでテストする方が軽い。

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -17,6 +17,7 @@
  * 既存レコードのUNIQUEフィールドを一時値に変更してから新レコードを作成し、旧を削除する。
  */
 
+import { buildExamSubtotalGroupId } from "../../prisma/deterministicId"
 import type { IdChangeTarget, IdMappings, PrismaTransaction } from "./types"
 
 /**
@@ -241,12 +242,30 @@ export const CLASSROOM_CASCADE_MOVERS: CascadeMover[] = [
  */
 export const SUBTOTAL_GROUP_CASCADE_MOVERS: CascadeMover[] = [
   {
+    // id が (examId, subtotalGroupId) から決まるので、付け替えたら id も組み直す。
+    // updateMany で subtotalGroupId だけ動かすと id が旧グループを指したまま残り、
+    // (a) 同じ試験のアーカイブを再取り込みしたとき組み合わせ一致の行を id で引けず
+    // unique 違反、(b) 同僚のPCは同じ組を新idで持つので同期で2行目が押し寄せる。
+    //
+    // UNIQUE([examId, subtotalGroupId]) の衝突は起きない。changeSubtotalGroupId が
+    // 移行先グループを必ず新規 create するので、その試験が移行先へのリンクを
+    // 既に持つことはありえない（兄弟の GradeStudent / CourseworkStudent は
+    // 移行先の生徒が実在しうるので重複潰しを持つ。ここは事情が違う）。
     model: "ExamSubtotalGroup",
-    move: (tx, from, to) =>
-      tx.examSubtotalGroup.updateMany({
+    move: async (tx, from, to) => {
+      const rows = await tx.examSubtotalGroup.findMany({
         where: { subtotalGroupId: from },
-        data: { subtotalGroupId: to },
-      }),
+      })
+      for (const link of rows) {
+        await tx.examSubtotalGroup.update({
+          where: { id: link.id },
+          data: {
+            subtotalGroupId: to,
+            id: buildExamSubtotalGroupId(link.examId, to),
+          },
+        })
+      }
+    },
   },
   {
     model: "Subtotal",

--- a/electron-src/lib/import/merge/importExamCore.ts
+++ b/electron-src/lib/import/merge/importExamCore.ts
@@ -9,6 +9,7 @@ import * as crypto from "crypto"
 import * as path from "path"
 
 import type { FileOverviewData } from "../../../../src/types/examArchive.types"
+import { buildExamSubtotalGroupId } from "../../prisma/deterministicId"
 import type { ExtractedArchiveData } from "../exam-archive/archiveExtractor"
 import type { IdMappings, ImportCounts, PrismaTransaction } from "./types"
 
@@ -243,34 +244,31 @@ export async function processExamSubtotalGroups(
   for (const examSubtotalGroup of data.examData.examSubtotalGroups) {
     const newGroupId =
       idMappings.subtotalGroup[examSubtotalGroup.subtotalGroupId]
-    if (newGroupId) {
-      const existing = await tx.examSubtotalGroup.findFirst({
-        where: { examId: newExamId, subtotalGroupId: newGroupId },
-      })
-      if (existing) {
-        idMappings.examSubtotalGroup[examSubtotalGroup.id] = existing.id
-      } else {
-        const existingById = await tx.examSubtotalGroup.findUnique({
-          where: { id: examSubtotalGroup.id },
-        })
-        if (existingById) {
-          idMappings.examSubtotalGroup[examSubtotalGroup.id] =
-            examSubtotalGroup.id
-        } else {
-          await tx.examSubtotalGroup.create({
-            data: {
-              id: examSubtotalGroup.id,
-              examId: newExamId,
-              subtotalGroupId: newGroupId,
-              selectedForTable: examSubtotalGroup.selectedForTable ?? false,
-              selectedForBoxPlot: examSubtotalGroup.selectedForBoxPlot ?? false,
-            },
-          })
-          idMappings.examSubtotalGroup[examSubtotalGroup.id] =
-            examSubtotalGroup.id
-        }
-      }
-    }
+    if (!newGroupId) continue
+
+    // **探すキーは DB が守っているキーに合わせる。** id は新規作成時にしか意味を持たない。
+    // 決定論的idは「これから作る行」の名前を決めるだけで、既にある行がその名前で
+    // 入っている保証は無い（旧バージョンで作られた行、id を再計算しない経路を通った行）。
+    // ここで id を探しにいくと、同じ組み合わせの行があるのに見つけられず create 側へ落ち、
+    // unique 違反でアーカイブ取り込みがトランザクションごと巻き戻る。
+    const linked = await tx.examSubtotalGroup.upsert({
+      where: {
+        examId_subtotalGroupId: {
+          examId: newExamId,
+          subtotalGroupId: newGroupId,
+        },
+      },
+      create: {
+        id: buildExamSubtotalGroupId(newExamId, newGroupId),
+        examId: newExamId,
+        subtotalGroupId: newGroupId,
+        selectedForTable: examSubtotalGroup.selectedForTable ?? false,
+        selectedForBoxPlot: examSubtotalGroup.selectedForBoxPlot ?? false,
+      },
+      update: {},
+    })
+    // 既存行に当たった場合その id は決定論的とは限らないので、実際の行の id を記録する
+    idMappings.examSubtotalGroup[examSubtotalGroup.id] = linked.id
   }
 }
 

--- a/electron-src/lib/prisma/deterministicId.ts
+++ b/electron-src/lib/prisma/deterministicId.ts
@@ -15,6 +15,14 @@ function joinIds(parentId: string, childKey: string): string {
   return `${parentId}:${childKey}`
 }
 
+/** 試験と小計点グループの紐付け（ExamSubtotalGroup）のid */
+export function buildExamSubtotalGroupId(
+  examId: string,
+  subtotalGroupId: string
+): string {
+  return joinIds(examId, subtotalGroupId)
+}
+
 /** consistency ルールの集計対象観点（GradeConstraintViewpoint）のid */
 export function buildConstraintViewpointId(
   constraintId: string,

--- a/electron-src/lib/prisma/masterAnswer.ts
+++ b/electron-src/lib/prisma/masterAnswer.ts
@@ -74,10 +74,7 @@ export const uploadMasterAnswers = async (
   examId: string,
   filesData: MasterAnswerFileData[]
 ): Promise<ExamPage[]> => {
-  const exam = await prisma.exam.findUnique({
-    where: { id: examId },
-    select: { id: true },
-  })
+  const exam = await prisma.exam.findUnique({ where: { id: examId } })
   if (!exam) {
     throw new Error("Exam not found for master answer upload")
   }
@@ -85,7 +82,6 @@ export const uploadMasterAnswers = async (
   const lastPage = await prisma.examPage.findFirst({
     where: { examId },
     orderBy: { pageNumber: "desc" },
-    select: { pageNumber: true },
   })
   const highestPageNumber = lastPage?.pageNumber ?? 0
 
@@ -196,7 +192,7 @@ export const deleteMasterAnswer = async (
 ): Promise<DeleteMasterAnswerResult> => {
   const targetPage = await prisma.examPage.findUnique({
     where: { id: examPageId },
-    include: { studentAnswerImages: { select: { imagePath: true } } },
+    include: { studentAnswerImages: true },
   })
 
   if (!targetPage) {
@@ -253,7 +249,6 @@ export const updateMasterAnswersOrder = async (
 
   const pages = await prisma.examPage.findMany({
     where: { id: { in: pageOrders.map((pageOrder) => pageOrder.id) } },
-    select: { id: true, examId: true, pageNumber: true },
   })
   if (pages.length === 0) {
     throw new Error("No exam pages found for reordering")

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -3,6 +3,7 @@ import type { Prisma } from "@prisma/client"
 import { recordAuditLog } from "./auditLog"
 import prisma from "./client"
 import { subtotalWithQuestionAssignmentsInclude } from "./cropSubtotal"
+import { buildExamSubtotalGroupId } from "./deterministicId"
 import { tagSubtotalGroupWithTagInclude } from "./tagSubtotalGroup"
 
 /**
@@ -326,18 +327,25 @@ export async function getActiveSubtotalGroupsForExam(examId: string) {
 }
 
 /**
- * 試験に小計点グループを追加
+ * 試験に小計点グループを追加する。
+ *
+ * idが(試験, 小計点グループ)から決まるので upsert で足りる。2端末が同時に同じ組み合わせを
+ * 追加しても同一idの1行へ収束し、既にある紐付けを二重に作ることもない
+ * （以前は素の create で、重複防止は @@unique も無いまま呼び出し側任せだった）。
  */
 export async function addSubtotalGroupToExam(
   examId: string,
   subtotalGroupId: string
 ) {
   try {
-    const examSubtotalGroup = await prisma.examSubtotalGroup.create({
-      data: {
+    const examSubtotalGroup = await prisma.examSubtotalGroup.upsert({
+      where: { examId_subtotalGroupId: { examId, subtotalGroupId } },
+      create: {
+        id: buildExamSubtotalGroupId(examId, subtotalGroupId),
         examId,
         subtotalGroupId,
       },
+      update: {},
       include: {
         subtotalGroup: {
           include: {

--- a/electron-src/lib/sync/syncTableConfig.ts
+++ b/electron-src/lib/sync/syncTableConfig.ts
@@ -1,9 +1,8 @@
 /**
  * sqlite-nas-syncのテーブル同期設定
  *
- * v0.8.0以降、同期対象テーブルはDBから自動検出される。
- * ここではローカル専用テーブルの除外リストと、
- * 特殊なテーブルオプションのみを定義する。
+ * v0.8.0以降、同期対象テーブルはDBから自動検出される（`id` と `updatedAt` を持つ非内部テーブル）。
+ * ここではローカル専用テーブルの除外リストと、特殊なテーブルオプションのみを定義する。
  */
 
 import type { TableOptions } from "sqlite-nas-sync"
@@ -11,17 +10,21 @@ import type { TableOptions } from "sqlite-nas-sync"
 /**
  * 同期から除外するテーブル一覧
  *
- * ローカル設定テーブル（UserKeyboardShortcut, UserPreference）と
- * Answer Sheet Builder関連テーブル（Asb*）は端末固有のため除外。
+ * **業務データはすべて同期する。** 解答用紙定義・試験・試験外成績資料・成績算出・生徒・学級・
+ * 小計点・タグはいずれも共有される。除外するのは端末ごとの設定だけで、それ以外を足すときは
+ * 「この端末でしか意味を持たないか」を基準に判断すること。
+ *
+ * かつては Asb\* も端末固有として除外していたが、除外していたのは親（AsbDefinition /
+ * AsbHeaderField / AsbMajorQuestion / AsbSubQuestion / AsbBranchQuestion）だけで、
+ * 後から増えた子（AsbTextElement / AsbImageElement / AsbOmrConfig / AsbOmrChoiceOption /
+ * AsbCharGuide / AsbDefinitionTag）は自動検出で同期されていた。親の作成は伝わらないのに
+ * 子の削除は伝わるという歪んだ状態で、端末Aで小問を消すと端末Bでは枠だけ残って中身が消えた。
+ * 除外リストは「テーブルを足したら書き足す」運用に依存していて2度漏れている（`AsbCharGuide` は
+ * #913、`AsbDefinitionTag` はタグ対応）ため、`syncTableConfig.test.ts` で漏れを検知する。
  */
 export const SYNC_EXCLUDE_TABLES: string[] = [
   "UserKeyboardShortcut",
   "UserPreference",
-  "AsbDefinition",
-  "AsbHeaderField",
-  "AsbMajorQuestion",
-  "AsbSubQuestion",
-  "AsbBranchQuestion",
 ]
 
 /** テーブル別の同期オプション */

--- a/prisma/migrations/20260802030000_asb_header_field_timestamps/migration.sql
+++ b/prisma/migrations/20260802030000_asb_header_field_timestamps/migration.sql
@@ -1,0 +1,67 @@
+-- AsbHeaderField に createdAt / updatedAt を足す。
+--
+-- sqlite-nas-sync は「`id` と `updatedAt` を持つ非内部テーブル」を同期対象として自動検出し、
+-- 競合解決（LWW）にも updatedAt を使う。AsbHeaderField は全71モデルで唯一この2列を持たず、
+-- 解答用紙定義を端末間で共有する際に、この表だけが同期から取り残される。
+--
+-- 既存行には**親 AsbDefinition の時刻をそのまま引き継ぐ**。移行を走らせた時刻を入れては
+-- いけない。updatedAt は sync の LWW 判定に使われるので、端末ごとに違う「移行した時刻」が
+-- 入ると、後からアップグレードした端末の**触ってもいない行**が、先にアップグレードした
+-- 端末の実際の編集を上回って勝ってしまう（編集が黙って巻き戻る）。
+--
+-- 親の時刻が正しい値である理由: saveAsbDefinition は定義を delete → recreate する。
+-- 子の id は定義側が持つ id をそのまま渡すので行の同一性は保たれ、ヘッダー項目が最後に
+-- 書かれたのは「その定義が保存された時刻」＝ AsbDefinition.updatedAt に一致する。
+-- 捏造ではなく事実を入れることになり、初回同期の LWW も実際の新しさで決まる。
+--
+-- ALTER TABLE ADD COLUMN は非定数の既定値（CURRENT_TIMESTAMP）を受け付けないので、
+-- RedefineTables で作り直す。日時は ISO text で統一する
+-- （integer/text 混在が範囲比較・ソート・sync LWW を壊すため）。
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_AsbHeaderField" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "definitionId" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'field',
+    "label" TEXT NOT NULL,
+    "widthMm" REAL NOT NULL DEFAULT 30,
+    "heightMm" REAL NOT NULL DEFAULT 8,
+    "gridCount" INTEGER NOT NULL DEFAULT 0,
+    "lineStyle" TEXT NOT NULL DEFAULT 'solid',
+    "lineWidth" REAL NOT NULL DEFAULT 0.4,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "fontSize" REAL,
+    "linkedRegionType" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "AsbHeaderField_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "AsbDefinition" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO "new_AsbHeaderField" ("id", "definitionId", "type", "label", "widthMm", "heightMm", "gridCount", "lineStyle", "lineWidth", "order", "fontSize", "linkedRegionType", "createdAt", "updatedAt")
+SELECT
+    "AsbHeaderField"."id",
+    "AsbHeaderField"."definitionId",
+    "AsbHeaderField"."type",
+    "AsbHeaderField"."label",
+    "AsbHeaderField"."widthMm",
+    "AsbHeaderField"."heightMm",
+    "AsbHeaderField"."gridCount",
+    "AsbHeaderField"."lineStyle",
+    "AsbHeaderField"."lineWidth",
+    "AsbHeaderField"."order",
+    "AsbHeaderField"."fontSize",
+    "AsbHeaderField"."linkedRegionType",
+    "AsbDefinition"."createdAt",
+    "AsbDefinition"."updatedAt"
+FROM "AsbHeaderField"
+JOIN "AsbDefinition" ON "AsbDefinition"."id" = "AsbHeaderField"."definitionId";
+
+DROP TABLE "AsbHeaderField";
+ALTER TABLE "new_AsbHeaderField" RENAME TO "AsbHeaderField";
+
+CREATE INDEX "AsbHeaderField_definitionId_idx" ON "AsbHeaderField"("definitionId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/migrations/20260802040000_exam_subtotal_group_deterministic_id/migration.sql
+++ b/prisma/migrations/20260802040000_exam_subtotal_group_deterministic_id/migration.sql
@@ -1,0 +1,78 @@
+-- ExamSubtotalGroup に @@unique([examId, subtotalGroupId]) を入れ、idを決定論的にする。
+--
+-- この表だけ同型の中間テーブル（UserExam / ExamClassroom / ExamTag / GradeClassroom …）が
+-- 持つ @@unique を欠いており、同じ組み合わせを2回追加すると重複行ができた。重複すると
+-- selectedForTable / selectedForBoxPlot が行ごとに食い違い、どちらが効くかが読み取り順
+-- 次第になる（Excelの小計点テーブルと箱ひげ図の対象が非決定的になる）。
+--
+-- ただし unique を足すだけでは不足で、id も決定論的にする必要がある。@default(uuid()) の
+-- ままだと、2端末が同じ組み合わせを追加したとき id 違い・unique 同値の行ができ、NAS同期で
+-- 衝突する。CropRegionAssignment / GradeConstraintViewpoint 等と同じく `親id:子id` 形式へ
+-- 揃える（deterministicId.ts の joinIds。uuidv5 でないのは、この移行が SQL 側で同じidを
+-- 組み立てられる必要があり SQLite に sha1 が無いため）。
+
+-- 重複行を潰す。先に**フラグを重複行をまたいで OR してから**1件へ絞る。
+-- 読み取り側（getSubtotalGroupSelection）が「1行でも true なら選択」と見ているため、
+-- 最古の行の値をそのまま採ると、新しい行にしか無い選択が黙って消える
+-- （箱ひげ図・小計点テーブルの対象が予告なく外れる）。
+UPDATE "ExamSubtotalGroup"
+SET
+    "selectedForTable" = (
+        SELECT MAX("sibling"."selectedForTable") FROM "ExamSubtotalGroup" AS "sibling"
+        WHERE "sibling"."examId" = "ExamSubtotalGroup"."examId"
+          AND "sibling"."subtotalGroupId" = "ExamSubtotalGroup"."subtotalGroupId"
+    ),
+    "selectedForBoxPlot" = (
+        SELECT MAX("sibling"."selectedForBoxPlot") FROM "ExamSubtotalGroup" AS "sibling"
+        WHERE "sibling"."examId" = "ExamSubtotalGroup"."examId"
+          AND "sibling"."subtotalGroupId" = "ExamSubtotalGroup"."subtotalGroupId"
+    );
+
+-- 残すのは createdAt が最も古い1件（同値なら id 順）。rowid ではなく行の値で選ぶのは、
+-- 各端末が自分のDBに対してこの移行を走らせるため。挿入順に依存すると端末ごとに
+-- 生き残る行が変わり、createdAt / updatedAt が食い違って以後の LWW がぶれる
+DELETE FROM "ExamSubtotalGroup"
+WHERE EXISTS (
+    SELECT 1 FROM "ExamSubtotalGroup" AS "older"
+    WHERE "older"."examId" = "ExamSubtotalGroup"."examId"
+      AND "older"."subtotalGroupId" = "ExamSubtotalGroup"."subtotalGroupId"
+      AND (
+        "older"."createdAt" < "ExamSubtotalGroup"."createdAt"
+        OR ("older"."createdAt" = "ExamSubtotalGroup"."createdAt"
+            AND "older"."id" < "ExamSubtotalGroup"."id")
+      )
+);
+
+-- 既存行のidを決定論的idへ振り直す。他テーブルからの外部キー参照は無い
+UPDATE "ExamSubtotalGroup"
+SET "id" = "examId" || ':' || "subtotalGroupId";
+
+-- RedefineTables（@default(uuid()) を外し、unique と index を付ける）
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_ExamSubtotalGroup" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "examId" TEXT NOT NULL,
+    "subtotalGroupId" TEXT NOT NULL,
+    "selectedForTable" BOOLEAN NOT NULL DEFAULT false,
+    "selectedForBoxPlot" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ExamSubtotalGroup_examId_fkey" FOREIGN KEY ("examId") REFERENCES "Exam" ("id") ON DELETE CASCADE ON UPDATE NO ACTION,
+    CONSTRAINT "ExamSubtotalGroup_subtotalGroupId_fkey" FOREIGN KEY ("subtotalGroupId") REFERENCES "SubtotalGroup" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+INSERT INTO "new_ExamSubtotalGroup" ("id", "examId", "subtotalGroupId", "selectedForTable", "selectedForBoxPlot", "createdAt", "updatedAt")
+SELECT "id", "examId", "subtotalGroupId", "selectedForTable", "selectedForBoxPlot", "createdAt", "updatedAt"
+FROM "ExamSubtotalGroup";
+
+DROP TABLE "ExamSubtotalGroup";
+ALTER TABLE "new_ExamSubtotalGroup" RENAME TO "ExamSubtotalGroup";
+
+CREATE UNIQUE INDEX "ExamSubtotalGroup_examId_subtotalGroupId_key" ON "ExamSubtotalGroup"("examId", "subtotalGroupId");
+CREATE INDEX "ExamSubtotalGroup_examId_idx" ON "ExamSubtotalGroup"("examId");
+CREATE INDEX "ExamSubtotalGroup_subtotalGroupId_idx" ON "ExamSubtotalGroup"("subtotalGroupId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -276,8 +276,13 @@ model UserExam {
   @@index([examId])
 }
 
+/// 試験で使う小計点グループ。どの集計に含めるかのフラグを持つ。
+///
+/// idは決定論的に生成する（`buildExamSubtotalGroupId`）。`@default(uuid())` だと
+/// 2端末が同じ(試験, 小計点グループ)を追加したとき、uuidが違い@@uniqueが同値の行が
+/// できてNAS同期で衝突する。同一idなら行レベルLWWで1行へ収束する。
 model ExamSubtotalGroup {
-  id                 String        @id @default(uuid())
+  id                 String        @id
   examId             String
   subtotalGroupId    String
   selectedForTable   Boolean       @default(false) // 小計点テーブルに含めるグループ
@@ -286,6 +291,10 @@ model ExamSubtotalGroup {
   updatedAt          DateTime      @default(now()) @updatedAt
   exam               Exam          @relation(fields: [examId], references: [id], onDelete: Cascade, onUpdate: NoAction)
   subtotalGroup      SubtotalGroup @relation(fields: [subtotalGroupId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([examId, subtotalGroupId])
+  @@index([examId])
+  @@index([subtotalGroupId])
 }
 
 model QuestionScore {
@@ -941,6 +950,20 @@ model GradeStudent {
 /// 成績データソース（6種: exam_total / subtotal / crop_region / coursework / coursework_total）
 /// coursework型は CourseworkItem（試験外成績資料の評価項目）を参照する
 /// coursework_total型は Coursework（試験外成績資料）全体を参照し、全評価項目のスコアを合算する
+///
+/// 参照列（examId / subtotalId / cropRegionId / courseworkItemId / courseworkId）は
+/// type ごとに使う組み合わせが変わり、**同じ列でも type によって意味が違う**。
+/// 特に examId は type によって必要だったり冗長だったりするので、消さないこと。
+///
+/// | type             | 参照列                    | examId の意味                                  |
+/// | ---------------- | ------------------------- | ---------------------------------------------- |
+/// | exam_total       | examId                    | 合計点を取る試験そのもの（必須）               |
+/// | subtotal         | examId + subtotalId       | **必須**。SubtotalGroup は Exam と多対多なので、|
+/// |                  |                           | どの試験のスコアを集計するかは subtotalId から |
+/// |                  |                           | は辿れない                                     |
+/// | crop_region      | examId + cropRegionId     | 冗長（cropRegion.examPage.examId で辿れる）    |
+/// | coursework       | courseworkItemId          | 使わない                                       |
+/// | coursework_total | courseworkId              | 使わない                                       |
 model GradeDataSource {
   id                     String   @id @default(uuid())
   gradeItemId            String
@@ -1360,6 +1383,11 @@ model AsbHeaderField {
   order            Int     @default(0)
   fontSize         Float? // label タイプ用
   linkedRegionType String? // "TOTAL_SCORE" | "SUBTOTAL_SCORE" | "STUDENT_NAME" | "STUDENT_ID"
+
+  /// sqlite-nas-sync は `id` と `updatedAt` を持つテーブルだけを同期対象として自動検出し、
+  /// LWW の判定にも updatedAt を使う。この2列が無いと同期の対象外になる
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   definition AsbDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
 

--- a/scripts/importTempSaiten.ts
+++ b/scripts/importTempSaiten.ts
@@ -11,6 +11,7 @@
  *   npx tsx scripts/importTempSaiten.ts --config path/to/config  # 設定ファイル指定
  */
 
+import { buildExamSubtotalGroupId } from "../electron-src/lib/prisma/deterministicId"
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
 import { PrismaClient } from "@prisma/client"
 import * as crypto from "crypto"
@@ -603,7 +604,7 @@ async function importExam(
     })
     await prisma.examSubtotalGroup.create({
       data: {
-        id: crypto.randomUUID(),
+        id: buildExamSubtotalGroupId(examId, groupId),
         examId,
         subtotalGroupId: groupId,
         createdAt: now,


### PR DESCRIPTION
Closes #1131

## 変更

`docs/schema-relation-audit.md` §6.1〜6.4 に対応した（4.4 は見送り、理由は §6.3）。

| 節 | 内容 |
| --- | --- |
| 6.1 | 除外リストを端末固有の2つに絞り、Asb 系を同期対象へ。`AsbHeaderField` に `createdAt`/`updatedAt` 追加 |
| 6.2 | `ExamSubtotalGroup` に `@@unique` と決定論的 id。重複潰し・upsert・移行を整備 |
| 6.3 | `GradeDataSource` の type 別参照列を表でコメント化 |
| 6.4 | IPC ハンドラのテストハーネスと OMR 検出のテスト |

マイグレーション2本（`20260802030000` / `20260802040000`）。`MIGRATION_CHECKSUMS` には未追加。

## 設計上の判断

**`AsbHeaderField` の既存行には親定義の時刻を引き継ぐ。** 移行を走らせた時刻を入れると、後からアップグレードした端末の**触ってもいない行**が LWW で実際の編集を上回り、編集が黙って巻き戻る。`saveAsbDefinition` は delete → recreate だが子の id を引き継ぐため、ヘッダー項目が最後に書かれたのは「その定義が保存された時刻」＝ `AsbDefinition.updatedAt` に一致する。捏造ではなく事実を入れられる。

**重複潰しはフラグを行をまたいで OR してから1件へ絞る。** 読み取り側（`getSubtotalGroupSelection`）が「1行でも true なら選択」と見ているため、最古の行の値をそのまま採ると新しい行にしか無い選択が消える。残す行は挿入順（rowid）ではなく行の値で選ぶ — 端末ごとに結果がぶれると `createdAt` が食い違い以後の LWW が不安定になる。

**upsert のキーは id ではなく複合 unique。** 決定論的 id は「これから作る行」の名前を決めるだけで、既にある行がその名前で入っている保証は無い（`idChangeExecutor` の付け替え、旧バージョンで作られた行）。id で探すと組み合わせ一致の行を見つけられず create 側へ落ち、アーカイブ取り込みがトランザクションごと巻き戻る。

**`idChangeExecutor` の mover は重複潰しを持たない。** `changeSubtotalGroupId` が移行先グループを必ず新規 `create` するので、その試験が移行先へのリンクを既に持つことはありえない。兄弟の `GradeStudent` / `CourseworkStudent` は移行先の生徒が実在しうるので事情が違う。到達不能な防御コードは書かず、理由をコメントに残した。

## 再発防止

- `__tests__/sync/syncTableConfig.test.ts` — 除外リストに無いテーブルは必ず同期対象として検出されることを検査。**参照関係だけを見る検査では捕まえられない**（子を持たないテーブルの漏れは「同期されない親」として現れないため）
- `__tests__/import-export/unit/deterministicIdCoverage.test.ts` — 決定論的id前提のテーブルへ uuid を渡している箇所をソースから検出。DB は id の形式を強制できず、移行は実行時にあった行しか直さない

いずれも修正を戻すと落ちることを確認済み（`AsbHeaderField` から `updatedAt` を抜く／`importTempSaiten.ts` を uuid に戻す／OMR のガードを外す）。

## 検証

- 型チェック: エラー0
- lint: エラー0（警告63件は既存の `react-hooks/set-state-in-effect`）
- テスト: 1307件通過

途中、本体リポジトリでの全実行が不安定に失敗した。隔離 worktree で `origin/main` の baseline（1263件通過）と自分の変更（3回連続で1280件通過）を比較し、**自分の変更由来ではない**ことを確認している。原因はテストDB（`data/test-database.db`）を並行セッションと共有していることによる競合で、`globalSetup` が実行のたびに削除・再作成するため、他セッションの実行と重なるとテーブルが消える。

## 続き

対応の過程で判明し、別 issue へ切り出した。

- #1126 解答用紙定義を同期対象にしたが、保存方式（delete→recreate）と噛み合っていない
- #1127 解答用紙定義の所有と共有の設計（`userId` 絞り込みと `getCurrentUser`）
- #1128 複合uniqueを持つ中間テーブルの id を決定論的にする（14テーブル）

**#1126 は本PRの 6.1 と関係が深い。** Asb を同期対象にしたが、`saveAsbDefinition` の delete → recreate と組み合わさると、tombstone の同時刻判定（同時刻なら削除が勝つ）で相手端末から定義が消えうる。#1126 では「まず Asb を除外リストへ戻す」ことを提案している。本PRはその判断を保留したまま同期対象にした状態で入る。