### PR TITLE
fix(answer-sheet-builder): マークシートの模範解答で、正解の選択肢を赤く塗る

### DIFF
--- a/__tests__/answer-sheet-builder/verticalTransform.test.ts
+++ b/__tests__/answer-sheet-builder/verticalTransform.test.ts
@@ -198,6 +198,7 @@ describe("transformLayoutToVertical", () => {
           normalizedHeight: 0.032,
           choiceIndex: 0,
           label: "ア",
+          isCorrectAnswer: false,
         },
       ],
     })

--- a/__tests__/omr/unit/markRecognizer.test.ts
+++ b/__tests__/omr/unit/markRecognizer.test.ts
@@ -214,6 +214,7 @@ function create4ChoiceBubbles(
     normalizedHeight: bubbleH,
     choiceIndex: i,
     label: ["①", "②", "③", "④"][i],
+    isCorrectAnswer: false,
   }))
 }
 
@@ -397,6 +398,7 @@ describe("markRecognizer", () => {
         normalizedHeight: 32 / imgHeight,
         choiceIndex: i,
         label: String(i),
+        isCorrectAnswer: false,
       })
     )
 

--- a/__tests__/omr/unit/recognitionConsistency.test.ts
+++ b/__tests__/omr/unit/recognitionConsistency.test.ts
@@ -67,6 +67,7 @@ function createBubbles(positionedChoiceIndices: number[]): ComputedOMRBubble[] {
     normalizedHeight: 48 / IMAGE_HEIGHT,
     choiceIndex,
     label: LABELS[choiceIndex],
+    isCorrectAnswer: false,
   }))
 }
 

--- a/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
+++ b/src/components/answer-sheet-builder/components/preview/AnswerSheetSVGRenderer.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_DASH_RATIO,
   DEFAULT_GAP_RATIO,
   DEFAULT_MANUSCRIPT_BOUNDARY_WIDTH,
+  MODEL_ANSWER_COLOR,
 } from "../../constants"
 import {
   getLineDashRatio,
@@ -318,7 +319,7 @@ export function AnswerSheetSVGRenderer({
                     fill={
                       seg.modelAnswer
                         ? renderMode === "model-answer"
-                          ? "#d00"
+                          ? MODEL_ANSWER_COLOR
                           : "transparent"
                         : "#000"
                     }
@@ -531,6 +532,11 @@ export function AnswerSheetSVGRenderer({
             const cy = bubble.normalizedCy * pageHeightMm
             const rx = (bubble.normalizedWidth * pageWidthMm) / 2
             const ry = (bubble.normalizedHeight * pageHeightMm) / 2
+            // 模範解答では正解のバブルを塗りつぶす。枠は解答用紙と同じ黒のまま
+            // （どこがバブルかの見え方を模範解答でも変えない）。文字は塗りの上でも
+            // 読めるよう白抜き。
+            const filled =
+              renderMode === "model-answer" && bubble.isCorrectAnswer
             return (
               <g key={`omr-bubble-${cellIdx}-${cell.label}-${bi}`}>
                 <ellipse
@@ -538,7 +544,7 @@ export function AnswerSheetSVGRenderer({
                   cy={cy}
                   rx={rx}
                   ry={ry}
-                  fill="none"
+                  fill={filled ? MODEL_ANSWER_COLOR : "none"}
                   stroke="black"
                   strokeWidth={0.3}
                 />
@@ -549,7 +555,7 @@ export function AnswerSheetSVGRenderer({
                   fontFamily="'Noto Sans JP', sans-serif"
                   textAnchor="middle"
                   dominantBaseline="central"
-                  fill="#333"
+                  fill={filled ? "white" : "#333"}
                 >
                   {bubble.label}
                 </text>

--- a/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
+++ b/src/components/answer-sheet-builder/components/preview/svgRenderUtils.tsx
@@ -15,7 +15,11 @@ import type {
 } from "@/types/answerSheetDefinition.types"
 import type { DragInfo } from "@/types/answerSheetLayout.types"
 
-import { DEFAULT_DASH_RATIO, DEFAULT_GAP_RATIO } from "../../constants"
+import {
+  DEFAULT_DASH_RATIO,
+  DEFAULT_GAP_RATIO,
+  MODEL_ANSWER_COLOR,
+} from "../../constants"
 
 /**
  * BorderLineStyle に応じた SVG strokeDasharray / offset / linecap を返す。
@@ -105,7 +109,8 @@ function getSegmentStyle(
       : "underline"
   }
   if (seg.modelAnswer) {
-    style.color = renderMode === "model-answer" ? "#d00" : "transparent"
+    style.color =
+      renderMode === "model-answer" ? MODEL_ANSWER_COLOR : "transparent"
   }
   return style
 }
@@ -132,7 +137,7 @@ export function renderSegmentsTspan(
       fill={
         seg.modelAnswer
           ? renderMode === "model-answer"
-            ? "#d00"
+            ? MODEL_ANSWER_COLOR
             : "transparent"
           : undefined
       }

--- a/src/components/answer-sheet-builder/constants.ts
+++ b/src/components/answer-sheet-builder/constants.ts
@@ -42,6 +42,13 @@ export const DEFAULT_DASH_RATIO = 3
 export const DEFAULT_GAP_RATIO = 2
 
 // =====================
+// 模範解答の表示
+// =====================
+
+/** 模範解答として見せる要素の色（文字・OMRバブルの塗りつぶし） */
+export const MODEL_ANSWER_COLOR = "#d00"
+
+// =====================
 // 用紙サイズ定数（mm）
 // =====================
 

--- a/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
+++ b/src/components/answer-sheet-builder/hooks/layout/cellBuilder.ts
@@ -95,6 +95,7 @@ function computeOMRBubbles(
         normalizedHeight: bubbleHeightMm / paperHeight,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
+        isCorrectAnswer: config.correctAnswers.includes(i),
       })
     }
   } else {
@@ -110,6 +111,7 @@ function computeOMRBubbles(
         normalizedHeight: bubbleHeightMm / paperHeight,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
+        isCorrectAnswer: config.correctAnswers.includes(i),
       })
     }
   }

--- a/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
+++ b/src/components/exams/07-score-at-once/OMRRecognition/hooks/useOmrAutoScoring.ts
@@ -517,6 +517,7 @@ function buildCellsFromRegions(
             normalizedHeight: option.normalizedHeight!,
             choiceIndex: option.choiceIndex,
             label: option.label,
+            isCorrectAnswer: option.isCorrect,
           }))
       } else {
         cell.omrBubbles = computeBubblesFromRegion(region, config)
@@ -556,6 +557,7 @@ function computeBubblesFromRegion(
         normalizedHeight: bubbleH,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
+        isCorrectAnswer: config.correctAnswers.includes(i),
       })
     }
   } else {
@@ -569,6 +571,7 @@ function computeBubblesFromRegion(
         normalizedHeight: bubbleH,
         choiceIndex: i,
         label: config.labels[i] ?? String(i + 1),
+        isCorrectAnswer: config.correctAnswers.includes(i),
       })
     }
   }

--- a/src/types/omr.types.ts
+++ b/src/types/omr.types.ts
@@ -198,6 +198,8 @@ export interface ComputedOMRBubble {
   choiceIndex: number
   /** ラベル（"ア", "イ" など） */
   label: string
+  /** この選択肢が正解か（模範解答の表示で塗りつぶす対象） */
+  isCorrectAnswer: boolean
 }
 
 // =====================


### PR DESCRIPTION
Closes #1253

## 何を直したか

マークシート（OMR選択肢）の模範解答で、正解のバブルを赤く塗りつぶすようにした。
これまでは「模範解答の表示」に切り替えてもバブルは輪郭を描くだけで、どれが正解かが
用紙から読み取れなかった。

正解そのものは DB に持っている（`AsbOmrChoiceOption.isCorrect` → `correctAnswers`）のに、
レイアウト計算が作る `ComputedOMRBubble` が「その選択肢が正解か」を運んでおらず、
描画側からは分からない状態だったのが原因。

## 変更点

- `ComputedOMRBubble` に `isCorrectAnswer` を追加。バブルを組み立てる3経路
  （解答用紙作成の縦並び・横並び、07採点のOMR認識）すべてで実データから埋める。
  **必須フィールド**にして、生成箇所の漏れが黙って「塗られない」に落ちないようにした
- 模範解答の表示で正解のバブルを赤で塗る。**枠は解答用紙と同じ黒のまま**にして
  バブルの見え方を変えず、選択肢ラベルは塗りの上でも読めるよう白抜きにした
- 直書きだった模範解答の色 `#d00`（3箇所）を `MODEL_ANSWER_COLOR` へ寄せ、
  模範解答テキストと塗りで色がずれないようにした

プレビュー・PDF出力・PNG出力・試験連携の模範解答画像はすべて同じ
`AnswerSheetSVGRenderer` を通るので、全経路で塗られる。縦組み変換
（`transposeBubble`）はスプレッドなのでフラグを保つ。

## 型規約の確認

- 新しい型は作らず、既存の `ComputedOMRBubble`（正規化座標＝DB非保存の計算結果）に
  フィールドを1つ足しただけ
- 独自型制限が守っている **DB書き込み整合性** に触れないことを確認済み。
  試験連携の書き込み `examConverter.ts` は `isCorrect` を設定側の `correctAnswers` から
  直接導いており、バブル側からは座標しか読んでいない（＝二重の書き込み源にならない）
- 正解判定は renderer 側のレイアウト計算で行い、main に専用IPCを足していない
- `any` / `as` の追加なし

## 検証

- `npm run check-all`: typecheck・eslint は通過。prettier は `ChangePreview.tsx`（今回未変更）
  で落ちるが、**これは origin/main 時点で既に赤い**。同ファイルは作業ツリーで HEAD と
  byte 一致しており、`origin/main` の内容そのものを prettier に掛けても同じ警告が出ることを
  確認した。今回の変更による新規エラーはゼロ
- ユニットテスト 217 passed（テスト用DBの初期化がAI保護でブロックされるため、DBを使う
  3ファイルは未実行）