### PR TITLE
test(scoring): 未検証だった出力・初期化・裁定サマリの3経路にテストを足す

### DIFF
--- a/__tests__/exam/integration/examDecisionSummary.test.ts
+++ b/__tests__/exam/integration/examDecisionSummary.test.ts
@@ -1,0 +1,306 @@
+/**
+ * 試験の裁定サマリ（getExamDecisionSummary）統合テスト
+ *
+ * この経路はテストから一度も呼ばれていなかった。裁定サマリは「出力を止めずに伝える」ための
+ * 唯一の導線なので、競合を数え落とすと誤った点数のまま黙って書き出される。
+ *
+ * 解決ルール自体は resolveEffectiveScores のテストが持つ。ここで固定するのは
+ * サマリ側の派生計算 — 裁定対象の抽出、失点見込み、担当と進捗の数え方。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { buildAssignmentId } from "@/electron-src/lib/prisma/cropRegionAssignment"
+import { getExamDecisionSummary } from "@/electron-src/lib/prisma/scoreDecisionSummary"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 追加の採点者を作る。メンバーにするかどうかで担当の数え方が変わる */
+async function createGrader(name: string, examId: string | null) {
+  const user = await testPrisma.user.create({
+    data: {
+      id: crypto.randomUUID(),
+      username: `grader_${crypto.randomUUID()}`,
+      name,
+      role: "teacher",
+    },
+  })
+  if (examId) {
+    await testPrisma.userExam.create({
+      data: {
+        id: crypto.randomUUID(),
+        userId: user.id,
+        examId,
+        role: "GRADER",
+      },
+    })
+  }
+  return user
+}
+
+async function assignGrader(cropRegionId: string, userId: string) {
+  await testPrisma.cropRegionAssignment.create({
+    // 決定論的id。uuid を振ると2端末で同値別idの行ができて同期で衝突する
+    data: { id: buildAssignmentId(cropRegionId, userId), cropRegionId, userId },
+  })
+}
+
+describe("試験の裁定サマリ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("裁定対象が無くても全ての設問を配点つきで返す", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    const { summary } = result
+
+    expect(summary.questions).toHaveLength(fixture.cropRegions.length)
+    for (const [index, question] of summary.questions.entries()) {
+      expect(question.cropRegionId).toBe(fixture.cropRegions[index].id)
+      expect(question.questionLabel).toBe(fixture.cropRegions[index].label)
+      expect(question.maxScore).toBe(fixture.cropRegions[index].points)
+      expect(question.cells).toEqual([])
+    }
+    expect(summary.conflictCount).toBe(0)
+    expect(summary.staleCount).toBe(0)
+    expect(summary.totalScoreImpact).toBe(0)
+    // 採点者が1人の試験は常に合意で解決される（個人利用と同一挙動）
+    expect(summary.graderCount).toBe(1)
+  })
+
+  it("食い違ったセルを競合として挙げ、失われうる点を見積もる", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const [firstCropRegion] = fixture.cropRegions
+    const otherGrader = await createGrader("別の採点者", fixture.exam.id)
+    await testPrisma.questionScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: firstCropRegion.id,
+        examStudentId: examStudent.id,
+        userId: otherGrader.id,
+        status: "incorrect",
+        partialScore: null,
+      },
+    })
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    if (!result.success) throw new Error(result.error)
+    const { summary } = result
+
+    expect(summary.conflictCount).toBe(1)
+    expect(summary.graderCount).toBe(2)
+    // 未解決のまま出力すると、正答(10点)側の主張が失われうる
+    expect(summary.totalScoreImpact).toBe(10)
+
+    const question = summary.questions.find(
+      (candidate) => candidate.cropRegionId === firstCropRegion.id
+    )!
+    expect(question.cells).toHaveLength(1)
+    const [cell] = question.cells
+    expect(cell.reason).toBe("conflict")
+    expect(cell.examStudentId).toBe(examStudent.id)
+    expect(cell.scoreImpact).toBe(10)
+    expect(cell.decision).toBeNull()
+    // 裁定画面は誰が何を主張したかを出す
+    expect(cell.proposals).toHaveLength(2)
+    expect(
+      cell.proposals.map((proposal) => proposal.scoreValue).sort()
+    ).toEqual([0, 10])
+    expect(cell.proposals.map((proposal) => proposal.userName).sort()).toEqual(
+      [fixture.user.name, otherGrader.name].sort()
+    )
+    // 氏名は裁定対象セルの分だけ引く。ID がそのまま出ていたら引けていない
+    expect(cell.studentName).not.toBe(examStudent.id)
+  })
+
+  it("確定より新しい提案が入ったセルを stale として挙げる", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const [firstCropRegion] = fixture.cropRegions
+    // 提案（試験作成時）より前に確定していた、という状態を作る
+    await testPrisma.scoreDecision.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: firstCropRegion.id,
+        examStudentId: examStudent.id,
+        verdict: "partial",
+        score: 3,
+        comment: "部分点で確定",
+        decidedByUserId: fixture.user.id,
+        decidedAt: new Date("2020-01-01"),
+      },
+    })
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    if (!result.success) throw new Error(result.error)
+    const { summary } = result
+
+    expect(summary.staleCount).toBe(1)
+    expect(summary.conflictCount).toBe(0)
+    expect(summary.decidedCount).toBe(1)
+    // 確定済みなので出力は止まらない（失点見込みは立たない）
+    expect(summary.totalScoreImpact).toBe(0)
+
+    const question = summary.questions.find(
+      (candidate) => candidate.cropRegionId === firstCropRegion.id
+    )!
+    expect(question.decidedCount).toBe(1)
+    const [cell] = question.cells
+    expect(cell.reason).toBe("stale")
+    expect(cell.decision!.verdict).toBe("partial")
+    expect(cell.decision!.score).toBe(3)
+    expect(cell.decision!.decidedByName).toBe(fixture.user.name)
+  })
+
+  it("担当は試験のメンバーだけを数える", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [firstCropRegion, secondCropRegion] = fixture.cropRegions
+    const member = await createGrader("担当の先生", fixture.exam.id)
+    const nonMember = await createGrader("外れた先生", null)
+    await assignGrader(firstCropRegion.id, member.id)
+    await assignGrader(secondCropRegion.id, nonMember.id)
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    if (!result.success) throw new Error(result.error)
+    const { summary } = result
+
+    const assigned = summary.questions.find(
+      (question) => question.cropRegionId === firstCropRegion.id
+    )!
+    expect(assigned.assignees.map((grader) => grader.userName)).toEqual([
+      member.name,
+    ])
+    // まだ1件も採点していない
+    expect(assigned.assignees[0].scoredCount).toBe(0)
+
+    // 非メンバーの割当が残っていても担当としては数えない
+    // （担当が居るのに誰も採点できない設問が生まれるため）
+    const orphaned = summary.questions.find(
+      (question) => question.cropRegionId === secondCropRegion.id
+    )!
+    expect(orphaned.assignees).toEqual([])
+
+    expect(
+      summary.members.map((memberRow) => memberRow.userName).sort()
+    ).toEqual([fixture.user.name, member.name].sort())
+  })
+
+  it("担当者の採点済み件数は未採点行を除いて数える", async () => {
+    const fixture = await createFullTestExam(testPrisma, {
+      includeScores: false,
+    })
+    const [firstCropRegion] = fixture.cropRegions
+    const [firstExamStudent, secondExamStudent] = fixture.examStudents
+    const member = await createGrader("担当の先生", fixture.exam.id)
+    await assignGrader(firstCropRegion.id, member.id)
+    await testPrisma.questionScore.createMany({
+      data: [
+        {
+          id: crypto.randomUUID(),
+          cropRegionId: firstCropRegion.id,
+          examStudentId: firstExamStudent.id,
+          userId: member.id,
+          status: "correct",
+          partialScore: null,
+        },
+        {
+          id: crypto.randomUUID(),
+          cropRegionId: firstCropRegion.id,
+          examStudentId: secondExamStudent.id,
+          userId: member.id,
+          status: "unscored",
+          partialScore: null,
+        },
+      ],
+    })
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    if (!result.success) throw new Error(result.error)
+
+    const question = result.summary.questions.find(
+      (candidate) => candidate.cropRegionId === firstCropRegion.id
+    )!
+    // 初期化が作る unscored 行は採点の意思表示ではない
+    expect(question.assignees[0].scoredCount).toBe(1)
+    expect(question.scoredCount).toBe(1)
+    expect(result.summary.graderCount).toBe(1)
+  })
+
+  it("進捗の分母は答案がある受験者数", async () => {
+    const fixture = await createFullTestExam(testPrisma, {
+      includeStudentAnswerImages: true,
+    })
+
+    const result = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    if (!result.success) throw new Error(result.error)
+
+    for (const question of result.summary.questions) {
+      // 答案は受験者×ページぶんあるが、分母は受験者の人数
+      expect(question.totalStudents).toBe(fixture.examStudents.length)
+      expect(question.scoredCount).toBe(fixture.examStudents.length)
+    }
+  })
+
+  it("確定できるのは OWNER だけ", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const grader = await createGrader("担当の先生", fixture.exam.id)
+
+    const asOwner = await getExamDecisionSummary(
+      fixture.exam.id,
+      fixture.user.id
+    )
+    const asGrader = await getExamDecisionSummary(fixture.exam.id, grader.id)
+
+    if (!asOwner.success || !asGrader.success) throw new Error("failed")
+    expect(asOwner.summary.canDecide).toBe(true)
+    expect(asGrader.summary.canDecide).toBe(false)
+  })
+})

--- a/__tests__/exam/integration/exportScoringData.test.ts
+++ b/__tests__/exam/integration/exportScoringData.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Excel 出力の採点データ（fetchExportData）統合テスト
+ *
+ * この経路を検証していたのは採番学級の引き当てだけ（exportPlacementKey.test.ts）で、
+ * 得点・配点・小計にはどのテストも触れていなかった。実際に
+ * `maxScore: region.points || 0` を `maxScore: 0` へ壊しても全テストが通る状態だったので、
+ * 配点が全て 0 の成績表が配布されても CI は緑のままになる。
+ *
+ * ここでは「設問列の配点」「判定ごとの得点」「合計」「小計」「競合と確定の扱い」を固定する。
+ * 解決ルール自体は resolveEffectiveScores のテストが持つので、ここは配線だけを見る。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { fetchExportData } from "@/electron-src/lib/export/excel/dataFetcher"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 受験者1名の設問スコアを、設問の並び順どおりの判定へ置き換える */
+async function setScores(
+  examStudentId: string,
+  cropRegionIds: string[],
+  verdicts: Array<{ status: string; partialScore: number | null }>
+) {
+  await testPrisma.questionScore.deleteMany({ where: { examStudentId } })
+  const user = await testPrisma.user.findFirstOrThrow()
+  for (const [index, cropRegionId] of cropRegionIds.entries()) {
+    await testPrisma.questionScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId,
+        examStudentId,
+        userId: user.id,
+        status: verdicts[index].status,
+        partialScore: verdicts[index].partialScore,
+      },
+    })
+  }
+}
+
+describe("Excel 出力の採点データ", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("設問列は orderIndex 順に並び、配点は領域の points がそのまま出る", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+
+    expect(result.success).toBe(true)
+    expect(result.questionRegions).toHaveLength(fixture.cropRegions.length)
+    expect(
+      result.questionRegions!.map((cropRegion) => cropRegion.label)
+    ).toEqual(fixture.cropRegions.map((cropRegion) => cropRegion.label))
+
+    const [scoringData] = result.scoringData!
+    // 配点が 0 に落ちると成績表の満点欄が全て 0 になる
+    for (const [index, score] of scoringData.scores.entries()) {
+      expect(score.maxScore).toBe(fixture.cropRegions[index].points)
+      expect(score.questionId).toBe(fixture.cropRegions[index].id)
+    }
+  })
+
+  it("判定ごとの得点と合計が配点から算出される", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const cropRegionIds = fixture.cropRegions.map((cropRegion) => cropRegion.id)
+    await setScores(examStudent.id, cropRegionIds, [
+      { status: "correct", partialScore: null },
+      { status: "incorrect", partialScore: null },
+      { status: "partial", partialScore: 4 },
+      { status: "unscored", partialScore: null },
+    ])
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+    const [scoringData] = result.scoringData!
+
+    // 正答は満点、誤答は 0、部分点は入力値、未採点は null
+    expect(scoringData.scores.map((score) => score.score)).toEqual([
+      10,
+      0,
+      4,
+      null,
+    ])
+    expect(scoringData.scores.map((score) => score.status)).toEqual([
+      "correct",
+      "incorrect",
+      "partial",
+      "unscored",
+    ])
+    expect(scoringData.totalScore).toBe(14)
+    expect(scoringData.totalMaxScore).toBe(40)
+  })
+
+  it("全問未採点の受験者は合計点を出さない（0 点と区別する）", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const cropRegionIds = fixture.cropRegions.map((cropRegion) => cropRegion.id)
+    await setScores(
+      examStudent.id,
+      cropRegionIds,
+      cropRegionIds.map(() => ({ status: "unscored", partialScore: null }))
+    )
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+    const [scoringData] = result.scoringData!
+
+    expect(scoringData.totalScore).toBeNull()
+    // 満点は採点状況に依らず設問の配点合計
+    expect(scoringData.totalMaxScore).toBe(40)
+  })
+
+  it("小計は割り当てられた設問の得点と配点だけを集める", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const cropRegionIds = fixture.cropRegions.map((cropRegion) => cropRegion.id)
+    // ビルダーは設問を小計へ交互に割り当てる（前半=問1,問3 / 後半=問2,問4）
+    await setScores(examStudent.id, cropRegionIds, [
+      { status: "correct", partialScore: null },
+      { status: "incorrect", partialScore: null },
+      { status: "partial", partialScore: 4 },
+      { status: "correct", partialScore: null },
+    ])
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+
+    expect(result.subtotalColumns!.map((column) => column.label)).toEqual([
+      "前半",
+      "後半",
+    ])
+
+    const [scoringData] = result.scoringData!
+    const [firstSubtotal, secondSubtotal] = fixture.subtotals
+    const firstHalf = scoringData.subtotalScores.find(
+      (subtotalScore) => subtotalScore.subtotalId === firstSubtotal.id
+    )!
+    const secondHalf = scoringData.subtotalScores.find(
+      (subtotalScore) => subtotalScore.subtotalId === secondSubtotal.id
+    )!
+
+    expect(firstHalf.score).toBe(14) // 問1(10) + 問3(4)
+    expect(firstHalf.maxScore).toBe(20)
+    expect(secondHalf.score).toBe(10) // 問2(0) + 問4(10)
+    expect(secondHalf.maxScore).toBe(20)
+    expect(firstHalf.subtotalGroupName).toBe(fixture.subtotalGroup.name)
+  })
+
+  it("割り当てが無い小計は満点も点も出さない", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    await testPrisma.cropSubtotal.deleteMany({})
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+    const [scoringData] = result.scoringData!
+
+    for (const subtotalScore of scoringData.subtotalScores) {
+      expect(subtotalScore.hasQuestionAssignments).toBe(false)
+      expect(subtotalScore.score).toBeNull()
+      expect(subtotalScore.maxScore).toBe(0)
+    }
+  })
+
+  it("採点者間で食い違うセルは競合として報告し、点を出さない", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const [firstCropRegion] = fixture.cropRegions
+
+    const otherUser = await testPrisma.user.create({
+      data: {
+        id: crypto.randomUUID(),
+        username: `other_${crypto.randomUUID()}`,
+        name: "別の採点者",
+        role: "teacher",
+      },
+    })
+    await testPrisma.questionScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: firstCropRegion.id,
+        examStudentId: examStudent.id,
+        userId: otherUser.id,
+        status: "incorrect",
+        partialScore: null,
+      },
+    })
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+
+    expect(result.scoreConflicts).toHaveLength(1)
+    expect(result.scoreConflicts![0].cropRegionId).toBe(firstCropRegion.id)
+
+    const [scoringData] = result.scoringData!
+    // 解決できないので値を出さない（未採点として書き出す）
+    expect(scoringData.scores[0].score).toBeNull()
+    expect(scoringData.scores[0].status).toBe("unscored")
+  })
+
+  it("確定（ScoreDecision）は採点者の提案より優先される", async () => {
+    const fixture = await createFullTestExam(testPrisma, {})
+    const [examStudent] = fixture.examStudents
+    const [firstCropRegion] = fixture.cropRegions
+
+    // 提案は正答（10点）。OWNER が部分点 3 点で確定する
+    await testPrisma.scoreDecision.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: firstCropRegion.id,
+        examStudentId: examStudent.id,
+        verdict: "partial",
+        score: 3,
+        decidedByUserId: fixture.user.id,
+      },
+    })
+
+    const result = await fetchExportData(fixture.exam.id, [examStudent.id])
+    const [scoringData] = result.scoringData!
+
+    expect(scoringData.scores[0].status).toBe("partial")
+    expect(scoringData.scores[0].score).toBe(3)
+  })
+})

--- a/__tests__/exam/integration/scoringInitializer.test.ts
+++ b/__tests__/exam/integration/scoringInitializer.test.ts
@@ -1,0 +1,181 @@
+/**
+ * 採点レコード初期化（initializeScoringRecords）統合テスト
+ *
+ * この経路はテストから一度も呼ばれていなかった。作成行を丸ごと空配列に落としても
+ * 全テストが通る状態で、07 採点画面が空になる不具合が素通りする。
+ *
+ * 既存行の突き合わせは「受験者の内側で閉じる」形（ExamStudent に子として同梱）へ
+ * 変えてあるため、既存判定の取りこぼしは重複行として現れる。
+ * QuestionScore には (examStudentId, cropRegionId, userId) の unique が無く、
+ * DB は重複を止めてくれないので、ここで固定する。
+ */
+
+import * as path from "path"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const TEST_DB_PATH = path.resolve(__dirname, "../../../data/test-database.db")
+
+vi.mock("../../../electron-src/lib/prisma/client", async () => {
+  const { getTestPrismaClient } = await import("../../helpers/testPrismaClient")
+  return {
+    default: getTestPrismaClient(),
+    getPrismaClient: () => getTestPrismaClient(),
+  }
+})
+
+import { initializeScoringRecords } from "@/electron-src/lib/prisma/scoringInitializer"
+
+import { createFullTestExam } from "../../helpers/testExamBuilder"
+import {
+  cleanupTestDatabase,
+  createPrismaClientForPath,
+  disconnectTestPrisma,
+} from "../../helpers/testPrismaClient"
+
+const testPrisma = createPrismaClientForPath(TEST_DB_PATH)
+
+/** 採点行が無い状態の試験を作る（初期化はこの状態から呼ばれる） */
+async function createUnscoredExam() {
+  return createFullTestExam(testPrisma, { includeScores: false })
+}
+
+describe("採点レコードの初期化", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanupTestDatabase()
+    await testPrisma.$disconnect()
+    await disconnectTestPrisma()
+  })
+
+  it("受験者×設問の全ての組み合わせに未採点行を作る", async () => {
+    const fixture = await createUnscoredExam()
+    const expected = fixture.examStudents.length * fixture.cropRegions.length
+
+    const result = await initializeScoringRecords(fixture.exam.id)
+
+    if (!result.success) throw new Error(result.error)
+    expect(result.initialized).toBe(expected)
+
+    const questionScores = await testPrisma.questionScore.findMany({
+      where: { examStudent: { examId: fixture.exam.id } },
+    })
+    expect(questionScores).toHaveLength(expected)
+    for (const questionScore of questionScores) {
+      expect(questionScore.status).toBe("unscored")
+      expect(questionScore.partialScore).toBeNull()
+      expect(questionScore.userId).toBe(fixture.user.id)
+    }
+
+    // 受験者ごとに全設問ぶん揃っている（取りこぼした受験者が居ない）
+    for (const examStudent of fixture.examStudents) {
+      const forExamStudent = questionScores.filter(
+        (questionScore) => questionScore.examStudentId === examStudent.id
+      )
+      expect(forExamStudent.map((row) => row.cropRegionId).sort()).toEqual(
+        fixture.cropRegions.map((cropRegion) => cropRegion.id).sort()
+      )
+    }
+  })
+
+  it("二度目の実行は1行も作らない（重複行を生まない）", async () => {
+    const fixture = await createUnscoredExam()
+    const first = await initializeScoringRecords(fixture.exam.id)
+
+    const second = await initializeScoringRecords(fixture.exam.id)
+
+    if (!first.success) throw new Error(first.error)
+    if (!second.success) throw new Error(second.error)
+    expect(second.initialized).toBe(0)
+    const count = await testPrisma.questionScore.count({
+      where: { examStudent: { examId: fixture.exam.id } },
+    })
+    expect(count).toBe(first.initialized)
+  })
+
+  it("既に採点済みのセルは作り直さず、判定を保つ", async () => {
+    const fixture = await createUnscoredExam()
+    const [examStudent] = fixture.examStudents
+    const [firstCropRegion] = fixture.cropRegions
+    const scored = await testPrisma.questionScore.create({
+      data: {
+        id: crypto.randomUUID(),
+        cropRegionId: firstCropRegion.id,
+        examStudentId: examStudent.id,
+        userId: fixture.user.id,
+        status: "correct",
+        partialScore: 10,
+      },
+    })
+
+    const result = await initializeScoringRecords(fixture.exam.id)
+
+    // 採点済みの1セルを除いた分だけ作られる
+    if (!result.success) throw new Error(result.error)
+    expect(result.initialized).toBe(
+      fixture.examStudents.length * fixture.cropRegions.length - 1
+    )
+    const rows = await testPrisma.questionScore.findMany({
+      where: {
+        examStudentId: examStudent.id,
+        cropRegionId: firstCropRegion.id,
+      },
+    })
+    // unscored 行を並べて足すと、以降どちらが有効か決められなくなる
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe(scored.id)
+    expect(rows[0].status).toBe("correct")
+  })
+
+  it("設問以外の領域（小計点欄など）には作らない", async () => {
+    const fixture = await createUnscoredExam()
+    const subtotalRegion = await testPrisma.cropRegion.create({
+      data: {
+        id: crypto.randomUUID(),
+        examPageId: fixture.pages[0].id,
+        label: "小計欄",
+        type: "SUBTOTAL_SCORE",
+        x: 0,
+        y: 500,
+        width: 100,
+        height: 40,
+        points: null,
+        orderIndex: 99,
+      },
+    })
+
+    await initializeScoringRecords(fixture.exam.id)
+
+    const rows = await testPrisma.questionScore.findMany({
+      where: { cropRegionId: subtotalRegion.id },
+    })
+    expect(rows).toEqual([])
+  })
+
+  it("他の試験の受験者・設問は巻き込まない", async () => {
+    const fixture = await createUnscoredExam()
+    const other = await createUnscoredExam()
+
+    await initializeScoringRecords(fixture.exam.id)
+
+    const otherRows = await testPrisma.questionScore.findMany({
+      where: { examStudent: { examId: other.exam.id } },
+    })
+    expect(otherRows).toEqual([])
+  })
+
+  it("ユーザーが1人も居なければ失敗を返す（誰の名義でも作らない）", async () => {
+    const fixture = await createUnscoredExam()
+    await testPrisma.userExam.deleteMany({})
+    await testPrisma.user.deleteMany({})
+
+    const result = await initializeScoringRecords(fixture.exam.id)
+
+    if (result.success) throw new Error("失敗を返すべき経路が成功した")
+    expect(result.error).toBeTruthy()
+    const count = await testPrisma.questionScore.count()
+    expect(count).toBe(0)
+  })
+})

--- a/electron-src/lib/prisma/scoringInitializer.ts
+++ b/electron-src/lib/prisma/scoringInitializer.ts
@@ -7,7 +7,12 @@ import prisma from "./client"
  * 採点領域も受験者も同じ examId から引くため、両者が別の試験のものになることは
  * 構造的に起こらない（examScopeGuard による検査を足す必要が無い唯一の書き込み経路）。
  */
-export const initializeScoringRecords = async (examId: string) => {
+export const initializeScoringRecords = async (
+  examId: string
+): Promise<
+  | { success: true; initialized: number; message: string }
+  | { success: false; error: string }
+> => {
   try {
     return await prisma.$transaction(
       async (tx) => {
@@ -74,7 +79,7 @@ export const initializeScoringRecords = async (examId: string) => {
         }
 
         return {
-          success: true,
+          success: true as const,
           initialized: scoringRecords.length,
           message: `${scoringRecords.length} scoring records initialized`,
         }
@@ -88,7 +93,7 @@ export const initializeScoringRecords = async (examId: string) => {
   } catch (error) {
     console.error("Failed to initialize scoring records:", error)
     return {
-      success: false,
+      success: false as const,
       error: error instanceof Error ? error.message : "Unknown error",
     }
   }


### PR DESCRIPTION
Closes #1136

#1133 でフィクスチャの `CropRegion.type` を正典へ直した結果、Excel 出力・採点レコード初期化・裁定サマリには実データが流れるようになった。しかし assertion がそこを見ていないため、直したあとも検証されていない状態が残っていた。

## 変更

### 追加したテスト（20件）

| ファイル | 対象 | 件数 |
|---|---|---|
| `__tests__/exam/integration/exportScoringData.test.ts` | `fetchExportData` の得点・配点・合計・小計・競合・確定 | 7 |
| `__tests__/exam/integration/scoringInitializer.test.ts` | `initializeScoringRecords` | 6 |
| `__tests__/exam/integration/examDecisionSummary.test.ts` | `getExamDecisionSummary` | 7 |

### `initializeScoringRecords` の返り値を判別可能な union へ

`success` が `boolean` だったため union が判別できず、呼び出し側から `initialized` も `error` も読めない型になっていた。`success: true` / `false` のリテラルへ絞った。

## 検証

**「テストがある」では足りないので、隔離した worktree でコードをわざと壊し、対応するテストが落ちることを確認した。8種類の変異が全て捕まる。**

| 壊した内容 | 落ちたテスト |
|---|---|
| Excel の設問配点を常に 0 | 3件 |
| 採点レコードを1件も作らない | 2件 |
| 裁定サマリの失点見積もりを常に 0 | 1件 |
| 小計へ渡す設問割り当てを空に | 1件 |
| 確定（ScoreDecision）を無視 | 1件 |
| 競合の報告を握りつぶす | 1件 |
| 担当のメンバー絞り込みを外す | 1件 |
| 進捗の分母から `distinct` を外す | 1件 |

なお #1133 の時点で「採点レコード初期化を空配列にしても全テストが通る」と報告していたが、あの変異は `const scoringRecords: never[] = []` という型注釈だけの変更で実行時には何も変わっていなかった。今回は `if (false)` で実際に作成を止めて計り直している（結論は同じ）。

## 確認

- `npx vitest run` → 138ファイル / 1327テスト 全通過（1307 → +20）
- `npm run check-all` → exit 0（警告63件はいずれも既存の `react-hooks/set-state-in-effect`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbE94RUdrwMAKhTZsQRzPQ