### PR TITLE
fix(scoring): 採点担当の解除を1文へ戻し、id統一の取り残しを片付ける

### DIFF
--- a/__tests__/helpers/testDataFactory.ts
+++ b/__tests__/helpers/testDataFactory.ts
@@ -389,7 +389,6 @@ export function createEmptyIdMappings(): IdMappings {
     studentAnswerImage: {},
     examStudent: {},
     userExam: {},
-    examSubtotalGroup: {},
     cropSubtotal: {},
     questionScore: {},
     drawingAnnotation: {},

--- a/__tests__/import-export/unit/idMappings.test.ts
+++ b/__tests__/import-export/unit/idMappings.test.ts
@@ -30,7 +30,6 @@ describe("IdMappings", () => {
         "studentAnswerImage",
         "examStudent",
         "userExam",
-        "examSubtotalGroup",
         "cropSubtotal",
         "questionScore",
         "drawingAnnotation",

--- a/electron-src/lib/import/merge/idChangeExecutor.ts
+++ b/electron-src/lib/import/merge/idChangeExecutor.ts
@@ -241,10 +241,7 @@ export const CLASSROOM_CASCADE_MOVERS: CascadeMover[] = [
  */
 export const SUBTOTAL_GROUP_CASCADE_MOVERS: CascadeMover[] = [
   {
-    // id が (examId, subtotalGroupId) から決まるので、付け替えたら id も組み直す。
-    // updateMany で subtotalGroupId だけ動かすと id が旧グループを指したまま残り、
-    // (a) 同じ試験のアーカイブを再取り込みしたとき組み合わせ一致の行を id で引けず
-    // unique 違反、(b) 同僚のPCは同じ組を新idで持つので同期で2行目が押し寄せる。
+    // id は uuidv4 で行の内容を反映しないので、付け替えても id は据え置く。
     //
     // UNIQUE([examId, subtotalGroupId]) の衝突は起きない。changeSubtotalGroupId が
     // 移行先グループを必ず新規 create するので、その試験が移行先へのリンクを

--- a/electron-src/lib/import/merge/idIntegrationImporter.ts
+++ b/electron-src/lib/import/merge/idIntegrationImporter.ts
@@ -114,7 +114,6 @@ export async function executeIdIntegrationImport(
     studentAnswerImage: {},
     examStudent: {},
     userExam: {},
-    examSubtotalGroup: {},
     cropSubtotal: {},
     questionScore: {},
     drawingAnnotation: {},

--- a/electron-src/lib/import/merge/importExamCore.ts
+++ b/electron-src/lib/import/merge/importExamCore.ts
@@ -249,7 +249,7 @@ export async function processExamSubtotalGroups(
     // アーカイブ側の id とも一致しない。ここで id を探しにいくと、同じ組み合わせの行が
     // あるのに見つけられず create 側へ落ち、unique 違反でアーカイブ取り込みが
     // トランザクションごと巻き戻る。
-    const linked = await tx.examSubtotalGroup.upsert({
+    await tx.examSubtotalGroup.upsert({
       where: {
         examId_subtotalGroupId: {
           examId: newExamId,
@@ -264,8 +264,6 @@ export async function processExamSubtotalGroups(
       },
       update: {},
     })
-    // idは uuidv4 なのでアーカイブ側の id とは一致しない。実際の行の id を記録する
-    idMappings.examSubtotalGroup[examSubtotalGroup.id] = linked.id
   }
 }
 

--- a/electron-src/lib/import/merge/types.ts
+++ b/electron-src/lib/import/merge/types.ts
@@ -17,7 +17,6 @@ export interface IdMappings {
   studentAnswerImage: Record<string, string>
   examStudent: Record<string, string>
   userExam: Record<string, string>
-  examSubtotalGroup: Record<string, string>
   cropSubtotal: Record<string, string>
   questionScore: Record<string, string>
   drawingAnnotation: Record<string, string>

--- a/electron-src/lib/import/student-archive/index.ts
+++ b/electron-src/lib/import/student-archive/index.ts
@@ -98,7 +98,6 @@ export async function executeStudentImport(
     studentAnswerImage: {},
     examStudent: {},
     userExam: {},
-    examSubtotalGroup: {},
     cropSubtotal: {},
     questionScore: {},
     drawingAnnotation: {},

--- a/electron-src/lib/prisma/cropRegionAssignment.ts
+++ b/electron-src/lib/prisma/cropRegionAssignment.ts
@@ -9,6 +9,7 @@
 import { recordAuditLog } from "./auditLog"
 import { resolveExamScopeByCropRegion, resolveUserLabel } from "./auditScope"
 import prisma from "./client"
+import { isRecordNotFoundError } from "./prismaErrors"
 import { canDecideExamScores } from "./scoreDecision"
 
 /**
@@ -131,21 +132,19 @@ export const unassignCropRegion = async (
       return { success: false as const, error: permission.reason }
     }
 
-    // 監査ログに実際の行のidを載せるため、削除前に引く（idは計算で出せない）
-    const assignment = await prisma.cropRegionAssignment.findUnique({
+    // 鍵は `@@unique`（idは uuidv4 で計算できない）。delete の戻り値から
+    // 監査ログ用のidを取る。事前に findUnique で引くと2文に割れ、その隙間で
+    // 同期が相手の DELETE を適用したときに P2025 で失敗扱いになる
+    const deleted = await prisma.cropRegionAssignment.delete({
       where: { cropRegionId_userId: { cropRegionId, userId } },
     })
-    if (!assignment) {
-      return { success: true as const }
-    }
-    await prisma.cropRegionAssignment.delete({ where: { id: assignment.id } })
 
     const userLabel = await resolveUserLabel(userId)
     await recordAuditLog({
       action: "exam.score.unassign",
       userId: requestedByUserId,
       entityType: "CropRegionAssignment",
-      entityId: assignment.id,
+      entityId: deleted.id,
       scopeId: scope.scopeId,
       scopeLabel: scope.scopeLabel,
       summary: `設問の採点担当から${userLabel ?? userId}を外しました`,
@@ -153,6 +152,10 @@ export const unassignCropRegion = async (
 
     return { success: true as const }
   } catch (error) {
+    // 既に外れている（同期で消えた・二重クリック）。求めた状態にはなっているので成功
+    if (isRecordNotFoundError(error)) {
+      return { success: true as const }
+    }
     console.error("Failed to unassign crop region:", error)
     return {
       success: false as const,

--- a/electron-src/lib/prisma/prismaErrors.ts
+++ b/electron-src/lib/prisma/prismaErrors.ts
@@ -1,0 +1,20 @@
+/**
+ * Prisma のエラー判定。
+ *
+ * 対象が消えたことを「失敗」ではなく「もうその状態になっている」と扱いたい経路が
+ * 複数あるため、判定をここに置く（採点の保存・採点担当の解除）。
+ */
+
+/**
+ * Prisma の「更新/削除対象が見つからない」エラー（P2025）か。
+ *
+ * 存在チェックと書き込みのあいだに同期が相手の DELETE を適用した、といった隙間で出る。
+ */
+export function isRecordNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2025"
+  )
+}

--- a/electron-src/lib/prisma/questionScore.ts
+++ b/electron-src/lib/prisma/questionScore.ts
@@ -7,6 +7,7 @@ import {
 } from "./auditScope"
 import prisma from "./client"
 import { assertCropRegionsInSameExam } from "./examScopeGuard"
+import { isRecordNotFoundError } from "./prismaErrors"
 
 /**
  * 採点対象が既に無いことを表す機械可読な理由コード。
@@ -20,16 +21,6 @@ export const SCORE_TARGET_DELETED = "target-deleted" as const
 /** 上記を利用者へ伝える文言（renderer はこれをそのまま表示してよい） */
 const SCORE_TARGET_DELETED_MESSAGE =
   "この答案は削除されたため採点を保存できません"
-
-/** Prisma の「更新/削除対象が見つからない」エラー（P2025）か */
-function isRecordNotFoundError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "P2025"
-  )
-}
 
 /** QuestionScore.status を日本語表示に変換（監査ログ差分用） */
 const scoreStatusLabel = (status: string | null | undefined): string => {

--- a/electron-src/lib/prisma/subtotalGroup.ts
+++ b/electron-src/lib/prisma/subtotalGroup.ts
@@ -328,8 +328,9 @@ export async function getActiveSubtotalGroupsForExam(examId: string) {
 /**
  * 試験に小計点グループを追加する。
  *
- * idが(試験, 小計点グループ)から決まるので upsert で足りる。2端末が同時に同じ組み合わせを
- * 追加しても同一idの1行へ収束し、既にある紐付けを二重に作ることもない
+ * **鍵は id ではなく `@@unique`。** id は uuidv4 なので端末ごとに異なり、同じ組み合わせの
+ * 行を引くのに使えない。2端末が同時に同じ組み合わせを追加すると id 違いの行が2つできるが、
+ * sqlite-nas-sync が LWW で1行へ収束させる
  * （以前は素の create で、重複防止は @@unique も無いまま呼び出し側任せだった）。
  */
 export async function addSubtotalGroupToExam(


### PR DESCRIPTION
## 概要

PR #1150（id の uuidv4 統一）のレビューで見つかった取り残し3件を片付ける。方針そのものには触れない。

Closes #1151

## 1. `unassignCropRegion` を1文へ戻す（回帰の是正）

#1150 で `buildAssignmentId` を消したとき、監査ログ用の id が計算で出せなくなり `findUnique` + `delete` の2文に割れていた。2文のあいだに同期が相手の DELETE を適用すると P2025 で catch に落ち、**実際には外れているのに**「採点担当の解除に失敗しました」と表示され、監査ログも残らない。

既存の作法どおり `delete()` の戻り値を使えば1文で済む。複合uniqueを鍵に原子的に消し、返った行の id を監査ログへ渡す。

```ts
const deleted = await prisma.cropRegionAssignment.delete({
  where: { cropRegionId_userId: { cropRegionId, userId } },
})
// entityId: deleted.id
```

行が既に無い場合は旧 `deleteMany` と同じく成功として返す。P2025 判定は `questionScore.ts` にあったものを `prismaErrors.ts` へ切り出し、採点の保存と担当の解除の両方から使う（同じ意味論が2箇所で要るため）。

## 2. `idMappings.examSubtotalGroup` を削除

書き手1つ・読み手ゼロ。`ExamSubtotalGroup` はどの子テーブルからも参照されないので読み替え表を持つ理由がない。型フィールド・初期化3箇所・代入・テストの期待キーをまとめて外した。

## 3. 古いコメント2箇所

- `idChangeExecutor.ts` — 直下の `updateMany` と逆のことを書いていた
- `subtotalGroup.ts` — 「id が (試験, 小計点グループ) から決まる」のままだった

いずれも実装（id は uuidv4・鍵は `@@unique`）に合わせて書き直した。

## 検証

- `npm run check-all` エラー0（警告64件は既存の react-hooks 警告で本 PR とは無関係）
- vitest 138ファイル / 1332テスト 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
