### PR TITLE
feat(list): 一覧の絞り込みを列見出しへ移し、年度の開始日を設定に持つ

### DIFF
--- a/__tests__/calculations/fiscalYear.test.ts
+++ b/__tests__/calculations/fiscalYear.test.ts
@@ -1,0 +1,123 @@
+/**
+ * 年度の数え方の検査。
+ *
+ * 4月始まりを決め打ちにしていないことと、**開始日より前の日はひとつ前の年度に居る**
+ * ことを固定する。ここを間違えると、3月に「今年度」で絞ったときに、その年度の
+ * 答案が1件も出てこない。
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_FISCAL_YEAR_START,
+  fiscalYearRange,
+  type FiscalYearStart,
+  formatFiscalYearStart,
+  isValidFiscalYearStart,
+  parseFiscalYearStart,
+  serializeFiscalYearStart,
+} from "@/lib/fiscalYear"
+
+const APRIL_FIRST: FiscalYearStart = { month: 4, day: 1 }
+
+describe("年度の範囲", () => {
+  it("開始日より後の日は、その年に始まった年度", () => {
+    expect(fiscalYearRange(new Date(2026, 7, 24), APRIL_FIRST)).toEqual({
+      from: "2026-04-01",
+      to: "2027-03-31",
+    })
+  })
+
+  it("開始日より前の日は、ひとつ前の年に始まった年度", () => {
+    expect(fiscalYearRange(new Date(2026, 1, 10), APRIL_FIRST)).toEqual({
+      from: "2025-04-01",
+      to: "2026-03-31",
+    })
+  })
+
+  it("開始日ちょうどは、その日から始まる年度に入る", () => {
+    expect(fiscalYearRange(new Date(2026, 3, 1), APRIL_FIRST)).toEqual({
+      from: "2026-04-01",
+      to: "2027-03-31",
+    })
+    // その前日は前の年度
+    expect(fiscalYearRange(new Date(2026, 2, 31), APRIL_FIRST)).toEqual({
+      from: "2025-04-01",
+      to: "2026-03-31",
+    })
+  })
+
+  it("1月1日始まりなら暦年と同じになる", () => {
+    expect(
+      fiscalYearRange(new Date(2026, 7, 24), { month: 1, day: 1 })
+    ).toEqual({ from: "2026-01-01", to: "2026-12-31" })
+  })
+
+  it("9月1日始まりも数えられる", () => {
+    expect(
+      fiscalYearRange(new Date(2026, 7, 24), { month: 9, day: 1 })
+    ).toEqual({ from: "2025-09-01", to: "2026-08-31" })
+  })
+
+  it("月の途中から始まる年度も、終わりは次の開始日の前日", () => {
+    expect(
+      fiscalYearRange(new Date(2026, 7, 24), { month: 4, day: 15 })
+    ).toEqual({ from: "2026-04-15", to: "2027-04-14" })
+  })
+
+  it("閏年をまたいでも終わりがずれない", () => {
+    // 2028 は閏年。3/1 始まりの年度は 2028-02-29 で終わる
+    expect(fiscalYearRange(new Date(2027, 5, 1), { month: 3, day: 1 })).toEqual(
+      {
+        from: "2027-03-01",
+        to: "2028-02-29",
+      }
+    )
+  })
+})
+
+describe("設定の読み書き", () => {
+  it("行が無ければ 4月1日で数える", () => {
+    expect(parseFiscalYearStart(null)).toEqual(DEFAULT_FISCAL_YEAR_START)
+  })
+
+  it("書いたものはそのまま読める", () => {
+    const start: FiscalYearStart = { month: 9, day: 1 }
+    expect(parseFiscalYearStart(serializeFiscalYearStart(start))).toEqual(start)
+  })
+
+  it("壊れていれば既定として扱う（読めないことを画面へ持ち込まない）", () => {
+    expect(parseFiscalYearStart("{")).toEqual(DEFAULT_FISCAL_YEAR_START)
+    expect(parseFiscalYearStart("null")).toEqual(DEFAULT_FISCAL_YEAR_START)
+    expect(parseFiscalYearStart('{"month":4}')).toEqual(
+      DEFAULT_FISCAL_YEAR_START
+    )
+    expect(parseFiscalYearStart('{"month":"4","day":"1"}')).toEqual(
+      DEFAULT_FISCAL_YEAR_START
+    )
+  })
+
+  it("在りえない日付は既定として扱う", () => {
+    expect(parseFiscalYearStart('{"month":13,"day":1}')).toEqual(
+      DEFAULT_FISCAL_YEAR_START
+    )
+    expect(parseFiscalYearStart('{"month":2,"day":30}')).toEqual(
+      DEFAULT_FISCAL_YEAR_START
+    )
+  })
+
+  it("2月29日は選ばせない（平年に年度が始まらなくなる）", () => {
+    expect(isValidFiscalYearStart({ month: 2, day: 29 })).toBe(false)
+    expect(isValidFiscalYearStart({ month: 2, day: 28 })).toBe(true)
+  })
+
+  it("整数でない値も弾く", () => {
+    expect(isValidFiscalYearStart({ month: 4.5, day: 1 })).toBe(false)
+  })
+})
+
+describe("表示", () => {
+  it("月日で言う", () => {
+    expect(formatFiscalYearStart({ month: 4, day: 1 })).toBe("4月1日")
+  })
+})

--- a/__tests__/migration/normalizeDatetime.test.ts
+++ b/__tests__/migration/normalizeDatetime.test.ts
@@ -196,6 +196,9 @@ describe("DateTime正規化マイグレーション", () => {
   // の混在が発生しない。よって正規化 UPDATE の対象外（網羅チェックから除外する）。
   // 歴史migrationは編集禁止のため、ここで明示的にホワイトリスト管理する。
   const POST_MIGRATION_TABLES = new Set([
+    // 20260824120000 で追加（アプリ全体の設定）。
+    // normalize migration より後で ISO text 生成
+    "AppPreference",
     "AsbCharGuide",
     "AsbDefinitionTag", // 20260713000000 で追加。normalize migration より後で ISO text 生成
     // 表そのものは normalize migration より前からあるが、当時は DateTime 列を持たなかった。

--- a/__tests__/renderer/components/auditLogList.test.tsx
+++ b/__tests__/renderer/components/auditLogList.test.tsx
@@ -17,7 +17,7 @@
  *    作りへ戻すとこの数は意味を失う
  *
  * jsdom は高さを持たない（`clientHeight` は 0）ので、1〜4 では「自動」が
- * `FALLBACK_AUDIT_LOG_PAGE_SIZE` へ落ちる。5 だけが高さを差し込む。
+ * `FALLBACK_PAGE_SIZE` へ落ちる。5 だけが高さを差し込む。
  */
 
 import "../setup"
@@ -27,21 +27,19 @@ import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { AuditLogList } from "@/app/(app)/audit-logs/components/AuditLogList"
-import {
-  AUDIT_LOG_ROW_HEIGHT,
-  FALLBACK_AUDIT_LOG_PAGE_SIZE,
-} from "@/app/(app)/audit-logs/constants"
+import { AUDIT_LOG_ROW_HEIGHT } from "@/app/(app)/audit-logs/constants"
 import type {
   AuditLogEntry,
   AuditLogQueryOptions,
 } from "@/electron-src/lib/prisma/auditQuery"
+import { FALLBACK_PAGE_SIZE } from "@/lib/listPagination"
 
 import { createQueryWrapper } from "../../helpers/queryWrapper"
 
 const TOTAL_ROWS = 120
 
 /** 高さが測れないときの件数。1〜3 の期待値はこれで組み立てる */
-const PAGE_SIZE = FALLBACK_AUDIT_LOG_PAGE_SIZE
+const PAGE_SIZE = FALLBACK_PAGE_SIZE
 
 /** 検索欄のデバウンス（300ms）を確実に越える待ち時間 */
 const DEBOUNCE_WAIT_MS = 400
@@ -321,7 +319,7 @@ describe("監査ログ一覧の「自動」件数", () => {
 
   it("表示領域の高さを1行の高さで割った件数を要求する", async () => {
     const expectedPageSize = Math.floor(VIEWPORT_HEIGHT / AUDIT_LOG_ROW_HEIGHT)
-    expect(expectedPageSize).not.toBe(FALLBACK_AUDIT_LOG_PAGE_SIZE)
+    expect(expectedPageSize).not.toBe(FALLBACK_PAGE_SIZE)
 
     render(<AuditLogList />, { wrapper: createQueryWrapper() })
 

--- a/__tests__/renderer/components/entityListPage.test.tsx
+++ b/__tests__/renderer/components/entityListPage.test.tsx
@@ -85,6 +85,16 @@ const ROWS: TestExamRow[] = [
   },
 ]
 
+/** ページ送りを見るための行。名前で並べれば順序が決まる */
+function manyRows(count: number): TestExamRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `exam-${String(i + 1).padStart(3, "0")}`,
+    examName: `試験${String(i + 1).padStart(3, "0")}`,
+    examDate: new Date(2026, 0, 1),
+    updatedAt: new Date(2026, 0, 1),
+  }))
+}
+
 const ACTIONS: ToolbarAction[] = [
   {
     id: "search",
@@ -94,8 +104,26 @@ const ACTIONS: ToolbarAction[] = [
   },
 ]
 
+/**
+ * jsdom は `ResizeObserver` を持たない。ページ送りの「自動」がこれで高さを測るので、
+ * 何も観測しないものを置く（高さ 0 のまま＝件数は既定へ落ちる）。
+ */
+global.ResizeObserver = class implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
 const toggleSelectSpy = vi.fn()
 const toggleSelectAllSpy = vi.fn()
+
+/** 絞り込みは列見出しの popover に入る。ここでは値を持つだけの空の設定を渡す */
+const NO_DATE_FILTER = {
+  from: "",
+  to: "",
+  onFromChange: () => {},
+  onToChange: () => {},
+}
 
 function renderList(
   overrides: Partial<Parameters<typeof EntityListPage<TestExamRow>>[0]> = {}
@@ -122,6 +150,9 @@ function renderList(
         </button>
       )}
       actions={ACTIONS}
+      search={{ term: "", onChange: () => {}, placeholder: "試験名で検索" }}
+      dateFilter={NO_DATE_FILTER}
+      updatedAtFilter={NO_DATE_FILTER}
       selectedIds={new Set<string>()}
       onToggleSelect={toggleSelectSpy}
       onToggleSelectAll={toggleSelectAllSpy}
@@ -280,5 +311,179 @@ describe("EntityListPage の出し分け", () => {
     ).toBeInTheDocument()
     // examDate が null の行も「—」で埋まる（列に穴を作らない）
     expect(within(rowOf("中間考査")).getByText("—")).toBeInTheDocument()
+  })
+})
+
+describe("列見出しが並べ替えと絞り込みを持つ", () => {
+  it("見出しを押すと、昇順・降順と絞り込みが1つの popover に出る", async () => {
+    renderList()
+
+    fireEvent.click(screen.getByRole("button", { name: /名前/ }))
+
+    expect(
+      await screen.findByRole("button", { name: "昇順" })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "降順" })).toBeInTheDocument()
+    // 横断検索は名前列の popover の中（ヘッダー右には置かない）
+    expect(screen.getByLabelText("試験名で検索")).toBeInTheDocument()
+  })
+
+  it("「昇順」「降順」は回さず名指しで並べる", async () => {
+    renderList({ rows: manyRows(3), totalCount: 3 })
+
+    const openNameFilter = () =>
+      fireEvent.click(screen.getByRole("button", { name: /名前/ }))
+    const rowNames = () =>
+      screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((row) => row.getAttribute("aria-label"))
+
+    openNameFilter()
+    fireEvent.click(await screen.findByRole("button", { name: "昇順" }))
+    expect(rowNames()).toEqual([
+      "試験001の概要を開く",
+      "試験002の概要を開く",
+      "試験003の概要を開く",
+    ])
+
+    // 同じ「昇順」をもう一度押しても向きは回らない（押した通りになる）
+    openNameFilter()
+    fireEvent.click(await screen.findByRole("button", { name: "昇順" }))
+    expect(rowNames()[0]).toBe("試験001の概要を開く")
+
+    openNameFilter()
+    fireEvent.click(await screen.findByRole("button", { name: "降順" }))
+    expect(rowNames()).toEqual([
+      "試験003の概要を開く",
+      "試験002の概要を開く",
+      "試験001の概要を開く",
+    ])
+  })
+
+  it("タグと学級は名前列の popover に同居する（渡した画面だけ）", async () => {
+    renderList({
+      tagFilter: {
+        options: [{ id: "tag-1", name: "中間" }],
+        selectedIds: new Set<string>(),
+        onToggle: () => {},
+        onClear: () => {},
+      },
+      classroomFilter: {
+        options: [{ id: "classroom-1", name: "1年A組" }],
+        selectedIds: new Set<string>(),
+        onToggle: () => {},
+        onClear: () => {},
+      },
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /名前/ }))
+
+    expect(await screen.findByText("タグ")).toBeInTheDocument()
+    expect(screen.getByText("中間")).toBeInTheDocument()
+    expect(screen.getByText("学級")).toBeInTheDocument()
+    expect(screen.getByText("1年A組")).toBeInTheDocument()
+  })
+
+  it("並べ替えているあいだは、filter の代わりに向きを出す", async () => {
+    const { container } = renderList()
+    const nameHead = () => screen.getByRole("columnheader", { name: /名前/ })
+
+    // 並べていない列は filter のまま
+    expect(nameHead()).toHaveAttribute("aria-sort", "none")
+    expect(container.querySelector(".lucide-list-filter")).not.toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: /名前/ }))
+    fireEvent.click(await screen.findByRole("button", { name: "降順" }))
+
+    expect(nameHead()).toHaveAttribute("aria-sort", "descending")
+    // 印は1つだけ。filter は chevron に置き換わる（並べて2つ出さない）
+    expect(nameHead().querySelector(".lucide-chevron-down")).not.toBeNull()
+    expect(nameHead().querySelector(".lucide-list-filter")).toBeNull()
+  })
+
+  it("「次のステップ」列は絞り込みを持たない", () => {
+    renderList()
+
+    // 絞り込みを持つ列だけが押せる見出しになる（名前・試験日・更新日時の3つ）
+    expect(screen.queryByRole("button", { name: /次のステップ/ })).toBeNull()
+  })
+})
+
+describe("日付の出し方", () => {
+  it("試験日は yy/mm/dd", () => {
+    renderList({
+      rows: [
+        {
+          id: "exam-1",
+          examName: "期末考査",
+          examDate: new Date(2026, 2, 1),
+          updatedAt: new Date(2026, 2, 2),
+        },
+      ],
+      totalCount: 1,
+    })
+
+    expect(screen.getByText("26/03/01")).toBeInTheDocument()
+  })
+
+  it("更新日時は今日と昨日だけ時刻まで出す", () => {
+    const now = new Date()
+    const today = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      13,
+      24
+    )
+    const yesterday = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - 1,
+      9,
+      5
+    )
+    renderList({
+      rows: [
+        {
+          id: "exam-1",
+          examName: "今日の試験",
+          examDate: null,
+          updatedAt: today,
+        },
+        {
+          id: "exam-2",
+          examName: "昨日の試験",
+          examDate: null,
+          updatedAt: yesterday,
+        },
+      ],
+      totalCount: 2,
+    })
+
+    expect(screen.getByText("今日 13:24")).toBeInTheDocument()
+    expect(screen.getByText("昨日 09:05")).toBeInTheDocument()
+  })
+})
+
+describe("ページ送り", () => {
+  it("1ページに入りきらない行は次のページへ回す", () => {
+    renderList({ rows: manyRows(12), totalCount: 12 })
+
+    // 高さが測れないので既定の10件（`FALLBACK_PAGE_SIZE`）
+    expect(screen.getByText("12 件中 1〜10 件")).toBeInTheDocument()
+    expect(screen.getAllByRole("row")).toHaveLength(11) // 見出し + 10行
+
+    fireEvent.click(screen.getByRole("link", { name: "次のページ" }))
+
+    expect(screen.getByText("12 件中 11〜12 件")).toBeInTheDocument()
+    expect(screen.getAllByRole("row")).toHaveLength(3)
+  })
+
+  it("1ページに収まってもフッターは消えない（一覧の高さを動かさない）", () => {
+    renderList()
+
+    expect(screen.getByText("2 件中 1〜2 件")).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "次のページ" })).toBeNull()
   })
 })

--- a/__tests__/renderer/components/listPager.test.tsx
+++ b/__tests__/renderer/components/listPager.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * ページ送りの検査。
+ *
+ * 見るのは**省略記号**。ページ数が3桁になると端と現在地の前後しかボタンが出ないので、
+ * 畳まれた区間へは「次へ」を何十回も押すしかなかった。押して番号を打てるようにした
+ * ことを固定する。
+ */
+
+import "@testing-library/jest-dom/vitest"
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ListPager } from "@/components/common/ListPager"
+
+/** jsdom は `ResizeObserver` を持たない。popover の位置決めが要求する */
+global.ResizeObserver = class implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+const onPageChange = vi.fn()
+
+function renderPager(pageNumber: number, pageCount: number) {
+  return render(
+    <ListPager
+      pageNumber={pageNumber}
+      pageCount={pageCount}
+      onPageChange={onPageChange}
+    />
+  )
+}
+
+/** 省略記号のボタン（畳まれた区間は複数あるので、いちばん左を取る） */
+function firstEllipsis() {
+  return screen.getAllByRole("button", {
+    name: "ページ番号を指定して移動",
+  })[0]
+}
+
+beforeEach(() => {
+  onPageChange.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("畳まれた区間", () => {
+  it("ページが少なければ省略しない", () => {
+    renderPager(1, 3)
+
+    expect(
+      screen.queryByRole("button", { name: "ページ番号を指定して移動" })
+    ).toBeNull()
+    expect(screen.getByRole("link", { name: "2ページ目" })).toBeInTheDocument()
+  })
+
+  it("端と現在地の前後だけを残す", () => {
+    renderPager(50, 100)
+
+    const pageLinks = screen
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("aria-label"))
+    expect(pageLinks).toEqual([
+      "前のページ",
+      "1ページ目",
+      "49ページ目",
+      "50ページ目",
+      "51ページ目",
+      "100ページ目",
+      "次のページ",
+    ])
+  })
+})
+
+describe("省略記号からページを指定する", () => {
+  it("押すと番号を打つ欄が出て、打った先へ移る", async () => {
+    renderPager(50, 100)
+
+    fireEvent.click(firstEllipsis())
+
+    const pageInput = await screen.findByLabelText("移動先のページ（1〜100）")
+    fireEvent.change(pageInput, { target: { value: "23" } })
+    fireEvent.click(screen.getByRole("button", { name: "移動" }))
+
+    expect(onPageChange).toHaveBeenCalledWith(23)
+  })
+
+  it("総ページ数を超える番号では移れない", async () => {
+    renderPager(50, 100)
+
+    fireEvent.click(firstEllipsis())
+
+    const pageInput = await screen.findByLabelText("移動先のページ（1〜100）")
+    fireEvent.change(pageInput, { target: { value: "101" } })
+
+    expect(screen.getByRole("button", { name: "移動" })).toBeDisabled()
+    fireEvent.click(screen.getByRole("button", { name: "移動" }))
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+
+  it("数でないものでも移れない", async () => {
+    renderPager(50, 100)
+
+    fireEvent.click(firstEllipsis())
+
+    const pageInput = await screen.findByLabelText("移動先のページ（1〜100）")
+    fireEvent.change(pageInput, { target: { value: "あ" } })
+
+    expect(screen.getByRole("button", { name: "移動" })).toBeDisabled()
+  })
+
+  it("閉じると打ちかけを捨てる（次に開いたとき前の入力が残らない）", async () => {
+    renderPager(50, 100)
+
+    fireEvent.click(firstEllipsis())
+    fireEvent.change(await screen.findByLabelText("移動先のページ（1〜100）"), {
+      target: { value: "23" },
+    })
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    })
+
+    fireEvent.click(firstEllipsis())
+
+    expect(
+      await screen.findByLabelText("移動先のページ（1〜100）")
+    ).toHaveValue("")
+  })
+})

--- a/electron-src/ipc-handlers/settingsHandlers.ts
+++ b/electron-src/ipc-handlers/settingsHandlers.ts
@@ -10,6 +10,7 @@ import type {
   AnswerOverlayStyle,
   AnswerOverlayVisibility,
 } from "../../src/types/scoringOverlay.types"
+import { getAppPreference, setAppPreference } from "../lib/prisma/appPreference"
 import type {
   ExamReportGraphSettingsValues,
   ExamReportTableSectionValues,
@@ -113,6 +114,15 @@ export const settingsHandlers = {
   "settings:resetUserKeyboardShortcuts": async (userId: string) => {
     await resetUserKeyboardShortcuts(userId)
   },
+
+  // =========================================================================
+  // AppPreference（KV方式・全員で同じ値）
+  // =========================================================================
+
+  "settings:getAppPreference": (key: string) => getAppPreference(key),
+
+  "settings:setAppPreference": (key: string, value: string) =>
+    setAppPreference(key, value),
 
   // =========================================================================
   // UserPreference（KV方式）

--- a/electron-src/lib/prisma/appPreference.ts
+++ b/electron-src/lib/prisma/appPreference.ts
@@ -1,0 +1,31 @@
+import prisma from "./client"
+
+/**
+ * アプリ全体の設定（KV方式）の読み書き。
+ *
+ * 利用者ごとの好みは `userSettings.ts` の側。ここに置くのは **DB を共有する全員で
+ * 同じであるべき決めごと**で、いまは年度の開始日だけである。
+ */
+
+/** 1キー分。行が無ければ null（呼び手が既定を決める） */
+export async function getAppPreference(key: string): Promise<string | null> {
+  const record = await prisma.appPreference.findUnique({ where: { key } })
+  return record?.value ?? null
+}
+
+/**
+ * 1キー分を書く。
+ *
+ * `key` は主キーではないので、別の端末が同じキーを同時に作ると id の違う行が2つできる。
+ * 子を持たない表なので、同期はそれを後勝ちで畳める。
+ */
+export async function setAppPreference(
+  key: string,
+  value: string
+): Promise<void> {
+  await prisma.appPreference.upsert({
+    where: { key },
+    update: { value },
+    create: { key, value },
+  })
+}

--- a/electron-src/preload-apis/settingsApi.ts
+++ b/electron-src/preload-apis/settingsApi.ts
@@ -16,6 +16,10 @@ export function createSettingsApi() {
       saveUserKeyboardShortcuts: bind("settings:saveUserKeyboardShortcuts"),
       resetUserKeyboardShortcuts: bind("settings:resetUserKeyboardShortcuts"),
 
+      // AppPreference（KV方式・DB を共有する全員で同じ値）
+      getAppPreference: bind("settings:getAppPreference"),
+      setAppPreference: bind("settings:setAppPreference"),
+
       // UserPreference（KV方式）
       getUserPreference: bind("settings:getUserPreference"),
       setUserPreference: bind("settings:setUserPreference"),

--- a/prisma/migrations/20260824120000_add_app_preference/migration.sql
+++ b/prisma/migrations/20260824120000_add_app_preference/migration.sql
@@ -1,0 +1,18 @@
+-- アプリ全体の設定（KV方式）を置く表を作る。
+--
+-- 利用者ごとの好みは UserPreference が持っているが、**組織の決めごと**を置く先が
+-- どこにも無かった。最初の住人は年度の開始日（既定は 4/1）で、一覧の絞り込みが
+-- 「今年度」を組み立てるのに読む。人によって違う値を持つと、同じ条件で絞ったのに
+-- 見えるものが人ごとに変わる。
+--
+-- 行が無いときは既定を使う（起動時に既定値を書き込まない）。書き込むと、まだ誰も
+-- 設定していないことと、既定を選んだこととが区別できなくなる。
+CREATE TABLE "AppPreference" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "AppPreference_key_key" ON "AppPreference"("key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -601,6 +601,23 @@ model UserKeyboardShortcut {
   @@index([userId])
 }
 
+/// アプリ全体の設定（KV方式・JSON文字列で保存）。
+///
+/// **DB を共有する全員が同じ値を見る。** 利用者ごとの好み（表示・キー割り当て）は
+/// UserPreference の側で、こちらに置くのは組織の決めごと —— 年度がいつ始まるか、など。
+/// 人によって違うと、同じ絞り込みでも見えるものが変わってしまう。
+///
+/// 別の端末が同じキーを同時に作ると id の違う行が2つできるが、子を持たない表なので
+/// 同期は unique 違反を後勝ちで畳める。
+model AppPreference {
+  id    String @id @default(uuid())
+  key   String @unique
+  value String // JSON文字列で保存
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
 model UserPreference {
   id     String @id @default(uuid())
   userId String

--- a/src/app/(app)/audit-logs/components/AuditLogList.tsx
+++ b/src/app/(app)/audit-logs/components/AuditLogList.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { History } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
+import { ListPaginationFooter } from "@/components/common/ListPaginationFooter"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -15,15 +16,9 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { type PublicUser, userListQuery } from "@/queries/user"
 
-import {
-  AUDIT_LOG_PAGE_SIZES,
-  AUTO_PAGE_SIZE,
-  CATEGORY_LABELS,
-  isAuditCategory,
-} from "../constants"
+import { CATEGORY_LABELS, isAuditCategory } from "../constants"
 import { useAuditLogs } from "../hooks/useAuditLogs"
 import { AuditLogItem } from "./AuditLogItem"
-import { AuditLogPager } from "./AuditLogPager"
 
 /** 未取得のときに毎回新しい配列を作らないための空値 */
 const EMPTY_USERS: PublicUser[] = []
@@ -176,46 +171,17 @@ export function AuditLogList() {
       {/* 初回の取得中は総件数が 0 なので出ない。ページを送っている間は
           前のページを出したままなので、フッターは動かない */}
       {total > 0 && (
-        <div className="flex flex-wrap items-center gap-4 border-t px-6 py-3">
-          <span className="text-sm text-muted-foreground">
-            {total} 件中 {firstRowNumber}〜{lastRowNumber} 件
-          </span>
-          <Select
-            value={
-              pageSizeChoice === AUTO_PAGE_SIZE
-                ? AUTO_PAGE_SIZE
-                : String(pageSizeChoice)
-            }
-            onValueChange={(value) =>
-              setPageSizeChoice(
-                value === AUTO_PAGE_SIZE ? AUTO_PAGE_SIZE : Number(value)
-              )
-            }
-          >
-            <SelectTrigger className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={AUTO_PAGE_SIZE}>
-                自動（{pageSize} 件）
-              </SelectItem>
-              {AUDIT_LOG_PAGE_SIZES.map((size) => (
-                <SelectItem key={size} value={String(size)}>
-                  {size} 件ずつ
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {pageCount > 1 && (
-            <div className="ml-auto">
-              <AuditLogPager
-                pageNumber={pageNumber}
-                pageCount={pageCount}
-                onPageChange={setPageNumber}
-              />
-            </div>
-          )}
-        </div>
+        <ListPaginationFooter
+          total={total}
+          firstRowNumber={firstRowNumber}
+          lastRowNumber={lastRowNumber}
+          pageSize={pageSize}
+          pageSizeChoice={pageSizeChoice}
+          onPageSizeChoiceChange={setPageSizeChoice}
+          pageNumber={pageNumber}
+          pageCount={pageCount}
+          onPageChange={setPageNumber}
+        />
       )}
     </div>
   )

--- a/src/app/(app)/audit-logs/constants.ts
+++ b/src/app/(app)/audit-logs/constants.ts
@@ -41,19 +41,13 @@ export const VERB_META: Record<
   other: { label: "操作", className: "text-muted-foreground", Icon: History },
 }
 
-/** 1ページに並べる件数を、表示領域の高さから決める指定 */
-export const AUTO_PAGE_SIZE = "auto"
-
-/** 1ページに並べる件数の選択肢（「自動」は別枠） */
-export const AUDIT_LOG_PAGE_SIZES = [10, 20, 50, 100] as const
-
 /**
  * 「自動」で高さから件数を割り出すときの、1行の見積もり（px）。
  *
  * 1行は「誰が何をした」と補足の2段（`AuditLogItem`）。実測より少し大きめに取り、
  * はみ出すより余らせる（足りない分はスクロールできるが、余白は操作できない）。
+ *
+ * 件数の選択肢と「自動」の指定そのものは一覧4画面と共有する（`lib/listPagination`）。
+ * 1行の高さだけが画面ごとに違う。
  */
 export const AUDIT_LOG_ROW_HEIGHT = 60
-
-/** 高さがまだ測れていないときに使う件数 */
-export const FALLBACK_AUDIT_LOG_PAGE_SIZE = 10

--- a/src/app/(app)/audit-logs/hooks/useAuditLogs.ts
+++ b/src/app/(app)/audit-logs/hooks/useAuditLogs.ts
@@ -12,17 +12,15 @@ import {
 } from "react"
 
 import type { AuditLogFilter } from "@/electron-src/lib/prisma/auditQuery"
+import {
+  AUTO_PAGE_SIZE,
+  FALLBACK_PAGE_SIZE,
+  type PageSizeChoice,
+} from "@/lib/listPagination"
 import { auditLogListQuery } from "@/queries/auditLog"
 import type { AuditLogEntry } from "@/types/auditLog.types"
 
-import {
-  AUDIT_LOG_ROW_HEIGHT,
-  AUTO_PAGE_SIZE,
-  FALLBACK_AUDIT_LOG_PAGE_SIZE,
-} from "../constants"
-
-/** 1ページの件数の指定。「自動」は表示領域の高さから決める */
-type AuditLogPageSizeChoice = typeof AUTO_PAGE_SIZE | number
+import { AUDIT_LOG_ROW_HEIGHT } from "../constants"
 
 /** 未取得のときに毎回新しい配列を作らないための空値 */
 const EMPTY_ENTRIES: AuditLogEntry[] = []
@@ -43,11 +41,11 @@ interface UseAuditLogsResult {
   pageNumber: number
   /** 実際に要求している件数（「自動」なら高さから決まった値） */
   pageSize: number
-  pageSizeChoice: AuditLogPageSizeChoice
+  pageSizeChoice: PageSizeChoice
   /** 総ページ数（0件でも1ページと数える） */
   pageCount: number
   setPageNumber: (pageNumber: number) => void
-  setPageSizeChoice: (choice: AuditLogPageSizeChoice) => void
+  setPageSizeChoice: (choice: PageSizeChoice) => void
   /** 「自動」が高さを測る相手。ログが縦に伸びる箱へ付ける */
   viewportRef: RefObject<HTMLDivElement | null>
 }
@@ -75,7 +73,7 @@ export function useAuditLogs(): UseAuditLogsResult {
    */
   const [firstRowIndex, setFirstRowIndex] = useState(0)
   const [pageSizeChoice, setPageSizeChoiceState] =
-    useState<AuditLogPageSizeChoice>(AUTO_PAGE_SIZE)
+    useState<PageSizeChoice>(AUTO_PAGE_SIZE)
 
   // 「自動」のときだけ使う。高さは表示領域そのものから測る（見積もりで
   // 決め打つと、サイドバーを畳んだ・窓を変えたときに合わなくなる）
@@ -98,7 +96,7 @@ export function useAuditLogs(): UseAuditLogsResult {
     pageSizeChoice === AUTO_PAGE_SIZE
       ? measuredPageSize > 0
         ? measuredPageSize
-        : FALLBACK_AUDIT_LOG_PAGE_SIZE
+        : FALLBACK_PAGE_SIZE
       : pageSizeChoice
 
   const pageNumber = Math.floor(firstRowIndex / pageSize) + 1
@@ -123,7 +121,7 @@ export function useAuditLogs(): UseAuditLogsResult {
 
   // 件数を選び直すのは利用者の操作なので、先頭から見直す（窓の大きさが変わった
   // ときと違い、いま見ている行に留まる理由がない）
-  const setPageSizeChoice = useCallback((choice: AuditLogPageSizeChoice) => {
+  const setPageSizeChoice = useCallback((choice: PageSizeChoice) => {
     setPageSizeChoiceState(choice)
     setFirstRowIndex(0)
   }, [])

--- a/src/app/(app)/settings/components/FiscalYearTab.tsx
+++ b/src/app/(app)/settings/components/FiscalYearTab.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  DEFAULT_FISCAL_YEAR_START,
+  FISCAL_YEAR_START_KEY,
+  fiscalYearRange,
+  type FiscalYearStart,
+  formatFiscalYearStart,
+  parseFiscalYearStart,
+  serializeFiscalYearStart,
+} from "@/lib/fiscalYear"
+import {
+  appPreferenceQuery,
+  setAppPreferenceMutation,
+} from "@/queries/settings"
+
+const MONTHS = Array.from({ length: 12 }, (_, i) => i + 1)
+
+/** その月に在る日。2月は28日まで（どの年にも在る日だけを選ばせる） */
+function daysOf(month: number): number[] {
+  const lastDay = new Date(2001, month, 0).getDate()
+  return Array.from({ length: lastDay }, (_, i) => i + 1)
+}
+
+/**
+ * 年度の設定。
+ *
+ * **利用者ごとではなく、DB を共有する全員で1つ**（`AppPreference`）。人によって
+ * 違う値を持つと、同じ「今年度」で絞ったのに見えるものが人ごとに変わる。
+ */
+export function FiscalYearTab() {
+  const { data: storedText } = useQuery(
+    appPreferenceQuery(FISCAL_YEAR_START_KEY)
+  )
+  const { mutate: saveFiscalYearStart } = useMutation(
+    setAppPreferenceMutation(FISCAL_YEAR_START_KEY)
+  )
+
+  const fiscalYearStart =
+    storedText === undefined
+      ? DEFAULT_FISCAL_YEAR_START
+      : parseFiscalYearStart(storedText)
+
+  // 月を変えた拍子に日が月末を越えることがある（1/31 → 2 月）。越えたぶんは
+  // その月の末日へ寄せる
+  const change = (next: FiscalYearStart) => {
+    const lastDay = daysOf(next.month).length
+    saveFiscalYearStart(
+      serializeFiscalYearStart({
+        month: next.month,
+        day: Math.min(next.day, lastDay),
+      })
+    )
+  }
+
+  // 「いま何年度なのか」を見せる。月日だけを選ばせると、それが何月何日から何月何日
+  // までを指すのかが分からない
+  const [today] = useState(() => new Date())
+  const currentRange = fiscalYearRange(today, fiscalYearStart)
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">年度の開始日</h2>
+          <p className="text-sm text-muted-foreground">
+            一覧の絞り込みで「今年度」がどこからどこまでを指すかを決めます。この設定は
+            このデータベースを共有する全員で同じものになります。
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Label className="w-36 shrink-0 text-sm">開始日</Label>
+          <Select
+            value={String(fiscalYearStart.month)}
+            onValueChange={(value) =>
+              change({ ...fiscalYearStart, month: Number(value) })
+            }
+          >
+            <SelectTrigger className="w-24" aria-label="年度開始の月">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MONTHS.map((month) => (
+                <SelectItem key={month} value={String(month)}>
+                  {month}月
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(fiscalYearStart.day)}
+            onValueChange={(value) =>
+              change({ ...fiscalYearStart, day: Number(value) })
+            }
+          >
+            <SelectTrigger className="w-24" aria-label="年度開始の日">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {daysOf(fiscalYearStart.month).map((day) => (
+                <SelectItem key={day} value={String(day)}>
+                  {day}日
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          {formatFiscalYearStart(fiscalYearStart)}始まり —— いまの年度は{" "}
+          <span className="tabular-nums">{currentRange.from}</span> から{" "}
+          <span className="tabular-nums">{currentRange.to}</span> まで
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,11 +1,19 @@
 "use client"
 
 import { useQuery } from "@tanstack/react-query"
-import { FolderSync, Keyboard, Monitor, Palette, Users } from "lucide-react"
+import {
+  CalendarRange,
+  FolderSync,
+  Keyboard,
+  Monitor,
+  Palette,
+  Users,
+} from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 
 import { DisplaySettingsTab } from "@/app/(app)/settings/components/DisplaySettingsTab"
+import { FiscalYearTab } from "@/app/(app)/settings/components/FiscalYearTab"
 import { KeyboardShortcutSection } from "@/app/(app)/settings/components/KeyboardShortcutSection"
 import { ScreenControlTab } from "@/app/(app)/settings/components/ScreenControlTab"
 import { SyncSettingsTab } from "@/app/(app)/settings/components/SyncSettingsTab"
@@ -75,6 +83,10 @@ export default function SettingsPage() {
             <Palette className="h-4 w-4" />
             表示設定
           </TabsTrigger>
+          <TabsTrigger value="fiscal-year" className="gap-2">
+            <CalendarRange className="h-4 w-4" />
+            年度
+          </TabsTrigger>
           <TabsTrigger value="user" className="gap-2">
             <Users className="h-4 w-4" />
             ユーザー管理
@@ -105,6 +117,10 @@ export default function SettingsPage() {
 
         <TabsContent value="display">
           <DisplaySettingsTab />
+        </TabsContent>
+
+        <TabsContent value="fiscal-year">
+          <FiscalYearTab />
         </TabsContent>
 
         <TabsContent value="user">

--- a/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
+++ b/src/components/answer-sheet-builder/AnswerSheetDefinitionList.tsx
@@ -25,13 +25,6 @@ import {
   type ExportOutcome,
   ExportResultSummary,
 } from "@/components/common/ExportResultSummary"
-import {
-  DateRangeFilterButton,
-  DateRangeFilterPanel,
-  ListSearchInput,
-  MultiSelectFilterPanel,
-  TagFilterButton,
-} from "@/components/common/ListFilterControls"
 import type { ToolbarAction } from "@/components/common/OverflowToolbar"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import {
@@ -95,6 +88,7 @@ const ASB_FILTER_ACCESSORS: ListFilterAccessors<ASBDefinitionListItem> = {
   // 日付範囲の絞り込みは列に出している日付＝使用日に合わせる
   // （以前は更新日時で絞っていて、列の「更新日時」と語だけが揃っていなかった）
   date: (definition) => definition.referenceDate ?? null,
+  updatedAt: (definition) => definition.updatedAt ?? null,
 }
 
 /**
@@ -227,6 +221,10 @@ export function AnswerSheetDefinitionList() {
     setDateFrom,
     dateTo,
     setDateTo,
+    updatedFrom,
+    setUpdatedFrom,
+    updatedTo,
+    setUpdatedTo,
   } = useListFilter(visibleDefinitions, ASB_FILTER_ACCESSORS)
 
   /**
@@ -396,17 +394,6 @@ export function AnswerSheetDefinitionList() {
     [allTags, filterTagIds, toggleTagId, clearTagIds]
   )
 
-  const dateRangeConfig = useMemo(
-    () => ({
-      label: "使用日",
-      from: dateFrom,
-      to: dateTo,
-      onFromChange: setDateFrom,
-      onToChange: setDateTo,
-    }),
-    [dateFrom, dateTo, setDateFrom, setDateTo]
-  )
-
   const actions = useMemo<ToolbarAction[]>(() => {
     // 並びに出す姿と「…」の中の姿が同じもの。作るのは1回にして、幅を測る控えの
     // 並びと本物で同じ要素が使われるようにする
@@ -503,57 +490,14 @@ export function AnswerSheetDefinitionList() {
       })
     }
 
-    toolbarActions.push(
-      {
-        id: "tag-filter",
-        priority: 90,
-        node: <TagFilterButton config={tagFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">タグで絞り込み</p>
-            <MultiSelectFilterPanel config={tagFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        id: "date-filter",
-        priority: 84,
-        node: <DateRangeFilterButton config={dateRangeConfig} />,
-        collapsedNode: <DateRangeFilterPanel config={dateRangeConfig} />,
-      },
-      {
-        // 検索欄は最後まで残す（検索できない一覧にしない）
-        id: "search",
-        priority: 100,
-        node: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="名前・タグで検索"
-          />
-        ),
-        collapsedNode: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="名前・タグで検索"
-          />
-        ),
-      }
-    )
-
     return toolbarActions
   }, [
     allTags,
-    dateRangeConfig,
     handleBulkAddTag,
     handleCreate,
     handleImport,
-    searchTerm,
     showAllOwners,
     selectedIds,
-    setSearchTerm,
-    tagFilterConfig,
   ])
 
   return (
@@ -567,17 +511,6 @@ export function AnswerSheetDefinitionList() {
         name={(definition) => definition.name}
         summary={(definition) => (
           <span className="flex flex-wrap items-center gap-1">
-            <span>
-              {definition.paperSize ?? "-"}{" "}
-              {definition.orientation === "landscape" ? "横" : "縦"}
-              {" / 設問数: "}
-              {definition.questionCount ?? 0}
-              {" / 合計配点: "}
-              {definition.totalPoints ?? 0}点 / 担当:{" "}
-              {definition.ownerId === currentUser.id
-                ? "自分"
-                : definition.ownerName}
-            </span>
             {(definition.tags ?? []).map((tag) => (
               <Badge
                 key={tag.id}
@@ -592,6 +525,17 @@ export function AnswerSheetDefinitionList() {
                 {tag.name}
               </Badge>
             ))}
+            <span>
+              {definition.paperSize ?? "-"}{" "}
+              {definition.orientation === "landscape" ? "横" : "縦"}
+              {" / 設問数: "}
+              {definition.questionCount ?? 0}
+              {" / 合計配点: "}
+              {definition.totalPoints ?? 0}点 / 担当:{" "}
+              {definition.ownerId === currentUser.id
+                ? "自分"
+                : definition.ownerName}
+            </span>
           </span>
         )}
         dateLabel="使用日"
@@ -660,6 +604,24 @@ export function AnswerSheetDefinitionList() {
           </DropdownMenu>
         )}
         actions={actions}
+        search={{
+          term: searchTerm,
+          onChange: setSearchTerm,
+          placeholder: "名前・タグで検索",
+        }}
+        tagFilter={tagFilterConfig}
+        dateFilter={{
+          from: dateFrom,
+          to: dateTo,
+          onFromChange: setDateFrom,
+          onToChange: setDateTo,
+        }}
+        updatedAtFilter={{
+          from: updatedFrom,
+          to: updatedTo,
+          onFromChange: setUpdatedFrom,
+          onToChange: setUpdatedTo,
+        }}
         selectedIds={selectedIds}
         selectionDisabledReason={(definition) =>
           isTaggable(definition)

--- a/src/components/common/EntityListPage.tsx
+++ b/src/components/common/EntityListPage.tsx
@@ -4,12 +4,23 @@ import { useRouter } from "next/navigation"
 import type { KeyboardEvent, MouseEvent, ReactNode } from "react"
 import { useMemo } from "react"
 
+import {
+  ColumnDivider,
+  FilterableTableHead,
+} from "@/components/common/FilterableTableHead"
+import type { MultiSelectFilterConfig } from "@/components/common/ListFilterControls"
+import {
+  DateRangeFilterPanel,
+  ListSearchInput,
+  MultiSelectFilterPanel,
+} from "@/components/common/ListFilterControls"
+import { ListPaginationFooter } from "@/components/common/ListPaginationFooter"
 import type { ToolbarAction } from "@/components/common/OverflowToolbar"
 import { OverflowToolbar } from "@/components/common/OverflowToolbar"
 import { HistoryNavButtons } from "@/components/layout/HistoryNavButtons"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import { SortableTableHead } from "@/components/ui/SortableTableHead"
+import { Separator } from "@/components/ui/separator"
 import {
   Table,
   TableBody,
@@ -18,6 +29,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useListPagination } from "@/hooks/useListPagination"
 import { useTableSort } from "@/hooks/useTableSort"
 
 /**
@@ -46,12 +63,39 @@ interface EntityListEmptyState {
   action?: ReactNode
 }
 
+/**
+ * 日付列の絞り込み。`useListFilter` が持っている値と setter をそのまま渡す。
+ *
+ * 見出しの語は列の見出しと同じものを使うので、ここでは受け取らない
+ * （呼び手が2回書くと、列の語と popover の語がずれる）。
+ */
+export interface EntityListDateFilter {
+  /** YYYY-MM-DD、空文字は未指定 */
+  from: string
+  to: string
+  onFromChange: (value: string) => void
+  onToChange: (value: string) => void
+}
+
+/**
+ * 名前列の popover に入る横断検索。
+ *
+ * 名前だけでなく説明・タグ名・学級名も見ているので、どの列の値でもない。
+ * 名前列に置くのは、行の中でいちばん多く目に入る列だからである。
+ */
+interface EntityListSearch {
+  term: string
+  onChange: (value: string) => void
+  /** 「試験名・タグで検索」など、何を見ているかを言う */
+  placeholder: string
+}
+
 interface EntityListPageProps<TRow extends { id: string }> {
   /** ヘッダーの中央に出す画面の題（「試験一覧」「解答用紙作成」など） */
   title: string
   /** ヘッダー右端の「使い方」。`usePageHelp` が作ったものを呼び手が渡す */
   helpButton?: ReactNode
-  /** 絞り込み済みの行（並べ替えは部品の中でやる） */
+  /** 絞り込み済みの行（並べ替えとページ分けは部品の中でやる） */
   rows: TRow[]
   /**
    * 絞り込む前の総数。`rows` が空でも「1件も無い」と「条件に一致しない」を
@@ -83,9 +127,19 @@ interface EntityListPageProps<TRow extends { id: string }> {
   rowMenu: (row: TRow) => ReactNode
   /** ヘッダー右の並び。溢れは「…」へ畳む */
   actions: ToolbarAction[]
+  /** 名前列の popover に入る横断検索 */
+  search: EntityListSearch
+  /** 名前列の popover に入るタグ絞り込み */
+  tagFilter?: MultiSelectFilterConfig
+  /** 名前列の popover に入る学級絞り込み。学級を持たない画面は渡さない */
+  classroomFilter?: MultiSelectFilterConfig
+  /** 日付列の絞り込み */
+  dateFilter: EntityListDateFilter
+  /** 更新日時列の絞り込み */
+  updatedAtFilter: EntityListDateFilter
   /**
    * 選択の状態。**呼び手が持つ**（ヘッダーの一括操作が選択を読むため）。
-   * 並べ替えは行の集合を変えないので、呼び手は絞り込み済みの行に対して
+   * 並べ替えとページ分けは行の集合を変えないので、呼び手は絞り込み済みの行に対して
    * `useRowSelection` を持てばよい
    */
   selectedIds: Set<string>
@@ -129,28 +183,70 @@ const COLUMN_COUNT = 6
  */
 const SORTABLE_KEYS = ["name", "referenceDate", "updatedAt"] as const
 
+/**
+ * 「自動」で高さから件数を割り出すときの、1行の見積もり（px）。
+ *
+ * 1行は名前と要約の2段（`px-4 py-3.5` の余白込み）。実測より少し大きめに取り、
+ * はみ出すより余らせる。
+ */
+const ENTITY_LIST_ROW_HEIGHT = 72
+
+/** 行の上に居座る見出し行の高さ（`h-12`） */
+const ENTITY_LIST_HEADER_HEIGHT = 48
+
+/** `yy/mm/dd`。列幅を食わないよう西暦は下2桁 */
 function formatDay(date: EntityListDate): string {
   if (date === null) return "—"
   const parsed = new Date(date)
   if (Number.isNaN(parsed.getTime())) return "—"
-  return parsed.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  })
+  return `${String(parsed.getFullYear()).slice(-2)}/${String(
+    parsed.getMonth() + 1
+  ).padStart(2, "0")}/${String(parsed.getDate()).padStart(2, "0")}`
 }
 
-function formatDayAndTime(date: EntityListDate): string {
+/** その日を指す鍵（`toLocaleDateString` を挟まず、ローカルの年月日で比べる） */
+function toDayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+}
+
+/**
+ * 更新日時の短い姿。今日と昨日は時刻まで、それより前は `yy/mm/dd`。
+ *
+ * 「今日」は**描いた時点の判定**なので、一覧を開いたまま日付を跨ぐと「今日」のまま
+ * 残る。正確な値は tooltip で常に読めるので、そのために時計を持たない。
+ */
+function formatUpdatedAt(date: EntityListDate): string {
   if (date === null) return "—"
   const parsed = new Date(date)
   if (Number.isNaN(parsed.getTime())) return "—"
-  return parsed.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  })
+
+  const now = new Date()
+  const dayKey = toDayKey(parsed)
+  const time = `${String(parsed.getHours()).padStart(2, "0")}:${String(
+    parsed.getMinutes()
+  ).padStart(2, "0")}`
+
+  if (dayKey === toDayKey(now)) return `今日 ${time}`
+  const yesterday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() - 1
+  )
+  if (dayKey === toDayKey(yesterday)) return `昨日 ${time}`
+  return formatDay(parsed)
+}
+
+/** tooltip に出す `yyyy/mm/dd hh:mm`。省略のない形はここだけ */
+function formatFullDateTime(date: EntityListDate): string | null {
+  if (date === null) return null
+  const parsed = new Date(date)
+  if (Number.isNaN(parsed.getTime())) return null
+  return `${parsed.getFullYear()}/${String(parsed.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}/${String(parsed.getDate()).padStart(2, "0")} ${String(
+    parsed.getHours()
+  ).padStart(2, "0")}:${String(parsed.getMinutes()).padStart(2, "0")}`
 }
 
 /**
@@ -165,6 +261,11 @@ function formatDayAndTime(date: EntityListDate): string {
  * - **行のどこを押しても概要ページへ飛ぶ。**「詳細」ボタンと列は持たない
  * - **チェックボックスの上だけが選択**（行の他の場所を押しても選択は動かない）
  * - **「…」と「次のステップ」は行クリックを止める**（別の飛び先を持つため）
+ *
+ * 絞り込みは**列見出しの中**にある。並べ替えも同じ popover へ入れてあるので、見出しが
+ * 持つ当たり判定は「popover を開く」1つだけ（`FilterableTableHead`）。「次のステップ」
+ * 列だけは絞り込みを持たない —— 絞ると選択した行が見えなくなり、ヘッダーの一括操作が
+ * 「見えていない行にも効く」ことになる。
  */
 export function EntityListPage<TRow extends { id: string }>({
   title,
@@ -181,6 +282,11 @@ export function EntityListPage<TRow extends { id: string }>({
   nextStep,
   rowMenu,
   actions,
+  search,
+  tagFilter,
+  classroomFilter,
+  dateFilter,
+  updatedAtFilter,
   selectedIds,
   selectionDisabledReason,
   onToggleSelect,
@@ -206,10 +312,48 @@ export function EntityListPage<TRow extends { id: string }>({
 
   // 既定は更新日時の新しい順。日付（実施日）は未設定を許すので、降順にすると
   // 未設定の行が先頭へ集まってしまう（`useTableSort` は降順で null を先に置く）
-  const { sortedData, sortConfig, requestSort } = useTableSort(sortableRows, {
+  const { sortedData, sortConfig, applySort } = useTableSort(sortableRows, {
     defaultSort: { key: "updatedAt", direction: "desc" },
     storageKey: sortStorageKey,
     sortableKeys: SORTABLE_KEYS,
+  })
+
+  const isNameFiltered =
+    search.term !== "" ||
+    (tagFilter?.selectedIds.size ?? 0) > 0 ||
+    (classroomFilter?.selectedIds.size ?? 0) > 0
+  const isDateFiltered = dateFilter.from !== "" || dateFilter.to !== ""
+  const isUpdatedAtFiltered =
+    updatedAtFilter.from !== "" || updatedAtFilter.to !== ""
+
+  // 条件か並び順が変わったら先頭のページから見る
+  const paginationResetKey = [
+    search.term,
+    [...(tagFilter?.selectedIds ?? [])].sort().join(","),
+    [...(classroomFilter?.selectedIds ?? [])].sort().join(","),
+    dateFilter.from,
+    dateFilter.to,
+    updatedAtFilter.from,
+    updatedAtFilter.to,
+    sortConfig.key ?? "",
+    sortConfig.direction ?? "",
+  ].join("|")
+
+  const {
+    pageRows,
+    pageNumber,
+    pageSize,
+    pageSizeChoice,
+    setPageSizeChoice,
+    pageCount,
+    setPageNumber,
+    firstRowNumber,
+    lastRowNumber,
+    viewportRef,
+  } = useListPagination(sortedData, {
+    rowHeight: ENTITY_LIST_ROW_HEIGHT,
+    reservedHeight: ENTITY_LIST_HEADER_HEIGHT,
+    resetKey: paginationResetKey,
   })
 
   /** 押されたのが行そのものか、行の中の別の導線かを分ける */
@@ -242,6 +386,8 @@ export function EntityListPage<TRow extends { id: string }>({
         題は**クイックアクセスのすぐ右**。行の中央に絶対配置していたが、目が最初に
         行くのは左端で、そこから中央まで戻って読むことになる。左から
         「どこへ行けるか → いま何を見ているか → 何件あるか」と並べば視線が一方向で済む。
+
+        絞り込みはここに置かない（列見出しへ移した）ので、並ぶのは操作だけである。
       */}
       <header className="flex shrink-0 items-center gap-2 border-b bg-background px-3 py-2">
         <div className="flex shrink-0 items-center gap-2">
@@ -271,138 +417,237 @@ export function EntityListPage<TRow extends { id: string }>({
             {empty.action}
           </div>
         ) : (
-          <div className="h-full overflow-hidden rounded-xl border border-border/50 shadow-sm">
-            <Table wrapperClassName="h-full">
-              <TableHeader className="sticky top-0 z-10 bg-card">
-                <TableRow className="hover:bg-transparent">
-                  <TableHead className="w-10 text-center">
-                    <Checkbox
-                      checked={allSelected}
-                      onCheckedChange={(checked) =>
-                        onToggleSelectAll(checked === true)
-                      }
-                      aria-label="全選択"
-                    />
-                  </TableHead>
-                  <SortableTableHead
-                    sortKey="name"
-                    currentSortKey={sortConfig.key}
-                    currentDirection={sortConfig.direction}
-                    onSort={requestSort}
-                  >
-                    名前
-                  </SortableTableHead>
-                  <SortableTableHead
-                    sortKey="referenceDate"
-                    currentSortKey={sortConfig.key}
-                    currentDirection={sortConfig.direction}
-                    onSort={requestSort}
-                    className="w-32 text-center"
-                  >
-                    {dateLabel}
-                  </SortableTableHead>
-                  <SortableTableHead
-                    sortKey="updatedAt"
-                    currentSortKey={sortConfig.key}
-                    currentDirection={sortConfig.direction}
-                    onSort={requestSort}
-                    className="w-40 text-center"
-                  >
-                    更新日時
-                  </SortableTableHead>
-                  <TableHead className="w-52 text-center">
-                    次のステップ
-                  </TableHead>
-                  <TableHead className="w-12" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {isLoading && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={COLUMN_COUNT}
-                      className="py-8 text-center text-muted-foreground"
+          <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border/50 shadow-sm">
+            {/*
+              「自動」はこの箱の高さを1行の高さで割る。上下の余白を置かない。
+
+              **縦に流すのは中の `Table` の側**（`wrapperClassName`）。ここで
+              `overflow-auto` を持つと、こちらが最も近いスクロール領域になり、
+              しかも中身の高さぶんに伸びて一度も流れないので、見出し行の `sticky` が
+              効かなくなる（貼り付く相手が動かない）。
+            */}
+            <div ref={viewportRef} className="min-h-0 flex-1">
+              <Table wrapperClassName="h-full">
+                <TableHeader className="sticky top-0 z-10 bg-card">
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="w-10 text-center">
+                      <Checkbox
+                        checked={allSelected}
+                        onCheckedChange={(checked) =>
+                          onToggleSelectAll(checked === true)
+                        }
+                        aria-label="全選択"
+                      />
+                    </TableHead>
+                    <FilterableTableHead
+                      label="名前"
+                      sortKey="name"
+                      currentSortKey={sortConfig.key}
+                      currentDirection={sortConfig.direction}
+                      onSort={applySort}
+                      isFiltered={isNameFiltered}
+                      showDivider={false}
                     >
-                      読み込み中...
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!isLoading && rows.length === 0 && (
-                  <TableRow>
-                    <TableCell
-                      colSpan={COLUMN_COUNT}
-                      className="py-8 text-center text-muted-foreground"
+                      <div className="space-y-2">
+                        <ListSearchInput
+                          searchTerm={search.term}
+                          onSearchTermChange={search.onChange}
+                          placeholder={search.placeholder}
+                          className="w-full"
+                        />
+                        {tagFilter && tagFilter.options.length > 0 && (
+                          <>
+                            <Separator />
+                            <div>
+                              <p className="px-1 pb-1 text-xs text-muted-foreground">
+                                タグ
+                              </p>
+                              <MultiSelectFilterPanel
+                                config={tagFilter}
+                                clearLabel="タグの選択を消す"
+                              />
+                            </div>
+                          </>
+                        )}
+                        {classroomFilter &&
+                          classroomFilter.options.length > 0 && (
+                            <>
+                              <Separator />
+                              <div>
+                                <p className="px-1 pb-1 text-xs text-muted-foreground">
+                                  学級
+                                </p>
+                                <MultiSelectFilterPanel
+                                  config={classroomFilter}
+                                  clearLabel="学級の選択を消す"
+                                />
+                              </div>
+                            </>
+                          )}
+                      </div>
+                    </FilterableTableHead>
+                    <FilterableTableHead
+                      label={dateLabel}
+                      sortKey="referenceDate"
+                      currentSortKey={sortConfig.key}
+                      currentDirection={sortConfig.direction}
+                      onSort={applySort}
+                      isFiltered={isDateFiltered}
+                      className="w-36"
                     >
-                      {noMatchMessage}
-                    </TableCell>
+                      <DateRangeFilterPanel
+                        config={{ label: dateLabel, ...dateFilter }}
+                      />
+                    </FilterableTableHead>
+                    <FilterableTableHead
+                      label="更新日時"
+                      sortKey="updatedAt"
+                      currentSortKey={sortConfig.key}
+                      currentDirection={sortConfig.direction}
+                      onSort={applySort}
+                      isFiltered={isUpdatedAtFiltered}
+                      className="w-40"
+                    >
+                      <DateRangeFilterPanel
+                        config={{ label: "更新日", ...updatedAtFilter }}
+                      />
+                    </FilterableTableHead>
+                    {/*
+                      絞り込みを持たない列。見出しに印は出さないが、列の区切り線は
+                      他の列と同じように引く
+                    */}
+                    <TableHead className="w-52 p-0 text-center">
+                      <div className="flex h-12 items-center">
+                        <ColumnDivider />
+                        <span className="flex-1 px-4">次のステップ</span>
+                      </div>
+                    </TableHead>
+                    <TableHead className="w-12 p-0">
+                      <div className="flex h-12 items-center">
+                        <ColumnDivider />
+                      </div>
+                    </TableHead>
                   </TableRow>
-                )}
-                {!isLoading &&
-                  sortedData.map((sortableRow) => {
-                    const row = sortableRow.row
-                    const step = nextStep(row)
-                    const disabledReason = selectionDisabledReason?.(row)
-                    return (
-                      <TableRow
-                        key={sortableRow.id}
-                        className="group cursor-pointer"
-                        tabIndex={0}
-                        aria-label={`${sortableRow.name}の概要を開く`}
-                        onClick={() => openOverview(row)}
-                        onKeyDown={(event) => handleRowKeyDown(event, row)}
+                </TableHeader>
+                <TableBody>
+                  {isLoading && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={COLUMN_COUNT}
+                        className="py-8 text-center text-muted-foreground"
                       >
-                        {/* 選択の当たり判定はこのセルの中のチェックボックスだけ */}
-                        <TableCell
-                          className="text-center"
-                          onClick={stopRowActivation}
+                        読み込み中...
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {!isLoading && rows.length === 0 && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={COLUMN_COUNT}
+                        className="py-8 text-center text-muted-foreground"
+                      >
+                        {noMatchMessage}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {!isLoading &&
+                    pageRows.map((sortableRow) => {
+                      const row = sortableRow.row
+                      const step = nextStep(row)
+                      const disabledReason = selectionDisabledReason?.(row)
+                      const fullUpdatedAt = formatFullDateTime(
+                        sortableRow.updatedAt
+                      )
+                      return (
+                        <TableRow
+                          key={sortableRow.id}
+                          className="group cursor-pointer"
+                          tabIndex={0}
+                          aria-label={`${sortableRow.name}の概要を開く`}
+                          onClick={() => openOverview(row)}
+                          onKeyDown={(event) => handleRowKeyDown(event, row)}
                         >
-                          <Checkbox
-                            checked={selectedIds.has(sortableRow.id)}
-                            onCheckedChange={(checked) =>
-                              onToggleSelect(sortableRow.id, checked === true)
-                            }
-                            disabled={disabledReason !== undefined}
-                            title={disabledReason}
-                            aria-label={`${sortableRow.name}を選択`}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <div className="font-medium">{sortableRow.name}</div>
-                          <div className="text-sm text-muted-foreground">
-                            {summary(row)}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-center text-sm text-muted-foreground tabular-nums">
-                          {formatDay(sortableRow.referenceDate)}
-                        </TableCell>
-                        <TableCell className="text-center text-sm text-muted-foreground tabular-nums">
-                          {formatDayAndTime(sortableRow.updatedAt)}
-                        </TableCell>
-                        {/* 概要とは別の飛び先なので、行の当たり判定を止める */}
-                        <TableCell
-                          className="text-center"
-                          onClick={stopRowActivation}
-                        >
-                          <Button
-                            size="sm"
-                            className="w-48 justify-start rounded-lg text-left"
-                            onClick={() => router.push(step.url)}
+                          {/* 選択の当たり判定はこのセルの中のチェックボックスだけ */}
+                          <TableCell
+                            className="text-center"
+                            onClick={stopRowActivation}
                           >
-                            <span className="text-xs">{step.label}</span>
-                          </Button>
-                        </TableCell>
-                        {/* 行メニュー。ここも行の当たり判定を止める */}
-                        <TableCell
-                          className="text-center"
-                          onClick={stopRowActivation}
-                        >
-                          {rowMenu(row)}
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-              </TableBody>
-            </Table>
+                            <Checkbox
+                              checked={selectedIds.has(sortableRow.id)}
+                              onCheckedChange={(checked) =>
+                                onToggleSelect(sortableRow.id, checked === true)
+                              }
+                              disabled={disabledReason !== undefined}
+                              title={disabledReason}
+                              aria-label={`${sortableRow.name}を選択`}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <div className="font-medium">
+                              {sortableRow.name}
+                            </div>
+                            <div className="text-sm text-muted-foreground">
+                              {summary(row)}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-center text-sm text-muted-foreground tabular-nums">
+                            {formatDay(sortableRow.referenceDate)}
+                          </TableCell>
+                          {/*
+                            短い姿だけを出し、省略のない日時は hover で読ませる。
+                            行はどこを押しても概要ページへ飛ぶので、押して開く形にはできない
+                          */}
+                          <TableCell className="text-center text-sm text-muted-foreground tabular-nums">
+                            {fullUpdatedAt === null ? (
+                              formatUpdatedAt(sortableRow.updatedAt)
+                            ) : (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span>
+                                    {formatUpdatedAt(sortableRow.updatedAt)}
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent>{fullUpdatedAt}</TooltipContent>
+                              </Tooltip>
+                            )}
+                          </TableCell>
+                          {/* 概要とは別の飛び先なので、行の当たり判定を止める */}
+                          <TableCell
+                            className="text-center"
+                            onClick={stopRowActivation}
+                          >
+                            <Button
+                              size="sm"
+                              className="w-48 justify-start rounded-lg text-left"
+                              onClick={() => router.push(step.url)}
+                            >
+                              <span className="text-xs">{step.label}</span>
+                            </Button>
+                          </TableCell>
+                          {/* 行メニュー。ここも行の当たり判定を止める */}
+                          <TableCell
+                            className="text-center"
+                            onClick={stopRowActivation}
+                          >
+                            {rowMenu(row)}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                </TableBody>
+              </Table>
+            </div>
+            <ListPaginationFooter
+              total={rows.length}
+              firstRowNumber={firstRowNumber}
+              lastRowNumber={lastRowNumber}
+              pageSize={pageSize}
+              pageSizeChoice={pageSizeChoice}
+              onPageSizeChoiceChange={setPageSizeChoice}
+              pageNumber={pageNumber}
+              pageCount={pageCount}
+              onPageChange={setPageNumber}
+            />
           </div>
         )}
       </div>

--- a/src/components/common/FilterableTableHead.tsx
+++ b/src/components/common/FilterableTableHead.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  ListFilter,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import { useState } from "react"
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { Separator } from "@/components/ui/separator"
+import type { SortDirection } from "@/hooks/useTableSort"
+import { cn } from "@/lib/utils"
+
+/**
+ * 列のあいだの区切り線。**見出しの高さいっぱいには引かない**（上下を少し空ける）。
+ *
+ * 置くのは列と列のあいだで、見出しの語とアイコンのあいだではない。後者に引くと、
+ * 語とアイコンが別のものに見えてしまう —— セル全体が1つのボタンなので、実際は
+ * どちらを押しても同じことが起きる。
+ */
+export function ColumnDivider() {
+  return (
+    <Separator
+      orientation="vertical"
+      className="my-2 data-[orientation=vertical]:h-8"
+    />
+  )
+}
+
+interface FilterableTableHeadProps<SortKey extends string> {
+  /** 見出しの語 */
+  label: string
+  sortKey: SortKey
+  currentSortKey: string | null
+  currentDirection: SortDirection
+  onSort: (sortKey: SortKey, direction: Exclude<SortDirection, null>) => void
+  /** この列で絞り込んでいるか。アイコンの色に出る */
+  isFiltered: boolean
+  /** popover の下半分（列ごとに違う絞り込み） */
+  children: ReactNode
+  /** popover の幅。既定は検索欄が入る幅 */
+  contentClassName?: string
+  /**
+   * 左に列の区切り線を引くか。
+   *
+   * 引かないのは**いちばん左の見出し**のときだけ。選択のチェックボックスと名前の
+   * あいだに線があると、チェックが列ではなく行の飾りに見える。
+   */
+  showDivider?: boolean
+  className?: string
+}
+
+/**
+ * 並べ替えと絞り込みを1つの popover にまとめた列見出し。
+ *
+ * **セル全体が押せる。** `SortableTableHead` は見出しを押すと並べ替えが回る作りで、
+ * 中に絞り込みのボタンを置くと押すたびに並べ替えも走ってしまう。並べ替えを popover の
+ * 中へ入れれば、見出しが持つ当たり判定は「popover を開く」1つだけになる。
+ *
+ * 並べ替えは**回さず名指しする**（「昇順」「降順」を並べて出す）。回す作りだと、
+ * いま何順なのかを覚えていないと目当ての向きに合わせられない。
+ *
+ * 状態は2つとも見出しの**右端の印1つ**で言う。並べ替えているあいだは filter が
+ * chevron に置き換わり、絞り込んでいるあいだは色が付く。**後者が無いと、絞ったことを
+ * 忘れて「データが消えた」と誤解する。**
+ */
+export function FilterableTableHead<SortKey extends string>({
+  label,
+  sortKey,
+  currentSortKey,
+  currentDirection,
+  onSort,
+  isFiltered,
+  children,
+  contentClassName,
+  showDivider = true,
+  className,
+}: FilterableTableHeadProps<SortKey>) {
+  const activeDirection = currentSortKey === sortKey ? currentDirection : null
+  // 並べ替えを選んだら閉じる（結果が見えないと、押せたのかどうか分からない）。
+  // 絞り込みの側は開いたまま —— タグは複数選ぶものなので、1つ選ぶたびに閉じると使えない
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        // padding はボタン側が持つ（セル全体を当たり判定にするため）
+        "h-12 p-0 align-middle font-medium whitespace-nowrap text-foreground",
+        "bg-card first:rounded-tl-lg last:rounded-tr-lg",
+        className
+      )}
+      aria-sort={
+        activeDirection === "asc"
+          ? "ascending"
+          : activeDirection === "desc"
+            ? "descending"
+            : "none"
+      }
+    >
+      <div className="flex h-12 items-center">
+        {showDivider && <ColumnDivider />}
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex h-12 flex-1 cursor-pointer items-center gap-1.5 px-4 text-left transition-colors select-none hover:bg-muted/60"
+            >
+              <span className="truncate">{label}</span>
+              <StateIcon direction={activeDirection} isFiltered={isFiltered} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className={cn("w-64 p-1", contentClassName)}
+          >
+            <SortMenuItem
+              label="昇順"
+              icon={<ArrowUp className="h-3.5 w-3.5" />}
+              isActive={activeDirection === "asc"}
+              onSelect={() => {
+                onSort(sortKey, "asc")
+                setIsOpen(false)
+              }}
+            />
+            <SortMenuItem
+              label="降順"
+              icon={<ArrowDown className="h-3.5 w-3.5" />}
+              isActive={activeDirection === "desc"}
+              onSelect={() => {
+                onSort(sortKey, "desc")
+                setIsOpen(false)
+              }}
+            />
+            <Separator className="my-2" />
+            <div className="p-1">{children}</div>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </th>
+  )
+}
+
+/**
+ * 見出しの右端に出す印。**並べ替えているあいだは chevron が filter を置き換える。**
+ *
+ * 印は1つだけ置き、絞り込みの有無は色で言う。2つ並べると、幅の狭い列
+ * （日付）で語が押し出される。
+ */
+function StateIcon({
+  direction,
+  isFiltered,
+}: {
+  direction: SortDirection
+  isFiltered: boolean
+}) {
+  const className = cn(
+    "ml-auto h-4 w-4 shrink-0",
+    isFiltered
+      ? "text-primary"
+      : direction === null
+        ? "text-muted-foreground/50"
+        : "text-foreground"
+  )
+  if (direction === "asc") return <ChevronUp className={className} />
+  if (direction === "desc") return <ChevronDown className={className} />
+  return <ListFilter className={className} />
+}
+
+/** popover 上部の「昇順」「降順」。選んでいる向きには ✓ が付く */
+function SortMenuItem({
+  label,
+  icon,
+  isActive,
+  onSelect,
+}: {
+  label: string
+  icon: ReactNode
+  isActive: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent"
+    >
+      <span className="text-muted-foreground">{icon}</span>
+      <span>{label}</span>
+      {isActive && <Check className="ml-auto h-3.5 w-3.5 text-primary" />}
+    </button>
+  )
+}

--- a/src/components/common/ListFilterControls.tsx
+++ b/src/components/common/ListFilterControls.tsx
@@ -2,6 +2,7 @@
 
 import type { LucideIcon } from "lucide-react"
 import { Calendar, School, Search, Tag, XIcon } from "lucide-react"
+import { useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -12,6 +13,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { useFiscalYearStart } from "@/hooks/useFiscalYearStart"
+import { fiscalYearRange, type FiscalYearStart } from "@/lib/fiscalYear"
+import { cn } from "@/lib/utils"
 
 /**
  * 一覧の絞り込み部品。
@@ -47,15 +51,22 @@ export interface DateRangeFilterConfig {
   onToChange: (value: string) => void
 }
 
-/** 一覧の検索欄。ヘッダーの並びでは最後まで畳まない（検索できない一覧にしない） */
+/**
+ * 一覧の検索欄。
+ *
+ * 幅を呼び手が決められるのは、置かれる場所が2つあるため。並びの中では畳まれない
+ * 固定幅、列見出しの popover の中では幅一杯になる。
+ */
 export function ListSearchInput({
   searchTerm,
   onSearchTermChange,
   placeholder,
+  className = "w-48",
 }: {
   searchTerm: string
   onSearchTermChange: (value: string) => void
   placeholder: string
+  className?: string
 }) {
   return (
     <div className="relative">
@@ -65,17 +76,24 @@ export function ListSearchInput({
         onChange={(event) => onSearchTermChange(event.target.value)}
         placeholder={placeholder}
         aria-label={placeholder}
-        className="h-8 w-48 pl-8 text-sm"
+        className={cn("h-8 pl-8 text-sm", className)}
       />
     </div>
   )
 }
 
-/** 複数選択フィルタの中身（選択肢の一覧とクリア） */
+/**
+ * 複数選択フィルタの中身（選択肢の一覧とクリア）。
+ *
+ * `clearLabel` を渡せるのは、名前列の popover が**タグと学級を縦に並べる**ため。
+ * 「フィルタをクリア」が2つ並ぶと、どちらがどちらを消すのか分からない。
+ */
 export function MultiSelectFilterPanel({
   config,
+  clearLabel = "フィルタをクリア",
 }: {
   config: MultiSelectFilterConfig
+  clearLabel?: string
 }) {
   const { options, selectedIds, onToggle, onClear } = config
   return (
@@ -104,7 +122,7 @@ export function MultiSelectFilterPanel({
           onClick={onClear}
         >
           <XIcon className="mr-1 h-3 w-3" />
-          フィルタをクリア
+          {clearLabel}
         </Button>
       )}
     </>
@@ -151,36 +169,152 @@ function MultiSelectFilterButton({
   )
 }
 
-/** 日付範囲フィルタの中身（開始・終了とクリア） */
+/** ローカル日の `YYYY-MM-DD`（`<input type="date">` が受け取る形） */
+function toDayValue(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}-${String(date.getDate()).padStart(2, "0")}`
+}
+
+/**
+ * よく使う範囲。
+ *
+ * 日付は行ごとに違うので、他の列のような「値を選ぶ」絞り込みができない。毎回2つ
+ * 打ち込むのは他の列と釣り合わないので、その代わりに置く。
+ *
+ * 「今年度」の切れ目は設定（`AppPreference`）から来る。4月始まりを決め打ちにすると、
+ * 別の区切りで動いている場所では毎回2つ打ち直すことになる。
+ */
+const DATE_RANGE_PRESETS: {
+  label: string
+  toRange: (
+    today: Date,
+    fiscalYearStart: FiscalYearStart
+  ) => { from: string; to: string }
+}[] = [
+  {
+    label: "今月",
+    toRange: (today) => ({
+      from: toDayValue(new Date(today.getFullYear(), today.getMonth(), 1)),
+      to: toDayValue(new Date(today.getFullYear(), today.getMonth() + 1, 0)),
+    }),
+  },
+  {
+    label: "今年度",
+    toRange: (today, fiscalYearStart) =>
+      fiscalYearRange(today, fiscalYearStart),
+  },
+  {
+    label: "直近30日",
+    toRange: (today) => ({
+      from: toDayValue(
+        new Date(today.getFullYear(), today.getMonth(), today.getDate() - 29)
+      ),
+      to: toDayValue(today),
+    }),
+  },
+]
+
+/**
+ * 日付を1つ受ける欄。ネイティブの `type="date"` のまま（打ち込みもカレンダーも使える）。
+ *
+ * ネイティブの空欄は「年/月/日」と出る。**この文言は差し替えられない**ので、空のあいだは
+ * 中の欄そのものを透明にし、上に自前の文言を重ねる。打ち込みに入った（focus した）時点で
+ * 元へ戻すので、キーボードから数字を入れる邪魔にはならない。
+ *
+ * 見出しは上ではなく左に置き、欄の高さぶんで1行に収める。
+ */
+function DayInput({
+  rangeLabel,
+  edge,
+  value,
+  onChange,
+}: {
+  /** 何の日付か（「試験日」など）。読み上げの名前に使う */
+  rangeLabel: string
+  edge: "開始" | "終了"
+  value: string
+  onChange: (value: string) => void
+}) {
+  const [isFocused, setIsFocused] = useState(false)
+  // 打ち込み中は本物の欄を出す。**空かどうかだけで決めると、途中まで打った状態が
+  // 見えない**（日付は全部揃うまで値が空のままなので）
+  const showsOwnPlaceholder = value === "" && !isFocused
+
+  return (
+    <label className="flex items-center gap-2">
+      <span className="w-7 shrink-0 text-xs text-muted-foreground">{edge}</span>
+      <div className="relative flex-1">
+        <Input
+          type="date"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          aria-label={`${rangeLabel}（${edge}）`}
+          data-blank={showsOwnPlaceholder}
+          className={cn(
+            "h-8 w-full px-2 text-sm tabular-nums",
+            // ネイティブの「年/月/日」を隠す（消せないので見えなくする）
+            "data-[blank=true]:[&::-webkit-datetime-edit]:opacity-0",
+            // 右端のカレンダーの絵。既定は大きく、暗い配色でも黒いまま
+            "[&::-webkit-calendar-picker-indicator]:h-3.5 [&::-webkit-calendar-picker-indicator]:w-3.5",
+            "[&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-40",
+            "[&::-webkit-calendar-picker-indicator]:hover:opacity-100",
+            "dark:[&::-webkit-calendar-picker-indicator]:invert"
+          )}
+        />
+        {showsOwnPlaceholder && (
+          <span className="pointer-events-none absolute inset-y-0 left-2 flex items-center text-sm text-muted-foreground">
+            指定なし
+          </span>
+        )}
+      </div>
+    </label>
+  )
+}
+
+/** 日付範囲フィルタの中身（よく使う範囲・開始・終了・クリア） */
 export function DateRangeFilterPanel({
   config,
 }: {
   config: DateRangeFilterConfig
 }) {
   const { label, from, to, onFromChange, onToChange } = config
+  const fiscalYearStart = useFiscalYearStart()
   const hasRange = from !== "" || to !== ""
   return (
     <div className="space-y-2">
-      <div className="space-y-1">
-        <span className="text-xs text-muted-foreground">{label}（開始）</span>
-        <Input
-          type="date"
-          value={from}
-          onChange={(event) => onFromChange(event.target.value)}
-          aria-label={`${label}（開始）`}
-          className="h-8 text-sm"
-        />
+      <div className="flex flex-wrap gap-1">
+        {DATE_RANGE_PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            variant="outline"
+            size="sm"
+            className="h-7 flex-1 text-xs"
+            onClick={() => {
+              const range = preset.toRange(new Date(), fiscalYearStart)
+              onFromChange(range.from)
+              onToChange(range.to)
+            }}
+          >
+            {preset.label}
+          </Button>
+        ))}
       </div>
-      <div className="space-y-1">
-        <span className="text-xs text-muted-foreground">{label}（終了）</span>
-        <Input
-          type="date"
-          value={to}
-          onChange={(event) => onToChange(event.target.value)}
-          aria-label={`${label}（終了）`}
-          className="h-8 text-sm"
-        />
-      </div>
+      <DayInput
+        rangeLabel={label}
+        edge="開始"
+        value={from}
+        onChange={onFromChange}
+      />
+      <DayInput
+        rangeLabel={label}
+        edge="終了"
+        value={to}
+        onChange={onToChange}
+      />
       {hasRange && (
         <Button
           variant="ghost"

--- a/src/components/common/ListPager.tsx
+++ b/src/components/common/ListPager.tsx
@@ -2,7 +2,10 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import type { MouseEvent } from "react"
+import { useState } from "react"
 
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import {
   Pagination,
   PaginationContent,
@@ -10,6 +13,11 @@ import {
   PaginationItem,
   PaginationLink,
 } from "@/components/ui/pagination"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 
 interface PageSlot {
@@ -39,7 +47,78 @@ const buildPageSlots = (pageNumber: number, pageCount: number): PageSlot[] => {
   })
 }
 
-interface AuditLogPagerProps {
+/**
+ * 畳まれた区間の省略記号。**押すとページ番号を打ち込んで飛べる。**
+ *
+ * ページ数が3桁になると、端と現在地の前後しかボタンが出ない。間のページへは
+ * 「次へ」を何十回も押すか、ここから番号を打つしかない。
+ */
+function PageJumpEllipsis({
+  pageCount,
+  onPageChange,
+}: {
+  pageCount: number
+  onPageChange: (pageNumber: number) => void
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [pageText, setPageText] = useState("")
+
+  const target = Number(pageText)
+  const canJump =
+    pageText !== "" &&
+    Number.isInteger(target) &&
+    target >= 1 &&
+    target <= pageCount
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={(nextOpen) => {
+        setIsOpen(nextOpen)
+        // 閉じたら打ちかけを捨てる（次に開いたとき前回の入力が残っていると、
+        // そのまま押して意図しないページへ飛ぶ）
+        if (!nextOpen) setPageText("")
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="ページ番号を指定して移動"
+          className="cursor-pointer rounded hover:bg-accent"
+        >
+          <PaginationEllipsis />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="center" className="w-52 p-2">
+        <form
+          className="flex items-center gap-1"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (!canJump) return
+            onPageChange(target)
+            setIsOpen(false)
+            setPageText("")
+          }}
+        >
+          <Input
+            value={pageText}
+            onChange={(event) => setPageText(event.target.value)}
+            inputMode="numeric"
+            placeholder={`1〜${pageCount}`}
+            aria-label={`移動先のページ（1〜${pageCount}）`}
+            className="h-8 text-sm"
+            autoFocus
+          />
+          <Button type="submit" size="sm" className="h-8" disabled={!canJump}>
+            移動
+          </Button>
+        </form>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface ListPagerProps {
   /** 1始まり */
   pageNumber: number
   pageCount: number
@@ -47,16 +126,16 @@ interface AuditLogPagerProps {
 }
 
 /**
- * 監査ログのページ送り。
+ * ページ送り。監査ログと一覧4画面が同じものを使う。
  *
  * 行き先は URL ではなく画面の状態なので、`<a>` の既定の遷移は止める
  * （未保存の確認を挟む `GuardedLink` の経路にも乗せない）。
  */
-export function AuditLogPager({
+export function ListPager({
   pageNumber,
   pageCount,
   onPageChange,
-}: AuditLogPagerProps) {
+}: ListPagerProps) {
   const goTo = (target: number) => (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
     if (target < 1 || target > pageCount || target === pageNumber) return
@@ -86,7 +165,10 @@ export function AuditLogPager({
         {buildPageSlots(pageNumber, pageCount).map((slot) =>
           slot.pageNumber === null ? (
             <PaginationItem key={slot.key}>
-              <PaginationEllipsis />
+              <PageJumpEllipsis
+                pageCount={pageCount}
+                onPageChange={onPageChange}
+              />
             </PaginationItem>
           ) : (
             <PaginationItem key={slot.key}>

--- a/src/components/common/ListPaginationFooter.tsx
+++ b/src/components/common/ListPaginationFooter.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { ListPager } from "@/components/common/ListPager"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  AUTO_PAGE_SIZE,
+  LIST_PAGE_SIZES,
+  type PageSizeChoice,
+} from "@/lib/listPagination"
+
+interface ListPaginationFooterProps {
+  /** 絞り込みに一致する総件数 */
+  total: number
+  /** いま見ている先頭の行番号（1始まり。0件なら 0） */
+  firstRowNumber: number
+  /** いま見ている末尾の行番号 */
+  lastRowNumber: number
+  /** 実際に並べている件数（「自動」なら測って決まった値） */
+  pageSize: number
+  pageSizeChoice: PageSizeChoice
+  onPageSizeChoiceChange: (choice: PageSizeChoice) => void
+  /** 1始まり */
+  pageNumber: number
+  pageCount: number
+  onPageChange: (pageNumber: number) => void
+}
+
+/**
+ * 一覧の下端。左に「何件中どこを見ているか」、真ん中に1ページの件数、右にページ送り。
+ *
+ * 1ページに収まるときもページ送りだけ消して**フッターは出したままにする**。出したり
+ * 消したりすると、絞り込むたびに一覧の高さが変わって行の位置が飛ぶ。
+ */
+export function ListPaginationFooter({
+  total,
+  firstRowNumber,
+  lastRowNumber,
+  pageSize,
+  pageSizeChoice,
+  onPageSizeChoiceChange,
+  pageNumber,
+  pageCount,
+  onPageChange,
+}: ListPaginationFooterProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 border-t px-6 py-3">
+      <span className="text-sm text-muted-foreground">
+        {total} 件中 {firstRowNumber}〜{lastRowNumber} 件
+      </span>
+      <Select
+        value={
+          pageSizeChoice === AUTO_PAGE_SIZE
+            ? AUTO_PAGE_SIZE
+            : String(pageSizeChoice)
+        }
+        onValueChange={(value) =>
+          onPageSizeChoiceChange(
+            value === AUTO_PAGE_SIZE ? AUTO_PAGE_SIZE : Number(value)
+          )
+        }
+      >
+        <SelectTrigger className="w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={AUTO_PAGE_SIZE}>自動（{pageSize} 件）</SelectItem>
+          {LIST_PAGE_SIZES.map((size) => (
+            <SelectItem key={size} value={String(size)}>
+              {size} 件ずつ
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {pageCount > 1 && (
+        <div className="ml-auto">
+          <ListPager
+            pageNumber={pageNumber}
+            pageCount={pageCount}
+            onPageChange={onPageChange}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/coursework/list/CourseworkListContainer.tsx
+++ b/src/components/coursework/list/CourseworkListContainer.tsx
@@ -17,14 +17,6 @@ import {
   BulkTagAssignPanel,
 } from "@/components/common/BulkTagAssignButton"
 import { EntityListPage } from "@/components/common/EntityListPage"
-import {
-  ClassroomFilterButton,
-  DateRangeFilterButton,
-  DateRangeFilterPanel,
-  ListSearchInput,
-  MultiSelectFilterPanel,
-  TagFilterButton,
-} from "@/components/common/ListFilterControls"
 import type { ToolbarAction } from "@/components/common/OverflowToolbar"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import { Badge } from "@/components/ui/badge"
@@ -77,6 +69,7 @@ const COURSEWORK_FILTER_ACCESSORS: ListFilterAccessors<CourseworkSummary> = {
       (courseworkClassroom) => courseworkClassroom.classroomId
     ),
   date: (coursework) => coursework.referenceDate,
+  updatedAt: (coursework) => coursework.updatedAt,
 }
 
 /** 未取得のときに毎回新しい配列を作らないための空値 */
@@ -246,6 +239,10 @@ export function CourseworkListContainer() {
     setDateFrom,
     dateTo,
     setDateTo,
+    updatedFrom,
+    setUpdatedFrom,
+    updatedTo,
+    setUpdatedTo,
   } = useListFilter(courseworks, COURSEWORK_FILTER_ACCESSORS)
 
   const {
@@ -309,17 +306,6 @@ export function CourseworkListContainer() {
       onClear: clearClassroomIds,
     }),
     [classroomOptions, filterClassroomIds, toggleClassroomId, clearClassroomIds]
-  )
-
-  const dateRangeConfig = useMemo(
-    () => ({
-      label: "実施日",
-      from: dateFrom,
-      to: dateTo,
-      onFromChange: setDateFrom,
-      onToChange: setDateTo,
-    }),
-    [dateFrom, dateTo, setDateFrom, setDateTo]
   )
 
   const actions = useMemo<ToolbarAction[]>(() => {
@@ -399,69 +385,8 @@ export function CourseworkListContainer() {
       })
     }
 
-    toolbarActions.push(
-      {
-        id: "tag-filter",
-        priority: 90,
-        node: <TagFilterButton config={tagFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">タグで絞り込み</p>
-            <MultiSelectFilterPanel config={tagFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        id: "classroom-filter",
-        priority: 85,
-        node: <ClassroomFilterButton config={classroomFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">学級で絞り込み</p>
-            <MultiSelectFilterPanel config={classroomFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        id: "date-filter",
-        priority: 84,
-        node: <DateRangeFilterButton config={dateRangeConfig} />,
-        collapsedNode: <DateRangeFilterPanel config={dateRangeConfig} />,
-      },
-      {
-        // 検索欄は最後まで残す（検索できない一覧にしない）
-        id: "search",
-        priority: 100,
-        node: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="資料名・タグ・学級で検索"
-          />
-        ),
-        collapsedNode: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="資料名・タグ・学級で検索"
-          />
-        ),
-      }
-    )
-
     return toolbarActions
-  }, [
-    allTags,
-    classroomFilterConfig,
-    dateRangeConfig,
-    handleBulkAddTag,
-    handleCreate,
-    handleImport,
-    searchTerm,
-    selectedIds,
-    setSearchTerm,
-    tagFilterConfig,
-  ])
+  }, [allTags, handleBulkAddTag, handleCreate, handleImport, selectedIds])
 
   return (
     <>
@@ -474,12 +399,6 @@ export function CourseworkListContainer() {
         name={(coursework) => coursework.name}
         summary={(coursework) => (
           <span className="flex flex-wrap items-center gap-1">
-            <span>
-              {coursework.description || "説明なし"}
-              {" / 生徒: "}
-              {coursework.students.length}名 / 評価項目:{" "}
-              {coursework.items.length}
-            </span>
             {coursework.tags.map((courseworkTag) => (
               <Badge
                 key={courseworkTag.tag.id}
@@ -497,6 +416,12 @@ export function CourseworkListContainer() {
                 {courseworkTag.tag.name}
               </Badge>
             ))}
+            <span>
+              {coursework.description || "説明なし"}
+              {" / 生徒: "}
+              {coursework.students.length}名 / 評価項目:{" "}
+              {coursework.items.length}
+            </span>
           </span>
         )}
         dateLabel="実施日"
@@ -535,6 +460,25 @@ export function CourseworkListContainer() {
           </DropdownMenu>
         )}
         actions={actions}
+        search={{
+          term: searchTerm,
+          onChange: setSearchTerm,
+          placeholder: "資料名・タグ・学級で検索",
+        }}
+        tagFilter={tagFilterConfig}
+        classroomFilter={classroomFilterConfig}
+        dateFilter={{
+          from: dateFrom,
+          to: dateTo,
+          onFromChange: setDateFrom,
+          onToChange: setDateTo,
+        }}
+        updatedAtFilter={{
+          from: updatedFrom,
+          to: updatedTo,
+          onFromChange: setUpdatedFrom,
+          onToChange: setUpdatedTo,
+        }}
         selectedIds={selectedIds}
         onToggleSelect={toggleSelect}
         onToggleSelectAll={toggleSelectAll}

--- a/src/components/exams/list/ExamList.tsx
+++ b/src/components/exams/list/ExamList.tsx
@@ -17,11 +17,6 @@ import {
 } from "@/components/common/BulkTagAssignButton"
 import { EntityListPage } from "@/components/common/EntityListPage"
 import type { ExportOutcome } from "@/components/common/ExportResultSummary"
-import {
-  ListSearchInput,
-  MultiSelectFilterPanel,
-  TagFilterButton,
-} from "@/components/common/ListFilterControls"
 import type { ToolbarAction } from "@/components/common/OverflowToolbar"
 import ExamArchiveExportModal from "@/components/exams/detail/ExamArchiveExportModal"
 import { usePageHelp } from "@/components/help/usePageHelp"
@@ -59,7 +54,7 @@ import type { ArchiveExportMode } from "@/types/examArchive.types"
 const EMPTY_TAGS: TagWithAllRelations[] = []
 const EMPTY_EXAMS: ExamSummary[] = []
 
-/** 試験一覧のフィルタ対象値の取り出し（検索=試験名・説明・タグ名、タグ絞り込み=タグ id） */
+/** 試験一覧のフィルタ対象値の取り出し（列見出しの popover が絞る先） */
 const EXAM_FILTER_ACCESSORS: ListFilterAccessors<ExamSummary> = {
   searchTexts: (exam) => [
     exam.examName,
@@ -67,6 +62,8 @@ const EXAM_FILTER_ACCESSORS: ListFilterAccessors<ExamSummary> = {
     ...exam.tags.map((tag) => tag.name),
   ],
   tagIds: (exam) => exam.tags.map((tag) => tag.id),
+  date: (exam) => exam.referenceDate,
+  updatedAt: (exam) => exam.updatedAt,
 }
 
 /**
@@ -135,6 +132,14 @@ const ExamList = () => {
     filterTagIds,
     toggleTagId,
     clearTagIds,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+    updatedFrom,
+    setUpdatedFrom,
+    updatedTo,
+    setUpdatedTo,
   } = useListFilter(exams, EXAM_FILTER_ACCESSORS)
 
   const {
@@ -386,50 +391,8 @@ const ExamList = () => {
       )
     }
 
-    toolbarActions.push(
-      {
-        id: "tag-filter",
-        priority: 90,
-        node: <TagFilterButton config={tagFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">タグで絞り込み</p>
-            <MultiSelectFilterPanel config={tagFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        // 検索欄は最後まで残す（検索できない一覧にしない）
-        id: "search",
-        priority: 100,
-        node: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="試験名・タグで検索"
-          />
-        ),
-        collapsedNode: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="試験名・タグで検索"
-          />
-        ),
-      }
-    )
-
     return toolbarActions
-  }, [
-    allTags,
-    handleBulkAddTag,
-    handleCreate,
-    isExporting,
-    searchTerm,
-    selectedIds,
-    setSearchTerm,
-    tagFilterConfig,
-  ])
+  }, [allTags, handleBulkAddTag, handleCreate, isExporting, selectedIds])
 
   return (
     <>
@@ -454,7 +417,6 @@ const ExamList = () => {
         name={(exam) => exam.examName}
         summary={(exam) => (
           <span className="flex flex-wrap items-center gap-1">
-            <span>{exam.description || "説明なし"}</span>
             {exam.tags.map((tag) => (
               <Badge
                 key={tag.id}
@@ -469,6 +431,7 @@ const ExamList = () => {
                 {tag.name}
               </Badge>
             ))}
+            <span>{exam.description || "説明なし"}</span>
           </span>
         )}
         dateLabel="試験日"
@@ -508,6 +471,24 @@ const ExamList = () => {
           </DropdownMenu>
         )}
         actions={actions}
+        search={{
+          term: searchTerm,
+          onChange: setSearchTerm,
+          placeholder: "試験名・タグで検索",
+        }}
+        tagFilter={tagFilterConfig}
+        dateFilter={{
+          from: dateFrom,
+          to: dateTo,
+          onFromChange: setDateFrom,
+          onToChange: setDateTo,
+        }}
+        updatedAtFilter={{
+          from: updatedFrom,
+          to: updatedTo,
+          onFromChange: setUpdatedFrom,
+          onToChange: setUpdatedTo,
+        }}
         selectedIds={selectedIds}
         onToggleSelect={toggleSelect}
         onToggleSelectAll={toggleSelectAll}

--- a/src/components/grades/list/GradeListContainer.tsx
+++ b/src/components/grades/list/GradeListContainer.tsx
@@ -18,14 +18,6 @@ import {
   BulkTagAssignPanel,
 } from "@/components/common/BulkTagAssignButton"
 import { EntityListPage } from "@/components/common/EntityListPage"
-import {
-  ClassroomFilterButton,
-  DateRangeFilterButton,
-  DateRangeFilterPanel,
-  ListSearchInput,
-  MultiSelectFilterPanel,
-  TagFilterButton,
-} from "@/components/common/ListFilterControls"
 import type { ToolbarAction } from "@/components/common/OverflowToolbar"
 import { usePageHelp } from "@/components/help/usePageHelp"
 import { Badge } from "@/components/ui/badge"
@@ -75,6 +67,7 @@ const GRADE_FILTER_ACCESSORS: ListFilterAccessors<GradeSummary> = {
   classroomIds: (grade) =>
     grade.gradeClassrooms.map((gradeClassroom) => gradeClassroom.classroomId),
   date: (grade) => grade.referenceDate,
+  updatedAt: (grade) => grade.updatedAt,
 }
 
 /** 未取得のときに毎回新しい配列を作らないための空値 */
@@ -212,6 +205,10 @@ export function GradeListContainer() {
     setDateFrom,
     dateTo,
     setDateTo,
+    updatedFrom,
+    setUpdatedFrom,
+    updatedTo,
+    setUpdatedTo,
   } = useListFilter(grades, GRADE_FILTER_ACCESSORS)
 
   const {
@@ -260,17 +257,6 @@ export function GradeListContainer() {
       onClear: clearClassroomIds,
     }),
     [classroomOptions, filterClassroomIds, toggleClassroomId, clearClassroomIds]
-  )
-
-  const dateRangeConfig = useMemo(
-    () => ({
-      label: "成績算出日",
-      from: dateFrom,
-      to: dateTo,
-      onFromChange: setDateFrom,
-      onToChange: setDateTo,
-    }),
-    [dateFrom, dateTo, setDateFrom, setDateTo]
   )
 
   const actions = useMemo<ToolbarAction[]>(() => {
@@ -350,69 +336,8 @@ export function GradeListContainer() {
       })
     }
 
-    toolbarActions.push(
-      {
-        id: "tag-filter",
-        priority: 90,
-        node: <TagFilterButton config={tagFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">タグで絞り込み</p>
-            <MultiSelectFilterPanel config={tagFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        id: "classroom-filter",
-        priority: 85,
-        node: <ClassroomFilterButton config={classroomFilterConfig} />,
-        collapsedNode: (
-          <div className="space-y-1">
-            <p className="px-2 text-xs text-muted-foreground">学級で絞り込み</p>
-            <MultiSelectFilterPanel config={classroomFilterConfig} />
-          </div>
-        ),
-      },
-      {
-        id: "date-filter",
-        priority: 84,
-        node: <DateRangeFilterButton config={dateRangeConfig} />,
-        collapsedNode: <DateRangeFilterPanel config={dateRangeConfig} />,
-      },
-      {
-        // 検索欄は最後まで残す（検索できない一覧にしない）
-        id: "search",
-        priority: 100,
-        node: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="成績算出名・タグ・学級で検索"
-          />
-        ),
-        collapsedNode: (
-          <ListSearchInput
-            searchTerm={searchTerm}
-            onSearchTermChange={setSearchTerm}
-            placeholder="成績算出名・タグ・学級で検索"
-          />
-        ),
-      }
-    )
-
     return toolbarActions
-  }, [
-    allTags,
-    classroomFilterConfig,
-    dateRangeConfig,
-    handleBulkAddTag,
-    handleCreate,
-    handleImport,
-    searchTerm,
-    selectedIds,
-    setSearchTerm,
-    tagFilterConfig,
-  ])
+  }, [allTags, handleBulkAddTag, handleCreate, handleImport, selectedIds])
 
   return (
     <>
@@ -429,12 +354,6 @@ export function GradeListContainer() {
             .join("、")
           return (
             <span className="flex flex-wrap items-center gap-1">
-              <span>
-                {classroomNames || "学級未登録"}
-                {" / 生徒: "}
-                {grade.gradeStudents.length}名 / 評価項目:{" "}
-                {grade.gradeItems.length}
-              </span>
               {grade.gradeTags.map((gradeTag) => (
                 <Badge
                   key={gradeTag.tag.id}
@@ -452,6 +371,12 @@ export function GradeListContainer() {
                   {gradeTag.tag.name}
                 </Badge>
               ))}
+              <span>
+                {classroomNames || "学級未登録"}
+                {" / 生徒: "}
+                {grade.gradeStudents.length}名 / 評価項目:{" "}
+                {grade.gradeItems.length}
+              </span>
             </span>
           )
         }}
@@ -495,6 +420,25 @@ export function GradeListContainer() {
           </DropdownMenu>
         )}
         actions={actions}
+        search={{
+          term: searchTerm,
+          onChange: setSearchTerm,
+          placeholder: "成績算出名・タグ・学級で検索",
+        }}
+        tagFilter={tagFilterConfig}
+        classroomFilter={classroomFilterConfig}
+        dateFilter={{
+          from: dateFrom,
+          to: dateTo,
+          onFromChange: setDateFrom,
+          onToChange: setDateTo,
+        }}
+        updatedAtFilter={{
+          from: updatedFrom,
+          to: updatedTo,
+          onFromChange: setUpdatedFrom,
+          onToChange: setUpdatedTo,
+        }}
         selectedIds={selectedIds}
         onToggleSelect={toggleSelect}
         onToggleSelectAll={toggleSelectAll}

--- a/src/hooks/useFiscalYearStart.ts
+++ b/src/hooks/useFiscalYearStart.ts
@@ -1,0 +1,23 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import {
+  DEFAULT_FISCAL_YEAR_START,
+  FISCAL_YEAR_START_KEY,
+  type FiscalYearStart,
+  parseFiscalYearStart,
+} from "@/lib/fiscalYear"
+import { appPreferenceQuery } from "@/queries/settings"
+
+/**
+ * 年度の開始日。設定が無い（まだ誰も決めていない）あいだは既定の 4/1。
+ *
+ * 読むのは絞り込みの「今年度」と設定画面の2か所。どちらも同じキャッシュを見るので、
+ * 設定を変えると絞り込みの側もその場で追いつく。
+ */
+export function useFiscalYearStart(): FiscalYearStart {
+  const { data } = useQuery(appPreferenceQuery(FISCAL_YEAR_START_KEY))
+  if (data === undefined) return DEFAULT_FISCAL_YEAR_START
+  return parseFiscalYearStart(data)
+}

--- a/src/hooks/useListFilter.ts
+++ b/src/hooks/useListFilter.ts
@@ -24,6 +24,11 @@ export interface ListFilterAccessors<T> {
    * 両方を許す（下の絞り込みは `new Date(...)` でどちらも扱える）。
    */
   date?: (listItem: T) => string | Date | null
+  /**
+   * 更新日時の範囲フィルタ用の値。`date` と別に持つのは、一覧が日付列を2つ
+   * （実施日と更新日時）出しており、**列見出しごとに絞れる**ようにするため。
+   */
+  updatedAt?: (listItem: T) => string | Date | null
 }
 
 interface UseListFilterResult<T> {
@@ -42,6 +47,38 @@ interface UseListFilterResult<T> {
   /** 日付範囲の上端（YYYY-MM-DD、空文字は未指定） */
   dateTo: string
   setDateTo: (value: string) => void
+  /** 更新日時の下端（YYYY-MM-DD、空文字は未指定） */
+  updatedFrom: string
+  setUpdatedFrom: (value: string) => void
+  /** 更新日時の上端（YYYY-MM-DD、空文字は未指定） */
+  updatedTo: string
+  setUpdatedTo: (value: string) => void
+}
+
+/**
+ * ローカル日の `YYYY-MM-DD`。
+ *
+ * 一覧の日付列は `toLocaleDateString` で描いているので、絞り込みも同じローカル日で
+ * 比べる（UTC で切ると、画面に出ている日と1日ずれる行が出る）。
+ */
+function toLocalDay(date: string | Date): string {
+  const localDate = new Date(date)
+  return `${localDate.getFullYear()}-${String(
+    localDate.getMonth() + 1
+  ).padStart(2, "0")}-${String(localDate.getDate()).padStart(2, "0")}`
+}
+
+/** 日付が範囲に入っているか。**未設定の行は範囲を指定した時点で外れる** */
+function isWithinDayRange(
+  date: string | Date | null,
+  from: string,
+  to: string
+): boolean {
+  if (date === null) return false
+  const day = toLocalDay(date)
+  if (from && day < from) return false
+  if (to && day > to) return false
+  return true
 }
 
 export function useListFilter<T>(
@@ -55,6 +92,8 @@ export function useListFilter<T>(
   )
   const [dateFrom, setDateFrom] = useState("")
   const [dateTo, setDateTo] = useState("")
+  const [updatedFrom, setUpdatedFrom] = useState("")
+  const [updatedTo, setUpdatedTo] = useState("")
 
   const toggleTagId = useCallback((tagId: string, checked: boolean) => {
     setFilterTagIds((prev) => {
@@ -114,16 +153,23 @@ export function useListFilter<T>(
         )
         if (!hasMatch) return false
       }
-      // 日付範囲フィルタ（表示(toLocaleDateString)と一致させるためローカル日で比較）
+      // 日付範囲フィルタ（実施日など、画面が持つ日付の列）
       if (accessors.date && (dateFrom || dateTo)) {
-        const isoDate = accessors.date(listItem)
-        if (!isoDate) return false
-        const localDate = new Date(isoDate)
-        const day = `${localDate.getFullYear()}-${String(
-          localDate.getMonth() + 1
-        ).padStart(2, "0")}-${String(localDate.getDate()).padStart(2, "0")}`
-        if (dateFrom && day < dateFrom) return false
-        if (dateTo && day > dateTo) return false
+        if (!isWithinDayRange(accessors.date(listItem), dateFrom, dateTo)) {
+          return false
+        }
+      }
+      // 更新日時の範囲フィルタ
+      if (accessors.updatedAt && (updatedFrom || updatedTo)) {
+        if (
+          !isWithinDayRange(
+            accessors.updatedAt(listItem),
+            updatedFrom,
+            updatedTo
+          )
+        ) {
+          return false
+        }
       }
       return true
     })
@@ -135,6 +181,8 @@ export function useListFilter<T>(
     filterClassroomIds,
     dateFrom,
     dateTo,
+    updatedFrom,
+    updatedTo,
   ])
 
   return {
@@ -151,5 +199,9 @@ export function useListFilter<T>(
     setDateFrom,
     dateTo,
     setDateTo,
+    updatedFrom,
+    setUpdatedFrom,
+    updatedTo,
+    setUpdatedTo,
   }
 }

--- a/src/hooks/useListPagination.ts
+++ b/src/hooks/useListPagination.ts
@@ -1,0 +1,138 @@
+"use client"
+
+import type { RefObject } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import {
+  AUTO_PAGE_SIZE,
+  FALLBACK_PAGE_SIZE,
+  type PageSizeChoice,
+} from "@/lib/listPagination"
+
+interface UseListPaginationOptions {
+  /**
+   * 1行の高さの見積もり（px）。「自動」はこれで割る。
+   *
+   * 実測より少し大きめに取り、はみ出すより余らせる（足りない分はスクロールできるが、
+   * 余白は操作できない）。
+   */
+  rowHeight: number
+  /** 行の上に居座るもの（見出し行など）の高さ（px） */
+  reservedHeight: number
+  /**
+   * 変わったら先頭のページへ戻す値。絞り込みと並び順を繋いだものを渡す。
+   *
+   * 3ページ目のまま絞り込むと、一致が1ページ分しかないときに空の画面へ着地する。
+   */
+  resetKey: string
+}
+
+interface UseListPaginationResult<Row> {
+  /** いま見ているページの行だけ */
+  pageRows: Row[]
+  /** 1始まり。件数が変われば「いま見ている行」から計算し直される */
+  pageNumber: number
+  /** 実際に並べている件数（「自動」なら高さから決まった値） */
+  pageSize: number
+  pageSizeChoice: PageSizeChoice
+  setPageSizeChoice: (choice: PageSizeChoice) => void
+  /** 総ページ数（0件でも1ページと数える） */
+  pageCount: number
+  setPageNumber: (pageNumber: number) => void
+  /** いま見ている先頭の行番号（1始まり。0件なら 0） */
+  firstRowNumber: number
+  /** いま見ている末尾の行番号 */
+  lastRowNumber: number
+  /** 「自動」が高さを測る相手。行が縦に伸びる箱へ付ける */
+  viewportRef: RefObject<HTMLDivElement | null>
+}
+
+/**
+ * 手元にある行をページへ切り分ける。
+ *
+ * 監査ログ（`useAuditLogs`）と違い、行は既に全部揃っている（main は一覧を丸ごと
+ * 返す）。ここでやるのは切り出しだけで、取得は起こらない。
+ *
+ * **覚えているのはページ番号ではなく先頭の行**（0始まり）なのは監査ログと同じ理由。
+ * 「自動」は表示領域の高さから件数を決めるので、窓を広げれば1ページの件数が増えて
+ * 総ページ数が減る。ページ番号を覚えていると、10ページ目を見ている最中に総数が
+ * 6ページへ縮んで空の一覧に着地する。
+ */
+export function useListPagination<Row>(
+  rows: Row[],
+  { rowHeight, reservedHeight, resetKey }: UseListPaginationOptions
+): UseListPaginationResult<Row> {
+  const [firstRowIndex, setFirstRowIndex] = useState(0)
+  const [pageSizeChoice, setPageSizeChoiceState] =
+    useState<PageSizeChoice>(AUTO_PAGE_SIZE)
+
+  // 「自動」のときだけ使う。高さは表示領域そのものから測る（見積もりで決め打つと、
+  // サイドバーを畳んだ・窓を変えたときに合わなくなる）
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [viewportHeight, setViewportHeight] = useState(0)
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+    // observe した時点で1度呼ばれるので、初回の高さもここで入る
+    const observer = new ResizeObserver(() =>
+      setViewportHeight(viewport.clientHeight)
+    )
+    observer.observe(viewport)
+    return () => observer.disconnect()
+  }, [])
+
+  const measuredPageSize = Math.floor(
+    (viewportHeight - reservedHeight) / rowHeight
+  )
+  const pageSize =
+    pageSizeChoice === AUTO_PAGE_SIZE
+      ? measuredPageSize > 0
+        ? measuredPageSize
+        : FALLBACK_PAGE_SIZE
+      : pageSizeChoice
+
+  const pageCount = Math.max(1, Math.ceil(rows.length / pageSize))
+
+  // 絞り込みと並び順を変えたら先頭のページから見る
+  const [seededResetKey, setSeededResetKey] = useState(resetKey)
+  if (seededResetKey !== resetKey) {
+    setSeededResetKey(resetKey)
+    setFirstRowIndex(0)
+  }
+
+  // 行が減って、いま見ている先頭が最後のページより後ろになったら詰め直す。
+  // `resetKey` を変えずに行が減る経路（別の端末の書き込みが同期で届く、削除した）
+  // があるので、鍵の付け替えだけでは足りない
+  const lastPageFirstRowIndex = (pageCount - 1) * pageSize
+  if (firstRowIndex > lastPageFirstRowIndex) {
+    setFirstRowIndex(lastPageFirstRowIndex)
+  }
+
+  // 件数を選び直すのは利用者の操作なので、先頭から見直す（窓の大きさが変わった
+  // ときと違い、いま見ている行に留まる理由がない）
+  const setPageSizeChoice = useCallback((choice: PageSizeChoice) => {
+    setPageSizeChoiceState(choice)
+    setFirstRowIndex(0)
+  }, [])
+
+  const setPageNumber = useCallback(
+    (nextPageNumber: number) => {
+      setFirstRowIndex((nextPageNumber - 1) * pageSize)
+    },
+    [pageSize]
+  )
+
+  return {
+    pageRows: rows.slice(firstRowIndex, firstRowIndex + pageSize),
+    pageNumber: Math.floor(firstRowIndex / pageSize) + 1,
+    pageSize,
+    pageSizeChoice,
+    setPageSizeChoice,
+    pageCount,
+    setPageNumber,
+    firstRowNumber: rows.length === 0 ? 0 : firstRowIndex + 1,
+    lastRowNumber: Math.min(rows.length, firstRowIndex + pageSize),
+    viewportRef,
+  }
+}

--- a/src/hooks/useTableSort.ts
+++ b/src/hooks/useTableSort.ts
@@ -160,22 +160,44 @@ export function useTableSort<T extends object>(
     })
   }, [data, sortConfig])
 
-  const requestSort = useCallback(
-    (key: keyof T & string) => {
-      const nextSort = nextTableSort(sortConfig, key)
+  /** 並び順を書き込む。永続化するときは localStorage が唯一の出所 */
+  const storeSort = useCallback(
+    (nextSort: TableSort) => {
       if (storageKey !== null) {
         setStoredText(JSON.stringify(nextSort))
         return
       }
       setChosenSort(nextSort)
     },
-    [setStoredText, sortConfig, storageKey]
+    [setStoredText, storageKey]
+  )
+
+  const requestSort = useCallback(
+    (key: keyof T & string) => {
+      storeSort(nextTableSort(sortConfig, key))
+    },
+    [sortConfig, storeSort]
+  )
+
+  /**
+   * 方向を名指しして並べ替える。
+   *
+   * 見出しを押して回す `requestSort` と違い、**押した通りの向きになる**。
+   * 列見出しの popover が「昇順」「降順」を並べて出すために要る（回す作りだと、
+   * いま何順なのかを覚えていないと目当ての向きに合わせられない）。
+   */
+  const applySort = useCallback(
+    (key: keyof T & string, direction: Exclude<SortDirection, null>) => {
+      storeSort({ key, direction })
+    },
+    [storeSort]
   )
 
   return {
     sortedData,
     sortConfig,
     requestSort,
+    applySort,
   }
 }
 

--- a/src/lib/fiscalYear.ts
+++ b/src/lib/fiscalYear.ts
@@ -1,0 +1,113 @@
+/**
+ * 年度の数え方。
+ *
+ * 開始日は設定（`AppPreference`）に持つ。**4月1日を決め打ちにしない**のは、
+ * 学校によって、また国によって年度の切れ目が違うため。行が無いときは 4/1 で数える。
+ */
+
+/** 年度の開始日を持つ設定のキー（`AppPreference.key`） */
+export const FISCAL_YEAR_START_KEY = "fiscalYearStart"
+
+/** 年度の開始日（月日だけ。年は数えるときの日付から決まる） */
+export interface FiscalYearStart {
+  /** 1〜12 */
+  month: number
+  /** 1〜31 */
+  day: number
+}
+
+/** 設定が無いときの年度開始日 */
+export const DEFAULT_FISCAL_YEAR_START: FiscalYearStart = { month: 4, day: 1 }
+
+/** その月に何日あるか（2月の閏を含む） */
+function daysInMonth(month: number): number {
+  // 年をまたいで変わるのは2月だけ。開始日として選べるのは「どの年にも在る日」なので、
+  // 閏日を選ばせない（2/29 を開始日にすると、平年に年度が始まらない）
+  return new Date(2001, month, 0).getDate()
+}
+
+/** 開始日として受け付けられる値か */
+export function isValidFiscalYearStart(start: FiscalYearStart): boolean {
+  if (!Number.isInteger(start.month) || !Number.isInteger(start.day)) {
+    return false
+  }
+  if (start.month < 1 || start.month > 12) return false
+  return start.day >= 1 && start.day <= daysInMonth(start.month)
+}
+
+/**
+ * 保存されている JSON 文字列を読む。**壊れていれば既定として扱う。**
+ *
+ * 設定が読めないことと、既定を選んだこととを画面で区別しない（どちらも 4/1 で数える）。
+ */
+export function parseFiscalYearStart(
+  storedText: string | null
+): FiscalYearStart {
+  if (storedText === null) return DEFAULT_FISCAL_YEAR_START
+  try {
+    const parsed: unknown = JSON.parse(storedText)
+    if (parsed === null || typeof parsed !== "object") {
+      return DEFAULT_FISCAL_YEAR_START
+    }
+    if (!("month" in parsed) || !("day" in parsed)) {
+      return DEFAULT_FISCAL_YEAR_START
+    }
+    const month = parsed.month
+    const day = parsed.day
+    if (typeof month !== "number" || typeof day !== "number") {
+      return DEFAULT_FISCAL_YEAR_START
+    }
+    const start = { month, day }
+    return isValidFiscalYearStart(start) ? start : DEFAULT_FISCAL_YEAR_START
+  } catch {
+    return DEFAULT_FISCAL_YEAR_START
+  }
+}
+
+export function serializeFiscalYearStart(start: FiscalYearStart): string {
+  return JSON.stringify({ month: start.month, day: start.day })
+}
+
+/** ローカル日の `YYYY-MM-DD`（`<input type="date">` と絞り込みが使う形） */
+function toDayValue(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}-${String(date.getDate()).padStart(2, "0")}`
+}
+
+/**
+ * その日が属する年度の範囲。
+ *
+ * 開始日より前なら**前の年**に始まった年度に居る。終わりは次の開始日の前日
+ * （`new Date(年, 月-1, 日-1)` は開始日の1日前を指す。日が 1 なら前月末になる）。
+ */
+export function fiscalYearRange(
+  today: Date,
+  start: FiscalYearStart
+): { from: string; to: string } {
+  const startThisYear = new Date(
+    today.getFullYear(),
+    start.month - 1,
+    start.day
+  )
+  const startedToday = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate()
+  )
+  const startYear =
+    startedToday.getTime() >= startThisYear.getTime()
+      ? today.getFullYear()
+      : today.getFullYear() - 1
+
+  return {
+    from: toDayValue(new Date(startYear, start.month - 1, start.day)),
+    to: toDayValue(new Date(startYear + 1, start.month - 1, start.day - 1)),
+  }
+}
+
+/** 「4月1日」のような表示（設定画面と絞り込みの語に使う） */
+export function formatFiscalYearStart(start: FiscalYearStart): string {
+  return `${start.month}月${start.day}日`
+}

--- a/src/lib/listPagination.ts
+++ b/src/lib/listPagination.ts
@@ -1,0 +1,15 @@
+/**
+ * ページ送りの共通の決めごと。監査ログと一覧4画面が同じ選択肢を出す。
+ */
+
+/** 1ページに並べる件数を、表示領域の高さから決める指定 */
+export const AUTO_PAGE_SIZE = "auto"
+
+/** 1ページの件数の指定。「自動」は表示領域の高さから決める */
+export type PageSizeChoice = typeof AUTO_PAGE_SIZE | number
+
+/** 1ページに並べる件数の選択肢（「自動」は別枠） */
+export const LIST_PAGE_SIZES = [10, 20, 50, 100] as const
+
+/** 高さがまだ測れていないときに使う件数 */
+export const FALLBACK_PAGE_SIZE = 10

--- a/src/queries/settings.ts
+++ b/src/queries/settings.ts
@@ -37,6 +37,18 @@ import { scopeKeys } from "./keys"
  * **保存されている文字列をそのまま返す。** 値の解釈（`parsePreference`）は
  * 表示側の計算なので、キャッシュには載せない。
  */
+/**
+ * アプリ全体の設定を1キー分。**DB を共有する全員が同じ値を見る。**
+ *
+ * `userPreferenceQuery` と同じく、保存されている文字列をそのまま返す
+ * （解釈は表示側の計算）。
+ */
+export const appPreferenceQuery = (key: string) =>
+  queryOptions({
+    queryKey: ["appPreference", key] as const,
+    queryFn: () => window.electronAPI.settings.getAppPreference(key),
+  })
+
 export const userPreferenceQuery = (userId: string, key: PreferenceKey) =>
   queryOptions({
     queryKey: ["userPreference", userId, key] as const,
@@ -107,6 +119,18 @@ export const examExportSettingsQuery = (examId: string) =>
 export type SetUserPreferenceInput = {
   [TKey in PreferenceKey]: { key: TKey; value: PreferenceValueType[TKey] }
 }[PreferenceKey]
+
+/** アプリ全体の設定を1キー分書く（値は呼び手が JSON 文字列にする） */
+export const setAppPreferenceMutation = (key: string) =>
+  defineMutation({
+    mutationFn: (value: string) =>
+      window.electronAPI.settings.setAppPreference(key, value),
+    scope: { id: `appPreference:${key}` },
+    meta: {
+      invalidates: [["appPreference", key]],
+      errorMessage: "設定を保存できませんでした",
+    },
+  })
 
 export const setUserPreferenceMutation = (userId: string) =>
   defineMutation({


### PR DESCRIPTION
一覧の絞り込みを、ヘッダー右の並びから列の見出しへ移す。あわせて「今年度」を組み立てるための年度の開始日を設定に持たせた。コミット2件。

## 一覧の絞り込みを列見出しへ移し、ページ送りを付ける

4画面（解答用紙作成・試験一覧・試験外成績資料・成績算出）の絞り込みは、ヘッダー右の並びに載っていて、幅が足りないと「…」へ畳まれていた。何で絞れるのかが並びを開くまで分からず、絞った結果がどの列のものなのかも読めない。見出しセル全体を popover にし、並べ替えもその中へ入れた。並べ替えは回さず昇順・降順を並べて名指しする。状態は右端の印1つで言い、絞り込んでいるあいだは色が付く（無いと、絞ったことを忘れて「データが消えた」と誤解する）。

名前列の popover には検索欄・タグ・学級を同居させた。検索は説明・タグ名・学級名も見ているのでどの列の値でもなく、行の中でいちばん多く目に入る列に置いている。「次のステップ」列は絞り込みを持たない（絞ると選択した行が見えなくなり、ヘッダーの一括操作が「見えていない行にも効く」ことになる）。

日付は yy/mm/dd、更新日時は今日と昨日だけ時刻まで出し、省略のない日時は tooltip で読ませる。日付の絞り込みには、よく使う範囲（今月・今年度・直近30日）を置いた。

ページ送りは監査ログと同じフッターへ寄せ、省略記号を押すとページ番号を打ち込んで飛べるようにした。監査ログ側も同じ部品へ差し替え、件数の選択肢は lib/listPagination で共有する。覚えているのはページ番号ではなく先頭の行。1ページに収まってもフッターは消さない。

見出し行の sticky が効かなくなる書き方をしていたのも直した。高さを測る箱に overflow-auto を持たせると、そちらが最も近いスクロール領域になり、しかも中身の高さぶんに伸びて一度も流れないので、貼り付く相手が動かない。

## 年度の開始日を設定に持ち、全員で同じ値を見る

置き場所として AppPreference を新設した。UserPreference が利用者ごとなのに対し、こちらは DB を共有する全員で1つ。人によって違う値を持つと、同じ条件で絞ったのに見えるものが人ごとに変わる。子を持たない表なので、別の端末が同じキーを同時に作っても、同期は unique 違反を後勝ちで畳める。

行が無いあいだは既定（4/1）で数え、起動時に書き込まない（書くと「まだ誰も決めていない」と「既定を選んだ」とが区別できなくなる）。2月29日は開始日に選べない。設定画面には「いまの年度は 2026-04-01 から 2027-03-31 まで」と出す。

## 検証

typecheck・lint・vitest（2,058件）をコミット前に通してある。

Closes #1245
Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
